### PR TITLE
d3-color: strict null checks and `instanceof`

### DIFF
--- a/types/d3-color/d3-color-tests.ts
+++ b/types/d3-color/d3-color-tests.ts
@@ -8,37 +8,21 @@
 
 import * as d3Color from 'd3-color';
 
-// RGB and HSL Typeguards
-
-function isRGB(color: d3Color.RGBColor | d3Color.HSLColor): color is d3Color.RGBColor {
-    return (color instanceof d3Color.rgb);
-}
-
-function isHSL(color: d3Color.RGBColor | d3Color.HSLColor): color is d3Color.HSLColor {
-    return (color instanceof d3Color.hsl);
-}
-
 // Signature tests for 'color', rgb and hsl
 
-let c: d3Color.RGBColor | d3Color.HSLColor;
+let c: d3Color.RGBColor | d3Color.HSLColor | null;
 let cRGB: d3Color.RGBColor;
 let cHSL: d3Color.HSLColor;
 let displayable: boolean;
 let cString: string;
+let nil: null;
 
-// string signature
+c = d3Color.color('oops');
 c = d3Color.color('steelblue');
-
-if (isRGB(c)) {
-    cRGB = c;
-} else {
-    cHSL = c;
-}
-
 c = d3Color.color('rgba(20, 100, 200, 0.5)');
-c = d3Color.color(cRGB);
+c = d3Color.color(d3Color.rgb(0, 0, 0));
 
-cRGB = d3Color.color('hsl(60, 100%, 20%, 0.5)').rgb();
+cRGB = d3Color.color('hsl(60, 100%, 20%, 0.5)')!.rgb();
 
 cRGB = d3Color.rgb(20, 100, 200);
 cRGB = d3Color.rgb(20, 100, 200, 0.5);
@@ -126,3 +110,27 @@ displayable = cCubehelix.displayable();
 cString = cCubehelix.toString();
 console.log('Channels = (h : %d, s: %d, l: %d)', cCubehelix.h, cCubehelix.s, cCubehelix.l);
 console.log('Opacity = %d', cCubehelix.opacity);
+
+// Prototype, instanceof and typeguard
+
+declare let color: d3Color.RGBColor | d3Color.HSLColor | d3Color.LabColor | d3Color.HCLColor | d3Color.CubehelixColor | null;
+
+if (color instanceof d3Color.rgb) {
+    cRGB = color;
+} else if (color instanceof d3Color.hsl) {
+    cHSL = color;
+} else if (color instanceof d3Color.lab) {
+    cLab = color;
+} else if (color instanceof d3Color.hcl) {
+    cHcl = color;
+} else if (color instanceof d3Color.cubehelix) {
+    cCubehelix = color;
+} else if (color === null) {
+    nil = color;
+}
+
+if (color instanceof d3Color.color) {
+    console.log(color.toString(), color.darker());
+} else {
+    nil = color;
+}

--- a/types/d3-color/index.d.ts
+++ b/types/d3-color/index.d.ts
@@ -1,6 +1,9 @@
 // Type definitions for D3JS d3-color module 1.0
 // Project: https://github.com/d3/d3-color/
-// Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
+// Definitions by: Tom Wanzek <https://github.com/tomwanzek>
+//                 Alex Ford <https://github.com/gustavderdrache>
+//                 Boris Yankov <https://github.com/borisyankov>
+//                 denisname <https://github.com/denisname>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 // Last module patch version validated against: 1.0.3

--- a/types/d3-color/index.d.ts
+++ b/types/d3-color/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-// Last module patch version validated against: 1.0.1
+// Last module patch version validated against: 1.0.3
 
 // ---------------------------------------------------------------------------
 // Shared Type Definitions and Interfaces
