### PR TITLE
[react] Remove createContext overload

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -261,7 +261,6 @@ declare namespace React {
         defaultValue: T,
         calculateChangedBits?: (prev: T, next: T) => number
     ): Context<T>;
-    function createContext<T>(): Context<T | undefined>;
 
     function isValidElement<P>(object: {} | null | undefined): object is ReactElement<P>;
 


### PR DESCRIPTION
It should not be a valid case for createContext to take no arguments.

This is a followup to #24509 and commentary after the merge about the intended usage of createContext.

See that PR, specifically this comment and its immediate predecessors, for further context: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/24509#issuecomment-382459861

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/24509#issuecomment-382459861
- [X] Increase the version number in the header if appropriate.
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.