### PR TITLE
Update pg Pool connect done callback 

### DIFF
--- a/types/pg/index.d.ts
+++ b/types/pg/index.d.ts
@@ -99,7 +99,7 @@ export class Pool extends events.EventEmitter {
     readonly waitingCount: number;
 
     connect(): Promise<PoolClient>;
-    connect(callback: (err: Error, client: PoolClient, done: () => void) => void): void;
+    connect(callback: (err: Error, client: PoolClient, done: (release?: any) => void) => void): void;
 
     end(): Promise<void>;
     end(callback: () => void): void;


### PR DESCRIPTION
The `done` function takes an optional release (boolean) argument that tells whether the client should be released or put back in the pool. 

- [X] Provide a URL to documentation or source code which provides context for the suggested changes: 
  https://node-postgres.com/api/pool
`
The releaseCallback releases an acquired client back to the pool. If you pass a truthy value in the err position to the callback, instead of releasing the client to the pool, the pool will be instructed to disconnect and destroy this client, leaving a space within itself for a new client.
`

- [X] Increase the version number in the header if appropriate.
  Not needed. Backward compatible change.
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
  No substantial changes.