### PR TITLE
dat.gui: Add default export. Add some JSDocs. Remove spurious addColor() overloads.

### DIFF
--- a/types/dat.gui/index.d.ts
+++ b/types/dat.gui/index.d.ts
@@ -117,12 +117,3 @@ export class GUIController {
     listen(): GUIController;
     remove(): GUIController;
 }
-
-declare var index: {
-    gui: {
-        GUI: typeof GUI
-    },
-    GUI: typeof GUI
-};
-
-export default index;

--- a/types/dat.gui/index.d.ts
+++ b/types/dat.gui/index.d.ts
@@ -118,11 +118,11 @@ export class GUIController {
     remove(): GUIController;
 }
 
-declare var _defaultExport: {
+declare var index: {
     gui: {
         GUI: typeof GUI
     },
     GUI: typeof GUI
 };
 
-export default _defaultExport;
+export default index;

--- a/types/dat.gui/index.d.ts
+++ b/types/dat.gui/index.d.ts
@@ -1,9 +1,48 @@
-// Type definitions for dat.GUI 0.6
+// Type definitions for dat.GUI 0.7
 // Project: https://github.com/dataarts/dat.gui
 // Definitions by: Satoru Kimura <https://github.com/gyohk>, ZongJing Lu <https://github.com/sonic3d>, Richard Roylance <https://github.com/rroylance>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 export as namespace dat;
+
+export interface GUIParams {
+    /**
+     * Handles GUI's element placement for you.
+     * @default true
+     */
+    autoPlace?: boolean;
+    /**
+     * If true, starts closed.
+     * @default false
+     */
+    closed?: boolean;
+    /**
+     * If true, close/open button shows on top of the GUI.
+     * @default false
+     */
+    closeOnTop?: boolean;
+    /**
+     * If true, GUI is closed by the "h" keypress.
+     * @default false
+     */
+    hideable?: boolean;
+    /**
+     * JSON object representing the saved state of this GUI.
+     */
+    load?: any;
+    /**
+     * The name of this GUI.
+     */
+    name?: string;
+    /**
+     * The identifier for a set of saved values.
+     */
+    preset?: string;
+    /**
+     * The width of GUI element.
+     */
+    width?: number;
+}
 
 export class GUI {
     constructor(option?: GUIParams);
@@ -20,9 +59,6 @@ export class GUI {
     add(target: Object, propName:string, items:Object): GUIController;
 
     addColor(target: Object, propName:string): GUIController;
-    addColor(target: Object, propName:string, color: string): GUIController;
-    addColor(target: Object, propName:string, rgba: number[]): GUIController; // rgb or rgba
-    addColor(target: Object, propName:string, hsv:{h:number; s:number; v:number}): GUIController;
 
     remove(controller: GUIController): void;
     destroy(): void;
@@ -55,16 +91,6 @@ export class GUI {
     useLocalStorage: boolean;
 }
 
-export interface GUIParams{
-    autoPlace?: boolean;
-    closed?: boolean;
-    closeOnTop?: boolean;
-    load?: any;
-    name?: string;
-    preset?: string;
-    width?: number;
-}
-
 export class GUIController {
     destroy(): void;
 
@@ -91,3 +117,12 @@ export class GUIController {
     listen(): GUIController;
     remove(): GUIController;
 }
+
+declare var _defaultExport: {
+    gui: {
+        GUI: typeof GUI
+    },
+    GUI: typeof GUI
+};
+
+export default _defaultExport;


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - Docs for removal of missing addColor overload: https://github.com/dataarts/dat.gui/blob/master/API.md#GUI+addColor
  - Proof that implementation uses only `export default`: https://github.com/dataarts/dat.gui/blob/master/src/dat/index.js#L31
  - Docs for added JSDoc comments: https://github.com/dataarts/dat.gui/blob/master/API.md#new_GUI_new
- [x] Increase the version number in the header if appropriate. **Bumped to 0.7**
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
