### PR TITLE
[react-popover] Fix for users without allowSyntheticDefaultExports or…

### DIFF
--- a/types/react-popover/index.d.ts
+++ b/types/react-popover/index.d.ts
@@ -6,30 +6,33 @@
 
 import * as React from 'react';
 
-export type PopoverPlace =
-    | 'above'
-    | 'right'
-    | 'below'
-    | 'left'
-    | 'row'
-    | 'column'
-    | 'start'
-    | 'end';
+export = Popover;
 
-export interface PopoverProps {
-    body: React.ReactNode;
-    isOpen?: boolean;
-    preferPlace?: PopoverPlace;
-    place?: PopoverPlace;
-    onOuterAction?: (event: Event) => void;
-    refreshIntervalMs?: number;
-    enterExitTransitionDurationMs?: number;
-    tipSize?: number;
-    className?: string;
-    style?: React.CSSProperties;
-    target?: React.ReactElement<any>;
-    appendTarget?: Element;
+declare class Popover extends React.Component<Popover.PopoverProps> {}
+
+declare namespace Popover {
+    type PopoverPlace =
+        | 'above'
+        | 'right'
+        | 'below'
+        | 'left'
+        | 'row'
+        | 'column'
+        | 'start'
+        | 'end';
+
+    interface PopoverProps {
+        body: React.ReactNode;
+        isOpen?: boolean;
+        preferPlace?: PopoverPlace;
+        place?: PopoverPlace;
+        onOuterAction?: (event: Event) => void;
+        refreshIntervalMs?: number;
+        enterExitTransitionDurationMs?: number;
+        tipSize?: number;
+        className?: string;
+        style?: React.CSSProperties;
+        target?: React.ReactElement<any>;
+        appendTarget?: Element;
+    }
 }
-
-declare class Popover extends React.Component<PopoverProps> {}
-export default Popover;

--- a/types/react-popover/react-popover-tests.tsx
+++ b/types/react-popover/react-popover-tests.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import Popover from 'react-popover';
+import Popover = require('react-popover');
 
 class Test extends React.Component {
     render() {


### PR DESCRIPTION
… esModuleInterop. The library doesn't use default export (ES modules).

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/littlebits/react-popover/blob/master/index.js>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
