### PR TITLE
Fix `gulp-mustache` types

### DIFF
--- a/types/gulp-mustache/gulp-mustache-tests.ts
+++ b/types/gulp-mustache/gulp-mustache-tests.ts
@@ -4,6 +4,34 @@ import { Transform } from "stream";
 mustache({ // $ExpectType Transform
     msg: "Hello Gulp!"
 });
+mustache({
+  name: "Chris",
+  value: 10000,
+  taxed_value: 10000 - (10000 * 0.4),
+  in_ca: true
+});
+mustache({
+  repo: [
+    { name: "resque" },
+    { name: "hub" },
+    { name: "rip" }
+  ]
+});
+mustache({
+  name: "Willy",
+  wrapped: () => {
+    return (text: string, render: (arg: string) => string) => {
+      return "<b>" + render(text) + "</b>"
+    }
+  }
+});
+mustache({
+  "person?": { "name": "Jon" }
+});
+mustache({
+  "repo": []
+});
+
 
 mustache({ // $ExpectType Transform
     msg: "Hello Gulp!",

--- a/types/gulp-mustache/gulp-mustache-tests.ts
+++ b/types/gulp-mustache/gulp-mustache-tests.ts
@@ -21,17 +21,16 @@ mustache({
   name: "Willy",
   wrapped: () => {
     return (text: string, render: (arg: string) => string) => {
-      return "<b>" + render(text) + "</b>"
-    }
+      return `<b>${render(text)}</b>`;
+    };
   }
 });
 mustache({
-  "person?": { "name": "Jon" }
+  "person?": { name: "Jon" }
 });
 mustache({
-  "repo": []
+  repo: []
 });
-
 
 mustache({ // $ExpectType Transform
     msg: "Hello Gulp!",

--- a/types/gulp-mustache/index.d.ts
+++ b/types/gulp-mustache/index.d.ts
@@ -11,7 +11,7 @@ declare namespace GulpMustache {
     type View = Hash | string | undefined;
 
     interface Hash {
-        [key: string]: string;
+        [key: string]: any;
     }
 
     interface Options {


### PR DESCRIPTION
Hello. I've fixed wrong types.

`mustache` can render template with any parameters types but it had been limited in previous d.ts.
http://mustache.github.io/mustache.5.html

Thank you.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://mustache.github.io/mustache.5.html
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
