### PR TITLE
[puppeteer] Add `Request.failure`

### DIFF
--- a/types/puppeteer/index.d.ts
+++ b/types/puppeteer/index.d.ts
@@ -628,6 +628,11 @@ export interface Request {
   continue(overrides?: Overrides): Promise<void>;
 
   /**
+   * @returns An object if the request failed, null otherwise.
+   */
+  failure(): { errorText: string; } | null;
+
+  /**
    * @returns The `Frame` object that initiated the request, or `null` if navigating to error pages
    */
   frame(): Promise<Frame | null>;

--- a/types/puppeteer/puppeteer-tests.ts
+++ b/types/puppeteer/puppeteer-tests.ts
@@ -282,6 +282,24 @@ puppeteer.launch().then(async browser => {
   browser.close();
 })();
 
+// Test 0.13 features
+(async () => {
+  const browser = await puppeteer.launch();
+  const page = await browser.newPage();
+  const handler = (r: puppeteer.Request) => {
+    const failure = r.failure();
+
+    if (failure == null) {
+      console.error("Request completed successfully");
+      return;
+    }
+
+    console.log("Request failed", failure.errorText.toUpperCase());
+  };
+  page.on('requestfinished', handler);
+  page.on('requestfailed', handler);
+})();
+
 // Test 1.0 features
 (async () => {
   const browser = await puppeteer.launch({


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#requestfailure
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

This is a bit of a weird one to write up. The method returns either `null` or an object with an `errorText` key. I wasn’t sure whether to create a new interface just for this; I decided to be conservative. The documentation is terse; I simply wrote an `@returns`, since I figured the type signature goes into more detail in any case. I also added a new section in the tests for 0.13 features but it only includes this one since I haven’t looked into the others.

Do let me know if any of those things need to be improved. I’d appreciate any guidance.