### PR TITLE
Add ArangoDB typescript typings

### DIFF
--- a/types/arangodb/arangodb-tests.ts
+++ b/types/arangodb/arangodb-tests.ts
@@ -1,12 +1,12 @@
 import { db } from "@arangodb";
 
-const context = (module as Foxx.Module).context;
+console.warnStack(new Error(), "something went wrong");
 
 interface User {
     username: string;
     password?: string;
 }
-const coll = context.collection("users")!;
+const coll = module.context.collection("users")!;
 coll.save({ username: "user" });
 const doc = coll.any();
 console.log(doc.username);

--- a/types/arangodb/arangodb-tests.ts
+++ b/types/arangodb/arangodb-tests.ts
@@ -1,6 +1,9 @@
 import { db } from "@arangodb";
 import { md5 } from "@arangodb/crypto";
 import { createRouter } from "@arangodb/foxx";
+import sessionsMiddleware = require("@arangodb/foxx/sessions");
+import jwtStorage = require("@arangodb/foxx/sessions/storages/jwt");
+import cookieTransport = require("@arangodb/foxx/sessions/transports/cookie");
 
 console.warnStack(new Error(), "something went wrong");
 
@@ -37,6 +40,19 @@ router.get("/", (req, res) => {
 });
 
 router.use((req, res, next) => {
-    if (req.is("json")) res.throw("i'm a teapot");
+    if (req.is("json")) res.throw("too many requests");
     next();
 });
+
+router.use(
+    sessionsMiddleware({
+        storage: jwtStorage({ algorithm: "none" }),
+        transport: "header"
+    })
+);
+router.use(
+    sessionsMiddleware({
+        storage: jwtStorage({ algorithm: "HS512", secret: "tacocat" }),
+        transport: cookieTransport({ secret: "banana", algorithm: "sha256" })
+    })
+);

--- a/types/arangodb/arangodb-tests.ts
+++ b/types/arangodb/arangodb-tests.ts
@@ -1,4 +1,4 @@
-import { db } from "@arangodb";
+import { db, aql } from "@arangodb";
 import { md5 } from "@arangodb/crypto";
 import { createRouter } from "@arangodb/foxx";
 import sessionsMiddleware = require("@arangodb/foxx/sessions");
@@ -20,6 +20,11 @@ const users = coll as ArangoDB.Collection<User>;
 const admin = users.firstExample({ username: "admin" })!;
 users.update(admin, { password: md5("hunter2") });
 console.logLines("user", admin._key, admin.username);
