### PR TITLE
[ember-data] Allow augmenting DS namespace

### DIFF
--- a/types/ember-data/index.d.ts
+++ b/types/ember-data/index.d.ts
@@ -43,7 +43,7 @@ declare module 'ember-data' {
         isRelationship: true;
     }
 
-    namespace DS {
+    export namespace DS {
         /**
          * Convert an hash of errors into an array with errors in JSON-API format.
          */


### PR DESCRIPTION
This change allows users to augment the DS namespace in their own app, like:
```ts
declare module 'ember-data' {
  namespace DS {
    // type augmentations...
  }
}
```
Currently, that's not possible because of how the DS namespace is defined (see Microsoft/TypeScript#11034). Adding `DS` as a non-default export allows users to update types locally without waiting for upstream releases, which is a much friendlier dev experience.

----

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] ~~Add or edit tests to reflect the change. (Run with `npm test`.)~~
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
https://github.com/Microsoft/TypeScript/issues/11034
- [ ] ~~Increase the version number in the header if appropriate.~~
- [ ] ~~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.~~
