### PR TITLE
[webidl2] extAttrs.rhs can be null

### DIFF
--- a/types/webidl2/index.d.ts
+++ b/types/webidl2/index.d.ts
@@ -249,7 +249,7 @@ export interface ExtendedAttributes {
     /** If the extended attribute takes arguments or if its right-hand side does they are listed here. */
     arguments: Argument[];
     /** If there is a right-hand side, this will capture its type ("identifier" or "identifier-list") and its value. */
-    rhs: ExtendedAttributeRightHandSideIdentifier | ExtendedAttributeRightHandSideIdentifierList;
+    rhs: ExtendedAttributeRightHandSideIdentifier | ExtendedAttributeRightHandSideIdentifierList | null;
 }
 
 export interface Token {

--- a/types/webidl2/webidl2-tests.ts
+++ b/types/webidl2/webidl2-tests.ts
@@ -106,6 +106,9 @@ function logExtAttrs(extAttrs: webidl2.ExtendedAttributes[]) {
     console.log(extAttrs[0].name);
     logArguments(extAttrs[0].arguments);
     const { rhs } = extAttrs[0];
+    if (rhs === null) {
+        return;
+    }
     if (rhs.type === "identifier") {
         console.log(rhs);
     } else {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/w3c/webidl2.js#extended-attributes
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
