### PR TITLE
[cors] Add delegate function and change owner

### DIFF
--- a/types/cors/cors-tests.ts
+++ b/types/cors/cors-tests.ts
@@ -47,4 +47,11 @@ app.use(cors({
         }
     }
 }));
+app.use(cors((req, cb) => {
+    if (req.query.trusted) {
+        cb(null, {origin: 'http://example.com', credentials: true});
+    } else {
+        cb(new Error('Not trusted'));
+    }
+}))
 

--- a/types/cors/index.d.ts
+++ b/types/cors/index.d.ts
@@ -1,11 +1,9 @@
 // Type definitions for cors 2.8
 // Project: https://github.com/troygoode/node-cors/
-// Definitions by: Mihhail Lapushkin <https://github.com/mihhail-lapushkin/>
+// Definitions by: Mihhail Lapushkin <https://github.com/mihhail-lapushkin>
+//                 Alan Plum <https://github.com/pluma>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
-
-
-
 
 import express = require('express');
 
@@ -25,7 +23,13 @@ declare namespace e {
         preflightContinue?: boolean;
         optionsSuccessStatus?: number;
     }
+    type CorsOptionsDelegate = (
+        req: express.Request,
+        callback: (err: Error | null, options?: CorsOptions) => void
+    ) => void;
 }
 
-declare function e(options?: e.CorsOptions): express.RequestHandler;
+declare function e(
+    options?: e.CorsOptions | e.CorsOptionsDelegate
+): express.RequestHandler;
 export = e;

--- a/types/cors/index.d.ts
+++ b/types/cors/index.d.ts
@@ -1,7 +1,6 @@
 // Type definitions for cors 2.8
 // Project: https://github.com/troygoode/node-cors/
-// Definitions by: Mihhail Lapushkin <https://github.com/mihhail-lapushkin>
-//                 Alan Plum <https://github.com/pluma>
+// Definitions by: Alan Plum <https://github.com/pluma>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/expressjs/cors#configuring-cors-asynchronously
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

---

This seems to be an unintentional omission. The delegate has been supported as early as v1.0 and the typings claim to be compatible with v2.8 which still supports this.

Basically instead of providing the config synchronously, one can provide a delegate function which takes a request object and a callback and passes the configuration on a per request basis. This is probably a rare use case but certainly supported by the library.