### PR TITLE
[react-is] Initial package typings

### DIFF
--- a/types/react-is/index.d.ts
+++ b/types/react-is/index.d.ts
@@ -6,7 +6,7 @@
 
 export as namespace ReactIs;
 
-import { ComponentClass, ReactElement, ReactType, SFC } from 'react';
+import { ReactElement, ReactType } from 'react';
 
 export function typeOf(value: any): symbol | undefined;
 export function isValidElementType(value: any): value is ReactType;

--- a/types/react-is/index.d.ts
+++ b/types/react-is/index.d.ts
@@ -6,10 +6,10 @@
 
 export as namespace ReactIs;
 
-import { ComponentClass, ReactElement, SFC } from 'react';
+import { ComponentClass, ReactElement, ReactType, SFC } from 'react';
 
 export function typeOf(value: any): symbol | undefined;
-export function isValidElementType(value: any): value is string | ComponentClass<any> | SFC<any>;
+export function isValidElementType(value: any): value is ReactType;
 
 export function isContextConsumer(value: any): value is ReactElement<any>;
 export function isContextProvider(value: any): value is ReactElement<any>;

--- a/types/react-is/index.d.ts
+++ b/types/react-is/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://reactjs.org/
 // Definitions by: Avi Vahl <https://github.com/AviVahl>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.6
 
 export as namespace ReactIs;
 

--- a/types/react-is/index.d.ts
+++ b/types/react-is/index.d.ts
@@ -1,0 +1,25 @@
+// Type definitions for react-is 16.3
+// Project: https://reactjs.org/
+// Definitions by: Avi Vahl <https://github.com/AviVahl>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export as namespace ReactIs;
+
+import { ComponentClass, ReactElement, SFC } from 'react';
+
+export function typeOf(value: any): symbol | undefined;
+export function isValidElementType<P = {}>(value: any): value is string | ComponentClass<P> | SFC<P>;
+
+export function isContextConsumer<P = {}>(value: any): value is ReactElement<P>;
+export function isContextProvider<P = {}>(value: any): value is ReactElement<P>;
+export function isElement<P = {}>(value: any): value is ReactElement<P>;
+export function isFragment<P = {}>(value: any): value is ReactElement<P>;
+export function isPortal<P = {}>(value: any): value is ReactElement<P>;
+export function isStrictMode<P = {}>(value: any): value is ReactElement<P>;
+
+export const ContextProvider: symbol;
+export const ContextConsumer: symbol;
+export const Element: symbol;
+export const Fragment: symbol;
+export const Portal: symbol;
+export const StrictMode: symbol;

--- a/types/react-is/index.d.ts
+++ b/types/react-is/index.d.ts
@@ -9,14 +9,14 @@ export as namespace ReactIs;
 import { ComponentClass, ReactElement, SFC } from 'react';
 
 export function typeOf(value: any): symbol | undefined;
-export function isValidElementType<P = {}>(value: any): value is string | ComponentClass<P> | SFC<P>;
+export function isValidElementType(value: any): value is string | ComponentClass<any> | SFC<any>;
 
-export function isContextConsumer<P = {}>(value: any): value is ReactElement<P>;
-export function isContextProvider<P = {}>(value: any): value is ReactElement<P>;
-export function isElement<P = {}>(value: any): value is ReactElement<P>;
-export function isFragment<P = {}>(value: any): value is ReactElement<P>;
-export function isPortal<P = {}>(value: any): value is ReactElement<P>;
-export function isStrictMode<P = {}>(value: any): value is ReactElement<P>;
+export function isContextConsumer(value: any): value is ReactElement<any>;
+export function isContextProvider(value: any): value is ReactElement<any>;
+export function isElement(value: any): value is ReactElement<any>;
+export function isFragment(value: any): value is ReactElement<any>;
+export function isPortal(value: any): value is ReactElement<any>;
+export function isStrictMode(value: any): value is ReactElement<any>;
 
 export const ContextProvider: symbol;
 export const ContextConsumer: symbol;

