### PR TITLE
fix(hapi): make all ext options properties optional

### DIFF
--- a/types/hapi/index.d.ts
+++ b/types/hapi/index.d.ts
@@ -2472,15 +2472,15 @@ export interface ServerExtOptions {
     /**
      * a string or array of strings of plugin names this method must execute before (on the same event). Otherwise, extension methods are executed in the order added.
      */
-    before: string | string[];
+    before?: string | string[];
     /**
      * a string or array of strings of plugin names this method must execute after (on the same event). Otherwise, extension methods are executed in the order added.
      */
-    after: string | string[];
+    after?: string | string[];
     /**
      * a context object passed back to the provided method (via this) when called. Ignored if the method is an arrow function.
      */
-    bind: object;
+    bind?: object;
     /**
      * if set to 'plugin' when adding a request extension points the extension is only added to routes defined by the current plugin. Not allowed when configuring route-level extensions, or when
      * adding server extensions. Defaults to 'server' which applies to any route added to the server the extension is added to.

--- a/types/hapi/test/request/event-types.ts
+++ b/types/hapi/test/request/event-types.ts
@@ -1,6 +1,6 @@
 // https://github.com/hapijs/hapi/blob/master/API.md#-servereventevents
 // https://github.com/hapijs/hapi/blob/master/API.md#-requestevents
-import { Lifecycle, Request, ResponseToolkit, RouteOptions, Server, ServerOptions, ServerRoute } from "hapi";
+import { Lifecycle, Request, Server, ServerOptions, ServerRoute } from "hapi";
 import * as Crypto from 'crypto';
 
 const options: ServerOptions = {
@@ -10,7 +10,7 @@ const options: ServerOptions = {
 const serverRoute: ServerRoute = {
     path: '/',
     method: 'GET',
-    handler(request, h) {
+    handler(request) {
         return 'ok: ' + request.path;
     }
 };
@@ -42,7 +42,7 @@ const onRequest: Lifecycle.Method = (request, h) => {
      */
     const hash = Crypto.createHash('sha1');
 
-    request.events.on("peek", (chunk, encoding) => {
+    request.events.on("peek", (chunk) => {
         hash.update(chunk);
     });
 
@@ -59,7 +59,9 @@ const onRequest: Lifecycle.Method = (request, h) => {
 
 const server = new Server(options);
 server.route(serverRoute);
-server.ext('onRequest', onRequest);
+server.ext('onRequest', onRequest, {
+    before: 'test',
+});
 
 server.start();
 console.log('Server started at: ' + server.info.uri);


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: See https://hapijs.com/api#-serverextevents, also the docs in the typings itself state they are optional.
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
