### PR TITLE
[got] Update to 8.3.0

### DIFF
--- a/types/got/got-tests.ts
+++ b/types/got/got-tests.ts
@@ -4,6 +4,7 @@ import FormData = require('form-data');
 import * as fs from 'fs';
 import * as http from 'http';
 import * as https from 'https';
+import * as url from 'url';
 
 let str: string;
 let buf: Buffer;
@@ -244,4 +245,6 @@ got('todomvc', {
     cache: new Map()
 }).then(res => res.fromCache);
 
-got(new URL('http://todomvc.com'));
+got(new url.URL('http://todomvc.com'));
+
+got(url.parse('http://todomvc.com'));

--- a/types/got/got-tests.ts
+++ b/types/got/got-tests.ts
@@ -3,6 +3,7 @@ import cookie = require('cookie');
 import FormData = require('form-data');
 import * as fs from 'fs';
 import * as http from 'http';
+import * as https from 'https';
 
 let str: string;
 let buf: Buffer;
@@ -94,6 +95,7 @@ let res: http.IncomingMessage | undefined;
 let opts: got.GotOptions<string | null>;
 let err: got.GotError;
 let href: string | undefined;
+let progress: got.Progress;
 
 const stream = got.stream('todomvc.com');
 stream.addListener('request', (r) => req = r);
@@ -107,6 +109,12 @@ stream.addListener('error', (e, b, r) => {
     err = e;
     res = r;
 });
+stream.addListener('downloadProgress', (p) => {
+    progress = p;
+});
+stream.addListener('uploadProgress', (p) => {
+    progress = p;
+});
 
 stream.on('request', (r) => req = r);
 stream.on('response', (r) => res = r);
