### PR TITLE
[Joi] - add schema option to .when

### DIFF
--- a/types/joi/v10/index.d.ts
+++ b/types/joi/v10/index.d.ts
@@ -8,6 +8,7 @@
 //                 Rytis Alekna <https://github.com/ralekna>
 //                 Pavel Ivanov <https://github.com/schfkt>
 //                 Youngrok Kim <https://github.com/rokoroku>
+//                 Conan Lai <https://github.com/aconanlai>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.4
 
@@ -132,6 +133,17 @@ export interface WhenOptions {
      * the required condition joi type.
      */
     is: SchemaLike;
+    /**
+     * the alternative schema type if the condition is true. Required if otherwise is missing.
+     */
+    then?: SchemaLike;
+    /**
+     * the alternative schema type if the condition is false. Required if then is missing
+     */
+    otherwise?: SchemaLike;
+}
+
+export interface WhenSchemaOptions {
     /**
      * the alternative schema type if the condition is true. Required if otherwise is missing.
      */
@@ -327,6 +339,7 @@ export interface AnySchema extends JoiObject {
      */
     when(ref: string, options: WhenOptions): AlternativesSchema;
     when(ref: Reference, options: WhenOptions): AlternativesSchema;
+    when(ref: Schema, options: WhenSchemaOptions): AlternativesSchema;
 
     /**
      * Overrides the key name in error messages.
@@ -878,6 +891,7 @@ export interface AlternativesSchema extends AnySchema {
     try(...types: SchemaLike[]): this;
     when(ref: string, options: WhenOptions): this;
     when(ref: Reference, options: WhenOptions): this;
+    when(ref: Schema, options: WhenSchemaOptions): this;
 }
 
 export interface LazySchema extends AnySchema {
@@ -1160,6 +1174,7 @@ export function concat<T>(schema: T): T;
  */
 export function when(ref: string, options: WhenOptions): AlternativesSchema;
 export function when(ref: Reference, options: WhenOptions): AlternativesSchema;
+export function when(ref: Schema, options: WhenSchemaOptions): AlternativesSchema;
 
 /**
  * Overrides the key name in error messages.

--- a/types/joi/v10/joi-tests.ts
+++ b/types/joi/v10/joi-tests.ts
@@ -122,6 +122,14 @@ whenOpts = { is: schemaLike, then: schemaLike, otherwise: schemaLike };
 
 // --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- ---
 
+var whenSchemaOpts: Joi.WhenSchemaOptions = null;
+
+whenSchemaOpts = { then: schema };
+whenSchemaOpts = { otherwise: schema };
+whenSchemaOpts = { then: schemaLike, otherwise: schemaLike };
+
+// --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- ---
+
 var refOpts: Joi.ReferenceOptions = null;
 
 refOpts = { separator: str };
@@ -263,6 +271,7 @@ namespace common {
 
     altSchema = anySchema.when(str, whenOpts);
     altSchema = anySchema.when(ref, whenOpts);
+    altSchema = anySchema.when(schema, whenSchemaOpts);
 
     anySchema = anySchema.label(str);
     anySchema = anySchema.raw();
@@ -350,6 +359,7 @@ namespace common_copy_paste {
 
     altSchema = arrSchema.when(str, whenOpts);
     altSchema = arrSchema.when(ref, whenOpts);
+    altSchema = arrSchema.when(schema, whenSchemaOpts);
 }
 
 // --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- ---
@@ -420,6 +430,7 @@ namespace common_copy_paste {
 
     altSchema = boolSchema.when(str, whenOpts);
     altSchema = boolSchema.when(ref, whenOpts);
+    altSchema = boolSchema.when(schema, whenSchemaOpts);
 }
 
 // --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- ---
@@ -476,6 +487,7 @@ namespace common {
 
     altSchema = binSchema.when(str, whenOpts);
     altSchema = binSchema.when(ref, whenOpts);
+    altSchema = binSchema.when(schema, whenSchemaOpts);
 }
 
 // --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- ---
@@ -548,6 +560,7 @@ namespace common {
 
     altSchema = dateSchema.when(str, whenOpts);
     altSchema = dateSchema.when(ref, whenOpts);
+    altSchema = dateSchema.when(schema, whenSchemaOpts);
 }
 
 // --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- ---
@@ -622,6 +635,7 @@ namespace common {
 
     altSchema = numSchema.when(str, whenOpts);
     altSchema = numSchema.when(ref, whenOpts);
+    altSchema = numSchema.when(schema, whenSchemaOpts);
 }
 
 // --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- ---
@@ -732,6 +746,7 @@ namespace common {
 
     altSchema = objSchema.when(str, whenOpts);
     altSchema = objSchema.when(ref, whenOpts);
+    altSchema = objSchema.when(schema, whenSchemaOpts);
 }
 
 // --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- ---
@@ -823,6 +838,7 @@ namespace common {
 
     altSchema = strSchema.when(str, whenOpts);
     altSchema = strSchema.when(ref, whenOpts);
+    altSchema = strSchema.when(schema, whenSchemaOpts);
 }
 
 // --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- ---
@@ -1007,6 +1023,7 @@ schema = Joi.concat(x);
 
 schema = Joi.when(str, whenOpts);
 schema = Joi.when(ref, whenOpts);
+schema = Joi.when(schema, whenSchemaOpts);
 
 schema = Joi.label(str);
 schema = Joi.raw();


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/hapijs/joi/blob/v13.2.0/API.md#anywhencondition-options>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

## Explanation:
`.when` can take a `schema` as it's first argument, which also affects the second option object. this mode of using `.when` is not reflected in the current types