### PR TITLE
Remove depricated @types/firebase from @types/angularfire dependings

### DIFF
--- a/types/angularfire/package.json
+++ b/types/angularfire/package.json
@@ -1,3 +1,3 @@
 {
-    "private": true,
+    "private": true
 }

--- a/types/angularfire/package.json
+++ b/types/angularfire/package.json
@@ -1,3 +1,6 @@
 {
-    "private": true
+    "private": true,
+    "dependencies": {
+        "firebase": "^3.9.0"
+    }
 }

--- a/types/angularfire/package.json
+++ b/types/angularfire/package.json
@@ -1,6 +1,3 @@
 {
     "private": true,
-    "dependencies": {
-        "@types/firebase": "^2.4.1"
-    }
 }


### PR DESCRIPTION
Error:
```
node_modules/@types/firebase/index.d.ts(326,11): error TS2300: Duplicate identifier 'Firebase'.
node_modules/firebase/firebase.d.ts(361,12): error TS2300: Duplicate identifier 'Firebase'.
```
"@types/firebase" is depricated, as firebase already have the type-definitions.

So "@types/angularfire" shouldn't have "@types/firebase" as dependensies