### PR TITLE
react-transition-group CSSTransition missing properties fix

### DIFF
--- a/types/react-transition-group/CSSTransition.d.ts
+++ b/types/react-transition-group/CSSTransition.d.ts
@@ -7,8 +7,10 @@ declare namespace CSSTransition {
         appearActive?: string;
         enter?: string;
         enterActive?: string;
+        enterDone?: string;
         exit?: string;
         exitActive?: string;
+        exitDone?: string;
     }
 
     /**

--- a/types/react-transition-group/react-transition-group-tests.tsx
+++ b/types/react-transition-group/react-transition-group-tests.tsx
@@ -71,8 +71,10 @@ const Test: React.StatelessComponent = () => {
                     appearActive: "fade-active-appear",
                     enter: "fade-enter",
                     enterActive: "fade-active-enter",
+                    enterDone: "fade-done-enter",
                     exit: "fade-exit",
-                    exitActive: "fade-active-exit"
+                    exitActive: "fade-active-exit",
+                    exitDone: "fade-done-exit",
                 } }
             >
                 <div>{ "test" }</div>


### PR DESCRIPTION
react-transition-group

Some properties were missing from classNames of the CSSTransition

https://reactcommunity.org/react-transition-group/css-transition#CSSTransition-prop-classNames