### PR TITLE
Use namespace with 'export =' to model self-referential chaining API in 'temp'

### DIFF
--- a/types/temp/index.d.ts
+++ b/types/temp/index.d.ts
@@ -8,41 +8,41 @@
 import * as fs from "fs";
 
 declare namespace temp {
-  export interface OpenFile {
+  interface OpenFile {
     path: string;
     fd: number;
   }
 
-  export interface Stats {
+  interface Stats {
     files: number;
     dirs: number;
   }
 
-  export interface AffixOptions {
+  interface AffixOptions {
     prefix?: string;
     suffix?: string;
     dir?: string;
   }
 
-  export let dir: string;
+  let dir: string;
 
-  export function track(value?: boolean): typeof temp;
+  function track(value?: boolean): typeof temp;
 
-  export function mkdir(affixes?: string | AffixOptions, callback?: (err: any, dirPath: string) => void): void;
+  function mkdir(affixes?: string | AffixOptions, callback?: (err: any, dirPath: string) => void): void;
 
-  export function mkdirSync(affixes?: string | AffixOptions): string;
+  function mkdirSync(affixes?: string | AffixOptions): string;
 
-  export function open(affixes?: string | AffixOptions, callback?: (err: any, result: OpenFile) => void): void;
+  function open(affixes?: string | AffixOptions, callback?: (err: any, result: OpenFile) => void): void;
 
-  export function openSync(affixes?: string | AffixOptions): OpenFile;
+  function openSync(affixes?: string | AffixOptions): OpenFile;
 
-  export function path(affixes?: string | AffixOptions, defaultPrefix?: string): string;
+  function path(affixes?: string | AffixOptions, defaultPrefix?: string): string;
 
-  export function cleanup(callback?: (result: boolean | Stats) => void): void;
+  function cleanup(callback?: (result: boolean | Stats) => void): void;
 
-  export function cleanupSync(): boolean | Stats;
+  function cleanupSync(): boolean | Stats;
 
-  export function createWriteStream(affixes?: string | AffixOptions): fs.WriteStream;
+  function createWriteStream(affixes?: string | AffixOptions): fs.WriteStream;
 }
 
 export = temp;

--- a/types/temp/index.d.ts
+++ b/types/temp/index.d.ts
@@ -5,41 +5,44 @@
 
 /// <reference types="node" />
 
-import * as temp from ".";
 import * as fs from "fs";
 
-export interface OpenFile {
-  path: string;
-  fd: number;
+declare namespace temp {
+  export interface OpenFile {
+    path: string;
+    fd: number;
+  }
+
+  export interface Stats {
+    files: number;
+    dirs: number;
+  }
+
+  export interface AffixOptions {
+    prefix?: string;
+    suffix?: string;
+    dir?: string;
+  }
+
+  export let dir: string;
+
+  export function track(value?: boolean): typeof temp;
+
+  export function mkdir(affixes?: string | AffixOptions, callback?: (err: any, dirPath: string) => void): void;
+
+  export function mkdirSync(affixes?: string | AffixOptions): string;
+
+  export function open(affixes?: string | AffixOptions, callback?: (err: any, result: OpenFile) => void): void;
+
+  export function openSync(affixes?: string | AffixOptions): OpenFile;
+
+  export function path(affixes?: string | AffixOptions, defaultPrefix?: string): string;
+
+  export function cleanup(callback?: (result: boolean | Stats) => void): void;
+
+  export function cleanupSync(): boolean | Stats;
+
+  export function createWriteStream(affixes?: string | AffixOptions): fs.WriteStream;
 }
 
-export interface Stats {
-  files: number;
-  dirs: number;
-}
-
-export interface AffixOptions {
-  prefix?: string;
-  suffix?: string;
-  dir?: string;
-}
-
-export let dir: string;
-
-export function track(value?: boolean): typeof temp;
-
-export function mkdir(affixes?: string | AffixOptions, callback?: (err: any, dirPath: string) => void): void;
-
-export function mkdirSync(affixes?: string | AffixOptions): string;
-
-export function open(affixes?: string | AffixOptions, callback?: (err: any, result: OpenFile) => void): void;
-
-export function openSync(affixes?: string | AffixOptions): OpenFile;
-
-export function path(affixes?: string | AffixOptions, defaultPrefix?: string): string;
-
-export function cleanup(callback?: (result: boolean | Stats) => void): void;
-
-export function cleanupSync(): boolean | Stats;
-
-export function createWriteStream(affixes?: string | AffixOptions): fs.WriteStream;
+export = temp;

--- a/types/temp/tslint.json
+++ b/types/temp/tslint.json
@@ -1,5 +1,6 @@
 {
     "extends": "dtslint/dt.json",
     "rules": {
+        "export-just-namespace": false
     }
 }


### PR DESCRIPTION
Just to avoid the whole self-import issues discussed in #20190.

@rogierschouten @rogerta

Fixes #24872.