### PR TITLE
[tea-merge] Remove attribution

### DIFF
--- a/types/tea-merge/index.d.ts
+++ b/types/tea-merge/index.d.ts
@@ -1,5 +1,6 @@
 // Type definitions for tea-merge
 // Project: https://github.com/qualiancy/tea-merge
+// Definitions by: No one <null@example.com>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 

--- a/types/tea-merge/index.d.ts
+++ b/types/tea-merge/index.d.ts
@@ -1,6 +1,5 @@
 // Type definitions for tea-merge
 // Project: https://github.com/qualiancy/tea-merge
-// Definitions by: Mihhail Lapushkin <https://github.com/mihhail-lapushkin/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 


### PR DESCRIPTION
The author of these typings (@mihhail-lapushkin) has asked for me to remove his attribution on his behalf because he is no longer actively using TypeScript. See https://github.com/DefinitelyTyped/DefinitelyTyped/pull/25177#issuecomment-383220067 for his authorisation of this change.

This PR only removes the attribution, it doesn't make any other changes.