### PR TITLE
Fixing @storybook/addon-info typings

### DIFF
--- a/types/storybook__addon-info/index.d.ts
+++ b/types/storybook__addon-info/index.d.ts
@@ -29,6 +29,6 @@ export interface Options {
   maxPropStringLength?: number;
 }
 
-export function withInfo(textOrOptions: string | Options): (storyFn: RenderFunction) => () => React.ReactElement<WrapStoryProps>;
+export function withInfo(textOrOptions: string | Options): (storyFn: RenderFunction) => (context?: object) => React.ReactElement<WrapStoryProps>;
 
 export function setDefaults(newDefaults: Options): Options;


### PR DESCRIPTION
Updated typings to fix compile error. Typings didn't fit the README provided example.
https://github.com/storybooks/storybook/blob/master/addons/info/README.md 