### PR TITLE
Add namespace to highcharts/highcharts-more.d.ts

### DIFF
--- a/types/highcharts/highcharts-more.d.ts
+++ b/types/highcharts/highcharts-more.d.ts
@@ -7,9 +7,7 @@
 import * as Highcharts from "highcharts";
 
 declare namespace HighChartsMore {
-    interface Static {
-        (H: Highcharts.Static): Highcharts.Static;
-    }
+    type Static = (H: Highcharts.Static) => Highcharts.Static;
 }
 
 declare const HighchartsMore: HighChartsMore.Static;

--- a/types/highcharts/highcharts-more.d.ts
+++ b/types/highcharts/highcharts-more.d.ts
@@ -1,10 +1,17 @@
 // Type definitions for Highcharts 4.2.6
 // Project: http://www.highcharts.com/
 // Definitions by: Maciej Suchecki <https://github.com/mc-suchecki>
+//                 Alasdair Shepherd <https://github.com/DaemonExMachina>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 import * as Highcharts from "highcharts";
 
-declare function HighchartsMore(H: Highcharts.Static): Highcharts.Static;
+declare namespace HighChartsMore {
+    interface Static {
+        (H: Highcharts.Static): Highcharts.Static;
+    }
+}
+
+declare const HighchartsMore: HighChartsMore.Static;
 export = HighchartsMore;
 export as namespace HighchartsMore;


### PR DESCRIPTION
This file was making it impossible to import from the actual
highcharts-more file. As it's not an ES6 native module, we have to
import it with:

    import * as HighchartsMore from 'highcharts/highcharts-more';

This is the same as the Highcharts object itself. However, because the
highcharts-more.d.ts file does not include a namespace declaration
(instead declaring a function and exporting it `as namespace
HighchartsMore`), this import syntax causes a tsc error:

> Error:(4, 45) TS2497: Module '.../highcharts-more' resolves to a
non-module entity and cannot be imported using this construct.

I have updated the file to properly declare and export a namespace in
the same way as other such files.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.