### PR TITLE
Add merge() method to ObjectLikeSequence<T>

### DIFF
--- a/types/lazy.js/index.d.ts
+++ b/types/lazy.js/index.d.ts
@@ -210,6 +210,7 @@ declare namespace LazyJS {
         get(property: string): ObjectLikeSequence<T>;
         invert(): ObjectLikeSequence<T>;
         keys(): Sequence<string>;
+        merge(others: Object | ObjectLikeSequence<T>, mergeFn?: Function): ObjectLikeSequence<T>;
         omit(properties: string[]): ObjectLikeSequence<T>;
         pairs(): Sequence<T>;
         pick(properties: string[]): ObjectLikeSequence<T>;


### PR DESCRIPTION
Added merge() method to ObjectLikeSequence<T>

- [ x] Provide a URL to documentation or source code which provides context for the suggested changes: http://danieltao.com/lazy.js/docs/#ObjectLikeSequence-merge
