### PR TITLE
[@types/when] Fix when.js then() when TResult is a subtype of T

### DIFF
--- a/types/when/index.d.ts
+++ b/types/when/index.d.ts
@@ -285,6 +285,11 @@ declare namespace When {
         // be a constructor with prototype set to an instance of Error.
         otherwise<U>(exceptionType: any, onRejected?: (reason: any) => U | Promise<U>): Promise<U>;
 
+        then<TResult1, TResult2>(
+            onFulfilled: ((value: T) => TResult1 | Thenable<TResult1>),
+            onRejected: ((reason: any) => TResult2 | Thenable<TResult2>),
+            onProgress?: (update: any) => void
+        ): Promise<TResult1 | TResult2>;
         then<TResult>(
             onFulfilled: ((value: T) => TResult | Thenable<TResult>),
             onRejected?: ((reason: any) => TResult | Thenable<TResult>) | undefined | null,
@@ -295,11 +300,6 @@ declare namespace When {
             onRejected: ((reason: any) => TResult | Thenable<TResult>),
             onProgress?: (update: any) => void
         ): Promise<T | TResult>;
-        then<TResult1, TResult2>(
-            onFulfilled: ((value: T) => TResult1 | Thenable<TResult1>),
-            onRejected: ((reason: any) => TResult2 | Thenable<TResult2>),
-            onProgress?: (update: any) => void
-        ): Promise<TResult1 | TResult2>;
         then(
             onFulfilled?: ((value: T) => T | Thenable<T>) | undefined | null,
             onRejected?: ((reason: any) => T | Thenable<T>) | undefined | null,

--- a/types/when/index.d.ts
+++ b/types/when/index.d.ts
@@ -285,11 +285,6 @@ declare namespace When {
         // be a constructor with prototype set to an instance of Error.
         otherwise<U>(exceptionType: any, onRejected?: (reason: any) => U | Promise<U>): Promise<U>;
 
-        then(
-            onFulfilled?: ((value: T) => T | Thenable<T>) | undefined | null,
-            onRejected?: ((reason: any) => T | Thenable<T>) | undefined | null,
-            onProgress?: (update: any) => void
-        ): Promise<T>;
         then<TResult>(
             onFulfilled: ((value: T) => TResult | Thenable<TResult>),
             onRejected?: ((reason: any) => TResult | Thenable<TResult>) | undefined | null,
@@ -305,6 +300,11 @@ declare namespace When {
             onRejected: ((reason: any) => TResult2 | Thenable<TResult2>),
             onProgress?: (update: any) => void
         ): Promise<TResult1 | TResult2>;
+        then(
+            onFulfilled?: ((value: T) => T | Thenable<T>) | undefined | null,
+            onRejected?: ((reason: any) => T | Thenable<T>) | undefined | null,
+            onProgress?: (update: any) => void
+        ): Promise<T>;
 
         spread<T>(onFulfilled: _.Fn0<Promise<T> | T>): Promise<T>;
         spread<A1, T>(onFulfilled: _.Fn1<A1, Promise<T> | T>): Promise<T>;

--- a/types/when/tsconfig.json
+++ b/types/when/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "compilerOptions": {
         "module": "commonjs",
+        "target": "es5",
         "lib": [
             "es6"
         ],

--- a/types/when/when-tests.ts
+++ b/types/when/when-tests.ts
@@ -14,9 +14,24 @@ class ForeignPromise<T> {
 	then(onFulfilled?: (value: T) => T, onRejected?: (reason: any) => T): ForeignPromise<T> {
 		return new ForeignPromise(onFulfilled ? onFulfilled(this.value) : this.value);
 	}
-};
+}
+
+interface IData {
+	timestamp: number;
+}
+
+class Data implements IData {
+	timestamp: number;
+	date: Date;
+
+	constructor({ timestamp }: IData) {
+		this.timestamp = timestamp;
+		this.date = new Date(timestamp);
+	}
+}
 
 var promise: when.Promise<number>;
+var promise2: when.Promise<Data>;
 var foreign = new ForeignPromise<number>(1);
 var error = new Error("boom!");
 var example: () => void;
@@ -221,6 +236,17 @@ promise = when(1).then((val: number) => when(val + val));
 promise = when(1).then(undefined, (err: any) => 2);
 promise = when(1).then((val: number) => val + val, (err: any) => 2);
 promise = when(1).then((val: number) => when(val + val), (err: any) => 2);
+
+promise = when('1').then((val: string) => parseInt(val));
+
+// Tests for when TResult is a subtype of T
+const subData: IData = { timestamp: Date.now() };
+const errorData: Data = new Data({ timestamp: -1 });
+
+promise2 = when(subData).then((val: IData) => new Data(val));
+promise2 = when(subData).then((val: IData) => when(new Data(val)));
+promise2 = when(subData).then((val: IData) => new Data(val), (err: any) => errorData);
+promise2 = when(subData).then((val: IData) => when(new Data(val)), (err: any) => errorData);
 
 /* promise.spread(onFulfilledArray) */
 


### PR DESCRIPTION
Change the order of .then overrides to deprioritize no generics.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <N/A>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

Caused by not testing https://github.com/DefinitelyTyped/DefinitelyTyped/pull/24904 thoroughly enough :(