### PR TITLE
parse-git-config: add `promise` method in version 2.0

### DIFF
--- a/types/parse-git-config/index.d.ts
+++ b/types/parse-git-config/index.d.ts
@@ -1,6 +1,7 @@
-// Type definitions for parse-git-config 1.1
+// Type definitions for parse-git-config 2.0
 // Project: https://github.com/jonschlinkert/parse-git-config
 // Definitions by: Leonard Thieu <https://github.com/leonard-thieu>
+//                 Nikita Litvin <https://github.com/deltaidea>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
@@ -18,6 +19,18 @@ interface Parse {
      * If only the callback is passed, the .git/config file relative to process.cwd() is used.
      */
     (cb: ParseCallback): void;
+    /**
+     * Asynchronously parse a .git/config file. Returns a promise.
+     * Resolves with `null` if unable to resolve path to the git config file.
+     * If no arguments are passed, the .git/config file relative to process.cwd() is used.
+     */
+    (options?: (Options | object) | string): Promise<Config | null>;
+    /**
+     * Asynchronously parse a .git/config file. Returns a promise.
+     * Resolves with `null` if unable to resolve path to the git config file.
+     * If no arguments are passed, the .git/config file relative to process.cwd() is used.
+     */
+    promise(options?: (Options | object) | string): Promise<Config | null>;
     /**
      * Synchronously parse a .git/config file.
      * If no arguments are passed, the .git/config file relative to process.cwd() is used.

--- a/types/parse-git-config/parse-git-config-tests.ts
+++ b/types/parse-git-config/parse-git-config-tests.ts
@@ -39,6 +39,39 @@ function test_parse() {
     });
 }
 
+async function test_promise_options() {
+    let config = await parse({ cwd: 'foo', path: '.git/config' });
+    config = await parse.promise({ cwd: 'foo', path: '.git/config' });
+    if (!config) return null;
+
+    const origin = config['remote "origin"'];
+    if (origin && origin.url) {
+        origin.url.split('/');
+    }
+}
+
+async function test_promise_cwd() {
+    let config = await parse('foo');
+    config = await parse.promise('foo');
+    if (!config) return null;
+
+    const origin = config['remote "origin"'];
+    if (origin && origin.url) {
+        origin.url.split('/');
+    }
+}
+
+async function test_promise() {
+    let config = await parse();
+    config = await parse.promise();
+    if (!config) return null;
+
+    const origin = config['remote "origin"'];
+    if (origin && origin.url) {
+        origin.url.split('/');
+    }
+}
+
 function test_sync_options() {
     const config = parse.sync({ cwd: 'foo', path: '.git/config' });
 


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [`parse-git-config/index.js:64`](https://github.com/jonschlinkert/parse-git-config/blob/a2a1ba179a115478f44938638e5d37ea33ae6632/index.js#L64)
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