--- a/types/react-is/react-is-tests.tsx
+++ b/types/react-is/react-is-tests.tsx
@@ -1,0 +1,74 @@
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+import * as ReactIs from 'react-is';
+
+// Below is taken from README of react-is
+// Determining if a Component is Valid
+
+interface CompProps {
+    forwardedRef?: React.Ref<any>;
+    children?: React.ReactNode;
+}
+
+class ClassComponent extends React.Component<CompProps> {
+  render() {
+    return React.createElement('div');
+  }
+}
+
+const StatelessComponent = () => React.createElement('div');
+
+const ForwardRefComponent = React.forwardRef((props, ref) =>
+  React.createElement(ClassComponent, { forwardedRef: ref, ...props })
+);
+
+const Context = React.createContext(false);
+
+ReactIs.isValidElementType('div'); // true
+ReactIs.isValidElementType(ClassComponent); // true
+ReactIs.isValidElementType(StatelessComponent); // true
+ReactIs.isValidElementType(ForwardRefComponent); // true
+ReactIs.isValidElementType(Context.Provider); // true
+ReactIs.isValidElementType(Context.Consumer); // true
+ReactIs.isValidElementType(React.createFactory('div')); // true
+
+// Determining an Element's Type
+
+// AsyncMode - unstable_AsyncMode is not implemented in @types/react yet
+// ReactIs.isAsyncMode(<React.unstable_AsyncMode />); // true
+// ReactIs.typeOf(<React.unstable_AsyncMode />) === ReactIs.AsyncMode; // true
+
+// Context
+const ThemeContext = React.createContext('blue');
+
+ReactIs.isContextConsumer(<ThemeContext.Consumer children={StatelessComponent} />); // true
+ReactIs.isContextProvider(<ThemeContext.Provider children={StatelessComponent} value='black' />); // true
+ReactIs.typeOf(<ThemeContext.Consumer children={StatelessComponent} />) === ReactIs.ContextConsumer; // true
+ReactIs.typeOf(<ThemeContext.Provider children={StatelessComponent} value='black' />) === ReactIs.ContextProvider; // true
+
+// Element
+ReactIs.isElement(<div />); // true
+ReactIs.typeOf(<div />) === ReactIs.Element; // true
+
+// Fragment
+ReactIs.isFragment(<></>); // true
+ReactIs.typeOf(<></>) === ReactIs.Fragment; // true
+
+// Portal
+const div = document.createElement('div');
+const portal = ReactDOM.createPortal(<div />, div);
+
+ReactIs.isPortal(portal); // true
+ReactIs.typeOf(portal) === ReactIs.Portal; // true
+
+// StrictMode
+ReactIs.isStrictMode(<React.StrictMode />); // true
+ReactIs.typeOf(<React.StrictMode />) === ReactIs.StrictMode; // true
+
+// Verify typeOf accepts any type of value (taken from tests of react-is)
+ReactIs.typeOf('abc') === undefined;
+ReactIs.typeOf(true) === undefined;
+ReactIs.typeOf(123) === undefined;
+ReactIs.typeOf({}) === undefined;
+ReactIs.typeOf(null) === undefined;
+ReactIs.typeOf(undefined) === undefined;

--- a/types/react-is/tsconfig.json
+++ b/types/react-is/tsconfig.json
@@ -15,6 +15,7 @@
         "types": [],
         "noEmit": true,
         "forceConsistentCasingInFileNames": true,
+        "strictFunctionTypes": false,
         "jsx": "preserve"
     },
     "files": [

--- a/types/react-is/tsconfig.json
+++ b/types/react-is/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "jsx": "preserve"
+    },
+    "files": [
+        "index.d.ts",
+        "react-is-tests.tsx"
+    ]
+}

--- a/types/react-is/tslint.json
+++ b/types/react-is/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
React introduced the react-is for assertions on elements and element types:
https://github.com/facebook/react/tree/master/packages/react-is

I took the README and tests, and created the matching ts types.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