+
+const query = aql`
+    FOR u IN ${users}
+    RETURN u
+`;
 
 db._createDocumentCollection("bananas").ensureIndex({
     type: "hash",

--- a/types/arangodb/arangodb-tests.ts
+++ b/types/arangodb/arangodb-tests.ts
@@ -1,4 +1,6 @@
 import { db } from "@arangodb";
+import { md5 } from "@arangodb/crypto";
+import { createRouter } from "@arangodb/foxx";
 
 console.warnStack(new Error(), "something went wrong");
 
@@ -13,4 +15,28 @@ console.log(doc.username);
 
 const users = coll as ArangoDB.Collection<User>;
 const admin = users.firstExample({ username: "admin" })!;
-users.update(admin, { password: "hunter2" });
+users.update(admin, { password: md5("hunter2") });
+console.logLines("user", admin._key, admin.username);
+
+db._createDocumentCollection("bananas").ensureIndex({
+    type: "hash",
+    unique: true,
+    fields: ["color", "shape"]
+});
+
+const router = createRouter();
+module.context.use(router);
+
+router.get("/", (req, res) => {
+    if (req.cookie("sid", { secret: "keyboardcat" })) {
+        res.set("content-type", "text/plain");
+        res.write("Welcome back, Commander");
+    } else {
+        res.json({ success: false });
+    }
+});
+
+router.use((req, res, next) => {
+    if (req.is("json")) res.throw("i'm a teapot");
+    next();
+});

--- a/types/arangodb/arangodb-tests.ts
+++ b/types/arangodb/arangodb-tests.ts
@@ -1,8 +1,10 @@
+import { db } from "@arangodb";
+
 interface User {
     username: string;
     password?: string;
 }
-const coll = module.context.collection("users")!;
+const coll = db._collection("users");
 coll.save({ username: "user" });
 const doc = coll.any();
 console.log(doc.username);

--- a/types/arangodb/arangodb-tests.ts
+++ b/types/arangodb/arangodb-tests.ts
@@ -1,10 +1,12 @@
 import { db } from "@arangodb";
 
+const context = (module as Foxx.Module).context;
+
 interface User {
     username: string;
     password?: string;
 }
-const coll = db._collection("users");
+const coll = context.collection("users")!;
 coll.save({ username: "user" });
 const doc = coll.any();
 console.log(doc.username);

--- a/types/arangodb/arangodb-tests.ts
+++ b/types/arangodb/arangodb-tests.ts
@@ -1,0 +1,12 @@
+interface User {
+    username: string;
+    password?: string;
+}
+const coll = module.context.collection("users")!;
+coll.save({ username: "user" });
+const doc = coll.any();
+console.log(doc.username);
+
+const users = coll as ArangoDB.Collection<User>;
+const admin = users.firstExample({ username: "admin" })!;
+users.update(admin, { password: "hunter2" });

--- a/types/arangodb/index.d.ts
+++ b/types/arangodb/index.d.ts
@@ -827,7 +827,7 @@ declare namespace ArangoDB {
         _engine(): EngineType;
         _engineStats(): PlainObject;
         _executeTransaction(transaction: Transaction): void;
-        [name: string]: Collection | undefined;
+        readonly [key: string]: any;
     }
 }
 
@@ -924,7 +924,7 @@ declare namespace Foxx {
         body: any;
         context: Context;
         database: string;
-        headers: { [key: string]: string | undefined };
+        headers: StringMap;
         hostname: string;
         method: ArangoDB.HttpMethod;
         originalUrl: string;
@@ -1631,7 +1631,7 @@ declare module "@arangodb/general-graph" {
         _radius(vertexExample: Example, options?: RadiusOptions): number;
         _diameter(vertexExample: Example, options?: DiameterOptions): number;
 
-        [key: string]: ArangoDB.Collection | undefined;
+        readonly [key: string]: any;
     }
     export function _create(
         name: string,

--- a/types/arangodb/index.d.ts
+++ b/types/arangodb/index.d.ts
@@ -9,6 +9,9 @@ interface PlainObject {
 interface StringMap {
     [key: string]: string | undefined;
 }
+interface CollectionMap {
+    [key: string]: ArangoDB.Collection | undefined;
+}
 
 declare namespace ArangoDB {
     type JwtAlgorithm = "HS512" | "HS384" | "HS256";
@@ -826,7 +829,6 @@ declare namespace ArangoDB {
         _engine(): EngineType;
         _engineStats(): PlainObject;
         _executeTransaction(transaction: Transaction): void;
-        readonly [key: string]: any;
     }
 }
 
@@ -1159,7 +1161,7 @@ declare namespace Foxx {
 declare module "@arangodb" {
     function aql(strings: string[], ...args: any[]): ArangoDB.Query;
     function time(): number;
-    const db: ArangoDB.Database;
+    const db: ArangoDB.Database & CollectionMap;
     const errors: {
         [Name in ArangoDB.ErrorName]: { code: number; message: string }
     };
@@ -1631,16 +1633,14 @@ declare module "@arangodb/general-graph" {
         ): Betweenness;
         _radius(vertexExample: Example, options?: RadiusOptions): number;
         _diameter(vertexExample: Example, options?: DiameterOptions): number;
-
-        readonly [key: string]: any;
     }
     function _create(
         name: string,
         edgeDefinitions?: EdgeDefinition[],
         orphanCollections?: string[]
-    ): Graph;
+    ): Graph & CollectionMap;
     function _list(): string[];
-    function _graph(name: string): Graph;
+    function _graph(name: string): Graph & CollectionMap;
     function _drop(name: string, dropCollections?: boolean): boolean;
     function _relation(
         name: string,

--- a/types/arangodb/index.d.ts
+++ b/types/arangodb/index.d.ts
@@ -1222,9 +1222,9 @@ declare module "@arangodb/foxx/router" {
 }
 
 declare module "@arangodb/foxx/graphql" {
-    type GraphQLSchema = any;
-    type GraphQLModule = any;
-    type GraphQLFormatErrorFunction = () => any;
+    type GraphQLSchema = object;
+    type GraphQLModule = object;
+    type GraphQLFormatErrorFunction = (error: any) => any;
     interface GraphQLOptions {
         schema: GraphQLSchema;
         context?: any;

--- a/types/arangodb/index.d.ts
+++ b/types/arangodb/index.d.ts
@@ -1156,7 +1156,7 @@ declare namespace Foxx {
     }
 }
 
-declare module "@arangodb/index" {
+declare module "@arangodb" {
     function aql(strings: string[], ...args: any[]): ArangoDB.Query;
     function time(): number;
     const db: ArangoDB.Database;

--- a/types/arangodb/index.d.ts
+++ b/types/arangodb/index.d.ts
@@ -1326,7 +1326,7 @@ declare namespace Foxx {
 }
 
 declare module "@arangodb" {
-    function aql(strings: string[], ...args: any[]): ArangoDB.Query;
+    function aql(strings: TemplateStringsArray, ...args: any[]): ArangoDB.Query;
     function time(): number;
     const db: ArangoDB.Database & {
         [key: string]: ArangoDB.Collection | undefined;

--- a/types/arangodb/index.d.ts
+++ b/types/arangodb/index.d.ts
@@ -484,11 +484,13 @@ declare namespace ArangoDB {
         _to: string;
     };
 
-    type InsertResult<T extends object = any> = DocumentMetadata | Document<T>;
-    type UpdateResult<T extends object = any> = UpdateMetadata & {
+    interface InsertResult<T extends object = any> extends DocumentMetadata {
+        new?: Document<T>;
+    }
+    interface UpdateResult<T extends object = any> extends UpdateMetadata {
         old?: Document<T>;
         new?: Document<T>;
-    };
+    }
     interface RemoveResult<T extends object = any> extends DocumentMetadata {
         old?: Document<T>;
     }

--- a/types/arangodb/index.d.ts
+++ b/types/arangodb/index.d.ts
@@ -3,9 +3,6 @@
 // Definitions by: Alan Plum <https://github.com/pluma>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-interface PlainObject {
-    [key: string]: any;
-}
 interface StringMap {
     [key: string]: string | undefined;
 }
@@ -437,7 +434,7 @@ declare namespace ArangoDB {
         deduplicate?: boolean;
     }
 
-    interface IndexResult<T = PlainObject> {
+    interface IndexResult<T = object> {
         id: string;
         type: IndexType;
         fields: Array<keyof T>;
@@ -473,17 +470,17 @@ declare namespace ArangoDB {
         _oldRev: string;
     }
 
-    type Document<T = PlainObject> = T &
+    type Document<T = object> = T &
         DocumentMetadata & { _from?: string; _to?: string };
-    type DocumentData<T = PlainObject> = T & Partial<DocumentMetadata>;
-    type Edge<T = PlainObject> = Document<T> & { _from: string; _to: string };
+    type DocumentData<T = object> = T & Partial<DocumentMetadata>;
+    type Edge<T = object> = Document<T> & { _from: string; _to: string };
 
-    type InsertResult<T = PlainObject> = DocumentMetadata | Document<T>;
-    type UpdateResult<T = PlainObject> = UpdateMetadata & {
+    type InsertResult<T = object> = DocumentMetadata | Document<T>;
+    type UpdateResult<T = object> = UpdateMetadata & {
         old?: Document<T>;
         ["new"]?: Document<T>;
     };
-    interface RemoveResult<T = PlainObject> extends DocumentMetadata {
+    interface RemoveResult<T = object> extends DocumentMetadata {
         old?: Document<T>;
     }
 
@@ -528,7 +525,7 @@ declare namespace ArangoDB {
 
     type DocumentIterator<T> = (document: Document<T>, number: number) => void;
 
-    interface Collection<T = PlainObject> {
+    interface Collection<T = object> {
         // Collection
         checksum(
             withRevisions?: boolean,
@@ -664,14 +661,14 @@ declare namespace ArangoDB {
         username: string;
         passwd?: string;
         active?: boolean;
-        extra?: PlainObject;
+        extra?: object;
     }
 
     // AQL
 
     interface Query {
         query: string;
-        bindVars?: PlainObject;
+        bindVars?: object;
         options?: QueryOptions;
     }
 
@@ -749,10 +746,10 @@ declare namespace ArangoDB {
     }
     interface Transaction {
         collections: TransactionCollections | string[];
-        action: (params: PlainObject) => void | string;
+        action: (params: object) => void | string;
         waitForSync?: boolean;
         lockTimeout?: number;
-        params?: PlainObject;
+        params?: object;
         // RocksDB
         maxTransactionsSize?: number;
         intermediateCommitSize?: number;
@@ -800,7 +797,7 @@ declare namespace ArangoDB {
         _createStatement(query: Query | string): Statement;
         _query(
             query: Query | string,
-            bindVars?: PlainObject,
+            bindVars?: object,
             options?: QueryOptions
         ): Cursor;
         _explain(query: Query | string): void;
@@ -812,11 +809,11 @@ declare namespace ArangoDB {
         _remove(selector: string | DocumentLike1): DocumentMetadata;
         _replace(
             selector: string | DocumentLike1,
-            data: PlainObject
+            data: object
         ): DocumentMetadata;
         _update(
             selector: string | DocumentLike1,
-            data: PlainObject
+            data: object
         ): DocumentMetadata;
 
         // TODO Views
@@ -827,7 +824,7 @@ declare namespace ArangoDB {
 
         // Global
         _engine(): EngineType;
-        _engineStats(): PlainObject;
+        _engineStats(): object;
         _executeTransaction(transaction: Transaction): void;
     }
 }
@@ -905,11 +902,11 @@ declare namespace Foxx {
         basePath: string;
         baseUrl: string;
         collectionPrefix: string;
-        configuration: PlainObject;
-        dependencies: PlainObject;
+        configuration: object;
+        dependencies: object;
         isDevelopment: boolean;
         isProduction: boolean;
-        manifest: PlainObject;
+        manifest: object;
         mount: string;
         collection(name: string): ArangoDB.Collection | null;
         collectionName(name: string): string;
@@ -946,7 +943,7 @@ declare namespace Foxx {
         pathParams: object;
         port: number;
         protocol: string;
-        queryParams: PlainObject;
+        queryParams: object;
         rawBody: Buffer;
         remoteAddress: string;
         remoteAddresses: string[];
@@ -978,7 +975,7 @@ declare namespace Foxx {
         makeAbsolute(path: string, query?: string | StringMap): string;
         param(name: string): any;
         range(size?: number): Ranges | number;
-        reverse(name: string, params?: PlainObject): string;
+        reverse(name: string, params?: object): string;
     }
 
     interface Response {
@@ -1179,7 +1176,7 @@ declare module "@arangodb/foxx/graphql" {
     interface GraphQLOptions {
         schema: GraphQLSchema;
         context?: any;
-        rootValue?: PlainObject;
+        rootValue?: object;
         pretty?: boolean;
         formatError?: GraphQLFormatErrorFunction;
         validationRules?: any[];
@@ -1376,7 +1373,7 @@ declare module "@arangodb/request" {
         throw(message?: string): void;
     }
     interface RequestOptions {
-        qs?: PlainObject;
+        qs?: object;
         useQuerystring?: boolean;
         headers?: StringMap;
         body?: any;
@@ -1478,9 +1475,9 @@ declare module "@arangodb/general-graph" {
         [key: string]: number | undefined;
     }
     interface Path<
-        A = PlainObject,
-        B = PlainObject,
-        E = PlainObject,
+        A = object,
+        B = object,
+        E = object,
         V = never
     > {
         source: ArangoDB.Document<A>;
@@ -1488,7 +1485,7 @@ declare module "@arangodb/general-graph" {
         edges: Array<ArangoDB.Edge<E>>;
         vertice: Array<ArangoDB.Document<A | B | V>>;
     }
-    interface ShortestPath<T = PlainObject> {
+    interface ShortestPath<T = object> {
         vertices: string[];
         edges: Array<ArangoDB.Edge<T>>;
         distance: number;
@@ -1503,7 +1500,7 @@ declare module "@arangodb/general-graph" {
     }
     type Closeness = Eccentricity;
     type Betweenness = Eccentricity;
-    type Example = Array<PlainObject | string> | PlainObject | string | null;
+    type Example = Array<object | string> | object | string | null;
     interface ConnectingEdgesOptions {
         edgeExamples?: Example;
         edgeCollectionRestriction?: string[] | string;

--- a/types/arangodb/index.d.ts
+++ b/types/arangodb/index.d.ts
@@ -866,10 +866,9 @@ declare namespace Foxx {
         set?: (res: Response, sid: string) => void;
         clear?: (res: Response) => void;
     }
-    type Handler = (req: Request, res: Response) => void;
 
     type Middleware = (req: Request, res: Response, next: NextFunction) => void;
-
+    type Handler = ((req: Request, res: Response) => void) | Middleware;
     type NextFunction = () => void;
 
     interface ValidationResult<T> {
@@ -1084,85 +1083,22 @@ declare namespace Foxx {
         tag(...tags: string[]): this;
     }
 
+    function route(
+        path: string,
+        ...handlers: Handler[],
+        name?: string
+    ): Endpoint;
+    function route(...handlers: Handler[], name?: string): Endpoint;
+    function route(path: string, handler: Handler, name?: string): Endpoint;
+    function route(handler: Handler, name?: string): Endpoint;
+
     interface Router {
-        get(
-            path: string,
-            ...middlewares: Middleware[],
-            handler: Handler,
-            name?: string
-        ): Endpoint;
-        get(path: string, handler: Handler, name?: string): Endpoint;
-        get(
-            ...middlewares: Middleware[],
-            handler: Handler,
-            name?: string
-        ): Endpoint;
-        get(handler: Handler, name?: string): Endpoint;
-        post(
-            path: string,
-            ...middlewares: Middleware[],
-            handler: Handler,
-            name?: string
-        ): Endpoint;
-        post(path: string, handler: Handler, name?: string): Endpoint;
-        post(
-            ...middlewares: Middleware[],
-            handler: Handler,
-            name?: string
-        ): Endpoint;
-        post(handler: Handler, name?: string): Endpoint;
-        put(
-            path: string,
-            ...middlewares: Middleware[],
-            handler: Handler,
-            name?: string
-        ): Endpoint;
-        put(path: string, handler: Handler, name?: string): Endpoint;
-        put(
-            ...middlewares: Middleware[],
-            handler: Handler,
-            name?: string
-        ): Endpoint;
-        put(handler: Handler, name?: string): Endpoint;
-        patch(
-            path: string,
-            ...middlewares: Middleware[],
-            handler: Handler,
-            name?: string
-        ): Endpoint;
-        patch(path: string, handler: Handler, name?: string): Endpoint;
-        patch(
-            ...middlewares: Middleware[],
-            handler: Handler,
-            name?: string
-        ): Endpoint;
-        patch(handler: Handler, name?: string): Endpoint;
-        delete(
-            path: string,
-            ...middlewares: Middleware[],
-            handler: Handler,
-            name?: string
-        ): Endpoint;
-        delete(path: string, handler: Handler, name?: string): Endpoint;
-        delete(
-            ...middlewares: Middleware[],
-            handler: Handler,
-            name?: string
-        ): Endpoint;
-        delete(handler: Handler, name?: string): Endpoint;
-        all(
-            path: string,
-            ...middlewares: Middleware[],
-            handler: Handler,
-            name?: string
-        ): Endpoint;
-        all(path: string, handler: Handler, name?: string): Endpoint;
-        all(
-            ...middlewares: Middleware[],
-            handler: Handler,
-            name?: string
-        ): Endpoint;
-        all(handler: Handler, name?: string): Endpoint;
+        get: typeof route;
+        post: typeof route;
+        put: typeof route;
+        patch: typeof route;
+        delete: typeof route;
+        all: typeof route;
         use(
             path: string,
             routerOrMiddleware: Router | Middleware,

--- a/types/arangodb/index.d.ts
+++ b/types/arangodb/index.d.ts
@@ -698,8 +698,8 @@ declare namespace ArangoDB {
         memoryLimit?: number;
         failOnWarning?: boolean;
         cache?: boolean;
-        count?: boolean; // TODO ???
-        fullCount?: boolean; // TODO ???
+        count?: boolean;
+        fullCount?: boolean;
         profile?: boolean;
         maxWarningCount?: number;
         maxNumberOfPlans?: number;

--- a/types/arangodb/index.d.ts
+++ b/types/arangodb/index.d.ts
@@ -760,6 +760,11 @@ declare namespace ArangoDB {
         ast: QueryAstNode[];
     }
 
+    // Views
+
+    type View = object; // TODO
+    type ViewProperties = object; // TODO
+
     // Global
 
     interface TransactionCollections {
@@ -839,11 +844,15 @@ declare namespace ArangoDB {
             data: object
         ): DocumentMetadata;
 
-        // TODO Views
-        // _view(name: string): ??? | null;
-        // _views(): ???[];
-        // _createView(name: string, type: ViewType, properties: ???): ???;
-        // _dropView(name: string): void;
+        // Views
+        _view(name: string): View | null;
+        _views(): View[];
+        _createView(
+            name: string,
+            type: ViewType,
+            properties: ViewProperties
+        ): View;
+        _dropView(name: string): void;
 
         // Global
         _engine(): EngineType;

--- a/types/arangodb/index.d.ts
+++ b/types/arangodb/index.d.ts
@@ -1842,6 +1842,7 @@ interface NodeModule {
 }
 
 interface Console {
+    logLines(...args: any[]): void;
     errorLines(...args: any[]): void;
     warnLines(...args: any[]): void;
     infoLines(...args: any[]): void;

--- a/types/arangodb/index.d.ts
+++ b/types/arangodb/index.d.ts
@@ -434,7 +434,7 @@ declare namespace ArangoDB {
         deduplicate?: boolean;
     }
 
-    interface IndexResult<T = object> {
+    interface IndexResult<T extends object = object> {
         id: string;
         type: IndexType;
         fields: Array<keyof T>;
@@ -470,17 +470,25 @@ declare namespace ArangoDB {
         _oldRev: string;
     }
 
-    type Document<T = object> = T &
-        DocumentMetadata & { _from?: string; _to?: string };
-    type DocumentData<T = object> = T & Partial<DocumentMetadata>;
-    type Edge<T = object> = Document<T> & { _from: string; _to: string };
+    type Document<T extends object = object> = T &
+        DocumentMetadata & { _from?: string; _to?: string } & {
+            [key: string]: any;
+        };
+    type DocumentData<T extends object = object> = T &
+        Partial<DocumentMetadata> & { [key: string]: any };
+    type Edge<T extends object = object> = Document<T> & {
+        _from: string;
+        _to: string;
+    };
 
-    type InsertResult<T = object> = DocumentMetadata | Document<T>;
-    type UpdateResult<T = object> = UpdateMetadata & {
+    type InsertResult<T extends object = object> =
+        | DocumentMetadata
+        | Document<T>;
+    type UpdateResult<T extends object = object> = UpdateMetadata & {
         old?: Document<T>;
         ["new"]?: Document<T>;
     };
-    interface RemoveResult<T = object> extends DocumentMetadata {
+    interface RemoveResult<T extends object = object> extends DocumentMetadata {
         old?: Document<T>;
     }
 
@@ -523,9 +531,12 @@ declare namespace ArangoDB {
         probability?: number;
     }
 
-    type DocumentIterator<T> = (document: Document<T>, number: number) => void;
+    type DocumentIterator<T extends object = object> = (
+        document: Document<T>,
+        number: number
+    ) => void;
 
-    interface Collection<T = object> {
+    interface Collection<T extends object = object> {
         // Collection
         checksum(
             withRevisions?: boolean,
@@ -1475,17 +1486,17 @@ declare module "@arangodb/general-graph" {
         [key: string]: number | undefined;
     }
     interface Path<
-        A = object,
-        B = object,
-        E = object,
-        V = never
+        A extends object = object,
+        B extends object = object,
+        E extends object = object,
+        V extends object = never
     > {
         source: ArangoDB.Document<A>;
         destination: ArangoDB.Document<B>;
         edges: Array<ArangoDB.Edge<E>>;
         vertice: Array<ArangoDB.Document<A | B | V>>;
     }
-    interface ShortestPath<T = object> {
+    interface ShortestPath<T extends object = object> {
         vertices: string[];
         edges: Array<ArangoDB.Edge<T>>;
         distance: number;

--- a/types/arangodb/index.d.ts
+++ b/types/arangodb/index.d.ts
@@ -3,8 +3,12 @@
 // Definitions by: Alan Plum <https://github.com/pluma>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-type PlainObject = { [key: string]: any };
-type StringMap = { [key: string]: string | undefined };
+interface PlainObject {
+    [key: string]: any;
+}
+interface StringMap {
+    [key: string]: string | undefined;
+}
 
 declare namespace ArangoDB {
     declare type JwtAlgorithm = "HS512" | "HS384" | "HS256";
@@ -467,12 +471,13 @@ declare namespace ArangoDB {
         _oldRev: string;
     }
 
-    type Document<T> = T & DocumentMetadata & { _from?: string; _to?: string };
-    type DocumentData<T> = T & Partial<DocumentMetadata>;
-    type Edge<T> = Document<T> & { _from: string; _to: string };
+    type Document<T = PlainObject> = T &
+        DocumentMetadata & { _from?: string; _to?: string };
+    type DocumentData<T = PlainObject> = T & Partial<DocumentMetadata>;
+    type Edge<T = PlainObject> = Document<T> & { _from: string; _to: string };
 
-    type InsertResult<T> = DocumentMetadata | Document<T>;
-    type UpdateResult<T> = UpdateMetadata & {
+    type InsertResult<T = PlainObject> = DocumentMetadata | Document<T>;
+    type UpdateResult<T = PlainObject> = UpdateMetadata & {
         old?: Document<T>;
         new?: Document<T>;
     };
@@ -618,9 +623,9 @@ declare namespace ArangoDB {
         ): number;
         save(data: DocumentData<T>, options?: InsertOptions): InsertResult<T>;
         save(
-            array: DocumentData<T>[],
+            array: Array<DocumentData<T>>,
             options?: InsertOptions
-        ): InsertResult<T>[];
+        ): Array<InsertResult<T>>;
         save(
             from: string,
             to: string,
@@ -633,10 +638,10 @@ declare namespace ArangoDB {
             options?: UpdateOptions
         ): UpdateResult<T>;
         update(
-            selectors: (string | DocumentLike)[],
-            data: Partial<Document<T>>[],
+            selectors: Array<string | DocumentLike>,
+            data: Array<Partial<Document<T>>>,
             options?: UpdateOptions
-        ): UpdateResult<T>[];
+        ): Array<UpdateResult<T>>;
         updateByExample(
             example: Partial<Document<T>>,
             newValue: Partial<Document<T>>,
@@ -778,7 +783,7 @@ declare namespace ArangoDB {
 
         // Collection
         _collection(name: string): Collection;
-        _collections(): Collection[];
+        _collections(): Array<Collection>;
         _create(name: string, properties?: CollectionProperties): Collection;
         _createDocumentCollection(
             name: string,
@@ -805,10 +810,10 @@ declare namespace ArangoDB {
         _document<T = PlainObject>(name: string): Document<T>;
         _exists(name: string): boolean;
         _remove(name: string): DocumentMetadata;
-        _replace(name: string, data: Object): DocumentMetadata;
-        _replace(doc: DocumentLike, data: Object): DocumentMetadata;
-        _update(name: string, data: Object): DocumentMetadata;
-        _update(doc: DocumentLike, data: Object): DocumentMetadata;
+        _replace(name: string, data: PlainObject): DocumentMetadata;
+        _replace(doc: DocumentLike, data: PlainObject): DocumentMetadata;
+        _update(name: string, data: PlainObject): DocumentMetadata;
+        _update(doc: DocumentLike, data: PlainObject): DocumentMetadata;
 
         // TODO Views
         // _view(name: string): ??? | null;
@@ -869,6 +874,16 @@ declare namespace Foxx {
         before: (req: Request, res: Response) => void | false;
     }
 
+    interface TypeDefinition {
+        // TODO
+        [key: string]: any;
+    }
+
+    interface Ranges {
+        // TODO
+        [key: string]: any;
+    }
+
     declare interface Context {
         argv: any[];
         basePath: string;
@@ -881,9 +896,9 @@ declare namespace Foxx {
         manifest: PlainObject;
         mount: string;
         collection<T = PlainObject>(
-            string: name
+            name: string
         ): ArangoDB.Collection<T> | null;
-        collectionName(string: name): string;
+        collectionName(name: string): string;
         createDocumentationRouter(
             opts?: Partial<DocumentationRouterOptions>
         ): Router;
@@ -1447,51 +1462,56 @@ declare module "@arangodb/general-graph" {
     };
     type CountCommonNeighbors = {
         [key: string]:
-            | {
+            | Array<{
                   [key: string]: number | undefined;
-              }[]
+              }>
             | undefined;
     };
     type CommonProperties = {
         [key: string]:
-            | {
+            | Array<{
                   _id: string;
                   [key: string]: any;
-              }[]
+              }>
             | undefined;
     };
     type CountCommonProperties = {
         [key: string]: number | undefined;
     };
-    type Path<A = PlainObject, B = PlainObject, E = PlainObject, V = never> = {
+    interface Path<
+        A = PlainObject,
+        B = PlainObject,
+        E = PlainObject,
+        V = never
+    > {
         source: ArangoDB.Document<A>;
         destination: ArangoDB.Document<B>;
-        edges: ArangoDB.Edge<E>[];
-        vertice: ArangoDB.Document<A | B | V>[];
-    };
-    type ShortestPath<T = PlainObject> = {
+        edges: Array<ArangoDB.Edge<E>>;
+        vertice: Array<ArangoDB.Document<A | B | V>>;
+    }
+    interface ShortestPath<T = PlainObject> {
         vertices: string[];
-        edges: ArangoDB.Edge<T>[];
+        edges: Array<ArangoDB.Edge<T>>;
         distance: number;
-    };
-    type Distance = {
+    }
+    interface Distance {
         startVertex: string;
         vertex: string;
         distance: number;
-    };
-    type Eccentricity = {
+    }
+    interface Eccentricity {
         [key: string]: number | undefined;
-    };
+    }
     type Closeness = Eccentricity;
     type Betweenness = Eccentricity;
-    type Example = (PlainObject | string)[] | PlainObject | string | null;
-    type ConnectingEdgesOptions = {
+    type Example = Array<PlainObject | string> | PlainObject | string | null;
+    interface ConnectingEdgesOptions {
         edgeExamples?: Example;
         edgeCollectionRestriction?: string[] | string;
         vertex1CollectionRestriction?: string[] | string;
         vertex2CollectionRestriction?: string[] | string;
-    };
-    type NeighborsOptions = {
+    }
+    interface NeighborsOptions {
         direction?: ArangoDB.EdgeDirection;
         edgeExamples?: Example;
         neighborExamples?: Example;
@@ -1499,33 +1519,33 @@ declare module "@arangodb/general-graph" {
         vertexCollectionRestriction?: string[] | string;
         minDepth?: number;
         maxDepth?: number;
-    };
-    type CommonPropertiesOptions = {
+    }
+    interface CommonPropertiesOptions {
         vertex1CollectionRestriction?: string[] | string;
         vertex2CollectionRestriction?: string[] | string;
         ignoredProperties?: string[] | string;
-    };
-    type PathsOptions = {
+    }
+    interface PathsOptions {
         direction?: ArangoDB.EdgeDirection;
         followCycles?: boolean;
         minLength?: number;
         maxLength?: number;
-    };
-    type ShortestPathOptions = {
+    }
+    interface ShortestPathOptions {
         direction?: ArangoDB.EdgeDirection;
         edgeCollectionRestriction?: string[] | string;
         startVertexCollectionRestriction?: string[] | string;
         endVertexCollectionRestriction?: string[] | string;
         weight?: string;
         defaultWeight?: number;
-    };
+    }
     type EccentricityOptions = ShortestPathOptions;
     type ClosenessOptions = ShortestPathOptions;
-    type BetweennessOptions = {
+    interface BetweennessOptions {
         direction?: ArangoDB.EdgeDirection;
         weight?: string;
         defaultWeight?: number;
-    };
+    }
     type RadiusOptions = BetweennessOptions;
     type DiameterOptions = BetweennessOptions;
     interface Graph {
@@ -1544,11 +1564,11 @@ declare module "@arangodb/general-graph" {
             orphanCollectionName: string,
             dropCollection?: boolean
         ): void;
-        _getConnectingEdges<T = PlainObject>(
+        _getConnectingEdges(
             vertexExample1: Example,
             vertexExample2: Example,
             options: ConnectingEdgesOptions
-        ): ArangoDB.Edge<T>;
+        ): ArangoDB.Edge;
         _fromVertex<T = PlainObject>(edgeId: string): ArangoDB.Document<T>;
         _toVertex<T = PlainObject>(edgeId: string): ArangoDB.Document<T>;
         _neighbors(
@@ -1577,7 +1597,7 @@ declare module "@arangodb/general-graph" {
             vertex2Example: Example,
             options?: CommonPropertiesOptions
         ): CountCommonProperties[];
-        _paths<A, B, E, V>(options?: PathsOptions): Path<A, B, E, V>[];
+        _paths(options?: PathsOptions): Path[];
         _shortestPath<T>(
             startVertexExample: Example,
             endVertexExample: Example,

--- a/types/arangodb/index.d.ts
+++ b/types/arangodb/index.d.ts
@@ -11,15 +11,15 @@ interface StringMap {
 }
 
 declare namespace ArangoDB {
-    declare type JwtAlgorithm = "HS512" | "HS384" | "HS256";
-    declare type HashAlgorithm =
+    type JwtAlgorithm = "HS512" | "HS384" | "HS256";
+    type HashAlgorithm =
         | "sha512"
         | "sha384"
         | "sha256"
         | "sha224"
         | "sha1"
         | "md5";
-    declare type HttpMethod =
+    type HttpMethod =
         | "HEAD"
         | "GET"
         | "POST"
@@ -27,11 +27,11 @@ declare namespace ArangoDB {
         | "PATCH"
         | "DELETE"
         | "OPTIONS";
-    declare type EdgeDirection = "any" | "inbound" | "outbound";
-    declare type EngineType = "mmfiles" | "rocksdb";
-    declare type IndexType = "hash" | "skiplist" | "fulltext" | "geo1" | "geo2";
-    declare type ViewType = "arangosearch";
-    declare type ErrorName =
+    type EdgeDirection = "any" | "inbound" | "outbound";
+    type EngineType = "mmfiles" | "rocksdb";
+    type IndexType = "hash" | "skiplist" | "fulltext" | "geo1" | "geo2";
+    type ViewType = "arangosearch";
+    type ErrorName =
         | "ERROR_NO_ERROR"
         | "ERROR_FAILED"
         | "ERROR_SYS_ERROR"
@@ -335,7 +335,7 @@ declare namespace ArangoDB {
 
     // Collection
 
-    declare const enum CollectionType {
+    export const enum CollectionType {
         Document = 2,
         Edge = 3
     }
@@ -526,7 +526,7 @@ declare namespace ArangoDB {
 
     type DocumentIterator<T> = (document: Document<T>, number: number) => void;
 
-    declare interface Collection<T = PlainObject> {
+    interface Collection<T = PlainObject> {
         // Collection
         checksum(
             withRevisions?: boolean,
@@ -667,13 +667,13 @@ declare namespace ArangoDB {
 
     // AQL
 
-    declare interface Query {
+    interface Query {
         query: string;
         bindVars?: PlainObject;
         options?: QueryOptions;
     }
 
-    declare interface Cursor<T = any> {
+    interface Cursor<T = any> {
         toArray(): T[];
         hasNext(): boolean;
         next(): T;
@@ -685,7 +685,7 @@ declare namespace ArangoDB {
         dispose(): void;
     }
 
-    declare interface Statement<T = any> {
+    interface Statement<T = any> {
         bind(name: string, value: any): void;
         setBatchSize(size: number): void;
         getBatchSize(): number;
@@ -757,7 +757,7 @@ declare namespace ArangoDB {
         intermediateCommitCount?: number;
     }
 
-    declare interface Database {
+    interface Database {
         // Database
         _createDatabase(
             name: string,
@@ -832,17 +832,17 @@ declare namespace ArangoDB {
 }
 
 declare namespace Foxx {
-    declare interface Session {
+    interface Session {
         uid: string | null;
         created: number;
         data: any;
     }
-    declare interface SessionStorage {
+    interface SessionStorage {
         ["new"]?: () => Session;
         fromClient: (sid: string) => Session | null;
         forClient: (session: Session) => string | null;
     }
-    declare interface SessionTransport {
+    interface SessionTransport {
         get?: (req: Request) => string | null;
         set?: (res: Response, sid: string) => void;
         clear?: (res: Response) => void;
@@ -899,7 +899,7 @@ declare namespace Foxx {
         end: number;
     }> & { type: string };
 
-    declare interface Context {
+    interface Context {
         argv: any[];
         basePath: string;
         baseUrl: string;
@@ -930,7 +930,7 @@ declare namespace Foxx {
         use(routerOrMiddleware: Router | Middleware, name?: string): Endpoint;
     }
 
-    declare interface Request {
+    interface Request {
         arangoUser: string | null;
         arangoVersion: number;
         baseUrl: string;
@@ -980,7 +980,7 @@ declare namespace Foxx {
         reverse(name: string, params?: PlainObject): string;
     }
 
-    declare interface Response {
+    interface Response {
         body: Buffer | string;
         context: Context;
         headers: object;
@@ -1029,7 +1029,7 @@ declare namespace Foxx {
         write(data: string | Buffer): this;
     }
 
-    declare interface Endpoint {
+    interface Endpoint {
         header(name: string, schema: Schema, description?: string): this;
         header(name: string, description: string): this;
         pathParam(name: string, schema: Schema, description?: string): this;
@@ -1065,7 +1065,7 @@ declare namespace Foxx {
         tag(...tags: string[]): this;
     }
 
-    declare interface Router {
+    interface Router {
         get(
             path: string,
             ...middlewares: Middleware[],
@@ -1152,22 +1152,18 @@ declare namespace Foxx {
         use(routerOrMiddleware: Router | Middleware, name?: string): Endpoint;
     }
 
-    declare class Module extends NodeJS.Module {
+    class Module extends NodeJS.Module {
         context: Context;
     }
 }
 
-declare module "@arangodb" {
+declare module "@arangodb/index" {
     export function aql(strings: string[], ...args: any[]): ArangoDB.Query;
     export function time(): number;
     export const db: ArangoDB.Database;
-    export type CollectionType = ArangoDB.CollectionType;
-
     export const errors: {
         [Name in ArangoDB.ErrorName]: { code: number; message: string }
     };
-    export type IndexType = ArangoDB.IndexType;
-    export type EngineType = ArangoDB.EngineType;
 }
 
 declare module "@arangodb/foxx/router" {
@@ -1364,8 +1360,7 @@ declare module "@arangodb/foxx/oauth2" {
 }
 
 declare module "@arangodb/foxx" {
-    import createRouter = require("@arangodb/foxx/router");
-    export { createRouter };
+    export function createRouter(): Foxx.Router;
 }
 
 declare module "@arangodb/request" {
@@ -1415,8 +1410,6 @@ declare module "@arangodb/request" {
 }
 
 declare module "@arangodb/crypto" {
-    export type JwtAlgorithm = ArangoDB.JwtAlgorithm;
-    export type HashAlgorithm = ArangoDB.HashAlgorithm;
     export function createNonce(): string;
     export function checkAndMarkNonce(nonce: string): void;
     export function rand(): number;
@@ -1426,7 +1419,7 @@ declare module "@arangodb/crypto" {
     export function jwtEncode(
         key: string,
         message: string,
-        algorithm: JwtAlgorithm
+        algorithm: ArangoDB.JwtAlgorithm
     ): string;
     export function jwtEncode(
         key: null,
@@ -1454,7 +1447,7 @@ declare module "@arangodb/crypto" {
     export function hmac(
         key: string,
         message: string,
-        algorithm: HashAlgorithm
+        algorithm: ArangoDB.HashAlgorithm
     ): string;
 }
 

--- a/types/arangodb/index.d.ts
+++ b/types/arangodb/index.d.ts
@@ -1210,7 +1210,7 @@ declare namespace Foxx {
     }
 
     interface Module extends NodeModule {
-        context: Foxx.Context;
+        context: Context;
     }
 }
 

--- a/types/arangodb/index.d.ts
+++ b/types/arangodb/index.d.ts
@@ -876,15 +876,28 @@ declare namespace Foxx {
         before: (req: Request, res: Response) => void | false;
     }
 
-    interface TypeDefinition {
-        // TODO
-        [key: string]: any;
+    interface MediaType {
+        type: string;
+        subtype: string;
+        suffix?: string;
+        parameters: {
+            charset: string;
+        };
     }
 
-    interface Ranges {
-        // TODO
-        [key: string]: any;
+    interface TypeDefinition {
+        fromClient?: (
+            body: string | Buffer,
+            req: Request,
+            type: MediaType
+        ) => any;
+        forClient?: (body: any) => { data: string; headers: StringMap };
     }
+
+    type Ranges = Array<{
+        start: number;
+        end: number;
+    }> & { type: string };
 
     declare interface Context {
         argv: any[];

--- a/types/arangodb/index.d.ts
+++ b/types/arangodb/index.d.ts
@@ -5,6 +5,7 @@
 // TypeScript Version: 2.3
 
 /// <reference types="node" />
+type NodeConsole = Console;
 
 interface StringMap {
     [key: string]: string | undefined;
@@ -850,6 +851,17 @@ declare namespace ArangoDB {
         _engineStats(): object;
         _executeTransaction(transaction: Transaction): void;
     }
+
+    interface Console extends NodeConsole {
+        errorLines: (...args: any[]) => void;
+        warnLines: (...args: any[]) => void;
+        infoLines: (...args: any[]) => void;
+        debugLines: (...args: any[]) => void;
+        errorStack: (err: Error, msg?: string) => void;
+        warnStack: (err: Error, msg?: string) => void;
+        infoStack: (err: Error, msg?: string) => void;
+        debugStack: (err: Error, msg?: string) => void;
+    }
 }
 
 declare namespace Foxx {
@@ -1197,8 +1209,8 @@ declare namespace Foxx {
         use(routerOrMiddleware: Router | Middleware, name?: string): Endpoint;
     }
 
-    interface Module extends NodeJS.Module {
-        context: Context;
+    interface Module extends NodeModule {
+        context: Foxx.Context;
     }
 }
 
@@ -1696,22 +1708,6 @@ declare module "@arangodb/general-graph" {
         edgeDefinitions: EdgeDefinition[],
         ...relations: EdgeDefinition[]
     ): EdgeDefinition[];
-}
-
-declare namespace NodeJS {
-    interface Module {
-        context: Foxx.Context;
-    }
-    interface Console {
-        errorLines: (...args: any[]) => void;
-        warnLines: (...args: any[]) => void;
-        infoLines: (...args: any[]) => void;
-        debugLines: (...args: any[]) => void;
-        errorStack: (err: Error, msg?: string) => void;
-        warnStack: (err: Error, msg?: string) => void;
-        infoStack: (err: Error, msg?: string) => void;
-        debugStack: (err: Error, msg?: string) => void;
-    }
 }
 
 // TODO figure out how to override `console` and `module`

--- a/types/arangodb/index.d.ts
+++ b/types/arangodb/index.d.ts
@@ -1100,17 +1100,17 @@ declare namespace Foxx {
         set(name: string, value: string): this;
         set(headers: { [name: string]: string }): this;
         status(status: number | string): this;
-        throw(status: number | string, reason: string, error: Error): void;
+        throw(status: number | string, reason: string, error: Error): never;
         throw(
             status: number | string,
             reason: string,
             options?: { cause?: Error; extra?: any }
-        ): void;
-        throw(status: number | string, error: Error): void;
+        ): never;
+        throw(status: number | string, error: Error): never;
         throw(
             status: number | string,
             options?: { cause?: Error; extra?: any }
-        ): void;
+        ): never;
         type(type?: string): string;
         vary(names: string[]): this;
         vary(...names: string[]): this;
@@ -1481,7 +1481,7 @@ declare module "@arangodb/request" {
         status: number;
         statusCode: number;
         message: string;
-        throw(message?: string): void;
+        throw(message?: string): void | never;
     }
     interface RequestOptions {
         qs?: object;

--- a/types/arangodb/index.d.ts
+++ b/types/arangodb/index.d.ts
@@ -4,6 +4,8 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
+/// <reference types="node" />
+
 interface StringMap {
     [key: string]: string | undefined;
 }
@@ -1696,15 +1698,20 @@ declare module "@arangodb/general-graph" {
     ): EdgeDefinition[];
 }
 
-declare var module: Foxx.Module;
+declare namespace NodeJS {
+    interface Module {
+        context: Foxx.Context;
+    }
+    interface Console {
+        errorLines: (...args: any[]) => void;
+        warnLines: (...args: any[]) => void;
+        infoLines: (...args: any[]) => void;
+        debugLines: (...args: any[]) => void;
+        errorStack: (err: Error, msg?: string) => void;
+        warnStack: (err: Error, msg?: string) => void;
+        infoStack: (err: Error, msg?: string) => void;
+        debugStack: (err: Error, msg?: string) => void;
+    }
+}
 
-declare var console: NodeJS.Console & {
-    errorLines: (...args: any[]) => void;
-    warnLines: (...args: any[]) => void;
-    infoLines: (...args: any[]) => void;
-    debugLines: (...args: any[]) => void;
-    errorStack: (err: Error, msg?: string) => void;
-    warnStack: (err: Error, msg?: string) => void;
-    infoStack: (err: Error, msg?: string) => void;
-    debugStack: (err: Error, msg?: string) => void;
-};
+// TODO figure out how to override `console` and `module`

--- a/types/arangodb/index.d.ts
+++ b/types/arangodb/index.d.ts
@@ -1372,10 +1372,10 @@ declare module "@arangodb/foxx/graphql" {
 }
 
 declare module "@arangodb/foxx/sessions" {
-    type SessionsMiddleware = Foxx.Middleware & {
+    interface SessionsMiddleware extends Foxx.Middleware {
         storage: Foxx.SessionStorage;
         transport: Foxx.SessionTransport[];
-    };
+    }
     interface SessionsOptions {
         storage: Foxx.SessionStorage | string | ArangoDB.Collection;
         transport:

--- a/types/arangodb/index.d.ts
+++ b/types/arangodb/index.d.ts
@@ -1,0 +1,1646 @@
+// Type definitions for ArangoDB 3.4
+// Project: https://github.com/arangodb/arangodb
+// Definitions by: Alan Plum <https://github.com/pluma>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+type PlainObject = { [key: string]: any };
+type StringMap = { [key: string]: string | undefined };
+
+declare namespace ArangoDB {
+    declare type JwtAlgorithm = "HS512" | "HS384" | "HS256";
+    declare type HashAlgorithm =
+        | "sha512"
+        | "sha384"
+        | "sha256"
+        | "sha224"
+        | "sha1"
+        | "md5";
+    declare type HttpMethod =
+        | "HEAD"
+        | "GET"
+        | "POST"
+        | "PUT"
+        | "PATCH"
+        | "DELETE"
+        | "OPTIONS";
+    declare type EdgeDirection = "any" | "inbound" | "outbound";
+    declare type EngineType = "mmfiles" | "rocksdb";
+    declare type ViewType = "arangosearch";
+    declare type ErrorName =
+        | "ERROR_NO_ERROR"
+        | "ERROR_FAILED"
+        | "ERROR_SYS_ERROR"
+        | "ERROR_OUT_OF_MEMORY"
+        | "ERROR_INTERNAL"
+        | "ERROR_ILLEGAL_NUMBER"
+        | "ERROR_NUMERIC_OVERFLOW"
+        | "ERROR_ILLEGAL_OPTION"
+        | "ERROR_DEAD_PID"
+        | "ERROR_NOT_IMPLEMENTED"
+        | "ERROR_BAD_PARAMETER"
+        | "ERROR_FORBIDDEN"
+        | "ERROR_OUT_OF_MEMORY_MMAP"
+        | "ERROR_CORRUPTED_CSV"
+        | "ERROR_FILE_NOT_FOUND"
+        | "ERROR_CANNOT_WRITE_FILE"
+        | "ERROR_CANNOT_OVERWRITE_FILE"
+        | "ERROR_TYPE_ERROR"
+        | "ERROR_LOCK_TIMEOUT"
+        | "ERROR_CANNOT_CREATE_DIRECTORY"
+        | "ERROR_CANNOT_CREATE_TEMP_FILE"
+        | "ERROR_REQUEST_CANCELED"
+        | "ERROR_DEBUG"
+        | "ERROR_IP_ADDRESS_INVALID"
+        | "ERROR_FILE_EXISTS"
+        | "ERROR_LOCKED"
+        | "ERROR_DEADLOCK"
+        | "ERROR_SHUTTING_DOWN"
+        | "ERROR_ONLY_ENTERPRISE"
+        | "ERROR_RESOURCE_LIMIT"
+        | "ERROR_ARANGO_ICU_ERROR"
+        | "ERROR_CANNOT_READ_FILE"
+        | "ERROR_HTTP_BAD_PARAMETER"
+        | "ERROR_HTTP_UNAUTHORIZED"
+        | "ERROR_HTTP_FORBIDDEN"
+        | "ERROR_HTTP_NOT_FOUND"
+        | "ERROR_HTTP_METHOD_NOT_ALLOWED"
+        | "ERROR_HTTP_NOT_ACCEPTABLE"
+        | "ERROR_HTTP_PRECONDITION_FAILED"
+        | "ERROR_HTTP_SERVER_ERROR"
+        | "ERROR_HTTP_SERVICE_UNAVAILABLE"
+        | "ERROR_HTTP_GATEWAY_TIMEOUT"
+        | "ERROR_HTTP_CORRUPTED_JSON"
+        | "ERROR_HTTP_SUPERFLUOUS_SUFFICES"
+        | "ERROR_ARANGO_ILLEGAL_STATE"
+        | "ERROR_ARANGO_DATAFILE_SEALED"
+        | "ERROR_ARANGO_READ_ONLY"
+        | "ERROR_ARANGO_DUPLICATE_IDENTIFIER"
+        | "ERROR_ARANGO_DATAFILE_UNREADABLE"
+        | "ERROR_ARANGO_DATAFILE_EMPTY"
+        | "ERROR_ARANGO_RECOVERY"
+        | "ERROR_ARANGO_DATAFILE_STATISTICS_NOT_FOUND"
+        | "ERROR_ARANGO_CORRUPTED_DATAFILE"
+        | "ERROR_ARANGO_ILLEGAL_PARAMETER_FILE"
+        | "ERROR_ARANGO_CORRUPTED_COLLECTION"
+        | "ERROR_ARANGO_MMAP_FAILED"
+        | "ERROR_ARANGO_FILESYSTEM_FULL"
+        | "ERROR_ARANGO_NO_JOURNAL"
+        | "ERROR_ARANGO_DATAFILE_ALREADY_EXISTS"
+        | "ERROR_ARANGO_DATADIR_LOCKED"
+        | "ERROR_ARANGO_COLLECTION_DIRECTORY_ALREADY_EXISTS"
+        | "ERROR_ARANGO_MSYNC_FAILED"
+        | "ERROR_ARANGO_DATADIR_UNLOCKABLE"
+        | "ERROR_ARANGO_SYNC_TIMEOUT"
+        | "ERROR_ARANGO_CONFLICT"
+        | "ERROR_ARANGO_DATADIR_INVALID"
+        | "ERROR_ARANGO_DOCUMENT_NOT_FOUND"
+        | "ERROR_ARANGO_DATA_SOURCE_NOT_FOUND"
+        | "ERROR_ARANGO_COLLECTION_PARAMETER_MISSING"
+        | "ERROR_ARANGO_DOCUMENT_HANDLE_BAD"
+        | "ERROR_ARANGO_MAXIMAL_SIZE_TOO_SMALL"
+        | "ERROR_ARANGO_DUPLICATE_NAME"
+        | "ERROR_ARANGO_ILLEGAL_NAME"
+        | "ERROR_ARANGO_NO_INDEX"
+        | "ERROR_ARANGO_UNIQUE_CONSTRAINT_VIOLATED"
+        | "ERROR_ARANGO_INDEX_NOT_FOUND"
+        | "ERROR_ARANGO_CROSS_COLLECTION_REQUEST"
+        | "ERROR_ARANGO_INDEX_HANDLE_BAD"
+        | "ERROR_ARANGO_DOCUMENT_TOO_LARGE"
+        | "ERROR_ARANGO_COLLECTION_NOT_UNLOADED"
+        | "ERROR_ARANGO_COLLECTION_TYPE_INVALID"
+        | "ERROR_ARANGO_VALIDATION_FAILED"
+        | "ERROR_ARANGO_ATTRIBUTE_PARSER_FAILED"
+        | "ERROR_ARANGO_DOCUMENT_KEY_BAD"
+        | "ERROR_ARANGO_DOCUMENT_KEY_UNEXPECTED"
+        | "ERROR_ARANGO_DATADIR_NOT_WRITABLE"
+        | "ERROR_ARANGO_OUT_OF_KEYS"
+        | "ERROR_ARANGO_DOCUMENT_KEY_MISSING"
+        | "ERROR_ARANGO_DOCUMENT_TYPE_INVALID"
+        | "ERROR_ARANGO_DATABASE_NOT_FOUND"
+        | "ERROR_ARANGO_DATABASE_NAME_INVALID"
+        | "ERROR_ARANGO_USE_SYSTEM_DATABASE"
+        | "ERROR_ARANGO_ENDPOINT_NOT_FOUND"
+        | "ERROR_ARANGO_INVALID_KEY_GENERATOR"
+        | "ERROR_ARANGO_INVALID_EDGE_ATTRIBUTE"
+        | "ERROR_ARANGO_INDEX_DOCUMENT_ATTRIBUTE_MISSING"
+        | "ERROR_ARANGO_INDEX_CREATION_FAILED"
+        | "ERROR_ARANGO_WRITE_THROTTLE_TIMEOUT"
+        | "ERROR_ARANGO_COLLECTION_TYPE_MISMATCH"
+        | "ERROR_ARANGO_COLLECTION_NOT_LOADED"
+        | "ERROR_ARANGO_DOCUMENT_REV_BAD"
+        | "ERROR_ARANGO_DATAFILE_FULL"
+        | "ERROR_ARANGO_EMPTY_DATADIR"
+        | "ERROR_ARANGO_TRY_AGAIN"
+        | "ERROR_ARANGO_BUSY"
+        | "ERROR_ARANGO_MERGE_IN_PROGRESS"
+        | "ERROR_ARANGO_IO_ERROR"
+        | "ERROR_REPLICATION_NO_RESPONSE"
+        | "ERROR_REPLICATION_INVALID_RESPONSE"
+        | "ERROR_REPLICATION_MASTER_ERROR"
+        | "ERROR_REPLICATION_MASTER_INCOMPATIBLE"
+        | "ERROR_REPLICATION_MASTER_CHANGE"
+        | "ERROR_REPLICATION_LOOP"
+        | "ERROR_REPLICATION_UNEXPECTED_MARKER"
+        | "ERROR_REPLICATION_INVALID_APPLIER_STATE"
+        | "ERROR_REPLICATION_UNEXPECTED_TRANSACTION"
+        | "ERROR_REPLICATION_INVALID_APPLIER_CONFIGURATION"
+        | "ERROR_REPLICATION_RUNNING"
+        | "ERROR_REPLICATION_APPLIER_STOPPED"
+        | "ERROR_REPLICATION_NO_START_TICK"
+        | "ERROR_REPLICATION_START_TICK_NOT_PRESENT"
+        | "ERROR_REPLICATION_WRONG_CHECKSUM"
+        | "ERROR_REPLICATION_SHARD_NONEMPTY"
+        | "ERROR_CLUSTER_NO_AGENCY"
+        | "ERROR_CLUSTER_NO_COORDINATOR_HEADER"
+        | "ERROR_CLUSTER_COULD_NOT_LOCK_PLAN"
+        | "ERROR_CLUSTER_COLLECTION_ID_EXISTS"
+        | "ERROR_CLUSTER_COULD_NOT_CREATE_COLLECTION_IN_PLAN"
+        | "ERROR_CLUSTER_COULD_NOT_READ_CURRENT_VERSION"
+        | "ERROR_CLUSTER_COULD_NOT_CREATE_COLLECTION"
+        | "ERROR_CLUSTER_TIMEOUT"
+        | "ERROR_CLUSTER_COULD_NOT_REMOVE_COLLECTION_IN_PLAN"
+        | "ERROR_CLUSTER_COULD_NOT_REMOVE_COLLECTION_IN_CURRENT"
+        | "ERROR_CLUSTER_COULD_NOT_CREATE_DATABASE_IN_PLAN"
+        | "ERROR_CLUSTER_COULD_NOT_CREATE_DATABASE"
+        | "ERROR_CLUSTER_COULD_NOT_REMOVE_DATABASE_IN_PLAN"
+        | "ERROR_CLUSTER_COULD_NOT_REMOVE_DATABASE_IN_CURRENT"
+        | "ERROR_CLUSTER_SHARD_GONE"
+        | "ERROR_CLUSTER_CONNECTION_LOST"
+        | "ERROR_CLUSTER_MUST_NOT_SPECIFY_KEY"
+        | "ERROR_CLUSTER_GOT_CONTRADICTING_ANSWERS"
+        | "ERROR_CLUSTER_NOT_ALL_SHARDING_ATTRIBUTES_GIVEN"
+        | "ERROR_CLUSTER_MUST_NOT_CHANGE_SHARDING_ATTRIBUTES"
+        | "ERROR_CLUSTER_UNSUPPORTED"
+        | "ERROR_CLUSTER_ONLY_ON_COORDINATOR"
+        | "ERROR_CLUSTER_READING_PLAN_AGENCY"
+        | "ERROR_CLUSTER_COULD_NOT_TRUNCATE_COLLECTION"
+        | "ERROR_CLUSTER_AQL_COMMUNICATION"
+        | "ERROR_ARANGO_DOCUMENT_NOT_FOUND_OR_SHARDING_ATTRIBUTES_CHANGED"
+        | "ERROR_CLUSTER_COULD_NOT_DETERMINE_ID"
+        | "ERROR_CLUSTER_ONLY_ON_DBSERVER"
+        | "ERROR_CLUSTER_BACKEND_UNAVAILABLE"
+        | "ERROR_CLUSTER_UNKNOWN_CALLBACK_ENDPOINT"
+        | "ERROR_CLUSTER_AGENCY_STRUCTURE_INVALID"
+        | "ERROR_CLUSTER_AQL_COLLECTION_OUT_OF_SYNC"
+        | "ERROR_CLUSTER_COULD_NOT_CREATE_INDEX_IN_PLAN"
+        | "ERROR_CLUSTER_COULD_NOT_DROP_INDEX_IN_PLAN"
+        | "ERROR_CLUSTER_CHAIN_OF_DISTRIBUTESHARDSLIKE"
+        | "ERROR_CLUSTER_MUST_NOT_DROP_COLL_OTHER_DISTRIBUTESHARDSLIKE"
+        | "ERROR_CLUSTER_UNKNOWN_DISTRIBUTESHARDSLIKE"
+        | "ERROR_CLUSTER_INSUFFICIENT_DBSERVERS"
+        | "ERROR_CLUSTER_COULD_NOT_DROP_FOLLOWER"
+        | "ERROR_CLUSTER_SHARD_LEADER_REFUSES_REPLICATION"
+        | "ERROR_CLUSTER_SHARD_FOLLOWER_REFUSES_OPERATION"
+        | "ERROR_CLUSTER_SHARD_LEADER_RESIGNED"
+        | "ERROR_CLUSTER_AGENCY_COMMUNICATION_FAILED"
+        | "ERROR_CLUSTER_DISTRIBUTE_SHARDS_LIKE_REPLICATION_FACTOR"
+        | "ERROR_CLUSTER_DISTRIBUTE_SHARDS_LIKE_NUMBER_OF_SHARDS"
+        | "ERROR_CLUSTER_LEADERSHIP_CHALLENGE_ONGOING"
+        | "ERROR_CLUSTER_NOT_LEADER"
+        | "ERROR_CLUSTER_COULD_NOT_CREATE_VIEW_IN_PLAN"
+        | "ERROR_QUERY_KILLED"
+        | "ERROR_QUERY_PARSE"
+        | "ERROR_QUERY_EMPTY"
+        | "ERROR_QUERY_SCRIPT"
+        | "ERROR_QUERY_NUMBER_OUT_OF_RANGE"
+        | "ERROR_QUERY_VARIABLE_NAME_INVALID"
+        | "ERROR_QUERY_VARIABLE_REDECLARED"
+        | "ERROR_QUERY_VARIABLE_NAME_UNKNOWN"
+        | "ERROR_QUERY_COLLECTION_LOCK_FAILED"
+        | "ERROR_QUERY_TOO_MANY_COLLECTIONS"
+        | "ERROR_QUERY_DOCUMENT_ATTRIBUTE_REDECLARED"
+        | "ERROR_QUERY_FUNCTION_NAME_UNKNOWN"
+        | "ERROR_QUERY_FUNCTION_ARGUMENT_NUMBER_MISMATCH"
+        | "ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH"
+        | "ERROR_QUERY_INVALID_REGEX"
+        | "ERROR_QUERY_BIND_PARAMETERS_INVALID"
+        | "ERROR_QUERY_BIND_PARAMETER_MISSING"
+        | "ERROR_QUERY_BIND_PARAMETER_UNDECLARED"
+        | "ERROR_QUERY_BIND_PARAMETER_TYPE"
+        | "ERROR_QUERY_INVALID_LOGICAL_VALUE"
+        | "ERROR_QUERY_INVALID_ARITHMETIC_VALUE"
+        | "ERROR_QUERY_DIVISION_BY_ZERO"
+        | "ERROR_QUERY_ARRAY_EXPECTED"
+        | "ERROR_QUERY_FAIL_CALLED"
+        | "ERROR_QUERY_GEO_INDEX_MISSING"
+        | "ERROR_QUERY_FULLTEXT_INDEX_MISSING"
+        | "ERROR_QUERY_INVALID_DATE_VALUE"
+        | "ERROR_QUERY_MULTI_MODIFY"
+        | "ERROR_QUERY_INVALID_AGGREGATE_EXPRESSION"
+        | "ERROR_QUERY_COMPILE_TIME_OPTIONS"
+        | "ERROR_QUERY_EXCEPTION_OPTIONS"
+        | "ERROR_QUERY_COLLECTION_USED_IN_EXPRESSION"
+        | "ERROR_QUERY_DISALLOWED_DYNAMIC_CALL"
+        | "ERROR_QUERY_ACCESS_AFTER_MODIFICATION"
+        | "ERROR_QUERY_FUNCTION_INVALID_NAME"
+        | "ERROR_QUERY_FUNCTION_INVALID_CODE"
+        | "ERROR_QUERY_FUNCTION_NOT_FOUND"
+        | "ERROR_QUERY_FUNCTION_RUNTIME_ERROR"
+        | "ERROR_QUERY_BAD_JSON_PLAN"
+        | "ERROR_QUERY_NOT_FOUND"
+        | "ERROR_QUERY_IN_USE"
+        | "ERROR_QUERY_USER_ASSERT"
+        | "ERROR_QUERY_USER_WARN"
+        | "ERROR_CURSOR_NOT_FOUND"
+        | "ERROR_CURSOR_BUSY"
+        | "ERROR_TRANSACTION_INTERNAL"
+        | "ERROR_TRANSACTION_NESTED"
+        | "ERROR_TRANSACTION_UNREGISTERED_COLLECTION"
+        | "ERROR_TRANSACTION_DISALLOWED_OPERATION"
+        | "ERROR_TRANSACTION_ABORTED"
+        | "ERROR_USER_INVALID_NAME"
+        | "ERROR_USER_INVALID_PASSWORD"
+        | "ERROR_USER_DUPLICATE"
+        | "ERROR_USER_NOT_FOUND"
+        | "ERROR_USER_CHANGE_PASSWORD"
+        | "ERROR_USER_EXTERNAL"
+        | "ERROR_SERVICE_INVALID_NAME"
+        | "ERROR_SERVICE_INVALID_MOUNT"
+        | "ERROR_SERVICE_DOWNLOAD_FAILED"
+        | "ERROR_SERVICE_UPLOAD_FAILED"
+        | "ERROR_LDAP_CANNOT_INIT"
+        | "ERROR_LDAP_CANNOT_SET_OPTION"
+        | "ERROR_LDAP_CANNOT_BIND"
+        | "ERROR_LDAP_CANNOT_UNBIND"
+        | "ERROR_LDAP_CANNOT_SEARCH"
+        | "ERROR_LDAP_CANNOT_START_TLS"
+        | "ERROR_LDAP_FOUND_NO_OBJECTS"
+        | "ERROR_LDAP_NOT_ONE_USER_FOUND"
+        | "ERROR_LDAP_USER_NOT_IDENTIFIED"
+        | "ERROR_LDAP_INVALID_MODE"
+        | "ERROR_TASK_INVALID_ID"
+        | "ERROR_TASK_DUPLICATE_ID"
+        | "ERROR_TASK_NOT_FOUND"
+        | "ERROR_GRAPH_INVALID_GRAPH"
+        | "ERROR_GRAPH_COULD_NOT_CREATE_GRAPH"
+        | "ERROR_GRAPH_INVALID_VERTEX"
+        | "ERROR_GRAPH_COULD_NOT_CREATE_VERTEX"
+        | "ERROR_GRAPH_COULD_NOT_CHANGE_VERTEX"
+        | "ERROR_GRAPH_INVALID_EDGE"
+        | "ERROR_GRAPH_COULD_NOT_CREATE_EDGE"
+        | "ERROR_GRAPH_COULD_NOT_CHANGE_EDGE"
+        | "ERROR_GRAPH_TOO_MANY_ITERATIONS"
+        | "ERROR_GRAPH_INVALID_FILTER_RESULT"
+        | "ERROR_GRAPH_EMPTY"
+        | "ERROR_SESSION_UNKNOWN"
+        | "ERROR_SESSION_EXPIRED"
+        | "SIMPLE_CLIENT_UNKNOWN_ERROR"
+        | "SIMPLE_CLIENT_COULD_NOT_CONNECT"
+        | "SIMPLE_CLIENT_COULD_NOT_WRITE"
+        | "SIMPLE_CLIENT_COULD_NOT_READ"
+        | "COMMUNICATOR_REQUEST_ABORTED"
+        | "COMMUNICATOR_DISABLED"
+        | "ERROR_MALFORMED_MANIFEST_FILE"
+        | "ERROR_INVALID_SERVICE_MANIFEST"
+        | "ERROR_SERVICE_FILES_MISSING"
+        | "ERROR_SERVICE_FILES_OUTDATED"
+        | "ERROR_INVALID_FOXX_OPTIONS"
+        | "ERROR_INVALID_MOUNTPOINT"
+        | "ERROR_SERVICE_NOT_FOUND"
+        | "ERROR_SERVICE_NEEDS_CONFIGURATION"
+        | "ERROR_SERVICE_MOUNTPOINT_CONFLICT"
+        | "ERROR_SERVICE_MANIFEST_NOT_FOUND"
+        | "ERROR_SERVICE_OPTIONS_MALFORMED"
+        | "ERROR_SERVICE_SOURCE_NOT_FOUND"
+        | "ERROR_SERVICE_SOURCE_ERROR"
+        | "ERROR_SERVICE_UNKNOWN_SCRIPT"
+        | "ERROR_MODULE_NOT_FOUND"
+        | "ERROR_MODULE_SYNTAX_ERROR"
+        | "ERROR_MODULE_FAILURE"
+        | "ERROR_NO_SMART_COLLECTION"
+        | "ERROR_NO_SMART_GRAPH_ATTRIBUTE"
+        | "ERROR_CANNOT_DROP_SMART_COLLECTION"
+        | "ERROR_KEY_MUST_BE_PREFIXED_WITH_SMART_GRAPH_ATTRIBUTE"
+        | "ERROR_ILLEGAL_SMART_GRAPH_ATTRIBUTE"
+        | "ERROR_AGENCY_INQUIRY_SYNTAX"
+        | "ERROR_AGENCY_INFORM_MUST_BE_OBJECT"
+        | "ERROR_AGENCY_INFORM_MUST_CONTAIN_TERM"
+        | "ERROR_AGENCY_INFORM_MUST_CONTAIN_ID"
+        | "ERROR_AGENCY_INFORM_MUST_CONTAIN_ACTIVE"
+        | "ERROR_AGENCY_INFORM_MUST_CONTAIN_POOL"
+        | "ERROR_AGENCY_INFORM_MUST_CONTAIN_MIN_PING"
+        | "ERROR_AGENCY_INFORM_MUST_CONTAIN_MAX_PING"
+        | "ERROR_AGENCY_INFORM_MUST_CONTAIN_TIMEOUT_MULT"
+        | "ERROR_AGENCY_INQUIRE_CLIENT_ID_MUST_BE_STRING"
+        | "ERROR_AGENCY_CANNOT_REBUILD_DBS"
+        | "ERROR_SUPERVISION_GENERAL_FAILURE"
+        | "ERROR_DISPATCHER_IS_STOPPING"
+        | "ERROR_QUEUE_UNKNOWN"
+        | "ERROR_QUEUE_FULL";
+
+    // Collection
+
+    declare const enum CollectionType {
+        Document = 2,
+        Edge = 3
+    }
+
+    type CollectionChecksum = {
+        checksum: string;
+        revision: string;
+    };
+
+    type CollectionFigures = {
+        alive: {
+            count: number;
+            size: number;
+        };
+        dead: {
+            count: number;
+            size: number;
+            deletion: number;
+        };
+        datafiles: {
+            count: number;
+            fileSize: number;
+        };
+        journals: {
+            count: number;
+            fileSize: number;
+        };
+        compactors: {
+            count: number;
+            fileSize: number;
+        };
+        shapefiles: {
+            count: number;
+            fileSize: number;
+        };
+        shapes: {
+            count: number;
+            size: number;
+        };
+        attributes: {
+            count: number;
+            size: number;
+        };
+        indexes: {
+            count: number;
+            size: number;
+        };
+        lastTick: number;
+        uncollectedLogfileEntries: number;
+        documentReferences: number;
+        waitingFor: string;
+        compactionStatus: {
+            time: string;
+            message: string;
+            count: number;
+            filesCombined: number;
+            bytesRead: number;
+            bytesWritten: number;
+        };
+    };
+
+    type CollectionProperties = {
+        waitForSync: boolean;
+        journalSize: number;
+        isVolatile: boolean;
+        keyOptions?: {
+            type: string;
+            allowUserKeys: boolean;
+            increment?: number;
+            offset?: number;
+        };
+        indexBuckets: number;
+        numberOfShards?: number;
+        shardKeys?: string[];
+        replicationFactor?: number;
+    };
+
+    // Indexes
+
+    declare type IndexType = "hash" | "skiplist" | "fulltext" | "geo1" | "geo2";
+
+    type IndexLike = {
+        [key: string]: any;
+        id: string;
+    };
+
+    type IndexDescription<T> = {
+        type: IndexType;
+        fields: (keyof T)[];
+        sparse?: boolean;
+        unique?: boolean;
+        deduplicate?: boolean;
+    };
+
+    type IndexResult<T> = {
+        id: string;
+        type: IndexType;
+        fields: (keyof T)[];
+        sparse: boolean;
+        unique: boolean;
+        deduplicate: boolean;
+        isNewlyCreated: boolean;
+        selectivityEstimate: number;
+        code: number;
+    };
+
+    // Document
+
+    type DocumentLike1 = {
+        [key: string]: any;
+        _id: string;
+    };
+
+    type DocumentLike2 = {
+        [key: string]: any;
+        _key: string;
+    };
+
+    type DocumentLike = DocumentLike1 | DocumentLike2;
+
+    interface DocumentMetadata {
+        _key: string;
+        _id: string;
+        _rev: string;
+    }
+
+    interface UpdateMetadata extends DocumentMetadata {
+        _oldRev: string;
+    }
+
+    type Document<T> = T & DocumentMetadata & { _from?: string; _to?: string };
+    type DocumentData<T> = T & Partial<DocumentMetadata>;
+    type Edge<T> = Document<T> & { _from: string; _to: string };
+
+    type InsertResult<T> = DocumentMetadata | Document<T>;
+    type UpdateResult<T> = UpdateMetadata & {
+        old?: Document<T>;
+        new?: Document<T>;
+    };
+    type RemoveResult<T> = DocumentMetadata & {
+        old?: Document<T>;
+    };
+
+    type InsertOptions = {
+        waitForSync?: boolean;
+        silent?: boolean;
+        returnNew?: boolean;
+    };
+
+    type ReplaceOptions = InsertOptions & {
+        overwrite?: boolean;
+        returnOld?: boolean;
+    };
+
+    type UpdateOptions = ReplaceOptions & {
+        keepNull?: boolean;
+        mergeObjects?: boolean;
+    };
+
+    type RemoveOptions = {
+        waitForSync?: boolean;
+        overwrite?: boolean;
+        returnOld?: boolean;
+        silent?: boolean;
+    };
+
+    type DocumentIterator<T> = (document: Document<T>, number: number) => void;
+
+    declare interface Collection<T = PlainObject> {
+        // Collection
+        checksum(
+            withRevisions?: boolean,
+            withData?: boolean
+        ): CollectionChecksum;
+        count(): number;
+        drop(options?: { isSystem?: boolean }): void;
+        figures(): CollectionFigures;
+        load(): void;
+        path(): string;
+        properties(): CollectionProperties;
+        properties(properties?: {
+            waitForSync?: boolean;
+            journalSize?: number;
+            indexBuckets?: number;
+            replicationFactor?: number;
+        }): CollectionProperties;
+        revision(): string;
+        rotate(): void;
+        toArray(): Document<T>[];
+        truncate(): void;
+        type(): CollectionType;
+        unload(): void;
+
+        // Indexes
+        dropIndex(index: string | IndexLike): boolean;
+        ensureIndex(description: IndexDescription<T>): IndexResult<T>;
+        getIndexes(): IndexResult<T>[];
+        index(index: string | IndexLike): IndexResult<T> | null;
+
+        // Document
+        all(): Cursor<Document<T>>;
+        any(): Document<T>;
+        byExample(example: Partial<Document<T>>): Cursor<Document<T>>;
+        document(selector: string | DocumentLike): Document<T>;
+        document(selectors: (string | DocumentLike)[]): Document<T>[];
+        exists(name: string): boolean;
+        firstExample(example: Partial<Document<T>>): Document<T> | null;
+        insert(data: DocumentData<T>, options?: InsertOptions): InsertResult<T>;
+        insert(
+            array: DocumentData<T>[],
+            options?: InsertOptions
+        ): InsertResult<T>[];
+        insert(
+            from: string,
+            to: string,
+            data: DocumentData<T>,
+            options?: InsertOptions
+        ): InsertResult<T>;
+        edges(vertex: string | DocumentLike1): Edge<T>[];
+        edges(vertices: (string | DocumentLike1)[]): Edge<T>[];
+        inEdges(vertex: string | DocumentLike1): Edge<T>[];
+        inEdges(vertices: (string | DocumentLike1)[]): Edge<T>[];
+        outEdges(vertex: string | DocumentLike1): Edge<T>[];
+        outEdges(vertices: (string | DocumentLike1)[]): Edge<T>[];
+        iterate(
+            iterator: DocumentIterator<T>,
+            options?: { limit?: number; probability?: number }
+        ): void;
+        remove(
+            selector: string | DocumentLike,
+            options?: RemoveOptions
+        ): RemoveResult<T>;
+        remove(
+            selectors: (string | DocumentLike)[],
+            options?: RemoveOptions
+        ): RemoveResult<T>[];
+        removeByExample(
+            example: Partial<Document<T>>,
+            waitForSync?: boolean,
+            limit?: number
+        ): number;
+        removeByExample(
+            example: Partial<Document<T>>,
+            options?: { waitForSync?: boolean; limit?: number }
+        ): number;
+        rename(newName: string): void;
+        replace(
+            selector: string | DocumentLike,
+            data: DocumentData<T>,
+            options?: ReplaceOptions
+        ): UpdateResult<T>;
+        replace(
+            selectors: (string | DocumentLike)[],
+            data: DocumentData<T>[],
+            options?: ReplaceOptions
+        ): UpdateResult<T>[];
+        replaceByExample(
+            example: Partial<Document<T>>,
+            newValue: DocumentData<T>,
+            waitForSync?: boolean,
+            limit?: number
+        ): number;
+        replaceByExample(
+            example: Partial<Document<T>>,
+            newValue: DocumentData<T>,
+            options?: { waitForSync?: boolean; limit?: number }
+        ): number;
+        save(data: DocumentData<T>, options?: InsertOptions): InsertResult<T>;
+        save(
+            array: DocumentData<T>[],
+            options?: InsertOptions
+        ): InsertResult<T>[];
+        save(
+            from: string,
+            to: string,
+            data: DocumentData<T>,
+            options?: InsertOptions
+        ): InsertResult<T>;
+        update(
+            selector: string | DocumentLike,
+            data: Partial<Document<T>>,
+            options?: UpdateOptions
+        ): UpdateResult<T>;
+        update(
+            selectors: (string | DocumentLike)[],
+            data: Partial<Document<T>>[],
+            options?: UpdateOptions
+        ): UpdateResult<T>[];
+        updateByExample(
+            example: Partial<Document<T>>,
+            newValue: Partial<Document<T>>,
+            keepNull?: boolean,
+            waitForSync?: boolean,
+            limit?: number
+        ): number;
+        updateByExample(
+            example: Partial<Document<T>>,
+            newValue: Partial<Document<T>>,
+            options?: {
+                keepNull?: boolean;
+                waitForSync?: boolean;
+                limit?: number;
+            }
+        ): number;
+    }
+
+    // Database
+
+    type DatabaseUser = {
+        username: string;
+        passwd?: string;
+        active?: boolean;
+        extra?: PlainObject;
+    };
+
+    // AQL
+
+    declare interface Query {
+        query: string;
+        bindVars?: PlainObject;
+        options?: QueryOptions;
+    }
+
+    declare interface Cursor<T = any> {
+        toArray(): T[];
+        hasNext(): boolean;
+        next(): T;
+        count(count?: boolean): number;
+        getExtra(): QueryExtra;
+        setBatchSize(size: number): void;
+        getBatchSize(): number;
+        execute(batchSize?: number): void;
+        dispose(): void;
+    }
+
+    declare interface Statement<T = any> {
+        bind(name: string, value: any): void;
+        setBatchSize(size: number): void;
+        getBatchSize(): number;
+        execute(): Cursor<T>;
+    }
+
+    type QueryOptions = {
+        memoryLimit?: number;
+        failOnWarning?: boolean;
+        cache?: boolean;
+        count?: boolean; // TODO ???
+        fullCount?: boolean; // TODO ???
+        profile?: boolean;
+        maxWarningCount?: number;
+        maxNumberOfPlans?: number;
+        stream?: boolean;
+        // RocksDB
+        maxTransactionsSize?: number;
+        intermediateCommitSize?: number;
+        intermediateCommitCount?: number;
+        // enterprise
+        skipInaccessibleCollections?: boolean;
+    };
+
+    type QueryExtra = {
+        stats: {
+            writesExecuted: number;
+            writesIgnored: number;
+            scannedFull: number;
+            scannedIndex: number;
+            filtered: number;
+            httpRequests: number;
+            fullCount: number;
+            executionTime: number;
+        };
+        warnings: string[];
+    };
+
+    type QueryAstNode = {
+        type: string;
+        subNodes?: QueryAstNode[];
+        [key: string]: any;
+    };
+
+    type ParsedQuery = {
+        parsed: boolean;
+        collections: string[];
+        parameters: string[];
+        bindVars: string[];
+        ast: QueryAstNode[];
+    };
+
+    // Global
+
+    type Transaction = {
+        collections:
+            | {
+                  read?: string | string[];
+                  write?: string | string[];
+                  allowImplicit?: boolean;
+              }
+            | string[];
+        action: (params: PlainObject) => void | string;
+        waitForSync?: boolean;
+        lockTimeout?: number;
+        params?: PlainObject;
+        // RocksDB
+        maxTransactionsSize?: number;
+        intermediateCommitSize?: number;
+        intermediateCommitCount?: number;
+    };
+
+    declare interface Database {
+        // Database
+        _createDatabase(
+            name: string,
+            options?: never,
+            users?: DatabaseUser[]
+        ): true;
+        _databases(): string[];
+        _dropDatabase(name: string): true;
+        _useDatabase(name: string): Database;
+
+        // Indexes
+        _index<T = PlainObject>(
+            index: string | IndexLike
+        ): IndexResult<T> | null;
+        _dropIndex(index: string | IndexLike): boolean;
+
+        // Properties
+        _id(): string;
+        _isSystem(): boolean;
+        _name(): string;
+        _path(): string;
+        _version(): string;
+
+        // Collection
+        _collection<T = PlainObject>(name: string): Collection<T>;
+        _collections(): Collection[];
+        _create<T = PlainObject>(
+            name: string,
+            properties?: CollectionProperties
+        ): Collection<T>;
+        _createDocumentCollection<T = PlainObject>(
+            name: string,
+            properties?: CollectionProperties
+        ): Collection<T>;
+        _createEdgeCollection<T = PlainObject>(
+            name: string,
+            properties?: CollectionProperties
+        ): Collection<T>;
+        _drop(name: string): void;
+        _truncate(name: string): void;
+
+        // AQL
+        _createStatement<T = any>(query: Query | string): Statement<T>;
+        _query<T = any>(
+            query: Query | string,
+            bindVars?: PlainObject,
+            options?: QueryOptions
+        ): Cursor<T>;
+        _explain(query: Query | string): void;
+        _parse(query: string): ParsedQuery;
+
+        // Document
+        _document<T = PlainObject>(name: string): Document<T>;
+        _exists(name: string): boolean;
+        _remove(name: string): DocumentMetadata;
+        _replace(name: string, data: Object): DocumentMetadata;
+        _replace(doc: DocumentLike, data: Object): DocumentMetadata;
+        _update(name: string, data: Object): DocumentMetadata;
+        _update(doc: DocumentLike, data: Object): DocumentMetadata;
+
+        // TODO Views
+        // _view(name: string): ??? | null;
+        // _views(): ???[];
+        // _createView(name: string, type: ViewType, properties: ???): ???;
+        // _dropView(name: string): void;
+
+        // Global
+        _engine(): EngineType;
+        _engineStats(): PlainObject;
+        _executeTransaction(transaction: Transaction): void;
+        [name: string]: Collection | undefined;
+    }
+}
+
+declare namespace Foxx {
+    declare type Session = {
+        uid: string | null;
+        created: number;
+        data: any | null;
+    };
+    declare type SessionStorage = {
+        new?: () => Session;
+        fromClient: (sid: string) => Session | null;
+        forClient: (session: Session) => string | null;
+    };
+    declare type SessionTransport = {
+        get?: (req: Foxx.Request) => string | null;
+        set?: (res: Foxx.Response, sid: string) => void;
+        clear?: (res: Foxx.Response) => void;
+    };
+    type Handler = (req: Request, res: Response) => void;
+
+    type Middleware = (req: Request, res: Response, next: NextFunction) => void;
+
+    type NextFunction = () => void;
+
+    type ValidationResult<T> = {
+        value: T;
+        error: any;
+    };
+
+    interface Schema {
+        isJoi: boolean;
+        validate<T>(value: T): ValidationResult<T>;
+    }
+
+    type Model = {
+        schema: Schema;
+        fromClient?: (value: any) => any;
+        forClient?: (value: any) => any;
+    };
+
+    interface DocumentationRouterOptions {
+        mount: string;
+        indexFile: string;
+        swaggerRoot: string;
+        before: (req: Request, res: Response) => void | false;
+    }
+
+    declare interface Context {
+        argv: any[];
+        basePath: string;
+        baseUrl: string;
+        collectionPrefix: string;
+        configuration: PlainObject;
+        dependencies: PlainObject;
+        isDevelopment: boolean;
+        isProduction: boolean;
+        manifest: PlainObject;
+        mount: string;
+        collection<T = PlainObject>(
+            string: name
+        ): ArangoDB.Collection<T> | null;
+        collectionName(string: name): string;
+        createDocumentationRouter(
+            opts?: Partial<DocumentationRouterOptions>
+        ): Router;
+        createDocumentationRouter(
+            beforeFn: DocumentationRouterOptions["before"]
+        ): Router;
+        createDocumentationRouter(
+            swaggerRoot: DocumentationRouterOptions["swaggerRoot"]
+        ): Router;
+        file(name: string): Buffer;
+        file(name: string, encoding: string): string;
+        fileName(name: string): string;
+        registerType(type: string, def: TypeDefinition): void;
+        use(path: string, middleware: Middleware, name?: string): Endpoint;
+        use(middleware: Middleware, name?: string): Endpoint;
+        use(path: string, router: Router, name?: string): Endpoint;
+        use(router: Router, name?: string): Endpoint;
+    }
+
+    declare interface Request {
+        arangoUser: string | null;
+        arangoVersion: number;
+        baseUrl: string;
+        body: any;
+        context: Context;
+        database: string;
+        headers: { [key: string]: string | undefined };
+        hostname: string;
+        method: ArangoDB.HttpMethod;
+        originalUrl: string;
+        path: string;
+        pathParams: object;
+        port: number;
+        protocol: string;
+        queryParams: PlainObject;
+        rawBody: Buffer;
+        remoteAddress: string;
+        remoteAddresses: string[];
+        remotePort: number;
+        secure: boolean;
+        session?: Session;
+        sessionStorage?: SessionStorage;
+        suffix: string;
+        trustProxy: boolean;
+        url: string;
+        xhr: boolean;
+        accepts(types: string[]): string | false;
+        accepts(...types: string[]): string | false;
+        acceptsCharsets(charsets: string[]): string | false;
+        acceptsCharsets(...charsets: string[]): string | false;
+        acceptsEncodings(encodings: string[]): string | false;
+        acceptsEncodings(...encodings: string[]): string | false;
+        acceptsLanguages(languages: string[]): string | false;
+        acceptsLanguages(...languages: string[]): string | false;
+        cookie(
+            name: string,
+            options?: { secret?: string; algorithm?: ArangoDB.HashAlgorithm }
+        ): string | null;
+        get(name: string): string | undefined;
+        header(name: string): string | undefined;
+        is(types: string[]): string;
+        is(...types: string[]): string;
+        json(): any;
+        makeAbsolute(path: string, query?: string | StringMap): string;
+        param(name: string): any | undefined;
+        range(size?: number): Ranges | number;
+        reverse(name: string, params?: PlainObject): string;
+    }
+
+    declare interface Response {
+        body: Buffer | string;
+        context: Context;
+        headers: object;
+        statusCode: number;
+        attachment(filename?: string): this;
+        cookie(
+            name: string,
+            value: string,
+            options?: {
+                ttl?: number;
+                algorithm?: ArangoDB.HashAlgorithm;
+                secret?: string;
+                path?: string;
+                domain?: string;
+                secure?: boolean;
+                httpOnly?: boolean;
+            }
+        ): this;
+        download(path: string, filename?: string): this;
+        getHeader(name: string): string | undefined;
+        json(data: any): this;
+        redirect(status: number | string, path: string): this;
+        redirect(path: string): this;
+        removeHeader(name: string): this;
+        send(data: any, type?: string): this;
+        sendFile(path: string, options?: { lastModified: boolean }): this;
+        sendStatus(status: number | string): this;
+        setHeader(name: string, value: string): this;
+        set(name: string, value: string): this;
+        set(headers: { [name: string]: string }): this;
+        status(status: number | string): this;
+        throw(status: number | string, reason: string, error: Error): void;
+        throw(
+            status: number | string,
+            reason: string,
+            options?: { cause?: Error; extra?: any }
+        ): void;
+        throw(status: number | string, error: Error): void;
+        throw(
+            status: number | string,
+            options?: { cause?: Error; extra?: any }
+        ): void;
+        type(type?: string): string;
+        vary(names: string[]): this;
+        vary(...names: string[]): this;
+        write(data: string | Buffer): this;
+    }
+
+    declare interface Endpoint {
+        header(name: string, schema: Schema, description?: string): this;
+        header(name: string, schema: Schema): this;
+        header(name: string, description: string): this;
+        pathParam(name: string, schema: Schema, description?: string): this;
+        pathParam(name: string, schema: Schema): this;
+        pathParam(name: string, description: string): this;
+        queryParam(name: string, schema: Schema, description?: string): this;
+        queryParam(name: string, schema: Schema): this;
+        queryParam(name: string, description: string): this;
+        body(
+            schema: Schema | Model | [Model],
+            mimes: string[],
+            description?: string
+        ): this;
+        body(schema: Schema | Model | [Model], mimes?: string[]): this;
+        body(schema: Schema | Model | [Model], description?: string): this;
+        body(schema: Schema | Model | [Model]): this;
+        body(mimes: string[], description?: string): this;
+        body(description: string): this;
+        response(
+            status: number | string,
+            schema: Schema | Model | [Model],
+            mimes: string[],
+            description?: string
+        ): this;
+        response(
+            status: number | string,
+            schema: Schema | Model | [Model],
+            mimes?: string[]
+        ): this;
+        response(
+            status: number | string,
+            mimes: string[],
+            description?: string
+        ): this;
+        response(status: number | string, description: string): this;
+        summary(summary: string): this;
+        description(description: string): this;
+        deprecated(deprecated: boolean): this;
+        error(status: number | string, description: string): this;
+        tag(...tags: string[]): this;
+    }
+
+    declare interface Router {
+        get(
+            path: string,
+            ...middlewares: Middleware[],
+            handler: Handler,
+            name?: string
+        ): Endpoint;
+        get(path: string, handler: Handler, name?: string): Endpoint;
+        get(
+            ...middlewares: Middleware[],
+            handler: Handler,
+            name?: string
+        ): Endpoint;
+        get(handler: Handler, name?: string): Endpoint;
+        post(
+            path: string,
+            ...middlewares: Middleware[],
+            handler: Handler,
+            name?: string
+        ): Endpoint;
+        post(path: string, handler: Handler, name?: string): Endpoint;
+        post(
+            ...middlewares: Middleware[],
+            handler: Handler,
+            name?: string
+        ): Endpoint;
+        post(handler: Handler, name?: string): Endpoint;
+        put(
+            path: string,
+            ...middlewares: Middleware[],
+            handler: Handler,
+            name?: string
+        ): Endpoint;
+        put(path: string, handler: Handler, name?: string): Endpoint;
+        put(
+            ...middlewares: Middleware[],
+            handler: Handler,
+            name?: string
+        ): Endpoint;
+        put(handler: Handler, name?: string): Endpoint;
+        patch(
+            path: string,
+            ...middlewares: Middleware[],
+            handler: Handler,
+            name?: string
+        ): Endpoint;
+        patch(path: string, handler: Handler, name?: string): Endpoint;
+        patch(
+            ...middlewares: Middleware[],
+            handler: Handler,
+            name?: string
+        ): Endpoint;
+        patch(handler: Handler, name?: string): Endpoint;
+        delete(
+            path: string,
+            ...middlewares: Middleware[],
+            handler: Handler,
+            name?: string
+        ): Endpoint;
+        delete(path: string, handler: Handler, name?: string): Endpoint;
+        delete(
+            ...middlewares: Middleware[],
+            handler: Handler,
+            name?: string
+        ): Endpoint;
+        delete(handler: Handler, name?: string): Endpoint;
+        all(
+            path: string,
+            ...middlewares: Middleware[],
+            handler: Handler,
+            name?: string
+        ): Endpoint;
+        all(path: string, handler: Handler, name?: string): Endpoint;
+        all(
+            ...middlewares: Middleware[],
+            handler: Handler,
+            name?: string
+        ): Endpoint;
+        all(handler: Handler, name?: string): Endpoint;
+        use(path: string, middleware: Middleware, name?: string): Endpoint;
+        use(middleware: Middleware, name?: string): Endpoint;
+        use(path: string, router: Router, name?: string): Endpoint;
+        use(router: Router, name?: string): Endpoint;
+    }
+
+    declare class Module extends NodeJS.Module {
+        context: Context;
+    }
+}
+
+declare module "@arangodb" {
+    export function aql(strings: string[], ...args: any[]): ArangoDB.Query;
+    export function time(): number;
+    export const db: ArangoDB.Database;
+    export type CollectionType = ArangoDB.CollectionType;
+
+    export const errors: {
+        [Name in ArangoDB.ErrorName]: { code: number; message: string }
+    };
+    export type IndexType = ArangoDB.IndexType;
+    export type EngineType = ArangoDB.EngineType;
+}
+
+declare module "@arangodb/foxx/router" {
+    function createRouter(): Foxx.Router;
+    export = createRouter;
+}
+
+declare module "@arangodb/foxx/graphql" {
+    type GraphQLSchema = any;
+    type GraphQLModule = any;
+    type GraphQLFormatErrorFunction = Function;
+    type GraphQLOptions = {
+        schema: GraphQLSchema;
+        context?: any;
+        rootValue?: PlainObject;
+        pretty?: boolean;
+        formatError?: GraphQLFormatErrorFunction;
+        validationRules?: any[];
+        graphiql?: boolean;
+        graphql?: GraphQLModule;
+    };
+    function createGraphQLRouter(
+        options: GraphQLOptions | GraphQLSchema
+    ): Foxx.Router;
+    export = createGraphQLRouter;
+}
+
+declare module "@arangodb/foxx/sessions" {
+    type SessionsMiddleware = Foxx.Middleware & {
+        storage: Foxx.SessionStorage;
+        transport: Foxx.SessionTransport[];
+    };
+    type SessionsOptions = {
+        storage: Foxx.SessionStorage | string | ArangoDB.Collection;
+        transport:
+            | Foxx.SessionTransport
+            | Foxx.SessionTransport[]
+            | "cookie"
+            | "header";
+        autoCreate?: boolean;
+    };
+    function sessionsMiddleware(options: SessionsOptions): Foxx.Middleware;
+    export = sessionsMiddleware;
+}
+
+declare module "@arangodb/foxx/sessions/storages/collection" {
+    type CollectionStorageOptions<T> = {
+        collection: string | ArangoDB.Collection<T>;
+        ttl?: number;
+        pruneExpired?: boolean;
+        autoUpdate?: boolean;
+    };
+    type CollectionStorage = Foxx.SessionStorage & {
+        prune: () => string[];
+    };
+    function collectionStorage<T>(
+        options: CollectionStorageOptions<T>
+    ): CollectionStorage;
+    function collectionStorage<T>(
+        collection: string | ArangoDB.Collection<T>
+    ): CollectionStorage;
+    export = collectionStorage;
+}
+
+declare module "@arangodb/foxx/sessions/storages/jwt" {
+    type JwtStorageOptions =
+        | {
+              algorithm?: ArangoDB.JwtAlgorithm;
+              secret: string;
+              ttl?: number;
+              verify?: boolean;
+              maxExp?: number;
+          }
+        | {
+              algorithm: "none";
+              ttl?: number;
+              verify?: boolean;
+              maxExp?: number;
+          };
+    function jwtStorage(options: JwtStorageOptions): Foxx.SessionStorage;
+    function jwtStorage(secret: string): Foxx.SessionStorage;
+    export = jwtStorage;
+}
+
+declare module "@arangodb/foxx/sessions/transports/cookie" {
+    type CookieTransportOptions = {
+        name?: string;
+        ttl?: number;
+        algorithm?: ArangoDB.HashAlgorithm;
+        secret?: string;
+        path?: string;
+        domain?: string;
+        secure?: string;
+        httpOnly?: string;
+    };
+    function cookieTransport(
+        options?: CookieTransportOptions
+    ): Foxx.SessionTransport;
+    function cookieTransport(name: string): Foxx.SessionTransport;
+    export = cookieTransport;
+}
+
+declare module "@arangodb/foxx/sessions/transports/header" {
+    type HeaderTransportOptions = {
+        name?: string;
+    };
+    function headerTransport(
+        options?: HeaderTransportOptions
+    ): Foxx.SessionTransport;
+    function headerTransport(name: string): Foxx.SessionTransport;
+    export = headerTransport;
+}
+
+declare module "@arangodb/foxx/auth" {
+    type AuthData = {
+        method: string;
+        salt: string;
+        hash: string;
+    };
+    interface Authenticator {
+        create(password: string): AuthData;
+        verify(hash?: AuthData, password?: string): boolean;
+    }
+    type AuthOptions = {
+        method?: ArangoDB.HashAlgorithm;
+        saltLength?: number;
+    };
+    function createAuth(options?: AuthOptions): Authenticator;
+    export = createAuth;
+}
+
+declare module "@arangodb/foxx/oauth1" {
+    type OAuth1Options = {
+        requestTokenEndpoint: string;
+        authEndpoint: string;
+        accessTokenEndpoint: string;
+        activeUserEndpoint?: string;
+        clientId: string;
+        clientSecret: string;
+        signatureMethod?: "HMAC-SHA1" | "PLAINTEXT";
+    };
+    interface OAuth1Client {
+        fetchRequestToken(oauth_callback: string, qs?: StringMap): any;
+        getAuthUrl(oauth_token: string, qs?: StringMap): string;
+        exchangeRequestToken(
+            oauth_token: string,
+            oauth_verifier: string,
+            qs?: StringMap
+        ): any;
+        fetchActiveUser(
+            oauth_token: string,
+            oauth_token_secret: string,
+            qs?: StringMap
+        ): any;
+        createSignedRequest(
+            method: ArangoDB.HttpMethod,
+            url: string,
+            parameters: string | StringMap | null,
+            oauth_token: string,
+            oauth_token_secret: string
+        ): {
+            url: string;
+            qs: string;
+            headers: { accept: "application/json"; authorization: string };
+        };
+    }
+    function createOAuth1Client(options: OAuth1Options): OAuth1Client;
+    export = createOAuth1Client;
+}
+
+declare module "@arangodb/foxx/oauth2" {
+    type OAuth2Options = {
+        authEndpoint: string;
+        tokenEndpoint: string;
+        refreshEndpoint?: string;
+        activeUserEndpoint?: string;
+        clientId: string;
+        clientSecret: string;
+    };
+    interface OAuth2Client {
+        getAuthUrl(
+            redirect_uri: string,
+            options?: { response_type?: string }
+        ): string;
+        exchangeGrantToken(
+            code: string,
+            redirect_uri: string,
+            options?: { grant_type?: string }
+        ): any;
+        fetchActiveUser(access_token: string): any;
+    }
+    function createOAuth2Client(options: OAuth2Options): OAuth2Client;
+    export = createOAuth2Client;
+}
+
+declare module "@arangodb/foxx" {
+    import createRouter = require("@arangodb/foxx/router");
+    export { createRouter };
+}
+
+declare module "@arangodb/request" {
+    export interface Response {
+        rawBody: Buffer;
+        body: string | Buffer;
+        json?: any;
+        headers: StringMap;
+        status: number;
+        statusCode: number;
+        message: string;
+        throw(message?: string): void;
+    }
+    type RequestOptions = {
+        qs?: PlainObject;
+        useQuerystring?: boolean;
+        headers?: StringMap;
+        body?: any;
+        json?: boolean;
+        form?: any;
+        auth?: { username: string; password?: string } | { bearer: string };
+        sslProtocol?: number;
+        followRedirect?: boolean;
+        maxRedirects?: number;
+        encoding?: string | null;
+        timeout?: number;
+        returnBodyOnError?: boolean;
+    };
+    function method(options: { url: string } & RequestOptions): Response;
+    function method(url: string, options?: RequestOptions): Response;
+    type Request = {
+        (
+            options: {
+                url: string;
+                method?: ArangoDB.HttpMethod;
+            } & RequestOptions
+        ): Response;
+        head: typeof method;
+        get: typeof method;
+        post: typeof method;
+        put: typeof method;
+        patch: typeof method;
+        delete: typeof method;
+    };
+    const request: Request;
+    export = request;
+}
+
+declare module "@arangodb/crypto" {
+    export type JwtAlgorithm = ArangoDB.JwtAlgorithm;
+    export type HashAlgorithm = ArangoDB.HashAlgorithm;
+    export function createNonce(): string;
+    export function checkAndMarkNonce(nonce: string): void;
+    export function rand(): number;
+    export function genRandomAlphaNumbers(length: number): string;
+    export function genRandomNumbers(length: number): string;
+    export function genRandomSalt(length: number): string;
+    export function jwtEncode(
+        key: string,
+        message: string,
+        algorithm: JwtAlgorithm
+    ): string;
+    export function jwtEncode(
+        key: null,
+        message: string,
+        algorithm: "none"
+    ): string;
+    export function jwtDecode(
+        key: string | null,
+        token: string,
+        noVerify?: boolean
+    ): string | null;
+    export function md5(message: string): string;
+    export function sha1(message: string): string;
+    export function sha224(message: string): string;
+    export function sha256(message: string): string;
+    export function sha384(message: string): string;
+    export function sha512(message: string): string;
+    export function constantEquals(a: string, b: string): boolean;
+    export function pbkdf2(
+        salt: string,
+        password: string,
+        iterations: number,
+        keyLength: number
+    ): string;
+    export function hmac(
+        key: string,
+        message: string,
+        algorithm: HashAlgorithm
+    ): string;
+}
+
+declare module "@arangodb/general-graph" {
+    type EdgeDefinition = {
+        collection: string;
+        from: string[];
+        to: string[];
+    };
+    type CommonNeighbors = {
+        left: string;
+        right: string;
+        neighbors: string[];
+    };
+    type CountCommonNeighbors = {
+        [key: string]:
+            | {
+                  [key: string]: number | undefined;
+              }[]
+            | undefined;
+    };
+    type CommonProperties = {
+        [key: string]:
+            | {
+                  _id: string;
+                  [key: string]: any;
+              }[]
+            | undefined;
+    };
+    type CountCommonProperties = {
+        [key: string]: number | undefined;
+    };
+    type Path<A = PlainObject, B = PlainObject, E = PlainObject, V = never> = {
+        source: ArangoDB.Document<A>;
+        destination: ArangoDB.Document<B>;
+        edges: ArangoDB.Edge<E>[];
+        vertice: ArangoDB.Document<A | B | V>[];
+    };
+    type ShortestPath<T = PlainObject> = {
+        vertices: string[];
+        edges: ArangoDB.Edge<T>[];
+        distance: number;
+    };
+    type Distance = {
+        startVertex: string;
+        vertex: string;
+        distance: number;
+    };
+    type Eccentricity = {
+        [key: string]: number | undefined;
+    };
+    type Closeness = Eccentricity;
+    type Betweenness = Eccentricity;
+    type Example = (PlainObject | string)[] | PlainObject | string | null;
+    type ConnectingEdgesOptions = {
+        edgeExamples?: Example;
+        edgeCollectionRestriction?: string[] | string;
+        vertex1CollectionRestriction?: string[] | string;
+        vertex2CollectionRestriction?: string[] | string;
+    };
+    type NeighborsOptions = {
+        direction?: ArangoDB.EdgeDirection;
+        edgeExamples?: Example;
+        neighborExamples?: Example;
+        edgeCollectionRestriction?: string[] | string;
+        vertexCollectionRestriction?: string[] | string;
+        minDepth?: number;
+        maxDepth?: number;
+    };
+    type CommonPropertiesOptions = {
+        vertex1CollectionRestriction?: string[] | string;
+        vertex2CollectionRestriction?: string[] | string;
+        ignoredProperties?: string[] | string;
+    };
+    type PathsOptions = {
+        direction?: ArangoDB.EdgeDirection;
+        followCycles?: boolean;
+        minLength?: number;
+        maxLength?: number;
+    };
+    type ShortestPathOptions = {
+        direction?: ArangoDB.EdgeDirection;
+        edgeCollectionRestriction?: string[] | string;
+        startVertexCollectionRestriction?: string[] | string;
+        endVertexCollectionRestriction?: string[] | string;
+        weight?: string;
+        defaultWeight?: number;
+    };
+    type EccentricityOptions = ShortestPathOptions;
+    type ClosenessOptions = ShortestPathOptions;
+    type BetweennessOptions = {
+        direction?: ArangoDB.EdgeDirection;
+        weight?: string;
+        defaultWeight?: number;
+    };
+    type RadiusOptions = BetweennessOptions;
+    type DiameterOptions = BetweennessOptions;
+    interface Graph {
+        _extendEdgeDefinitions(edgeDefinition: EdgeDefinition): void;
+        _editEdgeDefinitions(edgeDefinition: EdgeDefinition): void;
+        _deleteEdgeDefinition(
+            edgeCollectionName: string,
+            dropCollection?: boolean
+        ): void;
+        _addVertexCollection(
+            orphanCollectionName: string,
+            createCollection?: boolean
+        ): void;
+        _orphanCollections(): string[];
+        _removeVertexCollection(
+            orphanCollectionName: string,
+            dropCollection?: boolean
+        ): void;
+        _getConnectingEdges<T = PlainObject>(
+            vertexExample1: Example,
+            vertexExample2: Example,
+            options: ConnectingEdgesOptions
+        ): ArangoDB.Edge<T>;
+        _fromVertex<T = PlainObject>(edgeId: string): ArangoDB.Document<T>;
+        _toVertex<T = PlainObject>(edgeId: string): ArangoDB.Document<T>;
+        _neighbors(
+            vertexExample: Example,
+            options?: NeighborsOptions
+        ): string[];
+        _commonNeighbors(
+            vertex1Example: Example,
+            vertex2Example: Example,
+            vertex1Options?: NeighborsOptions,
+            vertex2Options?: NeighborsOptions
+        ): CommonNeighbors[];
+        _countCommonNeighbors(
+            vertex1Example: Example,
+            vertex2Example: Example,
+            vertex1Options?: NeighborsOptions,
+            vertex2Options?: NeighborsOptions
+        ): CountCommonNeighbors[];
+        _commonProperties(
+            vertexExample1: Example,
+            vertex2Example: Example,
+            options?: CommonPropertiesOptions
+        ): CommonProperties[];
+        _countCommonProperties(
+            vertex1Example: Example,
+            vertex2Example: Example,
+            options?: CommonPropertiesOptions
+        ): CountCommonProperties[];
+        _paths<A, B, E, V>(options?: PathsOptions): Path<A, B, E, V>[];
+        _shortestPath<T>(
+            startVertexExample: Example,
+            endVertexExample: Example,
+            options?: ShortestPathOptions
+        ): ShortestPath<T>[];
+        _distanceTo(
+            startVertexExample: Example,
+            endVertexExample: Example,
+            options?: ShortestPathOptions
+        ): Distance[];
+        _absoluteEccentricity(
+            vertexExample: Example,
+            options?: EccentricityOptions
+        ): Eccentricity;
+        _eccentricity(
+            vertexExample: Example,
+            options?: EccentricityOptions
+        ): Eccentricity;
+        _absoluteCloseness(
+            vertexExample: Example,
+            options?: ClosenessOptions
+        ): Closeness;
+        _closeness(
+            vertexExample: Example,
+            options?: ClosenessOptions
+        ): Closeness;
+        _absoluteBetweenness(
+            vertexExample: Example,
+            options?: BetweennessOptions
+        ): Betweenness;
+        _betweenness(
+            vertexExample: Example,
+            options?: BetweennessOptions
+        ): Betweenness;
+        _radius(vertexExample: Example, options?: RadiusOptions): number;
+        _diameter(vertexExample: Example, options?: DiameterOptions): number;
+
+        [key: string]: ArangoDB.Collection | undefined;
+    }
+    export function _create(
+        name: string,
+        edgeDefinitions?: EdgeDefinition[],
+        orphanCollections?: string[]
+    ): Graph;
+    export function _list(): string[];
+    export function _graph(name: string): Graph;
+    export function _drop(name: string, dropCollections?: boolean): boolean;
+    export function _relation(
+        name: string,
+        fromVertexCollections: string[] | string,
+        toVertexCollections: string[] | string
+    ): EdgeDefinition;
+    export function _edgeDefinitions(
+        ...relations: EdgeDefinition[]
+    ): EdgeDefinition[];
+    export function _extendEdgeDefinitions(
+        edgeDefinitions: EdgeDefinition[],
+        ...relations: EdgeDefinition[]
+    ): EdgeDefinition[];
+}
+
+declare var module: Foxx.Module;
+
+declare var console: NodeJS.Console & {
+    errorLines: (...args: any[]) => void;
+    warnLines: (...args: any[]) => void;
+    infoLines: (...args: any[]) => void;
+    debugLines: (...args: any[]) => void;
+    errorStack: (err: Error, msg?: string) => void;
+    warnStack: (err: Error, msg?: string) => void;
+    infoStack: (err: Error, msg?: string) => void;
+    debugStack: (err: Error, msg?: string) => void;
+};

--- a/types/arangodb/index.d.ts
+++ b/types/arangodb/index.d.ts
@@ -335,10 +335,9 @@ declare namespace ArangoDB {
 
     // Collection
 
-    export const enum CollectionType {
-        Document = 2,
-        Edge = 3
-    }
+    type DocumentCollectionType = 2;
+    type EdgeCollectionType = 3;
+    type CollectionType = DocumentCollectionType | EdgeCollectionType;
 
     interface CollectionChecksum {
         checksum: string;
@@ -1152,16 +1151,16 @@ declare namespace Foxx {
         use(routerOrMiddleware: Router | Middleware, name?: string): Endpoint;
     }
 
-    class Module extends NodeJS.Module {
+    interface Module extends NodeJS.Module {
         context: Context;
     }
 }
 
 declare module "@arangodb/index" {
-    export function aql(strings: string[], ...args: any[]): ArangoDB.Query;
-    export function time(): number;
-    export const db: ArangoDB.Database;
-    export const errors: {
+    function aql(strings: string[], ...args: any[]): ArangoDB.Query;
+    function time(): number;
+    const db: ArangoDB.Database;
+    const errors: {
         [Name in ArangoDB.ErrorName]: { code: number; message: string }
     };
 }
@@ -1360,7 +1359,7 @@ declare module "@arangodb/foxx/oauth2" {
 }
 
 declare module "@arangodb/foxx" {
-    export function createRouter(): Foxx.Router;
+    function createRouter(): Foxx.Router;
 }
 
 declare module "@arangodb/request" {
@@ -1410,41 +1409,37 @@ declare module "@arangodb/request" {
 }
 
 declare module "@arangodb/crypto" {
-    export function createNonce(): string;
-    export function checkAndMarkNonce(nonce: string): void;
-    export function rand(): number;
-    export function genRandomAlphaNumbers(length: number): string;
-    export function genRandomNumbers(length: number): string;
-    export function genRandomSalt(length: number): string;
-    export function jwtEncode(
+    function createNonce(): string;
+    function checkAndMarkNonce(nonce: string): void;
+    function rand(): number;
+    function genRandomAlphaNumbers(length: number): string;
+    function genRandomNumbers(length: number): string;
+    function genRandomSalt(length: number): string;
+    function jwtEncode(
         key: string,
         message: string,
         algorithm: ArangoDB.JwtAlgorithm
     ): string;
-    export function jwtEncode(
-        key: null,
-        message: string,
-        algorithm: "none"
-    ): string;
-    export function jwtDecode(
+    function jwtEncode(key: null, message: string, algorithm: "none"): string;
+    function jwtDecode(
         key: string | null,
         token: string,
         noVerify?: boolean
     ): string | null;
-    export function md5(message: string): string;
-    export function sha1(message: string): string;
-    export function sha224(message: string): string;
-    export function sha256(message: string): string;
-    export function sha384(message: string): string;
-    export function sha512(message: string): string;
-    export function constantEquals(a: string, b: string): boolean;
-    export function pbkdf2(
+    function md5(message: string): string;
+    function sha1(message: string): string;
+    function sha224(message: string): string;
+    function sha256(message: string): string;
+    function sha384(message: string): string;
+    function sha512(message: string): string;
+    function constantEquals(a: string, b: string): boolean;
+    function pbkdf2(
         salt: string,
         password: string,
         iterations: number,
         keyLength: number
     ): string;
-    export function hmac(
+    function hmac(
         key: string,
         message: string,
         algorithm: ArangoDB.HashAlgorithm
@@ -1639,23 +1634,21 @@ declare module "@arangodb/general-graph" {
 
         readonly [key: string]: any;
     }
-    export function _create(
+    function _create(
         name: string,
         edgeDefinitions?: EdgeDefinition[],
         orphanCollections?: string[]
     ): Graph;
-    export function _list(): string[];
-    export function _graph(name: string): Graph;
-    export function _drop(name: string, dropCollections?: boolean): boolean;
-    export function _relation(
+    function _list(): string[];
+    function _graph(name: string): Graph;
+    function _drop(name: string, dropCollections?: boolean): boolean;
+    function _relation(
         name: string,
         fromVertexCollections: string[] | string,
         toVertexCollections: string[] | string
     ): EdgeDefinition;
-    export function _edgeDefinitions(
-        ...relations: EdgeDefinition[]
-    ): EdgeDefinition[];
-    export function _extendEdgeDefinitions(
+    function _edgeDefinitions(...relations: EdgeDefinition[]): EdgeDefinition[];
+    function _extendEdgeDefinitions(
         edgeDefinitions: EdgeDefinition[],
         ...relations: EdgeDefinition[]
     ): EdgeDefinition[];

--- a/types/arangodb/index.d.ts
+++ b/types/arangodb/index.d.ts
@@ -30,6 +30,70 @@ declare namespace ArangoDB {
         | "PATCH"
         | "DELETE"
         | "OPTIONS";
+    type HttpStatus =
+        | "continue"
+        | "switching protocols"
+        | "processing"
+        | "ok"
+        | "created"
+        | "accepted"
+        | "non-authoritative information"
+        | "no content"
+        | "reset content"
+        | "partial content"
+        | "multi-status"
+        | "already reported"
+        | "im used"
+        | "multiple choices"
+        | "moved permanently"
+        | "found"
+        | "see other"
+        | "not modified"
+        | "use proxy"
+        | "(unused)"
+        | "temporary redirect"
+        | "permanent redirect"
+        | "bad request"
+        | "unauthorized"
+        | "payment required"
+        | "forbidden"
+        | "not found"
+        | "method not allowed"
+        | "not acceptable"
+        | "proxy authentication required"
+        | "request timeout"
+        | "conflict"
+        | "gone"
+        | "length required"
+        | "precondition failed"
+        | "payload too large"
+        | "uri too long"
+        | "unsupported media type"
+        | "range not satisfiable"
+        | "expectation failed"
+        | "i'm a teapot"
+        | "misdirected request"
+        | "unprocessable entity"
+        | "locked"
+        | "failed dependency"
+        | "unordered collection"
+        | "upgrade required"
+        | "precondition required"
+        | "too many requests"
+        | "request header fields too large"
+        | "unavailable for legal reasons"
+        | "internal server error"
+        | "not implemented"
+        | "bad gateway"
+        | "service unavailable"
+        | "gateway timeout"
+        | "http version not supported"
+        | "variant also negotiates"
+        | "insufficient storage"
+        | "loop detected"
+        | "bandwidth limit exceeded"
+        | "not extended"
+        | "network authentication required";
     type EdgeDirection = "any" | "inbound" | "outbound";
     type EngineType = "mmfiles" | "rocksdb";
     type IndexType = "hash" | "skiplist" | "fulltext" | "geo1" | "geo2";
@@ -1090,25 +1154,29 @@ declare namespace Foxx {
         download(path: string, filename?: string): this;
         getHeader(name: string): string | undefined;
         json(data: any): this;
-        redirect(status: number | string, path: string): this;
+        redirect(status: number | ArangoDB.HttpStatus, path: string): this;
         redirect(path: string): this;
         removeHeader(name: string): this;
         send(data: any, type?: string): this;
         sendFile(path: string, options?: { lastModified: boolean }): this;
-        sendStatus(status: number | string): this;
+        sendStatus(status: number | ArangoDB.HttpStatus): this;
         setHeader(name: string, value: string): this;
         set(name: string, value: string): this;
         set(headers: { [name: string]: string }): this;
-        status(status: number | string): this;
-        throw(status: number | string, reason: string, error: Error): never;
+        status(status: number | ArangoDB.HttpStatus): this;
         throw(
-            status: number | string,
+            status: number | ArangoDB.HttpStatus,
+            reason: string,
+            error: Error
+        ): never;
+        throw(
+            status: number | ArangoDB.HttpStatus,
             reason: string,
             options?: { cause?: Error; extra?: any }
         ): never;
-        throw(status: number | string, error: Error): never;
+        throw(status: number | ArangoDB.HttpStatus, error: Error): never;
         throw(
-            status: number | string,
+            status: number | ArangoDB.HttpStatus,
             options?: { cause?: Error; extra?: any }
         ): never;
         type(type?: string): string;
@@ -1135,21 +1203,24 @@ declare namespace Foxx {
         ): this;
         body(description: string): this;
         response(
-            status: number | string,
+            status: number | ArangoDB.HttpStatus,
             schema: Schema | Model | [Model],
             mimes?: string[],
             description?: string
         ): this;
         response(
-            status: number | string,
+            status: number | ArangoDB.HttpStatus,
             mimes: string[],
             description?: string
         ): this;
-        response(status: number | string, description: string): this;
+        response(
+            status: number | ArangoDB.HttpStatus,
+            description: string
+        ): this;
         summary(summary: string): this;
         description(description: string): this;
         deprecated(deprecated: boolean): this;
-        error(status: number | string, description: string): this;
+        error(status: number | ArangoDB.HttpStatus, description: string): this;
         tag(...tags: string[]): this;
     }
 

--- a/types/arangodb/index.d.ts
+++ b/types/arangodb/index.d.ts
@@ -487,7 +487,7 @@ declare namespace ArangoDB {
     type InsertResult<T extends object = any> = DocumentMetadata | Document<T>;
     type UpdateResult<T extends object = any> = UpdateMetadata & {
         old?: Document<T>;
-        ["new"]?: Document<T>;
+        new?: Document<T>;
     };
     interface RemoveResult<T extends object = any> extends DocumentMetadata {
         old?: Document<T>;
@@ -871,7 +871,7 @@ declare namespace Foxx {
         data: any;
     }
     interface SessionStorage {
-        ["new"]?: () => Session;
+        new?: () => Session;
         fromClient: (sid: string) => Session | null;
         forClient: (session: Session) => string | null;
     }

--- a/types/arangodb/index.d.ts
+++ b/types/arangodb/index.d.ts
@@ -1222,9 +1222,9 @@ declare module "@arangodb/foxx/router" {
 }
 
 declare module "@arangodb/foxx/graphql" {
-    type GraphQLSchema = object;
+    import { GraphQLSchema, formatError } from "graphql";
     type GraphQLModule = object;
-    type GraphQLFormatErrorFunction = (error: any) => any;
+    type GraphQLFormatErrorFunction = typeof formatError;
     interface GraphQLOptions {
         schema: GraphQLSchema;
         context?: any;

--- a/types/arangodb/index.d.ts
+++ b/types/arangodb/index.d.ts
@@ -478,7 +478,7 @@ declare namespace ArangoDB {
     type InsertResult<T = PlainObject> = DocumentMetadata | Document<T>;
     type UpdateResult<T = PlainObject> = UpdateMetadata & {
         old?: Document<T>;
-        new?: Document<T>;
+        ["new"]?: Document<T>;
     };
     interface RemoveResult<T = PlainObject> extends DocumentMetadata {
         old?: Document<T>;

--- a/types/arangodb/index.d.ts
+++ b/types/arangodb/index.d.ts
@@ -868,7 +868,7 @@ declare namespace Foxx {
     }
 
     type Middleware = (req: Request, res: Response, next: NextFunction) => void;
-    type Handler = ((req: Request, res: Response) => void) | Middleware;
+    type Handler = ((req: Request, res: Response) => void);
     type NextFunction = () => void;
 
     interface ValidationResult<T> {
@@ -1083,14 +1083,102 @@ declare namespace Foxx {
         tag(...tags: string[]): this;
     }
 
+    function route(handler: Handler, name?: string): Endpoint;
     function route(
-        path: string,
-        ...handlers: Handler[],
+        pathOrMiddleware: string | Middleware,
+        handler: Handler,
         name?: string
     ): Endpoint;
-    function route(...handlers: Handler[], name?: string): Endpoint;
-    function route(path: string, handler: Handler, name?: string): Endpoint;
-    function route(handler: Handler, name?: string): Endpoint;
+    function route(
+        pathOrMiddleware: string | Middleware,
+        middleware: Middleware,
+        handler: Handler,
+        name?: string
+    ): Endpoint;
+    function route(
+        pathOrMiddleware: string | Middleware,
+        middleware1: Middleware,
+        middleware2: Middleware,
+        handler: Handler,
+        name?: string
+    ): Endpoint;
+    function route(
+        pathOrMiddleware: string | Middleware,
+        middleware1: Middleware,
+        middleware2: Middleware,
+        middleware3: Middleware,
+        handler: Handler,
+        name?: string
+    ): Endpoint;
+    function route(
+        pathOrMiddleware: string | Middleware,
+        middleware1: Middleware,
+        middleware2: Middleware,
+        middleware3: Middleware,
+        middleware4: Middleware,
+        handler: Handler,
+        name?: string
+    ): Endpoint;
+    function route(
+        pathOrMiddleware: string | Middleware,
+        middleware1: Middleware,
+        middleware2: Middleware,
+        middleware3: Middleware,
+        middleware4: Middleware,
+        middleware5: Middleware,
+        handler: Handler,
+        name?: string
+    ): Endpoint;
+    function route(
+        pathOrMiddleware: string | Middleware,
+        middleware1: Middleware,
+        middleware2: Middleware,
+        middleware3: Middleware,
+        middleware4: Middleware,
+        middleware5: Middleware,
+        middleware6: Middleware,
+        handler: Handler,
+        name?: string
+    ): Endpoint;
+    function route(
+        pathOrMiddleware: string | Middleware,
+        middleware1: Middleware,
+        middleware2: Middleware,
+        middleware3: Middleware,
+        middleware4: Middleware,
+        middleware5: Middleware,
+        middleware6: Middleware,
+        middleware7: Middleware,
+        handler: Handler,
+        name?: string
+    ): Endpoint;
+    function route(
+        pathOrMiddleware: string | Middleware,
+        middleware1: Middleware,
+        middleware2: Middleware,
+        middleware3: Middleware,
+        middleware4: Middleware,
+        middleware5: Middleware,
+        middleware6: Middleware,
+        middleware7: Middleware,
+        middleware8: Middleware,
+        handler: Handler,
+        name?: string
+    ): Endpoint;
+    function route(
+        pathOrMiddleware: string | Middleware,
+        middleware1: Middleware,
+        middleware2: Middleware,
+        middleware3: Middleware,
+        middleware4: Middleware,
+        middleware5: Middleware,
+        middleware6: Middleware,
+        middleware7: Middleware,
+        middleware8: Middleware,
+        middleware9: Middleware,
+        handler: Handler,
+        name?: string
+    ): Endpoint;
 
     interface Router {
         get: typeof route;

--- a/types/arangodb/index.d.ts
+++ b/types/arangodb/index.d.ts
@@ -1411,9 +1411,11 @@ declare module "@arangodb/foxx/sessions/storages/jwt" {
         verify?: boolean;
         maxExp?: number;
     }
-    type JwtStorageOptions = SafeJwtStorageOptions | UnsafeJwtStorageOptions;
     function jwtStorage(
-        options: JwtStorageOptions | SafeJwtStorageOptions["secret"]
+        options:
+            | SafeJwtStorageOptions
+            | UnsafeJwtStorageOptions
+            | SafeJwtStorageOptions["secret"]
     ): Foxx.SessionStorage;
     export = jwtStorage;
 }

--- a/types/arangodb/index.d.ts
+++ b/types/arangodb/index.d.ts
@@ -762,7 +762,10 @@ declare namespace ArangoDB {
 
     // Views
 
-    type View = object; // TODO
+    interface View {
+        // TODO
+        [key: string]: any;
+    }
     type ViewProperties = object; // TODO
 
     // Global
@@ -856,7 +859,7 @@ declare namespace ArangoDB {
 
         // Global
         _engine(): EngineType;
-        _engineStats(): object;
+        _engineStats(): { [key: string]: any };
         _executeTransaction(transaction: Transaction): void;
     }
 }
@@ -928,16 +931,70 @@ declare namespace Foxx {
         end: number;
     }> & { type: string };
 
+    type ConfigurationType =
+        | "integer"
+        | "boolean"
+        | "string"
+        | "number"
+        | "json"
+        | "password"
+        | "int"
+        | "bool";
+    interface ConfigurationDefinition {
+        default?: any;
+        type?: ConfigurationType;
+        description?: string;
+        required: boolean;
+    }
+    interface DependencyDefinition {
+        name: string;
+        version: string;
+        description?: string;
+        required: boolean;
+        multiple: boolean;
+    }
+    interface AssetDefinition {
+        path: string;
+        gzip?: boolean;
+        type?: string;
+    }
+
+    interface Manifest {
+        name?: string;
+        version?: string;
+        keywords?: string;
+        license?: string;
+        repository?: { type: string; url: string };
+        author: string;
+        contributors?: any[];
+        description: string;
+        thumbnail?: string;
+        engines?: StringMap;
+        defaultDocument?: string;
+        lib: string;
+        main?: string;
+        configuration?: {
+            [key: string]: ConfigurationDefinition;
+        };
+        dependencies?: {
+            [key: string]: DependencyDefinition;
+        };
+        provides?: StringMap;
+        files?: { [key: string]: AssetDefinition };
+        scripts?: StringMap;
+        tests?: string[];
+    }
+
     interface Context {
         argv: any[];
         basePath: string;
         baseUrl: string;
         collectionPrefix: string;
-        configuration: object;
-        dependencies: object;
+        configuration: { [key: string]: any };
+        dependencies: { [key: string]: any };
         isDevelopment: boolean;
         isProduction: boolean;
-        manifest: object;
+        manifest: Manifest;
         mount: string;
         collection(name: string): ArangoDB.Collection | null;
         collectionName(name: string): string;
@@ -971,10 +1028,10 @@ declare namespace Foxx {
         method: ArangoDB.HttpMethod;
         originalUrl: string;
         path: string;
-        pathParams: object;
+        pathParams: { [key: string]: any };
         port: number;
         protocol: string;
-        queryParams: object;
+        queryParams: { [key: string]: any };
         rawBody: Buffer;
         remoteAddress: string;
         remoteAddresses: string[];
@@ -1012,7 +1069,7 @@ declare namespace Foxx {
     interface Response {
         body: Buffer | string;
         context: Context;
-        headers: object;
+        headers: { [key: string]: any };
         statusCode: number;
         attachment(filename?: string): this;
         cookie(

--- a/types/arangodb/index.d.ts
+++ b/types/arangodb/index.d.ts
@@ -5,7 +5,6 @@
 // TypeScript Version: 2.3
 
 /// <reference types="node" />
-type NodeConsole = Console;
 
 interface StringMap {
     [key: string]: string | undefined;
@@ -851,17 +850,6 @@ declare namespace ArangoDB {
         _engineStats(): object;
         _executeTransaction(transaction: Transaction): void;
     }
-
-    interface Console extends NodeConsole {
-        errorLines: (...args: any[]) => void;
-        warnLines: (...args: any[]) => void;
-        infoLines: (...args: any[]) => void;
-        debugLines: (...args: any[]) => void;
-        errorStack: (err: Error, msg?: string) => void;
-        warnStack: (err: Error, msg?: string) => void;
-        infoStack: (err: Error, msg?: string) => void;
-        debugStack: (err: Error, msg?: string) => void;
-    }
 }
 
 declare namespace Foxx {
@@ -1207,10 +1195,6 @@ declare namespace Foxx {
             name?: string
         ): Endpoint;
         use(routerOrMiddleware: Router | Middleware, name?: string): Endpoint;
-    }
-
-    interface Module extends NodeModule {
-        context: Context;
     }
 }
 
@@ -1710,4 +1694,21 @@ declare module "@arangodb/general-graph" {
     ): EdgeDefinition[];
 }
 
-// TODO figure out how to override `console` and `module`
+declare module "@arangodb/locals" {
+    const context: Foxx.Context;
+}
+
+interface NodeModule {
+    context: Foxx.Context;
+}
+
+interface Console {
+    errorLines(...args: any[]): void;
+    warnLines(...args: any[]): void;
+    infoLines(...args: any[]): void;
+    debugLines(...args: any[]): void;
+    errorStack(err: Error, msg?: string): void;
+    warnStack(err: Error, msg?: string): void;
+    infoStack(err: Error, msg?: string): void;
+    debugStack(err: Error, msg?: string): void;
+}

--- a/types/arangodb/index.d.ts
+++ b/types/arangodb/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/arangodb/arangodb
 // Definitions by: Alan Plum <https://github.com/pluma>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
 
 interface StringMap {
     [key: string]: string | undefined;
@@ -428,13 +429,13 @@ declare namespace ArangoDB {
 
     interface IndexDescription<T> {
         type: IndexType;
-        fields: Array<keyof T>;
+        fields: ReadonlyArray<keyof T>;
         sparse?: boolean;
         unique?: boolean;
         deduplicate?: boolean;
     }
 
-    interface IndexResult<T extends object = object> {
+    interface IndexResult<T extends object = any> {
         id: string;
         type: IndexType;
         fields: Array<keyof T>;
@@ -470,25 +471,23 @@ declare namespace ArangoDB {
         _oldRev: string;
     }
 
-    type Document<T extends object = object> = T &
+    type Document<T extends object = any> = { [K in keyof T]: T[K] } &
         DocumentMetadata & { _from?: string; _to?: string } & {
             [key: string]: any;
         };
-    type DocumentData<T extends object = object> = T &
-        Partial<DocumentMetadata> & { [key: string]: any };
-    type Edge<T extends object = object> = Document<T> & {
+    type DocumentData<T extends object = any> = { [K in keyof T]: T[K] } &
+        Partial<DocumentMetadata>;
+    type Edge<T extends object = any> = Document<T> & {
         _from: string;
         _to: string;
     };
 
-    type InsertResult<T extends object = object> =
-        | DocumentMetadata
-        | Document<T>;
-    type UpdateResult<T extends object = object> = UpdateMetadata & {
+    type InsertResult<T extends object = any> = DocumentMetadata | Document<T>;
+    type UpdateResult<T extends object = any> = UpdateMetadata & {
         old?: Document<T>;
         ["new"]?: Document<T>;
     };
-    interface RemoveResult<T extends object = object> extends DocumentMetadata {
+    interface RemoveResult<T extends object = any> extends DocumentMetadata {
         old?: Document<T>;
     }
 
@@ -531,12 +530,12 @@ declare namespace ArangoDB {
         probability?: number;
     }
 
-    type DocumentIterator<T extends object = object> = (
+    type DocumentIterator<T extends object> = (
         document: Document<T>,
         number: number
     ) => void;
 
-    interface Collection<T extends object = object> {
+    interface Collection<T extends object = any> {
         // Collection
         checksum(
             withRevisions?: boolean,
@@ -568,12 +567,14 @@ declare namespace ArangoDB {
         any(): Document<T>;
         byExample(example: Partial<Document<T>>): Cursor<Document<T>>;
         document(selector: string | DocumentLike): Document<T>;
-        document(selectors: Array<string | DocumentLike>): Array<Document<T>>;
+        document(
+            selectors: ReadonlyArray<string | DocumentLike>
+        ): Array<Document<T>>;
         exists(name: string): boolean;
         firstExample(example: Partial<Document<T>>): Document<T> | null;
         insert(data: DocumentData<T>, options?: InsertOptions): InsertResult<T>;
         insert(
-            array: Array<DocumentData<T>>,
+            array: ReadonlyArray<DocumentData<T>>,
             options?: InsertOptions
         ): Array<InsertResult<T>>;
         insert(
@@ -583,13 +584,22 @@ declare namespace ArangoDB {
             options?: InsertOptions
         ): InsertResult<T>;
         edges(
-            vertex: string | DocumentLike1 | Array<string | DocumentLike1>
+            vertex:
+                | string
+                | DocumentLike1
+                | ReadonlyArray<string | DocumentLike1>
         ): Array<Edge<T>>;
         inEdges(
-            vertex: string | DocumentLike1 | Array<string | DocumentLike1>
+            vertex:
+                | string
+                | DocumentLike1
+                | ReadonlyArray<string | DocumentLike1>
         ): Array<Edge<T>>;
         outEdges(
-            vertex: string | DocumentLike1 | Array<string | DocumentLike1>
+            vertex:
+                | string
+                | DocumentLike1
+                | ReadonlyArray<string | DocumentLike1>
         ): Array<Edge<T>>;
         iterate(iterator: DocumentIterator<T>, options?: IterateOptions): void;
         remove(
@@ -597,7 +607,7 @@ declare namespace ArangoDB {
             options?: RemoveOptions
         ): RemoveResult;
         remove(
-            selectors: Array<string | DocumentLike>,
+            selectors: ReadonlyArray<string | DocumentLike>,
             options?: RemoveOptions
         ): RemoveResult[];
         removeByExample(
@@ -616,8 +626,8 @@ declare namespace ArangoDB {
             options?: ReplaceOptions
         ): UpdateResult<T>;
         replace(
-            selectors: Array<string | DocumentLike>,
-            data: Array<DocumentData<T>>,
+            selectors: ReadonlyArray<string | DocumentLike>,
+            data: ReadonlyArray<DocumentData<T>>,
             options?: ReplaceOptions
         ): Array<UpdateResult<T>>;
         replaceByExample(
@@ -633,7 +643,7 @@ declare namespace ArangoDB {
         ): number;
         save(data: DocumentData<T>, options?: InsertOptions): InsertResult<T>;
         save(
-            array: Array<DocumentData<T>>,
+            array: ReadonlyArray<DocumentData<T>>,
             options?: InsertOptions
         ): Array<InsertResult<T>>;
         save(
@@ -648,8 +658,8 @@ declare namespace ArangoDB {
             options?: UpdateOptions
         ): UpdateResult<T>;
         update(
-            selectors: Array<string | DocumentLike>,
-            data: Array<Partial<Document<T>>>,
+            selectors: ReadonlyArray<string | DocumentLike>,
+            data: ReadonlyArray<Partial<Document<T>>>,
             options?: UpdateOptions
         ): Array<UpdateResult<T>>;
         updateByExample(
@@ -1486,9 +1496,9 @@ declare module "@arangodb/general-graph" {
         [key: string]: number | undefined;
     }
     interface Path<
-        A extends object = object,
-        B extends object = object,
-        E extends object = object,
+        A extends object = any,
+        B extends object = any,
+        E extends object = any,
         V extends object = never
     > {
         source: ArangoDB.Document<A>;
@@ -1496,7 +1506,7 @@ declare module "@arangodb/general-graph" {
         edges: Array<ArangoDB.Edge<E>>;
         vertice: Array<ArangoDB.Document<A | B | V>>;
     }
-    interface ShortestPath<T extends object = object> {
+    interface ShortestPath<T extends object = any> {
         vertices: string[];
         edges: Array<ArangoDB.Edge<T>>;
         distance: number;

--- a/types/arangodb/tsconfig.json
+++ b/types/arangodb/tsconfig.json
@@ -5,9 +5,10 @@
         "noImplicitAny": true,
         "noImplicitThis": true,
         "strictNullChecks": true,
+        "strictFunctionTypes": true,
         "baseUrl": "../",
         "typeRoots": ["../"],
-        "types": ["../node/v6"],
+        "types": [],
         "noEmit": true,
         "forceConsistentCasingInFileNames": true
     },

--- a/types/arangodb/tsconfig.json
+++ b/types/arangodb/tsconfig.json
@@ -1,0 +1,15 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "types": ["../node/v6"],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": ["index.d.ts", "arangodb-tests.ts"]
+}

--- a/types/arangodb/tslint.json
+++ b/types/arangodb/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

---

This is a WIP for the ArangoDB JavaScript environment (similar to Node.js but not running on Node.js). ArangoDB defines several built-in modules residing under the `@arangodb` prefix (including a bare `@arangodb` module, which is not supported by npm AFAIK).

I'm running into a few problems at the moment:

* ~~The typings are currently formatted with Prettier. I'll need to make sure to change it to 4 spaces.~~
* We literally have a function that returns an object with a property called "new", not sure how to distinguish that from a "new-able" object
* I'm unclear when to use `ReadonlyArray`. Most functions don't modify their inputs and some input types are objects containing arrays. Do I need to define those contained arrays as readonly too?
* ~~VSCode~~ linter freaks out about a few things:
    * ~~"using a declare modifier in an already ambient context" (declare inside a `declare namespace`) but the typings seem to work fine.~~
    * ~~`Datatabase` has a catch-all string index type which apparently conflicts with the named methods? Not sure how to type this correctly.~~
    * `Buffer`, `NodeJS.Module` and `NodeJS.Console` are apparently not in scope
    * rest parameters apparently must be last but we have some methods that have them in 
other places -- as far as I can tell TypeScript can handle that but VSCode still complains
    * ~~`const enum` is forbidden but having the collection type as a magic number seems smelly. Any way to work around this?~~
* The file needs to declare a number of different modules, not sure if it's doing that correctly considering most typings here just type individual NPM modules
* We're including [a bunch of compatibility modules mirroring node's built-in modules](https://docs.arangodb.com/3.3/Manual/Appendix/JavaScriptModules/) and I'm not sure whether these also need to be defined or if we can just delegate those to the Node.js typings.
* It makes sense to me for `ArangoDB` and `Foxx` to exist as global namespaces analogous to `NodeJS` but I'm not sure this is a good practice. Would love some feedback on this.
* I haven't started with the tests yet -- should I test every possible variation of each method (within reason) or just some of the basics?
*  ~~The linter currently blows up with this message:~~