### PR TITLE
Expo: Added missing props to Svg

### DIFF
--- a/types/expo/index.d.ts
+++ b/types/expo/index.d.ts
@@ -1985,7 +1985,7 @@ export interface SvgStopProps extends SvgCommonProps {
     stopOpacity?: string;
 }
 
-export class Svg extends Component<{ width: number, height: number, viewBox?: string}> {
+export class Svg extends Component<{ width: number, height: number, viewBox?: string }> {
     static Circle: ComponentClass<SvgCircleProps>;
     static ClipPath: ComponentClass<SvgCommonProps>;
     static Defs: ComponentClass;

--- a/types/expo/index.d.ts
+++ b/types/expo/index.d.ts
@@ -1874,6 +1874,7 @@ export interface SvgCommonProps {
     fill?: string;
     fillOpacity?: number | string;
     fillRule?: 'nonzero' | 'evenodd';
+    opacity?: number | string;
     stroke?: string;
     strokeWidth?: number | string;
     strokeOpacity?: number | string;
@@ -1984,7 +1985,7 @@ export interface SvgStopProps extends SvgCommonProps {
     stopOpacity?: string;
 }
 
-export class Svg extends Component<{ width: number, height: number }> {
+export class Svg extends Component<{ width: number, height: number, viewBox?: string}> {
     static Circle: ComponentClass<SvgCircleProps>;
     static ClipPath: ComponentClass<SvgCommonProps>;
     static Defs: ComponentClass;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
[Viewbox change](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/viewBox)
[Opacity change](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/opacity) - this one makes me wonder if opacity working for the "Path" element actually goes against the SVG spec (opacity affects both fill-opacity and stroke-opacity at the same time) as it doesn't list shapes as things that it works on 🤔 it definitely does work though 
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
