### PR TITLE
meteor: strong typings for mongo collections selectors and modifiers

### DIFF
--- a/types/angular-meteor/index.d.ts
+++ b/types/angular-meteor/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/Urigo/angular-meteor
 // Definitions by: Peter Grman <https://github.com/pgrm>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 /// <reference types="meteor" />
 
@@ -101,7 +101,7 @@ declare module 'angular' {
              * @param [autoClientSave=true] - By default, changes in the Angular object will automatically update the Meteor object.
              *                              - However if set to false, changes in the client won't be automatically propagated back to the Meteor object.
              */
-            object<T>(collection: Mongo.Collection<T>, selector: Mongo.Selector|Mongo.ObjectID|string, autoClientSave?: boolean): AngularMeteorObject<T>;
+            object<T>(collection: Mongo.Collection<T>, selector: Mongo.Selector<T>|Mongo.ObjectID|string, autoClientSave?: boolean): AngularMeteorObject<T>;
 
             /**
              * A service which is a wrapper for Meteor.subscribe. It subscribes to a Meteor.publish method in the client and returns a AngularJS promise when ready.

--- a/types/meteor-jboulhous-dev/index.d.ts
+++ b/types/meteor-jboulhous-dev/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/jboulhous/dev
 // Definitions by: Robbie Van Gorkom <https://github.com/vangorra>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.8
 
 /// <reference types="meteor" />
 

--- a/types/meteor-persistent-session/index.d.ts
+++ b/types/meteor-persistent-session/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/okgrow/meteor-persistent-session
 // Definitions by: Robbie Van Gorkom <https://github.com/vangorra>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.8
 
 /// <reference types="meteor" />
 

--- a/types/meteor-prime8consulting-oauth2/index.d.ts
+++ b/types/meteor-prime8consulting-oauth2/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/prime-8-consulting/meteor-oauth2/
 // Definitions by: Robbie Van Gorkom <https://github.com/vangorra>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.8
 
 /// <reference types="meteor" />
 

--- a/types/meteor-publish-composite/index.d.ts
+++ b/types/meteor-publish-composite/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/englue/meteor-publish-composite
 // Definitions by: Robert Van Gorkom <https://github.com/vangorra>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.8
 
 /// <reference types="meteor" />
 

--- a/types/meteor-roles/index.d.ts
+++ b/types/meteor-roles/index.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: Robbie Van Gorkom <https://github.com/vangorra>
 //                 Matthew Zartman <https://github.com/mattmm3d>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.8
 
 /// <reference types="meteor" />
 

--- a/types/meteor/index.d.ts
+++ b/types/meteor/index.d.ts
@@ -2,6 +2,7 @@
 // Project: http://www.meteor.com/
 // Definitions by: Alex Borodach <https://github.com/barbatus>, Dave Allen <https://github.com/fullflavedave>, Olivier Refalo <https://github.com/orefalo>, Daniel Neveux <https://github.com/dagatsoin>, Birk Skyum <https://github.com/birkskyum>, Arda TANRIKULU <https://github.com/ardatan>, Stefan Holzapfel <https://github.com/stefanholzapfel>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.8
 
 /// <reference path="./accounts.d.ts" />
 /// <reference path="./blaze.d.ts" />

--- a/types/meteor/index.d.ts
+++ b/types/meteor/index.d.ts
@@ -1,6 +1,13 @@
 // Type definitions for Meteor 1.4
 // Project: http://www.meteor.com/
-// Definitions by: Alex Borodach <https://github.com/barbatus>, Dave Allen <https://github.com/fullflavedave>, Olivier Refalo <https://github.com/orefalo>, Daniel Neveux <https://github.com/dagatsoin>, Birk Skyum <https://github.com/birkskyum>, Arda TANRIKULU <https://github.com/ardatan>, Stefan Holzapfel <https://github.com/stefanholzapfel>
+// Definitions by: Alex Borodach <https://github.com/barbatus>
+//                 Dave Allen <https://github.com/fullflavedave>
+//                 Olivier Refalo <https://github.com/orefalo>
+//                 Daniel Neveux <https://github.com/dagatsoin>
+//                 Birk Skyum <https://github.com/birkskyum>
+//                 Arda TANRIKULU <https://github.com/ardatan>
+//                 Stefan Holzapfel <https://github.com/stefanholzapfel>
+//                 Andrey Markeev <https://github.com/andrei-markeev>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 

--- a/types/meteor/meteor-tests.ts
+++ b/types/meteor/meteor-tests.ts
@@ -390,8 +390,21 @@ Comments.find({ inlineLinks: { $elemMatch: {
     objectType: InlineObjectType.Image, 
     objectUrl: { $regex: "https://(www\.?)youtube\.com" } 
 } } });
+Comments.find({ "inlineLinks.objectType": InlineObjectType.Person });
 Comments.find({ tags: "tag-1" });
 Comments.find({ tags: { $all: ["tag-1", "tag2"] } });
+
+Comments.update({ viewNumber: { $exists: false } }, { $set: { viewNumber: 0 } });
+Comments.update({ authorId: "author-id-1" }, { $push: { tags: "test-tag-1" } });
+Comments.update({ authorId: "author-id-1" }, { $push: { tags: { $each: [ "test-tag-2", "test-tag-3" ] } } });
+
+Comments.update({ authorId: "author-id-1" }, { $push: { inlineLinks: {
+    objectId: "test-object-id",
+    objectType: InlineObjectType.Link,
+    objectUrl: "https://test.url/"
+} } });
+Comments.update({ viewNumber: { $exists: false } }, { $set: { viewNumber: 0 } });
+Comments.update({ private: true }, { $unset: { tags: true } });
 
 /**
  * From Sessions, Session.set section

--- a/types/meteor/meteor-tests.ts
+++ b/types/meteor/meteor-tests.ts
@@ -352,6 +352,47 @@ let cursor: Mongo.Cursor<Object>;
 // After five seconds, stop keeping the count.
 setTimeout(function () { handle.stop(); }, 5000);
 
+// Additional testing for Mongo.Collection<T>
+enum InlineObjectType {
+    Invalid,
+    Link,
+    Image,
+    Video,
+    Person
+}
+interface CommentsDAO {
+    text: string;
+    authorId: string;
+    inlineLinks: { objectType: InlineObjectType, objectId: string, objectUrl: string }[],
+    tags: string[],
+    viewNumber: number,
+    private: boolean
+}
+
+var Comments = new Mongo.Collection<CommentsDAO>("comments");
+
+Comments.find({ text: { $regex: /test/ } });
+Comments.find({ viewNumber: { $gt: 100 } });
+Comments.find({ viewNumber: { $not: { $lt: 100, $gt: 1000 } } });
+Comments.find({ tags: { $in: [ "tag-1", "tag-2", "tag-3" ] } });
+Comments.find({ $or: [ { text: "hello" }, { text: "world" } ] });
+Comments.find({ $or: [ 
+    { text: "hello" }, 
+    { text: "world", viewNumber: { $gt: 0 } } 
+], authorId: "test-author-id" });
+Comments.find({ $and: [ 
+    { $or: [{ authorId: "author-id-1" }, { authorId: "author-id-2" }] }, 
+    { $or: [{ tags: "tag-1" }, { tags: "tag-2" }] }
+]});
+
+Comments.find({ inlineLinks: { $exists: true, $type: "array" } });
+Comments.find({ inlineLinks: { $elemMatch: { 
+    objectType: InlineObjectType.Image, 
+    objectUrl: { $regex: "https://(www\.?)youtube\.com" } 
+} } });
+Comments.find({ tags: "tag-1" });
+Comments.find({ tags: { $all: ["tag-1", "tag2"] } });
+
 /**
  * From Sessions, Session.set section
  */

--- a/types/meteor/mongo.d.ts
+++ b/types/meteor/mongo.d.ts
@@ -1,26 +1,26 @@
 declare module Mongo {
 
-    type BsonType = 1  | "double" |
-                    2  | "string" |
-                    3  | "object" |
-                    4  | "array" |
-                    5  | "binData" |
-                    6  | "undefined" |
-                    7  | "objectId" |
-                    8  | "bool" |
-                    9  | "date" |
-                    10 | "null" |
-                    11 | "regex" |
-                    12 | "dbPointer" |
-                    13 | "javascript" |
-                    14 | "symbol" |
-                    15 | "javascriptWithScope" |
-                    16 | "int" |
-                    17 | "timestamp" |
-                    18 | "long" |
-                    19 | "decimal" |
-                    -1 | "minKey" |
-                    127 | "maxKey" | "number"
+    type BsonType = 1 | "double" |
+        2 | "string" |
+        3 | "object" |
+        4 | "array" |
+        5 | "binData" |
+        6 | "undefined" |
+        7 | "objectId" |
+        8 | "bool" |
+        9 | "date" |
+        10 | "null" |
+        11 | "regex" |
+        12 | "dbPointer" |
+        13 | "javascript" |
+        14 | "symbol" |
+        15 | "javascriptWithScope" |
+        16 | "int" |
+        17 | "timestamp" |
+        18 | "long" |
+        19 | "decimal" |
+        -1 | "minKey" |
+        127 | "maxKey" | "number"
 
     type FieldExpression<T> = {
         $eq?: T,
@@ -60,10 +60,10 @@ declare module Mongo {
     type Query<T> = {
         [P in keyof T]?: Flatten<T[P]> | RegExp | FieldExpression<Flatten<T[P]>>
     } & {
-        $or?: Query<T>[],
-        $and?: Query<T>[],
-        $nor?: Query<T>[]
-    } & Dictionary<any>
+            $or?: Query<T>[],
+            $and?: Query<T>[],
+            $nor?: Query<T>[]
+        } & Dictionary<any>
 
     type QueryWithModifiers<T> = {
         $query: Query<T>,
@@ -87,15 +87,15 @@ declare module Mongo {
     type OnlyArrays<T> = T extends any[] ? T : never;
     type OnlyElementsOfArrays<T> = T extends any[] ? Partial<T[0]> : never
     type ElementsOf<T> = {
-    [P in keyof T]?: OnlyElementsOfArrays<T[P]>
+        [P in keyof T]?: OnlyElementsOfArrays<T[P]>
     }
     type PushModifier<T> = {
-    [P in keyof T]?: 
-        OnlyElementsOfArrays<T[P]> | 
-        { $each?: T[P], $position?: number, $slice: number, $sort: 1 | -1 | Dictionary<number> }
+        [P in keyof T]?:
+        OnlyElementsOfArrays<T[P]> |
+        { $each?: T[P], $position?: number, $slice?: number, $sort?: 1 | -1 | Dictionary<number> }
     }
     type ArraysOrEach<T> = {
-    [P in keyof T]?: OnlyArrays<T[P]> | { $each: T[P] }
+        [P in keyof T]?: OnlyArrays<T[P]> | { $each: T[P] }
     }
     type CurrentDateModifier = { $type: "timestamp" | "date" } | true
     type Modifier<T> = T | {
@@ -114,7 +114,7 @@ declare module Mongo {
         $pullAll?: Partial<T> & Dictionary<any>,
         $pop?: PartialMapTo<T, 1 | -1> & Dictionary<1 | -1>,
     }
-    
+
 
     interface SortSpecifier { }
     interface FieldSpecifier {
@@ -213,7 +213,7 @@ declare module Mongo {
 
     var ObjectID: ObjectIDStatic;
     interface ObjectIDStatic {
-        new (hexString?: string): ObjectID;
+        new(hexString?: string): ObjectID;
     }
     interface ObjectID {
         toHexString(): string;
@@ -225,27 +225,27 @@ declare module Mongo {
 
 declare module "meteor/mongo" {
     module Mongo {
-        type BsonType = 1  | "double" |
-                        2  | "string" |
-                        3  | "object" |
-                        4  | "array" |
-                        5  | "binData" |
-                        6  | "undefined" |
-                        7  | "objectId" |
-                        8  | "bool" |
-                        9  | "date" |
-                        10 | "null" |
-                        11 | "regex" |
-                        12 | "dbPointer" |
-                        13 | "javascript" |
-                        14 | "symbol" |
-                        15 | "javascriptWithScope" |
-                        16 | "int" |
-                        17 | "timestamp" |
-                        18 | "long" |
-                        19 | "decimal" |
-                        -1 | "minKey" |
-                        127 | "maxKey" | "number"
+        type BsonType = 1 | "double" |
+            2 | "string" |
+            3 | "object" |
+            4 | "array" |
+            5 | "binData" |
+            6 | "undefined" |
+            7 | "objectId" |
+            8 | "bool" |
+            9 | "date" |
+            10 | "null" |
+            11 | "regex" |
+            12 | "dbPointer" |
+            13 | "javascript" |
+            14 | "symbol" |
+            15 | "javascriptWithScope" |
+            16 | "int" |
+            17 | "timestamp" |
+            18 | "long" |
+            19 | "decimal" |
+            -1 | "minKey" |
+            127 | "maxKey" | "number"
 
         type FieldExpression<T> = {
             $eq?: T,
@@ -285,10 +285,10 @@ declare module "meteor/mongo" {
         type Query<T> = {
             [P in keyof T]?: Flatten<T[P]> | RegExp | FieldExpression<Flatten<T[P]>>
         } & {
-            $or?: Query<T>[],
-            $and?: Query<T>[],
-            $nor?: Query<T>[]
-        } & Dictionary<any>
+                $or?: Query<T>[],
+                $and?: Query<T>[],
+                $nor?: Query<T>[]
+            } & Dictionary<any>
 
         type QueryWithModifiers<T> = {
             $query: Query<T>,
@@ -312,15 +312,15 @@ declare module "meteor/mongo" {
         type OnlyArrays<T> = T extends any[] ? T : never;
         type OnlyElementsOfArrays<T> = T extends any[] ? Partial<T[0]> : never
         type ElementsOf<T> = {
-        [P in keyof T]?: OnlyElementsOfArrays<T[P]>
+            [P in keyof T]?: OnlyElementsOfArrays<T[P]>
         }
         type PushModifier<T> = {
-        [P in keyof T]?: 
-            OnlyElementsOfArrays<T[P]> | 
-            { $each?: T[P], $position?: number, $slice: number, $sort: 1 | -1 | Dictionary<number> }
+            [P in keyof T]?:
+            OnlyElementsOfArrays<T[P]> |
+            { $each?: T[P], $position?: number, $slice?: number, $sort?: 1 | -1 | Dictionary<number> }
         }
         type ArraysOrEach<T> = {
-        [P in keyof T]?: OnlyArrays<T[P]> | { $each: T[P] }
+            [P in keyof T]?: OnlyArrays<T[P]> | { $each: T[P] }
         }
         type CurrentDateModifier = { $type: "timestamp" | "date" } | true
         type Modifier<T> = T | {
@@ -437,12 +437,12 @@ declare module "meteor/mongo" {
 
         var ObjectID: ObjectIDStatic;
         interface ObjectIDStatic {
-            new (hexString?: string): ObjectID;
+            new(hexString?: string): ObjectID;
         }
         interface ObjectID {
             toHexString(): string;
             equals(otherID: ObjectID): boolean;
-         }
+        }
 
         function setConnectionOptions(options: any): void;
     }

--- a/types/meteor/mongo.d.ts
+++ b/types/meteor/mongo.d.ts
@@ -1,9 +1,121 @@
 declare module Mongo {
-    interface Selector {
-        [key: string]: any;
+
+    type BsonType = 1  | "double" |
+                    2  | "string" |
+                    3  | "object" |
+                    4  | "array" |
+                    5  | "binData" |
+                    6  | "undefined" |
+                    7  | "objectId" |
+                    8  | "bool" |
+                    9  | "date" |
+                    10 | "null" |
+                    11 | "regex" |
+                    12 | "dbPointer" |
+                    13 | "javascript" |
+                    14 | "symbol" |
+                    15 | "javascriptWithScope" |
+                    16 | "int" |
+                    17 | "timestamp" |
+                    18 | "long" |
+                    19 | "decimal" |
+                    -1 | "minKey" |
+                    127 | "maxKey" | "number"
+
+    type FieldExpression<T> = {
+        $eq?: T,
+        $gt?: T,
+        $gte?: T,
+        $lt?: T,
+        $lte?: T,
+        $in?: T[],
+        $nin?: T[],
+        $ne?: T,
+        $exists?: boolean,
+        $type?: BsonType[] | BsonType,
+        $not?: FieldExpression<T>,
+        $expr?: FieldExpression<T>,
+        $jsonSchema?: any,
+        $mod?: number[],
+        $regex?: RegExp | string,
+        $options?: string,
+        $text?: { $search: string, $language?: string, $caseSensitive?: boolean, $diacriticSensitive?: boolean },
+        $where?: string | Function,
+        $geoIntersects?: any,
+        $geoWithin?: any,
+        $near?: any,
+        $nearSphere?: any,
+        $all?: T[],
+        $elemMatch?: T extends {} ? Query<T> : FieldExpression<T>,
+        $size?: number,
+        $bitsAllClear?: any,
+        $bitsAllSet?: any,
+        $bitsAnyClear?: any,
+        $bitsAnySet?: any,
+        $comment?: string
     }
-    interface Selector extends Object { }
-    interface Modifier { }
+
+    type Flatten<T> = T extends any[] ? T[0] : T
+
+    type Query<T> = {
+        [P in keyof T]?: Flatten<T[P]> | RegExp | FieldExpression<Flatten<T[P]>>
+    } & {
+        $or?: Query<T>[],
+        $and?: Query<T>[],
+        $nor?: Query<T>[]
+    } & Dictionary<any>
+
+    type QueryWithModifiers<T> = {
+        $query: Query<T>,
+        $comment?: string,
+        $explain?: any,
+        $hint?: any,
+        $maxScan?: any,
+        $max?: any,
+        $maxTimeMS?: any,
+        $min?: any,
+        $orderby?: any,
+        $returnKey?: any,
+        $showDiskLoc?: any,
+        $natural?: any
+    }
+
+    type Selector<T> = Query<T> | QueryWithModifiers<T>
+
+    type Dictionary<T> = { [key: string]: T }
+    type PartialMapTo<T, M> = Partial<Record<keyof T, M>>
+    type OnlyArrays<T> = T extends any[] ? T : never;
+    type OnlyElementsOfArrays<T> = T extends any[] ? Partial<T[0]> : never
+    type ElementsOf<T> = {
+    [P in keyof T]?: OnlyElementsOfArrays<T[P]>
+    }
+    type PushModifier<T> = {
+    [P in keyof T]?: 
+        OnlyElementsOfArrays<T[P]> | 
+        { $each?: T[P], $position?: number, $slice: number, $sort: 1 | -1 | Dictionary<number> }
+    }
+    type ArraysOrEach<T> = {
+    [P in keyof T]?: OnlyArrays<T[P]> | { $each: T[P] }
+    }
+    type CurrentDateModifier = { $type: "timestamp" | "date" } | true
+    type Modifier<T> = T | {
+        $currentDate?: Partial<Record<keyof T, CurrentDateModifier>> & Dictionary<CurrentDateModifier>,
+        $inc?: PartialMapTo<T, number> & Dictionary<number>,
+        $min?: PartialMapTo<T, Date | number> & Dictionary<Date | number>,
+        $max?: PartialMapTo<T, Date | number> & Dictionary<Date | number>,
+        $mul?: PartialMapTo<T, number> & Dictionary<number>,
+        $rename?: PartialMapTo<T, string> & Dictionary<string>,
+        $set?: Partial<T> & Dictionary<any>,
+        $setOnInsert?: Partial<T> & Dictionary<any>,
+        $unset?: PartialMapTo<T, boolean | 1 | 0> & Dictionary<any>,
+        $addToSet?: ArraysOrEach<T> & Dictionary<any>,
+        $push?: PushModifier<T> & Dictionary<any>,
+        $pull?: ElementsOf<T> & Dictionary<any>,
+        $pullAll?: Partial<T> & Dictionary<any>,
+        $pop?: PartialMapTo<T, 1 | -1> & Dictionary<1 | -1>,
+    }
+    
+
     interface SortSpecifier { }
     interface FieldSpecifier {
         [id: string]: Number;
@@ -32,7 +144,7 @@ declare module Mongo {
             fetch?: string[];
             transform?: Function;
         }): boolean;
-        find(selector?: Selector | ObjectID | string, options?: {
+        find(selector?: Selector<T> | ObjectID | string, options?: {
             sort?: SortSpecifier;
             skip?: number;
             limit?: number;
@@ -40,7 +152,7 @@ declare module Mongo {
             reactive?: boolean;
             transform?: Function;
         }): Cursor<T>;
-        findOne(selector?: Selector | ObjectID | string, options?: {
+        findOne(selector?: Selector<T> | ObjectID | string, options?: {
             sort?: SortSpecifier;
             skip?: number;
             fields?: FieldSpecifier;
@@ -50,12 +162,12 @@ declare module Mongo {
         insert(doc: T, callback?: Function): string;
         rawCollection(): any;
         rawDatabase(): any;
-        remove(selector: Selector | ObjectID | string, callback?: Function): number;
-        update(selector: Selector | ObjectID | string, modifier: Modifier, options?: {
+        remove(selector: Selector<T> | ObjectID | string, callback?: Function): number;
+        update(selector: Selector<T> | ObjectID | string, modifier: Modifier<T>, options?: {
             multi?: boolean;
             upsert?: boolean;
         }, callback?: Function): number;
-        upsert(selector: Selector | ObjectID | string, modifier: Modifier, options?: {
+        upsert(selector: Selector<T> | ObjectID | string, modifier: Modifier<T>, options?: {
             multi?: boolean;
         }, callback?: Function): {
                 numberAffected?: number; insertedId?: string;
@@ -113,11 +225,121 @@ declare module Mongo {
 
 declare module "meteor/mongo" {
     module Mongo {
-        interface Selector {
-            [key: string]: any;
+        type BsonType = 1  | "double" |
+                        2  | "string" |
+                        3  | "object" |
+                        4  | "array" |
+                        5  | "binData" |
+                        6  | "undefined" |
+                        7  | "objectId" |
+                        8  | "bool" |
+                        9  | "date" |
+                        10 | "null" |
+                        11 | "regex" |
+                        12 | "dbPointer" |
+                        13 | "javascript" |
+                        14 | "symbol" |
+                        15 | "javascriptWithScope" |
+                        16 | "int" |
+                        17 | "timestamp" |
+                        18 | "long" |
+                        19 | "decimal" |
+                        -1 | "minKey" |
+                        127 | "maxKey" | "number"
+
+        type FieldExpression<T> = {
+            $eq?: T,
+            $gt?: T,
+            $gte?: T,
+            $lt?: T,
+            $lte?: T,
+            $in?: T[],
+            $nin?: T[],
+            $ne?: T,
+            $exists?: boolean,
+            $type?: BsonType[] | BsonType,
+            $not?: FieldExpression<T>,
+            $expr?: FieldExpression<T>,
+            $jsonSchema?: any,
+            $mod?: number[],
+            $regex?: RegExp | string,
+            $options?: string,
+            $text?: { $search: string, $language?: string, $caseSensitive?: boolean, $diacriticSensitive?: boolean },
+            $where?: string | Function,
+            $geoIntersects?: any,
+            $geoWithin?: any,
+            $near?: any,
+            $nearSphere?: any,
+            $all?: T[],
+            $elemMatch?: T extends {} ? Query<T> : FieldExpression<T>,
+            $size?: number,
+            $bitsAllClear?: any,
+            $bitsAllSet?: any,
+            $bitsAnyClear?: any,
+            $bitsAnySet?: any,
+            $comment?: string
         }
-        interface Selector extends Object { }
-        interface Modifier { }
+
+        type Flatten<T> = T extends any[] ? T[0] : T
+
+        type Query<T> = {
+            [P in keyof T]?: Flatten<T[P]> | RegExp | FieldExpression<Flatten<T[P]>>
+        } & {
+            $or?: Query<T>[],
+            $and?: Query<T>[],
+            $nor?: Query<T>[]
+        } & Dictionary<any>
+
+        type QueryWithModifiers<T> = {
+            $query: Query<T>,
+            $comment?: string,
+            $explain?: any,
+            $hint?: any,
+            $maxScan?: any,
+            $max?: any,
+            $maxTimeMS?: any,
+            $min?: any,
+            $orderby?: any,
+            $returnKey?: any,
+            $showDiskLoc?: any,
+            $natural?: any
+        }
+
+        type Selector<T> = Query<T> | QueryWithModifiers<T>
+
+        type Dictionary<T> = { [key: string]: T }
+        type PartialMapTo<T, M> = Partial<Record<keyof T, M>>
+        type OnlyArrays<T> = T extends any[] ? T : never;
+        type OnlyElementsOfArrays<T> = T extends any[] ? Partial<T[0]> : never
+        type ElementsOf<T> = {
+        [P in keyof T]?: OnlyElementsOfArrays<T[P]>
+        }
+        type PushModifier<T> = {
+        [P in keyof T]?: 
+            OnlyElementsOfArrays<T[P]> | 
+            { $each?: T[P], $position?: number, $slice: number, $sort: 1 | -1 | Dictionary<number> }
+        }
+        type ArraysOrEach<T> = {
+        [P in keyof T]?: OnlyArrays<T[P]> | { $each: T[P] }
+        }
+        type CurrentDateModifier = { $type: "timestamp" | "date" } | true
+        type Modifier<T> = T | {
+            $currentDate?: Partial<Record<keyof T, CurrentDateModifier>> & Dictionary<CurrentDateModifier>,
+            $inc?: PartialMapTo<T, number> & Dictionary<number>,
+            $min?: PartialMapTo<T, Date | number> & Dictionary<Date | number>,
+            $max?: PartialMapTo<T, Date | number> & Dictionary<Date | number>,
+            $mul?: PartialMapTo<T, number> & Dictionary<number>,
+            $rename?: PartialMapTo<T, string> & Dictionary<string>,
+            $set?: Partial<T> & Dictionary<any>,
+            $setOnInsert?: Partial<T> & Dictionary<any>,
+            $unset?: PartialMapTo<T, boolean | 1 | 0> & Dictionary<any>,
+            $addToSet?: ArraysOrEach<T> & Dictionary<any>,
+            $push?: PushModifier<T> & Dictionary<any>,
+            $pull?: ElementsOf<T> & Dictionary<any>,
+            $pullAll?: Partial<T> & Dictionary<any>,
+            $pop?: PartialMapTo<T, 1 | -1> & Dictionary<1 | -1>,
+        }
+
         interface SortSpecifier { }
         interface FieldSpecifier {
             [id: string]: Number;
@@ -146,7 +368,7 @@ declare module "meteor/mongo" {
                 fetch?: string[];
                 transform?: Function;
             }): boolean;
-            find(selector?: Selector | ObjectID | string, options?: {
+            find(selector?: Selector<T> | ObjectID | string, options?: {
                 sort?: SortSpecifier;
                 skip?: number;
                 limit?: number;
@@ -154,7 +376,7 @@ declare module "meteor/mongo" {
                 reactive?: boolean;
                 transform?: Function;
             }): Cursor<T>;
-            findOne(selector?: Selector | ObjectID | string, options?: {
+            findOne(selector?: Selector<T> | ObjectID | string, options?: {
                 sort?: SortSpecifier;
                 skip?: number;
                 fields?: FieldSpecifier;
@@ -164,12 +386,12 @@ declare module "meteor/mongo" {
             insert(doc: T, callback?: Function): string;
             rawCollection(): any;
             rawDatabase(): any;
-            remove(selector: Selector | ObjectID | string, callback?: Function): number;
-            update(selector: Selector | ObjectID | string, modifier: Modifier, options?: {
+            remove(selector: Selector<T> | ObjectID | string, callback?: Function): number;
+            update(selector: Selector<T> | ObjectID | string, modifier: Modifier<T>, options?: {
                 multi?: boolean;
                 upsert?: boolean;
             }, callback?: Function): number;
-            upsert(selector: Selector | ObjectID | string, modifier: Modifier, options?: {
+            upsert(selector: Selector<T> | ObjectID | string, modifier: Modifier<T>, options?: {
                 multi?: boolean;
             }, callback?: Function): {
                     numberAffected?: number; insertedId?: string;


### PR DESCRIPTION
### Rationale

Personally was struggling for a long time with the lack of intellisense in Mongo selectors and modifiers. This prevents efficient refactoring of data model. Using mapped and conditional types from TypeScript 2.8 I finally managed to solve this problem, and all selectors except composite (e.g. "arr.$.prop") are now covered by intellisense. Thanks to this change I was able to spot couple of serious bugs in a production application I am developing.

### Checklist

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.mongodb.com/manual/reference/
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
