### PR TITLE
linkify-it: fix typings to reflect the api

### DIFF
--- a/types/linkify-it/index.d.ts
+++ b/types/linkify-it/index.d.ts
@@ -4,47 +4,55 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare const LinkifyIt: {
-  (schemas?: LinkifyIt.SchemaRules, options?: LinkifyIt.Options): LinkifyIt.LinkifyIt;
-  new (schemas?: LinkifyIt.SchemaRules, options?: LinkifyIt.Options): LinkifyIt.LinkifyIt;
+    (
+        schemas?: LinkifyIt.SchemaRules | LinkifyIt.Options,
+        options?: LinkifyIt.Options
+    ): LinkifyIt.LinkifyIt;
+    new (
+        schemas?: LinkifyIt.SchemaRules | LinkifyIt.Options,
+        options?: LinkifyIt.Options
+    ): LinkifyIt.LinkifyIt;
 };
 
 declare namespace LinkifyIt {
-  interface FullRule {
-    validate(text: string, pos: number, self: LinkifyIt): number;
-    normalize?(match: string): string;
-  }
+    type Validate = (text: string, pos: number, self: LinkifyIt) => number;
 
-  type Rule = string | RegExp | FullRule;
+    interface FullRule {
+        validate: string | RegExp | Validate;
+        normalize?(match: string): string;
+    }
 
-  interface SchemaRules {
-    [schema: string]: Rule;
-  }
+    type Rule = string | FullRule;
 
-  interface Options {
-    fuzzyLink?: boolean;
-    fuzzyIP?: boolean;
-    fuzzyEmail?: boolean;
-  }
+    interface SchemaRules {
+        [schema: string]: Rule;
+    }
 
-  interface Match {
-    index: number;
-    lastIndex: number;
-    raw: string;
-    schema: string;
-    text: string;
-    url: string;
-  }
+    interface Options {
+        fuzzyLink?: boolean;
+        fuzzyIP?: boolean;
+        fuzzyEmail?: boolean;
+    }
 
-  interface LinkifyIt {
-    add(schema: string, rule: Rule): LinkifyIt;
-    match(text: string): Match[];
-    normalize(raw: string): string;
-    pretest(text: string): boolean;
-    set(options: Options): LinkifyIt;
-    test(text: string): boolean;
-    testSchemaAt(text: string, schemaName: string, pos: number): number;
-    tlds(list: string | string[], keepOld?: boolean): LinkifyIt;
-  }
+    interface Match {
+        index: number;
+        lastIndex: number;
+        raw: string;
+        schema: string;
+        text: string;
+        url: string;
+    }
+
+    interface LinkifyIt {
+        add(schema: string, rule: Rule): LinkifyIt;
+        match(text: string): Match[];
+        normalize(raw: string): string;
+        pretest(text: string): boolean;
+        set(options: Options): LinkifyIt;
+        test(text: string): boolean;
+        testSchemaAt(text: string, schemaName: string, pos: number): number;
+        tlds(list: string | string[], keepOld?: boolean): LinkifyIt;
+    }
 }
 
 export = LinkifyIt;

--- a/types/linkify-it/linkify-it-tests.ts
+++ b/types/linkify-it/linkify-it-tests.ts
@@ -1,24 +1,48 @@
-import LinkifyIt = require('linkify-it');
+import LinkifyIt = require("linkify-it");
+
+// constructor formats
+const linkifier = new LinkifyIt();
+const withOptions = new LinkifyIt({ fuzzyLink: false });
+const withSchema = new LinkifyIt(
+    {
+        "myCustom:": {
+            validate: /23/
+        },
+        "other:": {
+            validate: (text, pos, self) => 42
+        },
+        "git:": "http:"
+    },
+    {
+        fuzzyIP: false,
+        fuzzyLink: false
+    }
+);
 
 // fluent interface
-const linkifier = new LinkifyIt();
-
 linkifier
-    .add('git:', 'http:')
+    .add("git:", "http:")
     .set({ fuzzyIP: true })
-    .tlds('onion', true)
+    .tlds("onion", true)
     .test("https://github.com/DefinitelyTyped/DefinitelyTyped/");
 
 // match
-const matches = linkifier.match("https://github.com/DefinitelyTyped/DefinitelyTyped/");
-matches.forEach(({index, lastIndex, raw, schema, text, url}) => {});
+const matches = linkifier.match(
+    "https://github.com/DefinitelyTyped/DefinitelyTyped/"
+);
+matches.forEach(({ index, lastIndex, raw, schema, text, url }) => {});
 
 // complex rule
-linkifier.add('@', {
+linkifier.add("@", {
     validate: (text, pos, self) => {
         return 42;
     },
-    normalize: (match) => {
-        return 'forty-two';
+    normalize: match => {
+        return "forty-two";
     }
+});
+
+// regexp rule
+linkifier.add("custom:", {
+    validate: /^\/\/\d+/
 });


### PR DESCRIPTION
* the constructor accepts as first parameter or the SchemaRules or the
Options
* the validate callback can be either a string, RegExp or Validate type
* Rule only accepts a string or a FullRule, where when a string is set,
it applies the same rules as the given schema name
* add more tests to showcase and type test the implementation

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/markdown-it/linkify-it/blob/master/test/test.js
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
