### PR TITLE
[simple-oauth2] Add 'scope' to Authorization Code flow

### DIFF
--- a/types/simple-oauth2/index.d.ts
+++ b/types/simple-oauth2/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for simple-oauth2 1.0
 // Project: https://github.com/lelylan/simple-oauth2
-// Definitions by: [Michael Müller] <https://github.com/mad-mike>
+// Definitions by: Michael Müller <https://github.com/mad-mike>,
+//                 Troy Lamerton <https://github.com/troy-lamerton>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -63,6 +64,7 @@ export type AuthorizationCode = string;
 export interface AuthorizationTokenConfig {
     code: AuthorizationCode;
     redirect_uri: string;
+    scope?: string | string[];
 }
 
 export interface PasswordTokenConfig {
@@ -70,13 +72,13 @@ export interface PasswordTokenConfig {
     username: string;
     /** A string that represents the registered password. */
     password: string;
-    /** A string that represents the application privileges */
-    scope: string;
+    /** A string or array of strings that represents the application privileges */
+    scope: string | string[];
 }
 
 export interface ClientCredentialTokenConfig {
     /** A string that represents the application privileges */
-    scope?: string;
+    scope?: string | string[];
 }
 
 export interface OAuthClient {
@@ -88,9 +90,9 @@ export interface OAuthClient {
         authorizeURL(params?: {
             /** A string that represents the registered application URI where the user is redirected after authentication */
             redirect_uri?: string,
-            /** A String that represents the application privileges */
-            scope?: string,
-            /** A String that represents an option opaque value used by the client to main the state between the request and the callback */
+            /** A string or array of strings that represents the application privileges */
+            scope?: string | string[],
+            /** A string that represents an option opaque value used by the client to main the state between the request and the callback */
             state?: string
         }): string,
 

--- a/types/simple-oauth2/simple-oauth2-tests.ts
+++ b/types/simple-oauth2/simple-oauth2-tests.ts
@@ -32,7 +32,8 @@ const oauth2 = oauth2lib.create(credentials);
     // Get the access token object (the authorization code is given from the previous step).
     const tokenConfig = {
         code: '<code>',
-        redirect_uri: 'http://localhost:3000/callback'
+        redirect_uri: 'http://localhost:3000/callback',
+        scope: ['<scope1>', '<scope2>']
     };
 
     // Callbacks


### PR DESCRIPTION
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/lelylan/simple-oauth2#authorization-code-flow
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

Adds the `scope` parameter to the Authorization Code flow.
Also updates `scope` type to accept `string[]`.