### PR TITLE
http-proxy: Provide argument option as already parsed url

### DIFF
--- a/types/http-proxy/http-proxy-tests.ts
+++ b/types/http-proxy/http-proxy-tests.ts
@@ -24,3 +24,11 @@ proxy.on("start", (req, res, target) => {
 http.createServer((req, res) => {
   proxy.web(req, res);
 });
+
+const newProxy = HttpProxy.createProxyServer({
+    target: {
+        host: 'localhost',
+        port: '9015'
+    },
+    ws: true
+});

--- a/types/http-proxy/index.d.ts
+++ b/types/http-proxy/index.d.ts
@@ -1,6 +1,8 @@
 // Type definitions for node-http-proxy 1.16
 // Project: https://github.com/nodejitsu/node-http-proxy
-// Definitions by: Maxime LUCE <https://github.com/SomaticIT>, Florian Oellerich <https://github.com/Raigen>
+// Definitions by: Maxime LUCE <https://github.com/SomaticIT>
+//                 Florian Oellerich <https://github.com/Raigen>
+//                 Daniel Schmidt <https://github.com/DanielMSchmidt>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />
@@ -166,9 +168,9 @@ declare namespace Server {
     /** Buffer */
     buffer?: stream.Stream;
     /** URL string to be parsed with the url module. */
-    target?: string;
+    target?: ProxyTargetUrl;
     /** URL string to be parsed with the url module. */
-    forward?: string;
+    forward?: ProxyTargetUrl;
     /** Object to be passed to http(s).request. */
     agent?: any;
     /** Object to be passed to https.createServer(). */


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).



If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/nodejitsu/node-http-proxy/blob/master/lib/http-proxy/index.js#L64 in the source code and https://github.com/nodejitsu/node-http-proxy/#proxying-websockets in the docs
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
