### PR TITLE
[auth0] Fix ManagementClient.linkUsers signature

### DIFF
--- a/types/auth0/auth0-tests.ts
+++ b/types/auth0/auth0-tests.ts
@@ -141,3 +141,12 @@ management.createPasswordChangeTicket({
 }, (err: Error, data) => {
   console.log(data.ticket);
 });
+
+// Link users
+management.linkUsers('primaryId', { user_id: 'secondaryId' })
+  .then((result: any) => console.log(result));
+
+// Link users with callback
+management.linkUsers('primaryId', { user_id: 'secondaryId' },
+  (err: Error, result: any) => {});
+

--- a/types/auth0/index.d.ts
+++ b/types/auth0/index.d.ts
@@ -664,8 +664,8 @@ export class ManagementClient {
   unlinkUsers(params: UnlinkAccountsParams): Promise<UnlinkAccountsResponse>;
   unlinkUsers(params: UnlinkAccountsParams, cb: (err: Error, data: UnlinkAccountsResponse) => void): void;
 
-  linkUsers(params: ObjectWithId, data: LinkAccountsData): Promise<any>;
-  linkUsers(params: ObjectWithId, data: LinkAccountsData, cb: (err: Error, data: any) => void): void;
+  linkUsers(userId: string, data: LinkAccountsData): Promise<any>;
+  linkUsers(userId: string, data: LinkAccountsData, cb: (err: Error, data: any) => void): void;
 
 
   // Tokens


### PR DESCRIPTION
Hey, this is a simple change to have the `linkUsers` signature match Auth0's source code [here](https://github.com/auth0/node-auth0/blob/e249f53143e4a8921aa3eb0f095a717a2f37d713/src/management/index.js#L1121).

It warrants a patch version bump but I can't figure out how to do that!

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/auth0/node-auth0/blob/e249f53143e4a8921aa3eb0f095a717a2f37d713/src/management/index.js#L1121
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.