### PR TITLE
Change to use proper ES module code

### DIFF
--- a/types/url-parse/index.d.ts
+++ b/types/url-parse/index.d.ts
@@ -4,7 +4,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
-import URLSearchParams = require("url-search-params");
+import URLSearchParams from "url-search-params";
 
 type UrlQueryParamsParser = (url: string) => string;
 
@@ -49,4 +49,4 @@ interface ExtendedParseFunctionType extends ParseFunctionNodeType, ParseFunction
 
 declare const parse: ExtendedParseFunctionType;
 
-export = parse;
+export default parse;


### PR DESCRIPTION
changed `export = parse` to `export default parse`
changed `import URLSearchParams = require("url-search-params");` to `import URLSearchParams from "url-search-params";`

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