@@ -118,6 +126,12 @@ stream.on('redirect', (r, o) => {
 stream.on('error', (e, b, r) => {
     err = e;
     res = r;
+});
+stream.on('downloadProgress', (p) => {
+    progress = p;
+});
+stream.on('uploadProgress', (p) => {
+    progress = p;
 });
 
 stream.once('request', (r) => req = r);
@@ -131,6 +145,12 @@ stream.once('error', (e, b, r) => {
     err = e;
     res = r;
 });
+stream.once('downloadProgress', (p) => {
+    progress = p;
+});
+stream.once('uploadProgress', (p) => {
+    progress = p;
+});
 
 stream.prependListener('request', (r) => req = r);
 stream.prependListener('response', (r) => res = r);
@@ -142,6 +162,12 @@ stream.prependListener('redirect', (r, o) => {
 stream.prependListener('error', (e, b, r) => {
     err = e;
     res = r;
+});
+stream.prependListener('downloadProgress', (p) => {
+    progress = p;
+});
+stream.prependListener('uploadProgress', (p) => {
+    progress = p;
 });
 
 stream.prependOnceListener('request', (r) => req = r);
@@ -155,6 +181,12 @@ stream.prependOnceListener('error', (e, b, r) => {
     err = e;
     res = r;
 });
+stream.prependOnceListener('downloadProgress', (p) => {
+    progress = p;
+});
+stream.prependOnceListener('uploadProgress', (p) => {
+    progress = p;
+});
 
 stream.removeListener('request', (r) => req = r);
 stream.removeListener('response', (r) => res = r);
@@ -166,6 +198,12 @@ stream.removeListener('redirect', (r, o) => {
 stream.removeListener('error', (e, b, r) => {
     err = e;
     res = r;
+});
+stream.removeListener('downloadProgress', (p) => {
+    progress = p;
+});
+stream.removeListener('uploadProgress', (p) => {
+    progress = p;
 });
 
 got('google.com', {
@@ -190,3 +228,20 @@ got('todomvc.com', {
 
 got('https://httpbin.org/404')
     .catch(err => err instanceof got.HTTPError && err.statusCode === 404);
+
+got('todomvc', {
+    throwHttpErrors: false
+});
+
+got('todomvc', {
+    agent: {
+        http: new http.Agent(),
+        https: new https.Agent()
+    }
+});
+
+got('todomvc', {
+    cache: new Map()
+}).then(res => res.fromCache);
+
+got(new URL('http://todomvc.com'));

--- a/types/got/index.d.ts
+++ b/types/got/index.d.ts
@@ -119,7 +119,7 @@ declare namespace got {
         decompress?: boolean;
         useElectronNet?: boolean;
         cache?: Map<string, any>;
-        agent?: http.Agent | https.Agent | boolean | AgentOptions;
+        agent?: http.Agent | boolean | AgentOptions;
         throwHttpErrors?: boolean;
     }
 

--- a/types/got/index.d.ts
+++ b/types/got/index.d.ts
@@ -7,7 +7,7 @@
 
 /// <reference types="node"/>
 
-import { URL } from 'url';
+import { Url, URL } from 'url';
 import * as http from 'http';
 import * as https from 'https';
 import * as nodeStream from 'stream';
@@ -86,7 +86,7 @@ declare namespace got {
 
     type GotStreamFn = (url: GotUrl, options?: GotOptions<string | null>) => GotEmitter & nodeStream.Duplex;
 
-    type GotUrl = string | http.RequestOptions | URL;
+    type GotUrl = string | http.RequestOptions | Url | URL;
 
     interface GotBodyOptions<E extends string | null> extends GotOptions<E> {
         body?: string | Buffer | nodeStream.Readable;
@@ -149,42 +149,42 @@ declare namespace got {
     interface GotEmitter {
         addListener(event: 'request', listener: (req: http.ClientRequest) => void): this;
         addListener(event: 'response', listener: (res: http.IncomingMessage) => void): this;
-        addListener(event: 'redirect', listener: (res: http.IncomingMessage, nextOptions: GotOptions<string | null> & URL) => void): this;
+        addListener(event: 'redirect', listener: (res: http.IncomingMessage, nextOptions: GotOptions<string | null> & Url) => void): this;
         addListener(event: 'error', listener: (error: GotError, body?: any, res?: http.IncomingMessage) => void): this;
         addListener(event: 'downloadProgress', listener: (progress: Progress) => void): this;
         addListener(event: 'uploadProgress', listener: (progress: Progress) => void): this;
 
         on(event: 'request', listener: (req: http.ClientRequest) => void): this;
         on(event: 'response', listener: (res: http.IncomingMessage) => void): this;
-        on(event: 'redirect', listener: (res: http.IncomingMessage, nextOptions: GotOptions<string | null> & URL) => void): this;
+        on(event: 'redirect', listener: (res: http.IncomingMessage, nextOptions: GotOptions<string | null> & Url) => void): this;
         on(event: 'error', listener: (error: GotError, body?: any, res?: http.IncomingMessage) => void): this;
         on(event: 'downloadProgress', listener: (progress: Progress) => void): this;
         on(event: 'uploadProgress', listener: (progress: Progress) => void): this;
 
         once(event: 'request', listener: (req: http.ClientRequest) => void): this;
         once(event: 'response', listener: (res: http.IncomingMessage) => void): this;
-        once(event: 'redirect', listener: (res: http.IncomingMessage, nextOptions: GotOptions<string | null> & URL) => void): this;
+        once(event: 'redirect', listener: (res: http.IncomingMessage, nextOptions: GotOptions<string | null> & Url) => void): this;
         once(event: 'error', listener: (error: GotError, body?: any, res?: http.IncomingMessage) => void): this;
         once(event: 'downloadProgress', listener: (progress: Progress) => void): this;
         once(event: 'uploadProgress', listener: (progress: Progress) => void): this;
 
         prependListener(event: 'request', listener: (req: http.ClientRequest) => void): this;
         prependListener(event: 'response', listener: (res: http.IncomingMessage) => void): this;
-        prependListener(event: 'redirect', listener: (res: http.IncomingMessage, nextOptions: GotOptions<string | null> & URL) => void): this;
+        prependListener(event: 'redirect', listener: (res: http.IncomingMessage, nextOptions: GotOptions<string | null> & Url) => void): this;
         prependListener(event: 'error', listener: (error: GotError, body?: any, res?: http.IncomingMessage) => void): this;
         prependListener(event: 'downloadProgress', listener: (progress: Progress) => void): this;
         prependListener(event: 'uploadProgress', listener: (progress: Progress) => void): this;
 
         prependOnceListener(event: 'request', listener: (req: http.ClientRequest) => void): this;
         prependOnceListener(event: 'response', listener: (res: http.IncomingMessage) => void): this;
-        prependOnceListener(event: 'redirect', listener: (res: http.IncomingMessage, nextOptions: GotOptions<string | null> & URL) => void): this;
+        prependOnceListener(event: 'redirect', listener: (res: http.IncomingMessage, nextOptions: GotOptions<string | null> & Url) => void): this;
         prependOnceListener(event: 'error', listener: (error: GotError, body?: any, res?: http.IncomingMessage) => void): this;
         prependOnceListener(event: 'downloadProgress', listener: (progress: Progress) => void): this;
         prependOnceListener(event: 'uploadProgress', listener: (progress: Progress) => void): this;
 
         removeListener(event: 'request', listener: (req: http.ClientRequest) => void): this;
         removeListener(event: 'response', listener: (res: http.IncomingMessage) => void): this;
-        removeListener(event: 'redirect', listener: (res: http.IncomingMessage, nextOptions: GotOptions<string | null> & URL) => void): this;
+        removeListener(event: 'redirect', listener: (res: http.IncomingMessage, nextOptions: GotOptions<string | null> & Url) => void): this;
         removeListener(event: 'error', listener: (error: GotError, body?: any, res?: http.IncomingMessage) => void): this;
         removeListener(event: 'downloadProgress', listener: (progress: Progress) => void): this;
         removeListener(event: 'uploadProgress', listener: (progress: Progress) => void): this;

--- a/types/got/index.d.ts
+++ b/types/got/index.d.ts
@@ -74,6 +74,12 @@ declare const got: got.GotFn &
         CancelError: typeof CancelError;
     };
 
+interface InternalRequestOptions extends http.RequestOptions {
+    // Redeclare options with `any` type for allow specify types incompatible with http.RequestOptions.
+    timeout?: any;
+    agent?: any;
+}
+
 declare namespace got {
     interface GotFn {
         (url: GotUrl): GotPromise<string>;
@@ -104,13 +110,7 @@ declare namespace got {
         json?: boolean;
     }
 
-    interface RequestOptions extends http.RequestOptions {
-        // Redeclare options with `any` type for allow specify types incompatible with http.RequestOptions.
-        timeout?: any;
-        agent?: any;
-    }
-
-    interface GotOptions<E extends string | null> extends RequestOptions {
+    interface GotOptions<E extends string | null> extends InternalRequestOptions {
         encoding?: E;
         query?: string | object;
         timeout?: number | TimeoutOptions;

--- a/types/got/index.d.ts
+++ b/types/got/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for got 7.1
+// Type definitions for got 8.3
 // Project: https://github.com/sindresorhus/got#readme
 // Definitions by: BendingBender <https://github.com/BendingBender>
 //                 Linus Unnebäck <https://github.com/LinusU>
@@ -7,8 +7,9 @@
 
 /// <reference types="node"/>
 
-import { Url } from 'url';
+import { URL } from 'url';
 import * as http from 'http';
+import * as https from 'https';
 import * as nodeStream from 'stream';
 
 export = got;
@@ -45,6 +46,10 @@ declare class UnsupportedProtocolError extends StdError {
     name: 'UnsupportedProtocolError';
 }
 
+declare class CancelError extends StdError {
+    name: 'CancelError';
+}
+
 declare class StdError extends Error {
     code?: string;
     host?: string;
@@ -59,13 +64,14 @@ declare class StdError extends Error {
 declare const got: got.GotFn &
     Record<'get' | 'post' | 'put' | 'patch' | 'head' | 'delete', got.GotFn> &
     {
-        stream: got.GotStreamFn & Record<'get' | 'post' | 'put' | 'patch' | 'head' | 'delete', got.GotStreamFn>
-        RequestError: typeof RequestError
-        ReadError: typeof ReadError
-        ParseError: typeof ParseError
-        HTTPError: typeof HTTPError
-        MaxRedirectsError: typeof MaxRedirectsError
-        UnsupportedProtocolError: typeof UnsupportedProtocolError
+        stream: got.GotStreamFn & Record<'get' | 'post' | 'put' | 'patch' | 'head' | 'delete', got.GotStreamFn>;
+        RequestError: typeof RequestError;
+        ReadError: typeof ReadError;
+        ParseError: typeof ParseError;
+        HTTPError: typeof HTTPError;
+        MaxRedirectsError: typeof MaxRedirectsError;
+        UnsupportedProtocolError: typeof UnsupportedProtocolError;
+        CancelError: typeof CancelError;
     };
 
 declare namespace got {
@@ -80,7 +86,7 @@ declare namespace got {
 
     type GotStreamFn = (url: GotUrl, options?: GotOptions<string | null>) => GotEmitter & nodeStream.Duplex;
 
-    type GotUrl = string | http.RequestOptions | Url;
+    type GotUrl = string | http.RequestOptions | URL;
 
     interface GotBodyOptions<E extends string | null> extends GotOptions<E> {
         body?: string | Buffer | nodeStream.Readable;
@@ -98,11 +104,13 @@ declare namespace got {
         json?: boolean;
     }
 
-    interface TimoutRequestOptions extends http.RequestOptions {
+    interface RequestOptions extends http.RequestOptions {
+        // Redeclare options with `any` type for allow specify types incompatible with http.RequestOptions.
         timeout?: any;
+        agent?: any;
     }
 
-    interface GotOptions<E extends string | null> extends TimoutRequestOptions {
+    interface GotOptions<E extends string | null> extends RequestOptions {
         encoding?: E;
         query?: string | object;
         timeout?: number | TimeoutOptions;
@@ -110,6 +118,9 @@ declare namespace got {
         followRedirect?: boolean;
         decompress?: boolean;
         useElectronNet?: boolean;
+        cache?: Map<string, any>;
+        agent?: http.Agent | https.Agent | boolean | AgentOptions;
+        throwHttpErrors?: boolean;
     }
 
     interface TimeoutOptions {
@@ -118,12 +129,18 @@ declare namespace got {
         request?: number;
     }
 
+    interface AgentOptions {
+        http: http.Agent;
+        https: https.Agent;
+    }
+
     type RetryFunction = (retry: number, error: any) => number;
 
     interface Response<B extends Buffer | string | object> extends http.IncomingMessage {
         body: B;
         url: string;
         requestUrl: string;
+        fromCache: boolean;
         redirectUrls?: string[];
     }
 
@@ -132,34 +149,52 @@ declare namespace got {
     interface GotEmitter {
         addListener(event: 'request', listener: (req: http.ClientRequest) => void): this;
         addListener(event: 'response', listener: (res: http.IncomingMessage) => void): this;
-        addListener(event: 'redirect', listener: (res: http.IncomingMessage, nextOptions: GotOptions<string | null> & Url) => void): this;
+        addListener(event: 'redirect', listener: (res: http.IncomingMessage, nextOptions: GotOptions<string | null> & URL) => void): this;
         addListener(event: 'error', listener: (error: GotError, body?: any, res?: http.IncomingMessage) => void): this;
+        addListener(event: 'downloadProgress', listener: (progress: Progress) => void): this;
+        addListener(event: 'uploadProgress', listener: (progress: Progress) => void): this;
 
         on(event: 'request', listener: (req: http.ClientRequest) => void): this;
         on(event: 'response', listener: (res: http.IncomingMessage) => void): this;
-        on(event: 'redirect', listener: (res: http.IncomingMessage, nextOptions: GotOptions<string | null> & Url) => void): this;
+        on(event: 'redirect', listener: (res: http.IncomingMessage, nextOptions: GotOptions<string | null> & URL) => void): this;
         on(event: 'error', listener: (error: GotError, body?: any, res?: http.IncomingMessage) => void): this;
+        on(event: 'downloadProgress', listener: (progress: Progress) => void): this;
+        on(event: 'uploadProgress', listener: (progress: Progress) => void): this;
 
         once(event: 'request', listener: (req: http.ClientRequest) => void): this;
         once(event: 'response', listener: (res: http.IncomingMessage) => void): this;
-        once(event: 'redirect', listener: (res: http.IncomingMessage, nextOptions: GotOptions<string | null> & Url) => void): this;
+        once(event: 'redirect', listener: (res: http.IncomingMessage, nextOptions: GotOptions<string | null> & URL) => void): this;
         once(event: 'error', listener: (error: GotError, body?: any, res?: http.IncomingMessage) => void): this;
+        once(event: 'downloadProgress', listener: (progress: Progress) => void): this;
+        once(event: 'uploadProgress', listener: (progress: Progress) => void): this;
 
         prependListener(event: 'request', listener: (req: http.ClientRequest) => void): this;
         prependListener(event: 'response', listener: (res: http.IncomingMessage) => void): this;
-        prependListener(event: 'redirect', listener: (res: http.IncomingMessage, nextOptions: GotOptions<string | null> & Url) => void): this;
+        prependListener(event: 'redirect', listener: (res: http.IncomingMessage, nextOptions: GotOptions<string | null> & URL) => void): this;
         prependListener(event: 'error', listener: (error: GotError, body?: any, res?: http.IncomingMessage) => void): this;
+        prependListener(event: 'downloadProgress', listener: (progress: Progress) => void): this;
+        prependListener(event: 'uploadProgress', listener: (progress: Progress) => void): this;
 
         prependOnceListener(event: 'request', listener: (req: http.ClientRequest) => void): this;
         prependOnceListener(event: 'response', listener: (res: http.IncomingMessage) => void): this;
-        prependOnceListener(event: 'redirect', listener: (res: http.IncomingMessage, nextOptions: GotOptions<string | null> & Url) => void): this;
+        prependOnceListener(event: 'redirect', listener: (res: http.IncomingMessage, nextOptions: GotOptions<string | null> & URL) => void): this;
         prependOnceListener(event: 'error', listener: (error: GotError, body?: any, res?: http.IncomingMessage) => void): this;
+        prependOnceListener(event: 'downloadProgress', listener: (progress: Progress) => void): this;
+        prependOnceListener(event: 'uploadProgress', listener: (progress: Progress) => void): this;
 
         removeListener(event: 'request', listener: (req: http.ClientRequest) => void): this;
         removeListener(event: 'response', listener: (res: http.IncomingMessage) => void): this;
-        removeListener(event: 'redirect', listener: (res: http.IncomingMessage, nextOptions: GotOptions<string | null> & Url) => void): this;
+        removeListener(event: 'redirect', listener: (res: http.IncomingMessage, nextOptions: GotOptions<string | null> & URL) => void): this;
         removeListener(event: 'error', listener: (error: GotError, body?: any, res?: http.IncomingMessage) => void): this;
+        removeListener(event: 'downloadProgress', listener: (progress: Progress) => void): this;
+        removeListener(event: 'uploadProgress', listener: (progress: Progress) => void): this;
     }
 
-    type GotError = RequestError | ReadError | ParseError | HTTPError | MaxRedirectsError | UnsupportedProtocolError;
+    type GotError = RequestError | ReadError | ParseError | HTTPError | MaxRedirectsError | UnsupportedProtocolError | CancelError;
+
+    interface Progress {
+        percent: number;
+        transferred: number;
+        total: number | null;
+    }
 }

--- a/types/got/index.d.ts
+++ b/types/got/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/sindresorhus/got#readme
 // Definitions by: BendingBender <https://github.com/BendingBender>
 //                 Linus Unnebäck <https://github.com/LinusU>
+//                 Konstantin Ikonnikov <https://github.com/ikokostya>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 


### PR DESCRIPTION
Fixes #23454

**Notable changes**

* Add support for WHATWG URL to `got` function.
* Add `got.CancelError` error type.
* Add `downloadProgress`, `uploadProgress` events.
* Add `cache` option to `GotOptions` and `fromCache` property to `Response` object.
* Add `throwHttpErrors` option to `GotOptions`.
* Add support for agent object to `GotOptions`.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/sindresorhus/got/releases
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.