### PR TITLE
chai: Add Date comparison overloads

### DIFF
--- a/types/chai/chai-tests.ts
+++ b/types/chai/chai-tests.ts
@@ -191,6 +191,18 @@ function within() {
     expect(10).to.be.within(50, 100, 'blah');
     (10).should.be.within(50, 100, 'blah');
 
+    expect(new Date('December 17, 1995 03:24:30')).to.not.be.within(new Date('December 17, 1995 03:24:20'), new Date('December 17, 1995 03:24:40'));
+    new Date('December 17, 1995 03:24:30').should.not.be.within(new Date('December 17, 1995 03:24:20'), new Date('December 17, 1995 03:24:40'));
+
+    expect(new Date('December 17, 1995 03:24:30')).to.be.within(new Date('December 17, 1995 03:24:20'), new Date('December 17, 1995 03:24:40'));
+    new Date('December 17, 1995 03:24:30').should.be.within(new Date('December 17, 1995 03:24:20'), new Date('December 17, 1995 03:24:40'));
+
+    expect(new Date('December 17, 1995 03:24:30')).to.not.be.within(new Date('December 17, 1995 03:24:20'), new Date('December 17, 1995 03:24:40'), 'blah');
+    new Date('December 17, 1995 03:24:30').should.not.be.within(new Date('December 17, 1995 03:24:20'), new Date('December 17, 1995 03:24:40'), 'blah');
+
+    expect(new Date('December 17, 1995 03:24:30')).to.be.within(new Date('December 17, 1995 03:24:20'), new Date('December 17, 1995 03:24:40'), 'blah');
+    new Date('December 17, 1995 03:24:30').should.be.within(new Date('December 17, 1995 03:24:20'), new Date('December 17, 1995 03:24:40'), 'blah');
+
     expect('foo').to.have.length.within(5, 7, 'blah');
     'foo'.should.have.length.within(5, 7, 'blah');
 
@@ -218,6 +230,18 @@ function above() {
     expect(10).to.not.be.above(6, 'blah');
     (10).should.not.be.above(6, 'blah');
 
+    expect(new Date('December 17, 1995 03:24:30')).to.not.be.above(new Date('December 17, 1995 03:24:20'));
+    new Date('December 17, 1995 03:24:30').should.not.be.above(new Date('December 17, 1995 03:24:20'));
+
+    expect(new Date('December 17, 1995 03:24:30')).to.be.above(new Date('December 17, 1995 03:24:20'));
+    new Date('December 17, 1995 03:24:30').should.be.above(new Date('December 17, 1995 03:24:20'));
+
+    expect(new Date('December 17, 1995 03:24:30')).to.not.be.above(new Date('December 17, 1995 03:24:20'), 'blah');
+    new Date('December 17, 1995 03:24:30').should.not.be.above(new Date('December 17, 1995 03:24:20'), 'blah');
+
+    expect(new Date('December 17, 1995 03:24:30')).to.be.above(new Date('December 17, 1995 03:24:20'), 'blah');
+    new Date('December 17, 1995 03:24:30').should.be.above(new Date('December 17, 1995 03:24:20'), 'blah');
+
     expect('foo').to.have.length.above(4, 'blah');
     'foo'.should.have.length.above(4, 'blah');
 
@@ -242,6 +266,18 @@ function least() {
 
     expect(10).to.not.be.at.least(6, 'blah');
     (10).should.not.be.at.least(6, 'blah');
+
+    expect(new Date('December 17, 1995 03:24:30')).to.not.be.least(new Date('December 17, 1995 03:24:20'));
+    new Date('December 17, 1995 03:24:30').should.not.be.least(new Date('December 17, 1995 03:24:20'));
+
+    expect(new Date('December 17, 1995 03:24:30')).to.be.least(new Date('December 17, 1995 03:24:20'));
+    new Date('December 17, 1995 03:24:30').should.be.least(new Date('December 17, 1995 03:24:20'));
+
+    expect(new Date('December 17, 1995 03:24:30')).to.not.be.least(new Date('December 17, 1995 03:24:20'), 'blah');
+    new Date('December 17, 1995 03:24:30').should.not.be.least(new Date('December 17, 1995 03:24:20'), 'blah');
+
+    expect(new Date('December 17, 1995 03:24:30')).to.be.least(new Date('December 17, 1995 03:24:20'), 'blah');
+    new Date('December 17, 1995 03:24:30').should.be.least(new Date('December 17, 1995 03:24:20'), 'blah');
 
     expect('foo').to.have.length.of.at.least(4, 'blah');
     'foo'.should.have.length.of.at.least(4, 'blah');
@@ -273,6 +309,18 @@ function below() {
     expect(6).to.not.be.below(10, 'blah');
     (6).should.not.be.below(10, 'blah');
 
+    expect(new Date('December 17, 1995 03:24:30')).to.not.be.below(new Date('December 17, 1995 03:24:20'));
+    new Date('December 17, 1995 03:24:30').should.not.be.below(new Date('December 17, 1995 03:24:20'));
+
+    expect(new Date('December 17, 1995 03:24:30')).to.be.below(new Date('December 17, 1995 03:24:20'));
+    new Date('December 17, 1995 03:24:30').should.be.below(new Date('December 17, 1995 03:24:20'));
+
+    expect(new Date('December 17, 1995 03:24:30')).to.not.be.below(new Date('December 17, 1995 03:24:20'), 'blah');
+    new Date('December 17, 1995 03:24:30').should.not.be.below(new Date('December 17, 1995 03:24:20'), 'blah');
+
+    expect(new Date('December 17, 1995 03:24:30')).to.be.below(new Date('December 17, 1995 03:24:20'), 'blah');
+    new Date('December 17, 1995 03:24:30').should.be.below(new Date('December 17, 1995 03:24:20'), 'blah');
+
     expect('foo').to.have.length.below(2, 'blah');
     'foo'.should.have.length.below(2, 'blah');
 
@@ -299,6 +347,18 @@ function most() {
 
     expect(6).to.not.be.at.most(10, 'blah');
     (6).should.not.be.at.most(10, 'blah');
+
+    expect(new Date('December 17, 1995 03:24:30')).to.not.be.most(new Date('December 17, 1995 03:24:20'));
+    new Date('December 17, 1995 03:24:30').should.not.be.most(new Date('December 17, 1995 03:24:20'));
+
+    expect(new Date('December 17, 1995 03:24:30')).to.be.most(new Date('December 17, 1995 03:24:20'));
+    new Date('December 17, 1995 03:24:30').should.be.most(new Date('December 17, 1995 03:24:20'));
+
+    expect(new Date('December 17, 1995 03:24:30')).to.not.be.most(new Date('December 17, 1995 03:24:20'), 'blah');
+    new Date('December 17, 1995 03:24:30').should.not.be.most(new Date('December 17, 1995 03:24:20'), 'blah');
+
+    expect(new Date('December 17, 1995 03:24:30')).to.be.most(new Date('December 17, 1995 03:24:20'), 'blah');
+    new Date('December 17, 1995 03:24:30').should.be.most(new Date('December 17, 1995 03:24:20'), 'blah');
 
     expect('foo').to.have.length.of.at.most(2, 'blah');
     'foo'.should.have.length.of.at.most(2, 'blah');

--- a/types/chai/index.d.ts
+++ b/types/chai/index.d.ts
@@ -9,6 +9,7 @@
 //                 Shaun Luttin <https://github.com/shaunluttin>
 //                 Gintautas Miselis <https://github.com/Naktibalda>
 //                 Satana Charuwichitratana <https://github.com/micksatana>
+//                 Erik Schierboom <https://github.com/ErikSchierboom>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare namespace Chai {
@@ -150,10 +151,11 @@ declare namespace Chai {
         most: NumberComparer;
         lte: NumberComparer;
         within(start: number, finish: number, message?: string): Assertion;
+        within(start: Date, finish: Date, message?: string): Assertion;
     }
 
     interface NumberComparer {
-        (value: number, message?: string): Assertion;
+        (value: number | Date, message?: string): Assertion;
     }
 
     interface TypeComparison {


### PR DESCRIPTION
This PR adds overloads to Chai that can take a `Date`. Basically, all the assertions that validate numbers can also take a `Date`. Note that the [documentation](http://www.chaijs.com/api/bdd/#withinstart-finish-msg) also notes that these methods can take a number of a Date. One can also verify this behavior by running this JSFiddle: https://jsfiddle.net/ErikSchierboom/aec8mco7/17/