### PR TITLE
[next] Update SingletonRouter interface with RouterProps for next@5

### DIFF
--- a/types/next/index.d.ts
+++ b/types/next/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/zeit/next.js
 // Definitions by: Drew Hays <https://github.com/dru89>
 //                 Brice BERNARD <https://github.com/brikou>
+//                 Scott Jones <https://github.com/scottdj92>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.6
 

--- a/types/next/router.d.ts
+++ b/types/next/router.d.ts
@@ -10,9 +10,6 @@ export interface EventChangeOptions {
 
 export type RouterCallback = () => void;
 export interface RouterProps {
-    readyCallbacks: RouterCallback[];
-    ready(cb: RouterCallback): void;
-
     // router properties
     readonly components: {
         [key: string]: { Component: React.ComponentType<any>; err: any };
@@ -55,6 +52,8 @@ export interface RouterProps {
 
 export interface SingletonRouter {
     router: RouterProps;
+    readyCallbacks: RouterCallback[];
+    ready(cb: RouterCallback): void;
 }
 
 export function withRouter<T extends {}>(

--- a/types/next/router.d.ts
+++ b/types/next/router.d.ts
@@ -9,7 +9,7 @@ export interface EventChangeOptions {
 }
 
 export type RouterCallback = () => void;
-export interface SingletonRouter {
+export interface RouterProps {
     readyCallbacks: RouterCallback[];
     ready(cb: RouterCallback): void;
 
@@ -53,8 +53,12 @@ export interface SingletonRouter {
     onRouteChangeError?(error: any, url: string): void;
 }
 
+export interface SingletonRouter {
+    router: RouterProps;
+}
+
 export function withRouter<T extends {}>(
-    Component: React.ComponentType<T & { router: SingletonRouter }>,
+    Component: React.ComponentType<T & SingletonRouter>,
 ): React.ComponentType<T>;
 
 export const Singleton: SingletonRouter;

--- a/types/next/router.d.ts
+++ b/types/next/router.d.ts
@@ -61,4 +61,5 @@ export function withRouter<T extends {}>(
 ): React.ComponentType<T>;
 
 export const Singleton: SingletonRouter;
+export type ImperativeRouter = RouterProps;
 export default Singleton;

--- a/types/next/test/next-router-tests.tsx
+++ b/types/next/test/next-router-tests.tsx
@@ -2,10 +2,10 @@ import Router, * as r from "next/router";
 import * as React from "react";
 import * as qs from "querystring";
 
-Router.router.readyCallbacks.push(() => {
+Router.readyCallbacks.push(() => {
     console.log("I'll get called when the router initializes.");
 });
-Router.router.ready(() => {
+Router.ready(() => {
     console.log(
         "I'll get called immediately if the router initializes, or when it eventually does.",
     );

--- a/types/next/test/next-router-tests.tsx
+++ b/types/next/test/next-router-tests.tsx
@@ -2,10 +2,10 @@ import Router, * as r from "next/router";
 import * as React from "react";
 import * as qs from "querystring";
 
-Router.readyCallbacks.push(() => {
+Router.router.readyCallbacks.push(() => {
     console.log("I'll get called when the router initializes.");
 });
-Router.ready(() => {
+Router.router.ready(() => {
     console.log(
         "I'll get called immediately if the router initializes, or when it eventually does.",
     );
@@ -13,8 +13,8 @@ Router.ready(() => {
 
 // Access readonly properties of the router.
 
-Object.keys(Router.components).forEach(key => {
-    const c = Router.components[key];
+Object.keys(Router.router.components).forEach(key => {
+    const c = Router.router.components[key];
     c.err.isAnAny;
 
     return <c.Component />;
@@ -26,51 +26,51 @@ function split(routeLike: string) {
     });
 }
 
-if (Router.asPath) {
-    split(Router.asPath);
-    split(Router.asPath);
+if (Router.router.asPath) {
+    split(Router.router.asPath);
+    split(Router.router.asPath);
 }
 
-split(Router.pathname);
+split(Router.router.pathname);
 
-const query = `?${qs.stringify(Router.query)}`;
+const query = `?${qs.stringify(Router.router.query)}`;
 
 // Assign some callback methods.
-Router.onAppUpdated = (nextRoute: string) => console.log(nextRoute);
-Router.onRouteChangeStart = (url: string) =>
+Router.router.onAppUpdated = (nextRoute: string) => console.log(nextRoute);
+Router.router.onRouteChangeStart = (url: string) =>
     console.log("Route is starting to change.", url);
-Router.onBeforeHistoryChange = (as: string) =>
+Router.router.onBeforeHistoryChange = (as: string) =>
     console.log("History hasn't changed yet.", as);
-Router.onRouteChangeComplete = (url: string) =>
+Router.router.onRouteChangeComplete = (url: string) =>
     console.log("Route chaneg is complete.", url);
-Router.onRouteChangeError = (err: any, url: string) =>
+Router.router.onRouteChangeError = (err: any, url: string) =>
     console.log("Route is starting to change.", url, err);
 
 // Call methods on the router itself.
-Router.reload("/route").then(() => console.log("route was reloaded"));
-Router.back();
+Router.router.reload("/route").then(() => console.log("route was reloaded"));
+Router.router.back();
 
-Router.push("/route").then((success: boolean) =>
+Router.router.push("/route").then((success: boolean) =>
     console.log("route push success: ", success),
 );
-Router.push("/route", "/asRoute").then((success: boolean) =>
+Router.router.push("/route", "/asRoute").then((success: boolean) =>
     console.log("route push success: ", success),
 );
-Router.push("/route", "/asRoute", { shallow: false }).then((success: boolean) =>
+Router.router.push("/route", "/asRoute", { shallow: false }).then((success: boolean) =>
     console.log("route push success: ", success),
 );
 
-Router.replace("/route").then((success: boolean) =>
+Router.router.replace("/route").then((success: boolean) =>
     console.log("route replace success: ", success),
 );
-Router.replace("/route", "/asRoute").then((success: boolean) =>
+Router.router.replace("/route", "/asRoute").then((success: boolean) =>
     console.log("route replace success: ", success),
 );
-Router.replace("/route", "/asRoute", {
+Router.router.replace("/route", "/asRoute", {
     shallow: false,
 }).then((success: boolean) => console.log("route replace success: ", success));
 
-Router.prefetch("/route").then(Component => {
+Router.router.prefetch("/route").then(Component => {
     const element = <Component />;
 });
 


### PR DESCRIPTION
* add name to index.ts
* update tests

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/zeit/next.js/blob/canary/lib/router/index.js>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.


Updating because Nextjs's router doesn't directly own it's own props, but has its own instance of Router. Importing this package would mean that an interface would need to be created to type `router: SingletonRouter` rather than have SingletonRouter contain an instance of `router`.
