### PR TITLE
[atom] Support version v1.26.

### DIFF
--- a/types/atom/atom-tests.ts
+++ b/types/atom/atom-tests.ts
@@ -88,6 +88,10 @@ function testAtomEnvironment() {
                 { label: "Undo", command: "core:undo" },
                 { label: "Redo", command: "core:redo" },
             ],
+            after: ["test"],
+            before: ["test"],
+            afterGroupContaining: ["test"],
+            beforeGroupContaining: ["test"]
         }],
     });
 

--- a/types/atom/autocomplete-plus/index.d.ts
+++ b/types/atom/autocomplete-plus/index.d.ts
@@ -31,15 +31,6 @@ export interface SuggestionInsertedEvent {
 }
 
 /**
- *  COMPATIBILITY STUB. WILL BE REMOVED
- */
-// tslint:disable-next-line:no-empty-interface
-export interface Suggestion<
-  T extends { text: string }|{ snippet: string }
-  > extends SuggestionBase {}
-// TODO: Remove on next minor version
-
-/**
  *  An autocompletion suggestion for the user.
  *  Primary data type for the Atom Autocomplete+ service.
  */

--- a/types/atom/index.d.ts
+++ b/types/atom/index.d.ts
@@ -6167,7 +6167,7 @@ export interface ConfirmationOptions {
     normalizeAccessKeys?: boolean;
 }
 
-export interface ContextMenuOptions {
+export interface ContextMenuItemOptions {
     /** The menu item's label. */
     label?: string;
 
@@ -6186,12 +6186,6 @@ export interface ContextMenuOptions {
     /** An array of additional items. */
     submenu?: ReadonlyArray<ContextMenuOptions>;
 
-    /**
-     *  If you want to create a separator, provide an item with type: 'separator'
-     *  and no other keys.
-     */
-    type?: "separator";
-
     /** Whether the menu item should appear in the menu. Defaults to true. */
     visible?: boolean;
 
@@ -6206,7 +6200,27 @@ export interface ContextMenuOptions {
      *  given context menu deployment.
      */
     shouldDisplay?(event: Event): void;
+
+    /** Place this menu item before the menu items representing the given commands. */
+    before?: ReadonlyArray<string>;
+
+    /** Place this menu item after the menu items representing the given commands. */
+    after?: ReadonlyArray<string>;
+
+    /**
+     * Place this menu item's group before the containing group of the menu items
+     * representing the given commands.
+     */
+    beforeGroupContaining?: ReadonlyArray<string>;
+
+    /**
+     * Place this menu item's group after the containing group of the menu items
+     * representing the given commands.
+     */
+    afterGroupContaining?: ReadonlyArray<string>;
 }
+
+export type ContextMenuOptions = ContextMenuItemOptions | { type: "separator" };
 
 export interface CopyMarkerOptions {
     /** Whether or not the marker should be tailed. */

--- a/types/atom/index.d.ts
+++ b/types/atom/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Atom 1.25
+// Type definitions for Atom 1.26
 // Project: https://github.com/atom/atom
 // Definitions by: GlenCFL <https://github.com/GlenCFL>
 //                 smhxx <https://github.com/smhxx>
@@ -7,7 +7,7 @@
 // TypeScript Version: 2.3
 
 // NOTE: only those classes exported within this file should be retain that status below.
-// https://github.com/atom/atom/blob/v1.25.0/exports/atom.js
+// https://github.com/atom/atom/blob/v1.26.0/exports/atom.js
 
 /// <reference types="node" />
 
@@ -1529,7 +1529,7 @@ export class TextEditor {
 
     /** Set the text in the given Range in buffer coordinates. */
     setTextInBufferRange(range: RangeCompatible, text: string, options?:
-        { normalizeLineEndings?: boolean, undo?: "skip" }): Range;
+        TextEditOptions): Range;
 
     /* For each selection, replace the selected text with the given text. */
     insertText(text: string, options?: TextInsertionOptions): Range|false;
@@ -5145,16 +5145,13 @@ export class TextBuffer {
     setTextViaDiff(text: string): void;
 
     /** Set the text in the given range. */
-    setTextInRange(range: RangeCompatible, text: string, options?:
-        { normalizeLineEndings?: boolean, undo?: "skip" }): Range;
+    setTextInRange(range: RangeCompatible, text: string, options?: TextEditOptions): Range;
 
     /** Insert text at the given position. */
-    insert(position: PointCompatible, text: string, options?:
-        { normalizeLineEndings?: boolean, undo?: "skip" }): Range;
+    insert(position: PointCompatible, text: string, options?: TextEditOptions): Range;
 
     /** Append text to the end of the buffer. */
-    append(text: string, options?: { normalizeLineEndings?: boolean, undo?:
-        "skip" }): Range;
+    append(text: string, options?: TextEditOptions): Range;
 
     /** Delete the text in the given range. */
     delete(range: RangeCompatible): Range;
@@ -5831,7 +5828,7 @@ export interface TextEditorObservedEvent {
 // information under certain contexts.
 
 // NOTE: the config schema with these defaults can be found here:
-//   https://github.com/atom/atom/blob/v1.25.0/src/config-schema.js
+//   https://github.com/atom/atom/blob/v1.26.0/src/config-schema.js
 /**
  *  Allows you to strongly type Atom configuration variables. Additional key:value
  *  pairings merged into this interface will result in configuration values under
@@ -6483,7 +6480,18 @@ export interface SpawnProcessOptions {
     shell?: boolean | string;
 }
 
-export interface TextInsertionOptions {
+export interface TextEditOptions {
+    /** If true, all line endings will be normalized to match the editor's current mode. */
+    normalizeLineEndings?: boolean;
+
+    /**
+     * If skip, skips the undo stack for this operation.
+     * @deprecated Call groupLastChanges() on the TextBuffer afterward instead.
+     */
+    undo?: "skip";
+}
+
+export interface TextInsertionOptions extends TextEditOptions {
     /** If true, selects the newly added text. */
     select?: boolean;
 
@@ -6506,12 +6514,6 @@ export interface TextInsertionOptions {
      *  true, this behavior is suppressed.
      */
     preserveTrailingLineIndentation?: boolean;
-
-    /** If true, all line endings will be normalized to match the editor's current mode. */
-    normalizeLineEndings?: boolean;
-
-    /** If skip, skips the undo stack for this operation. */
-    undo?: "skip";
 }
 
 /** The options for a Bootstrap 3 Tooltip class, which Atom uses a variant of. */


### PR DESCRIPTION
- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: 
[Atom v1.26 Release Page](https://github.com/atom/atom/releases/tag/v1.26.0)
[Atom v1.26 Blog Post](http://blog.atom.io/2018/04/18/atom-1-26.html)
- [X] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

Atom v1.26 has no changes to the API whatsoever. With no changes, we're really just following up on a few things here:
1. Pull request #24967, which kept a type around in order to prevent breakage within a patch version.
2. The deprecation of a property, now that we have clarification from the Atom team [here](https://github.com/atom/atom/pull/17089).