@@ -32,9 +32,9 @@ export interface Color {
 }
 
 export interface ColorFactory extends Function {
-    (cssColorSpecifier: string): RGBColor | HSLColor;
+    (cssColorSpecifier: string): RGBColor | HSLColor | null;
     (color: ColorSpaceObject | ColorCommonInstance): RGBColor | HSLColor;
-    //    prototype: Color;
+    readonly prototype: Color;
 }
 
 export interface RGBColor extends Color {
@@ -44,16 +44,14 @@ export interface RGBColor extends Color {
     opacity: number;
     brighter(k?: number): this;
     darker(k?: number): this;
-    displayable(): boolean;
-    rgb(): RGBColor;
-    toString(): string;
+    rgb(): this;
 }
 
 export interface RGBColorFactory extends Function {
     (r: number, g: number, b: number, opacity?: number): RGBColor;
     (cssColorSpecifier: string): RGBColor;
     (color: ColorSpaceObject | ColorCommonInstance): RGBColor;
-    //    prototype: RGBColor;
+    readonly prototype: RGBColor;
 }
 
 export interface HSLColor extends Color {
@@ -63,7 +61,6 @@ export interface HSLColor extends Color {
     opacity: number;
     brighter(k?: number): this;
     darker(k?: number): this;
-    displayable(): boolean;
     rgb(): RGBColor;
 }
 
@@ -71,7 +68,7 @@ export interface HSLColorFactory extends Function {
     (h: number, s: number, l: number, opacity?: number): HSLColor;
     (cssColorSpecifier: string): HSLColor;
     (color: ColorSpaceObject | ColorCommonInstance): HSLColor;
-    //    prototype: HSLColor;
+    readonly prototype: HSLColor;
 }
 
 export interface LabColor extends Color {
@@ -88,7 +85,7 @@ export interface LabColorFactory extends Function {
     (l: number, a: number, b: number, opacity?: number): LabColor;
     (cssColorSpecifier: string): LabColor;
     (color: ColorSpaceObject | ColorCommonInstance): LabColor;
-    //    prototype: LabColor;
+    readonly prototype: LabColor;
 }
 
 export interface HCLColor extends Color {
@@ -105,7 +102,7 @@ export interface HCLColorFactory extends Function {
     (h: number, l: number, c: number, opacity?: number): HCLColor;
     (cssColorSpecifier: string): HCLColor;
     (color: ColorSpaceObject | ColorCommonInstance): HCLColor;
-    //    prototype: HCLColor;
+    readonly prototype: HCLColor;
 }
 
 export interface CubehelixColor extends Color {
@@ -122,7 +119,7 @@ export interface CubehelixColorFactory extends Function {
     (h: number, s: number, l: number, opacity?: number): CubehelixColor;
     (cssColorSpecifier: string): CubehelixColor;
     (color: ColorSpaceObject | ColorCommonInstance): CubehelixColor;
-    //    prototype: CubehelixColor;
+    readonly prototype: CubehelixColor;
 }
 
 // --------------------------------------------------------------------------

--- a/types/d3-color/tsconfig.json
+++ b/types/d3-color/tsconfig.json
@@ -7,7 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
-        "strictNullChecks": false,
+        "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",
         "typeRoots": [


### PR DESCRIPTION
To avoid long discussion about `d3-color` in #23611. I made a pull request, so we can discuss it here with code. We can always close this pull request, if it does not fit.

This pull request does not contain (yet?) `d3.lch` and `d3.gray` (release v1.1.0).

Code changes are as follows.
Activate _strict null check_. Only changes `d3Color.color(·)` who return `undefined` on _bad_ input.
In `RGBColor`, `rgb(·)` returns this,
In `RGBColor` and `HSLColor`, remove `displayable(·)` and `toString(·)` which are inherited from the `Color` interface.
Made it possible to use `instanceof` on color types (and removed type-guards in test file). 

For the `instanceof` _feature_, it was [proposed](https://github.com/DefinitelyTyped/DefinitelyTyped/issues/23611#issuecomment-378805513) to use `new (·)`. But it is [not working](https://github.com/DefinitelyTyped/DefinitelyTyped/issues/23611#issuecomment-382520633) for all cases needed in this library. So or other solutions are to use `prototype` properties or mixing `new (·)` and `prototype`. I'm not really for the mixing solution:

* I prefer a more consistent solution (all `new` or all `prototype`).
* It will probably be unclear to many users why the type definition sometimes uses `new`, sometimes `prototype`.
* The `new` definition adds, in every interface, two or three new lines of code almost identical to the others ones. Where` prototype` only needs a single line.
* With `new`, it is possible the write code like `new d3.color("green")`, although working it is not documented in d3 API.

So in the end I used only `prototype`. I'm listening for comments...

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/d3/d3-color
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
