### PR TITLE
[@types/body-parser] Fix so body-parser works with connect/vanilla node.js apps.

### DIFF
--- a/types/body-parser/body-parser-tests.ts
+++ b/types/body-parser/body-parser-tests.ts
@@ -1,3 +1,4 @@
+import * as http from 'http';
 import express = require('express');
 import {
     json,
@@ -12,6 +13,21 @@ app.use(json());
 app.use(raw());
 app.use(text());
 app.use(urlencoded());
+
+const jsonParser = app.use(json({
+    inflate: true,
+    limit: '100kb',
+    type: 'application/*',
+    verify: (
+        req: http.IncomingMessage,
+        res: http.ServerResponse,
+        buf: Buffer,
+        encoding: string
+    ) => {
+        return true;
+    }
+}));
+app.use(jsonParser);
 
 // send any data, it should be parsed and printed
 app.all('/', (req, res, next) => {

--- a/types/body-parser/index.d.ts
+++ b/types/body-parser/index.d.ts
@@ -1,24 +1,30 @@
-// Type definitions for body-parser 1.16
+// Type definitions for body-parser 1.17
 // Project: https://github.com/expressjs/body-parser
-// Definitions by: Santi Albo <https://github.com/santialbo>, Vilic Vane <https://github.com/vilic>, Jonathan Häberle <https://github.com/dreampulse>, Gevik Babakhani <https://github.com/blendsdk>, Tomasz Łaziuk <https://github.com/tlaziuk>
+// Definitions by: Santi Albo <https://github.com/santialbo>
+//                 Vilic Vane <https://github.com/vilic>
+//                 Jonathan Häberle <https://github.com/dreampulse>
+//                 Gevik Babakhani <https://github.com/blendsdk>
+//                 Tomasz Łaziuk <https://github.com/tlaziuk>
+//                 Jason Walton <https://github.com/jwalton>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
 /// <reference types="node" />
 
-import { Request, RequestHandler, Response } from 'express';
+import { NextHandleFunction } from 'connect';
+import * as http from 'http';
 
 // for docs go to https://github.com/expressjs/body-parser/tree/1.16.0#body-parser
 
 // @deprecated
-declare function bodyParser(options?: bodyParser.OptionsJson & bodyParser.OptionsText & bodyParser.OptionsUrlencoded): RequestHandler;
+declare function bodyParser(options?: bodyParser.OptionsJson & bodyParser.OptionsText & bodyParser.OptionsUrlencoded): NextHandleFunction;
 
 declare namespace bodyParser {
     interface Options {
         inflate?: boolean;
         limit?: number | string;
-        type?: string | string[] | ((req: Request) => any);
-        verify?(req: Request, res: Response, buf: Buffer, encoding: string): void;
+        type?: string | string[] | ((req: http.IncomingMessage) => any);
+        verify?(req: http.IncomingMessage, res: http.ServerResponse, buf: Buffer, encoding: string): void;
     }
 
     interface OptionsJson extends Options {
@@ -35,13 +41,13 @@ declare namespace bodyParser {
         parameterLimit?: number;
     }
 
-    function json(options?: OptionsJson): RequestHandler;
+    function json(options?: OptionsJson): NextHandleFunction;
 
-    function raw(options?: Options): RequestHandler;
+    function raw(options?: Options): NextHandleFunction;
 
-    function text(options?: OptionsText): RequestHandler;
+    function text(options?: OptionsText): NextHandleFunction;
 
-    function urlencoded(options?: OptionsUrlencoded): RequestHandler;
+    function urlencoded(options?: OptionsUrlencoded): NextHandleFunction;
 }
 
 export = bodyParser;


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/expressjs/body-parser/issues/304
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

The existing body-parser definitions are all built on @types/express.  Basically, this means that `bodyParser.json()` returns a `RequestHandler` function which expects an express-style `Request` and an express-style `Response` (which extend `http.IncomingMessage` and `http.ServerResponse` respectively, but adding in all the extra fields and functions that express adds).

But body-parser uses none of the extra functionality added by express, so the middleware functions returned by body-parser are perfectly happy taking a plain old vanilla `http.IncomingMessage` as `req` instead of the fancy express version.

This PR updates the body-parser definitions to use `NextHandleFunction` from @types/connect, which is the same as `RequestHandler` from @types/request, but which uses the plain `http.*` req and res definitions.  This lets us use body-parser with express, but also with connect, and with a vanilla node.js HTTP server.

I also added a test case to populate some options for `json()`.

