### PR TITLE
[next-redux-wrapper]: Change reference to React.Component to [react-redux.]Component

### DIFF
--- a/types/next-redux-wrapper/index.d.ts
+++ b/types/next-redux-wrapper/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for next-redux-wrapper 1.3.5
+// Type definitions for next-redux-wrapper 1.4
 // Project: https://github.com/kirill-konshin/next-redux-wrapper
 // Definitions by: Steve <https://github.com/stevegeek>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/next-redux-wrapper/index.d.ts
+++ b/types/next-redux-wrapper/index.d.ts
@@ -25,20 +25,20 @@ export = nextReduxWrapper;
 
 declare function nextReduxWrapper<TInitialState = any, TStateProps = any, TDispatchProps = any, TOwnProps = any, TMergedProps = any>(
     options: nextReduxWrapper.Options<TInitialState, TStateProps, TDispatchProps, TOwnProps, TMergedProps>
-): (Component: Component<TOwnProps & TMergedProps>) => nextReduxWrapper.NextReduxWrappedComponent;
+): (Component: Component<TOwnProps & TMergedProps>) => nextReduxWrapper.NextReduxWrappedComponent<TOwnProps & TMergedProps>;
 declare function nextReduxWrapper<TInitialState = any, TStateProps = any, TDispatchProps = any, TOwnProps = any, TMergedProps = any>(
     createStore: nextReduxWrapper.NextStoreCreator<TInitialState, TStateProps, TDispatchProps, TOwnProps, TMergedProps>,
     mapStateToProps?: MapStateToPropsParam<TStateProps, TOwnProps, any>,
     mapDispatchToProps?: MapDispatchToPropsParam<TDispatchProps, TOwnProps>,
     mergeProps?: MergeProps<TStateProps, TDispatchProps, TOwnProps, TMergedProps>,
     options?: ConnectOptions
-): (Component: Component<TOwnProps & TMergedProps>) => nextReduxWrapper.NextReduxWrappedComponent;
+): (Component: Component<TOwnProps & TMergedProps>) => nextReduxWrapper.NextReduxWrappedComponent<TOwnProps & TMergedProps>;
 
 declare namespace nextReduxWrapper {
     interface NextPageComponentMethods {
         getInitialProps(props: any): Promise<any>;
     }
-    type NextReduxWrappedComponent = React.Component & NextPageComponentMethods;
+    type NextReduxWrappedComponent<P> = Component<P> & NextPageComponentMethods;
 
     type NextStoreCreator<TInitialState, TStateProps, TDispatchProps, TOwnProps, TMergedProps> = (
         initialState: TInitialState,

--- a/types/next-redux-wrapper/index.d.ts
+++ b/types/next-redux-wrapper/index.d.ts
@@ -25,14 +25,14 @@ export = nextReduxWrapper;
 
 declare function nextReduxWrapper<TInitialState = any, TStateProps = any, TDispatchProps = any, TOwnProps = any, TMergedProps = any>(
     options: nextReduxWrapper.Options<TInitialState, TStateProps, TDispatchProps, TOwnProps, TMergedProps>
-): (Component: Component<TOwnProps & TMergedProps>) => nextReduxWrapper.NextReduxWrappedComponent<TOwnProps & TMergedProps>;
+): (Component: Component<TOwnProps & TMergedProps>) => nextReduxWrapper.NextReduxWrappedComponent<TOwnProps>;
 declare function nextReduxWrapper<TInitialState = any, TStateProps = any, TDispatchProps = any, TOwnProps = any, TMergedProps = any>(
     createStore: nextReduxWrapper.NextStoreCreator<TInitialState, TStateProps, TDispatchProps, TOwnProps, TMergedProps>,
     mapStateToProps?: MapStateToPropsParam<TStateProps, TOwnProps, any>,
     mapDispatchToProps?: MapDispatchToPropsParam<TDispatchProps, TOwnProps>,
     mergeProps?: MergeProps<TStateProps, TDispatchProps, TOwnProps, TMergedProps>,
     options?: ConnectOptions
-): (Component: Component<TOwnProps & TMergedProps>) => nextReduxWrapper.NextReduxWrappedComponent<TOwnProps & TMergedProps>;
+): (Component: Component<TOwnProps & TMergedProps>) => nextReduxWrapper.NextReduxWrappedComponent<TOwnProps>;
 
 declare namespace nextReduxWrapper {
     interface NextPageComponentMethods {

--- a/types/next-redux-wrapper/index.d.ts
+++ b/types/next-redux-wrapper/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for next-redux-wrapper 1.3
+// Type definitions for next-redux-wrapper 1.3.5
 // Project: https://github.com/kirill-konshin/next-redux-wrapper
 // Definitions by: Steve <https://github.com/stevegeek>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/next-redux-wrapper/next-redux-wrapper-tests.tsx
+++ b/types/next-redux-wrapper/next-redux-wrapper-tests.tsx
@@ -20,6 +20,10 @@ const makeStore = (initialState: InitialState): Store<InitialState> => {
     return createStore(reducer, initialState);
 };
 
+interface OwnProps {
+    bar: string;
+}
+
 interface Props {
     foo: string;
     custom: string;
@@ -29,7 +33,7 @@ interface ReduxStore {
     foo: string;
 }
 
-class Page extends React.Component<Props> {
+class Page extends React.Component<OwnProps & Props> {
     static getInitialProps({store, isServer, pathname, query}: any) {
         store.dispatch({type: 'FOO', payload: 'foo'});
         return {custom: 'custom'};
@@ -46,29 +50,28 @@ class Page extends React.Component<Props> {
 
 type ConnectStateProps = Props;
 type DispatchProps = Props;
-type OwnProps = Props;
 type MergedProps = Props;
 
 // Test various typings
-const com1 = withRedux(makeStore, (state: ReduxStore) => ({foo: state.foo}))(Page);
+const Com1 = withRedux(makeStore, (state: ReduxStore) => ({foo: state.foo}))(Page);
 
-const com2 = withRedux(makeStore, (state: ReduxStore) => ({foo: state.foo}))(Page);
+const Com2 = withRedux(makeStore, (state: ReduxStore) => ({foo: state.foo}))(Page);
 
-const com3 = withRedux<InitialState>(makeStore, (state: ReduxStore) => ({foo: state.foo}))(Page);
+const Com3 = withRedux<InitialState>(makeStore, (state: ReduxStore) => ({foo: state.foo}))(Page);
 
-const com4 = withRedux<InitialState, ConnectStateProps>(
+const Com4 = withRedux<InitialState, ConnectStateProps>(
     makeStore,
     (state: ReduxStore) => ({foo: state.foo, custom: 'hi'})
 )(Page);
 
-const com5 = withRedux<InitialState, ConnectStateProps, DispatchProps, OwnProps, MergedProps>(
+const Com5 = withRedux<InitialState, ConnectStateProps, DispatchProps, OwnProps, MergedProps>(
     makeStore,
     (state: ReduxStore) => ({foo: state.foo, custom: 'hi'}),
     undefined,
     (state: Props) => ({foo: state.foo, custom: 'hi'})
 )(Page);
 
-const com6 = withRedux<InitialState, ConnectStateProps, DispatchProps, OwnProps, MergedProps>(
+const Com6 = withRedux<InitialState, ConnectStateProps, DispatchProps, OwnProps, MergedProps>(
     (initialState: InitialState, options: StoreCreatorOptions<InitialState, ConnectStateProps, DispatchProps, OwnProps, MergedProps>) => {
         if (options.isServer || options.req || options.query || options.res) {
             const a = 1;
@@ -80,10 +83,18 @@ const com6 = withRedux<InitialState, ConnectStateProps, DispatchProps, OwnProps,
     (state: Props) => ({foo: state.foo, custom: 'hi'})
 )(Page);
 
-const com7 = withRedux({
+const Com7 = withRedux({
     createStore: makeStore,
     mapStateToProps: (state: ReduxStore) => ({foo: state.foo})
 })(Page);
+
+const com1Instance = (<Com1 />);
+const com2Instance = (<Com2 />);
+const com3Instance = (<Com3 />);
+const com4Instance = (<Com4 />);
+const com5Instance = (<Com5 bar="foo" />);
+const com6Instance = (<Com6 bar="foo" />);
+const com7Instance = (<Com7 />);
 
 withRedux.setPromise(Promise);
 withRedux.setDebug(true);


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)  
  ~~Ran `npm test`, but did not add or edit tests. It seems to me that if this solution is right, and tests were robust enough, they should currently be failing… but they aren't.~~  
  Extended/adjusted tests. Definitely want another pair of eyes on that.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:  
  - Issue is outlined in #24293
  - Example repo is at https://github.com/bensaufley/example-next-redux-wrapper-problem
- [x] Increase the version number in the header if appropriate.  
  _~~I bumped it to match the current release of the `next-redux-wrapper` package, 1.3.5.~~ Bumped to 1.4 because patch version is frowned upon. I think it's appropriate to bump the version number because references to `NextReduxWrappedComponent` might break without the associated type, but I'm not sure exactly how much to bump._
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.  
  I don't consider these _substantial_ changes

# Notes

These changes appear to fix the problem as seen in the example repo, and while I'm still relatively new to TypeScript, I think I understand why—it's not just a shot in the dark:

`React.Component` is an _instance_ of a `Component` but `React.ComponentType`, which is aliased in `react-redux` to `Component` (referenced elsewhere in these definitions) is a class or stateless component function. In adjusting that reference, I also passed along the Props types from the `nextReduxWrapper` HOC to the returned React Component Type so that the props passed in the JSX can be understood by TypeScript.