### PR TITLE
fix(aws-lambda): make CloudFrontHeaders values optional

### DIFF
--- a/types/aws-lambda/index.d.ts
+++ b/types/aws-lambda/index.d.ts
@@ -501,7 +501,7 @@ export interface CloudFrontHeaders {
     [name: string]: Array<{
         key: string;
         value: string;
-    }>;
+    }> | undefined;
 }
 
 export interface CloudFrontResponse {


### PR DESCRIPTION
Please fill in this template.

- [ ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

It's impossible for every header to be supplied in a request. This PR expresses that in the `CloudFrontHeaders` interface.
