### PR TITLE
[jQuery] Fixed documentation URLs to JSDoc

### DIFF
--- a/types/jquery/index.d.ts
+++ b/types/jquery/index.d.ts
@@ -42,7 +42,7 @@ type _Promise<T> = Promise<T>;
 
 interface JQueryStatic<TElement extends Node = HTMLElement> {
     /**
-     * @see [jquery.ajax](https://api.jquery.com/jquery.ajax/)
+     * @see [jquery.ajax on api.jquery.com](https://api.jquery.com/jquery.ajax/)
      * @deprecated Use jQuery.ajaxSetup(options)
      */
     ajaxSettings: JQuery.AjaxSettings;
@@ -52,7 +52,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * any synchronous or asynchronous function.
      *
      * @param beforeStart A function that is called just before the constructor returns.
-     * @see [jQuery.Deferred](https://api.jquery.com/jQuery.Deferred/)
+     * @see [jQuery.Deferred on api.jquery.com](https://api.jquery.com/jQuery.Deferred/)
      * @since 1.5
      */
     Deferred: JQuery.DeferredStatic;
@@ -61,7 +61,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * Hook directly into jQuery to override how particular CSS properties are retrieved or set, normalize
      * CSS property naming, or create custom properties.
      *
-     * @see [jQuery.cssHooks](https://api.jquery.com/jQuery.cssHooks/)
+     * @see [jQuery.cssHooks on api.jquery.com](https://api.jquery.com/jQuery.cssHooks/)
      * @since 1.4.3
      */
     cssHooks: JQuery.PlainObject<JQuery.CSSHook<TElement>>;
@@ -69,7 +69,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * An object containing all CSS properties that may be used without a unit. The .css() method uses this
      * object to see if it may append px to unitless values.
      *
-     * @see [jQuery.cssNumber](https://api.jquery.com/jQuery.cssNumber/)
+     * @see [jQuery.cssNumber on api.jquery.com](https://api.jquery.com/jQuery.cssNumber/)
      * @since 1.4.3
      */
     cssNumber: JQuery.PlainObject<boolean>;
@@ -78,7 +78,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
         /**
          * The rate (in milliseconds) at which animations fire.
          *
-         * @see [jQuery.fx.interval](https://api.jquery.com/jQuery.fx.interval/)
+         * @see [jQuery.fx.interval on api.jquery.com](https://api.jquery.com/jQuery.fx.interval/)
          * @since 1.4.3
          * @deprecated 3.0
          */
@@ -86,7 +86,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
         /**
          * Globally disable all animations.
          *
-         * @see [jQuery.fx.off](https://api.jquery.com/jQuery.fx.off/)
+         * @see [jQuery.fx.off on api.jquery.com](https://api.jquery.com/jQuery.fx.off/)
          * @since 1.3
          */
         off: boolean;
@@ -95,7 +95,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
     /**
      * A Promise-like object (or "thenable") that resolves when the document is ready.
      *
-     * @see [jQuery.ready](https://api.jquery.com/jQuery.ready/)
+     * @see [jQuery.ready on api.jquery.com](https://api.jquery.com/jQuery.ready/)
      * @since 1.8
      */
     ready: JQuery.Thenable<JQueryStatic<TElement>>;
@@ -106,7 +106,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * needs, we strongly recommend the use of an external library such as Modernizr instead of dependency
      * on properties in jQuery.support.
      *
-     * @see [jQuery.support](https://api.jquery.com/jQuery.support/)
+     * @see [jQuery.support on api.jquery.com](https://api.jquery.com/jQuery.support/)
      * @since 1.3
      * @deprecated 1.9
      */
@@ -119,7 +119,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *             A string defining a single, standalone, HTML element (e.g. <div/> or <div></div>).
      * @param ownerDocument_attributes A document in which the new elements will be created.
      *                                 An object of attributes, events, and methods to call on the newly-created element.
-     * @see [jQuery](https://api.jquery.com/jQuery/)
+     * @see [jQuery on api.jquery.com](https://api.jquery.com/jQuery/)
      * @since 1.0
      * @since 1.4
      */
@@ -129,7 +129,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param selector A string containing a selector expression
      * @param context A DOM Element, Document, or jQuery to use as context
-     * @see [jQuery](https://api.jquery.com/jQuery/)
+     * @see [jQuery on api.jquery.com](https://api.jquery.com/jQuery/)
      * @since 1.0
      */
     (selector: JQuery.Selector, context: Element | Document | JQuery | undefined): JQuery<TElement>;
@@ -147,7 +147,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *                                 A plain object to wrap in a jQuery object.
      *                                 An existing jQuery object to clone.
      *                                 The function to execute when the DOM is ready.
-     * @see [jQuery](https://api.jquery.com/jQuery/)
+     * @see [jQuery on api.jquery.com](https://api.jquery.com/jQuery/)
      * @since 1.0
      * @since 1.4
      */
@@ -158,7 +158,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * A multi-purpose callbacks list object that provides a powerful way to manage callback lists.
      *
      * @param flags An optional list of space-separated flags that change how the callback list behaves.
-     * @see [jQuery.Callbacks](https://api.jquery.com/jQuery.Callbacks/)
+     * @see [jQuery.Callbacks on api.jquery.com](https://api.jquery.com/jQuery.Callbacks/)
      * @since 1.7
      */
     Callbacks<T extends Function>(flags?: string): JQuery.Callbacks<T>;
@@ -168,7 +168,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * @param url A string containing the URL to which the request is sent.
      * @param settings A set of key/value pairs that configure the Ajax request. All settings are optional. A default can
      *                 be set for any option with $.ajaxSetup(). See jQuery.ajax( settings ) below for a complete list of all settings.
-     * @see [jQuery.ajax](https://api.jquery.com/jQuery.ajax/)
+     * @see [jQuery.ajax on api.jquery.com](https://api.jquery.com/jQuery.ajax/)
      * @since 1.5
      */
     ajax(url: string, settings?: JQuery.AjaxSettings): JQuery.jqXHR;
@@ -177,7 +177,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param settings A set of key/value pairs that configure the Ajax request. All settings are optional. A default can
      *                 be set for any option with $.ajaxSetup().
-     * @see [jQuery.ajax](https://api.jquery.com/jQuery.ajax/)
+     * @see [jQuery.ajax on api.jquery.com](https://api.jquery.com/jQuery.ajax/)
      * @since 1.0
      */
     ajax(settings?: JQuery.AjaxSettings): JQuery.jqXHR;
@@ -187,7 +187,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param dataTypes An optional string containing one or more space-separated dataTypes
      * @param handler A handler to set default values for future Ajax requests.
-     * @see [jQuery.ajaxPrefilter](https://api.jquery.com/jQuery.ajaxPrefilter/)
+     * @see [jQuery.ajaxPrefilter on api.jquery.com](https://api.jquery.com/jQuery.ajaxPrefilter/)
      * @since 1.5
      */
     ajaxPrefilter(dataTypes: string,
@@ -197,7 +197,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * are processed by $.ajax().
      *
      * @param handler A handler to set default values for future Ajax requests.
-     * @see [jQuery.ajaxPrefilter](https://api.jquery.com/jQuery.ajaxPrefilter/)
+     * @see [jQuery.ajaxPrefilter on api.jquery.com](https://api.jquery.com/jQuery.ajaxPrefilter/)
      * @since 1.5
      */
     ajaxPrefilter(handler: (options: JQuery.AjaxSettings, originalOptions: JQuery.AjaxSettings, jqXHR: JQuery.jqXHR) => string | void): void;
@@ -205,7 +205,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * Set default values for future Ajax requests. Its use is not recommended.
      *
      * @param options A set of key/value pairs that configure the default Ajax request. All options are optional.
-     * @see [jQuery.ajaxSetup](https://api.jquery.com/jQuery.ajaxSetup/)
+     * @see [jQuery.ajaxSetup on api.jquery.com](https://api.jquery.com/jQuery.ajaxSetup/)
      * @since 1.1
      */
     ajaxSetup(options: JQuery.AjaxSettings): JQuery.AjaxSettings;
@@ -214,7 +214,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param dataType A string identifying the data type to use
      * @param handler A handler to return the new transport object to use with the data type provided in the first argument.
-     * @see [jQuery.ajaxTransport](https://api.jquery.com/jQuery.ajaxTransport/)
+     * @see [jQuery.ajaxTransport on api.jquery.com](https://api.jquery.com/jQuery.ajaxTransport/)
      * @since 1.5
      */
     ajaxTransport(dataType: string,
@@ -228,7 +228,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param container The DOM element that may contain the other element.
      * @param contained The DOM element that may be contained by (a descendant of) the other element.
-     * @see [jQuery.contains](https://api.jquery.com/jQuery.contains/)
+     * @see [jQuery.contains on api.jquery.com](https://api.jquery.com/jQuery.contains/)
      * @since 1.4
      */
     contains(container: Element, contained: Element): boolean;
@@ -239,7 +239,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param element The DOM element to query for the data.
      * @param key Name of the data stored.
-     * @see [jQuery.data](https://api.jquery.com/jQuery.data/)
+     * @see [jQuery.data on api.jquery.com](https://api.jquery.com/jQuery.data/)
      * @since 1.2.3
      */
     data(element: Element, key: string, undefined: undefined): any; // tslint:disable-line:unified-signatures
@@ -249,7 +249,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * @param element The DOM element to associate with the data.
      * @param key A string naming the piece of data to set.
      * @param value The new data value; this can be any Javascript type except undefined.
-     * @see [jQuery.data](https://api.jquery.com/jQuery.data/)
+     * @see [jQuery.data on api.jquery.com](https://api.jquery.com/jQuery.data/)
      * @since 1.2.3
      */
     data<T>(element: Element, key: string, value: T): T;
@@ -259,7 +259,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param element The DOM element to query for the data.
      * @param key Name of the data stored.
-     * @see [jQuery.data](https://api.jquery.com/jQuery.data/)
+     * @see [jQuery.data on api.jquery.com](https://api.jquery.com/jQuery.data/)
      * @since 1.2.3
      * @since 1.4
      */
@@ -269,7 +269,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param element A DOM element from which to remove and execute a queued function.
      * @param queueName A string containing the name of the queue. Defaults to fx, the standard effects queue.
-     * @see [jQuery.dequeue](https://api.jquery.com/jQuery.dequeue/)
+     * @see [jQuery.dequeue on api.jquery.com](https://api.jquery.com/jQuery.dequeue/)
      * @since 1.3
      */
     dequeue(element: Element, queueName?: string): void;
@@ -280,7 +280,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param array The array to iterate over.
      * @param callback The function that will be executed on every object.
-     * @see [jQuery.each](https://api.jquery.com/jQuery.each/)
+     * @see [jQuery.each on api.jquery.com](https://api.jquery.com/jQuery.each/)
      * @since 1.0
      */
     each<T>(array: ArrayLike<T>, callback: (this: T, indexInArray: number, value: T) => false | any): ArrayLike<T>;
@@ -291,7 +291,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param obj The object to iterate over.
      * @param callback The function that will be executed on every object.
-     * @see [jQuery.each](https://api.jquery.com/jQuery.each/)
+     * @see [jQuery.each on api.jquery.com](https://api.jquery.com/jQuery.each/)
      * @since 1.0
      */
     each<T, K extends keyof T>(obj: T, callback: (this: T[K], propertyName: K, valueOfProperty: T[K]) => false | any): T;
@@ -299,7 +299,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * Takes a string and throws an exception containing it.
      *
      * @param message The message to send out.
-     * @see [jQuery.error](https://api.jquery.com/jQuery.error/)
+     * @see [jQuery.error on api.jquery.com](https://api.jquery.com/jQuery.error/)
      * @since 1.4.1
      */
     error(message: string): any;
@@ -307,7 +307,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * Escapes any character that has a special meaning in a CSS selector.
      *
      * @param selector A string containing a selector expression to escape.
-     * @see [jQuery.escapeSelector](https://api.jquery.com/jQuery.escapeSelector/)
+     * @see [jQuery.escapeSelector on api.jquery.com](https://api.jquery.com/jQuery.escapeSelector/)
      * @since 3.0
      */
     escapeSelector(selector: JQuery.Selector): JQuery.Selector;
@@ -316,7 +316,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param deep If true, the merge becomes recursive (aka. deep copy). Passing false for this argument is not supported.
      * @param target The object to extend. It will receive the new properties.
-     * @see [jQuery.extend](https://api.jquery.com/jQuery.extend/)
+     * @see [jQuery.extend on api.jquery.com](https://api.jquery.com/jQuery.extend/)
      * @since 1.1.4
      */
     extend<T, U, V, W, X, Y, Z>(deep: true, target: T, object1: U, object2: V, object3: W, object4: X, object5: Y, object6: Z): T & U & V & W & X & Y & Z;
@@ -325,7 +325,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param deep If true, the merge becomes recursive (aka. deep copy). Passing false for this argument is not supported.
      * @param target The object to extend. It will receive the new properties.
-     * @see [jQuery.extend](https://api.jquery.com/jQuery.extend/)
+     * @see [jQuery.extend on api.jquery.com](https://api.jquery.com/jQuery.extend/)
      * @since 1.1.4
      */
     extend<T, U, V, W, X, Y>(deep: true, target: T, object1: U, object2: V, object3: W, object4: X, object5: Y): T & U & V & W & X & Y;
@@ -334,7 +334,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param deep If true, the merge becomes recursive (aka. deep copy). Passing false for this argument is not supported.
      * @param target The object to extend. It will receive the new properties.
-     * @see [jQuery.extend](https://api.jquery.com/jQuery.extend/)
+     * @see [jQuery.extend on api.jquery.com](https://api.jquery.com/jQuery.extend/)
      * @since 1.1.4
      */
     extend<T, U, V, W, X>(deep: true, target: T, object1: U, object2: V, object3: W, object4: X): T & U & V & W & X;
@@ -343,7 +343,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param deep If true, the merge becomes recursive (aka. deep copy). Passing false for this argument is not supported.
      * @param target The object to extend. It will receive the new properties.
-     * @see [jQuery.extend](https://api.jquery.com/jQuery.extend/)
+     * @see [jQuery.extend on api.jquery.com](https://api.jquery.com/jQuery.extend/)
      * @since 1.1.4
      */
     extend<T, U, V, W>(deep: true, target: T, object1: U, object2: V, object3: W): T & U & V & W;
@@ -352,7 +352,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param deep If true, the merge becomes recursive (aka. deep copy). Passing false for this argument is not supported.
      * @param target The object to extend. It will receive the new properties.
-     * @see [jQuery.extend](https://api.jquery.com/jQuery.extend/)
+     * @see [jQuery.extend on api.jquery.com](https://api.jquery.com/jQuery.extend/)
      * @since 1.1.4
      */
     extend<T, U, V>(deep: true, target: T, object1: U, object2: V): T & U & V;
@@ -361,7 +361,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param deep If true, the merge becomes recursive (aka. deep copy). Passing false for this argument is not supported.
      * @param target The object to extend. It will receive the new properties.
-     * @see [jQuery.extend](https://api.jquery.com/jQuery.extend/)
+     * @see [jQuery.extend on api.jquery.com](https://api.jquery.com/jQuery.extend/)
      * @since 1.1.4
      */
     extend<T, U>(deep: true, target: T, object1: U): T & U;
@@ -370,7 +370,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param deep If true, the merge becomes recursive (aka. deep copy). Passing false for this argument is not supported.
      * @param target The object to extend. It will receive the new properties.
-     * @see [jQuery.extend](https://api.jquery.com/jQuery.extend/)
+     * @see [jQuery.extend on api.jquery.com](https://api.jquery.com/jQuery.extend/)
      * @since 1.1.4
      */
     extend(deep: true, target: any, object1: any, ...objects: any[]): any;
@@ -379,7 +379,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param target An object that will receive the new properties if additional objects are passed in or that will
      *               extend the jQuery namespace if it is the sole argument.
-     * @see [jQuery.extend](https://api.jquery.com/jQuery.extend/)
+     * @see [jQuery.extend on api.jquery.com](https://api.jquery.com/jQuery.extend/)
      * @since 1.0
      */
     extend<T, U, V, W, X, Y, Z>(target: T, object1: U, object2: V, object3: W, object4: X, object5: Y, object6: Z): T & U & V & W & X & Y & Z;
@@ -388,7 +388,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param target An object that will receive the new properties if additional objects are passed in or that will
      *               extend the jQuery namespace if it is the sole argument.
-     * @see [jQuery.extend](https://api.jquery.com/jQuery.extend/)
+     * @see [jQuery.extend on api.jquery.com](https://api.jquery.com/jQuery.extend/)
      * @since 1.0
      */
     extend<T, U, V, W, X, Y>(target: T, object1: U, object2: V, object3: W, object4: X, object5: Y): T & U & V & W & X & Y;
@@ -397,7 +397,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param target An object that will receive the new properties if additional objects are passed in or that will
      *               extend the jQuery namespace if it is the sole argument.
-     * @see [jQuery.extend](https://api.jquery.com/jQuery.extend/)
+     * @see [jQuery.extend on api.jquery.com](https://api.jquery.com/jQuery.extend/)
      * @since 1.0
      */
     extend<T, U, V, W, X>(target: T, object1: U, object2: V, object3: W, object4: X): T & U & V & W & X;
@@ -406,7 +406,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param target An object that will receive the new properties if additional objects are passed in or that will
      *               extend the jQuery namespace if it is the sole argument.
-     * @see [jQuery.extend](https://api.jquery.com/jQuery.extend/)
+     * @see [jQuery.extend on api.jquery.com](https://api.jquery.com/jQuery.extend/)
      * @since 1.0
      */
     extend<T, U, V, W>(target: T, object1: U, object2: V, object3: W): T & U & V & W;
@@ -415,7 +415,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param target An object that will receive the new properties if additional objects are passed in or that will
      *               extend the jQuery namespace if it is the sole argument.
-     * @see [jQuery.extend](https://api.jquery.com/jQuery.extend/)
+     * @see [jQuery.extend on api.jquery.com](https://api.jquery.com/jQuery.extend/)
      * @since 1.0
      */
     extend<T, U, V>(target: T, object1: U, object2: V): T & U & V;
@@ -424,7 +424,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param target An object that will receive the new properties if additional objects are passed in or that will
      *               extend the jQuery namespace if it is the sole argument.
-     * @see [jQuery.extend](https://api.jquery.com/jQuery.extend/)
+     * @see [jQuery.extend on api.jquery.com](https://api.jquery.com/jQuery.extend/)
      * @since 1.0
      */
     extend<T, U>(target: T, object1: U): T & U;
@@ -433,7 +433,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param target An object that will receive the new properties if additional objects are passed in or that will
      *               extend the jQuery namespace if it is the sole argument.
-     * @see [jQuery.extend](https://api.jquery.com/jQuery.extend/)
+     * @see [jQuery.extend on api.jquery.com](https://api.jquery.com/jQuery.extend/)
      * @since 1.0
      */
     extend(target: any, object1: any, ...objects: any[]): any;
@@ -445,7 +445,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * @param success A callback function that is executed if the request succeeds. Required if dataType is provided, but
      *                you can use null or jQuery.noop as a placeholder.
      * @param dataType The type of data expected from the server. Default: Intelligent Guess (xml, json, script, text, html).
-     * @see [jQuery.get](https://api.jquery.com/jQuery.get/)
+     * @see [jQuery.get on api.jquery.com](https://api.jquery.com/jQuery.get/)
      * @since 1.0
      */
     get(url: string,
@@ -459,7 +459,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * @param success A callback function that is executed if the request succeeds. Required if dataType is provided, but
      *                you can use null or jQuery.noop as a placeholder.
      * @param dataType The type of data expected from the server. Default: Intelligent Guess (xml, json, script, text, html).
-     * @see [jQuery.get](https://api.jquery.com/jQuery.get/)
+     * @see [jQuery.get on api.jquery.com](https://api.jquery.com/jQuery.get/)
      * @since 1.0
      */
     get(url: string,
@@ -472,7 +472,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * @param success_data A callback function that is executed if the request succeeds. Required if dataType is provided, but
      *                     you can use null or jQuery.noop as a placeholder.
      *                     A plain object or string that is sent to the server with the request.
-     * @see [jQuery.get](https://api.jquery.com/jQuery.get/)
+     * @see [jQuery.get on api.jquery.com](https://api.jquery.com/jQuery.get/)
      * @since 1.0
      */
     get(url: string,
@@ -484,7 +484,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *                     A set of key/value pairs that configure the Ajax request. All properties except for url are
      *                     optional. A default can be set for any option with $.ajaxSetup(). See jQuery.ajax( settings ) for a
      *                     complete list of all settings. The type option will automatically be set to GET.
-     * @see [jQuery.get](https://api.jquery.com/jQuery.get/)
+     * @see [jQuery.get on api.jquery.com](https://api.jquery.com/jQuery.get/)
      * @since 1.0
      * @since 1.12
      * @since 2.2
@@ -496,7 +496,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * @param url A string containing the URL to which the request is sent.
      * @param data A plain object or string that is sent to the server with the request.
      * @param success A callback function that is executed if the request succeeds.
-     * @see [jQuery.getJSON](https://api.jquery.com/jQuery.getJSON/)
+     * @see [jQuery.getJSON on api.jquery.com](https://api.jquery.com/jQuery.getJSON/)
      * @since 1.0
      */
     getJSON(url: string,
@@ -508,7 +508,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * @param url A string containing the URL to which the request is sent.
      * @param success_data A callback function that is executed if the request succeeds.
      *                     A plain object or string that is sent to the server with the request.
-     * @see [jQuery.getJSON](https://api.jquery.com/jQuery.getJSON/)
+     * @see [jQuery.getJSON on api.jquery.com](https://api.jquery.com/jQuery.getJSON/)
      * @since 1.0
      */
     getJSON(url: string,
@@ -518,7 +518,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param url A string containing the URL to which the request is sent.
      * @param success A callback function that is executed if the request succeeds.
-     * @see [jQuery.getScript](https://api.jquery.com/jQuery.getScript/)
+     * @see [jQuery.getScript on api.jquery.com](https://api.jquery.com/jQuery.getScript/)
      * @since 1.0
      */
     getScript(url: string,
@@ -527,7 +527,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * Execute some JavaScript code globally.
      *
      * @param code The JavaScript code to execute.
-     * @see [jQuery.globalEval](https://api.jquery.com/jQuery.globalEval/)
+     * @see [jQuery.globalEval on api.jquery.com](https://api.jquery.com/jQuery.globalEval/)
      * @since 1.0.4
      */
     globalEval(code: string): void;
@@ -540,7 +540,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * @param invert If "invert" is false, or not provided, then the function returns an array consisting of all elements
      *               for which "callback" returns true. If "invert" is true, then the function returns an array
      *               consisting of all elements for which "callback" returns false.
-     * @see [jQuery.grep](https://api.jquery.com/jQuery.grep/)
+     * @see [jQuery.grep on api.jquery.com](https://api.jquery.com/jQuery.grep/)
      * @since 1.0
      */
     grep<T>(array: ArrayLike<T>,
@@ -550,7 +550,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * Determine whether an element has any jQuery data associated with it.
      *
      * @param element A DOM element to be checked for data.
-     * @see [jQuery.hasData](https://api.jquery.com/jQuery.hasData/)
+     * @see [jQuery.hasData on api.jquery.com](https://api.jquery.com/jQuery.hasData/)
      * @since 1.5
      */
     hasData(element: Element): boolean;
@@ -558,7 +558,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * Holds or releases the execution of jQuery's ready event.
      *
      * @param hold Indicates whether the ready hold is being requested or released
-     * @see [jQuery.holdReady](https://api.jquery.com/jQuery.holdReady/)
+     * @see [jQuery.holdReady on api.jquery.com](https://api.jquery.com/jQuery.holdReady/)
      * @since 1.6
      * @deprecated 3.2
      */
@@ -567,7 +567,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * Modify and filter HTML strings passed through jQuery manipulation methods.
      *
      * @param html The HTML string on which to operate.
-     * @see [jQuery.htmlPrefilter](https://api.jquery.com/jQuery.htmlPrefilter/)
+     * @see [jQuery.htmlPrefilter on api.jquery.com](https://api.jquery.com/jQuery.htmlPrefilter/)
      * @since 1.12/2.2
      */
     htmlPrefilter(html: JQuery.htmlString): JQuery.htmlString;
@@ -577,7 +577,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * @param value The value to search for.
      * @param array An array through which to search.
      * @param fromIndex The index of the array at which to begin the search. The default is 0, which will search the whole array.
-     * @see [jQuery.inArray](https://api.jquery.com/jQuery.inArray/)
+     * @see [jQuery.inArray on api.jquery.com](https://api.jquery.com/jQuery.inArray/)
      * @since 1.2
      */
     inArray<T>(value: T, array: T[], fromIndex?: number): number;
@@ -585,7 +585,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * Determine whether the argument is an array.
      *
      * @param obj Object to test whether or not it is an array.
-     * @see [jQuery.isArray](https://api.jquery.com/jQuery.isArray/)
+     * @see [jQuery.isArray on api.jquery.com](https://api.jquery.com/jQuery.isArray/)
      * @since 1.3
      * @deprecated 3.2
      */
@@ -594,7 +594,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * Check to see if an object is empty (contains no enumerable properties).
      *
      * @param obj The object that will be checked to see if it's empty.
-     * @see [jQuery.isEmptyObject](https://api.jquery.com/jQuery.isEmptyObject/)
+     * @see [jQuery.isEmptyObject on api.jquery.com](https://api.jquery.com/jQuery.isEmptyObject/)
      * @since 1.4
      */
     isEmptyObject(obj: any): boolean;
@@ -602,7 +602,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * Determine if the argument passed is a JavaScript function object.
      *
      * @param obj Object to test whether or not it is a function.
-     * @see [jQuery.isFunction](https://api.jquery.com/jQuery.isFunction/)
+     * @see [jQuery.isFunction on api.jquery.com](https://api.jquery.com/jQuery.isFunction/)
      * @since 1.2
      * @deprecated 3.3
      */
@@ -611,7 +611,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * Determines whether its argument represents a JavaScript number.
      *
      * @param value The value to be tested.
-     * @see [jQuery.isNumeric](https://api.jquery.com/jQuery.isNumeric/)
+     * @see [jQuery.isNumeric on api.jquery.com](https://api.jquery.com/jQuery.isNumeric/)
      * @since 1.7
      * @deprecated 3.3
      */
@@ -620,7 +620,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * Check to see if an object is a plain object (created using "{}" or "new Object").
      *
      * @param obj The object that will be checked to see if it's a plain object.
-     * @see [jQuery.isPlainObject](https://api.jquery.com/jQuery.isPlainObject/)
+     * @see [jQuery.isPlainObject on api.jquery.com](https://api.jquery.com/jQuery.isPlainObject/)
      * @since 1.4
      */
     isPlainObject(obj: any): obj is JQuery.PlainObject;
@@ -628,7 +628,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * Determine whether the argument is a window.
      *
      * @param obj Object to test whether or not it is a window.
-     * @see [jQuery.isWindow](https://api.jquery.com/jQuery.isWindow/)
+     * @see [jQuery.isWindow on api.jquery.com](https://api.jquery.com/jQuery.isWindow/)
      * @since 1.4.3
      * @deprecated 3.3
      */
@@ -637,7 +637,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * Check to see if a DOM node is within an XML document (or is an XML document).
      *
      * @param node The DOM node that will be checked to see if it's in an XML document.
-     * @see [jQuery.isXMLDoc](https://api.jquery.com/jQuery.isXMLDoc/)
+     * @see [jQuery.isXMLDoc on api.jquery.com](https://api.jquery.com/jQuery.isXMLDoc/)
      * @since 1.1.4
      */
     isXMLDoc(node: Node): boolean;
@@ -645,7 +645,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * Convert an array-like object into a true JavaScript array.
      *
      * @param obj Any object to turn into a native Array.
-     * @see [jQuery.makeArray](https://api.jquery.com/jQuery.makeArray/)
+     * @see [jQuery.makeArray on api.jquery.com](https://api.jquery.com/jQuery.makeArray/)
      * @since 1.2
      */
     makeArray<T>(obj: ArrayLike<T>): T[];
@@ -656,7 +656,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * @param callback The function to process each item against. The first argument to the function is the array item, the
      *                 second argument is the index in array The function can return any value. A returned array will be
      *                 flattened into the resulting array. Within the function, this refers to the global (window) object.
-     * @see [jQuery.map](https://api.jquery.com/jQuery.map/)
+     * @see [jQuery.map on api.jquery.com](https://api.jquery.com/jQuery.map/)
      * @since 1.0
      */
     map<T, R>(array: T[], callback: (elementOfArray: T, indexInArray: number) => R): R[];
@@ -668,7 +668,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *                 second argument is the key of the object property. The function can return any value to add to the
      *                 array. A returned array will be flattened into the resulting array. Within the function, this refers
      *                 to the global (window) object.
-     * @see [jQuery.map](https://api.jquery.com/jQuery.map/)
+     * @see [jQuery.map on api.jquery.com](https://api.jquery.com/jQuery.map/)
      * @since 1.6
      */
     map<T, K extends keyof T, R>(obj: T, callback: (propertyOfObject: T[K], key: K) => R): R[];
@@ -677,7 +677,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param first The first array-like object to merge, the elements of second added.
      * @param second The second array-like object to merge into the first, unaltered.
-     * @see [jQuery.merge](https://api.jquery.com/jQuery.merge/)
+     * @see [jQuery.merge on api.jquery.com](https://api.jquery.com/jQuery.merge/)
      * @since 1.0
      */
     merge<T, U>(first: ArrayLike<T>, second: ArrayLike<U>): Array<T | U>;
@@ -685,21 +685,21 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * Relinquish jQuery's control of the $ variable.
      *
      * @param removeAll A Boolean indicating whether to remove all jQuery variables from the global scope (including jQuery itself).
-     * @see [jQuery.noConflict](https://api.jquery.com/jQuery.noConflict/)
+     * @see [jQuery.noConflict on api.jquery.com](https://api.jquery.com/jQuery.noConflict/)
      * @since 1.0
      */
     noConflict(removeAll?: boolean): this;
     /**
      * An empty function.
      *
-     * @see [jQuery.noop](https://api.jquery.com/jQuery.noop/)
+     * @see [jQuery.noop on api.jquery.com](https://api.jquery.com/jQuery.noop/)
      * @since 1.4
      */
     noop(): undefined;
     /**
      * Return a number representing the current time.
      *
-     * @see [jQuery.now](https://api.jquery.com/jQuery.now/)
+     * @see [jQuery.now on api.jquery.com](https://api.jquery.com/jQuery.now/)
      * @since 1.4.3
      * @deprecated 3.3 Use Date.now().
      */
@@ -711,7 +711,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param obj An array, a plain object, or a jQuery object to serialize.
      * @param traditional A Boolean indicating whether to perform a traditional "shallow" serialization.
-     * @see [jQuery.param](https://api.jquery.com/jQuery.param/)
+     * @see [jQuery.param on api.jquery.com](https://api.jquery.com/jQuery.param/)
      * @since 1.2
      * @since 1.4
      */
@@ -722,7 +722,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * @param data HTML string to be parsed
      * @param context Document element to serve as the context in which the HTML fragment will be created
      * @param keepScripts A Boolean indicating whether to include scripts passed in the HTML string
-     * @see [jQuery.parseHTML](https://api.jquery.com/jQuery.parseHTML/)
+     * @see [jQuery.parseHTML on api.jquery.com](https://api.jquery.com/jQuery.parseHTML/)
      * @since 1.8
      */
     parseHTML(data: string, context: Document | null | undefined, keepScripts: boolean): JQuery.Node[];
@@ -732,7 +732,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * @param data HTML string to be parsed
      * @param context_keepScripts Document element to serve as the context in which the HTML fragment will be created
      *                            A Boolean indicating whether to include scripts passed in the HTML string
-     * @see [jQuery.parseHTML](https://api.jquery.com/jQuery.parseHTML/)
+     * @see [jQuery.parseHTML on api.jquery.com](https://api.jquery.com/jQuery.parseHTML/)
      * @since 1.8
      */
     parseHTML(data: string, context_keepScripts?: Document | null | boolean): JQuery.Node[];
@@ -740,7 +740,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * Takes a well-formed JSON string and returns the resulting JavaScript value.
      *
      * @param json The JSON string to parse.
-     * @see [jQuery.parseJSON](https://api.jquery.com/jQuery.parseJSON/)
+     * @see [jQuery.parseJSON on api.jquery.com](https://api.jquery.com/jQuery.parseJSON/)
      * @since 1.4.1
      * @deprecated 3.0
      */
@@ -749,7 +749,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * Parses a string into an XML document.
      *
      * @param data a well-formed XML string to be parsed
-     * @see [jQuery.parseXML](https://api.jquery.com/jQuery.parseXML/)
+     * @see [jQuery.parseXML on api.jquery.com](https://api.jquery.com/jQuery.parseXML/)
      * @since 1.5
      */
     parseXML(data: string): XMLDocument;
@@ -761,7 +761,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * @param success A callback function that is executed if the request succeeds. Required if dataType is provided, but
      *                can be null in that case.
      * @param dataType The type of data expected from the server. Default: Intelligent Guess (xml, json, script, text, html).
-     * @see [jQuery.post](https://api.jquery.com/jQuery.post/)
+     * @see [jQuery.post on api.jquery.com](https://api.jquery.com/jQuery.post/)
      * @since 1.0
      */
     post(url: string,
@@ -775,7 +775,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * @param success A callback function that is executed if the request succeeds. Required if dataType is provided, but
      *                can be null in that case.
      * @param dataType The type of data expected from the server. Default: Intelligent Guess (xml, json, script, text, html).
-     * @see [jQuery.post](https://api.jquery.com/jQuery.post/)
+     * @see [jQuery.post on api.jquery.com](https://api.jquery.com/jQuery.post/)
      * @since 1.0
      */
     post(url: string,
@@ -788,7 +788,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * @param success_data A callback function that is executed if the request succeeds. Required if dataType is provided, but
      *                     can be null in that case.
      *                     A plain object or string that is sent to the server with the request.
-     * @see [jQuery.post](https://api.jquery.com/jQuery.post/)
+     * @see [jQuery.post on api.jquery.com](https://api.jquery.com/jQuery.post/)
      * @since 1.0
      */
     post(url: string,
@@ -800,7 +800,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *                     A set of key/value pairs that configure the Ajax request. All properties except for url are
      *                     optional. A default can be set for any option with $.ajaxSetup(). See jQuery.ajax( settings ) for a
      *                     complete list of all settings. Type will automatically be set to POST.
-     * @see [jQuery.post](https://api.jquery.com/jQuery.post/)
+     * @see [jQuery.post on api.jquery.com](https://api.jquery.com/jQuery.post/)
      * @since 1.0
      * @since 1.12
      * @since 2.2
@@ -820,7 +820,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -833,7 +833,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -846,7 +846,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -859,7 +859,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -872,7 +872,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -885,7 +885,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -898,7 +898,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4`
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -912,7 +912,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -928,7 +928,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -943,7 +943,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -958,7 +958,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -973,7 +973,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -988,7 +988,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1003,7 +1003,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1018,7 +1018,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1033,7 +1033,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1050,7 +1050,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1065,7 +1065,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1080,7 +1080,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1095,7 +1095,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1110,7 +1110,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1125,7 +1125,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1140,7 +1140,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1155,7 +1155,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1172,7 +1172,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1187,7 +1187,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1202,7 +1202,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1217,7 +1217,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1232,7 +1232,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1247,7 +1247,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1262,7 +1262,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1277,7 +1277,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1294,7 +1294,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1309,7 +1309,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1324,7 +1324,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1339,7 +1339,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1354,7 +1354,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1369,7 +1369,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1384,7 +1384,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1399,7 +1399,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1416,7 +1416,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1431,7 +1431,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1446,7 +1446,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1461,7 +1461,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1476,7 +1476,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1491,7 +1491,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1506,7 +1506,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1521,7 +1521,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1538,7 +1538,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1553,7 +1553,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1568,7 +1568,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1583,7 +1583,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1598,7 +1598,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1613,7 +1613,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1628,7 +1628,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1643,7 +1643,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1660,7 +1660,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1675,7 +1675,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1690,7 +1690,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1705,7 +1705,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1720,7 +1720,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1735,7 +1735,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1750,7 +1750,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1765,7 +1765,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1785,7 +1785,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
      * @param additionalArguments Any number of arguments to be passed to the function referenced in the function argument.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1808,7 +1808,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -1823,7 +1823,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -1838,7 +1838,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -1853,7 +1853,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -1868,7 +1868,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -1883,7 +1883,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -1898,7 +1898,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4`
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -1913,7 +1913,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -1931,7 +1931,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -1948,7 +1948,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -1965,7 +1965,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -1982,7 +1982,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -1999,7 +1999,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2016,7 +2016,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2033,7 +2033,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2050,7 +2050,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2069,7 +2069,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2086,7 +2086,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2103,7 +2103,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2120,7 +2120,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2137,7 +2137,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2154,7 +2154,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2171,7 +2171,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2188,7 +2188,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2207,7 +2207,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2224,7 +2224,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2241,7 +2241,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2258,7 +2258,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2275,7 +2275,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2292,7 +2292,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2309,7 +2309,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2326,7 +2326,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2345,7 +2345,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2362,7 +2362,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2379,7 +2379,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2396,7 +2396,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2413,7 +2413,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2430,7 +2430,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2447,7 +2447,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2464,7 +2464,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2483,7 +2483,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2500,7 +2500,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2517,7 +2517,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2534,7 +2534,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2551,7 +2551,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2568,7 +2568,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2585,7 +2585,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2602,7 +2602,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2621,7 +2621,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2638,7 +2638,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2655,7 +2655,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2672,7 +2672,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2689,7 +2689,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2706,7 +2706,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2723,7 +2723,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2740,7 +2740,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2759,7 +2759,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2776,7 +2776,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2793,7 +2793,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2810,7 +2810,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2827,7 +2827,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2844,7 +2844,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2861,7 +2861,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2878,7 +2878,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2900,7 +2900,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
      * @param additionalArguments Any number of arguments to be passed to the function referenced in the function argument.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2922,7 +2922,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * @param context The object to which the context of the function should be set.
      * @param name The name of the function whose context will be changed (should be a property of the context object).
      * @param additionalArguments Any number of arguments to be passed to the function named in the name argument.
-     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
+     * @see [jQuery.proxy on api.jquery.com](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2942,7 +2942,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * @param queueName A string containing the name of the queue. Defaults to fx, the standard effects queue.
      * @param newQueue The new function to add to the queue.
      *                 An array of functions to replace the current queue contents.
-     * @see [jQuery.queue](https://api.jquery.com/jQuery.queue/)
+     * @see [jQuery.queue on api.jquery.com](https://api.jquery.com/jQuery.queue/)
      * @since 1.3
      */
     queue<T extends Element>(element: T, queueName?: string, newQueue?: JQuery.TypeOrArray<JQuery.QueueFunction<T>>): JQuery.Queue<T>;
@@ -2950,7 +2950,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * Handles errors thrown synchronously in functions wrapped in jQuery().
      *
      * @param error An error thrown in the function wrapped in jQuery().
-     * @see [jQuery.readyException](https://api.jquery.com/jQuery.readyException/)
+     * @see [jQuery.readyException on api.jquery.com](https://api.jquery.com/jQuery.readyException/)
      * @since 3.1
      */
     readyException(error: Error): any;
@@ -2959,7 +2959,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param element A DOM element from which to remove data.
      * @param name A string naming the piece of data to remove.
-     * @see [jQuery.removeData](https://api.jquery.com/jQuery.removeData/)
+     * @see [jQuery.removeData on api.jquery.com](https://api.jquery.com/jQuery.removeData/)
      * @since 1.2.3
      */
     removeData(element: Element, name?: string): void;
@@ -2969,7 +2969,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * @param duration A string or number determining how long the animation will run.
      * @param easing A string indicating which easing function to use for the transition.
      * @param complete A function to call once the animation is complete, called once per matched element.
-     * @see [jQuery.speed](https://api.jquery.com/jQuery.speed/)
+     * @see [jQuery.speed on api.jquery.com](https://api.jquery.com/jQuery.speed/)
      * @since 1.1
      */
     speed(duration: JQuery.Duration, easing: string, complete: (this: TElement) => void): JQuery.EffectsOptions<TElement>;
@@ -2979,7 +2979,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * @param duration A string or number determining how long the animation will run.
      * @param easing_complete A string indicating which easing function to use for the transition.
      *                        A function to call once the animation is complete, called once per matched element.
-     * @see [jQuery.speed](https://api.jquery.com/jQuery.speed/)
+     * @see [jQuery.speed on api.jquery.com](https://api.jquery.com/jQuery.speed/)
      * @since 1.0
      * @since 1.1
      */
@@ -2990,7 +2990,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param duration_complete_settings A string or number determining how long the animation will run.
      *                                   A function to call once the animation is complete, called once per matched element.
-     * @see [jQuery.speed](https://api.jquery.com/jQuery.speed/)
+     * @see [jQuery.speed on api.jquery.com](https://api.jquery.com/jQuery.speed/)
      * @since 1.0
      * @since 1.1
      */
@@ -2999,7 +2999,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * Remove the whitespace from the beginning and end of a string.
      *
      * @param str The string to trim.
-     * @see [jQuery.trim](https://api.jquery.com/jQuery.trim/)
+     * @see [jQuery.trim on api.jquery.com](https://api.jquery.com/jQuery.trim/)
      * @since 1.0
      */
     trim(str: string): string;
@@ -3007,7 +3007,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * Determine the internal JavaScript [[Class]] of an object.
      *
      * @param obj Object to get the internal JavaScript [[Class]] of.
-     * @see [jQuery.type](https://api.jquery.com/jQuery.type/)
+     * @see [jQuery.type on api.jquery.com](https://api.jquery.com/jQuery.type/)
      * @since 1.4.3
      * @deprecated 3.3
      */
@@ -3017,7 +3017,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * arrays of DOM elements, not strings or numbers.
      *
      * @param array The Array of DOM elements.
-     * @see [jQuery.unique](https://api.jquery.com/jQuery.unique/)
+     * @see [jQuery.unique on api.jquery.com](https://api.jquery.com/jQuery.unique/)
      * @since 1.1.3
      * @deprecated 3.0
      */
@@ -3027,7 +3027,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * arrays of DOM elements, not strings or numbers.
      *
      * @param array The Array of DOM elements.
-     * @see [jQuery.uniqueSort](https://api.jquery.com/jQuery.uniqueSort/)
+     * @see [jQuery.uniqueSort on api.jquery.com](https://api.jquery.com/jQuery.uniqueSort/)
      * @since 1.12
      * @since 2.2
      */
@@ -3036,7 +3036,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * Provides a way to execute callback functions based on zero or more Thenable objects, usually
      * Deferred objects that represent asynchronous events.
      *
-     * @see [jQuery.when](https://api.jquery.com/jQuery.when/)
+     * @see [jQuery.when on api.jquery.com](https://api.jquery.com/jQuery.when/)
      * @since 1.5
      */
     when<TR1, UR1, VR1,
@@ -3050,7 +3050,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * Provides a way to execute callback functions based on zero or more Thenable objects, usually
      * Deferred objects that represent asynchronous events.
      *
-     * @see [jQuery.when](https://api.jquery.com/jQuery.when/)
+     * @see [jQuery.when on api.jquery.com](https://api.jquery.com/jQuery.when/)
      * @since 1.5
      */
     when<TR1, UR1,
@@ -3062,7 +3062,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * Provides a way to execute callback functions based on zero or more Thenable objects, usually
      * Deferred objects that represent asynchronous events.
      *
-     * @see [jQuery.when](https://api.jquery.com/jQuery.when/)
+     * @see [jQuery.when on api.jquery.com](https://api.jquery.com/jQuery.when/)
      * @since 1.5
      */
     when<TR1, TJ1,
@@ -3074,7 +3074,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * Provides a way to execute callback functions based on zero or more Thenable objects, usually
      * Deferred objects that represent asynchronous events.
      *
-     * @see [jQuery.when](https://api.jquery.com/jQuery.when/)
+     * @see [jQuery.when on api.jquery.com](https://api.jquery.com/jQuery.when/)
      * @since 1.5
      */
     when<TR1, TJ1 = any>(deferred: JQuery.Promise<TR1, TJ1, any> | JQuery.Thenable<TR1> | TR1): JQuery.Promise<TR1, TJ1, never>;
@@ -3083,7 +3083,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * Deferred objects that represent asynchronous events.
      *
      * @param deferreds Zero or more Thenable objects.
-     * @see [jQuery.when](https://api.jquery.com/jQuery.when/)
+     * @see [jQuery.when on api.jquery.com](https://api.jquery.com/jQuery.when/)
      * @since 1.5
      */
     when<TR1 = never, TJ1 = never>(...deferreds: Array<JQuery.Promise<TR1, TJ1, any> | JQuery.Thenable<TR1> | TR1>): JQuery.Promise<TR1, TJ1, never>;
@@ -3092,7 +3092,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * Deferred objects that represent asynchronous events.
      *
      * @param deferreds Zero or more Thenable objects.
-     * @see [jQuery.when](https://api.jquery.com/jQuery.when/)
+     * @see [jQuery.when on api.jquery.com](https://api.jquery.com/jQuery.when/)
      * @since 1.5
      */
     when(...deferreds: any[]): JQuery.Promise<any, any, never>;
@@ -3102,14 +3102,14 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
     /**
      * A string containing the jQuery version number.
      *
-     * @see [jquery](https://api.jquery.com/jquery/)
+     * @see [jquery on api.jquery.com](https://api.jquery.com/jquery/)
      * @since 1.0
      */
     jquery: string;
     /**
      * The number of elements in the jQuery object.
      *
-     * @see [length](https://api.jquery.com/length/)
+     * @see [length on api.jquery.com](https://api.jquery.com/length/)
      * @since 1.0
      */
     length: number;
@@ -3119,7 +3119,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param selector A string representing a selector expression to find additional elements to add to the set of matched elements.
      * @param context The point in the document at which the selector should begin matching; similar to the context
      *                argument of the $(selector, context) method.
-     * @see [add](https://api.jquery.com/add/)
+     * @see [add on api.jquery.com](https://api.jquery.com/add/)
      * @since 1.4
      */
     add(selector: JQuery.Selector, context: Element): this;
@@ -3130,7 +3130,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *                 One or more elements to add to the set of matched elements.
      *                 An HTML fragment to add to the set of matched elements.
      *                 An existing jQuery object to add to the set of matched elements.
-     * @see [add](https://api.jquery.com/add/)
+     * @see [add on api.jquery.com](https://api.jquery.com/add/)
      * @since 1.0
      * @since 1.3.2
      */
@@ -3139,7 +3139,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Add the previous set of elements on the stack to the current set, optionally filtered by a selector.
      *
      * @param selector A string containing a selector expression to match the current set of elements against.
-     * @see [addBack](https://api.jquery.com/addBack/)
+     * @see [addBack on api.jquery.com](https://api.jquery.com/addBack/)
      * @since 1.8
      */
     addBack(selector?: JQuery.Selector): this;
@@ -3151,7 +3151,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *                  A function returning one or more space-separated class names to be added to the existing class
      *                  name(s). Receives the index position of the element in the set and the existing class name(s) as
      *                  arguments. Within the function, this refers to the current element in the set.
-     * @see [addClass](https://api.jquery.com/addClass/)
+     * @see [addClass on api.jquery.com](https://api.jquery.com/addClass/)
      * @since 1.0
      * @since 1.4
      * @since 3.3
@@ -3162,7 +3162,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param contents One or more additional DOM elements, text nodes, arrays of elements and text nodes, HTML strings, or
      *                 jQuery objects to insert after each element in the set of matched elements.
-     * @see [after](https://api.jquery.com/after/)
+     * @see [after on api.jquery.com](https://api.jquery.com/after/)
      * @since 1.0
      */
     after(...contents: Array<JQuery.htmlString | JQuery.TypeOrArray<JQuery.Node | JQuery<JQuery.Node>>>): this;
@@ -3173,7 +3173,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *           after each element in the set of matched elements. Receives the index position of the element in the
      *           set and the old HTML value of the element as arguments. Within the function, this refers to the
      *           current element in the set.
-     * @see [after](https://api.jquery.com/after/)
+     * @see [after on api.jquery.com](https://api.jquery.com/after/)
      * @since 1.4
      * @since 1.10
      */
@@ -3182,7 +3182,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Register a handler to be called when Ajax requests complete. This is an AjaxEvent.
      *
      * @param handler The function to be invoked.
-     * @see [ajaxComplete](https://api.jquery.com/ajaxComplete/)
+     * @see [ajaxComplete on api.jquery.com](https://api.jquery.com/ajaxComplete/)
      * @since 1.0
      */
     ajaxComplete(handler: (this: Document, event: JQuery.Event<Document>, jqXHR: JQuery.jqXHR, ajaxOptions: JQuery.AjaxSettings) => void | false): this;
@@ -3190,7 +3190,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Register a handler to be called when Ajax requests complete with an error. This is an Ajax Event.
      *
      * @param handler The function to be invoked.
-     * @see [ajaxError](https://api.jquery.com/ajaxError/)
+     * @see [ajaxError on api.jquery.com](https://api.jquery.com/ajaxError/)
      * @since 1.0
      */
     ajaxError(handler: (this: Document, event: JQuery.Event<Document>, jqXHR: JQuery.jqXHR, ajaxSettings: JQuery.AjaxSettings, thrownError: string) => void | false): this;
@@ -3198,7 +3198,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Attach a function to be executed before an Ajax request is sent. This is an Ajax Event.
      *
      * @param handler The function to be invoked.
-     * @see [ajaxSend](https://api.jquery.com/ajaxSend/)
+     * @see [ajaxSend on api.jquery.com](https://api.jquery.com/ajaxSend/)
      * @since 1.0
      */
     ajaxSend(handler: (this: Document, event: JQuery.Event<Document>, jqXHR: JQuery.jqXHR, ajaxOptions: JQuery.AjaxSettings) => void | false): this;
@@ -3206,7 +3206,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Register a handler to be called when the first Ajax request begins. This is an Ajax Event.
      *
      * @param handler The function to be invoked.
-     * @see [ajaxStart](https://api.jquery.com/ajaxStart/)
+     * @see [ajaxStart on api.jquery.com](https://api.jquery.com/ajaxStart/)
      * @since 1.0
      */
     ajaxStart(handler: (this: Document) => void | false): this;
@@ -3214,7 +3214,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Register a handler to be called when all Ajax requests have completed. This is an Ajax Event.
      *
      * @param handler The function to be invoked.
-     * @see [ajaxStop](https://api.jquery.com/ajaxStop/)
+     * @see [ajaxStop on api.jquery.com](https://api.jquery.com/ajaxStop/)
      * @since 1.0
      */
     ajaxStop(handler: (this: Document) => void | false): this;
@@ -3222,7 +3222,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Attach a function to be executed whenever an Ajax request completes successfully. This is an Ajax Event.
      *
      * @param handler The function to be invoked.
-     * @see [ajaxSuccess](https://api.jquery.com/ajaxSuccess/)
+     * @see [ajaxSuccess on api.jquery.com](https://api.jquery.com/ajaxSuccess/)
      * @since 1.0
      */
     ajaxSuccess(handler: (this: Document, event: JQuery.Event<Document>, jqXHR: JQuery.jqXHR, ajaxOptions: JQuery.AjaxSettings, data: JQuery.PlainObject) => void | false): this;
@@ -3233,7 +3233,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param duration A string or number determining how long the animation will run.
      * @param easing A string indicating which easing function to use for the transition.
      * @param complete A function to call once the animation is complete, called once per matched element.
-     * @see [animate](https://api.jquery.com/animate/)
+     * @see [animate on api.jquery.com](https://api.jquery.com/animate/)
      * @since 1.0
      */
     animate(properties: JQuery.PlainObject,
@@ -3247,7 +3247,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param duration_easing A string or number determining how long the animation will run.
      *                        A string indicating which easing function to use for the transition.
      * @param complete A function to call once the animation is complete, called once per matched element.
-     * @see [animate](https://api.jquery.com/animate/)
+     * @see [animate on api.jquery.com](https://api.jquery.com/animate/)
      * @since 1.0
      */
     animate(properties: JQuery.PlainObject,
@@ -3258,7 +3258,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param properties An object of CSS properties and values that the animation will move toward.
      * @param options A map of additional options to pass to the method.
-     * @see [animate](https://api.jquery.com/animate/)
+     * @see [animate on api.jquery.com](https://api.jquery.com/animate/)
      * @since 1.0
      */
     animate(properties: JQuery.PlainObject,
@@ -3268,7 +3268,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param properties An object of CSS properties and values that the animation will move toward.
      * @param complete A function to call once the animation is complete, called once per matched element.
-     * @see [animate](https://api.jquery.com/animate/)
+     * @see [animate on api.jquery.com](https://api.jquery.com/animate/)
      * @since 1.0
      */
     animate(properties: JQuery.PlainObject,
@@ -3278,7 +3278,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param contents One or more additional DOM elements, text nodes, arrays of elements and text nodes, HTML strings, or
      *                 jQuery objects to insert at the end of each element in the set of matched elements.
-     * @see [append](https://api.jquery.com/append/)
+     * @see [append on api.jquery.com](https://api.jquery.com/append/)
      * @since 1.0
      */
     append(...contents: Array<JQuery.htmlString | JQuery.TypeOrArray<JQuery.Node | JQuery<JQuery.Node>>>): this;
@@ -3289,7 +3289,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *           the end of each element in the set of matched elements. Receives the index position of the element
      *           in the set and the old HTML value of the element as arguments. Within the function, this refers to
      *           the current element in the set.
-     * @see [append](https://api.jquery.com/append/)
+     * @see [append on api.jquery.com](https://api.jquery.com/append/)
      * @since 1.4
      */
     append(fn: (this: TElement, index: number, html: string) => JQuery.htmlString | JQuery.TypeOrArray<JQuery.Node | JQuery<JQuery.Node>>): this;
@@ -3298,7 +3298,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param target A selector, element, HTML string, array of elements, or jQuery object; the matched set of elements
      *               will be inserted at the end of the element(s) specified by this parameter.
-     * @see [appendTo](https://api.jquery.com/appendTo/)
+     * @see [appendTo on api.jquery.com](https://api.jquery.com/appendTo/)
      * @since 1.0
      */
     appendTo(target: JQuery.Selector | JQuery.htmlString | JQuery.TypeOrArray<Element> | JQuery): this;
@@ -3309,7 +3309,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param value A value to set for the attribute. If null, the specified attribute will be removed (as in .removeAttr()).
      *              A function returning the value to set. this is the current element. Receives the index position of
      *              the element in the set and the old attribute value as arguments.
-     * @see [attr](https://api.jquery.com/attr/)
+     * @see [attr on api.jquery.com](https://api.jquery.com/attr/)
      * @since 1.0
      * @since 1.1
      */
@@ -3319,7 +3319,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Set one or more attributes for the set of matched elements.
      *
      * @param attributes An object of attribute-value pairs to set.
-     * @see [attr](https://api.jquery.com/attr/)
+     * @see [attr on api.jquery.com](https://api.jquery.com/attr/)
      * @since 1.0
      */
     attr(attributes: JQuery.PlainObject): this;
@@ -3327,7 +3327,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Get the value of an attribute for the first element in the set of matched elements.
      *
      * @param attributeName The name of the attribute to get.
-     * @see [attr](https://api.jquery.com/attr/)
+     * @see [attr on api.jquery.com](https://api.jquery.com/attr/)
      * @since 1.0
      */
     attr(attributeName: string): string | undefined;
@@ -3336,7 +3336,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param contents One or more additional DOM elements, text nodes, arrays of elements and text nodes, HTML strings, or
      *                 jQuery objects to insert before each element in the set of matched elements.
-     * @see [before](https://api.jquery.com/before/)
+     * @see [before on api.jquery.com](https://api.jquery.com/before/)
      * @since 1.0
      */
     before(...contents: Array<JQuery.htmlString | JQuery.TypeOrArray<JQuery.Node | JQuery<JQuery.Node>>>): this;
@@ -3347,7 +3347,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *           before each element in the set of matched elements. Receives the index position of the element in
      *           the set and the old HTML value of the element as arguments. Within the function, this refers to the
      *           current element in the set.
-     * @see [before](https://api.jquery.com/before/)
+     * @see [before on api.jquery.com](https://api.jquery.com/before/)
      * @since 1.4
      * @since 1.10
      */
@@ -3359,7 +3359,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param eventType A string containing one or more DOM event types, such as "click" or "submit," or custom event names.
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute each time the event is triggered.
-     * @see [bind](https://api.jquery.com/bind/)
+     * @see [bind on api.jquery.com](https://api.jquery.com/bind/)
      * @since 1.0
      * @since 1.4.3
      * @deprecated 3.0
@@ -3374,7 +3374,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param handler A function to execute each time the event is triggered.
      *                Setting the second argument to false will attach a function that prevents the default action from
      *                occurring and stops the event from bubbling.
-     * @see [bind](https://api.jquery.com/bind/)
+     * @see [bind on api.jquery.com](https://api.jquery.com/bind/)
      * @since 1.0
      * @since 1.4.3
      * @deprecated 3.0
@@ -3385,7 +3385,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Attach a handler to an event for the elements.
      *
      * @param events An object containing one or more DOM event types and functions to execute for them.
-     * @see [bind](https://api.jquery.com/bind/)
+     * @see [bind on api.jquery.com](https://api.jquery.com/bind/)
      * @since 1.4
      * @deprecated 3.0
      */
@@ -3395,7 +3395,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute each time the event is triggered.
-     * @see [blur](https://api.jquery.com/blur/)
+     * @see [blur on api.jquery.com](https://api.jquery.com/blur/)
      * @since 1.4.3
      * @deprecated 3.3
      */
@@ -3405,7 +3405,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Bind an event handler to the "blur" JavaScript event, or trigger that event on an element.
      *
      * @param handler A function to execute each time the event is triggered.
-     * @see [blur](https://api.jquery.com/blur/)
+     * @see [blur on api.jquery.com](https://api.jquery.com/blur/)
      * @since 1.0
      * @deprecated 3.3
      */
@@ -3415,7 +3415,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute each time the event is triggered.
-     * @see [change](https://api.jquery.com/change/)
+     * @see [change on api.jquery.com](https://api.jquery.com/change/)
      * @since 1.4.3
      * @deprecated 3.3
      */
@@ -3425,7 +3425,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Bind an event handler to the "change" JavaScript event, or trigger that event on an element.
      *
      * @param handler A function to execute each time the event is triggered.
-     * @see [change](https://api.jquery.com/change/)
+     * @see [change on api.jquery.com](https://api.jquery.com/change/)
      * @since 1.0
      * @deprecated 3.3
      */
@@ -3434,7 +3434,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Get the children of each element in the set of matched elements, optionally filtered by a selector.
      *
      * @param selector A string containing a selector expression to match elements against.
-     * @see [children](https://api.jquery.com/children/)
+     * @see [children on api.jquery.com](https://api.jquery.com/children/)
      * @since 1.0
      */
     children(selector?: JQuery.Selector): this;
@@ -3442,7 +3442,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Remove from the queue all items that have not yet been run.
      *
      * @param queueName A string containing the name of the queue. Defaults to fx, the standard effects queue.
-     * @see [clearQueue](https://api.jquery.com/clearQueue/)
+     * @see [clearQueue on api.jquery.com](https://api.jquery.com/clearQueue/)
      * @since 1.4
      */
     clearQueue(queueName?: string): this;
@@ -3451,7 +3451,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute each time the event is triggered.
-     * @see [click](https://api.jquery.com/click/)
+     * @see [click on api.jquery.com](https://api.jquery.com/click/)
      * @since 1.4.3
      * @deprecated 3.3
      */
@@ -3461,7 +3461,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Bind an event handler to the "click" JavaScript event, or trigger that event on an element.
      *
      * @param handler A function to execute each time the event is triggered.
-     * @see [click](https://api.jquery.com/click/)
+     * @see [click on api.jquery.com](https://api.jquery.com/click/)
      * @since 1.0
      * @deprecated 3.3
      */
@@ -3474,7 +3474,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *                          to false in 1.5.1 and up.
      * @param deepWithDataAndEvents A Boolean indicating whether event handlers and data for all children of the cloned element should
      *                              be copied. By default its value matches the first argument's value (which defaults to false).
-     * @see [clone](https://api.jquery.com/clone/)
+     * @see [clone on api.jquery.com](https://api.jquery.com/clone/)
      * @since 1.0
      * @since 1.5
      */
@@ -3485,7 +3485,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param selector A string containing a selector expression to match elements against.
      * @param context A DOM element within which a matching element may be found.
-     * @see [closest](https://api.jquery.com/closest/)
+     * @see [closest on api.jquery.com](https://api.jquery.com/closest/)
      * @since 1.4
      */
     closest(selector: JQuery.Selector, context: Element): this;
@@ -3496,7 +3496,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param selector A string containing a selector expression to match elements against.
      *                 A jQuery object to match elements against.
      *                 An element to match elements against.
-     * @see [closest](https://api.jquery.com/closest/)
+     * @see [closest on api.jquery.com](https://api.jquery.com/closest/)
      * @since 1.3
      * @since 1.6
      */
@@ -3504,7 +3504,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
     /**
      * Get the children of each element in the set of matched elements, including text and comment nodes.
      *
-     * @see [contents](https://api.jquery.com/contents/)
+     * @see [contents on api.jquery.com](https://api.jquery.com/contents/)
      * @since 1.2
      */
     contents(): JQuery<TElement | Text | Comment>;
@@ -3513,7 +3513,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute each time the event is triggered.
-     * @see [contextmenu](https://api.jquery.com/contextmenu/)
+     * @see [contextmenu on api.jquery.com](https://api.jquery.com/contextmenu/)
      * @since 1.4.3
      * @deprecated 3.3
      */
@@ -3523,7 +3523,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Bind an event handler to the "contextmenu" JavaScript event, or trigger that event on an element.
      *
      * @param handler A function to execute each time the event is triggered.
-     * @see [contextmenu](https://api.jquery.com/contextmenu/)
+     * @see [contextmenu on api.jquery.com](https://api.jquery.com/contextmenu/)
      * @since 1.0
      * @deprecated 3.3
      */
@@ -3535,7 +3535,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param value A value to set for the property.
      *              A function returning the value to set. this is the current element. Receives the index position of
      *              the element in the set and the old value as arguments.
-     * @see [css](https://api.jquery.com/css/)
+     * @see [css on api.jquery.com](https://api.jquery.com/css/)
      * @since 1.0
      * @since 1.4
      */
@@ -3545,7 +3545,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Set one or more CSS properties for the set of matched elements.
      *
      * @param properties An object of property-value pairs to set.
-     * @see [css](https://api.jquery.com/css/)
+     * @see [css on api.jquery.com](https://api.jquery.com/css/)
      * @since 1.0
      */
     css(properties: JQuery.PlainObject<string | number | ((this: TElement, index: number, value: string) => string | number | void | undefined)>): this;
@@ -3554,7 +3554,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param propertyName A CSS property.
      *                     An array of one or more CSS properties.
-     * @see [css](https://api.jquery.com/css/)
+     * @see [css on api.jquery.com](https://api.jquery.com/css/)
      * @since 1.0
      */
     css(propertyName: string): string;
@@ -3562,7 +3562,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Get the computed style properties for the first element in the set of matched elements.
      *
      * @param propertyNames An array of one or more CSS properties.
-     * @see [css](https://api.jquery.com/css/)
+     * @see [css on api.jquery.com](https://api.jquery.com/css/)
      * @since 1.9
      */
     css(propertyNames: string[]): JQuery.PlainObject<string>;
@@ -3571,7 +3571,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * data(name, value) or by an HTML5 data-* attribute.
      *
      * @param key Name of the data stored.
-     * @see [data](https://api.jquery.com/data/)
+     * @see [data on api.jquery.com](https://api.jquery.com/data/)
      * @since 1.2.3
      */
     data(key: string, undefined: undefined): any; // tslint:disable-line:unified-signatures
@@ -3580,7 +3580,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param key A string naming the piece of data to set.
      * @param value The new data value; this can be any Javascript type except undefined.
-     * @see [data](https://api.jquery.com/data/)
+     * @see [data on api.jquery.com](https://api.jquery.com/data/)
      * @since 1.2.3
      */
     data(key: string, value: any): this;
@@ -3588,7 +3588,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Store arbitrary data associated with the matched elements.
      *
      * @param obj An object of key-value pairs of data to update.
-     * @see [data](https://api.jquery.com/data/)
+     * @see [data on api.jquery.com](https://api.jquery.com/data/)
      * @since 1.4.3
      */
     data(obj: JQuery.PlainObject): this;
@@ -3597,7 +3597,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * data(name, value) or by an HTML5 data-* attribute.
      *
      * @param key Name of the data stored.
-     * @see [data](https://api.jquery.com/data/)
+     * @see [data on api.jquery.com](https://api.jquery.com/data/)
      * @since 1.2.3
      */
     data(key: string): any;
@@ -3605,7 +3605,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Return the value at the named data store for the first element in the jQuery collection, as set by
      * data(name, value) or by an HTML5 data-* attribute.
      *
-     * @see [data](https://api.jquery.com/data/)
+     * @see [data on api.jquery.com](https://api.jquery.com/data/)
      * @since 1.4
      */
     data(): JQuery.PlainObject;
@@ -3614,7 +3614,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute each time the event is triggered.
-     * @see [dblclick](https://api.jquery.com/dblclick/)
+     * @see [dblclick on api.jquery.com](https://api.jquery.com/dblclick/)
      * @since 1.4.3
      * @deprecated 3.3
      */
@@ -3624,7 +3624,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Bind an event handler to the "dblclick" JavaScript event, or trigger that event on an element.
      *
      * @param handler A function to execute each time the event is triggered.
-     * @see [dblclick](https://api.jquery.com/dblclick/)
+     * @see [dblclick on api.jquery.com](https://api.jquery.com/dblclick/)
      * @since 1.0
      * @deprecated 3.3
      */
@@ -3634,7 +3634,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param duration An integer indicating the number of milliseconds to delay execution of the next item in the queue.
      * @param queueName A string containing the name of the queue. Defaults to fx, the standard effects queue.
-     * @see [delay](https://api.jquery.com/delay/)
+     * @see [delay on api.jquery.com](https://api.jquery.com/delay/)
      * @since 1.4
      */
     delay(duration: JQuery.Duration, queueName?: string): this;
@@ -3647,7 +3647,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *                  "keydown," or custom event names.
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute each time the event is triggered.
-     * @see [delegate](https://api.jquery.com/delegate/)
+     * @see [delegate on api.jquery.com](https://api.jquery.com/delegate/)
      * @since 1.4.2
      * @deprecated 3.0
      */
@@ -3663,7 +3663,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param eventType A string containing one or more space-separated JavaScript event types, such as "click" or
      *                  "keydown," or custom event names.
      * @param handler A function to execute each time the event is triggered.
-     * @see [delegate](https://api.jquery.com/delegate/)
+     * @see [delegate on api.jquery.com](https://api.jquery.com/delegate/)
      * @since 1.4.2
      * @deprecated 3.0
      */
@@ -3676,7 +3676,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param selector A selector to filter the elements that trigger the event.
      * @param events A plain object of one or more event types and functions to execute for them.
-     * @see [delegate](https://api.jquery.com/delegate/)
+     * @see [delegate on api.jquery.com](https://api.jquery.com/delegate/)
      * @since 1.4.3
      * @deprecated 3.0
      */
@@ -3686,7 +3686,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Execute the next function on the queue for the matched elements.
      *
      * @param queueName A string containing the name of the queue. Defaults to fx, the standard effects queue.
-     * @see [dequeue](https://api.jquery.com/dequeue/)
+     * @see [dequeue on api.jquery.com](https://api.jquery.com/dequeue/)
      * @since 1.2
      */
     dequeue(queueName?: string): this;
@@ -3694,7 +3694,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Remove the set of matched elements from the DOM.
      *
      * @param selector A selector expression that filters the set of matched elements to be removed.
-     * @see [detach](https://api.jquery.com/detach/)
+     * @see [detach on api.jquery.com](https://api.jquery.com/detach/)
      * @since 1.4
      */
     detach(selector?: JQuery.Selector): this;
@@ -3702,14 +3702,14 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Iterate over a jQuery object, executing a function for each matched element.
      *
      * @param fn A function to execute for each matched element.
-     * @see [each](https://api.jquery.com/each/)
+     * @see [each on api.jquery.com](https://api.jquery.com/each/)
      * @since 1.0
      */
     each(fn: (this: TElement, index: number, element: TElement) => void | false): this;
     /**
      * Remove all child nodes of the set of matched elements from the DOM.
      *
-     * @see [empty](https://api.jquery.com/empty/)
+     * @see [empty on api.jquery.com](https://api.jquery.com/empty/)
      * @since 1.0
      */
     empty(): this;
@@ -3717,7 +3717,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * End the most recent filtering operation in the current chain and return the set of matched elements
      * to its previous state.
      *
-     * @see [end](https://api.jquery.com/end/)
+     * @see [end on api.jquery.com](https://api.jquery.com/end/)
      * @since 1.0
      */
     end(): this;
@@ -3726,7 +3726,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param index An integer indicating the 0-based position of the element.
      *              An integer indicating the position of the element, counting backwards from the last element in the set.
-     * @see [eq](https://api.jquery.com/eq/)
+     * @see [eq on api.jquery.com](https://api.jquery.com/eq/)
      * @since 1.1.2
      * @since 1.4
      */
@@ -3735,7 +3735,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Merge the contents of an object onto the jQuery prototype to provide new jQuery instance methods.
      *
      * @param obj An object to merge onto the jQuery prototype.
-     * @see [jQuery.fn.extend](https://api.jquery.com/jQuery.fn.extend/)
+     * @see [jQuery.fn.extend on api.jquery.com](https://api.jquery.com/jQuery.fn.extend/)
      * @since 1.0
      */
     extend(obj: object): this;
@@ -3745,7 +3745,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param duration A string or number determining how long the animation will run.
      * @param easing A string indicating which easing function to use for the transition.
      * @param complete A function to call once the animation is complete, called once per matched element.
-     * @see [fadeIn](https://api.jquery.com/fadeIn/)
+     * @see [fadeIn on api.jquery.com](https://api.jquery.com/fadeIn/)
      * @since 1.4.3
      */
     fadeIn(duration: JQuery.Duration, easing: string, complete?: (this: TElement) => void): this;
@@ -3755,7 +3755,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param duration_easing A string or number determining how long the animation will run.
      *                        A string indicating which easing function to use for the transition.
      * @param complete A function to call once the animation is complete, called once per matched element.
-     * @see [fadeIn](https://api.jquery.com/fadeIn/)
+     * @see [fadeIn on api.jquery.com](https://api.jquery.com/fadeIn/)
      * @since 1.0
      * @since 1.4.3
      */
@@ -3767,7 +3767,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *                                         A string indicating which easing function to use for the transition.
      *                                         A function to call once the animation is complete, called once per matched element.
      *                                         A map of additional options to pass to the method.
-     * @see [fadeIn](https://api.jquery.com/fadeIn/)
+     * @see [fadeIn on api.jquery.com](https://api.jquery.com/fadeIn/)
      * @since 1.0
      * @since 1.4.3
      */
@@ -3778,7 +3778,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param duration A string or number determining how long the animation will run.
      * @param easing A string indicating which easing function to use for the transition.
      * @param complete A function to call once the animation is complete, called once per matched element.
-     * @see [fadeOut](https://api.jquery.com/fadeOut/)
+     * @see [fadeOut on api.jquery.com](https://api.jquery.com/fadeOut/)
      * @since 1.4.3
      */
     fadeOut(duration: JQuery.Duration, easing: string, complete?: (this: TElement) => void): this;
@@ -3788,7 +3788,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param duration_easing A string or number determining how long the animation will run.
      *                        A string indicating which easing function to use for the transition.
      * @param complete A function to call once the animation is complete, called once per matched element.
-     * @see [fadeOut](https://api.jquery.com/fadeOut/)
+     * @see [fadeOut on api.jquery.com](https://api.jquery.com/fadeOut/)
      * @since 1.0
      * @since 1.4.3
      */
@@ -3800,7 +3800,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *                                         A string indicating which easing function to use for the transition.
      *                                         A function to call once the animation is complete, called once per matched element.
      *                                         A map of additional options to pass to the method.
-     * @see [fadeOut](https://api.jquery.com/fadeOut/)
+     * @see [fadeOut on api.jquery.com](https://api.jquery.com/fadeOut/)
      * @since 1.0
      * @since 1.4.3
      */
@@ -3812,7 +3812,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param opacity A number between 0 and 1 denoting the target opacity.
      * @param easing A string indicating which easing function to use for the transition.
      * @param complete A function to call once the animation is complete, called once per matched element.
-     * @see [fadeTo](https://api.jquery.com/fadeTo/)
+     * @see [fadeTo on api.jquery.com](https://api.jquery.com/fadeTo/)
      * @since 1.4.3
      */
     fadeTo(duration: JQuery.Duration, opacity: number, easing: string, complete?: (this: TElement) => void): this;
@@ -3822,7 +3822,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param duration A string or number determining how long the animation will run.
      * @param opacity A number between 0 and 1 denoting the target opacity.
      * @param complete A function to call once the animation is complete, called once per matched element.
-     * @see [fadeTo](https://api.jquery.com/fadeTo/)
+     * @see [fadeTo on api.jquery.com](https://api.jquery.com/fadeTo/)
      * @since 1.0
      */
     fadeTo(duration: JQuery.Duration, opacity: number, complete?: (this: TElement) => void): this;
@@ -3832,7 +3832,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param duration A string or number determining how long the animation will run.
      * @param easing A string indicating which easing function to use for the transition.
      * @param complete A function to call once the animation is complete, called once per matched element.
-     * @see [fadeToggle](https://api.jquery.com/fadeToggle/)
+     * @see [fadeToggle on api.jquery.com](https://api.jquery.com/fadeToggle/)
      * @since 1.4.4
      */
     fadeToggle(duration: JQuery.Duration, easing: string, complete?: (this: TElement) => void): this;
@@ -3842,7 +3842,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param duration_easing A string or number determining how long the animation will run.
      *                        A string indicating which easing function to use for the transition.
      * @param complete A function to call once the animation is complete, called once per matched element.
-     * @see [fadeToggle](https://api.jquery.com/fadeToggle/)
+     * @see [fadeToggle on api.jquery.com](https://api.jquery.com/fadeToggle/)
      * @since 1.0
      * @since 1.4.3
      */
@@ -3854,7 +3854,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *                                         A string indicating which easing function to use for the transition.
      *                                         A function to call once the animation is complete, called once per matched element.
      *                                         A map of additional options to pass to the method.
-     * @see [fadeToggle](https://api.jquery.com/fadeToggle/)
+     * @see [fadeToggle on api.jquery.com](https://api.jquery.com/fadeToggle/)
      * @since 1.0
      * @since 1.4.3
      */
@@ -3866,7 +3866,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *                 One or more DOM elements to match the current set of elements against.
      *                 An existing jQuery object to match the current set of elements against.
      *                 A function used as a test for each element in the set. this is the current DOM element.
-     * @see [filter](https://api.jquery.com/filter/)
+     * @see [filter on api.jquery.com](https://api.jquery.com/filter/)
      * @since 1.0
      * @since 1.4
      */
@@ -3877,7 +3877,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param selector A string containing a selector expression to match elements against.
      *                 An element or a jQuery object to match elements against.
-     * @see [find](https://api.jquery.com/find/)
+     * @see [find on api.jquery.com](https://api.jquery.com/find/)
      * @since 1.0
      * @since 1.6
      */
@@ -3887,14 +3887,14 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * the matched elements.
      *
      * @param queue The name of the queue in which to stop animations.
-     * @see [finish](https://api.jquery.com/finish/)
+     * @see [finish on api.jquery.com](https://api.jquery.com/finish/)
      * @since 1.9
      */
     finish(queue?: string): this;
     /**
      * Reduce the set of matched elements to the first in the set.
      *
-     * @see [first](https://api.jquery.com/first/)
+     * @see [first on api.jquery.com](https://api.jquery.com/first/)
      * @since 1.4
      */
     first(): this;
@@ -3903,7 +3903,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute each time the event is triggered.
-     * @see [focus](https://api.jquery.com/focus/)
+     * @see [focus on api.jquery.com](https://api.jquery.com/focus/)
      * @since 1.4.3
      * @deprecated 3.3
      */
@@ -3913,7 +3913,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Bind an event handler to the "focus" JavaScript event, or trigger that event on an element.
      *
      * @param handler A function to execute each time the event is triggered.
-     * @see [focus](https://api.jquery.com/focus/)
+     * @see [focus on api.jquery.com](https://api.jquery.com/focus/)
      * @since 1.0
      * @deprecated 3.3
      */
@@ -3923,7 +3923,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute each time the event is triggered.
-     * @see [focusin](https://api.jquery.com/focusin/)
+     * @see [focusin on api.jquery.com](https://api.jquery.com/focusin/)
      * @since 1.4.3
      * @deprecated 3.3
      */
@@ -3933,7 +3933,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Bind an event handler to the "focusin" event.
      *
      * @param handler A function to execute each time the event is triggered.
-     * @see [focusin](https://api.jquery.com/focusin/)
+     * @see [focusin on api.jquery.com](https://api.jquery.com/focusin/)
      * @since 1.4
      * @deprecated 3.3
      */
@@ -3943,7 +3943,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute each time the event is triggered.
-     * @see [focusout](https://api.jquery.com/focusout/)
+     * @see [focusout on api.jquery.com](https://api.jquery.com/focusout/)
      * @since 1.4.3
      * @deprecated 3.3
      */
@@ -3953,7 +3953,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Bind an event handler to the "focusout" JavaScript event.
      *
      * @param handler A function to execute each time the event is triggered.
-     * @see [focusout](https://api.jquery.com/focusout/)
+     * @see [focusout on api.jquery.com](https://api.jquery.com/focusout/)
      * @since 1.4
      * @deprecated 3.3
      */
@@ -3962,14 +3962,14 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Retrieve one of the elements matched by the jQuery object.
      *
      * @param index A zero-based integer indicating which element to retrieve.
-     * @see [get](https://api.jquery.com/get/)
+     * @see [get on api.jquery.com](https://api.jquery.com/get/)
      * @since 1.0
      */
     get(index: number): TElement;
     /**
      * Retrieve the elements matched by the jQuery object.
      *
-     * @see [get](https://api.jquery.com/get/)
+     * @see [get on api.jquery.com](https://api.jquery.com/get/)
      * @since 1.0
      */
     get(): TElement[];
@@ -3978,7 +3978,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param selector A string containing a selector expression to match elements against.
      *                 A DOM element to match elements against.
-     * @see [has](https://api.jquery.com/has/)
+     * @see [has on api.jquery.com](https://api.jquery.com/has/)
      * @since 1.4
      */
     has(selector: string | Element): this;
@@ -3986,7 +3986,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Determine whether any of the matched elements are assigned the given class.
      *
      * @param className The class name to search for.
-     * @see [hasClass](https://api.jquery.com/hasClass/)
+     * @see [hasClass on api.jquery.com](https://api.jquery.com/hasClass/)
      * @since 1.2
      */
     hasClass(className: string): boolean;
@@ -3997,7 +3997,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *              appended (as a string).
      *              A function returning the height to set. Receives the index position of the element in the set and
      *              the old height as arguments. Within the function, this refers to the current element in the set.
-     * @see [height](https://api.jquery.com/height/)
+     * @see [height on api.jquery.com](https://api.jquery.com/height/)
      * @since 1.0
      * @since 1.4.1
      */
@@ -4005,7 +4005,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
     /**
      * Get the current computed height for the first element in the set of matched elements.
      *
-     * @see [height](https://api.jquery.com/height/)
+     * @see [height on api.jquery.com](https://api.jquery.com/height/)
      * @since 1.0
      */
     height(): number | undefined;
@@ -4015,7 +4015,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param duration A string or number determining how long the animation will run.
      * @param easing A string indicating which easing function to use for the transition.
      * @param complete A function to call once the animation is complete, called once per matched element.
-     * @see [hide](https://api.jquery.com/hide/)
+     * @see [hide on api.jquery.com](https://api.jquery.com/hide/)
      * @since 1.4.3
      */
     hide(duration: JQuery.Duration, easing: string, complete: (this: TElement) => void): this;
@@ -4025,7 +4025,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param duration A string or number determining how long the animation will run.
      * @param easing_complete A string indicating which easing function to use for the transition.
      *                        A function to call once the animation is complete, called once per matched element.
-     * @see [hide](https://api.jquery.com/hide/)
+     * @see [hide on api.jquery.com](https://api.jquery.com/hide/)
      * @since 1.0
      * @since 1.4.3
      */
@@ -4036,7 +4036,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param duration_complete_options A string or number determining how long the animation will run.
      *                                  A function to call once the animation is complete, called once per matched element.
      *                                  A map of additional options to pass to the method.
-     * @see [hide](https://api.jquery.com/hide/)
+     * @see [hide on api.jquery.com](https://api.jquery.com/hide/)
      * @since 1.0
      */
     hide(duration_complete_options?: JQuery.Duration | ((this: TElement) => void) | JQuery.EffectsOptions<TElement>): this;
@@ -4046,7 +4046,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param handlerInOut A function to execute when the mouse pointer enters or leaves the element.
      * @param handlerOut A function to execute when the mouse pointer leaves the element.
-     * @see [hover](https://api.jquery.com/hover/)
+     * @see [hover on api.jquery.com](https://api.jquery.com/hover/)
      * @since 1.0
      * @since 1.4
      */
@@ -4060,7 +4060,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *                   A function returning the HTML content to set. Receives the index position of the element in the set
      *                   and the old HTML value as arguments. jQuery empties the element before calling the function; use the
      *                   oldhtml argument to reference the previous content. Within the function, this refers to the current element in the set.
-     * @see [html](https://api.jquery.com/html/)
+     * @see [html on api.jquery.com](https://api.jquery.com/html/)
      * @since 1.0
      * @since 1.4
      */
@@ -4068,7 +4068,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
     /**
      * Get the HTML contents of the first element in the set of matched elements.
      *
-     * @see [html](https://api.jquery.com/html/)
+     * @see [html on api.jquery.com](https://api.jquery.com/html/)
      * @since 1.0
      */
     html(): string;
@@ -4077,7 +4077,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param element The DOM element or first element within the jQuery object to look for.
      *                A selector representing a jQuery collection in which to look for an element.
-     * @see [index](https://api.jquery.com/index/)
+     * @see [index on api.jquery.com](https://api.jquery.com/index/)
      * @since 1.0
      * @since 1.4
      */
@@ -4090,7 +4090,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *              A function returning the inner height (including padding but not border) to set. Receives the index
      *              position of the element in the set and the old inner height as arguments. Within the function, this
      *              refers to the current element in the set.
-     * @see [innerHeight](https://api.jquery.com/innerHeight/)
+     * @see [innerHeight on api.jquery.com](https://api.jquery.com/innerHeight/)
      * @since 1.8.0
      */
     innerHeight(value: string | number | ((this: TElement, index: number, height: number) => string | number)): this;
@@ -4098,7 +4098,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Get the current computed height for the first element in the set of matched elements, including
      * padding but not border.
      *
-     * @see [innerHeight](https://api.jquery.com/innerHeight/)
+     * @see [innerHeight on api.jquery.com](https://api.jquery.com/innerHeight/)
      * @since 1.2.6
      */
     innerHeight(): number | undefined;
@@ -4110,7 +4110,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *              A function returning the inner width (including padding but not border) to set. Receives the index
      *              position of the element in the set and the old inner width as arguments. Within the function, this
      *              refers to the current element in the set.
-     * @see [innerWidth](https://api.jquery.com/innerWidth/)
+     * @see [innerWidth on api.jquery.com](https://api.jquery.com/innerWidth/)
      * @since 1.8.0
      */
     innerWidth(value: string | number | ((this: TElement, index: number, width: number) => string | number)): this;
@@ -4118,7 +4118,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Get the current computed inner width for the first element in the set of matched elements, including
      * padding but not border.
      *
-     * @see [innerWidth](https://api.jquery.com/innerWidth/)
+     * @see [innerWidth on api.jquery.com](https://api.jquery.com/innerWidth/)
      * @since 1.2.6
      */
     innerWidth(): number | undefined;
@@ -4127,7 +4127,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param target A selector, element, array of elements, HTML string, or jQuery object; the matched set of elements
      *               will be inserted after the element(s) specified by this parameter.
-     * @see [insertAfter](https://api.jquery.com/insertAfter/)
+     * @see [insertAfter on api.jquery.com](https://api.jquery.com/insertAfter/)
      * @since 1.0
      */
     insertAfter(target: JQuery.Selector | JQuery.htmlString | JQuery.TypeOrArray<Element> | JQuery): this;
@@ -4136,7 +4136,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param target A selector, element, array of elements, HTML string, or jQuery object; the matched set of elements
      *               will be inserted before the element(s) specified by this parameter.
-     * @see [insertBefore](https://api.jquery.com/insertBefore/)
+     * @see [insertBefore on api.jquery.com](https://api.jquery.com/insertBefore/)
      * @since 1.0
      */
     insertBefore(target: JQuery.Selector | JQuery.htmlString | JQuery.TypeOrArray<Element> | JQuery): this;
@@ -4150,7 +4150,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *                 function, this refers to the current DOM element.
      *                 An existing jQuery object to match the current set of elements against.
      *                 One or more elements to match the current set of elements against.
-     * @see [is](https://api.jquery.com/is/)
+     * @see [is on api.jquery.com](https://api.jquery.com/is/)
      * @since 1.0
      * @since 1.6
      */
@@ -4160,7 +4160,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute each time the event is triggered.
-     * @see [keydown](https://api.jquery.com/keydown/)
+     * @see [keydown on api.jquery.com](https://api.jquery.com/keydown/)
      * @since 1.4.3
      * @deprecated 3.3
      */
@@ -4170,7 +4170,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Bind an event handler to the "keydown" JavaScript event, or trigger that event on an element.
      *
      * @param handler A function to execute each time the event is triggered.
-     * @see [keydown](https://api.jquery.com/keydown/)
+     * @see [keydown on api.jquery.com](https://api.jquery.com/keydown/)
      * @since 1.0
      * @deprecated 3.3
      */
@@ -4180,7 +4180,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute each time the event is triggered.
-     * @see [keypress](https://api.jquery.com/keypress/)
+     * @see [keypress on api.jquery.com](https://api.jquery.com/keypress/)
      * @since 1.4.3
      * @deprecated 3.3
      */
@@ -4190,7 +4190,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Bind an event handler to the "keypress" JavaScript event, or trigger that event on an element.
      *
      * @param handler A function to execute each time the event is triggered.
-     * @see [keypress](https://api.jquery.com/keypress/)
+     * @see [keypress on api.jquery.com](https://api.jquery.com/keypress/)
      * @since 1.0
      * @deprecated 3.3
      */
@@ -4200,7 +4200,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute each time the event is triggered.
-     * @see [keyup](https://api.jquery.com/keyup/)
+     * @see [keyup on api.jquery.com](https://api.jquery.com/keyup/)
      * @since 1.4.3
      * @deprecated 3.3
      */
@@ -4210,7 +4210,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Bind an event handler to the "keyup" JavaScript event, or trigger that event on an element.
      *
      * @param handler A function to execute each time the event is triggered.
-     * @see [keyup](https://api.jquery.com/keyup/)
+     * @see [keyup on api.jquery.com](https://api.jquery.com/keyup/)
      * @since 1.0
      * @deprecated 3.3
      */
@@ -4218,7 +4218,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
     /**
      * Reduce the set of matched elements to the final one in the set.
      *
-     * @see [last](https://api.jquery.com/last/)
+     * @see [last on api.jquery.com](https://api.jquery.com/last/)
      * @since 1.4
      */
     last(): this;
@@ -4228,7 +4228,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param url A string containing the URL to which the request is sent.
      * @param data A plain object or string that is sent to the server with the request.
      * @param complete A callback function that is executed when the request completes.
-     * @see [load](https://api.jquery.com/load/)
+     * @see [load on api.jquery.com](https://api.jquery.com/load/)
      * @since 1.0
      */
     load(url: string,
@@ -4240,7 +4240,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param url A string containing the URL to which the request is sent.
      * @param complete_data A callback function that is executed when the request completes.
      *                      A plain object or string that is sent to the server with the request.
-     * @see [load](https://api.jquery.com/load/)
+     * @see [load on api.jquery.com](https://api.jquery.com/load/)
      * @since 1.0
      */
     load(url: string,
@@ -4250,7 +4250,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * containing the return values.
      *
      * @param callback A function object that will be invoked for each element in the current set.
-     * @see [map](https://api.jquery.com/map/)
+     * @see [map on api.jquery.com](https://api.jquery.com/map/)
      * @since 1.2
      */
     map(callback: (this: TElement, index: number, domElement: TElement) => any | any[] | null | undefined): this;
@@ -4259,7 +4259,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute each time the event is triggered.
-     * @see [mousedown](https://api.jquery.com/mousedown/)
+     * @see [mousedown on api.jquery.com](https://api.jquery.com/mousedown/)
      * @since 1.4.3
      * @deprecated 3.3
      */
@@ -4269,7 +4269,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Bind an event handler to the "mousedown" JavaScript event, or trigger that event on an element.
      *
      * @param handler A function to execute each time the event is triggered.
-     * @see [mousedown](https://api.jquery.com/mousedown/)
+     * @see [mousedown on api.jquery.com](https://api.jquery.com/mousedown/)
      * @since 1.0
      * @deprecated 3.3
      */
@@ -4279,7 +4279,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute each time the event is triggered.
-     * @see [mouseenter](https://api.jquery.com/mouseenter/)
+     * @see [mouseenter on api.jquery.com](https://api.jquery.com/mouseenter/)
      * @since 1.4.3
      * @deprecated 3.3
      */
@@ -4289,7 +4289,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Bind an event handler to be fired when the mouse enters an element, or trigger that handler on an element.
      *
      * @param handler A function to execute each time the event is triggered.
-     * @see [mouseenter](https://api.jquery.com/mouseenter/)
+     * @see [mouseenter on api.jquery.com](https://api.jquery.com/mouseenter/)
      * @since 1.0
      * @deprecated 3.3
      */
@@ -4299,7 +4299,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute each time the event is triggered.
-     * @see [mouseleave](https://api.jquery.com/mouseleave/)
+     * @see [mouseleave on api.jquery.com](https://api.jquery.com/mouseleave/)
      * @since 1.4.3
      * @deprecated 3.3
      */
@@ -4309,7 +4309,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Bind an event handler to be fired when the mouse leaves an element, or trigger that handler on an element.
      *
      * @param handler A function to execute each time the event is triggered.
-     * @see [mouseleave](https://api.jquery.com/mouseleave/)
+     * @see [mouseleave on api.jquery.com](https://api.jquery.com/mouseleave/)
      * @since 1.0
      * @deprecated 3.3
      */
@@ -4319,7 +4319,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute each time the event is triggered.
-     * @see [mousemove](https://api.jquery.com/mousemove/)
+     * @see [mousemove on api.jquery.com](https://api.jquery.com/mousemove/)
      * @since 1.4.3
      * @deprecated 3.3
      */
@@ -4329,7 +4329,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Bind an event handler to the "mousemove" JavaScript event, or trigger that event on an element.
      *
      * @param handler A function to execute each time the event is triggered.
-     * @see [mousemove](https://api.jquery.com/mousemove/)
+     * @see [mousemove on api.jquery.com](https://api.jquery.com/mousemove/)
      * @since 1.0
      * @deprecated 3.3
      */
@@ -4339,7 +4339,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute each time the event is triggered.
-     * @see [mouseout](https://api.jquery.com/mouseout/)
+     * @see [mouseout on api.jquery.com](https://api.jquery.com/mouseout/)
      * @since 1.4.3
      * @deprecated 3.3
      */
@@ -4349,7 +4349,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Bind an event handler to the "mouseout" JavaScript event, or trigger that event on an element.
      *
      * @param handler A function to execute each time the event is triggered.
-     * @see [mouseout](https://api.jquery.com/mouseout/)
+     * @see [mouseout on api.jquery.com](https://api.jquery.com/mouseout/)
      * @since 1.0
      * @deprecated 3.3
      */
@@ -4359,7 +4359,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute each time the event is triggered.
-     * @see [mouseover](https://api.jquery.com/mouseover/)
+     * @see [mouseover on api.jquery.com](https://api.jquery.com/mouseover/)
      * @since 1.4.3
      * @deprecated 3.3
      */
@@ -4369,7 +4369,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Bind an event handler to the "mouseover" JavaScript event, or trigger that event on an element.
      *
      * @param handler A function to execute each time the event is triggered.
-     * @see [mouseover](https://api.jquery.com/mouseover/)
+     * @see [mouseover on api.jquery.com](https://api.jquery.com/mouseover/)
      * @since 1.0
      * @deprecated 3.3
      */
@@ -4379,7 +4379,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute each time the event is triggered.
-     * @see [mouseup](https://api.jquery.com/mouseup/)
+     * @see [mouseup on api.jquery.com](https://api.jquery.com/mouseup/)
      * @since 1.4.3
      * @deprecated 3.3
      */
@@ -4389,7 +4389,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Bind an event handler to the "mouseup" JavaScript event, or trigger that event on an element.
      *
      * @param handler A function to execute each time the event is triggered.
-     * @see [mouseup](https://api.jquery.com/mouseup/)
+     * @see [mouseup on api.jquery.com](https://api.jquery.com/mouseup/)
      * @since 1.0
      * @deprecated 3.3
      */
@@ -4399,7 +4399,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * is provided, it retrieves the next sibling only if it matches that selector.
      *
      * @param selector A string containing a selector expression to match elements against.
-     * @see [next](https://api.jquery.com/next/)
+     * @see [next on api.jquery.com](https://api.jquery.com/next/)
      * @since 1.0
      */
     next(selector?: JQuery.Selector): this;
@@ -4407,7 +4407,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Get all following siblings of each element in the set of matched elements, optionally filtered by a selector.
      *
      * @param selector A string containing a selector expression to match elements against.
-     * @see [nextAll](https://api.jquery.com/nextAll/)
+     * @see [nextAll on api.jquery.com](https://api.jquery.com/nextAll/)
      * @since 1.2
      */
     nextAll(selector?: string): this;
@@ -4418,7 +4418,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param selector A string containing a selector expression to indicate where to stop matching following sibling elements.
      *                 A DOM node or jQuery object indicating where to stop matching following sibling elements.
      * @param filter A string containing a selector expression to match elements against.
-     * @see [nextUntil](https://api.jquery.com/nextUntil/)
+     * @see [nextUntil on api.jquery.com](https://api.jquery.com/nextUntil/)
      * @since 1.4
      * @since 1.6
      */
@@ -4431,7 +4431,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *                 element's index in the jQuery collection, and element, which is the DOM element. Within the
      *                 function, this refers to the current DOM element.
      *                 An existing jQuery object to match the current set of elements against.
-     * @see [not](https://api.jquery.com/not/)
+     * @see [not on api.jquery.com](https://api.jquery.com/not/)
      * @since 1.0
      * @since 1.4
      */
@@ -4443,7 +4443,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *               "click", "keydown.myPlugin", or ".myPlugin".
      * @param selector A selector which should match the one originally passed to .on() when attaching event handlers.
      * @param handler A function to execute each time the event is triggered.
-     * @see [off](https://api.jquery.com/off/)
+     * @see [off on api.jquery.com](https://api.jquery.com/off/)
      * @since 1.7
      */
     off(events: string, selector: JQuery.Selector, handler: JQuery.EventHandlerBase<any, JQuery.Event<TElement, any>> | false): this;
@@ -4454,7 +4454,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *               "click", "keydown.myPlugin", or ".myPlugin".
      * @param selector_handler A selector which should match the one originally passed to .on() when attaching event handlers.
      *                         A function to execute each time the event is triggered.
-     * @see [off](https://api.jquery.com/off/)
+     * @see [off on api.jquery.com](https://api.jquery.com/off/)
      * @since 1.7
      */
     off(events: string, selector_handler?: JQuery.Selector | JQuery.EventHandlerBase<any, JQuery.Event<TElement, any>> | false): this;
@@ -4464,7 +4464,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param events An object where the string keys represent one or more space-separated event types and optional
      *               namespaces, and the values represent handler functions previously attached for the event(s).
      * @param selector A selector which should match the one originally passed to .on() when attaching event handlers.
-     * @see [off](https://api.jquery.com/off/)
+     * @see [off on api.jquery.com](https://api.jquery.com/off/)
      * @since 1.7
      */
     off(events: JQuery.PlainObject<JQuery.EventHandlerBase<any, JQuery.Event<TElement, any>> | false>, selector?: JQuery.Selector): this;
@@ -4472,7 +4472,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Remove an event handler.
      *
      * @param event A jQuery.Event object.
-     * @see [off](https://api.jquery.com/off/)
+     * @see [off on api.jquery.com](https://api.jquery.com/off/)
      * @since 1.7
      */
     off(event?: JQuery.Event<TElement>): this;
@@ -4484,21 +4484,21 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *                    A function to return the coordinates to set. Receives the index of the element in the collection as
      *                    the first argument and the current coordinates as the second argument. The function should return an
      *                    object with the new top and left properties.
-     * @see [offset](https://api.jquery.com/offset/)
+     * @see [offset on api.jquery.com](https://api.jquery.com/offset/)
      * @since 1.4
      */
     offset(coordinates: JQuery.Coordinates | ((this: TElement, index: number, coords: JQuery.Coordinates) => JQuery.Coordinates)): this;
     /**
      * Get the current coordinates of the first element in the set of matched elements, relative to the document.
      *
-     * @see [offset](https://api.jquery.com/offset/)
+     * @see [offset on api.jquery.com](https://api.jquery.com/offset/)
      * @since 1.2
      */
     offset(): JQuery.Coordinates | undefined;
     /**
      * Get the closest ancestor element that is positioned.
      *
-     * @see [offsetParent](https://api.jquery.com/offsetParent/)
+     * @see [offsetParent on api.jquery.com](https://api.jquery.com/offsetParent/)
      * @since 1.2.6
      */
     offsetParent(): this;
@@ -4510,7 +4510,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *                 selector is null or omitted, the event is always triggered when it reaches the selected element.
      * @param data Data to be passed to the handler in event.data when an event is triggered.
      * @param handler A function to execute when the event is triggered.
-     * @see [on](https://api.jquery.com/on/)
+     * @see [on on api.jquery.com](https://api.jquery.com/on/)
      * @since 1.7
      */
     on<TData>(events: string,
@@ -4525,7 +4525,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *                 selector is null or omitted, the event is always triggered when it reaches the selected element.
      * @param handler A function to execute when the event is triggered. The value false is also allowed as a shorthand
      *                for a function that simply does return false.
-     * @see [on](https://api.jquery.com/on/)
+     * @see [on on api.jquery.com](https://api.jquery.com/on/)
      * @since 1.7
      */
     on(events: string,
@@ -4537,7 +4537,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param events One or more space-separated event types and optional namespaces, such as "click" or "keydown.myPlugin".
      * @param data Data to be passed to the handler in event.data when an event is triggered.
      * @param handler A function to execute when the event is triggered.
-     * @see [on](https://api.jquery.com/on/)
+     * @see [on on api.jquery.com](https://api.jquery.com/on/)
      * @since 1.7
      */
     on<TData>(events: string,
@@ -4549,7 +4549,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param events One or more space-separated event types and optional namespaces, such as "click" or "keydown.myPlugin".
      * @param handler A function to execute when the event is triggered. The value false is also allowed as a shorthand
      *                for a function that simply does return false.
-     * @see [on](https://api.jquery.com/on/)
+     * @see [on on api.jquery.com](https://api.jquery.com/on/)
      * @since 1.7
      */
     on(events: string,
@@ -4562,7 +4562,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param selector A selector string to filter the descendants of the selected elements that will call the handler. If
      *                 the selector is null or omitted, the handler is always called when it reaches the selected element.
      * @param data Data to be passed to the handler in event.data when an event occurs.
-     * @see [on](https://api.jquery.com/on/)
+     * @see [on on api.jquery.com](https://api.jquery.com/on/)
      * @since 1.7
      */
     on<TData>(events: JQuery.PlainObject<JQuery.EventHandler<TElement, TData> | JQuery.EventHandlerBase<any, JQuery.Event<TElement, TData>> | false>,
@@ -4575,7 +4575,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *               namespaces, and the values represent a handler function to be called for the event(s).
      * @param selector A selector string to filter the descendants of the selected elements that will call the handler. If
      *                 the selector is null or omitted, the handler is always called when it reaches the selected element.
-     * @see [on](https://api.jquery.com/on/)
+     * @see [on on api.jquery.com](https://api.jquery.com/on/)
      * @since 1.7
      */
     on(events: JQuery.PlainObject<JQuery.EventHandler<TElement> | JQuery.EventHandlerBase<any, JQuery.Event<TElement>> | false>,
@@ -4586,7 +4586,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param events An object in which the string keys represent one or more space-separated event types and optional
      *               namespaces, and the values represent a handler function to be called for the event(s).
      * @param data Data to be passed to the handler in event.data when an event occurs.
-     * @see [on](https://api.jquery.com/on/)
+     * @see [on on api.jquery.com](https://api.jquery.com/on/)
      * @since 1.7
      */
     on<TData>(events: JQuery.PlainObject<JQuery.EventHandler<TElement, TData> | JQuery.EventHandlerBase<any, JQuery.Event<TElement, TData>> | false>,
@@ -4596,7 +4596,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param events An object in which the string keys represent one or more space-separated event types and optional
      *               namespaces, and the values represent a handler function to be called for the event(s).
-     * @see [on](https://api.jquery.com/on/)
+     * @see [on on api.jquery.com](https://api.jquery.com/on/)
      * @since 1.7
      */
     on(events: JQuery.PlainObject<JQuery.EventHandler<TElement> | JQuery.EventHandlerBase<any, JQuery.Event<TElement>> | false>): this;
@@ -4608,7 +4608,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *                 selector is null or omitted, the event is always triggered when it reaches the selected element.
      * @param data Data to be passed to the handler in event.data when an event is triggered.
      * @param handler A function to execute when the event is triggered.
-     * @see [one](https://api.jquery.com/one/)
+     * @see [one on api.jquery.com](https://api.jquery.com/one/)
      * @since 1.7
      */
     one<TData>(events: string,
@@ -4623,7 +4623,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *                 selector is null or omitted, the event is always triggered when it reaches the selected element.
      * @param handler A function to execute when the event is triggered. The value false is also allowed as a shorthand
      *                for a function that simply does return false.
-     * @see [one](https://api.jquery.com/one/)
+     * @see [one on api.jquery.com](https://api.jquery.com/one/)
      * @since 1.7
      */
     one(events: string,
@@ -4635,7 +4635,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param events One or more space-separated event types and optional namespaces, such as "click" or "keydown.myPlugin".
      * @param data Data to be passed to the handler in event.data when an event is triggered.
      * @param handler A function to execute when the event is triggered.
-     * @see [one](https://api.jquery.com/one/)
+     * @see [one on api.jquery.com](https://api.jquery.com/one/)
      * @since 1.7
      */
     one<TData>(events: string,
@@ -4647,7 +4647,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param events One or more space-separated event types and optional namespaces, such as "click" or "keydown.myPlugin".
      * @param handler A function to execute when the event is triggered. The value false is also allowed as a shorthand
      *                for a function that simply does return false.
-     * @see [one](https://api.jquery.com/one/)
+     * @see [one on api.jquery.com](https://api.jquery.com/one/)
      * @since 1.7
      */
     one(events: string,
@@ -4660,7 +4660,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param selector A selector string to filter the descendants of the selected elements that will call the handler. If
      *                 the selector is null or omitted, the handler is always called when it reaches the selected element.
      * @param data Data to be passed to the handler in event.data when an event occurs.
-     * @see [one](https://api.jquery.com/one/)
+     * @see [one on api.jquery.com](https://api.jquery.com/one/)
      * @since 1.7
      */
     one<TData>(events: JQuery.PlainObject<JQuery.EventHandler<TElement, TData> | JQuery.EventHandlerBase<any, JQuery.Event<TElement, TData>> | false>,
@@ -4673,7 +4673,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *               namespaces, and the values represent a handler function to be called for the event(s).
      * @param selector A selector string to filter the descendants of the selected elements that will call the handler. If
      *                 the selector is null or omitted, the handler is always called when it reaches the selected element.
-     * @see [one](https://api.jquery.com/one/)
+     * @see [one on api.jquery.com](https://api.jquery.com/one/)
      * @since 1.7
      */
     one(events: JQuery.PlainObject<JQuery.EventHandler<TElement> | JQuery.EventHandlerBase<any, JQuery.Event<TElement>> | false>,
@@ -4684,7 +4684,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param events An object in which the string keys represent one or more space-separated event types and optional
      *               namespaces, and the values represent a handler function to be called for the event(s).
      * @param data Data to be passed to the handler in event.data when an event occurs.
-     * @see [one](https://api.jquery.com/one/)
+     * @see [one on api.jquery.com](https://api.jquery.com/one/)
      * @since 1.7
      */
     one<TData>(events: JQuery.PlainObject<JQuery.EventHandler<TElement, TData> | JQuery.EventHandlerBase<any, JQuery.Event<TElement, TData>> | false>,
@@ -4694,7 +4694,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param events An object in which the string keys represent one or more space-separated event types and optional
      *               namespaces, and the values represent a handler function to be called for the event(s).
-     * @see [one](https://api.jquery.com/one/)
+     * @see [one on api.jquery.com](https://api.jquery.com/one/)
      * @since 1.7
      */
     one(events: JQuery.PlainObject<JQuery.EventHandler<TElement> | JQuery.EventHandlerBase<any, JQuery.Event<TElement>> | false>): this;
@@ -4703,7 +4703,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param value A number representing the number of pixels, or a number along with an optional unit of measure
      *              appended (as a string).
-     * @see [outerHeight](https://api.jquery.com/outerHeight/)
+     * @see [outerHeight on api.jquery.com](https://api.jquery.com/outerHeight/)
      * @since 1.8.0
      */
     outerHeight(value: string | number | ((this: TElement, index: number, height: number) => string | number)): this;
@@ -4712,7 +4712,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * first element in the set of matched elements.
      *
      * @param includeMargin A Boolean indicating whether to include the element's margin in the calculation.
-     * @see [outerHeight](https://api.jquery.com/outerHeight/)
+     * @see [outerHeight on api.jquery.com](https://api.jquery.com/outerHeight/)
      * @since 1.2.6
      */
     outerHeight(includeMargin?: boolean): number | undefined;
@@ -4723,7 +4723,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *              appended (as a string).
      *              A function returning the outer width to set. Receives the index position of the element in the set
      *              and the old outer width as arguments. Within the function, this refers to the current element in the set.
-     * @see [outerWidth](https://api.jquery.com/outerWidth/)
+     * @see [outerWidth on api.jquery.com](https://api.jquery.com/outerWidth/)
      * @since 1.8.0
      */
     outerWidth(value: string | number | ((this: TElement, index: number, width: number) => string | number)): this;
@@ -4732,7 +4732,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * first element in the set of matched elements.
      *
      * @param includeMargin A Boolean indicating whether to include the element's margin in the calculation.
-     * @see [outerWidth](https://api.jquery.com/outerWidth/)
+     * @see [outerWidth on api.jquery.com](https://api.jquery.com/outerWidth/)
      * @since 1.2.6
      */
     outerWidth(includeMargin?: boolean): number | undefined;
@@ -4740,7 +4740,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Get the parent of each element in the current set of matched elements, optionally filtered by a selector.
      *
      * @param selector A string containing a selector expression to match elements against.
-     * @see [parent](https://api.jquery.com/parent/)
+     * @see [parent on api.jquery.com](https://api.jquery.com/parent/)
      * @since 1.0
      */
     parent(selector?: JQuery.Selector): this;
@@ -4748,7 +4748,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Get the ancestors of each element in the current set of matched elements, optionally filtered by a selector.
      *
      * @param selector A string containing a selector expression to match elements against.
-     * @see [parents](https://api.jquery.com/parents/)
+     * @see [parents on api.jquery.com](https://api.jquery.com/parents/)
      * @since 1.0
      */
     parents(selector?: JQuery.Selector): this;
@@ -4759,7 +4759,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param selector A string containing a selector expression to indicate where to stop matching ancestor elements.
      *                 A DOM node or jQuery object indicating where to stop matching ancestor elements.
      * @param filter A string containing a selector expression to match elements against.
-     * @see [parentsUntil](https://api.jquery.com/parentsUntil/)
+     * @see [parentsUntil on api.jquery.com](https://api.jquery.com/parentsUntil/)
      * @since 1.4
      * @since 1.6
      */
@@ -4767,7 +4767,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
     /**
      * Get the current coordinates of the first element in the set of matched elements, relative to the offset parent.
      *
-     * @see [position](https://api.jquery.com/position/)
+     * @see [position on api.jquery.com](https://api.jquery.com/position/)
      * @since 1.2
      */
     position(): JQuery.Coordinates;
@@ -4776,7 +4776,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param contents One or more additional DOM elements, text nodes, arrays of elements and text nodes, HTML strings, or
      *                 jQuery objects to insert at the beginning of each element in the set of matched elements.
-     * @see [prepend](https://api.jquery.com/prepend/)
+     * @see [prepend on api.jquery.com](https://api.jquery.com/prepend/)
      * @since 1.0
      */
     prepend(...contents: Array<JQuery.htmlString | JQuery.TypeOrArray<JQuery.Node | JQuery<JQuery.Node>>>): this;
@@ -4787,7 +4787,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *           the beginning of each element in the set of matched elements. Receives the index position of the
      *           element in the set and the old HTML value of the element as arguments. Within the function, this
      *           refers to the current element in the set.
-     * @see [prepend](https://api.jquery.com/prepend/)
+     * @see [prepend on api.jquery.com](https://api.jquery.com/prepend/)
      * @since 1.4
      */
     prepend(fn: (this: TElement, index: number, html: string) => JQuery.htmlString | JQuery.TypeOrArray<JQuery.Node | JQuery<JQuery.Node>>): this;
@@ -4796,7 +4796,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param target A selector, element, HTML string, array of elements, or jQuery object; the matched set of elements
      *               will be inserted at the beginning of the element(s) specified by this parameter.
-     * @see [prependTo](https://api.jquery.com/prependTo/)
+     * @see [prependTo on api.jquery.com](https://api.jquery.com/prependTo/)
      * @since 1.0
      */
     prependTo(target: JQuery.Selector | JQuery.htmlString | JQuery.TypeOrArray<Element> | JQuery): this;
@@ -4805,7 +4805,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * is provided, it retrieves the previous sibling only if it matches that selector.
      *
      * @param selector A string containing a selector expression to match elements against.
-     * @see [prev](https://api.jquery.com/prev/)
+     * @see [prev on api.jquery.com](https://api.jquery.com/prev/)
      * @since 1.0
      */
     prev(selector?: JQuery.Selector): this;
@@ -4813,7 +4813,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Get all preceding siblings of each element in the set of matched elements, optionally filtered by a selector.
      *
      * @param selector A string containing a selector expression to match elements against.
-     * @see [prevAll](https://api.jquery.com/prevAll/)
+     * @see [prevAll on api.jquery.com](https://api.jquery.com/prevAll/)
      * @since 1.2
      */
     prevAll(selector?: JQuery.Selector): this;
@@ -4824,7 +4824,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param selector A string containing a selector expression to indicate where to stop matching preceding sibling elements.
      *                 A DOM node or jQuery object indicating where to stop matching preceding sibling elements.
      * @param filter A string containing a selector expression to match elements against.
-     * @see [prevUntil](https://api.jquery.com/prevUntil/)
+     * @see [prevUntil on api.jquery.com](https://api.jquery.com/prevUntil/)
      * @since 1.4
      * @since 1.6
      */
@@ -4835,7 +4835,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param type The type of queue that needs to be observed.
      * @param target Object onto which the promise methods have to be attached
-     * @see [promise](https://api.jquery.com/promise/)
+     * @see [promise on api.jquery.com](https://api.jquery.com/promise/)
      * @since 1.6
      */
     promise<T extends object>(type: string, target: T): T & JQuery.Promise<this>;
@@ -4844,7 +4844,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * queued or not, have finished.
      *
      * @param target Object onto which the promise methods have to be attached
-     * @see [promise](https://api.jquery.com/promise/)
+     * @see [promise on api.jquery.com](https://api.jquery.com/promise/)
      * @since 1.6
      */
     promise<T extends object>(target: T): T & JQuery.Promise<this>;
@@ -4853,7 +4853,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * queued or not, have finished.
      *
      * @param type The type of queue that needs to be observed.
-     * @see [promise](https://api.jquery.com/promise/)
+     * @see [promise on api.jquery.com](https://api.jquery.com/promise/)
      * @since 1.6
      */
     promise(type?: string): JQuery.Promise<this>;
@@ -4863,7 +4863,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param propertyName The name of the property to set.
      * @param value A function returning the value to set. Receives the index position of the element in the set and the
      *              old property value as arguments. Within the function, the keyword this refers to the current element.
-     * @see [prop](https://api.jquery.com/prop/)
+     * @see [prop on api.jquery.com](https://api.jquery.com/prop/)
      * @since 1.6
      */
     prop(propertyName: string, value: (this: TElement, index: number, oldPropertyValue: any) => any): this;
@@ -4872,7 +4872,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param propertyName The name of the property to set.
      * @param value A value to set for the property.
-     * @see [prop](https://api.jquery.com/prop/)
+     * @see [prop on api.jquery.com](https://api.jquery.com/prop/)
      * @since 1.6
      */
     prop(propertyName: string, value: any): this; // tslint:disable-line:unified-signatures
@@ -4880,7 +4880,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Set one or more properties for the set of matched elements.
      *
      * @param properties An object of property-value pairs to set.
-     * @see [prop](https://api.jquery.com/prop/)
+     * @see [prop on api.jquery.com](https://api.jquery.com/prop/)
      * @since 1.6
      */
     prop(properties: JQuery.PlainObject): this;
@@ -4888,7 +4888,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Get the value of a property for the first element in the set of matched elements.
      *
      * @param propertyName The name of the property to get.
-     * @see [prop](https://api.jquery.com/prop/)
+     * @see [prop on api.jquery.com](https://api.jquery.com/prop/)
      * @since 1.6
      */
     prop(propertyName: string): any | undefined;
@@ -4898,7 +4898,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param elements An array of elements to push onto the stack and make into a new jQuery object.
      * @param name The name of a jQuery method that generated the array of elements.
      * @param args The arguments that were passed in to the jQuery method (for serialization).
-     * @see [pushStack](https://api.jquery.com/pushStack/)
+     * @see [pushStack on api.jquery.com](https://api.jquery.com/pushStack/)
      * @since 1.3
      */
     pushStack(elements: ArrayLike<Element>, name: string, args: any[]): this;
@@ -4906,7 +4906,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Add a collection of DOM elements onto the jQuery stack.
      *
      * @param elements An array of elements to push onto the stack and make into a new jQuery object.
-     * @see [pushStack](https://api.jquery.com/pushStack/)
+     * @see [pushStack on api.jquery.com](https://api.jquery.com/pushStack/)
      * @since 1.0
      */
     pushStack(elements: ArrayLike<Element>): this;
@@ -4916,7 +4916,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param queueName A string containing the name of the queue. Defaults to fx, the standard effects queue.
      * @param newQueue The new function to add to the queue, with a function to call that will dequeue the next item.
      *                 An array of functions to replace the current queue contents.
-     * @see [queue](https://api.jquery.com/queue/)
+     * @see [queue on api.jquery.com](https://api.jquery.com/queue/)
      * @since 1.2
      */
     queue(queueName: string, newQueue: JQuery.TypeOrArray<JQuery.QueueFunction<TElement>>): this;
@@ -4925,7 +4925,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param newQueue The new function to add to the queue, with a function to call that will dequeue the next item.
      *                 An array of functions to replace the current queue contents.
-     * @see [queue](https://api.jquery.com/queue/)
+     * @see [queue on api.jquery.com](https://api.jquery.com/queue/)
      * @since 1.2
      */
     queue(newQueue: JQuery.TypeOrArray<JQuery.QueueFunction<TElement>>): this;
@@ -4933,7 +4933,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Show the queue of functions to be executed on the matched elements.
      *
      * @param queueName A string containing the name of the queue. Defaults to fx, the standard effects queue.
-     * @see [queue](https://api.jquery.com/queue/)
+     * @see [queue on api.jquery.com](https://api.jquery.com/queue/)
      * @since 1.2
      */
     queue(queueName?: string): JQuery.Queue<Node>;
@@ -4941,7 +4941,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Specify a function to execute when the DOM is fully loaded.
      *
      * @param handler A function to execute after the DOM is ready.
-     * @see [ready](https://api.jquery.com/ready/)
+     * @see [ready on api.jquery.com](https://api.jquery.com/ready/)
      * @since 1.0
      * @deprecated 3.0
      */
@@ -4950,7 +4950,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Remove the set of matched elements from the DOM.
      *
      * @param selector A selector expression that filters the set of matched elements to be removed.
-     * @see [remove](https://api.jquery.com/remove/)
+     * @see [remove on api.jquery.com](https://api.jquery.com/remove/)
      * @since 1.0
      */
     remove(selector?: string): this;
@@ -4958,7 +4958,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Remove an attribute from each element in the set of matched elements.
      *
      * @param attributeName An attribute to remove; as of version 1.7, it can be a space-separated list of attributes.
-     * @see [removeAttr](https://api.jquery.com/removeAttr/)
+     * @see [removeAttr on api.jquery.com](https://api.jquery.com/removeAttr/)
      * @since 1.0
      */
     removeAttr(attributeName: string): this;
@@ -4969,7 +4969,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *                  An array of classes to be removed from the class attribute of each matched element.
      *                  A function returning one or more space-separated class names to be removed. Receives the index
      *                  position of the element in the set and the old class value as arguments.
-     * @see [removeClass](https://api.jquery.com/removeClass/)
+     * @see [removeClass on api.jquery.com](https://api.jquery.com/removeClass/)
      * @since 1.0
      * @since 1.4
      * @since 3.3
@@ -4980,7 +4980,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param name A string naming the piece of data to delete.
      *             An array or space-separated string naming the pieces of data to delete.
-     * @see [removeData](https://api.jquery.com/removeData/)
+     * @see [removeData on api.jquery.com](https://api.jquery.com/removeData/)
      * @since 1.2.3
      * @since 1.7
      */
@@ -4989,7 +4989,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Remove a property for the set of matched elements.
      *
      * @param propertyName The name of the property to remove.
-     * @see [removeProp](https://api.jquery.com/removeProp/)
+     * @see [removeProp on api.jquery.com](https://api.jquery.com/removeProp/)
      * @since 1.6
      */
     removeProp(propertyName: string): this;
@@ -4997,7 +4997,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Replace each target element with the set of matched elements.
      *
      * @param target A selector string, jQuery object, DOM element, or array of elements indicating which element(s) to replace.
-     * @see [replaceAll](https://api.jquery.com/replaceAll/)
+     * @see [replaceAll on api.jquery.com](https://api.jquery.com/replaceAll/)
      * @since 1.2
      */
     replaceAll(target: JQuery.Selector | JQuery | JQuery.TypeOrArray<Element>): this;
@@ -5007,7 +5007,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param newContent The content to insert. May be an HTML string, DOM element, array of DOM elements, or jQuery object.
      *                   A function that returns content with which to replace the set of matched elements.
-     * @see [replaceWith](https://api.jquery.com/replaceWith/)
+     * @see [replaceWith on api.jquery.com](https://api.jquery.com/replaceWith/)
      * @since 1.2
      * @since 1.4
      */
@@ -5017,7 +5017,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute each time the event is triggered.
-     * @see [resize](https://api.jquery.com/resize/)
+     * @see [resize on api.jquery.com](https://api.jquery.com/resize/)
      * @since 1.4.3
      * @deprecated 3.3
      */
@@ -5027,7 +5027,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Bind an event handler to the "resize" JavaScript event, or trigger that event on an element.
      *
      * @param handler A function to execute each time the event is triggered.
-     * @see [resize](https://api.jquery.com/resize/)
+     * @see [resize on api.jquery.com](https://api.jquery.com/resize/)
      * @since 1.0
      * @deprecated 3.3
      */
@@ -5037,7 +5037,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute each time the event is triggered.
-     * @see [scroll](https://api.jquery.com/scroll/)
+     * @see [scroll on api.jquery.com](https://api.jquery.com/scroll/)
      * @since 1.4.3
      * @deprecated 3.3
      */
@@ -5047,7 +5047,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Bind an event handler to the "scroll" JavaScript event, or trigger that event on an element.
      *
      * @param handler A function to execute each time the event is triggered.
-     * @see [scroll](https://api.jquery.com/scroll/)
+     * @see [scroll on api.jquery.com](https://api.jquery.com/scroll/)
      * @since 1.0
      * @deprecated 3.3
      */
@@ -5056,14 +5056,14 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Set the current horizontal position of the scroll bar for each of the set of matched elements.
      *
      * @param value An integer indicating the new position to set the scroll bar to.
-     * @see [scrollLeft](https://api.jquery.com/scrollLeft/)
+     * @see [scrollLeft on api.jquery.com](https://api.jquery.com/scrollLeft/)
      * @since 1.2.6
      */
     scrollLeft(value: number): this;
     /**
      * Get the current horizontal position of the scroll bar for the first element in the set of matched elements.
      *
-     * @see [scrollLeft](https://api.jquery.com/scrollLeft/)
+     * @see [scrollLeft on api.jquery.com](https://api.jquery.com/scrollLeft/)
      * @since 1.2.6
      */
     scrollLeft(): number | undefined;
@@ -5071,7 +5071,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Set the current vertical position of the scroll bar for each of the set of matched elements.
      *
      * @param value A number indicating the new position to set the scroll bar to.
-     * @see [scrollTop](https://api.jquery.com/scrollTop/)
+     * @see [scrollTop on api.jquery.com](https://api.jquery.com/scrollTop/)
      * @since 1.2.6
      */
     scrollTop(value: number): this;
@@ -5079,7 +5079,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Get the current vertical position of the scroll bar for the first element in the set of matched
      * elements or set the vertical position of the scroll bar for every matched element.
      *
-     * @see [scrollTop](https://api.jquery.com/scrollTop/)
+     * @see [scrollTop on api.jquery.com](https://api.jquery.com/scrollTop/)
      * @since 1.2.6
      */
     scrollTop(): number | undefined;
@@ -5088,7 +5088,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute each time the event is triggered.
-     * @see [select](https://api.jquery.com/select/)
+     * @see [select on api.jquery.com](https://api.jquery.com/select/)
      * @since 1.4.3
      * @deprecated 3.3
      */
@@ -5098,7 +5098,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Bind an event handler to the "select" JavaScript event, or trigger that event on an element.
      *
      * @param handler A function to execute each time the event is triggered.
-     * @see [select](https://api.jquery.com/select/)
+     * @see [select on api.jquery.com](https://api.jquery.com/select/)
      * @since 1.0
      * @deprecated 3.3
      */
@@ -5106,14 +5106,14 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
     /**
      * Encode a set of form elements as a string for submission.
      *
-     * @see [serialize](https://api.jquery.com/serialize/)
+     * @see [serialize on api.jquery.com](https://api.jquery.com/serialize/)
      * @since 1.0
      */
     serialize(): string;
     /**
      * Encode a set of form elements as an array of names and values.
      *
-     * @see [serializeArray](https://api.jquery.com/serializeArray/)
+     * @see [serializeArray on api.jquery.com](https://api.jquery.com/serializeArray/)
      * @since 1.2
      */
     serializeArray(): JQuery.NameValuePair[];
@@ -5123,7 +5123,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param duration A string or number determining how long the animation will run.
      * @param easing A string indicating which easing function to use for the transition.
      * @param complete A function to call once the animation is complete, called once per matched element.
-     * @see [show](https://api.jquery.com/show/)
+     * @see [show on api.jquery.com](https://api.jquery.com/show/)
      * @since 1.4.3
      */
     show(duration: JQuery.Duration, easing: string, complete: (this: TElement) => void): this;
@@ -5133,7 +5133,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param duration A string or number determining how long the animation will run.
      * @param easing_complete A string indicating which easing function to use for the transition.
      *                        A function to call once the animation is complete, called once per matched element.
-     * @see [show](https://api.jquery.com/show/)
+     * @see [show on api.jquery.com](https://api.jquery.com/show/)
      * @since 1.0
      * @since 1.4.3
      */
@@ -5144,7 +5144,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param duration_complete_options A string or number determining how long the animation will run.
      *                                  A function to call once the animation is complete, called once per matched element.
      *                                  A map of additional options to pass to the method.
-     * @see [show](https://api.jquery.com/show/)
+     * @see [show on api.jquery.com](https://api.jquery.com/show/)
      * @since 1.0
      */
     show(duration_complete_options?: JQuery.Duration | ((this: TElement) => void) | JQuery.EffectsOptions<TElement>): this;
@@ -5152,7 +5152,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Get the siblings of each element in the set of matched elements, optionally filtered by a selector.
      *
      * @param selector A string containing a selector expression to match elements against.
-     * @see [siblings](https://api.jquery.com/siblings/)
+     * @see [siblings on api.jquery.com](https://api.jquery.com/siblings/)
      * @since 1.0
      */
     siblings(selector?: JQuery.Selector): this;
@@ -5163,7 +5163,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *              it indicates an offset from the end of the set.
      * @param end An integer indicating the 0-based position at which the elements stop being selected. If negative,
      *            it indicates an offset from the end of the set. If omitted, the range continues until the end of the set.
-     * @see [slice](https://api.jquery.com/slice/)
+     * @see [slice on api.jquery.com](https://api.jquery.com/slice/)
      * @since 1.1.4
      */
     slice(start: number, end?: number): this;
@@ -5173,7 +5173,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param duration A string or number determining how long the animation will run.
      * @param easing A string indicating which easing function to use for the transition.
      * @param complete A function to call once the animation is complete, called once per matched element.
-     * @see [slideDown](https://api.jquery.com/slideDown/)
+     * @see [slideDown on api.jquery.com](https://api.jquery.com/slideDown/)
      * @since 1.4.3
      */
     slideDown(duration: JQuery.Duration, easing: string, complete?: (this: TElement) => void): this;
@@ -5183,7 +5183,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param duration_easing A string or number determining how long the animation will run.
      *                        A string indicating which easing function to use for the transition.
      * @param complete A function to call once the animation is complete, called once per matched element.
-     * @see [slideDown](https://api.jquery.com/slideDown/)
+     * @see [slideDown on api.jquery.com](https://api.jquery.com/slideDown/)
      * @since 1.0
      * @since 1.4.3
      */
@@ -5195,7 +5195,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *                                         A string indicating which easing function to use for the transition.
      *                                         A function to call once the animation is complete, called once per matched element.
      *                                         A map of additional options to pass to the method.
-     * @see [slideDown](https://api.jquery.com/slideDown/)
+     * @see [slideDown on api.jquery.com](https://api.jquery.com/slideDown/)
      * @since 1.0
      * @since 1.4.3
      */
@@ -5206,7 +5206,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param duration A string or number determining how long the animation will run.
      * @param easing A string indicating which easing function to use for the transition.
      * @param complete A function to call once the animation is complete, called once per matched element.
-     * @see [slideToggle](https://api.jquery.com/slideToggle/)
+     * @see [slideToggle on api.jquery.com](https://api.jquery.com/slideToggle/)
      * @since 1.4.3
      */
     slideToggle(duration: JQuery.Duration, easing: string, complete?: (this: TElement) => void): this;
@@ -5216,7 +5216,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param duration_easing A string or number determining how long the animation will run.
      *                        A string indicating which easing function to use for the transition.
      * @param complete A function to call once the animation is complete, called once per matched element.
-     * @see [slideToggle](https://api.jquery.com/slideToggle/)
+     * @see [slideToggle on api.jquery.com](https://api.jquery.com/slideToggle/)
      * @since 1.0
      * @since 1.4.3
      */
@@ -5228,7 +5228,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *                                         A string indicating which easing function to use for the transition.
      *                                         A function to call once the animation is complete, called once per matched element.
      *                                         A map of additional options to pass to the method.
-     * @see [slideToggle](https://api.jquery.com/slideToggle/)
+     * @see [slideToggle on api.jquery.com](https://api.jquery.com/slideToggle/)
      * @since 1.0
      * @since 1.4.3
      */
@@ -5239,7 +5239,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param duration A string or number determining how long the animation will run.
      * @param easing A string indicating which easing function to use for the transition.
      * @param complete A function to call once the animation is complete, called once per matched element.
-     * @see [slideUp](https://api.jquery.com/slideUp/)
+     * @see [slideUp on api.jquery.com](https://api.jquery.com/slideUp/)
      * @since 1.4.3
      */
     slideUp(duration: JQuery.Duration, easing: string, complete?: (this: TElement) => void): this;
@@ -5249,7 +5249,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param duration_easing A string or number determining how long the animation will run.
      *                        A string indicating which easing function to use for the transition.
      * @param complete A function to call once the animation is complete, called once per matched element.
-     * @see [slideUp](https://api.jquery.com/slideUp/)
+     * @see [slideUp on api.jquery.com](https://api.jquery.com/slideUp/)
      * @since 1.0
      * @since 1.4.3
      */
@@ -5261,7 +5261,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *                                         A string indicating which easing function to use for the transition.
      *                                         A function to call once the animation is complete, called once per matched element.
      *                                         A map of additional options to pass to the method.
-     * @see [slideUp](https://api.jquery.com/slideUp/)
+     * @see [slideUp on api.jquery.com](https://api.jquery.com/slideUp/)
      * @since 1.0
      * @since 1.4.3
      */
@@ -5272,7 +5272,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param queue The name of the queue in which to stop animations.
      * @param clearQueue A Boolean indicating whether to remove queued animation as well. Defaults to false.
      * @param jumpToEnd A Boolean indicating whether to complete the current animation immediately. Defaults to false.
-     * @see [stop](https://api.jquery.com/stop/)
+     * @see [stop on api.jquery.com](https://api.jquery.com/stop/)
      * @since 1.7
      */
     stop(queue: string, clearQueue?: boolean, jumpToEnd?: boolean): this;
@@ -5281,7 +5281,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param clearQueue A Boolean indicating whether to remove queued animation as well. Defaults to false.
      * @param jumpToEnd A Boolean indicating whether to complete the current animation immediately. Defaults to false.
-     * @see [stop](https://api.jquery.com/stop/)
+     * @see [stop on api.jquery.com](https://api.jquery.com/stop/)
      * @since 1.2
      */
     stop(clearQueue?: boolean, jumpToEnd?: boolean): this;
@@ -5290,7 +5290,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute each time the event is triggered.
-     * @see [submit](https://api.jquery.com/submit/)
+     * @see [submit on api.jquery.com](https://api.jquery.com/submit/)
      * @since 1.4.3
      * @deprecated 3.3
      */
@@ -5300,7 +5300,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Bind an event handler to the "submit" JavaScript event, or trigger that event on an element.
      *
      * @param handler A function to execute each time the event is triggered.
-     * @see [submit](https://api.jquery.com/submit/)
+     * @see [submit on api.jquery.com](https://api.jquery.com/submit/)
      * @since 1.0
      * @deprecated 3.3
      */
@@ -5312,7 +5312,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *             be converted to a String representation.
      *             A function returning the text content to set. Receives the index position of the element in the set
      *             and the old text value as arguments.
-     * @see [text](https://api.jquery.com/text/)
+     * @see [text on api.jquery.com](https://api.jquery.com/text/)
      * @since 1.0
      * @since 1.4
      */
@@ -5320,14 +5320,14 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
     /**
      * Get the combined text contents of each element in the set of matched elements, including their descendants.
      *
-     * @see [text](https://api.jquery.com/text/)
+     * @see [text on api.jquery.com](https://api.jquery.com/text/)
      * @since 1.0
      */
     text(): string;
     /**
      * Retrieve all the elements contained in the jQuery set, as an array.
      *
-     * @see [toArray](https://api.jquery.com/toArray/)
+     * @see [toArray on api.jquery.com](https://api.jquery.com/toArray/)
      * @since 1.4
      */
     toArray(): TElement[];
@@ -5337,7 +5337,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param duration A string or number determining how long the animation will run.
      * @param easing A string indicating which easing function to use for the transition.
      * @param complete A function to call once the animation is complete, called once per matched element.
-     * @see [toggle](https://api.jquery.com/toggle/)
+     * @see [toggle on api.jquery.com](https://api.jquery.com/toggle/)
      * @since 1.4.3
      */
     toggle(duration: JQuery.Duration, easing: string, complete?: (this: TElement) => void): this;
@@ -5346,7 +5346,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param duration A string or number determining how long the animation will run.
      * @param complete A function to call once the animation is complete, called once per matched element.
-     * @see [toggle](https://api.jquery.com/toggle/)
+     * @see [toggle on api.jquery.com](https://api.jquery.com/toggle/)
      * @since 1.0
      */
     toggle(duration: JQuery.Duration, complete: (this: TElement) => void): this;
@@ -5357,7 +5357,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *                                          A function to call once the animation is complete, called once per matched element.
      *                                          A map of additional options to pass to the method.
      *                                          Use true to show the element or false to hide it.
-     * @see [toggle](https://api.jquery.com/toggle/)
+     * @see [toggle on api.jquery.com](https://api.jquery.com/toggle/)
      * @since 1.0
      * @since 1.3
      */
@@ -5371,7 +5371,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *                  A function that returns class names to be toggled in the class attribute of each element in the
      *                  matched set. Receives the index position of the element in the set, the old class value, and the state as arguments.
      * @param state A Boolean (not just truthy/falsy) value to determine whether the class should be added or removed.
-     * @see [toggleClass](https://api.jquery.com/toggleClass/)
+     * @see [toggleClass on api.jquery.com](https://api.jquery.com/toggleClass/)
      * @since 1.0
      * @since 1.3
      * @since 1.4
@@ -5384,7 +5384,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * either the class's presence or the value of the state argument.
      *
      * @param state A boolean value to determine whether the class should be added or removed.
-     * @see [toggleClass](https://api.jquery.com/toggleClass/)
+     * @see [toggleClass on api.jquery.com](https://api.jquery.com/toggleClass/)
      * @since 1.4
      * @deprecated 3.0
      */
@@ -5395,7 +5395,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param eventType A string containing a JavaScript event type, such as click or submit.
      *                  A jQuery.Event object.
      * @param extraParameters Additional parameters to pass along to the event handler.
-     * @see [trigger](https://api.jquery.com/trigger/)
+     * @see [trigger on api.jquery.com](https://api.jquery.com/trigger/)
      * @since 1.0
      * @since 1.3
      */
@@ -5406,7 +5406,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param eventType A string containing a JavaScript event type, such as click or submit.
      *                  A jQuery.Event object.
      * @param extraParameters Additional parameters to pass along to the event handler.
-     * @see [triggerHandler](https://api.jquery.com/triggerHandler/)
+     * @see [triggerHandler on api.jquery.com](https://api.jquery.com/triggerHandler/)
      * @since 1.2
      * @since 1.3
      */
@@ -5416,7 +5416,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param event A string containing one or more DOM event types, such as "click" or "submit," or custom event names.
      * @param handler A function to execute each time the event is triggered.
-     * @see [unbind](https://api.jquery.com/unbind/)
+     * @see [unbind on api.jquery.com](https://api.jquery.com/unbind/)
      * @since 1.0
      * @since 1.4.3
      * @deprecated 3.0
@@ -5427,7 +5427,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param event A string containing one or more DOM event types, such as "click" or "submit," or custom event names.
      *              A jQuery.Event object.
-     * @see [unbind](https://api.jquery.com/unbind/)
+     * @see [unbind on api.jquery.com](https://api.jquery.com/unbind/)
      * @since 1.0
      * @deprecated 3.0
      */
@@ -5439,7 +5439,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param selector A selector which will be used to filter the event results.
      * @param eventType A string containing a JavaScript event type, such as "click" or "keydown"
      * @param handler A function to execute each time the event is triggered.
-     * @see [undelegate](https://api.jquery.com/undelegate/)
+     * @see [undelegate on api.jquery.com](https://api.jquery.com/undelegate/)
      * @since 1.4.2
      * @deprecated 3.0
      */
@@ -5451,7 +5451,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param selector A selector which will be used to filter the event results.
      * @param eventTypes A string containing a JavaScript event type, such as "click" or "keydown"
      *                   An object of one or more event types and previously bound functions to unbind from them.
-     * @see [undelegate](https://api.jquery.com/undelegate/)
+     * @see [undelegate on api.jquery.com](https://api.jquery.com/undelegate/)
      * @since 1.4.2
      * @since 1.4.3
      * @deprecated 3.0
@@ -5462,7 +5462,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * specific set of root elements.
      *
      * @param namespace A selector which will be used to filter the event results.
-     * @see [undelegate](https://api.jquery.com/undelegate/)
+     * @see [undelegate on api.jquery.com](https://api.jquery.com/undelegate/)
      * @since 1.4.2
      * @since 1.6
      * @deprecated 3.0
@@ -5473,7 +5473,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param selector A selector to check the parent element against. If an element's parent does not match the selector,
      *                 the element won't be unwrapped.
-     * @see [unwrap](https://api.jquery.com/unwrap/)
+     * @see [unwrap on api.jquery.com](https://api.jquery.com/unwrap/)
      * @since 1.4
      * @since 3.0
      */
@@ -5485,7 +5485,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *              element to set as selected/checked.
      *              A function returning the value to set. this is the current element. Receives the index position of
      *              the element in the set and the old value as arguments.
-     * @see [val](https://api.jquery.com/val/)
+     * @see [val on api.jquery.com](https://api.jquery.com/val/)
      * @since 1.0
      * @since 1.4
      */
@@ -5493,7 +5493,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
     /**
      * Get the current value of the first element in the set of matched elements.
      *
-     * @see [val](https://api.jquery.com/val/)
+     * @see [val on api.jquery.com](https://api.jquery.com/val/)
      * @since 1.0
      */
     val(): string | number | string[] | undefined;
@@ -5504,7 +5504,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *              appended (as a string).
      *              A function returning the width to set. Receives the index position of the element in the set and the
      *              old width as arguments. Within the function, this refers to the current element in the set.
-     * @see [width](https://api.jquery.com/width/)
+     * @see [width on api.jquery.com](https://api.jquery.com/width/)
      * @since 1.0
      * @since 1.4.1
      */
@@ -5512,7 +5512,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
     /**
      * Get the current computed width for the first element in the set of matched elements.
      *
-     * @see [width](https://api.jquery.com/width/)
+     * @see [width on api.jquery.com](https://api.jquery.com/width/)
      * @since 1.0
      */
     width(): number | undefined;
@@ -5525,7 +5525,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *                        A callback function returning the HTML content or jQuery object to wrap around the matched elements.
      *                        Receives the index position of the element in the set as an argument. Within the function, this
      *                        refers to the current element in the set.
-     * @see [wrap](https://api.jquery.com/wrap/)
+     * @see [wrap on api.jquery.com](https://api.jquery.com/wrap/)
      * @since 1.0
      * @since 1.4
      */
@@ -5538,7 +5538,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *                        elements. Within the function, this refers to the first element in the set. Prior to jQuery 3.0, the
      *                        callback was incorrectly called for every element in the set and received the index position of the
      *                        element in the set as an argument.
-     * @see [wrapAll](https://api.jquery.com/wrapAll/)
+     * @see [wrapAll on api.jquery.com](https://api.jquery.com/wrapAll/)
      * @since 1.2
      * @since 1.4
      */
@@ -5551,7 +5551,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *                        A callback function which generates a structure to wrap around the content of the matched elements.
      *                        Receives the index position of the element in the set as an argument. Within the function, this
      *                        refers to the current element in the set.
-     * @see [wrapInner](https://api.jquery.com/wrapInner/)
+     * @see [wrapInner on api.jquery.com](https://api.jquery.com/wrapInner/)
      * @since 1.2
      * @since 1.4
      */
@@ -5641,7 +5641,7 @@ declare namespace JQuery {
         }
 
         /**
-         * @see [jquery.ajax](https://api.jquery.com/jquery.ajax/)
+         * @see [jquery.ajax on api.jquery.com](https://api.jquery.com/jquery.ajax/)
          */
         interface AjaxSettingsBase<TContext> {
             /**
@@ -6328,7 +6328,7 @@ declare namespace JQuery {
     }
 
     /**
-     * @see [jquery.ajax](https://api.jquery.com/jquery.ajax/)
+     * @see [jquery.ajax on api.jquery.com](https://api.jquery.com/jquery.ajax/)
      */
     interface jqXHR<TResolve = any> extends Promise3<TResolve, jqXHR<TResolve>, never,
         Ajax.SuccessTextStatus, Ajax.ErrorTextStatus, never,
@@ -6341,7 +6341,7 @@ declare namespace JQuery {
         /**
          * Determine the current state of a Deferred object.
          *
-         * @see [deferred.state](https://api.jquery.com/deferred.state/)
+         * @see [deferred.state on api.jquery.com](https://api.jquery.com/deferred.state/)
          * @since 1.7
          */
         state(): 'pending' | 'resolved' | 'rejected';
@@ -6375,28 +6375,28 @@ declare namespace JQuery {
          *
          * @param callback A function, or array of functions, that are to be added to the callback list.
          * @param callbacks A function, or array of functions, that are to be added to the callback list.
-         * @see [callbacks.add](https://api.jquery.com/callbacks.add/)
+         * @see [callbacks.add on api.jquery.com](https://api.jquery.com/callbacks.add/)
          * @since 1.7
          */
         add(callback: TypeOrArray<T>, ...callbacks: Array<TypeOrArray<T>>): this;
         /**
          * Disable a callback list from doing anything more.
          *
-         * @see [callbacks.disable](https://api.jquery.com/callbacks.disable/)
+         * @see [callbacks.disable on api.jquery.com](https://api.jquery.com/callbacks.disable/)
          * @since 1.7
          */
         disable(): this;
         /**
          * Determine if the callbacks list has been disabled.
          *
-         * @see [callbacks.disabled](https://api.jquery.com/callbacks.disabled/)
+         * @see [callbacks.disabled on api.jquery.com](https://api.jquery.com/callbacks.disabled/)
          * @since 1.7
          */
         disabled(): boolean;
         /**
          * Remove all of the callbacks from a list.
          *
-         * @see [callbacks.empty](https://api.jquery.com/callbacks.empty/)
+         * @see [callbacks.empty on api.jquery.com](https://api.jquery.com/callbacks.empty/)
          * @since 1.7
          */
         empty(): this;
@@ -6404,7 +6404,7 @@ declare namespace JQuery {
          * Call all of the callbacks with the given arguments.
          *
          * @param args The argument or list of arguments to pass back to the callback list.
-         * @see [callbacks.fire](https://api.jquery.com/callbacks.fire/)
+         * @see [callbacks.fire on api.jquery.com](https://api.jquery.com/callbacks.fire/)
          * @since 1.7
          */
         fire(...args: any[]): this;
@@ -6413,14 +6413,14 @@ declare namespace JQuery {
          *
          * @param context A reference to the context in which the callbacks in the list should be fired.
          * @param args An argument, or array of arguments, to pass to the callbacks in the list.
-         * @see [callbacks.fireWith](https://api.jquery.com/callbacks.fireWith/)
+         * @see [callbacks.fireWith on api.jquery.com](https://api.jquery.com/callbacks.fireWith/)
          * @since 1.7
          */
         fireWith(context: object, args?: ArrayLike<any>): this;
         /**
          * Determine if the callbacks have already been called at least once.
          *
-         * @see [callbacks.fired](https://api.jquery.com/callbacks.fired/)
+         * @see [callbacks.fired on api.jquery.com](https://api.jquery.com/callbacks.fired/)
          * @since 1.7
          */
         fired(): boolean;
@@ -6429,21 +6429,21 @@ declare namespace JQuery {
          * argument, determine whether it is in a list.
          *
          * @param callback The callback to search for.
-         * @see [callbacks.has](https://api.jquery.com/callbacks.has/)
+         * @see [callbacks.has on api.jquery.com](https://api.jquery.com/callbacks.has/)
          * @since 1.7
          */
         has(callback?: T): boolean;
         /**
          * Lock a callback list in its current state.
          *
-         * @see [callbacks.lock](https://api.jquery.com/callbacks.lock/)
+         * @see [callbacks.lock on api.jquery.com](https://api.jquery.com/callbacks.lock/)
          * @since 1.7
          */
         lock(): this;
         /**
          * Determine if the callbacks list has been locked.
          *
-         * @see [callbacks.locked](https://api.jquery.com/callbacks.locked/)
+         * @see [callbacks.locked on api.jquery.com](https://api.jquery.com/callbacks.locked/)
          * @since 1.7
          */
         locked(): boolean;
@@ -6451,7 +6451,7 @@ declare namespace JQuery {
          * Remove a callback or a collection of callbacks from a callback list.
          *
          * @param callbacks A function, or array of functions, that are to be removed from the callback list.
-         * @see [callbacks.remove](https://api.jquery.com/callbacks.remove/)
+         * @see [callbacks.remove on api.jquery.com](https://api.jquery.com/callbacks.remove/)
          * @since 1.7
          */
         remove(...callbacks: T[]): this;
@@ -6494,7 +6494,7 @@ declare namespace JQuery {
      * This object provides a subset of the methods of the Deferred object (then, done, fail, always,
      * pipe, progress, state and promise) to prevent users from changing the state of the Deferred.
      *
-     * @see [Types](https://api.jquery.com/Types/)
+     * @see [Types on api.jquery.com](https://api.jquery.com/Types/)
      * @deprecated Experimental. Avoid referncing this type directly in your code.
      */
     interface PromiseBase<TR, TJ, TN,
@@ -6506,7 +6506,7 @@ declare namespace JQuery {
          *
          * @param alwaysCallback A function, or array of functions, that is called when the Deferred is resolved or rejected.
          * @param alwaysCallbacks Optional additional functions, or arrays of functions, that are called when the Deferred is resolved or rejected.
-         * @see [deferred.always](https://api.jquery.com/deferred.always/)
+         * @see [deferred.always on api.jquery.com](https://api.jquery.com/deferred.always/)
          * @since 1.6
          */
         always(alwaysCallback: TypeOrArray<Deferred.CallbackBase<TR | TJ, UR | UJ, VR | VJ, SR | SJ>>,
@@ -6516,7 +6516,7 @@ declare namespace JQuery {
          *
          * @param doneCallback A function, or array of functions, that are called when the Deferred is resolved.
          * @param doneCallbacks Optional additional functions, or arrays of functions, that are called when the Deferred is resolved.
-         * @see [deferred.done](https://api.jquery.com/deferred.done/)
+         * @see [deferred.done on api.jquery.com](https://api.jquery.com/deferred.done/)
          * @since 1.5
          */
         done(doneCallback: TypeOrArray<Deferred.CallbackBase<TR, UR, VR, SR>>,
@@ -6526,7 +6526,7 @@ declare namespace JQuery {
          *
          * @param failCallback A function, or array of functions, that are called when the Deferred is rejected.
          * @param failCallbacks Optional additional functions, or arrays of functions, that are called when the Deferred is rejected.
-         * @see [deferred.fail](https://api.jquery.com/deferred.fail/)
+         * @see [deferred.fail on api.jquery.com](https://api.jquery.com/deferred.fail/)
          * @since 1.5
          */
         fail(failCallback: TypeOrArray<Deferred.CallbackBase<TJ, UJ, VJ, SJ>>,
@@ -6537,7 +6537,7 @@ declare namespace JQuery {
          * @param progressCallback A function, or array of functions, to be called when the Deferred generates progress notifications.
          * @param progressCallbacks Optional additional functions, or arrays of functions, to be called when the Deferred generates
          *                          progress notifications.
-         * @see [deferred.progress](https://api.jquery.com/deferred.progress/)
+         * @see [deferred.progress on api.jquery.com](https://api.jquery.com/deferred.progress/)
          * @since 1.7
          */
         progress(progressCallback: TypeOrArray<Deferred.CallbackBase<TN, UN, VN, SN>>,
@@ -6546,21 +6546,21 @@ declare namespace JQuery {
          * Return a Deferred's Promise object.
          *
          * @param target Object onto which the promise methods have to be attached
-         * @see [deferred.promise](https://api.jquery.com/deferred.promise/)
+         * @see [deferred.promise on api.jquery.com](https://api.jquery.com/deferred.promise/)
          * @since 1.5
          */
         promise<TTarget extends object>(target: TTarget): this & TTarget;
         /**
          * Return a Deferred's Promise object.
          *
-         * @see [deferred.promise](https://api.jquery.com/deferred.promise/)
+         * @see [deferred.promise on api.jquery.com](https://api.jquery.com/deferred.promise/)
          * @since 1.5
          */
         promise(): this;
         /**
          * Determine the current state of a Deferred object.
          *
-         * @see [deferred.state](https://api.jquery.com/deferred.state/)
+         * @see [deferred.state on api.jquery.com](https://api.jquery.com/deferred.state/)
          * @since 1.7
          */
         state(): 'pending' | 'resolved' | 'rejected';
@@ -6573,7 +6573,7 @@ declare namespace JQuery {
          * @param doneFilter An optional function that is called when the Deferred is resolved.
          * @param failFilter An optional function that is called when the Deferred is rejected.
          * @param progressFilter An optional function that is called when progress notifications are sent to the Deferred.
-         * @see [deferred.pipe](https://api.jquery.com/deferred.pipe/)
+         * @see [deferred.pipe on api.jquery.com](https://api.jquery.com/deferred.pipe/)
          * @since 1.6
          * @since 1.7
          * @deprecated 1.8
@@ -6611,7 +6611,7 @@ declare namespace JQuery {
          * @param doneFilter An optional function that is called when the Deferred is resolved.
          * @param failFilter An optional function that is called when the Deferred is rejected.
          * @param progressFilter An optional function that is called when progress notifications are sent to the Deferred.
-         * @see [deferred.pipe](https://api.jquery.com/deferred.pipe/)
+         * @see [deferred.pipe on api.jquery.com](https://api.jquery.com/deferred.pipe/)
          * @since 1.6
          * @since 1.7
          * @deprecated 1.8
@@ -6642,7 +6642,7 @@ declare namespace JQuery {
          * @param doneFilter An optional function that is called when the Deferred is resolved.
          * @param failFilter An optional function that is called when the Deferred is rejected.
          * @param progressFilter An optional function that is called when progress notifications are sent to the Deferred.
-         * @see [deferred.pipe](https://api.jquery.com/deferred.pipe/)
+         * @see [deferred.pipe on api.jquery.com](https://api.jquery.com/deferred.pipe/)
          * @since 1.6
          * @since 1.7
          * @deprecated 1.8
@@ -6673,7 +6673,7 @@ declare namespace JQuery {
          * @param doneFilter An optional function that is called when the Deferred is resolved.
          * @param failFilter An optional function that is called when the Deferred is rejected.
          * @param progressFilter An optional function that is called when progress notifications are sent to the Deferred.
-         * @see [deferred.pipe](https://api.jquery.com/deferred.pipe/)
+         * @see [deferred.pipe on api.jquery.com](https://api.jquery.com/deferred.pipe/)
          * @since 1.6
          * @since 1.7
          * @deprecated 1.8
@@ -6697,7 +6697,7 @@ declare namespace JQuery {
          * @param doneFilter An optional function that is called when the Deferred is resolved.
          * @param failFilter An optional function that is called when the Deferred is rejected.
          * @param progressFilter An optional function that is called when progress notifications are sent to the Deferred.
-         * @see [deferred.pipe](https://api.jquery.com/deferred.pipe/)
+         * @see [deferred.pipe on api.jquery.com](https://api.jquery.com/deferred.pipe/)
          * @since 1.6
          * @since 1.7
          * @deprecated 1.8
@@ -6728,7 +6728,7 @@ declare namespace JQuery {
          * @param doneFilter An optional function that is called when the Deferred is resolved.
          * @param failFilter An optional function that is called when the Deferred is rejected.
          * @param progressFilter An optional function that is called when progress notifications are sent to the Deferred.
-         * @see [deferred.pipe](https://api.jquery.com/deferred.pipe/)
+         * @see [deferred.pipe on api.jquery.com](https://api.jquery.com/deferred.pipe/)
          * @since 1.6
          * @since 1.7
          * @deprecated 1.8
@@ -6752,7 +6752,7 @@ declare namespace JQuery {
          * @param doneFilter An optional function that is called when the Deferred is resolved.
          * @param failFilter An optional function that is called when the Deferred is rejected.
          * @param progressFilter An optional function that is called when progress notifications are sent to the Deferred.
-         * @see [deferred.pipe](https://api.jquery.com/deferred.pipe/)
+         * @see [deferred.pipe on api.jquery.com](https://api.jquery.com/deferred.pipe/)
          * @since 1.6
          * @since 1.7
          * @deprecated 1.8
@@ -6781,7 +6781,7 @@ declare namespace JQuery {
          * @param doneFilter An optional function that is called when the Deferred is resolved.
          * @param failFilter An optional function that is called when the Deferred is rejected.
          * @param progressFilter An optional function that is called when progress notifications are sent to the Deferred.
-         * @see [deferred.then](https://api.jquery.com/deferred.then/)
+         * @see [deferred.then on api.jquery.com](https://api.jquery.com/deferred.then/)
          * @since 1.8
          */
         then<ARD = never, AJD = never, AND = never,
@@ -6817,7 +6817,7 @@ declare namespace JQuery {
          * @param doneFilter An optional function that is called when the Deferred is resolved.
          * @param failFilter An optional function that is called when the Deferred is rejected.
          * @param progressFilter An optional function that is called when progress notifications are sent to the Deferred.
-         * @see [deferred.then](https://api.jquery.com/deferred.then/)
+         * @see [deferred.then on api.jquery.com](https://api.jquery.com/deferred.then/)
          * @since 1.8
          */
         then<ARF = never, AJF = never, ANF = never,
@@ -6846,7 +6846,7 @@ declare namespace JQuery {
          * @param doneFilter An optional function that is called when the Deferred is resolved.
          * @param failFilter An optional function that is called when the Deferred is rejected.
          * @param progressFilter An optional function that is called when progress notifications are sent to the Deferred.
-         * @see [deferred.then](https://api.jquery.com/deferred.then/)
+         * @see [deferred.then on api.jquery.com](https://api.jquery.com/deferred.then/)
          * @since 1.8
          */
         then<ARD = never, AJD = never, AND = never,
@@ -6875,7 +6875,7 @@ declare namespace JQuery {
          * @param doneFilter An optional function that is called when the Deferred is resolved.
          * @param failFilter An optional function that is called when the Deferred is rejected.
          * @param progressFilter An optional function that is called when progress notifications are sent to the Deferred.
-         * @see [deferred.then](https://api.jquery.com/deferred.then/)
+         * @see [deferred.then on api.jquery.com](https://api.jquery.com/deferred.then/)
          * @since 1.8
          */
         then<ARP = never, AJP = never, ANP = never,
@@ -6897,7 +6897,7 @@ declare namespace JQuery {
          * @param doneFilter An optional function that is called when the Deferred is resolved.
          * @param failFilter An optional function that is called when the Deferred is rejected.
          * @param progressFilter An optional function that is called when progress notifications are sent to the Deferred.
-         * @see [deferred.then](https://api.jquery.com/deferred.then/)
+         * @see [deferred.then on api.jquery.com](https://api.jquery.com/deferred.then/)
          * @since 1.8
          */
         then<ARD = never, AJD = never, AND = never,
@@ -6926,7 +6926,7 @@ declare namespace JQuery {
          * @param doneFilter An optional function that is called when the Deferred is resolved.
          * @param failFilter An optional function that is called when the Deferred is rejected.
          * @param progressFilter An optional function that is called when progress notifications are sent to the Deferred.
-         * @see [deferred.then](https://api.jquery.com/deferred.then/)
+         * @see [deferred.then on api.jquery.com](https://api.jquery.com/deferred.then/)
          * @since 1.8
          */
         then<ARF = never, AJF = never, ANF = never,
@@ -6948,7 +6948,7 @@ declare namespace JQuery {
          * @param doneFilter An optional function that is called when the Deferred is resolved.
          * @param failFilter An optional function that is called when the Deferred is rejected.
          * @param progressFilter An optional function that is called when progress notifications are sent to the Deferred.
-         * @see [deferred.then](https://api.jquery.com/deferred.then/)
+         * @see [deferred.then on api.jquery.com](https://api.jquery.com/deferred.then/)
          * @since 1.8
          */
         then<ARD = never, AJD = never, AND = never,
@@ -6971,7 +6971,7 @@ declare namespace JQuery {
          * Add handlers to be called when the Deferred object is rejected.
          *
          * @param failFilter A function that is called when the Deferred is rejected.
-         * @see [deferred.catch](https://api.jquery.com/deferred.catch/)
+         * @see [deferred.catch on api.jquery.com](https://api.jquery.com/deferred.catch/)
          * @since 3.0
          */
         catch<ARF = never, AJF = never, ANF = never,
@@ -6991,7 +6991,7 @@ declare namespace JQuery {
      * This object provides a subset of the methods of the Deferred object (then, done, fail, always,
      * pipe, progress, state and promise) to prevent users from changing the state of the Deferred.
      *
-     * @see [Types](https://api.jquery.com/Types/)
+     * @see [Types on api.jquery.com](https://api.jquery.com/Types/)
      */
     interface Promise3<TR, TJ, TN,
         UR, UJ, UN,
@@ -7004,7 +7004,7 @@ declare namespace JQuery {
      * This object provides a subset of the methods of the Deferred object (then, done, fail, always,
      * pipe, progress, state and promise) to prevent users from changing the state of the Deferred.
      *
-     * @see [Types](https://api.jquery.com/Types/)
+     * @see [Types on api.jquery.com](https://api.jquery.com/Types/)
      */
     interface Promise2<TR, TJ, TN,
         UR, UJ, UN> extends PromiseBase<TR, TJ, TN,
@@ -7016,7 +7016,7 @@ declare namespace JQuery {
      * This object provides a subset of the methods of the Deferred object (then, done, fail, always,
      * pipe, progress, state and promise) to prevent users from changing the state of the Deferred.
      *
-     * @see [Types](https://api.jquery.com/Types/)
+     * @see [Types on api.jquery.com](https://api.jquery.com/Types/)
      */
     interface Promise<TR, TJ = any, TN = any> extends PromiseBase<TR, TJ, TN,
         TR, TJ, TN,
@@ -7034,7 +7034,7 @@ declare namespace JQuery {
          * Call the progressCallbacks on a Deferred object with the given args.
          *
          * @param args Optional arguments that are passed to the progressCallbacks.
-         * @see [deferred.notify](https://api.jquery.com/deferred.notify/)
+         * @see [deferred.notify on api.jquery.com](https://api.jquery.com/deferred.notify/)
          * @since 1.7
          */
         notify(...args: TN[]): this;
@@ -7043,7 +7043,7 @@ declare namespace JQuery {
          *
          * @param context Context passed to the progressCallbacks as the this object.
          * @param args An optional array of arguments that are passed to the progressCallbacks.
-         * @see [deferred.notifyWith](https://api.jquery.com/deferred.notifyWith/)
+         * @see [deferred.notifyWith on api.jquery.com](https://api.jquery.com/deferred.notifyWith/)
          * @since 1.7
          */
         notifyWith(context: object, args?: ArrayLike<TN>): this;
@@ -7051,7 +7051,7 @@ declare namespace JQuery {
          * Reject a Deferred object and call any failCallbacks with the given args.
          *
          * @param args Optional arguments that are passed to the failCallbacks.
-         * @see [deferred.reject](https://api.jquery.com/deferred.reject/)
+         * @see [deferred.reject on api.jquery.com](https://api.jquery.com/deferred.reject/)
          * @since 1.5
          */
         reject(...args: TJ[]): this;
@@ -7060,7 +7060,7 @@ declare namespace JQuery {
          *
          * @param context Context passed to the failCallbacks as the this object.
          * @param args An optional array of arguments that are passed to the failCallbacks.
-         * @see [deferred.rejectWith](https://api.jquery.com/deferred.rejectWith/)
+         * @see [deferred.rejectWith on api.jquery.com](https://api.jquery.com/deferred.rejectWith/)
          * @since 1.5
          */
         rejectWith(context: object, args?: ArrayLike<TJ>): this;
@@ -7068,7 +7068,7 @@ declare namespace JQuery {
          * Resolve a Deferred object and call any doneCallbacks with the given args.
          *
          * @param args Optional arguments that are passed to the doneCallbacks.
-         * @see [deferred.resolve](https://api.jquery.com/deferred.resolve/)
+         * @see [deferred.resolve on api.jquery.com](https://api.jquery.com/deferred.resolve/)
          * @since 1.5
          */
         resolve(...args: TR[]): this;
@@ -7077,7 +7077,7 @@ declare namespace JQuery {
          *
          * @param context Context passed to the doneCallbacks as the this object.
          * @param args An optional array of arguments that are passed to the doneCallbacks.
-         * @see [deferred.resolveWith](https://api.jquery.com/deferred.resolveWith/)
+         * @see [deferred.resolveWith on api.jquery.com](https://api.jquery.com/deferred.resolveWith/)
          * @since 1.5
          */
         resolveWith(context: object, args?: ArrayLike<TR>): this;
@@ -7087,7 +7087,7 @@ declare namespace JQuery {
          *
          * @param alwaysCallback A function, or array of functions, that is called when the Deferred is resolved or rejected.
          * @param alwaysCallbacks Optional additional functions, or arrays of functions, that are called when the Deferred is resolved or rejected.
-         * @see [deferred.always](https://api.jquery.com/deferred.always/)
+         * @see [deferred.always on api.jquery.com](https://api.jquery.com/deferred.always/)
          * @since 1.6
          */
         always(alwaysCallback: TypeOrArray<Deferred.Callback<TR | TJ>>,
@@ -7097,7 +7097,7 @@ declare namespace JQuery {
          *
          * @param doneCallback A function, or array of functions, that are called when the Deferred is resolved.
          * @param doneCallbacks Optional additional functions, or arrays of functions, that are called when the Deferred is resolved.
-         * @see [deferred.done](https://api.jquery.com/deferred.done/)
+         * @see [deferred.done on api.jquery.com](https://api.jquery.com/deferred.done/)
          * @since 1.5
          */
         done(doneCallback: TypeOrArray<Deferred.Callback<TR>>,
@@ -7107,7 +7107,7 @@ declare namespace JQuery {
          *
          * @param failCallback A function, or array of functions, that are called when the Deferred is rejected.
          * @param failCallbacks Optional additional functions, or arrays of functions, that are called when the Deferred is rejected.
-         * @see [deferred.fail](https://api.jquery.com/deferred.fail/)
+         * @see [deferred.fail on api.jquery.com](https://api.jquery.com/deferred.fail/)
          * @since 1.5
          */
         fail(failCallback: TypeOrArray<Deferred.Callback<TJ>>,
@@ -7118,7 +7118,7 @@ declare namespace JQuery {
          * @param progressCallback A function, or array of functions, to be called when the Deferred generates progress notifications.
          * @param progressCallbacks Optional additional functions, or arrays of functions, to be called when the Deferred generates
          *                          progress notifications.
-         * @see [deferred.progress](https://api.jquery.com/deferred.progress/)
+         * @see [deferred.progress on api.jquery.com](https://api.jquery.com/deferred.progress/)
          * @since 1.7
          */
         progress(progressCallback: TypeOrArray<Deferred.Callback<TN>>,
@@ -7127,21 +7127,21 @@ declare namespace JQuery {
          * Return a Deferred's Promise object.
          *
          * @param target Object onto which the promise methods have to be attached
-         * @see [deferred.promise](https://api.jquery.com/deferred.promise/)
+         * @see [deferred.promise on api.jquery.com](https://api.jquery.com/deferred.promise/)
          * @since 1.5
          */
         promise<TTarget extends object>(target: TTarget): JQuery.Promise<TR, TJ, TN> & TTarget;
         /**
          * Return a Deferred's Promise object.
          *
-         * @see [deferred.promise](https://api.jquery.com/deferred.promise/)
+         * @see [deferred.promise on api.jquery.com](https://api.jquery.com/deferred.promise/)
          * @since 1.5
          */
         promise(): JQuery.Promise<TR, TJ, TN>;
         /**
          * Determine the current state of a Deferred object.
          *
-         * @see [deferred.state](https://api.jquery.com/deferred.state/)
+         * @see [deferred.state on api.jquery.com](https://api.jquery.com/deferred.state/)
          * @since 1.7
          */
         state(): 'pending' | 'resolved' | 'rejected';
@@ -7154,7 +7154,7 @@ declare namespace JQuery {
          * @param doneFilter An optional function that is called when the Deferred is resolved.
          * @param failFilter An optional function that is called when the Deferred is rejected.
          * @param progressFilter An optional function that is called when progress notifications are sent to the Deferred.
-         * @see [deferred.pipe](https://api.jquery.com/deferred.pipe/)
+         * @see [deferred.pipe on api.jquery.com](https://api.jquery.com/deferred.pipe/)
          * @since 1.6
          * @since 1.7
          * @deprecated 1.8
@@ -7192,7 +7192,7 @@ declare namespace JQuery {
          * @param doneFilter An optional function that is called when the Deferred is resolved.
          * @param failFilter An optional function that is called when the Deferred is rejected.
          * @param progressFilter An optional function that is called when progress notifications are sent to the Deferred.
-         * @see [deferred.pipe](https://api.jquery.com/deferred.pipe/)
+         * @see [deferred.pipe on api.jquery.com](https://api.jquery.com/deferred.pipe/)
          * @since 1.6
          * @since 1.7
          * @deprecated 1.8
@@ -7223,7 +7223,7 @@ declare namespace JQuery {
          * @param doneFilter An optional function that is called when the Deferred is resolved.
          * @param failFilter An optional function that is called when the Deferred is rejected.
          * @param progressFilter An optional function that is called when progress notifications are sent to the Deferred.
-         * @see [deferred.pipe](https://api.jquery.com/deferred.pipe/)
+         * @see [deferred.pipe on api.jquery.com](https://api.jquery.com/deferred.pipe/)
          * @since 1.6
          * @since 1.7
          * @deprecated 1.8
@@ -7254,7 +7254,7 @@ declare namespace JQuery {
          * @param doneFilter An optional function that is called when the Deferred is resolved.
          * @param failFilter An optional function that is called when the Deferred is rejected.
          * @param progressFilter An optional function that is called when progress notifications are sent to the Deferred.
-         * @see [deferred.pipe](https://api.jquery.com/deferred.pipe/)
+         * @see [deferred.pipe on api.jquery.com](https://api.jquery.com/deferred.pipe/)
          * @since 1.6
          * @since 1.7
          * @deprecated 1.8
@@ -7278,7 +7278,7 @@ declare namespace JQuery {
          * @param doneFilter An optional function that is called when the Deferred is resolved.
          * @param failFilter An optional function that is called when the Deferred is rejected.
          * @param progressFilter An optional function that is called when progress notifications are sent to the Deferred.
-         * @see [deferred.pipe](https://api.jquery.com/deferred.pipe/)
+         * @see [deferred.pipe on api.jquery.com](https://api.jquery.com/deferred.pipe/)
          * @since 1.6
          * @since 1.7
          * @deprecated 1.8
@@ -7309,7 +7309,7 @@ declare namespace JQuery {
          * @param doneFilter An optional function that is called when the Deferred is resolved.
          * @param failFilter An optional function that is called when the Deferred is rejected.
          * @param progressFilter An optional function that is called when progress notifications are sent to the Deferred.
-         * @see [deferred.pipe](https://api.jquery.com/deferred.pipe/)
+         * @see [deferred.pipe on api.jquery.com](https://api.jquery.com/deferred.pipe/)
          * @since 1.6
          * @since 1.7
          * @deprecated 1.8
@@ -7333,7 +7333,7 @@ declare namespace JQuery {
          * @param doneFilter An optional function that is called when the Deferred is resolved.
          * @param failFilter An optional function that is called when the Deferred is rejected.
          * @param progressFilter An optional function that is called when progress notifications are sent to the Deferred.
-         * @see [deferred.pipe](https://api.jquery.com/deferred.pipe/)
+         * @see [deferred.pipe on api.jquery.com](https://api.jquery.com/deferred.pipe/)
          * @since 1.6
          * @since 1.7
          * @deprecated 1.8
@@ -7362,7 +7362,7 @@ declare namespace JQuery {
          * @param doneFilter A function that is called when the Deferred is resolved.
          * @param failFilter An optional function that is called when the Deferred is rejected.
          * @param progressFilter An optional function that is called when progress notifications are sent to the Deferred.
-         * @see [deferred.then](https://api.jquery.com/deferred.then/)
+         * @see [deferred.then on api.jquery.com](https://api.jquery.com/deferred.then/)
          * @since 1.8
          */
         then<ARD = never, AJD = never, AND = never,
@@ -7398,7 +7398,7 @@ declare namespace JQuery {
          * @param doneFilter A function that is called when the Deferred is resolved.
          * @param failFilter An optional function that is called when the Deferred is rejected.
          * @param progressFilter An optional function that is called when progress notifications are sent to the Deferred.
-         * @see [deferred.then](https://api.jquery.com/deferred.then/)
+         * @see [deferred.then on api.jquery.com](https://api.jquery.com/deferred.then/)
          * @since 1.8
          */
         then<ARF = never, AJF = never, ANF = never,
@@ -7427,7 +7427,7 @@ declare namespace JQuery {
          * @param doneFilter A function that is called when the Deferred is resolved.
          * @param failFilter An optional function that is called when the Deferred is rejected.
          * @param progressFilter An optional function that is called when progress notifications are sent to the Deferred.
-         * @see [deferred.then](https://api.jquery.com/deferred.then/)
+         * @see [deferred.then on api.jquery.com](https://api.jquery.com/deferred.then/)
          * @since 1.8
          */
         then<ARD = never, AJD = never, AND = never,
@@ -7456,7 +7456,7 @@ declare namespace JQuery {
          * @param doneFilter A function that is called when the Deferred is resolved.
          * @param failFilter An optional function that is called when the Deferred is rejected.
          * @param progressFilter An optional function that is called when progress notifications are sent to the Deferred.
-         * @see [deferred.then](https://api.jquery.com/deferred.then/)
+         * @see [deferred.then on api.jquery.com](https://api.jquery.com/deferred.then/)
          * @since 1.8
          */
         then<ARP = never, AJP = never, ANP = never,
@@ -7478,7 +7478,7 @@ declare namespace JQuery {
          * @param doneFilter An optional function that is called when the Deferred is resolved.
          * @param failFilter An optional function that is called when the Deferred is rejected.
          * @param progressFilter An optional function that is called when progress notifications are sent to the Deferred.
-         * @see [deferred.then](https://api.jquery.com/deferred.then/)
+         * @see [deferred.then on api.jquery.com](https://api.jquery.com/deferred.then/)
          * @since 1.8
          */
         then<ARD = never, AJD = never, AND = never,
@@ -7507,7 +7507,7 @@ declare namespace JQuery {
          * @param doneFilter An optional function that is called when the Deferred is resolved.
          * @param failFilter An optional function that is called when the Deferred is rejected.
          * @param progressFilter An optional function that is called when progress notifications are sent to the Deferred.
-         * @see [deferred.then](https://api.jquery.com/deferred.then/)
+         * @see [deferred.then on api.jquery.com](https://api.jquery.com/deferred.then/)
          * @since 1.8
          */
         then<ARF = never, AJF = never, ANF = never,
@@ -7529,7 +7529,7 @@ declare namespace JQuery {
          * @param doneFilter An optional function that is called when the Deferred is resolved.
          * @param failFilter An optional function that is called when the Deferred is rejected.
          * @param progressFilter An optional function that is called when progress notifications are sent to the Deferred.
-         * @see [deferred.then](https://api.jquery.com/deferred.then/)
+         * @see [deferred.then on api.jquery.com](https://api.jquery.com/deferred.then/)
          * @since 1.8
          */
         then<ARD = never, AJD = never, AND = never,
@@ -7552,7 +7552,7 @@ declare namespace JQuery {
          * Add handlers to be called when the Deferred object is rejected.
          *
          * @param failFilter A function that is called when the Deferred is rejected.
-         * @see [deferred.catch](https://api.jquery.com/deferred.catch/)
+         * @see [deferred.catch on api.jquery.com](https://api.jquery.com/deferred.catch/)
          * @since 3.0
          */
         catch<ARF = never, AJF = never, ANF = never,
@@ -7613,7 +7613,7 @@ declare namespace JQuery {
     }
 
     /**
-     * @see [animate](https://api.jquery.com/animate/)
+     * @see [animate on api.jquery.com](https://api.jquery.com/animate/)
      */
     interface EffectsOptions<TElement> {
         /**
@@ -7725,98 +7725,98 @@ declare namespace JQuery {
         /**
          * Indicates whether the META key was pressed when the event fired.
          *
-         * @see [event.metaKey](https://api.jquery.com/event.metaKey/)
+         * @see [event.metaKey on api.jquery.com](https://api.jquery.com/event.metaKey/)
          * @since 1.0.4
          */
         metaKey: boolean;
         /**
          * The namespace specified when the event was triggered.
          *
-         * @see [event.namespace](https://api.jquery.com/event.namespace/)
+         * @see [event.namespace on api.jquery.com](https://api.jquery.com/event.namespace/)
          * @since 1.4.3
          */
         namespace: string;
         /**
          * The mouse position relative to the left edge of the document.
          *
-         * @see [event.pageX](https://api.jquery.com/event.pageX/)
+         * @see [event.pageX on api.jquery.com](https://api.jquery.com/event.pageX/)
          * @since 1.0.4
          */
         pageX: number;
         /**
          * The mouse position relative to the top edge of the document.
          *
-         * @see [event.pageY](https://api.jquery.com/event.pageY/)
+         * @see [event.pageY on api.jquery.com](https://api.jquery.com/event.pageY/)
          * @since 1.0.4
          */
         pageY: number;
         /**
          * The last value returned by an event handler that was triggered by this event, unless the value was undefined.
          *
-         * @see [event.result](https://api.jquery.com/event.result/)
+         * @see [event.result on api.jquery.com](https://api.jquery.com/event.result/)
          * @since 1.3
          */
         result: any;
         /**
          * The difference in milliseconds between the time the browser created the event and January 1, 1970.
          *
-         * @see [event.timeStamp](https://api.jquery.com/event.timeStamp/)
+         * @see [event.timeStamp on api.jquery.com](https://api.jquery.com/event.timeStamp/)
          * @since 1.2.6
          */
         timeStamp: number;
         /**
          * Describes the nature of the event.
          *
-         * @see [event.type](https://api.jquery.com/event.type/)
+         * @see [event.type on api.jquery.com](https://api.jquery.com/event.type/)
          * @since 1.0
          */
         type: string;
         /**
          * For key or mouse events, this property indicates the specific key or button that was pressed.
          *
-         * @see [event.which](https://api.jquery.com/event.which/)
+         * @see [event.which on api.jquery.com](https://api.jquery.com/event.which/)
          * @since 1.1.3
          */
         which: number;
         /**
          * Returns whether event.preventDefault() was ever called on this event object.
          *
-         * @see [event.isDefaultPrevented](https://api.jquery.com/event.isDefaultPrevented/)
+         * @see [event.isDefaultPrevented on api.jquery.com](https://api.jquery.com/event.isDefaultPrevented/)
          * @since 1.3
          */
         isDefaultPrevented(): boolean;
         /**
          * Returns whether event.stopImmediatePropagation() was ever called on this event object.
          *
-         * @see [event.isImmediatePropagationStopped](https://api.jquery.com/event.isImmediatePropagationStopped/)
+         * @see [event.isImmediatePropagationStopped on api.jquery.com](https://api.jquery.com/event.isImmediatePropagationStopped/)
          * @since 1.3
          */
         isImmediatePropagationStopped(): boolean;
         /**
          * Returns whether event.stopPropagation() was ever called on this event object.
          *
-         * @see [event.isPropagationStopped](https://api.jquery.com/event.isPropagationStopped/)
+         * @see [event.isPropagationStopped on api.jquery.com](https://api.jquery.com/event.isPropagationStopped/)
          * @since 1.3
          */
         isPropagationStopped(): boolean;
         /**
          * If this method is called, the default action of the event will not be triggered.
          *
-         * @see [event.preventDefault](https://api.jquery.com/event.preventDefault/)
+         * @see [event.preventDefault on api.jquery.com](https://api.jquery.com/event.preventDefault/)
          * @since 1.0
          */
         preventDefault(): void;
         /**
          * Keeps the rest of the handlers from being executed and prevents the event from bubbling up the DOM tree.
          *
-         * @see [event.stopImmediatePropagation](https://api.jquery.com/event.stopImmediatePropagation/)
+         * @see [event.stopImmediatePropagation on api.jquery.com](https://api.jquery.com/event.stopImmediatePropagation/)
          * @since 1.3
          */
         stopImmediatePropagation(): void;
         /**
          * Prevents the event from bubbling up the DOM tree, preventing any parent handlers from being notified of the event.
          *
-         * @see [event.stopPropagation](https://api.jquery.com/event.stopPropagation/)
+         * @see [event.stopPropagation on api.jquery.com](https://api.jquery.com/event.stopPropagation/)
          * @since 1.0
          */
         stopPropagation(): void;
@@ -7831,21 +7831,21 @@ declare namespace JQuery {
         /**
          * The current DOM element within the event bubbling phase.
          *
-         * @see [event.currentTarget](https://api.jquery.com/event.currentTarget/)
+         * @see [event.currentTarget on api.jquery.com](https://api.jquery.com/event.currentTarget/)
          * @since 1.3
          */
         currentTarget: TTarget;
         /**
          * An optional object of data passed to an event method when the current executing handler is bound.
          *
-         * @see [event.data](https://api.jquery.com/event.data/)
+         * @see [event.data on api.jquery.com](https://api.jquery.com/event.data/)
          * @since 1.1
          */
         data: TData;
         /**
          * The element where the currently-called jQuery event handler was attached.
          *
-         * @see [event.delegateTarget](https://api.jquery.com/event.delegateTarget/)
+         * @see [event.delegateTarget on api.jquery.com](https://api.jquery.com/event.delegateTarget/)
          * @since 1.7
          */
         delegateTarget: TTarget;
@@ -7853,14 +7853,14 @@ declare namespace JQuery {
         /**
          * The other DOM element involved in the event, if any.
          *
-         * @see [event.relatedTarget](https://api.jquery.com/event.relatedTarget/)
+         * @see [event.relatedTarget on api.jquery.com](https://api.jquery.com/event.relatedTarget/)
          * @since 1.1.4
          */
         relatedTarget: TTarget | null;
         /**
          * The DOM element that initiated the event.
          *
-         * @see [event.target](https://api.jquery.com/event.target/)
+         * @see [event.target on api.jquery.com](https://api.jquery.com/event.target/)
          * @since 1.0
          */
         target: TTarget;
@@ -8067,92 +8067,92 @@ interface JQueryParam {
 interface BaseJQueryEventObject extends Event {
     /**
      * The current DOM element within the event bubbling phase.
-     * @see [event.currentTarget](https://api.jquery.com/event.currentTarget/)
+     * @see [event.currentTarget on api.jquery.com](https://api.jquery.com/event.currentTarget/)
      */
     currentTarget: Element;
     /**
      * An optional object of data passed to an event method when the current executing handler is bound.
-     * @see [event.data](https://api.jquery.com/event.data/)
+     * @see [event.data on api.jquery.com](https://api.jquery.com/event.data/)
      */
     data: any;
     /**
      * The element where the currently-called jQuery event handler was attached.
-     * @see [event.delegateTarget](https://api.jquery.com/event.delegateTarget/)
+     * @see [event.delegateTarget on api.jquery.com](https://api.jquery.com/event.delegateTarget/)
      */
     delegateTarget: Element;
     /**
      * Returns whether event.preventDefault() was ever called on this event object.
-     * @see [event.isDefaultPrevented](https://api.jquery.com/event.isDefaultPrevented/)
+     * @see [event.isDefaultPrevented on api.jquery.com](https://api.jquery.com/event.isDefaultPrevented/)
      */
     isDefaultPrevented(): boolean;
     /**
      * Returns whether event.stopImmediatePropagation() was ever called on this event object.
-     * @see [event.isImmediatePropagationStopped](https://api.jquery.com/event.isImmediatePropagationStopped/)
+     * @see [event.isImmediatePropagationStopped on api.jquery.com](https://api.jquery.com/event.isImmediatePropagationStopped/)
      */
     isImmediatePropagationStopped(): boolean;
     /**
      * Returns whether event.stopPropagation() was ever called on this event object.
-     * @see [event.isPropagationStopped](https://api.jquery.com/event.isPropagationStopped/)
+     * @see [event.isPropagationStopped on api.jquery.com](https://api.jquery.com/event.isPropagationStopped/)
      */
     isPropagationStopped(): boolean;
     /**
      * The namespace specified when the event was triggered.
-     * @see [event.namespace](https://api.jquery.com/event.namespace/)
+     * @see [event.namespace on api.jquery.com](https://api.jquery.com/event.namespace/)
      */
     namespace: string;
     /**
      * The browser's original Event object.
-     * @see [category](https://api.jquery.com/category/)
+     * @see [category on api.jquery.com](https://api.jquery.com/category/)
      */
     originalEvent: Event;
     /**
      * If this method is called, the default action of the event will not be triggered.
-     * @see [event.preventDefault](https://api.jquery.com/event.preventDefault/)
+     * @see [event.preventDefault on api.jquery.com](https://api.jquery.com/event.preventDefault/)
      */
     preventDefault(): any;
     /**
      * The other DOM element involved in the event, if any.
-     * @see [event.relatedTarget](https://api.jquery.com/event.relatedTarget/)
+     * @see [event.relatedTarget on api.jquery.com](https://api.jquery.com/event.relatedTarget/)
      */
     relatedTarget: Element;
     /**
      * The last value returned by an event handler that was triggered by this event, unless the value was undefined.
-     * @see [event.result](https://api.jquery.com/event.result/)
+     * @see [event.result on api.jquery.com](https://api.jquery.com/event.result/)
      */
     result: any;
     /**
      * Keeps the rest of the handlers from being executed and prevents the event from bubbling up the DOM tree.
-     * @see [event.stopImmediatePropagation](https://api.jquery.com/event.stopImmediatePropagation/)
+     * @see [event.stopImmediatePropagation on api.jquery.com](https://api.jquery.com/event.stopImmediatePropagation/)
      */
     stopImmediatePropagation(): void;
     /**
      * Prevents the event from bubbling up the DOM tree, preventing any parent handlers from being notified of the event.
-     * @see [event.stopPropagation](https://api.jquery.com/event.stopPropagation/)
+     * @see [event.stopPropagation on api.jquery.com](https://api.jquery.com/event.stopPropagation/)
      */
     stopPropagation(): void;
     /**
      * The DOM element that initiated the event.
-     * @see [event.target](https://api.jquery.com/event.target/)
+     * @see [event.target on api.jquery.com](https://api.jquery.com/event.target/)
      */
     target: Element;
     /**
      * The mouse position relative to the left edge of the document.
-     * @see [event.pageX](https://api.jquery.com/event.pageX/)
+     * @see [event.pageX on api.jquery.com](https://api.jquery.com/event.pageX/)
      */
     pageX: number;
     /**
      * The mouse position relative to the top edge of the document.
-     * @see [event.pageY](https://api.jquery.com/event.pageY/)
+     * @see [event.pageY on api.jquery.com](https://api.jquery.com/event.pageY/)
      */
     pageY: number;
     /**
      * For key or mouse events, this property indicates the specific key or button that was pressed.
-     * @see [event.which](https://api.jquery.com/event.which/)
+     * @see [event.which on api.jquery.com](https://api.jquery.com/event.which/)
      */
     which: number;
     /**
      * Indicates whether the META key was pressed when the event fired.
-     * @see [event.metaKey](https://api.jquery.com/event.metaKey/)
+     * @see [event.metaKey on api.jquery.com](https://api.jquery.com/event.metaKey/)
      */
     metaKey: boolean;
 }

--- a/types/jquery/index.d.ts
+++ b/types/jquery/index.d.ts
@@ -42,7 +42,7 @@ type _Promise<T> = Promise<T>;
 
 interface JQueryStatic<TElement extends Node = HTMLElement> {
     /**
-     * @see {@link http://api.jquery.com/jquery.ajax/#jQuery-ajax1}
+     * @see [jquery.ajax](https://api.jquery.com/jquery.ajax/)
      * @deprecated Use jQuery.ajaxSetup(options)
      */
     ajaxSettings: JQuery.AjaxSettings;
@@ -52,7 +52,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * any synchronous or asynchronous function.
      *
      * @param beforeStart A function that is called just before the constructor returns.
-     * @see {@link https://api.jquery.com/jQuery.Deferred/}
+     * @see [jQuery.Deferred](https://api.jquery.com/jQuery.Deferred/)
      * @since 1.5
      */
     Deferred: JQuery.DeferredStatic;
@@ -61,7 +61,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * Hook directly into jQuery to override how particular CSS properties are retrieved or set, normalize
      * CSS property naming, or create custom properties.
      *
-     * @see {@link https://api.jquery.com/jQuery.cssHooks/}
+     * @see [jQuery.cssHooks](https://api.jquery.com/jQuery.cssHooks/)
      * @since 1.4.3
      */
     cssHooks: JQuery.PlainObject<JQuery.CSSHook<TElement>>;
@@ -69,7 +69,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * An object containing all CSS properties that may be used without a unit. The .css() method uses this
      * object to see if it may append px to unitless values.
      *
-     * @see {@link https://api.jquery.com/jQuery.cssNumber/}
+     * @see [jQuery.cssNumber](https://api.jquery.com/jQuery.cssNumber/)
      * @since 1.4.3
      */
     cssNumber: JQuery.PlainObject<boolean>;
@@ -78,7 +78,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
         /**
          * The rate (in milliseconds) at which animations fire.
          *
-         * @see {@link https://api.jquery.com/jQuery.fx.interval/}
+         * @see [jQuery.fx.interval](https://api.jquery.com/jQuery.fx.interval/)
          * @since 1.4.3
          * @deprecated 3.0
          */
@@ -86,7 +86,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
         /**
          * Globally disable all animations.
          *
-         * @see {@link https://api.jquery.com/jQuery.fx.off/}
+         * @see [jQuery.fx.off](https://api.jquery.com/jQuery.fx.off/)
          * @since 1.3
          */
         off: boolean;
@@ -95,7 +95,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
     /**
      * A Promise-like object (or "thenable") that resolves when the document is ready.
      *
-     * @see {@link https://api.jquery.com/jQuery.ready/}
+     * @see [jQuery.ready](https://api.jquery.com/jQuery.ready/)
      * @since 1.8
      */
     ready: JQuery.Thenable<JQueryStatic<TElement>>;
@@ -106,7 +106,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * needs, we strongly recommend the use of an external library such as Modernizr instead of dependency
      * on properties in jQuery.support.
      *
-     * @see {@link https://api.jquery.com/jQuery.support/}
+     * @see [jQuery.support](https://api.jquery.com/jQuery.support/)
      * @since 1.3
      * @deprecated 1.9
      */
@@ -119,7 +119,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *             A string defining a single, standalone, HTML element (e.g. <div/> or <div></div>).
      * @param ownerDocument_attributes A document in which the new elements will be created.
      *                                 An object of attributes, events, and methods to call on the newly-created element.
-     * @see {@link https://api.jquery.com/jQuery/}
+     * @see [jQuery](https://api.jquery.com/jQuery/)
      * @since 1.0
      * @since 1.4
      */
@@ -129,7 +129,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param selector A string containing a selector expression
      * @param context A DOM Element, Document, or jQuery to use as context
-     * @see {@link https://api.jquery.com/jQuery/}
+     * @see [jQuery](https://api.jquery.com/jQuery/)
      * @since 1.0
      */
     (selector: JQuery.Selector, context: Element | Document | JQuery | undefined): JQuery<TElement>;
@@ -147,7 +147,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *                                 A plain object to wrap in a jQuery object.
      *                                 An existing jQuery object to clone.
      *                                 The function to execute when the DOM is ready.
-     * @see {@link https://api.jquery.com/jQuery/}
+     * @see [jQuery](https://api.jquery.com/jQuery/)
      * @since 1.0
      * @since 1.4
      */
@@ -158,7 +158,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * A multi-purpose callbacks list object that provides a powerful way to manage callback lists.
      *
      * @param flags An optional list of space-separated flags that change how the callback list behaves.
-     * @see {@link https://api.jquery.com/jQuery.Callbacks/}
+     * @see [jQuery.Callbacks](https://api.jquery.com/jQuery.Callbacks/)
      * @since 1.7
      */
     Callbacks<T extends Function>(flags?: string): JQuery.Callbacks<T>;
@@ -168,7 +168,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * @param url A string containing the URL to which the request is sent.
      * @param settings A set of key/value pairs that configure the Ajax request. All settings are optional. A default can
      *                 be set for any option with $.ajaxSetup(). See jQuery.ajax( settings ) below for a complete list of all settings.
-     * @see {@link https://api.jquery.com/jQuery.ajax/}
+     * @see [jQuery.ajax](https://api.jquery.com/jQuery.ajax/)
      * @since 1.5
      */
     ajax(url: string, settings?: JQuery.AjaxSettings): JQuery.jqXHR;
@@ -177,7 +177,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param settings A set of key/value pairs that configure the Ajax request. All settings are optional. A default can
      *                 be set for any option with $.ajaxSetup().
-     * @see {@link https://api.jquery.com/jQuery.ajax/}
+     * @see [jQuery.ajax](https://api.jquery.com/jQuery.ajax/)
      * @since 1.0
      */
     ajax(settings?: JQuery.AjaxSettings): JQuery.jqXHR;
@@ -187,7 +187,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param dataTypes An optional string containing one or more space-separated dataTypes
      * @param handler A handler to set default values for future Ajax requests.
-     * @see {@link https://api.jquery.com/jQuery.ajaxPrefilter/}
+     * @see [jQuery.ajaxPrefilter](https://api.jquery.com/jQuery.ajaxPrefilter/)
      * @since 1.5
      */
     ajaxPrefilter(dataTypes: string,
@@ -197,7 +197,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * are processed by $.ajax().
      *
      * @param handler A handler to set default values for future Ajax requests.
-     * @see {@link https://api.jquery.com/jQuery.ajaxPrefilter/}
+     * @see [jQuery.ajaxPrefilter](https://api.jquery.com/jQuery.ajaxPrefilter/)
      * @since 1.5
      */
     ajaxPrefilter(handler: (options: JQuery.AjaxSettings, originalOptions: JQuery.AjaxSettings, jqXHR: JQuery.jqXHR) => string | void): void;
@@ -205,7 +205,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * Set default values for future Ajax requests. Its use is not recommended.
      *
      * @param options A set of key/value pairs that configure the default Ajax request. All options are optional.
-     * @see {@link https://api.jquery.com/jQuery.ajaxSetup/}
+     * @see [jQuery.ajaxSetup](https://api.jquery.com/jQuery.ajaxSetup/)
      * @since 1.1
      */
     ajaxSetup(options: JQuery.AjaxSettings): JQuery.AjaxSettings;
@@ -214,7 +214,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param dataType A string identifying the data type to use
      * @param handler A handler to return the new transport object to use with the data type provided in the first argument.
-     * @see {@link https://api.jquery.com/jQuery.ajaxTransport/}
+     * @see [jQuery.ajaxTransport](https://api.jquery.com/jQuery.ajaxTransport/)
      * @since 1.5
      */
     ajaxTransport(dataType: string,
@@ -228,7 +228,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param container The DOM element that may contain the other element.
      * @param contained The DOM element that may be contained by (a descendant of) the other element.
-     * @see {@link https://api.jquery.com/jQuery.contains/}
+     * @see [jQuery.contains](https://api.jquery.com/jQuery.contains/)
      * @since 1.4
      */
     contains(container: Element, contained: Element): boolean;
@@ -239,7 +239,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param element The DOM element to query for the data.
      * @param key Name of the data stored.
-     * @see {@link https://api.jquery.com/jQuery.data/}
+     * @see [jQuery.data](https://api.jquery.com/jQuery.data/)
      * @since 1.2.3
      */
     data(element: Element, key: string, undefined: undefined): any; // tslint:disable-line:unified-signatures
@@ -249,7 +249,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * @param element The DOM element to associate with the data.
      * @param key A string naming the piece of data to set.
      * @param value The new data value; this can be any Javascript type except undefined.
-     * @see {@link https://api.jquery.com/jQuery.data/}
+     * @see [jQuery.data](https://api.jquery.com/jQuery.data/)
      * @since 1.2.3
      */
     data<T>(element: Element, key: string, value: T): T;
@@ -259,7 +259,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param element The DOM element to query for the data.
      * @param key Name of the data stored.
-     * @see {@link https://api.jquery.com/jQuery.data/}
+     * @see [jQuery.data](https://api.jquery.com/jQuery.data/)
      * @since 1.2.3
      * @since 1.4
      */
@@ -269,7 +269,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param element A DOM element from which to remove and execute a queued function.
      * @param queueName A string containing the name of the queue. Defaults to fx, the standard effects queue.
-     * @see {@link https://api.jquery.com/jQuery.dequeue/}
+     * @see [jQuery.dequeue](https://api.jquery.com/jQuery.dequeue/)
      * @since 1.3
      */
     dequeue(element: Element, queueName?: string): void;
@@ -280,7 +280,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param array The array to iterate over.
      * @param callback The function that will be executed on every object.
-     * @see {@link https://api.jquery.com/jQuery.each/}
+     * @see [jQuery.each](https://api.jquery.com/jQuery.each/)
      * @since 1.0
      */
     each<T>(array: ArrayLike<T>, callback: (this: T, indexInArray: number, value: T) => false | any): ArrayLike<T>;
@@ -291,7 +291,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param obj The object to iterate over.
      * @param callback The function that will be executed on every object.
-     * @see {@link https://api.jquery.com/jQuery.each/}
+     * @see [jQuery.each](https://api.jquery.com/jQuery.each/)
      * @since 1.0
      */
     each<T, K extends keyof T>(obj: T, callback: (this: T[K], propertyName: K, valueOfProperty: T[K]) => false | any): T;
@@ -299,7 +299,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * Takes a string and throws an exception containing it.
      *
      * @param message The message to send out.
-     * @see {@link https://api.jquery.com/jQuery.error/}
+     * @see [jQuery.error](https://api.jquery.com/jQuery.error/)
      * @since 1.4.1
      */
     error(message: string): any;
@@ -307,7 +307,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * Escapes any character that has a special meaning in a CSS selector.
      *
      * @param selector A string containing a selector expression to escape.
-     * @see {@link https://api.jquery.com/jQuery.escapeSelector/}
+     * @see [jQuery.escapeSelector](https://api.jquery.com/jQuery.escapeSelector/)
      * @since 3.0
      */
     escapeSelector(selector: JQuery.Selector): JQuery.Selector;
@@ -316,7 +316,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param deep If true, the merge becomes recursive (aka. deep copy). Passing false for this argument is not supported.
      * @param target The object to extend. It will receive the new properties.
-     * @see {@link https://api.jquery.com/jQuery.extend/}
+     * @see [jQuery.extend](https://api.jquery.com/jQuery.extend/)
      * @since 1.1.4
      */
     extend<T, U, V, W, X, Y, Z>(deep: true, target: T, object1: U, object2: V, object3: W, object4: X, object5: Y, object6: Z): T & U & V & W & X & Y & Z;
@@ -325,7 +325,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param deep If true, the merge becomes recursive (aka. deep copy). Passing false for this argument is not supported.
      * @param target The object to extend. It will receive the new properties.
-     * @see {@link https://api.jquery.com/jQuery.extend/}
+     * @see [jQuery.extend](https://api.jquery.com/jQuery.extend/)
      * @since 1.1.4
      */
     extend<T, U, V, W, X, Y>(deep: true, target: T, object1: U, object2: V, object3: W, object4: X, object5: Y): T & U & V & W & X & Y;
@@ -334,7 +334,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param deep If true, the merge becomes recursive (aka. deep copy). Passing false for this argument is not supported.
      * @param target The object to extend. It will receive the new properties.
-     * @see {@link https://api.jquery.com/jQuery.extend/}
+     * @see [jQuery.extend](https://api.jquery.com/jQuery.extend/)
      * @since 1.1.4
      */
     extend<T, U, V, W, X>(deep: true, target: T, object1: U, object2: V, object3: W, object4: X): T & U & V & W & X;
@@ -343,7 +343,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param deep If true, the merge becomes recursive (aka. deep copy). Passing false for this argument is not supported.
      * @param target The object to extend. It will receive the new properties.
-     * @see {@link https://api.jquery.com/jQuery.extend/}
+     * @see [jQuery.extend](https://api.jquery.com/jQuery.extend/)
      * @since 1.1.4
      */
     extend<T, U, V, W>(deep: true, target: T, object1: U, object2: V, object3: W): T & U & V & W;
@@ -352,7 +352,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param deep If true, the merge becomes recursive (aka. deep copy). Passing false for this argument is not supported.
      * @param target The object to extend. It will receive the new properties.
-     * @see {@link https://api.jquery.com/jQuery.extend/}
+     * @see [jQuery.extend](https://api.jquery.com/jQuery.extend/)
      * @since 1.1.4
      */
     extend<T, U, V>(deep: true, target: T, object1: U, object2: V): T & U & V;
@@ -361,7 +361,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param deep If true, the merge becomes recursive (aka. deep copy). Passing false for this argument is not supported.
      * @param target The object to extend. It will receive the new properties.
-     * @see {@link https://api.jquery.com/jQuery.extend/}
+     * @see [jQuery.extend](https://api.jquery.com/jQuery.extend/)
      * @since 1.1.4
      */
     extend<T, U>(deep: true, target: T, object1: U): T & U;
@@ -370,7 +370,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param deep If true, the merge becomes recursive (aka. deep copy). Passing false for this argument is not supported.
      * @param target The object to extend. It will receive the new properties.
-     * @see {@link https://api.jquery.com/jQuery.extend/}
+     * @see [jQuery.extend](https://api.jquery.com/jQuery.extend/)
      * @since 1.1.4
      */
     extend(deep: true, target: any, object1: any, ...objects: any[]): any;
@@ -379,7 +379,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param target An object that will receive the new properties if additional objects are passed in or that will
      *               extend the jQuery namespace if it is the sole argument.
-     * @see {@link https://api.jquery.com/jQuery.extend/}
+     * @see [jQuery.extend](https://api.jquery.com/jQuery.extend/)
      * @since 1.0
      */
     extend<T, U, V, W, X, Y, Z>(target: T, object1: U, object2: V, object3: W, object4: X, object5: Y, object6: Z): T & U & V & W & X & Y & Z;
@@ -388,7 +388,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param target An object that will receive the new properties if additional objects are passed in or that will
      *               extend the jQuery namespace if it is the sole argument.
-     * @see {@link https://api.jquery.com/jQuery.extend/}
+     * @see [jQuery.extend](https://api.jquery.com/jQuery.extend/)
      * @since 1.0
      */
     extend<T, U, V, W, X, Y>(target: T, object1: U, object2: V, object3: W, object4: X, object5: Y): T & U & V & W & X & Y;
@@ -397,7 +397,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param target An object that will receive the new properties if additional objects are passed in or that will
      *               extend the jQuery namespace if it is the sole argument.
-     * @see {@link https://api.jquery.com/jQuery.extend/}
+     * @see [jQuery.extend](https://api.jquery.com/jQuery.extend/)
      * @since 1.0
      */
     extend<T, U, V, W, X>(target: T, object1: U, object2: V, object3: W, object4: X): T & U & V & W & X;
@@ -406,7 +406,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param target An object that will receive the new properties if additional objects are passed in or that will
      *               extend the jQuery namespace if it is the sole argument.
-     * @see {@link https://api.jquery.com/jQuery.extend/}
+     * @see [jQuery.extend](https://api.jquery.com/jQuery.extend/)
      * @since 1.0
      */
     extend<T, U, V, W>(target: T, object1: U, object2: V, object3: W): T & U & V & W;
@@ -415,7 +415,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param target An object that will receive the new properties if additional objects are passed in or that will
      *               extend the jQuery namespace if it is the sole argument.
-     * @see {@link https://api.jquery.com/jQuery.extend/}
+     * @see [jQuery.extend](https://api.jquery.com/jQuery.extend/)
      * @since 1.0
      */
     extend<T, U, V>(target: T, object1: U, object2: V): T & U & V;
@@ -424,7 +424,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param target An object that will receive the new properties if additional objects are passed in or that will
      *               extend the jQuery namespace if it is the sole argument.
-     * @see {@link https://api.jquery.com/jQuery.extend/}
+     * @see [jQuery.extend](https://api.jquery.com/jQuery.extend/)
      * @since 1.0
      */
     extend<T, U>(target: T, object1: U): T & U;
@@ -433,7 +433,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param target An object that will receive the new properties if additional objects are passed in or that will
      *               extend the jQuery namespace if it is the sole argument.
-     * @see {@link https://api.jquery.com/jQuery.extend/}
+     * @see [jQuery.extend](https://api.jquery.com/jQuery.extend/)
      * @since 1.0
      */
     extend(target: any, object1: any, ...objects: any[]): any;
@@ -445,7 +445,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * @param success A callback function that is executed if the request succeeds. Required if dataType is provided, but
      *                you can use null or jQuery.noop as a placeholder.
      * @param dataType The type of data expected from the server. Default: Intelligent Guess (xml, json, script, text, html).
-     * @see {@link https://api.jquery.com/jQuery.get/}
+     * @see [jQuery.get](https://api.jquery.com/jQuery.get/)
      * @since 1.0
      */
     get(url: string,
@@ -459,7 +459,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * @param success A callback function that is executed if the request succeeds. Required if dataType is provided, but
      *                you can use null or jQuery.noop as a placeholder.
      * @param dataType The type of data expected from the server. Default: Intelligent Guess (xml, json, script, text, html).
-     * @see {@link https://api.jquery.com/jQuery.get/}
+     * @see [jQuery.get](https://api.jquery.com/jQuery.get/)
      * @since 1.0
      */
     get(url: string,
@@ -472,7 +472,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * @param success_data A callback function that is executed if the request succeeds. Required if dataType is provided, but
      *                     you can use null or jQuery.noop as a placeholder.
      *                     A plain object or string that is sent to the server with the request.
-     * @see {@link https://api.jquery.com/jQuery.get/}
+     * @see [jQuery.get](https://api.jquery.com/jQuery.get/)
      * @since 1.0
      */
     get(url: string,
@@ -484,7 +484,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *                     A set of key/value pairs that configure the Ajax request. All properties except for url are
      *                     optional. A default can be set for any option with $.ajaxSetup(). See jQuery.ajax( settings ) for a
      *                     complete list of all settings. The type option will automatically be set to GET.
-     * @see {@link https://api.jquery.com/jQuery.get/}
+     * @see [jQuery.get](https://api.jquery.com/jQuery.get/)
      * @since 1.0
      * @since 1.12
      * @since 2.2
@@ -496,7 +496,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * @param url A string containing the URL to which the request is sent.
      * @param data A plain object or string that is sent to the server with the request.
      * @param success A callback function that is executed if the request succeeds.
-     * @see {@link https://api.jquery.com/jQuery.getJSON/}
+     * @see [jQuery.getJSON](https://api.jquery.com/jQuery.getJSON/)
      * @since 1.0
      */
     getJSON(url: string,
@@ -508,7 +508,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * @param url A string containing the URL to which the request is sent.
      * @param success_data A callback function that is executed if the request succeeds.
      *                     A plain object or string that is sent to the server with the request.
-     * @see {@link https://api.jquery.com/jQuery.getJSON/}
+     * @see [jQuery.getJSON](https://api.jquery.com/jQuery.getJSON/)
      * @since 1.0
      */
     getJSON(url: string,
@@ -518,7 +518,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param url A string containing the URL to which the request is sent.
      * @param success A callback function that is executed if the request succeeds.
-     * @see {@link https://api.jquery.com/jQuery.getScript/}
+     * @see [jQuery.getScript](https://api.jquery.com/jQuery.getScript/)
      * @since 1.0
      */
     getScript(url: string,
@@ -527,7 +527,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * Execute some JavaScript code globally.
      *
      * @param code The JavaScript code to execute.
-     * @see {@link https://api.jquery.com/jQuery.globalEval/}
+     * @see [jQuery.globalEval](https://api.jquery.com/jQuery.globalEval/)
      * @since 1.0.4
      */
     globalEval(code: string): void;
@@ -540,7 +540,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * @param invert If "invert" is false, or not provided, then the function returns an array consisting of all elements
      *               for which "callback" returns true. If "invert" is true, then the function returns an array
      *               consisting of all elements for which "callback" returns false.
-     * @see {@link https://api.jquery.com/jQuery.grep/}
+     * @see [jQuery.grep](https://api.jquery.com/jQuery.grep/)
      * @since 1.0
      */
     grep<T>(array: ArrayLike<T>,
@@ -550,7 +550,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * Determine whether an element has any jQuery data associated with it.
      *
      * @param element A DOM element to be checked for data.
-     * @see {@link https://api.jquery.com/jQuery.hasData/}
+     * @see [jQuery.hasData](https://api.jquery.com/jQuery.hasData/)
      * @since 1.5
      */
     hasData(element: Element): boolean;
@@ -558,7 +558,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * Holds or releases the execution of jQuery's ready event.
      *
      * @param hold Indicates whether the ready hold is being requested or released
-     * @see {@link https://api.jquery.com/jQuery.holdReady/}
+     * @see [jQuery.holdReady](https://api.jquery.com/jQuery.holdReady/)
      * @since 1.6
      * @deprecated 3.2
      */
@@ -567,7 +567,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * Modify and filter HTML strings passed through jQuery manipulation methods.
      *
      * @param html The HTML string on which to operate.
-     * @see {@link https://api.jquery.com/jQuery.htmlPrefilter/}
+     * @see [jQuery.htmlPrefilter](https://api.jquery.com/jQuery.htmlPrefilter/)
      * @since 1.12/2.2
      */
     htmlPrefilter(html: JQuery.htmlString): JQuery.htmlString;
@@ -577,7 +577,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * @param value The value to search for.
      * @param array An array through which to search.
      * @param fromIndex The index of the array at which to begin the search. The default is 0, which will search the whole array.
-     * @see {@link https://api.jquery.com/jQuery.inArray/}
+     * @see [jQuery.inArray](https://api.jquery.com/jQuery.inArray/)
      * @since 1.2
      */
     inArray<T>(value: T, array: T[], fromIndex?: number): number;
@@ -585,7 +585,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * Determine whether the argument is an array.
      *
      * @param obj Object to test whether or not it is an array.
-     * @see {@link https://api.jquery.com/jQuery.isArray/}
+     * @see [jQuery.isArray](https://api.jquery.com/jQuery.isArray/)
      * @since 1.3
      * @deprecated 3.2
      */
@@ -594,7 +594,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * Check to see if an object is empty (contains no enumerable properties).
      *
      * @param obj The object that will be checked to see if it's empty.
-     * @see {@link https://api.jquery.com/jQuery.isEmptyObject/}
+     * @see [jQuery.isEmptyObject](https://api.jquery.com/jQuery.isEmptyObject/)
      * @since 1.4
      */
     isEmptyObject(obj: any): boolean;
@@ -602,7 +602,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * Determine if the argument passed is a JavaScript function object.
      *
      * @param obj Object to test whether or not it is a function.
-     * @see {@link https://api.jquery.com/jQuery.isFunction/}
+     * @see [jQuery.isFunction](https://api.jquery.com/jQuery.isFunction/)
      * @since 1.2
      * @deprecated 3.3
      */
@@ -611,7 +611,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * Determines whether its argument represents a JavaScript number.
      *
      * @param value The value to be tested.
-     * @see {@link https://api.jquery.com/jQuery.isNumeric/}
+     * @see [jQuery.isNumeric](https://api.jquery.com/jQuery.isNumeric/)
      * @since 1.7
      * @deprecated 3.3
      */
@@ -620,7 +620,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * Check to see if an object is a plain object (created using "{}" or "new Object").
      *
      * @param obj The object that will be checked to see if it's a plain object.
-     * @see {@link https://api.jquery.com/jQuery.isPlainObject/}
+     * @see [jQuery.isPlainObject](https://api.jquery.com/jQuery.isPlainObject/)
      * @since 1.4
      */
     isPlainObject(obj: any): obj is JQuery.PlainObject;
@@ -628,7 +628,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * Determine whether the argument is a window.
      *
      * @param obj Object to test whether or not it is a window.
-     * @see {@link https://api.jquery.com/jQuery.isWindow/}
+     * @see [jQuery.isWindow](https://api.jquery.com/jQuery.isWindow/)
      * @since 1.4.3
      * @deprecated 3.3
      */
@@ -637,7 +637,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * Check to see if a DOM node is within an XML document (or is an XML document).
      *
      * @param node The DOM node that will be checked to see if it's in an XML document.
-     * @see {@link https://api.jquery.com/jQuery.isXMLDoc/}
+     * @see [jQuery.isXMLDoc](https://api.jquery.com/jQuery.isXMLDoc/)
      * @since 1.1.4
      */
     isXMLDoc(node: Node): boolean;
@@ -645,7 +645,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * Convert an array-like object into a true JavaScript array.
      *
      * @param obj Any object to turn into a native Array.
-     * @see {@link https://api.jquery.com/jQuery.makeArray/}
+     * @see [jQuery.makeArray](https://api.jquery.com/jQuery.makeArray/)
      * @since 1.2
      */
     makeArray<T>(obj: ArrayLike<T>): T[];
@@ -656,7 +656,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * @param callback The function to process each item against. The first argument to the function is the array item, the
      *                 second argument is the index in array The function can return any value. A returned array will be
      *                 flattened into the resulting array. Within the function, this refers to the global (window) object.
-     * @see {@link https://api.jquery.com/jQuery.map/}
+     * @see [jQuery.map](https://api.jquery.com/jQuery.map/)
      * @since 1.0
      */
     map<T, R>(array: T[], callback: (elementOfArray: T, indexInArray: number) => R): R[];
@@ -668,7 +668,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *                 second argument is the key of the object property. The function can return any value to add to the
      *                 array. A returned array will be flattened into the resulting array. Within the function, this refers
      *                 to the global (window) object.
-     * @see {@link https://api.jquery.com/jQuery.map/}
+     * @see [jQuery.map](https://api.jquery.com/jQuery.map/)
      * @since 1.6
      */
     map<T, K extends keyof T, R>(obj: T, callback: (propertyOfObject: T[K], key: K) => R): R[];
@@ -677,7 +677,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param first The first array-like object to merge, the elements of second added.
      * @param second The second array-like object to merge into the first, unaltered.
-     * @see {@link https://api.jquery.com/jQuery.merge/}
+     * @see [jQuery.merge](https://api.jquery.com/jQuery.merge/)
      * @since 1.0
      */
     merge<T, U>(first: ArrayLike<T>, second: ArrayLike<U>): Array<T | U>;
@@ -685,21 +685,21 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * Relinquish jQuery's control of the $ variable.
      *
      * @param removeAll A Boolean indicating whether to remove all jQuery variables from the global scope (including jQuery itself).
-     * @see {@link https://api.jquery.com/jQuery.noConflict/}
+     * @see [jQuery.noConflict](https://api.jquery.com/jQuery.noConflict/)
      * @since 1.0
      */
     noConflict(removeAll?: boolean): this;
     /**
      * An empty function.
      *
-     * @see {@link https://api.jquery.com/jQuery.noop/}
+     * @see [jQuery.noop](https://api.jquery.com/jQuery.noop/)
      * @since 1.4
      */
     noop(): undefined;
     /**
      * Return a number representing the current time.
      *
-     * @see {@link https://api.jquery.com/jQuery.now/}
+     * @see [jQuery.now](https://api.jquery.com/jQuery.now/)
      * @since 1.4.3
      * @deprecated 3.3 Use Date.now().
      */
@@ -711,7 +711,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param obj An array, a plain object, or a jQuery object to serialize.
      * @param traditional A Boolean indicating whether to perform a traditional "shallow" serialization.
-     * @see {@link https://api.jquery.com/jQuery.param/}
+     * @see [jQuery.param](https://api.jquery.com/jQuery.param/)
      * @since 1.2
      * @since 1.4
      */
@@ -722,7 +722,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * @param data HTML string to be parsed
      * @param context Document element to serve as the context in which the HTML fragment will be created
      * @param keepScripts A Boolean indicating whether to include scripts passed in the HTML string
-     * @see {@link https://api.jquery.com/jQuery.parseHTML/}
+     * @see [jQuery.parseHTML](https://api.jquery.com/jQuery.parseHTML/)
      * @since 1.8
      */
     parseHTML(data: string, context: Document | null | undefined, keepScripts: boolean): JQuery.Node[];
@@ -732,7 +732,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * @param data HTML string to be parsed
      * @param context_keepScripts Document element to serve as the context in which the HTML fragment will be created
      *                            A Boolean indicating whether to include scripts passed in the HTML string
-     * @see {@link https://api.jquery.com/jQuery.parseHTML/}
+     * @see [jQuery.parseHTML](https://api.jquery.com/jQuery.parseHTML/)
      * @since 1.8
      */
     parseHTML(data: string, context_keepScripts?: Document | null | boolean): JQuery.Node[];
@@ -740,7 +740,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * Takes a well-formed JSON string and returns the resulting JavaScript value.
      *
      * @param json The JSON string to parse.
-     * @see {@link https://api.jquery.com/jQuery.parseJSON/}
+     * @see [jQuery.parseJSON](https://api.jquery.com/jQuery.parseJSON/)
      * @since 1.4.1
      * @deprecated 3.0
      */
@@ -749,7 +749,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * Parses a string into an XML document.
      *
      * @param data a well-formed XML string to be parsed
-     * @see {@link https://api.jquery.com/jQuery.parseXML/}
+     * @see [jQuery.parseXML](https://api.jquery.com/jQuery.parseXML/)
      * @since 1.5
      */
     parseXML(data: string): XMLDocument;
@@ -761,7 +761,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * @param success A callback function that is executed if the request succeeds. Required if dataType is provided, but
      *                can be null in that case.
      * @param dataType The type of data expected from the server. Default: Intelligent Guess (xml, json, script, text, html).
-     * @see {@link https://api.jquery.com/jQuery.post/}
+     * @see [jQuery.post](https://api.jquery.com/jQuery.post/)
      * @since 1.0
      */
     post(url: string,
@@ -775,7 +775,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * @param success A callback function that is executed if the request succeeds. Required if dataType is provided, but
      *                can be null in that case.
      * @param dataType The type of data expected from the server. Default: Intelligent Guess (xml, json, script, text, html).
-     * @see {@link https://api.jquery.com/jQuery.post/}
+     * @see [jQuery.post](https://api.jquery.com/jQuery.post/)
      * @since 1.0
      */
     post(url: string,
@@ -788,7 +788,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * @param success_data A callback function that is executed if the request succeeds. Required if dataType is provided, but
      *                     can be null in that case.
      *                     A plain object or string that is sent to the server with the request.
-     * @see {@link https://api.jquery.com/jQuery.post/}
+     * @see [jQuery.post](https://api.jquery.com/jQuery.post/)
      * @since 1.0
      */
     post(url: string,
@@ -800,7 +800,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *                     A set of key/value pairs that configure the Ajax request. All properties except for url are
      *                     optional. A default can be set for any option with $.ajaxSetup(). See jQuery.ajax( settings ) for a
      *                     complete list of all settings. Type will automatically be set to POST.
-     * @see {@link https://api.jquery.com/jQuery.post/}
+     * @see [jQuery.post](https://api.jquery.com/jQuery.post/)
      * @since 1.0
      * @since 1.12
      * @since 2.2
@@ -820,7 +820,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -833,7 +833,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -846,7 +846,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -859,7 +859,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -872,7 +872,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -885,7 +885,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -898,7 +898,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4`
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -912,7 +912,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -928,7 +928,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -943,7 +943,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -958,7 +958,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -973,7 +973,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -988,7 +988,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1003,7 +1003,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1018,7 +1018,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1033,7 +1033,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1050,7 +1050,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1065,7 +1065,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1080,7 +1080,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1095,7 +1095,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1110,7 +1110,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1125,7 +1125,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1140,7 +1140,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1155,7 +1155,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1172,7 +1172,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1187,7 +1187,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1202,7 +1202,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1217,7 +1217,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1232,7 +1232,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1247,7 +1247,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1262,7 +1262,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1277,7 +1277,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1294,7 +1294,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1309,7 +1309,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1324,7 +1324,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1339,7 +1339,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1354,7 +1354,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1369,7 +1369,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1384,7 +1384,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1399,7 +1399,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1416,7 +1416,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1431,7 +1431,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1446,7 +1446,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1461,7 +1461,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1476,7 +1476,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1491,7 +1491,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1506,7 +1506,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1521,7 +1521,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1538,7 +1538,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1553,7 +1553,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1568,7 +1568,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1583,7 +1583,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1598,7 +1598,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1613,7 +1613,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1628,7 +1628,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1643,7 +1643,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1660,7 +1660,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1675,7 +1675,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1690,7 +1690,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1705,7 +1705,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1720,7 +1720,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1735,7 +1735,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1750,7 +1750,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1765,7 +1765,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1785,7 +1785,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
      * @param additionalArguments Any number of arguments to be passed to the function referenced in the function argument.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1808,7 +1808,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -1823,7 +1823,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -1838,7 +1838,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -1853,7 +1853,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -1868,7 +1868,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -1883,7 +1883,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -1898,7 +1898,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4`
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -1913,7 +1913,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -1931,7 +1931,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -1948,7 +1948,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -1965,7 +1965,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -1982,7 +1982,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -1999,7 +1999,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2016,7 +2016,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2033,7 +2033,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2050,7 +2050,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2069,7 +2069,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2086,7 +2086,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2103,7 +2103,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2120,7 +2120,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2137,7 +2137,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2154,7 +2154,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2171,7 +2171,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2188,7 +2188,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2207,7 +2207,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2224,7 +2224,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2241,7 +2241,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2258,7 +2258,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2275,7 +2275,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2292,7 +2292,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2309,7 +2309,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2326,7 +2326,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2345,7 +2345,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2362,7 +2362,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2379,7 +2379,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2396,7 +2396,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2413,7 +2413,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2430,7 +2430,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2447,7 +2447,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2464,7 +2464,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2483,7 +2483,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2500,7 +2500,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2517,7 +2517,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2534,7 +2534,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2551,7 +2551,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2568,7 +2568,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2585,7 +2585,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2602,7 +2602,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2621,7 +2621,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2638,7 +2638,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2655,7 +2655,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2672,7 +2672,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2689,7 +2689,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2706,7 +2706,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2723,7 +2723,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2740,7 +2740,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2759,7 +2759,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2776,7 +2776,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2793,7 +2793,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2810,7 +2810,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2827,7 +2827,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2844,7 +2844,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2861,7 +2861,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2878,7 +2878,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2900,7 +2900,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
      * @param additionalArguments Any number of arguments to be passed to the function referenced in the function argument.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2922,7 +2922,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * @param context The object to which the context of the function should be set.
      * @param name The name of the function whose context will be changed (should be a property of the context object).
      * @param additionalArguments Any number of arguments to be passed to the function named in the name argument.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see [jQuery.proxy](https://api.jquery.com/jQuery.proxy/)
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2942,7 +2942,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * @param queueName A string containing the name of the queue. Defaults to fx, the standard effects queue.
      * @param newQueue The new function to add to the queue.
      *                 An array of functions to replace the current queue contents.
-     * @see {@link https://api.jquery.com/jQuery.queue/}
+     * @see [jQuery.queue](https://api.jquery.com/jQuery.queue/)
      * @since 1.3
      */
     queue<T extends Element>(element: T, queueName?: string, newQueue?: JQuery.TypeOrArray<JQuery.QueueFunction<T>>): JQuery.Queue<T>;
@@ -2950,7 +2950,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * Handles errors thrown synchronously in functions wrapped in jQuery().
      *
      * @param error An error thrown in the function wrapped in jQuery().
-     * @see {@link https://api.jquery.com/jQuery.readyException/}
+     * @see [jQuery.readyException](https://api.jquery.com/jQuery.readyException/)
      * @since 3.1
      */
     readyException(error: Error): any;
@@ -2959,7 +2959,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param element A DOM element from which to remove data.
      * @param name A string naming the piece of data to remove.
-     * @see {@link https://api.jquery.com/jQuery.removeData/}
+     * @see [jQuery.removeData](https://api.jquery.com/jQuery.removeData/)
      * @since 1.2.3
      */
     removeData(element: Element, name?: string): void;
@@ -2969,7 +2969,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * @param duration A string or number determining how long the animation will run.
      * @param easing A string indicating which easing function to use for the transition.
      * @param complete A function to call once the animation is complete, called once per matched element.
-     * @see {@link https://api.jquery.com/jQuery.speed/}
+     * @see [jQuery.speed](https://api.jquery.com/jQuery.speed/)
      * @since 1.1
      */
     speed(duration: JQuery.Duration, easing: string, complete: (this: TElement) => void): JQuery.EffectsOptions<TElement>;
@@ -2979,7 +2979,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * @param duration A string or number determining how long the animation will run.
      * @param easing_complete A string indicating which easing function to use for the transition.
      *                        A function to call once the animation is complete, called once per matched element.
-     * @see {@link https://api.jquery.com/jQuery.speed/}
+     * @see [jQuery.speed](https://api.jquery.com/jQuery.speed/)
      * @since 1.0
      * @since 1.1
      */
@@ -2990,7 +2990,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param duration_complete_settings A string or number determining how long the animation will run.
      *                                   A function to call once the animation is complete, called once per matched element.
-     * @see {@link https://api.jquery.com/jQuery.speed/}
+     * @see [jQuery.speed](https://api.jquery.com/jQuery.speed/)
      * @since 1.0
      * @since 1.1
      */
@@ -2999,7 +2999,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * Remove the whitespace from the beginning and end of a string.
      *
      * @param str The string to trim.
-     * @see {@link https://api.jquery.com/jQuery.trim/}
+     * @see [jQuery.trim](https://api.jquery.com/jQuery.trim/)
      * @since 1.0
      */
     trim(str: string): string;
@@ -3007,7 +3007,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * Determine the internal JavaScript [[Class]] of an object.
      *
      * @param obj Object to get the internal JavaScript [[Class]] of.
-     * @see {@link https://api.jquery.com/jQuery.type/}
+     * @see [jQuery.type](https://api.jquery.com/jQuery.type/)
      * @since 1.4.3
      * @deprecated 3.3
      */
@@ -3017,7 +3017,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * arrays of DOM elements, not strings or numbers.
      *
      * @param array The Array of DOM elements.
-     * @see {@link https://api.jquery.com/jQuery.unique/}
+     * @see [jQuery.unique](https://api.jquery.com/jQuery.unique/)
      * @since 1.1.3
      * @deprecated 3.0
      */
@@ -3027,7 +3027,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * arrays of DOM elements, not strings or numbers.
      *
      * @param array The Array of DOM elements.
-     * @see {@link https://api.jquery.com/jQuery.uniqueSort/}
+     * @see [jQuery.uniqueSort](https://api.jquery.com/jQuery.uniqueSort/)
      * @since 1.12
      * @since 2.2
      */
@@ -3036,7 +3036,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * Provides a way to execute callback functions based on zero or more Thenable objects, usually
      * Deferred objects that represent asynchronous events.
      *
-     * @see {@link https://api.jquery.com/jQuery.when/}
+     * @see [jQuery.when](https://api.jquery.com/jQuery.when/)
      * @since 1.5
      */
     when<TR1, UR1, VR1,
@@ -3050,7 +3050,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * Provides a way to execute callback functions based on zero or more Thenable objects, usually
      * Deferred objects that represent asynchronous events.
      *
-     * @see {@link https://api.jquery.com/jQuery.when/}
+     * @see [jQuery.when](https://api.jquery.com/jQuery.when/)
      * @since 1.5
      */
     when<TR1, UR1,
@@ -3062,7 +3062,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * Provides a way to execute callback functions based on zero or more Thenable objects, usually
      * Deferred objects that represent asynchronous events.
      *
-     * @see {@link https://api.jquery.com/jQuery.when/}
+     * @see [jQuery.when](https://api.jquery.com/jQuery.when/)
      * @since 1.5
      */
     when<TR1, TJ1,
@@ -3074,7 +3074,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * Provides a way to execute callback functions based on zero or more Thenable objects, usually
      * Deferred objects that represent asynchronous events.
      *
-     * @see {@link https://api.jquery.com/jQuery.when/}
+     * @see [jQuery.when](https://api.jquery.com/jQuery.when/)
      * @since 1.5
      */
     when<TR1, TJ1 = any>(deferred: JQuery.Promise<TR1, TJ1, any> | JQuery.Thenable<TR1> | TR1): JQuery.Promise<TR1, TJ1, never>;
@@ -3083,7 +3083,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * Deferred objects that represent asynchronous events.
      *
      * @param deferreds Zero or more Thenable objects.
-     * @see {@link https://api.jquery.com/jQuery.when/}
+     * @see [jQuery.when](https://api.jquery.com/jQuery.when/)
      * @since 1.5
      */
     when<TR1 = never, TJ1 = never>(...deferreds: Array<JQuery.Promise<TR1, TJ1, any> | JQuery.Thenable<TR1> | TR1>): JQuery.Promise<TR1, TJ1, never>;
@@ -3092,7 +3092,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * Deferred objects that represent asynchronous events.
      *
      * @param deferreds Zero or more Thenable objects.
-     * @see {@link https://api.jquery.com/jQuery.when/}
+     * @see [jQuery.when](https://api.jquery.com/jQuery.when/)
      * @since 1.5
      */
     when(...deferreds: any[]): JQuery.Promise<any, any, never>;
@@ -3102,14 +3102,14 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
     /**
      * A string containing the jQuery version number.
      *
-     * @see {@link https://api.jquery.com/jquery/}
+     * @see [jquery](https://api.jquery.com/jquery/)
      * @since 1.0
      */
     jquery: string;
     /**
      * The number of elements in the jQuery object.
      *
-     * @see {@link https://api.jquery.com/length/}
+     * @see [length](https://api.jquery.com/length/)
      * @since 1.0
      */
     length: number;
@@ -3119,7 +3119,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param selector A string representing a selector expression to find additional elements to add to the set of matched elements.
      * @param context The point in the document at which the selector should begin matching; similar to the context
      *                argument of the $(selector, context) method.
-     * @see {@link https://api.jquery.com/add/}
+     * @see [add](https://api.jquery.com/add/)
      * @since 1.4
      */
     add(selector: JQuery.Selector, context: Element): this;
@@ -3130,7 +3130,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *                 One or more elements to add to the set of matched elements.
      *                 An HTML fragment to add to the set of matched elements.
      *                 An existing jQuery object to add to the set of matched elements.
-     * @see {@link https://api.jquery.com/add/}
+     * @see [add](https://api.jquery.com/add/)
      * @since 1.0
      * @since 1.3.2
      */
@@ -3139,7 +3139,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Add the previous set of elements on the stack to the current set, optionally filtered by a selector.
      *
      * @param selector A string containing a selector expression to match the current set of elements against.
-     * @see {@link https://api.jquery.com/addBack/}
+     * @see [addBack](https://api.jquery.com/addBack/)
      * @since 1.8
      */
     addBack(selector?: JQuery.Selector): this;
@@ -3151,7 +3151,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *                  A function returning one or more space-separated class names to be added to the existing class
      *                  name(s). Receives the index position of the element in the set and the existing class name(s) as
      *                  arguments. Within the function, this refers to the current element in the set.
-     * @see {@link https://api.jquery.com/addClass/}
+     * @see [addClass](https://api.jquery.com/addClass/)
      * @since 1.0
      * @since 1.4
      * @since 3.3
@@ -3162,7 +3162,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param contents One or more additional DOM elements, text nodes, arrays of elements and text nodes, HTML strings, or
      *                 jQuery objects to insert after each element in the set of matched elements.
-     * @see {@link https://api.jquery.com/after/}
+     * @see [after](https://api.jquery.com/after/)
      * @since 1.0
      */
     after(...contents: Array<JQuery.htmlString | JQuery.TypeOrArray<JQuery.Node | JQuery<JQuery.Node>>>): this;
@@ -3173,7 +3173,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *           after each element in the set of matched elements. Receives the index position of the element in the
      *           set and the old HTML value of the element as arguments. Within the function, this refers to the
      *           current element in the set.
-     * @see {@link https://api.jquery.com/after/}
+     * @see [after](https://api.jquery.com/after/)
      * @since 1.4
      * @since 1.10
      */
@@ -3182,7 +3182,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Register a handler to be called when Ajax requests complete. This is an AjaxEvent.
      *
      * @param handler The function to be invoked.
-     * @see {@link https://api.jquery.com/ajaxComplete/}
+     * @see [ajaxComplete](https://api.jquery.com/ajaxComplete/)
      * @since 1.0
      */
     ajaxComplete(handler: (this: Document, event: JQuery.Event<Document>, jqXHR: JQuery.jqXHR, ajaxOptions: JQuery.AjaxSettings) => void | false): this;
@@ -3190,7 +3190,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Register a handler to be called when Ajax requests complete with an error. This is an Ajax Event.
      *
      * @param handler The function to be invoked.
-     * @see {@link https://api.jquery.com/ajaxError/}
+     * @see [ajaxError](https://api.jquery.com/ajaxError/)
      * @since 1.0
      */
     ajaxError(handler: (this: Document, event: JQuery.Event<Document>, jqXHR: JQuery.jqXHR, ajaxSettings: JQuery.AjaxSettings, thrownError: string) => void | false): this;
@@ -3198,7 +3198,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Attach a function to be executed before an Ajax request is sent. This is an Ajax Event.
      *
      * @param handler The function to be invoked.
-     * @see {@link https://api.jquery.com/ajaxSend/}
+     * @see [ajaxSend](https://api.jquery.com/ajaxSend/)
      * @since 1.0
      */
     ajaxSend(handler: (this: Document, event: JQuery.Event<Document>, jqXHR: JQuery.jqXHR, ajaxOptions: JQuery.AjaxSettings) => void | false): this;
@@ -3206,7 +3206,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Register a handler to be called when the first Ajax request begins. This is an Ajax Event.
      *
      * @param handler The function to be invoked.
-     * @see {@link https://api.jquery.com/ajaxStart/}
+     * @see [ajaxStart](https://api.jquery.com/ajaxStart/)
      * @since 1.0
      */
     ajaxStart(handler: (this: Document) => void | false): this;
@@ -3214,7 +3214,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Register a handler to be called when all Ajax requests have completed. This is an Ajax Event.
      *
      * @param handler The function to be invoked.
-     * @see {@link https://api.jquery.com/ajaxStop/}
+     * @see [ajaxStop](https://api.jquery.com/ajaxStop/)
      * @since 1.0
      */
     ajaxStop(handler: (this: Document) => void | false): this;
@@ -3222,7 +3222,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Attach a function to be executed whenever an Ajax request completes successfully. This is an Ajax Event.
      *
      * @param handler The function to be invoked.
-     * @see {@link https://api.jquery.com/ajaxSuccess/}
+     * @see [ajaxSuccess](https://api.jquery.com/ajaxSuccess/)
      * @since 1.0
      */
     ajaxSuccess(handler: (this: Document, event: JQuery.Event<Document>, jqXHR: JQuery.jqXHR, ajaxOptions: JQuery.AjaxSettings, data: JQuery.PlainObject) => void | false): this;
@@ -3233,7 +3233,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param duration A string or number determining how long the animation will run.
      * @param easing A string indicating which easing function to use for the transition.
      * @param complete A function to call once the animation is complete, called once per matched element.
-     * @see {@link https://api.jquery.com/animate/}
+     * @see [animate](https://api.jquery.com/animate/)
      * @since 1.0
      */
     animate(properties: JQuery.PlainObject,
@@ -3247,7 +3247,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param duration_easing A string or number determining how long the animation will run.
      *                        A string indicating which easing function to use for the transition.
      * @param complete A function to call once the animation is complete, called once per matched element.
-     * @see {@link https://api.jquery.com/animate/}
+     * @see [animate](https://api.jquery.com/animate/)
      * @since 1.0
      */
     animate(properties: JQuery.PlainObject,
@@ -3258,7 +3258,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param properties An object of CSS properties and values that the animation will move toward.
      * @param options A map of additional options to pass to the method.
-     * @see {@link https://api.jquery.com/animate/}
+     * @see [animate](https://api.jquery.com/animate/)
      * @since 1.0
      */
     animate(properties: JQuery.PlainObject,
@@ -3268,7 +3268,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param properties An object of CSS properties and values that the animation will move toward.
      * @param complete A function to call once the animation is complete, called once per matched element.
-     * @see {@link https://api.jquery.com/animate/}
+     * @see [animate](https://api.jquery.com/animate/)
      * @since 1.0
      */
     animate(properties: JQuery.PlainObject,
@@ -3278,7 +3278,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param contents One or more additional DOM elements, text nodes, arrays of elements and text nodes, HTML strings, or
      *                 jQuery objects to insert at the end of each element in the set of matched elements.
-     * @see {@link https://api.jquery.com/append/}
+     * @see [append](https://api.jquery.com/append/)
      * @since 1.0
      */
     append(...contents: Array<JQuery.htmlString | JQuery.TypeOrArray<JQuery.Node | JQuery<JQuery.Node>>>): this;
@@ -3289,7 +3289,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *           the end of each element in the set of matched elements. Receives the index position of the element
      *           in the set and the old HTML value of the element as arguments. Within the function, this refers to
      *           the current element in the set.
-     * @see {@link https://api.jquery.com/append/}
+     * @see [append](https://api.jquery.com/append/)
      * @since 1.4
      */
     append(fn: (this: TElement, index: number, html: string) => JQuery.htmlString | JQuery.TypeOrArray<JQuery.Node | JQuery<JQuery.Node>>): this;
@@ -3298,7 +3298,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param target A selector, element, HTML string, array of elements, or jQuery object; the matched set of elements
      *               will be inserted at the end of the element(s) specified by this parameter.
-     * @see {@link https://api.jquery.com/appendTo/}
+     * @see [appendTo](https://api.jquery.com/appendTo/)
      * @since 1.0
      */
     appendTo(target: JQuery.Selector | JQuery.htmlString | JQuery.TypeOrArray<Element> | JQuery): this;
@@ -3309,7 +3309,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param value A value to set for the attribute. If null, the specified attribute will be removed (as in .removeAttr()).
      *              A function returning the value to set. this is the current element. Receives the index position of
      *              the element in the set and the old attribute value as arguments.
-     * @see {@link https://api.jquery.com/attr/}
+     * @see [attr](https://api.jquery.com/attr/)
      * @since 1.0
      * @since 1.1
      */
@@ -3319,7 +3319,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Set one or more attributes for the set of matched elements.
      *
      * @param attributes An object of attribute-value pairs to set.
-     * @see {@link https://api.jquery.com/attr/}
+     * @see [attr](https://api.jquery.com/attr/)
      * @since 1.0
      */
     attr(attributes: JQuery.PlainObject): this;
@@ -3327,7 +3327,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Get the value of an attribute for the first element in the set of matched elements.
      *
      * @param attributeName The name of the attribute to get.
-     * @see {@link https://api.jquery.com/attr/}
+     * @see [attr](https://api.jquery.com/attr/)
      * @since 1.0
      */
     attr(attributeName: string): string | undefined;
@@ -3336,7 +3336,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param contents One or more additional DOM elements, text nodes, arrays of elements and text nodes, HTML strings, or
      *                 jQuery objects to insert before each element in the set of matched elements.
-     * @see {@link https://api.jquery.com/before/}
+     * @see [before](https://api.jquery.com/before/)
      * @since 1.0
      */
     before(...contents: Array<JQuery.htmlString | JQuery.TypeOrArray<JQuery.Node | JQuery<JQuery.Node>>>): this;
@@ -3347,7 +3347,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *           before each element in the set of matched elements. Receives the index position of the element in
      *           the set and the old HTML value of the element as arguments. Within the function, this refers to the
      *           current element in the set.
-     * @see {@link https://api.jquery.com/before/}
+     * @see [before](https://api.jquery.com/before/)
      * @since 1.4
      * @since 1.10
      */
@@ -3359,7 +3359,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param eventType A string containing one or more DOM event types, such as "click" or "submit," or custom event names.
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute each time the event is triggered.
-     * @see {@link https://api.jquery.com/bind/}
+     * @see [bind](https://api.jquery.com/bind/)
      * @since 1.0
      * @since 1.4.3
      * @deprecated 3.0
@@ -3374,7 +3374,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param handler A function to execute each time the event is triggered.
      *                Setting the second argument to false will attach a function that prevents the default action from
      *                occurring and stops the event from bubbling.
-     * @see {@link https://api.jquery.com/bind/}
+     * @see [bind](https://api.jquery.com/bind/)
      * @since 1.0
      * @since 1.4.3
      * @deprecated 3.0
@@ -3385,7 +3385,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Attach a handler to an event for the elements.
      *
      * @param events An object containing one or more DOM event types and functions to execute for them.
-     * @see {@link https://api.jquery.com/bind/}
+     * @see [bind](https://api.jquery.com/bind/)
      * @since 1.4
      * @deprecated 3.0
      */
@@ -3395,7 +3395,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute each time the event is triggered.
-     * @see {@link https://api.jquery.com/blur/}
+     * @see [blur](https://api.jquery.com/blur/)
      * @since 1.4.3
      * @deprecated 3.3
      */
@@ -3405,7 +3405,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Bind an event handler to the "blur" JavaScript event, or trigger that event on an element.
      *
      * @param handler A function to execute each time the event is triggered.
-     * @see {@link https://api.jquery.com/blur/}
+     * @see [blur](https://api.jquery.com/blur/)
      * @since 1.0
      * @deprecated 3.3
      */
@@ -3415,7 +3415,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute each time the event is triggered.
-     * @see {@link https://api.jquery.com/change/}
+     * @see [change](https://api.jquery.com/change/)
      * @since 1.4.3
      * @deprecated 3.3
      */
@@ -3425,7 +3425,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Bind an event handler to the "change" JavaScript event, or trigger that event on an element.
      *
      * @param handler A function to execute each time the event is triggered.
-     * @see {@link https://api.jquery.com/change/}
+     * @see [change](https://api.jquery.com/change/)
      * @since 1.0
      * @deprecated 3.3
      */
@@ -3434,7 +3434,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Get the children of each element in the set of matched elements, optionally filtered by a selector.
      *
      * @param selector A string containing a selector expression to match elements against.
-     * @see {@link https://api.jquery.com/children/}
+     * @see [children](https://api.jquery.com/children/)
      * @since 1.0
      */
     children(selector?: JQuery.Selector): this;
@@ -3442,7 +3442,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Remove from the queue all items that have not yet been run.
      *
      * @param queueName A string containing the name of the queue. Defaults to fx, the standard effects queue.
-     * @see {@link https://api.jquery.com/clearQueue/}
+     * @see [clearQueue](https://api.jquery.com/clearQueue/)
      * @since 1.4
      */
     clearQueue(queueName?: string): this;
@@ -3451,7 +3451,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute each time the event is triggered.
-     * @see {@link https://api.jquery.com/click/}
+     * @see [click](https://api.jquery.com/click/)
      * @since 1.4.3
      * @deprecated 3.3
      */
@@ -3461,7 +3461,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Bind an event handler to the "click" JavaScript event, or trigger that event on an element.
      *
      * @param handler A function to execute each time the event is triggered.
-     * @see {@link https://api.jquery.com/click/}
+     * @see [click](https://api.jquery.com/click/)
      * @since 1.0
      * @deprecated 3.3
      */
@@ -3474,7 +3474,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *                          to false in 1.5.1 and up.
      * @param deepWithDataAndEvents A Boolean indicating whether event handlers and data for all children of the cloned element should
      *                              be copied. By default its value matches the first argument's value (which defaults to false).
-     * @see {@link https://api.jquery.com/clone/}
+     * @see [clone](https://api.jquery.com/clone/)
      * @since 1.0
      * @since 1.5
      */
@@ -3485,7 +3485,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param selector A string containing a selector expression to match elements against.
      * @param context A DOM element within which a matching element may be found.
-     * @see {@link https://api.jquery.com/closest/}
+     * @see [closest](https://api.jquery.com/closest/)
      * @since 1.4
      */
     closest(selector: JQuery.Selector, context: Element): this;
@@ -3496,7 +3496,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param selector A string containing a selector expression to match elements against.
      *                 A jQuery object to match elements against.
      *                 An element to match elements against.
-     * @see {@link https://api.jquery.com/closest/}
+     * @see [closest](https://api.jquery.com/closest/)
      * @since 1.3
      * @since 1.6
      */
@@ -3504,7 +3504,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
     /**
      * Get the children of each element in the set of matched elements, including text and comment nodes.
      *
-     * @see {@link https://api.jquery.com/contents/}
+     * @see [contents](https://api.jquery.com/contents/)
      * @since 1.2
      */
     contents(): JQuery<TElement | Text | Comment>;
@@ -3513,7 +3513,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute each time the event is triggered.
-     * @see {@link https://api.jquery.com/contextmenu/}
+     * @see [contextmenu](https://api.jquery.com/contextmenu/)
      * @since 1.4.3
      * @deprecated 3.3
      */
@@ -3523,7 +3523,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Bind an event handler to the "contextmenu" JavaScript event, or trigger that event on an element.
      *
      * @param handler A function to execute each time the event is triggered.
-     * @see {@link https://api.jquery.com/contextmenu/}
+     * @see [contextmenu](https://api.jquery.com/contextmenu/)
      * @since 1.0
      * @deprecated 3.3
      */
@@ -3535,7 +3535,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param value A value to set for the property.
      *              A function returning the value to set. this is the current element. Receives the index position of
      *              the element in the set and the old value as arguments.
-     * @see {@link https://api.jquery.com/css/}
+     * @see [css](https://api.jquery.com/css/)
      * @since 1.0
      * @since 1.4
      */
@@ -3545,7 +3545,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Set one or more CSS properties for the set of matched elements.
      *
      * @param properties An object of property-value pairs to set.
-     * @see {@link https://api.jquery.com/css/}
+     * @see [css](https://api.jquery.com/css/)
      * @since 1.0
      */
     css(properties: JQuery.PlainObject<string | number | ((this: TElement, index: number, value: string) => string | number | void | undefined)>): this;
@@ -3554,7 +3554,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param propertyName A CSS property.
      *                     An array of one or more CSS properties.
-     * @see {@link https://api.jquery.com/css/}
+     * @see [css](https://api.jquery.com/css/)
      * @since 1.0
      */
     css(propertyName: string): string;
@@ -3562,7 +3562,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Get the computed style properties for the first element in the set of matched elements.
      *
      * @param propertyNames An array of one or more CSS properties.
-     * @see {@link https://api.jquery.com/css/}
+     * @see [css](https://api.jquery.com/css/)
      * @since 1.9
      */
     css(propertyNames: string[]): JQuery.PlainObject<string>;
@@ -3571,7 +3571,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * data(name, value) or by an HTML5 data-* attribute.
      *
      * @param key Name of the data stored.
-     * @see {@link https://api.jquery.com/data/}
+     * @see [data](https://api.jquery.com/data/)
      * @since 1.2.3
      */
     data(key: string, undefined: undefined): any; // tslint:disable-line:unified-signatures
@@ -3580,7 +3580,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param key A string naming the piece of data to set.
      * @param value The new data value; this can be any Javascript type except undefined.
-     * @see {@link https://api.jquery.com/data/}
+     * @see [data](https://api.jquery.com/data/)
      * @since 1.2.3
      */
     data(key: string, value: any): this;
@@ -3588,7 +3588,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Store arbitrary data associated with the matched elements.
      *
      * @param obj An object of key-value pairs of data to update.
-     * @see {@link https://api.jquery.com/data/}
+     * @see [data](https://api.jquery.com/data/)
      * @since 1.4.3
      */
     data(obj: JQuery.PlainObject): this;
@@ -3597,7 +3597,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * data(name, value) or by an HTML5 data-* attribute.
      *
      * @param key Name of the data stored.
-     * @see {@link https://api.jquery.com/data/}
+     * @see [data](https://api.jquery.com/data/)
      * @since 1.2.3
      */
     data(key: string): any;
@@ -3605,7 +3605,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Return the value at the named data store for the first element in the jQuery collection, as set by
      * data(name, value) or by an HTML5 data-* attribute.
      *
-     * @see {@link https://api.jquery.com/data/}
+     * @see [data](https://api.jquery.com/data/)
      * @since 1.4
      */
     data(): JQuery.PlainObject;
@@ -3614,7 +3614,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute each time the event is triggered.
-     * @see {@link https://api.jquery.com/dblclick/}
+     * @see [dblclick](https://api.jquery.com/dblclick/)
      * @since 1.4.3
      * @deprecated 3.3
      */
@@ -3624,7 +3624,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Bind an event handler to the "dblclick" JavaScript event, or trigger that event on an element.
      *
      * @param handler A function to execute each time the event is triggered.
-     * @see {@link https://api.jquery.com/dblclick/}
+     * @see [dblclick](https://api.jquery.com/dblclick/)
      * @since 1.0
      * @deprecated 3.3
      */
@@ -3634,7 +3634,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param duration An integer indicating the number of milliseconds to delay execution of the next item in the queue.
      * @param queueName A string containing the name of the queue. Defaults to fx, the standard effects queue.
-     * @see {@link https://api.jquery.com/delay/}
+     * @see [delay](https://api.jquery.com/delay/)
      * @since 1.4
      */
     delay(duration: JQuery.Duration, queueName?: string): this;
@@ -3647,7 +3647,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *                  "keydown," or custom event names.
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute each time the event is triggered.
-     * @see {@link https://api.jquery.com/delegate/}
+     * @see [delegate](https://api.jquery.com/delegate/)
      * @since 1.4.2
      * @deprecated 3.0
      */
@@ -3663,7 +3663,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param eventType A string containing one or more space-separated JavaScript event types, such as "click" or
      *                  "keydown," or custom event names.
      * @param handler A function to execute each time the event is triggered.
-     * @see {@link https://api.jquery.com/delegate/}
+     * @see [delegate](https://api.jquery.com/delegate/)
      * @since 1.4.2
      * @deprecated 3.0
      */
@@ -3676,7 +3676,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param selector A selector to filter the elements that trigger the event.
      * @param events A plain object of one or more event types and functions to execute for them.
-     * @see {@link https://api.jquery.com/delegate/}
+     * @see [delegate](https://api.jquery.com/delegate/)
      * @since 1.4.3
      * @deprecated 3.0
      */
@@ -3686,7 +3686,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Execute the next function on the queue for the matched elements.
      *
      * @param queueName A string containing the name of the queue. Defaults to fx, the standard effects queue.
-     * @see {@link https://api.jquery.com/dequeue/}
+     * @see [dequeue](https://api.jquery.com/dequeue/)
      * @since 1.2
      */
     dequeue(queueName?: string): this;
@@ -3694,7 +3694,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Remove the set of matched elements from the DOM.
      *
      * @param selector A selector expression that filters the set of matched elements to be removed.
-     * @see {@link https://api.jquery.com/detach/}
+     * @see [detach](https://api.jquery.com/detach/)
      * @since 1.4
      */
     detach(selector?: JQuery.Selector): this;
@@ -3702,14 +3702,14 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Iterate over a jQuery object, executing a function for each matched element.
      *
      * @param fn A function to execute for each matched element.
-     * @see {@link https://api.jquery.com/each/}
+     * @see [each](https://api.jquery.com/each/)
      * @since 1.0
      */
     each(fn: (this: TElement, index: number, element: TElement) => void | false): this;
     /**
      * Remove all child nodes of the set of matched elements from the DOM.
      *
-     * @see {@link https://api.jquery.com/empty/}
+     * @see [empty](https://api.jquery.com/empty/)
      * @since 1.0
      */
     empty(): this;
@@ -3717,7 +3717,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * End the most recent filtering operation in the current chain and return the set of matched elements
      * to its previous state.
      *
-     * @see {@link https://api.jquery.com/end/}
+     * @see [end](https://api.jquery.com/end/)
      * @since 1.0
      */
     end(): this;
@@ -3726,7 +3726,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param index An integer indicating the 0-based position of the element.
      *              An integer indicating the position of the element, counting backwards from the last element in the set.
-     * @see {@link https://api.jquery.com/eq/}
+     * @see [eq](https://api.jquery.com/eq/)
      * @since 1.1.2
      * @since 1.4
      */
@@ -3735,7 +3735,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Merge the contents of an object onto the jQuery prototype to provide new jQuery instance methods.
      *
      * @param obj An object to merge onto the jQuery prototype.
-     * @see {@link https://api.jquery.com/jQuery.fn.extend/}
+     * @see [jQuery.fn.extend](https://api.jquery.com/jQuery.fn.extend/)
      * @since 1.0
      */
     extend(obj: object): this;
@@ -3745,7 +3745,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param duration A string or number determining how long the animation will run.
      * @param easing A string indicating which easing function to use for the transition.
      * @param complete A function to call once the animation is complete, called once per matched element.
-     * @see {@link https://api.jquery.com/fadeIn/}
+     * @see [fadeIn](https://api.jquery.com/fadeIn/)
      * @since 1.4.3
      */
     fadeIn(duration: JQuery.Duration, easing: string, complete?: (this: TElement) => void): this;
@@ -3755,7 +3755,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param duration_easing A string or number determining how long the animation will run.
      *                        A string indicating which easing function to use for the transition.
      * @param complete A function to call once the animation is complete, called once per matched element.
-     * @see {@link https://api.jquery.com/fadeIn/}
+     * @see [fadeIn](https://api.jquery.com/fadeIn/)
      * @since 1.0
      * @since 1.4.3
      */
@@ -3767,7 +3767,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *                                         A string indicating which easing function to use for the transition.
      *                                         A function to call once the animation is complete, called once per matched element.
      *                                         A map of additional options to pass to the method.
-     * @see {@link https://api.jquery.com/fadeIn/}
+     * @see [fadeIn](https://api.jquery.com/fadeIn/)
      * @since 1.0
      * @since 1.4.3
      */
@@ -3778,7 +3778,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param duration A string or number determining how long the animation will run.
      * @param easing A string indicating which easing function to use for the transition.
      * @param complete A function to call once the animation is complete, called once per matched element.
-     * @see {@link https://api.jquery.com/fadeOut/}
+     * @see [fadeOut](https://api.jquery.com/fadeOut/)
      * @since 1.4.3
      */
     fadeOut(duration: JQuery.Duration, easing: string, complete?: (this: TElement) => void): this;
@@ -3788,7 +3788,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param duration_easing A string or number determining how long the animation will run.
      *                        A string indicating which easing function to use for the transition.
      * @param complete A function to call once the animation is complete, called once per matched element.
-     * @see {@link https://api.jquery.com/fadeOut/}
+     * @see [fadeOut](https://api.jquery.com/fadeOut/)
      * @since 1.0
      * @since 1.4.3
      */
@@ -3800,7 +3800,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *                                         A string indicating which easing function to use for the transition.
      *                                         A function to call once the animation is complete, called once per matched element.
      *                                         A map of additional options to pass to the method.
-     * @see {@link https://api.jquery.com/fadeOut/}
+     * @see [fadeOut](https://api.jquery.com/fadeOut/)
      * @since 1.0
      * @since 1.4.3
      */
@@ -3812,7 +3812,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param opacity A number between 0 and 1 denoting the target opacity.
      * @param easing A string indicating which easing function to use for the transition.
      * @param complete A function to call once the animation is complete, called once per matched element.
-     * @see {@link https://api.jquery.com/fadeTo/}
+     * @see [fadeTo](https://api.jquery.com/fadeTo/)
      * @since 1.4.3
      */
     fadeTo(duration: JQuery.Duration, opacity: number, easing: string, complete?: (this: TElement) => void): this;
@@ -3822,7 +3822,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param duration A string or number determining how long the animation will run.
      * @param opacity A number between 0 and 1 denoting the target opacity.
      * @param complete A function to call once the animation is complete, called once per matched element.
-     * @see {@link https://api.jquery.com/fadeTo/}
+     * @see [fadeTo](https://api.jquery.com/fadeTo/)
      * @since 1.0
      */
     fadeTo(duration: JQuery.Duration, opacity: number, complete?: (this: TElement) => void): this;
@@ -3832,7 +3832,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param duration A string or number determining how long the animation will run.
      * @param easing A string indicating which easing function to use for the transition.
      * @param complete A function to call once the animation is complete, called once per matched element.
-     * @see {@link https://api.jquery.com/fadeToggle/}
+     * @see [fadeToggle](https://api.jquery.com/fadeToggle/)
      * @since 1.4.4
      */
     fadeToggle(duration: JQuery.Duration, easing: string, complete?: (this: TElement) => void): this;
@@ -3842,7 +3842,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param duration_easing A string or number determining how long the animation will run.
      *                        A string indicating which easing function to use for the transition.
      * @param complete A function to call once the animation is complete, called once per matched element.
-     * @see {@link https://api.jquery.com/fadeToggle/}
+     * @see [fadeToggle](https://api.jquery.com/fadeToggle/)
      * @since 1.0
      * @since 1.4.3
      */
@@ -3854,7 +3854,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *                                         A string indicating which easing function to use for the transition.
      *                                         A function to call once the animation is complete, called once per matched element.
      *                                         A map of additional options to pass to the method.
-     * @see {@link https://api.jquery.com/fadeToggle/}
+     * @see [fadeToggle](https://api.jquery.com/fadeToggle/)
      * @since 1.0
      * @since 1.4.3
      */
@@ -3866,7 +3866,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *                 One or more DOM elements to match the current set of elements against.
      *                 An existing jQuery object to match the current set of elements against.
      *                 A function used as a test for each element in the set. this is the current DOM element.
-     * @see {@link https://api.jquery.com/filter/}
+     * @see [filter](https://api.jquery.com/filter/)
      * @since 1.0
      * @since 1.4
      */
@@ -3877,7 +3877,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param selector A string containing a selector expression to match elements against.
      *                 An element or a jQuery object to match elements against.
-     * @see {@link https://api.jquery.com/find/}
+     * @see [find](https://api.jquery.com/find/)
      * @since 1.0
      * @since 1.6
      */
@@ -3887,14 +3887,14 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * the matched elements.
      *
      * @param queue The name of the queue in which to stop animations.
-     * @see {@link https://api.jquery.com/finish/}
+     * @see [finish](https://api.jquery.com/finish/)
      * @since 1.9
      */
     finish(queue?: string): this;
     /**
      * Reduce the set of matched elements to the first in the set.
      *
-     * @see {@link https://api.jquery.com/first/}
+     * @see [first](https://api.jquery.com/first/)
      * @since 1.4
      */
     first(): this;
@@ -3903,7 +3903,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute each time the event is triggered.
-     * @see {@link https://api.jquery.com/focus/}
+     * @see [focus](https://api.jquery.com/focus/)
      * @since 1.4.3
      * @deprecated 3.3
      */
@@ -3913,7 +3913,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Bind an event handler to the "focus" JavaScript event, or trigger that event on an element.
      *
      * @param handler A function to execute each time the event is triggered.
-     * @see {@link https://api.jquery.com/focus/}
+     * @see [focus](https://api.jquery.com/focus/)
      * @since 1.0
      * @deprecated 3.3
      */
@@ -3923,7 +3923,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute each time the event is triggered.
-     * @see {@link https://api.jquery.com/focusin/}
+     * @see [focusin](https://api.jquery.com/focusin/)
      * @since 1.4.3
      * @deprecated 3.3
      */
@@ -3933,7 +3933,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Bind an event handler to the "focusin" event.
      *
      * @param handler A function to execute each time the event is triggered.
-     * @see {@link https://api.jquery.com/focusin/}
+     * @see [focusin](https://api.jquery.com/focusin/)
      * @since 1.4
      * @deprecated 3.3
      */
@@ -3943,7 +3943,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute each time the event is triggered.
-     * @see {@link https://api.jquery.com/focusout/}
+     * @see [focusout](https://api.jquery.com/focusout/)
      * @since 1.4.3
      * @deprecated 3.3
      */
@@ -3953,7 +3953,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Bind an event handler to the "focusout" JavaScript event.
      *
      * @param handler A function to execute each time the event is triggered.
-     * @see {@link https://api.jquery.com/focusout/}
+     * @see [focusout](https://api.jquery.com/focusout/)
      * @since 1.4
      * @deprecated 3.3
      */
@@ -3962,14 +3962,14 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Retrieve one of the elements matched by the jQuery object.
      *
      * @param index A zero-based integer indicating which element to retrieve.
-     * @see {@link https://api.jquery.com/get/}
+     * @see [get](https://api.jquery.com/get/)
      * @since 1.0
      */
     get(index: number): TElement;
     /**
      * Retrieve the elements matched by the jQuery object.
      *
-     * @see {@link https://api.jquery.com/get/}
+     * @see [get](https://api.jquery.com/get/)
      * @since 1.0
      */
     get(): TElement[];
@@ -3978,7 +3978,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param selector A string containing a selector expression to match elements against.
      *                 A DOM element to match elements against.
-     * @see {@link https://api.jquery.com/has/}
+     * @see [has](https://api.jquery.com/has/)
      * @since 1.4
      */
     has(selector: string | Element): this;
@@ -3986,7 +3986,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Determine whether any of the matched elements are assigned the given class.
      *
      * @param className The class name to search for.
-     * @see {@link https://api.jquery.com/hasClass/}
+     * @see [hasClass](https://api.jquery.com/hasClass/)
      * @since 1.2
      */
     hasClass(className: string): boolean;
@@ -3997,7 +3997,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *              appended (as a string).
      *              A function returning the height to set. Receives the index position of the element in the set and
      *              the old height as arguments. Within the function, this refers to the current element in the set.
-     * @see {@link https://api.jquery.com/height/}
+     * @see [height](https://api.jquery.com/height/)
      * @since 1.0
      * @since 1.4.1
      */
@@ -4005,7 +4005,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
     /**
      * Get the current computed height for the first element in the set of matched elements.
      *
-     * @see {@link https://api.jquery.com/height/}
+     * @see [height](https://api.jquery.com/height/)
      * @since 1.0
      */
     height(): number | undefined;
@@ -4015,7 +4015,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param duration A string or number determining how long the animation will run.
      * @param easing A string indicating which easing function to use for the transition.
      * @param complete A function to call once the animation is complete, called once per matched element.
-     * @see {@link https://api.jquery.com/hide/}
+     * @see [hide](https://api.jquery.com/hide/)
      * @since 1.4.3
      */
     hide(duration: JQuery.Duration, easing: string, complete: (this: TElement) => void): this;
@@ -4025,7 +4025,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param duration A string or number determining how long the animation will run.
      * @param easing_complete A string indicating which easing function to use for the transition.
      *                        A function to call once the animation is complete, called once per matched element.
-     * @see {@link https://api.jquery.com/hide/}
+     * @see [hide](https://api.jquery.com/hide/)
      * @since 1.0
      * @since 1.4.3
      */
@@ -4036,7 +4036,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param duration_complete_options A string or number determining how long the animation will run.
      *                                  A function to call once the animation is complete, called once per matched element.
      *                                  A map of additional options to pass to the method.
-     * @see {@link https://api.jquery.com/hide/}
+     * @see [hide](https://api.jquery.com/hide/)
      * @since 1.0
      */
     hide(duration_complete_options?: JQuery.Duration | ((this: TElement) => void) | JQuery.EffectsOptions<TElement>): this;
@@ -4046,7 +4046,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param handlerInOut A function to execute when the mouse pointer enters or leaves the element.
      * @param handlerOut A function to execute when the mouse pointer leaves the element.
-     * @see {@link https://api.jquery.com/hover/}
+     * @see [hover](https://api.jquery.com/hover/)
      * @since 1.0
      * @since 1.4
      */
@@ -4060,7 +4060,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *                   A function returning the HTML content to set. Receives the index position of the element in the set
      *                   and the old HTML value as arguments. jQuery empties the element before calling the function; use the
      *                   oldhtml argument to reference the previous content. Within the function, this refers to the current element in the set.
-     * @see {@link https://api.jquery.com/html/}
+     * @see [html](https://api.jquery.com/html/)
      * @since 1.0
      * @since 1.4
      */
@@ -4068,7 +4068,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
     /**
      * Get the HTML contents of the first element in the set of matched elements.
      *
-     * @see {@link https://api.jquery.com/html/}
+     * @see [html](https://api.jquery.com/html/)
      * @since 1.0
      */
     html(): string;
@@ -4077,7 +4077,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param element The DOM element or first element within the jQuery object to look for.
      *                A selector representing a jQuery collection in which to look for an element.
-     * @see {@link https://api.jquery.com/index/}
+     * @see [index](https://api.jquery.com/index/)
      * @since 1.0
      * @since 1.4
      */
@@ -4090,7 +4090,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *              A function returning the inner height (including padding but not border) to set. Receives the index
      *              position of the element in the set and the old inner height as arguments. Within the function, this
      *              refers to the current element in the set.
-     * @see {@link https://api.jquery.com/innerHeight/}
+     * @see [innerHeight](https://api.jquery.com/innerHeight/)
      * @since 1.8.0
      */
     innerHeight(value: string | number | ((this: TElement, index: number, height: number) => string | number)): this;
@@ -4098,7 +4098,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Get the current computed height for the first element in the set of matched elements, including
      * padding but not border.
      *
-     * @see {@link https://api.jquery.com/innerHeight/}
+     * @see [innerHeight](https://api.jquery.com/innerHeight/)
      * @since 1.2.6
      */
     innerHeight(): number | undefined;
@@ -4110,7 +4110,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *              A function returning the inner width (including padding but not border) to set. Receives the index
      *              position of the element in the set and the old inner width as arguments. Within the function, this
      *              refers to the current element in the set.
-     * @see {@link https://api.jquery.com/innerWidth/}
+     * @see [innerWidth](https://api.jquery.com/innerWidth/)
      * @since 1.8.0
      */
     innerWidth(value: string | number | ((this: TElement, index: number, width: number) => string | number)): this;
@@ -4118,7 +4118,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Get the current computed inner width for the first element in the set of matched elements, including
      * padding but not border.
      *
-     * @see {@link https://api.jquery.com/innerWidth/}
+     * @see [innerWidth](https://api.jquery.com/innerWidth/)
      * @since 1.2.6
      */
     innerWidth(): number | undefined;
@@ -4127,7 +4127,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param target A selector, element, array of elements, HTML string, or jQuery object; the matched set of elements
      *               will be inserted after the element(s) specified by this parameter.
-     * @see {@link https://api.jquery.com/insertAfter/}
+     * @see [insertAfter](https://api.jquery.com/insertAfter/)
      * @since 1.0
      */
     insertAfter(target: JQuery.Selector | JQuery.htmlString | JQuery.TypeOrArray<Element> | JQuery): this;
@@ -4136,7 +4136,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param target A selector, element, array of elements, HTML string, or jQuery object; the matched set of elements
      *               will be inserted before the element(s) specified by this parameter.
-     * @see {@link https://api.jquery.com/insertBefore/}
+     * @see [insertBefore](https://api.jquery.com/insertBefore/)
      * @since 1.0
      */
     insertBefore(target: JQuery.Selector | JQuery.htmlString | JQuery.TypeOrArray<Element> | JQuery): this;
@@ -4150,7 +4150,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *                 function, this refers to the current DOM element.
      *                 An existing jQuery object to match the current set of elements against.
      *                 One or more elements to match the current set of elements against.
-     * @see {@link https://api.jquery.com/is/}
+     * @see [is](https://api.jquery.com/is/)
      * @since 1.0
      * @since 1.6
      */
@@ -4160,7 +4160,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute each time the event is triggered.
-     * @see {@link https://api.jquery.com/keydown/}
+     * @see [keydown](https://api.jquery.com/keydown/)
      * @since 1.4.3
      * @deprecated 3.3
      */
@@ -4170,7 +4170,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Bind an event handler to the "keydown" JavaScript event, or trigger that event on an element.
      *
      * @param handler A function to execute each time the event is triggered.
-     * @see {@link https://api.jquery.com/keydown/}
+     * @see [keydown](https://api.jquery.com/keydown/)
      * @since 1.0
      * @deprecated 3.3
      */
@@ -4180,7 +4180,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute each time the event is triggered.
-     * @see {@link https://api.jquery.com/keypress/}
+     * @see [keypress](https://api.jquery.com/keypress/)
      * @since 1.4.3
      * @deprecated 3.3
      */
@@ -4190,7 +4190,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Bind an event handler to the "keypress" JavaScript event, or trigger that event on an element.
      *
      * @param handler A function to execute each time the event is triggered.
-     * @see {@link https://api.jquery.com/keypress/}
+     * @see [keypress](https://api.jquery.com/keypress/)
      * @since 1.0
      * @deprecated 3.3
      */
@@ -4200,7 +4200,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute each time the event is triggered.
-     * @see {@link https://api.jquery.com/keyup/}
+     * @see [keyup](https://api.jquery.com/keyup/)
      * @since 1.4.3
      * @deprecated 3.3
      */
@@ -4210,7 +4210,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Bind an event handler to the "keyup" JavaScript event, or trigger that event on an element.
      *
      * @param handler A function to execute each time the event is triggered.
-     * @see {@link https://api.jquery.com/keyup/}
+     * @see [keyup](https://api.jquery.com/keyup/)
      * @since 1.0
      * @deprecated 3.3
      */
@@ -4218,7 +4218,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
     /**
      * Reduce the set of matched elements to the final one in the set.
      *
-     * @see {@link https://api.jquery.com/last/}
+     * @see [last](https://api.jquery.com/last/)
      * @since 1.4
      */
     last(): this;
@@ -4228,7 +4228,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param url A string containing the URL to which the request is sent.
      * @param data A plain object or string that is sent to the server with the request.
      * @param complete A callback function that is executed when the request completes.
-     * @see {@link https://api.jquery.com/load/}
+     * @see [load](https://api.jquery.com/load/)
      * @since 1.0
      */
     load(url: string,
@@ -4240,7 +4240,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param url A string containing the URL to which the request is sent.
      * @param complete_data A callback function that is executed when the request completes.
      *                      A plain object or string that is sent to the server with the request.
-     * @see {@link https://api.jquery.com/load/}
+     * @see [load](https://api.jquery.com/load/)
      * @since 1.0
      */
     load(url: string,
@@ -4250,7 +4250,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * containing the return values.
      *
      * @param callback A function object that will be invoked for each element in the current set.
-     * @see {@link https://api.jquery.com/map/}
+     * @see [map](https://api.jquery.com/map/)
      * @since 1.2
      */
     map(callback: (this: TElement, index: number, domElement: TElement) => any | any[] | null | undefined): this;
@@ -4259,7 +4259,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute each time the event is triggered.
-     * @see {@link https://api.jquery.com/mousedown/}
+     * @see [mousedown](https://api.jquery.com/mousedown/)
      * @since 1.4.3
      * @deprecated 3.3
      */
@@ -4269,7 +4269,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Bind an event handler to the "mousedown" JavaScript event, or trigger that event on an element.
      *
      * @param handler A function to execute each time the event is triggered.
-     * @see {@link https://api.jquery.com/mousedown/}
+     * @see [mousedown](https://api.jquery.com/mousedown/)
      * @since 1.0
      * @deprecated 3.3
      */
@@ -4279,7 +4279,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute each time the event is triggered.
-     * @see {@link https://api.jquery.com/mouseenter/}
+     * @see [mouseenter](https://api.jquery.com/mouseenter/)
      * @since 1.4.3
      * @deprecated 3.3
      */
@@ -4289,7 +4289,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Bind an event handler to be fired when the mouse enters an element, or trigger that handler on an element.
      *
      * @param handler A function to execute each time the event is triggered.
-     * @see {@link https://api.jquery.com/mouseenter/}
+     * @see [mouseenter](https://api.jquery.com/mouseenter/)
      * @since 1.0
      * @deprecated 3.3
      */
@@ -4299,7 +4299,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute each time the event is triggered.
-     * @see {@link https://api.jquery.com/mouseleave/}
+     * @see [mouseleave](https://api.jquery.com/mouseleave/)
      * @since 1.4.3
      * @deprecated 3.3
      */
@@ -4309,7 +4309,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Bind an event handler to be fired when the mouse leaves an element, or trigger that handler on an element.
      *
      * @param handler A function to execute each time the event is triggered.
-     * @see {@link https://api.jquery.com/mouseleave/}
+     * @see [mouseleave](https://api.jquery.com/mouseleave/)
      * @since 1.0
      * @deprecated 3.3
      */
@@ -4319,7 +4319,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute each time the event is triggered.
-     * @see {@link https://api.jquery.com/mousemove/}
+     * @see [mousemove](https://api.jquery.com/mousemove/)
      * @since 1.4.3
      * @deprecated 3.3
      */
@@ -4329,7 +4329,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Bind an event handler to the "mousemove" JavaScript event, or trigger that event on an element.
      *
      * @param handler A function to execute each time the event is triggered.
-     * @see {@link https://api.jquery.com/mousemove/}
+     * @see [mousemove](https://api.jquery.com/mousemove/)
      * @since 1.0
      * @deprecated 3.3
      */
@@ -4339,7 +4339,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute each time the event is triggered.
-     * @see {@link https://api.jquery.com/mouseout/}
+     * @see [mouseout](https://api.jquery.com/mouseout/)
      * @since 1.4.3
      * @deprecated 3.3
      */
@@ -4349,7 +4349,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Bind an event handler to the "mouseout" JavaScript event, or trigger that event on an element.
      *
      * @param handler A function to execute each time the event is triggered.
-     * @see {@link https://api.jquery.com/mouseout/}
+     * @see [mouseout](https://api.jquery.com/mouseout/)
      * @since 1.0
      * @deprecated 3.3
      */
@@ -4359,7 +4359,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute each time the event is triggered.
-     * @see {@link https://api.jquery.com/mouseover/}
+     * @see [mouseover](https://api.jquery.com/mouseover/)
      * @since 1.4.3
      * @deprecated 3.3
      */
@@ -4369,7 +4369,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Bind an event handler to the "mouseover" JavaScript event, or trigger that event on an element.
      *
      * @param handler A function to execute each time the event is triggered.
-     * @see {@link https://api.jquery.com/mouseover/}
+     * @see [mouseover](https://api.jquery.com/mouseover/)
      * @since 1.0
      * @deprecated 3.3
      */
@@ -4379,7 +4379,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute each time the event is triggered.
-     * @see {@link https://api.jquery.com/mouseup/}
+     * @see [mouseup](https://api.jquery.com/mouseup/)
      * @since 1.4.3
      * @deprecated 3.3
      */
@@ -4389,7 +4389,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Bind an event handler to the "mouseup" JavaScript event, or trigger that event on an element.
      *
      * @param handler A function to execute each time the event is triggered.
-     * @see {@link https://api.jquery.com/mouseup/}
+     * @see [mouseup](https://api.jquery.com/mouseup/)
      * @since 1.0
      * @deprecated 3.3
      */
@@ -4399,7 +4399,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * is provided, it retrieves the next sibling only if it matches that selector.
      *
      * @param selector A string containing a selector expression to match elements against.
-     * @see {@link https://api.jquery.com/next/}
+     * @see [next](https://api.jquery.com/next/)
      * @since 1.0
      */
     next(selector?: JQuery.Selector): this;
@@ -4407,7 +4407,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Get all following siblings of each element in the set of matched elements, optionally filtered by a selector.
      *
      * @param selector A string containing a selector expression to match elements against.
-     * @see {@link https://api.jquery.com/nextAll/}
+     * @see [nextAll](https://api.jquery.com/nextAll/)
      * @since 1.2
      */
     nextAll(selector?: string): this;
@@ -4418,7 +4418,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param selector A string containing a selector expression to indicate where to stop matching following sibling elements.
      *                 A DOM node or jQuery object indicating where to stop matching following sibling elements.
      * @param filter A string containing a selector expression to match elements against.
-     * @see {@link https://api.jquery.com/nextUntil/}
+     * @see [nextUntil](https://api.jquery.com/nextUntil/)
      * @since 1.4
      * @since 1.6
      */
@@ -4431,7 +4431,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *                 element's index in the jQuery collection, and element, which is the DOM element. Within the
      *                 function, this refers to the current DOM element.
      *                 An existing jQuery object to match the current set of elements against.
-     * @see {@link https://api.jquery.com/not/}
+     * @see [not](https://api.jquery.com/not/)
      * @since 1.0
      * @since 1.4
      */
@@ -4443,7 +4443,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *               "click", "keydown.myPlugin", or ".myPlugin".
      * @param selector A selector which should match the one originally passed to .on() when attaching event handlers.
      * @param handler A function to execute each time the event is triggered.
-     * @see {@link https://api.jquery.com/off/}
+     * @see [off](https://api.jquery.com/off/)
      * @since 1.7
      */
     off(events: string, selector: JQuery.Selector, handler: JQuery.EventHandlerBase<any, JQuery.Event<TElement, any>> | false): this;
@@ -4454,7 +4454,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *               "click", "keydown.myPlugin", or ".myPlugin".
      * @param selector_handler A selector which should match the one originally passed to .on() when attaching event handlers.
      *                         A function to execute each time the event is triggered.
-     * @see {@link https://api.jquery.com/off/}
+     * @see [off](https://api.jquery.com/off/)
      * @since 1.7
      */
     off(events: string, selector_handler?: JQuery.Selector | JQuery.EventHandlerBase<any, JQuery.Event<TElement, any>> | false): this;
@@ -4464,7 +4464,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param events An object where the string keys represent one or more space-separated event types and optional
      *               namespaces, and the values represent handler functions previously attached for the event(s).
      * @param selector A selector which should match the one originally passed to .on() when attaching event handlers.
-     * @see {@link https://api.jquery.com/off/}
+     * @see [off](https://api.jquery.com/off/)
      * @since 1.7
      */
     off(events: JQuery.PlainObject<JQuery.EventHandlerBase<any, JQuery.Event<TElement, any>> | false>, selector?: JQuery.Selector): this;
@@ -4472,7 +4472,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Remove an event handler.
      *
      * @param event A jQuery.Event object.
-     * @see {@link https://api.jquery.com/off/}
+     * @see [off](https://api.jquery.com/off/)
      * @since 1.7
      */
     off(event?: JQuery.Event<TElement>): this;
@@ -4484,21 +4484,21 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *                    A function to return the coordinates to set. Receives the index of the element in the collection as
      *                    the first argument and the current coordinates as the second argument. The function should return an
      *                    object with the new top and left properties.
-     * @see {@link https://api.jquery.com/offset/}
+     * @see [offset](https://api.jquery.com/offset/)
      * @since 1.4
      */
     offset(coordinates: JQuery.Coordinates | ((this: TElement, index: number, coords: JQuery.Coordinates) => JQuery.Coordinates)): this;
     /**
      * Get the current coordinates of the first element in the set of matched elements, relative to the document.
      *
-     * @see {@link https://api.jquery.com/offset/}
+     * @see [offset](https://api.jquery.com/offset/)
      * @since 1.2
      */
     offset(): JQuery.Coordinates | undefined;
     /**
      * Get the closest ancestor element that is positioned.
      *
-     * @see {@link https://api.jquery.com/offsetParent/}
+     * @see [offsetParent](https://api.jquery.com/offsetParent/)
      * @since 1.2.6
      */
     offsetParent(): this;
@@ -4510,7 +4510,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *                 selector is null or omitted, the event is always triggered when it reaches the selected element.
      * @param data Data to be passed to the handler in event.data when an event is triggered.
      * @param handler A function to execute when the event is triggered.
-     * @see {@link https://api.jquery.com/on/}
+     * @see [on](https://api.jquery.com/on/)
      * @since 1.7
      */
     on<TData>(events: string,
@@ -4525,7 +4525,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *                 selector is null or omitted, the event is always triggered when it reaches the selected element.
      * @param handler A function to execute when the event is triggered. The value false is also allowed as a shorthand
      *                for a function that simply does return false.
-     * @see {@link https://api.jquery.com/on/}
+     * @see [on](https://api.jquery.com/on/)
      * @since 1.7
      */
     on(events: string,
@@ -4537,7 +4537,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param events One or more space-separated event types and optional namespaces, such as "click" or "keydown.myPlugin".
      * @param data Data to be passed to the handler in event.data when an event is triggered.
      * @param handler A function to execute when the event is triggered.
-     * @see {@link https://api.jquery.com/on/}
+     * @see [on](https://api.jquery.com/on/)
      * @since 1.7
      */
     on<TData>(events: string,
@@ -4549,7 +4549,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param events One or more space-separated event types and optional namespaces, such as "click" or "keydown.myPlugin".
      * @param handler A function to execute when the event is triggered. The value false is also allowed as a shorthand
      *                for a function that simply does return false.
-     * @see {@link https://api.jquery.com/on/}
+     * @see [on](https://api.jquery.com/on/)
      * @since 1.7
      */
     on(events: string,
@@ -4562,7 +4562,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param selector A selector string to filter the descendants of the selected elements that will call the handler. If
      *                 the selector is null or omitted, the handler is always called when it reaches the selected element.
      * @param data Data to be passed to the handler in event.data when an event occurs.
-     * @see {@link https://api.jquery.com/on/}
+     * @see [on](https://api.jquery.com/on/)
      * @since 1.7
      */
     on<TData>(events: JQuery.PlainObject<JQuery.EventHandler<TElement, TData> | JQuery.EventHandlerBase<any, JQuery.Event<TElement, TData>> | false>,
@@ -4575,7 +4575,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *               namespaces, and the values represent a handler function to be called for the event(s).
      * @param selector A selector string to filter the descendants of the selected elements that will call the handler. If
      *                 the selector is null or omitted, the handler is always called when it reaches the selected element.
-     * @see {@link https://api.jquery.com/on/}
+     * @see [on](https://api.jquery.com/on/)
      * @since 1.7
      */
     on(events: JQuery.PlainObject<JQuery.EventHandler<TElement> | JQuery.EventHandlerBase<any, JQuery.Event<TElement>> | false>,
@@ -4586,7 +4586,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param events An object in which the string keys represent one or more space-separated event types and optional
      *               namespaces, and the values represent a handler function to be called for the event(s).
      * @param data Data to be passed to the handler in event.data when an event occurs.
-     * @see {@link https://api.jquery.com/on/}
+     * @see [on](https://api.jquery.com/on/)
      * @since 1.7
      */
     on<TData>(events: JQuery.PlainObject<JQuery.EventHandler<TElement, TData> | JQuery.EventHandlerBase<any, JQuery.Event<TElement, TData>> | false>,
@@ -4596,7 +4596,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param events An object in which the string keys represent one or more space-separated event types and optional
      *               namespaces, and the values represent a handler function to be called for the event(s).
-     * @see {@link https://api.jquery.com/on/}
+     * @see [on](https://api.jquery.com/on/)
      * @since 1.7
      */
     on(events: JQuery.PlainObject<JQuery.EventHandler<TElement> | JQuery.EventHandlerBase<any, JQuery.Event<TElement>> | false>): this;
@@ -4608,7 +4608,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *                 selector is null or omitted, the event is always triggered when it reaches the selected element.
      * @param data Data to be passed to the handler in event.data when an event is triggered.
      * @param handler A function to execute when the event is triggered.
-     * @see {@link https://api.jquery.com/one/}
+     * @see [one](https://api.jquery.com/one/)
      * @since 1.7
      */
     one<TData>(events: string,
@@ -4623,7 +4623,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *                 selector is null or omitted, the event is always triggered when it reaches the selected element.
      * @param handler A function to execute when the event is triggered. The value false is also allowed as a shorthand
      *                for a function that simply does return false.
-     * @see {@link https://api.jquery.com/one/}
+     * @see [one](https://api.jquery.com/one/)
      * @since 1.7
      */
     one(events: string,
@@ -4635,7 +4635,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param events One or more space-separated event types and optional namespaces, such as "click" or "keydown.myPlugin".
      * @param data Data to be passed to the handler in event.data when an event is triggered.
      * @param handler A function to execute when the event is triggered.
-     * @see {@link https://api.jquery.com/one/}
+     * @see [one](https://api.jquery.com/one/)
      * @since 1.7
      */
     one<TData>(events: string,
@@ -4647,7 +4647,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param events One or more space-separated event types and optional namespaces, such as "click" or "keydown.myPlugin".
      * @param handler A function to execute when the event is triggered. The value false is also allowed as a shorthand
      *                for a function that simply does return false.
-     * @see {@link https://api.jquery.com/one/}
+     * @see [one](https://api.jquery.com/one/)
      * @since 1.7
      */
     one(events: string,
@@ -4660,7 +4660,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param selector A selector string to filter the descendants of the selected elements that will call the handler. If
      *                 the selector is null or omitted, the handler is always called when it reaches the selected element.
      * @param data Data to be passed to the handler in event.data when an event occurs.
-     * @see {@link https://api.jquery.com/one/}
+     * @see [one](https://api.jquery.com/one/)
      * @since 1.7
      */
     one<TData>(events: JQuery.PlainObject<JQuery.EventHandler<TElement, TData> | JQuery.EventHandlerBase<any, JQuery.Event<TElement, TData>> | false>,
@@ -4673,7 +4673,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *               namespaces, and the values represent a handler function to be called for the event(s).
      * @param selector A selector string to filter the descendants of the selected elements that will call the handler. If
      *                 the selector is null or omitted, the handler is always called when it reaches the selected element.
-     * @see {@link https://api.jquery.com/one/}
+     * @see [one](https://api.jquery.com/one/)
      * @since 1.7
      */
     one(events: JQuery.PlainObject<JQuery.EventHandler<TElement> | JQuery.EventHandlerBase<any, JQuery.Event<TElement>> | false>,
@@ -4684,7 +4684,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param events An object in which the string keys represent one or more space-separated event types and optional
      *               namespaces, and the values represent a handler function to be called for the event(s).
      * @param data Data to be passed to the handler in event.data when an event occurs.
-     * @see {@link https://api.jquery.com/one/}
+     * @see [one](https://api.jquery.com/one/)
      * @since 1.7
      */
     one<TData>(events: JQuery.PlainObject<JQuery.EventHandler<TElement, TData> | JQuery.EventHandlerBase<any, JQuery.Event<TElement, TData>> | false>,
@@ -4694,7 +4694,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param events An object in which the string keys represent one or more space-separated event types and optional
      *               namespaces, and the values represent a handler function to be called for the event(s).
-     * @see {@link https://api.jquery.com/one/}
+     * @see [one](https://api.jquery.com/one/)
      * @since 1.7
      */
     one(events: JQuery.PlainObject<JQuery.EventHandler<TElement> | JQuery.EventHandlerBase<any, JQuery.Event<TElement>> | false>): this;
@@ -4703,7 +4703,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param value A number representing the number of pixels, or a number along with an optional unit of measure
      *              appended (as a string).
-     * @see {@link https://api.jquery.com/outerHeight/}
+     * @see [outerHeight](https://api.jquery.com/outerHeight/)
      * @since 1.8.0
      */
     outerHeight(value: string | number | ((this: TElement, index: number, height: number) => string | number)): this;
@@ -4712,7 +4712,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * first element in the set of matched elements.
      *
      * @param includeMargin A Boolean indicating whether to include the element's margin in the calculation.
-     * @see {@link https://api.jquery.com/outerHeight/}
+     * @see [outerHeight](https://api.jquery.com/outerHeight/)
      * @since 1.2.6
      */
     outerHeight(includeMargin?: boolean): number | undefined;
@@ -4723,7 +4723,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *              appended (as a string).
      *              A function returning the outer width to set. Receives the index position of the element in the set
      *              and the old outer width as arguments. Within the function, this refers to the current element in the set.
-     * @see {@link https://api.jquery.com/outerWidth/}
+     * @see [outerWidth](https://api.jquery.com/outerWidth/)
      * @since 1.8.0
      */
     outerWidth(value: string | number | ((this: TElement, index: number, width: number) => string | number)): this;
@@ -4732,7 +4732,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * first element in the set of matched elements.
      *
      * @param includeMargin A Boolean indicating whether to include the element's margin in the calculation.
-     * @see {@link https://api.jquery.com/outerWidth/}
+     * @see [outerWidth](https://api.jquery.com/outerWidth/)
      * @since 1.2.6
      */
     outerWidth(includeMargin?: boolean): number | undefined;
@@ -4740,7 +4740,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Get the parent of each element in the current set of matched elements, optionally filtered by a selector.
      *
      * @param selector A string containing a selector expression to match elements against.
-     * @see {@link https://api.jquery.com/parent/}
+     * @see [parent](https://api.jquery.com/parent/)
      * @since 1.0
      */
     parent(selector?: JQuery.Selector): this;
@@ -4748,7 +4748,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Get the ancestors of each element in the current set of matched elements, optionally filtered by a selector.
      *
      * @param selector A string containing a selector expression to match elements against.
-     * @see {@link https://api.jquery.com/parents/}
+     * @see [parents](https://api.jquery.com/parents/)
      * @since 1.0
      */
     parents(selector?: JQuery.Selector): this;
@@ -4759,7 +4759,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param selector A string containing a selector expression to indicate where to stop matching ancestor elements.
      *                 A DOM node or jQuery object indicating where to stop matching ancestor elements.
      * @param filter A string containing a selector expression to match elements against.
-     * @see {@link https://api.jquery.com/parentsUntil/}
+     * @see [parentsUntil](https://api.jquery.com/parentsUntil/)
      * @since 1.4
      * @since 1.6
      */
@@ -4767,7 +4767,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
     /**
      * Get the current coordinates of the first element in the set of matched elements, relative to the offset parent.
      *
-     * @see {@link https://api.jquery.com/position/}
+     * @see [position](https://api.jquery.com/position/)
      * @since 1.2
      */
     position(): JQuery.Coordinates;
@@ -4776,7 +4776,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param contents One or more additional DOM elements, text nodes, arrays of elements and text nodes, HTML strings, or
      *                 jQuery objects to insert at the beginning of each element in the set of matched elements.
-     * @see {@link https://api.jquery.com/prepend/}
+     * @see [prepend](https://api.jquery.com/prepend/)
      * @since 1.0
      */
     prepend(...contents: Array<JQuery.htmlString | JQuery.TypeOrArray<JQuery.Node | JQuery<JQuery.Node>>>): this;
@@ -4787,7 +4787,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *           the beginning of each element in the set of matched elements. Receives the index position of the
      *           element in the set and the old HTML value of the element as arguments. Within the function, this
      *           refers to the current element in the set.
-     * @see {@link https://api.jquery.com/prepend/}
+     * @see [prepend](https://api.jquery.com/prepend/)
      * @since 1.4
      */
     prepend(fn: (this: TElement, index: number, html: string) => JQuery.htmlString | JQuery.TypeOrArray<JQuery.Node | JQuery<JQuery.Node>>): this;
@@ -4796,7 +4796,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param target A selector, element, HTML string, array of elements, or jQuery object; the matched set of elements
      *               will be inserted at the beginning of the element(s) specified by this parameter.
-     * @see {@link https://api.jquery.com/prependTo/}
+     * @see [prependTo](https://api.jquery.com/prependTo/)
      * @since 1.0
      */
     prependTo(target: JQuery.Selector | JQuery.htmlString | JQuery.TypeOrArray<Element> | JQuery): this;
@@ -4805,7 +4805,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * is provided, it retrieves the previous sibling only if it matches that selector.
      *
      * @param selector A string containing a selector expression to match elements against.
-     * @see {@link https://api.jquery.com/prev/}
+     * @see [prev](https://api.jquery.com/prev/)
      * @since 1.0
      */
     prev(selector?: JQuery.Selector): this;
@@ -4813,7 +4813,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Get all preceding siblings of each element in the set of matched elements, optionally filtered by a selector.
      *
      * @param selector A string containing a selector expression to match elements against.
-     * @see {@link https://api.jquery.com/prevAll/}
+     * @see [prevAll](https://api.jquery.com/prevAll/)
      * @since 1.2
      */
     prevAll(selector?: JQuery.Selector): this;
@@ -4824,7 +4824,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param selector A string containing a selector expression to indicate where to stop matching preceding sibling elements.
      *                 A DOM node or jQuery object indicating where to stop matching preceding sibling elements.
      * @param filter A string containing a selector expression to match elements against.
-     * @see {@link https://api.jquery.com/prevUntil/}
+     * @see [prevUntil](https://api.jquery.com/prevUntil/)
      * @since 1.4
      * @since 1.6
      */
@@ -4835,7 +4835,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param type The type of queue that needs to be observed.
      * @param target Object onto which the promise methods have to be attached
-     * @see {@link https://api.jquery.com/promise/}
+     * @see [promise](https://api.jquery.com/promise/)
      * @since 1.6
      */
     promise<T extends object>(type: string, target: T): T & JQuery.Promise<this>;
@@ -4844,7 +4844,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * queued or not, have finished.
      *
      * @param target Object onto which the promise methods have to be attached
-     * @see {@link https://api.jquery.com/promise/}
+     * @see [promise](https://api.jquery.com/promise/)
      * @since 1.6
      */
     promise<T extends object>(target: T): T & JQuery.Promise<this>;
@@ -4853,7 +4853,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * queued or not, have finished.
      *
      * @param type The type of queue that needs to be observed.
-     * @see {@link https://api.jquery.com/promise/}
+     * @see [promise](https://api.jquery.com/promise/)
      * @since 1.6
      */
     promise(type?: string): JQuery.Promise<this>;
@@ -4863,7 +4863,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param propertyName The name of the property to set.
      * @param value A function returning the value to set. Receives the index position of the element in the set and the
      *              old property value as arguments. Within the function, the keyword this refers to the current element.
-     * @see {@link https://api.jquery.com/prop/}
+     * @see [prop](https://api.jquery.com/prop/)
      * @since 1.6
      */
     prop(propertyName: string, value: (this: TElement, index: number, oldPropertyValue: any) => any): this;
@@ -4872,7 +4872,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param propertyName The name of the property to set.
      * @param value A value to set for the property.
-     * @see {@link https://api.jquery.com/prop/}
+     * @see [prop](https://api.jquery.com/prop/)
      * @since 1.6
      */
     prop(propertyName: string, value: any): this; // tslint:disable-line:unified-signatures
@@ -4880,7 +4880,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Set one or more properties for the set of matched elements.
      *
      * @param properties An object of property-value pairs to set.
-     * @see {@link https://api.jquery.com/prop/}
+     * @see [prop](https://api.jquery.com/prop/)
      * @since 1.6
      */
     prop(properties: JQuery.PlainObject): this;
@@ -4888,7 +4888,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Get the value of a property for the first element in the set of matched elements.
      *
      * @param propertyName The name of the property to get.
-     * @see {@link https://api.jquery.com/prop/}
+     * @see [prop](https://api.jquery.com/prop/)
      * @since 1.6
      */
     prop(propertyName: string): any | undefined;
@@ -4898,7 +4898,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param elements An array of elements to push onto the stack and make into a new jQuery object.
      * @param name The name of a jQuery method that generated the array of elements.
      * @param args The arguments that were passed in to the jQuery method (for serialization).
-     * @see {@link https://api.jquery.com/pushStack/}
+     * @see [pushStack](https://api.jquery.com/pushStack/)
      * @since 1.3
      */
     pushStack(elements: ArrayLike<Element>, name: string, args: any[]): this;
@@ -4906,7 +4906,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Add a collection of DOM elements onto the jQuery stack.
      *
      * @param elements An array of elements to push onto the stack and make into a new jQuery object.
-     * @see {@link https://api.jquery.com/pushStack/}
+     * @see [pushStack](https://api.jquery.com/pushStack/)
      * @since 1.0
      */
     pushStack(elements: ArrayLike<Element>): this;
@@ -4916,7 +4916,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param queueName A string containing the name of the queue. Defaults to fx, the standard effects queue.
      * @param newQueue The new function to add to the queue, with a function to call that will dequeue the next item.
      *                 An array of functions to replace the current queue contents.
-     * @see {@link https://api.jquery.com/queue/}
+     * @see [queue](https://api.jquery.com/queue/)
      * @since 1.2
      */
     queue(queueName: string, newQueue: JQuery.TypeOrArray<JQuery.QueueFunction<TElement>>): this;
@@ -4925,7 +4925,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param newQueue The new function to add to the queue, with a function to call that will dequeue the next item.
      *                 An array of functions to replace the current queue contents.
-     * @see {@link https://api.jquery.com/queue/}
+     * @see [queue](https://api.jquery.com/queue/)
      * @since 1.2
      */
     queue(newQueue: JQuery.TypeOrArray<JQuery.QueueFunction<TElement>>): this;
@@ -4933,7 +4933,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Show the queue of functions to be executed on the matched elements.
      *
      * @param queueName A string containing the name of the queue. Defaults to fx, the standard effects queue.
-     * @see {@link https://api.jquery.com/queue/}
+     * @see [queue](https://api.jquery.com/queue/)
      * @since 1.2
      */
     queue(queueName?: string): JQuery.Queue<Node>;
@@ -4941,7 +4941,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Specify a function to execute when the DOM is fully loaded.
      *
      * @param handler A function to execute after the DOM is ready.
-     * @see {@link https://api.jquery.com/ready/}
+     * @see [ready](https://api.jquery.com/ready/)
      * @since 1.0
      * @deprecated 3.0
      */
@@ -4950,7 +4950,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Remove the set of matched elements from the DOM.
      *
      * @param selector A selector expression that filters the set of matched elements to be removed.
-     * @see {@link https://api.jquery.com/remove/}
+     * @see [remove](https://api.jquery.com/remove/)
      * @since 1.0
      */
     remove(selector?: string): this;
@@ -4958,7 +4958,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Remove an attribute from each element in the set of matched elements.
      *
      * @param attributeName An attribute to remove; as of version 1.7, it can be a space-separated list of attributes.
-     * @see {@link https://api.jquery.com/removeAttr/}
+     * @see [removeAttr](https://api.jquery.com/removeAttr/)
      * @since 1.0
      */
     removeAttr(attributeName: string): this;
@@ -4969,7 +4969,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *                  An array of classes to be removed from the class attribute of each matched element.
      *                  A function returning one or more space-separated class names to be removed. Receives the index
      *                  position of the element in the set and the old class value as arguments.
-     * @see {@link https://api.jquery.com/removeClass/}
+     * @see [removeClass](https://api.jquery.com/removeClass/)
      * @since 1.0
      * @since 1.4
      * @since 3.3
@@ -4980,7 +4980,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param name A string naming the piece of data to delete.
      *             An array or space-separated string naming the pieces of data to delete.
-     * @see {@link https://api.jquery.com/removeData/}
+     * @see [removeData](https://api.jquery.com/removeData/)
      * @since 1.2.3
      * @since 1.7
      */
@@ -4989,7 +4989,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Remove a property for the set of matched elements.
      *
      * @param propertyName The name of the property to remove.
-     * @see {@link https://api.jquery.com/removeProp/}
+     * @see [removeProp](https://api.jquery.com/removeProp/)
      * @since 1.6
      */
     removeProp(propertyName: string): this;
@@ -4997,7 +4997,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Replace each target element with the set of matched elements.
      *
      * @param target A selector string, jQuery object, DOM element, or array of elements indicating which element(s) to replace.
-     * @see {@link https://api.jquery.com/replaceAll/}
+     * @see [replaceAll](https://api.jquery.com/replaceAll/)
      * @since 1.2
      */
     replaceAll(target: JQuery.Selector | JQuery | JQuery.TypeOrArray<Element>): this;
@@ -5007,7 +5007,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param newContent The content to insert. May be an HTML string, DOM element, array of DOM elements, or jQuery object.
      *                   A function that returns content with which to replace the set of matched elements.
-     * @see {@link https://api.jquery.com/replaceWith/}
+     * @see [replaceWith](https://api.jquery.com/replaceWith/)
      * @since 1.2
      * @since 1.4
      */
@@ -5017,7 +5017,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute each time the event is triggered.
-     * @see {@link https://api.jquery.com/resize/}
+     * @see [resize](https://api.jquery.com/resize/)
      * @since 1.4.3
      * @deprecated 3.3
      */
@@ -5027,7 +5027,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Bind an event handler to the "resize" JavaScript event, or trigger that event on an element.
      *
      * @param handler A function to execute each time the event is triggered.
-     * @see {@link https://api.jquery.com/resize/}
+     * @see [resize](https://api.jquery.com/resize/)
      * @since 1.0
      * @deprecated 3.3
      */
@@ -5037,7 +5037,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute each time the event is triggered.
-     * @see {@link https://api.jquery.com/scroll/}
+     * @see [scroll](https://api.jquery.com/scroll/)
      * @since 1.4.3
      * @deprecated 3.3
      */
@@ -5047,7 +5047,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Bind an event handler to the "scroll" JavaScript event, or trigger that event on an element.
      *
      * @param handler A function to execute each time the event is triggered.
-     * @see {@link https://api.jquery.com/scroll/}
+     * @see [scroll](https://api.jquery.com/scroll/)
      * @since 1.0
      * @deprecated 3.3
      */
@@ -5056,14 +5056,14 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Set the current horizontal position of the scroll bar for each of the set of matched elements.
      *
      * @param value An integer indicating the new position to set the scroll bar to.
-     * @see {@link https://api.jquery.com/scrollLeft/}
+     * @see [scrollLeft](https://api.jquery.com/scrollLeft/)
      * @since 1.2.6
      */
     scrollLeft(value: number): this;
     /**
      * Get the current horizontal position of the scroll bar for the first element in the set of matched elements.
      *
-     * @see {@link https://api.jquery.com/scrollLeft/}
+     * @see [scrollLeft](https://api.jquery.com/scrollLeft/)
      * @since 1.2.6
      */
     scrollLeft(): number | undefined;
@@ -5071,7 +5071,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Set the current vertical position of the scroll bar for each of the set of matched elements.
      *
      * @param value A number indicating the new position to set the scroll bar to.
-     * @see {@link https://api.jquery.com/scrollTop/}
+     * @see [scrollTop](https://api.jquery.com/scrollTop/)
      * @since 1.2.6
      */
     scrollTop(value: number): this;
@@ -5079,7 +5079,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Get the current vertical position of the scroll bar for the first element in the set of matched
      * elements or set the vertical position of the scroll bar for every matched element.
      *
-     * @see {@link https://api.jquery.com/scrollTop/}
+     * @see [scrollTop](https://api.jquery.com/scrollTop/)
      * @since 1.2.6
      */
     scrollTop(): number | undefined;
@@ -5088,7 +5088,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute each time the event is triggered.
-     * @see {@link https://api.jquery.com/select/}
+     * @see [select](https://api.jquery.com/select/)
      * @since 1.4.3
      * @deprecated 3.3
      */
@@ -5098,7 +5098,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Bind an event handler to the "select" JavaScript event, or trigger that event on an element.
      *
      * @param handler A function to execute each time the event is triggered.
-     * @see {@link https://api.jquery.com/select/}
+     * @see [select](https://api.jquery.com/select/)
      * @since 1.0
      * @deprecated 3.3
      */
@@ -5106,14 +5106,14 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
     /**
      * Encode a set of form elements as a string for submission.
      *
-     * @see {@link https://api.jquery.com/serialize/}
+     * @see [serialize](https://api.jquery.com/serialize/)
      * @since 1.0
      */
     serialize(): string;
     /**
      * Encode a set of form elements as an array of names and values.
      *
-     * @see {@link https://api.jquery.com/serializeArray/}
+     * @see [serializeArray](https://api.jquery.com/serializeArray/)
      * @since 1.2
      */
     serializeArray(): JQuery.NameValuePair[];
@@ -5123,7 +5123,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param duration A string or number determining how long the animation will run.
      * @param easing A string indicating which easing function to use for the transition.
      * @param complete A function to call once the animation is complete, called once per matched element.
-     * @see {@link https://api.jquery.com/show/}
+     * @see [show](https://api.jquery.com/show/)
      * @since 1.4.3
      */
     show(duration: JQuery.Duration, easing: string, complete: (this: TElement) => void): this;
@@ -5133,7 +5133,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param duration A string or number determining how long the animation will run.
      * @param easing_complete A string indicating which easing function to use for the transition.
      *                        A function to call once the animation is complete, called once per matched element.
-     * @see {@link https://api.jquery.com/show/}
+     * @see [show](https://api.jquery.com/show/)
      * @since 1.0
      * @since 1.4.3
      */
@@ -5144,7 +5144,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param duration_complete_options A string or number determining how long the animation will run.
      *                                  A function to call once the animation is complete, called once per matched element.
      *                                  A map of additional options to pass to the method.
-     * @see {@link https://api.jquery.com/show/}
+     * @see [show](https://api.jquery.com/show/)
      * @since 1.0
      */
     show(duration_complete_options?: JQuery.Duration | ((this: TElement) => void) | JQuery.EffectsOptions<TElement>): this;
@@ -5152,7 +5152,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Get the siblings of each element in the set of matched elements, optionally filtered by a selector.
      *
      * @param selector A string containing a selector expression to match elements against.
-     * @see {@link https://api.jquery.com/siblings/}
+     * @see [siblings](https://api.jquery.com/siblings/)
      * @since 1.0
      */
     siblings(selector?: JQuery.Selector): this;
@@ -5163,7 +5163,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *              it indicates an offset from the end of the set.
      * @param end An integer indicating the 0-based position at which the elements stop being selected. If negative,
      *            it indicates an offset from the end of the set. If omitted, the range continues until the end of the set.
-     * @see {@link https://api.jquery.com/slice/}
+     * @see [slice](https://api.jquery.com/slice/)
      * @since 1.1.4
      */
     slice(start: number, end?: number): this;
@@ -5173,7 +5173,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param duration A string or number determining how long the animation will run.
      * @param easing A string indicating which easing function to use for the transition.
      * @param complete A function to call once the animation is complete, called once per matched element.
-     * @see {@link https://api.jquery.com/slideDown/}
+     * @see [slideDown](https://api.jquery.com/slideDown/)
      * @since 1.4.3
      */
     slideDown(duration: JQuery.Duration, easing: string, complete?: (this: TElement) => void): this;
@@ -5183,7 +5183,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param duration_easing A string or number determining how long the animation will run.
      *                        A string indicating which easing function to use for the transition.
      * @param complete A function to call once the animation is complete, called once per matched element.
-     * @see {@link https://api.jquery.com/slideDown/}
+     * @see [slideDown](https://api.jquery.com/slideDown/)
      * @since 1.0
      * @since 1.4.3
      */
@@ -5195,7 +5195,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *                                         A string indicating which easing function to use for the transition.
      *                                         A function to call once the animation is complete, called once per matched element.
      *                                         A map of additional options to pass to the method.
-     * @see {@link https://api.jquery.com/slideDown/}
+     * @see [slideDown](https://api.jquery.com/slideDown/)
      * @since 1.0
      * @since 1.4.3
      */
@@ -5206,7 +5206,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param duration A string or number determining how long the animation will run.
      * @param easing A string indicating which easing function to use for the transition.
      * @param complete A function to call once the animation is complete, called once per matched element.
-     * @see {@link https://api.jquery.com/slideToggle/}
+     * @see [slideToggle](https://api.jquery.com/slideToggle/)
      * @since 1.4.3
      */
     slideToggle(duration: JQuery.Duration, easing: string, complete?: (this: TElement) => void): this;
@@ -5216,7 +5216,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param duration_easing A string or number determining how long the animation will run.
      *                        A string indicating which easing function to use for the transition.
      * @param complete A function to call once the animation is complete, called once per matched element.
-     * @see {@link https://api.jquery.com/slideToggle/}
+     * @see [slideToggle](https://api.jquery.com/slideToggle/)
      * @since 1.0
      * @since 1.4.3
      */
@@ -5228,7 +5228,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *                                         A string indicating which easing function to use for the transition.
      *                                         A function to call once the animation is complete, called once per matched element.
      *                                         A map of additional options to pass to the method.
-     * @see {@link https://api.jquery.com/slideToggle/}
+     * @see [slideToggle](https://api.jquery.com/slideToggle/)
      * @since 1.0
      * @since 1.4.3
      */
@@ -5239,7 +5239,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param duration A string or number determining how long the animation will run.
      * @param easing A string indicating which easing function to use for the transition.
      * @param complete A function to call once the animation is complete, called once per matched element.
-     * @see {@link https://api.jquery.com/slideUp/}
+     * @see [slideUp](https://api.jquery.com/slideUp/)
      * @since 1.4.3
      */
     slideUp(duration: JQuery.Duration, easing: string, complete?: (this: TElement) => void): this;
@@ -5249,7 +5249,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param duration_easing A string or number determining how long the animation will run.
      *                        A string indicating which easing function to use for the transition.
      * @param complete A function to call once the animation is complete, called once per matched element.
-     * @see {@link https://api.jquery.com/slideUp/}
+     * @see [slideUp](https://api.jquery.com/slideUp/)
      * @since 1.0
      * @since 1.4.3
      */
@@ -5261,7 +5261,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *                                         A string indicating which easing function to use for the transition.
      *                                         A function to call once the animation is complete, called once per matched element.
      *                                         A map of additional options to pass to the method.
-     * @see {@link https://api.jquery.com/slideUp/}
+     * @see [slideUp](https://api.jquery.com/slideUp/)
      * @since 1.0
      * @since 1.4.3
      */
@@ -5272,7 +5272,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param queue The name of the queue in which to stop animations.
      * @param clearQueue A Boolean indicating whether to remove queued animation as well. Defaults to false.
      * @param jumpToEnd A Boolean indicating whether to complete the current animation immediately. Defaults to false.
-     * @see {@link https://api.jquery.com/stop/}
+     * @see [stop](https://api.jquery.com/stop/)
      * @since 1.7
      */
     stop(queue: string, clearQueue?: boolean, jumpToEnd?: boolean): this;
@@ -5281,7 +5281,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param clearQueue A Boolean indicating whether to remove queued animation as well. Defaults to false.
      * @param jumpToEnd A Boolean indicating whether to complete the current animation immediately. Defaults to false.
-     * @see {@link https://api.jquery.com/stop/}
+     * @see [stop](https://api.jquery.com/stop/)
      * @since 1.2
      */
     stop(clearQueue?: boolean, jumpToEnd?: boolean): this;
@@ -5290,7 +5290,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute each time the event is triggered.
-     * @see {@link https://api.jquery.com/submit/}
+     * @see [submit](https://api.jquery.com/submit/)
      * @since 1.4.3
      * @deprecated 3.3
      */
@@ -5300,7 +5300,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Bind an event handler to the "submit" JavaScript event, or trigger that event on an element.
      *
      * @param handler A function to execute each time the event is triggered.
-     * @see {@link https://api.jquery.com/submit/}
+     * @see [submit](https://api.jquery.com/submit/)
      * @since 1.0
      * @deprecated 3.3
      */
@@ -5312,7 +5312,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *             be converted to a String representation.
      *             A function returning the text content to set. Receives the index position of the element in the set
      *             and the old text value as arguments.
-     * @see {@link https://api.jquery.com/text/}
+     * @see [text](https://api.jquery.com/text/)
      * @since 1.0
      * @since 1.4
      */
@@ -5320,14 +5320,14 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
     /**
      * Get the combined text contents of each element in the set of matched elements, including their descendants.
      *
-     * @see {@link https://api.jquery.com/text/}
+     * @see [text](https://api.jquery.com/text/)
      * @since 1.0
      */
     text(): string;
     /**
      * Retrieve all the elements contained in the jQuery set, as an array.
      *
-     * @see {@link https://api.jquery.com/toArray/}
+     * @see [toArray](https://api.jquery.com/toArray/)
      * @since 1.4
      */
     toArray(): TElement[];
@@ -5337,7 +5337,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param duration A string or number determining how long the animation will run.
      * @param easing A string indicating which easing function to use for the transition.
      * @param complete A function to call once the animation is complete, called once per matched element.
-     * @see {@link https://api.jquery.com/toggle/}
+     * @see [toggle](https://api.jquery.com/toggle/)
      * @since 1.4.3
      */
     toggle(duration: JQuery.Duration, easing: string, complete?: (this: TElement) => void): this;
@@ -5346,7 +5346,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param duration A string or number determining how long the animation will run.
      * @param complete A function to call once the animation is complete, called once per matched element.
-     * @see {@link https://api.jquery.com/toggle/}
+     * @see [toggle](https://api.jquery.com/toggle/)
      * @since 1.0
      */
     toggle(duration: JQuery.Duration, complete: (this: TElement) => void): this;
@@ -5357,7 +5357,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *                                          A function to call once the animation is complete, called once per matched element.
      *                                          A map of additional options to pass to the method.
      *                                          Use true to show the element or false to hide it.
-     * @see {@link https://api.jquery.com/toggle/}
+     * @see [toggle](https://api.jquery.com/toggle/)
      * @since 1.0
      * @since 1.3
      */
@@ -5371,7 +5371,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *                  A function that returns class names to be toggled in the class attribute of each element in the
      *                  matched set. Receives the index position of the element in the set, the old class value, and the state as arguments.
      * @param state A Boolean (not just truthy/falsy) value to determine whether the class should be added or removed.
-     * @see {@link https://api.jquery.com/toggleClass/}
+     * @see [toggleClass](https://api.jquery.com/toggleClass/)
      * @since 1.0
      * @since 1.3
      * @since 1.4
@@ -5384,7 +5384,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * either the class's presence or the value of the state argument.
      *
      * @param state A boolean value to determine whether the class should be added or removed.
-     * @see {@link https://api.jquery.com/toggleClass/}
+     * @see [toggleClass](https://api.jquery.com/toggleClass/)
      * @since 1.4
      * @deprecated 3.0
      */
@@ -5395,7 +5395,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param eventType A string containing a JavaScript event type, such as click or submit.
      *                  A jQuery.Event object.
      * @param extraParameters Additional parameters to pass along to the event handler.
-     * @see {@link https://api.jquery.com/trigger/}
+     * @see [trigger](https://api.jquery.com/trigger/)
      * @since 1.0
      * @since 1.3
      */
@@ -5406,7 +5406,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param eventType A string containing a JavaScript event type, such as click or submit.
      *                  A jQuery.Event object.
      * @param extraParameters Additional parameters to pass along to the event handler.
-     * @see {@link https://api.jquery.com/triggerHandler/}
+     * @see [triggerHandler](https://api.jquery.com/triggerHandler/)
      * @since 1.2
      * @since 1.3
      */
@@ -5416,7 +5416,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param event A string containing one or more DOM event types, such as "click" or "submit," or custom event names.
      * @param handler A function to execute each time the event is triggered.
-     * @see {@link https://api.jquery.com/unbind/}
+     * @see [unbind](https://api.jquery.com/unbind/)
      * @since 1.0
      * @since 1.4.3
      * @deprecated 3.0
@@ -5427,7 +5427,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param event A string containing one or more DOM event types, such as "click" or "submit," or custom event names.
      *              A jQuery.Event object.
-     * @see {@link https://api.jquery.com/unbind/}
+     * @see [unbind](https://api.jquery.com/unbind/)
      * @since 1.0
      * @deprecated 3.0
      */
@@ -5439,7 +5439,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param selector A selector which will be used to filter the event results.
      * @param eventType A string containing a JavaScript event type, such as "click" or "keydown"
      * @param handler A function to execute each time the event is triggered.
-     * @see {@link https://api.jquery.com/undelegate/}
+     * @see [undelegate](https://api.jquery.com/undelegate/)
      * @since 1.4.2
      * @deprecated 3.0
      */
@@ -5451,7 +5451,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param selector A selector which will be used to filter the event results.
      * @param eventTypes A string containing a JavaScript event type, such as "click" or "keydown"
      *                   An object of one or more event types and previously bound functions to unbind from them.
-     * @see {@link https://api.jquery.com/undelegate/}
+     * @see [undelegate](https://api.jquery.com/undelegate/)
      * @since 1.4.2
      * @since 1.4.3
      * @deprecated 3.0
@@ -5462,7 +5462,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * specific set of root elements.
      *
      * @param namespace A selector which will be used to filter the event results.
-     * @see {@link https://api.jquery.com/undelegate/}
+     * @see [undelegate](https://api.jquery.com/undelegate/)
      * @since 1.4.2
      * @since 1.6
      * @deprecated 3.0
@@ -5473,7 +5473,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param selector A selector to check the parent element against. If an element's parent does not match the selector,
      *                 the element won't be unwrapped.
-     * @see {@link https://api.jquery.com/unwrap/}
+     * @see [unwrap](https://api.jquery.com/unwrap/)
      * @since 1.4
      * @since 3.0
      */
@@ -5485,7 +5485,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *              element to set as selected/checked.
      *              A function returning the value to set. this is the current element. Receives the index position of
      *              the element in the set and the old value as arguments.
-     * @see {@link https://api.jquery.com/val/}
+     * @see [val](https://api.jquery.com/val/)
      * @since 1.0
      * @since 1.4
      */
@@ -5493,7 +5493,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
     /**
      * Get the current value of the first element in the set of matched elements.
      *
-     * @see {@link https://api.jquery.com/val/}
+     * @see [val](https://api.jquery.com/val/)
      * @since 1.0
      */
     val(): string | number | string[] | undefined;
@@ -5504,7 +5504,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *              appended (as a string).
      *              A function returning the width to set. Receives the index position of the element in the set and the
      *              old width as arguments. Within the function, this refers to the current element in the set.
-     * @see {@link https://api.jquery.com/width/}
+     * @see [width](https://api.jquery.com/width/)
      * @since 1.0
      * @since 1.4.1
      */
@@ -5512,7 +5512,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
     /**
      * Get the current computed width for the first element in the set of matched elements.
      *
-     * @see {@link https://api.jquery.com/width/}
+     * @see [width](https://api.jquery.com/width/)
      * @since 1.0
      */
     width(): number | undefined;
@@ -5525,7 +5525,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *                        A callback function returning the HTML content or jQuery object to wrap around the matched elements.
      *                        Receives the index position of the element in the set as an argument. Within the function, this
      *                        refers to the current element in the set.
-     * @see {@link https://api.jquery.com/wrap/}
+     * @see [wrap](https://api.jquery.com/wrap/)
      * @since 1.0
      * @since 1.4
      */
@@ -5538,7 +5538,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *                        elements. Within the function, this refers to the first element in the set. Prior to jQuery 3.0, the
      *                        callback was incorrectly called for every element in the set and received the index position of the
      *                        element in the set as an argument.
-     * @see {@link https://api.jquery.com/wrapAll/}
+     * @see [wrapAll](https://api.jquery.com/wrapAll/)
      * @since 1.2
      * @since 1.4
      */
@@ -5551,7 +5551,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *                        A callback function which generates a structure to wrap around the content of the matched elements.
      *                        Receives the index position of the element in the set as an argument. Within the function, this
      *                        refers to the current element in the set.
-     * @see {@link https://api.jquery.com/wrapInner/}
+     * @see [wrapInner](https://api.jquery.com/wrapInner/)
      * @since 1.2
      * @since 1.4
      */
@@ -5641,7 +5641,7 @@ declare namespace JQuery {
         }
 
         /**
-         * @see {@link http://api.jquery.com/jquery.ajax/#jQuery-ajax-settings}
+         * @see [jquery.ajax](https://api.jquery.com/jquery.ajax/)
          */
         interface AjaxSettingsBase<TContext> {
             /**
@@ -6328,7 +6328,7 @@ declare namespace JQuery {
     }
 
     /**
-     * @see {@link http://api.jquery.com/jquery.ajax/#jqXHR}
+     * @see [jquery.ajax](https://api.jquery.com/jquery.ajax/)
      */
     interface jqXHR<TResolve = any> extends Promise3<TResolve, jqXHR<TResolve>, never,
         Ajax.SuccessTextStatus, Ajax.ErrorTextStatus, never,
@@ -6341,7 +6341,7 @@ declare namespace JQuery {
         /**
          * Determine the current state of a Deferred object.
          *
-         * @see {@link https://api.jquery.com/deferred.state/}
+         * @see [deferred.state](https://api.jquery.com/deferred.state/)
          * @since 1.7
          */
         state(): 'pending' | 'resolved' | 'rejected';
@@ -6375,28 +6375,28 @@ declare namespace JQuery {
          *
          * @param callback A function, or array of functions, that are to be added to the callback list.
          * @param callbacks A function, or array of functions, that are to be added to the callback list.
-         * @see {@link https://api.jquery.com/callbacks.add/}
+         * @see [callbacks.add](https://api.jquery.com/callbacks.add/)
          * @since 1.7
          */
         add(callback: TypeOrArray<T>, ...callbacks: Array<TypeOrArray<T>>): this;
         /**
          * Disable a callback list from doing anything more.
          *
-         * @see {@link https://api.jquery.com/callbacks.disable/}
+         * @see [callbacks.disable](https://api.jquery.com/callbacks.disable/)
          * @since 1.7
          */
         disable(): this;
         /**
          * Determine if the callbacks list has been disabled.
          *
-         * @see {@link https://api.jquery.com/callbacks.disabled/}
+         * @see [callbacks.disabled](https://api.jquery.com/callbacks.disabled/)
          * @since 1.7
          */
         disabled(): boolean;
         /**
          * Remove all of the callbacks from a list.
          *
-         * @see {@link https://api.jquery.com/callbacks.empty/}
+         * @see [callbacks.empty](https://api.jquery.com/callbacks.empty/)
          * @since 1.7
          */
         empty(): this;
@@ -6404,7 +6404,7 @@ declare namespace JQuery {
          * Call all of the callbacks with the given arguments.
          *
          * @param args The argument or list of arguments to pass back to the callback list.
-         * @see {@link https://api.jquery.com/callbacks.fire/}
+         * @see [callbacks.fire](https://api.jquery.com/callbacks.fire/)
          * @since 1.7
          */
         fire(...args: any[]): this;
@@ -6413,14 +6413,14 @@ declare namespace JQuery {
          *
          * @param context A reference to the context in which the callbacks in the list should be fired.
          * @param args An argument, or array of arguments, to pass to the callbacks in the list.
-         * @see {@link https://api.jquery.com/callbacks.fireWith/}
+         * @see [callbacks.fireWith](https://api.jquery.com/callbacks.fireWith/)
          * @since 1.7
          */
         fireWith(context: object, args?: ArrayLike<any>): this;
         /**
          * Determine if the callbacks have already been called at least once.
          *
-         * @see {@link https://api.jquery.com/callbacks.fired/}
+         * @see [callbacks.fired](https://api.jquery.com/callbacks.fired/)
          * @since 1.7
          */
         fired(): boolean;
@@ -6429,21 +6429,21 @@ declare namespace JQuery {
          * argument, determine whether it is in a list.
          *
          * @param callback The callback to search for.
-         * @see {@link https://api.jquery.com/callbacks.has/}
+         * @see [callbacks.has](https://api.jquery.com/callbacks.has/)
          * @since 1.7
          */
         has(callback?: T): boolean;
         /**
          * Lock a callback list in its current state.
          *
-         * @see {@link https://api.jquery.com/callbacks.lock/}
+         * @see [callbacks.lock](https://api.jquery.com/callbacks.lock/)
          * @since 1.7
          */
         lock(): this;
         /**
          * Determine if the callbacks list has been locked.
          *
-         * @see {@link https://api.jquery.com/callbacks.locked/}
+         * @see [callbacks.locked](https://api.jquery.com/callbacks.locked/)
          * @since 1.7
          */
         locked(): boolean;
@@ -6451,7 +6451,7 @@ declare namespace JQuery {
          * Remove a callback or a collection of callbacks from a callback list.
          *
          * @param callbacks A function, or array of functions, that are to be removed from the callback list.
-         * @see {@link https://api.jquery.com/callbacks.remove/}
+         * @see [callbacks.remove](https://api.jquery.com/callbacks.remove/)
          * @since 1.7
          */
         remove(...callbacks: T[]): this;
@@ -6494,7 +6494,7 @@ declare namespace JQuery {
      * This object provides a subset of the methods of the Deferred object (then, done, fail, always,
      * pipe, progress, state and promise) to prevent users from changing the state of the Deferred.
      *
-     * @see {@link http://api.jquery.com/Types/#Promise}
+     * @see [Types](https://api.jquery.com/Types/)
      * @deprecated Experimental. Avoid referncing this type directly in your code.
      */
     interface PromiseBase<TR, TJ, TN,
@@ -6506,7 +6506,7 @@ declare namespace JQuery {
          *
          * @param alwaysCallback A function, or array of functions, that is called when the Deferred is resolved or rejected.
          * @param alwaysCallbacks Optional additional functions, or arrays of functions, that are called when the Deferred is resolved or rejected.
-         * @see {@link https://api.jquery.com/deferred.always/}
+         * @see [deferred.always](https://api.jquery.com/deferred.always/)
          * @since 1.6
          */
         always(alwaysCallback: TypeOrArray<Deferred.CallbackBase<TR | TJ, UR | UJ, VR | VJ, SR | SJ>>,
@@ -6516,7 +6516,7 @@ declare namespace JQuery {
          *
          * @param doneCallback A function, or array of functions, that are called when the Deferred is resolved.
          * @param doneCallbacks Optional additional functions, or arrays of functions, that are called when the Deferred is resolved.
-         * @see {@link https://api.jquery.com/deferred.done/}
+         * @see [deferred.done](https://api.jquery.com/deferred.done/)
          * @since 1.5
          */
         done(doneCallback: TypeOrArray<Deferred.CallbackBase<TR, UR, VR, SR>>,
@@ -6526,7 +6526,7 @@ declare namespace JQuery {
          *
          * @param failCallback A function, or array of functions, that are called when the Deferred is rejected.
          * @param failCallbacks Optional additional functions, or arrays of functions, that are called when the Deferred is rejected.
-         * @see {@link https://api.jquery.com/deferred.fail/}
+         * @see [deferred.fail](https://api.jquery.com/deferred.fail/)
          * @since 1.5
          */
         fail(failCallback: TypeOrArray<Deferred.CallbackBase<TJ, UJ, VJ, SJ>>,
@@ -6537,7 +6537,7 @@ declare namespace JQuery {
          * @param progressCallback A function, or array of functions, to be called when the Deferred generates progress notifications.
          * @param progressCallbacks Optional additional functions, or arrays of functions, to be called when the Deferred generates
          *                          progress notifications.
-         * @see {@link https://api.jquery.com/deferred.progress/}
+         * @see [deferred.progress](https://api.jquery.com/deferred.progress/)
          * @since 1.7
          */
         progress(progressCallback: TypeOrArray<Deferred.CallbackBase<TN, UN, VN, SN>>,
@@ -6546,21 +6546,21 @@ declare namespace JQuery {
          * Return a Deferred's Promise object.
          *
          * @param target Object onto which the promise methods have to be attached
-         * @see {@link https://api.jquery.com/deferred.promise/}
+         * @see [deferred.promise](https://api.jquery.com/deferred.promise/)
          * @since 1.5
          */
         promise<TTarget extends object>(target: TTarget): this & TTarget;
         /**
          * Return a Deferred's Promise object.
          *
-         * @see {@link https://api.jquery.com/deferred.promise/}
+         * @see [deferred.promise](https://api.jquery.com/deferred.promise/)
          * @since 1.5
          */
         promise(): this;
         /**
          * Determine the current state of a Deferred object.
          *
-         * @see {@link https://api.jquery.com/deferred.state/}
+         * @see [deferred.state](https://api.jquery.com/deferred.state/)
          * @since 1.7
          */
         state(): 'pending' | 'resolved' | 'rejected';
@@ -6573,7 +6573,7 @@ declare namespace JQuery {
          * @param doneFilter An optional function that is called when the Deferred is resolved.
          * @param failFilter An optional function that is called when the Deferred is rejected.
          * @param progressFilter An optional function that is called when progress notifications are sent to the Deferred.
-         * @see {@link https://api.jquery.com/deferred.pipe/}
+         * @see [deferred.pipe](https://api.jquery.com/deferred.pipe/)
          * @since 1.6
          * @since 1.7
          * @deprecated 1.8
@@ -6611,7 +6611,7 @@ declare namespace JQuery {
          * @param doneFilter An optional function that is called when the Deferred is resolved.
          * @param failFilter An optional function that is called when the Deferred is rejected.
          * @param progressFilter An optional function that is called when progress notifications are sent to the Deferred.
-         * @see {@link https://api.jquery.com/deferred.pipe/}
+         * @see [deferred.pipe](https://api.jquery.com/deferred.pipe/)
          * @since 1.6
          * @since 1.7
          * @deprecated 1.8
@@ -6642,7 +6642,7 @@ declare namespace JQuery {
          * @param doneFilter An optional function that is called when the Deferred is resolved.
          * @param failFilter An optional function that is called when the Deferred is rejected.
          * @param progressFilter An optional function that is called when progress notifications are sent to the Deferred.
-         * @see {@link https://api.jquery.com/deferred.pipe/}
+         * @see [deferred.pipe](https://api.jquery.com/deferred.pipe/)
          * @since 1.6
          * @since 1.7
          * @deprecated 1.8
@@ -6673,7 +6673,7 @@ declare namespace JQuery {
          * @param doneFilter An optional function that is called when the Deferred is resolved.
          * @param failFilter An optional function that is called when the Deferred is rejected.
          * @param progressFilter An optional function that is called when progress notifications are sent to the Deferred.
-         * @see {@link https://api.jquery.com/deferred.pipe/}
+         * @see [deferred.pipe](https://api.jquery.com/deferred.pipe/)
          * @since 1.6
          * @since 1.7
          * @deprecated 1.8
@@ -6697,7 +6697,7 @@ declare namespace JQuery {
          * @param doneFilter An optional function that is called when the Deferred is resolved.
          * @param failFilter An optional function that is called when the Deferred is rejected.
          * @param progressFilter An optional function that is called when progress notifications are sent to the Deferred.
-         * @see {@link https://api.jquery.com/deferred.pipe/}
+         * @see [deferred.pipe](https://api.jquery.com/deferred.pipe/)
          * @since 1.6
          * @since 1.7
          * @deprecated 1.8
@@ -6728,7 +6728,7 @@ declare namespace JQuery {
          * @param doneFilter An optional function that is called when the Deferred is resolved.
          * @param failFilter An optional function that is called when the Deferred is rejected.
          * @param progressFilter An optional function that is called when progress notifications are sent to the Deferred.
-         * @see {@link https://api.jquery.com/deferred.pipe/}
+         * @see [deferred.pipe](https://api.jquery.com/deferred.pipe/)
          * @since 1.6
          * @since 1.7
          * @deprecated 1.8
@@ -6752,7 +6752,7 @@ declare namespace JQuery {
          * @param doneFilter An optional function that is called when the Deferred is resolved.
          * @param failFilter An optional function that is called when the Deferred is rejected.
          * @param progressFilter An optional function that is called when progress notifications are sent to the Deferred.
-         * @see {@link https://api.jquery.com/deferred.pipe/}
+         * @see [deferred.pipe](https://api.jquery.com/deferred.pipe/)
          * @since 1.6
          * @since 1.7
          * @deprecated 1.8
@@ -6781,7 +6781,7 @@ declare namespace JQuery {
          * @param doneFilter An optional function that is called when the Deferred is resolved.
          * @param failFilter An optional function that is called when the Deferred is rejected.
          * @param progressFilter An optional function that is called when progress notifications are sent to the Deferred.
-         * @see {@link https://api.jquery.com/deferred.then/}
+         * @see [deferred.then](https://api.jquery.com/deferred.then/)
          * @since 1.8
          */
         then<ARD = never, AJD = never, AND = never,
@@ -6817,7 +6817,7 @@ declare namespace JQuery {
          * @param doneFilter An optional function that is called when the Deferred is resolved.
          * @param failFilter An optional function that is called when the Deferred is rejected.
          * @param progressFilter An optional function that is called when progress notifications are sent to the Deferred.
-         * @see {@link https://api.jquery.com/deferred.then/}
+         * @see [deferred.then](https://api.jquery.com/deferred.then/)
          * @since 1.8
          */
         then<ARF = never, AJF = never, ANF = never,
@@ -6846,7 +6846,7 @@ declare namespace JQuery {
          * @param doneFilter An optional function that is called when the Deferred is resolved.
          * @param failFilter An optional function that is called when the Deferred is rejected.
          * @param progressFilter An optional function that is called when progress notifications are sent to the Deferred.
-         * @see {@link https://api.jquery.com/deferred.then/}
+         * @see [deferred.then](https://api.jquery.com/deferred.then/)
          * @since 1.8
          */
         then<ARD = never, AJD = never, AND = never,
@@ -6875,7 +6875,7 @@ declare namespace JQuery {
          * @param doneFilter An optional function that is called when the Deferred is resolved.
          * @param failFilter An optional function that is called when the Deferred is rejected.
          * @param progressFilter An optional function that is called when progress notifications are sent to the Deferred.
-         * @see {@link https://api.jquery.com/deferred.then/}
+         * @see [deferred.then](https://api.jquery.com/deferred.then/)
          * @since 1.8
          */
         then<ARP = never, AJP = never, ANP = never,
@@ -6897,7 +6897,7 @@ declare namespace JQuery {
          * @param doneFilter An optional function that is called when the Deferred is resolved.
          * @param failFilter An optional function that is called when the Deferred is rejected.
          * @param progressFilter An optional function that is called when progress notifications are sent to the Deferred.
-         * @see {@link https://api.jquery.com/deferred.then/}
+         * @see [deferred.then](https://api.jquery.com/deferred.then/)
          * @since 1.8
          */
         then<ARD = never, AJD = never, AND = never,
@@ -6926,7 +6926,7 @@ declare namespace JQuery {
          * @param doneFilter An optional function that is called when the Deferred is resolved.
          * @param failFilter An optional function that is called when the Deferred is rejected.
          * @param progressFilter An optional function that is called when progress notifications are sent to the Deferred.
-         * @see {@link https://api.jquery.com/deferred.then/}
+         * @see [deferred.then](https://api.jquery.com/deferred.then/)
          * @since 1.8
          */
         then<ARF = never, AJF = never, ANF = never,
@@ -6948,7 +6948,7 @@ declare namespace JQuery {
          * @param doneFilter An optional function that is called when the Deferred is resolved.
          * @param failFilter An optional function that is called when the Deferred is rejected.
          * @param progressFilter An optional function that is called when progress notifications are sent to the Deferred.
-         * @see {@link https://api.jquery.com/deferred.then/}
+         * @see [deferred.then](https://api.jquery.com/deferred.then/)
          * @since 1.8
          */
         then<ARD = never, AJD = never, AND = never,
@@ -6971,7 +6971,7 @@ declare namespace JQuery {
          * Add handlers to be called when the Deferred object is rejected.
          *
          * @param failFilter A function that is called when the Deferred is rejected.
-         * @see {@link https://api.jquery.com/deferred.catch/}
+         * @see [deferred.catch](https://api.jquery.com/deferred.catch/)
          * @since 3.0
          */
         catch<ARF = never, AJF = never, ANF = never,
@@ -6991,7 +6991,7 @@ declare namespace JQuery {
      * This object provides a subset of the methods of the Deferred object (then, done, fail, always,
      * pipe, progress, state and promise) to prevent users from changing the state of the Deferred.
      *
-     * @see {@link http://api.jquery.com/Types/#Promise}
+     * @see [Types](https://api.jquery.com/Types/)
      */
     interface Promise3<TR, TJ, TN,
         UR, UJ, UN,
@@ -7004,7 +7004,7 @@ declare namespace JQuery {
      * This object provides a subset of the methods of the Deferred object (then, done, fail, always,
      * pipe, progress, state and promise) to prevent users from changing the state of the Deferred.
      *
-     * @see {@link http://api.jquery.com/Types/#Promise}
+     * @see [Types](https://api.jquery.com/Types/)
      */
     interface Promise2<TR, TJ, TN,
         UR, UJ, UN> extends PromiseBase<TR, TJ, TN,
@@ -7016,7 +7016,7 @@ declare namespace JQuery {
      * This object provides a subset of the methods of the Deferred object (then, done, fail, always,
      * pipe, progress, state and promise) to prevent users from changing the state of the Deferred.
      *
-     * @see {@link http://api.jquery.com/Types/#Promise}
+     * @see [Types](https://api.jquery.com/Types/)
      */
     interface Promise<TR, TJ = any, TN = any> extends PromiseBase<TR, TJ, TN,
         TR, TJ, TN,
@@ -7034,7 +7034,7 @@ declare namespace JQuery {
          * Call the progressCallbacks on a Deferred object with the given args.
          *
          * @param args Optional arguments that are passed to the progressCallbacks.
-         * @see {@link https://api.jquery.com/deferred.notify/}
+         * @see [deferred.notify](https://api.jquery.com/deferred.notify/)
          * @since 1.7
          */
         notify(...args: TN[]): this;
@@ -7043,7 +7043,7 @@ declare namespace JQuery {
          *
          * @param context Context passed to the progressCallbacks as the this object.
          * @param args An optional array of arguments that are passed to the progressCallbacks.
-         * @see {@link https://api.jquery.com/deferred.notifyWith/}
+         * @see [deferred.notifyWith](https://api.jquery.com/deferred.notifyWith/)
          * @since 1.7
          */
         notifyWith(context: object, args?: ArrayLike<TN>): this;
@@ -7051,7 +7051,7 @@ declare namespace JQuery {
          * Reject a Deferred object and call any failCallbacks with the given args.
          *
          * @param args Optional arguments that are passed to the failCallbacks.
-         * @see {@link https://api.jquery.com/deferred.reject/}
+         * @see [deferred.reject](https://api.jquery.com/deferred.reject/)
          * @since 1.5
          */
         reject(...args: TJ[]): this;
@@ -7060,7 +7060,7 @@ declare namespace JQuery {
          *
          * @param context Context passed to the failCallbacks as the this object.
          * @param args An optional array of arguments that are passed to the failCallbacks.
-         * @see {@link https://api.jquery.com/deferred.rejectWith/}
+         * @see [deferred.rejectWith](https://api.jquery.com/deferred.rejectWith/)
          * @since 1.5
          */
         rejectWith(context: object, args?: ArrayLike<TJ>): this;
@@ -7068,7 +7068,7 @@ declare namespace JQuery {
          * Resolve a Deferred object and call any doneCallbacks with the given args.
          *
          * @param args Optional arguments that are passed to the doneCallbacks.
-         * @see {@link https://api.jquery.com/deferred.resolve/}
+         * @see [deferred.resolve](https://api.jquery.com/deferred.resolve/)
          * @since 1.5
          */
         resolve(...args: TR[]): this;
@@ -7077,7 +7077,7 @@ declare namespace JQuery {
          *
          * @param context Context passed to the doneCallbacks as the this object.
          * @param args An optional array of arguments that are passed to the doneCallbacks.
-         * @see {@link https://api.jquery.com/deferred.resolveWith/}
+         * @see [deferred.resolveWith](https://api.jquery.com/deferred.resolveWith/)
          * @since 1.5
          */
         resolveWith(context: object, args?: ArrayLike<TR>): this;
@@ -7087,7 +7087,7 @@ declare namespace JQuery {
          *
          * @param alwaysCallback A function, or array of functions, that is called when the Deferred is resolved or rejected.
          * @param alwaysCallbacks Optional additional functions, or arrays of functions, that are called when the Deferred is resolved or rejected.
-         * @see {@link https://api.jquery.com/deferred.always/}
+         * @see [deferred.always](https://api.jquery.com/deferred.always/)
          * @since 1.6
          */
         always(alwaysCallback: TypeOrArray<Deferred.Callback<TR | TJ>>,
@@ -7097,7 +7097,7 @@ declare namespace JQuery {
          *
          * @param doneCallback A function, or array of functions, that are called when the Deferred is resolved.
          * @param doneCallbacks Optional additional functions, or arrays of functions, that are called when the Deferred is resolved.
-         * @see {@link https://api.jquery.com/deferred.done/}
+         * @see [deferred.done](https://api.jquery.com/deferred.done/)
          * @since 1.5
          */
         done(doneCallback: TypeOrArray<Deferred.Callback<TR>>,
@@ -7107,7 +7107,7 @@ declare namespace JQuery {
          *
          * @param failCallback A function, or array of functions, that are called when the Deferred is rejected.
          * @param failCallbacks Optional additional functions, or arrays of functions, that are called when the Deferred is rejected.
-         * @see {@link https://api.jquery.com/deferred.fail/}
+         * @see [deferred.fail](https://api.jquery.com/deferred.fail/)
          * @since 1.5
          */
         fail(failCallback: TypeOrArray<Deferred.Callback<TJ>>,
@@ -7118,7 +7118,7 @@ declare namespace JQuery {
          * @param progressCallback A function, or array of functions, to be called when the Deferred generates progress notifications.
          * @param progressCallbacks Optional additional functions, or arrays of functions, to be called when the Deferred generates
          *                          progress notifications.
-         * @see {@link https://api.jquery.com/deferred.progress/}
+         * @see [deferred.progress](https://api.jquery.com/deferred.progress/)
          * @since 1.7
          */
         progress(progressCallback: TypeOrArray<Deferred.Callback<TN>>,
@@ -7127,21 +7127,21 @@ declare namespace JQuery {
          * Return a Deferred's Promise object.
          *
          * @param target Object onto which the promise methods have to be attached
-         * @see {@link https://api.jquery.com/deferred.promise/}
+         * @see [deferred.promise](https://api.jquery.com/deferred.promise/)
          * @since 1.5
          */
         promise<TTarget extends object>(target: TTarget): JQuery.Promise<TR, TJ, TN> & TTarget;
         /**
          * Return a Deferred's Promise object.
          *
-         * @see {@link https://api.jquery.com/deferred.promise/}
+         * @see [deferred.promise](https://api.jquery.com/deferred.promise/)
          * @since 1.5
          */
         promise(): JQuery.Promise<TR, TJ, TN>;
         /**
          * Determine the current state of a Deferred object.
          *
-         * @see {@link https://api.jquery.com/deferred.state/}
+         * @see [deferred.state](https://api.jquery.com/deferred.state/)
          * @since 1.7
          */
         state(): 'pending' | 'resolved' | 'rejected';
@@ -7154,7 +7154,7 @@ declare namespace JQuery {
          * @param doneFilter An optional function that is called when the Deferred is resolved.
          * @param failFilter An optional function that is called when the Deferred is rejected.
          * @param progressFilter An optional function that is called when progress notifications are sent to the Deferred.
-         * @see {@link https://api.jquery.com/deferred.pipe/}
+         * @see [deferred.pipe](https://api.jquery.com/deferred.pipe/)
          * @since 1.6
          * @since 1.7
          * @deprecated 1.8
@@ -7192,7 +7192,7 @@ declare namespace JQuery {
          * @param doneFilter An optional function that is called when the Deferred is resolved.
          * @param failFilter An optional function that is called when the Deferred is rejected.
          * @param progressFilter An optional function that is called when progress notifications are sent to the Deferred.
-         * @see {@link https://api.jquery.com/deferred.pipe/}
+         * @see [deferred.pipe](https://api.jquery.com/deferred.pipe/)
          * @since 1.6
          * @since 1.7
          * @deprecated 1.8
@@ -7223,7 +7223,7 @@ declare namespace JQuery {
          * @param doneFilter An optional function that is called when the Deferred is resolved.
          * @param failFilter An optional function that is called when the Deferred is rejected.
          * @param progressFilter An optional function that is called when progress notifications are sent to the Deferred.
-         * @see {@link https://api.jquery.com/deferred.pipe/}
+         * @see [deferred.pipe](https://api.jquery.com/deferred.pipe/)
          * @since 1.6
          * @since 1.7
          * @deprecated 1.8
@@ -7254,7 +7254,7 @@ declare namespace JQuery {
          * @param doneFilter An optional function that is called when the Deferred is resolved.
          * @param failFilter An optional function that is called when the Deferred is rejected.
          * @param progressFilter An optional function that is called when progress notifications are sent to the Deferred.
-         * @see {@link https://api.jquery.com/deferred.pipe/}
+         * @see [deferred.pipe](https://api.jquery.com/deferred.pipe/)
          * @since 1.6
          * @since 1.7
          * @deprecated 1.8
@@ -7278,7 +7278,7 @@ declare namespace JQuery {
          * @param doneFilter An optional function that is called when the Deferred is resolved.
          * @param failFilter An optional function that is called when the Deferred is rejected.
          * @param progressFilter An optional function that is called when progress notifications are sent to the Deferred.
-         * @see {@link https://api.jquery.com/deferred.pipe/}
+         * @see [deferred.pipe](https://api.jquery.com/deferred.pipe/)
          * @since 1.6
          * @since 1.7
          * @deprecated 1.8
@@ -7309,7 +7309,7 @@ declare namespace JQuery {
          * @param doneFilter An optional function that is called when the Deferred is resolved.
          * @param failFilter An optional function that is called when the Deferred is rejected.
          * @param progressFilter An optional function that is called when progress notifications are sent to the Deferred.
-         * @see {@link https://api.jquery.com/deferred.pipe/}
+         * @see [deferred.pipe](https://api.jquery.com/deferred.pipe/)
          * @since 1.6
          * @since 1.7
          * @deprecated 1.8
@@ -7333,7 +7333,7 @@ declare namespace JQuery {
          * @param doneFilter An optional function that is called when the Deferred is resolved.
          * @param failFilter An optional function that is called when the Deferred is rejected.
          * @param progressFilter An optional function that is called when progress notifications are sent to the Deferred.
-         * @see {@link https://api.jquery.com/deferred.pipe/}
+         * @see [deferred.pipe](https://api.jquery.com/deferred.pipe/)
          * @since 1.6
          * @since 1.7
          * @deprecated 1.8
@@ -7362,7 +7362,7 @@ declare namespace JQuery {
          * @param doneFilter A function that is called when the Deferred is resolved.
          * @param failFilter An optional function that is called when the Deferred is rejected.
          * @param progressFilter An optional function that is called when progress notifications are sent to the Deferred.
-         * @see {@link https://api.jquery.com/deferred.then/}
+         * @see [deferred.then](https://api.jquery.com/deferred.then/)
          * @since 1.8
          */
         then<ARD = never, AJD = never, AND = never,
@@ -7398,7 +7398,7 @@ declare namespace JQuery {
          * @param doneFilter A function that is called when the Deferred is resolved.
          * @param failFilter An optional function that is called when the Deferred is rejected.
          * @param progressFilter An optional function that is called when progress notifications are sent to the Deferred.
-         * @see {@link https://api.jquery.com/deferred.then/}
+         * @see [deferred.then](https://api.jquery.com/deferred.then/)
          * @since 1.8
          */
         then<ARF = never, AJF = never, ANF = never,
@@ -7427,7 +7427,7 @@ declare namespace JQuery {
          * @param doneFilter A function that is called when the Deferred is resolved.
          * @param failFilter An optional function that is called when the Deferred is rejected.
          * @param progressFilter An optional function that is called when progress notifications are sent to the Deferred.
-         * @see {@link https://api.jquery.com/deferred.then/}
+         * @see [deferred.then](https://api.jquery.com/deferred.then/)
          * @since 1.8
          */
         then<ARD = never, AJD = never, AND = never,
@@ -7456,7 +7456,7 @@ declare namespace JQuery {
          * @param doneFilter A function that is called when the Deferred is resolved.
          * @param failFilter An optional function that is called when the Deferred is rejected.
          * @param progressFilter An optional function that is called when progress notifications are sent to the Deferred.
-         * @see {@link https://api.jquery.com/deferred.then/}
+         * @see [deferred.then](https://api.jquery.com/deferred.then/)
          * @since 1.8
          */
         then<ARP = never, AJP = never, ANP = never,
@@ -7478,7 +7478,7 @@ declare namespace JQuery {
          * @param doneFilter An optional function that is called when the Deferred is resolved.
          * @param failFilter An optional function that is called when the Deferred is rejected.
          * @param progressFilter An optional function that is called when progress notifications are sent to the Deferred.
-         * @see {@link https://api.jquery.com/deferred.then/}
+         * @see [deferred.then](https://api.jquery.com/deferred.then/)
          * @since 1.8
          */
         then<ARD = never, AJD = never, AND = never,
@@ -7507,7 +7507,7 @@ declare namespace JQuery {
          * @param doneFilter An optional function that is called when the Deferred is resolved.
          * @param failFilter An optional function that is called when the Deferred is rejected.
          * @param progressFilter An optional function that is called when progress notifications are sent to the Deferred.
-         * @see {@link https://api.jquery.com/deferred.then/}
+         * @see [deferred.then](https://api.jquery.com/deferred.then/)
          * @since 1.8
          */
         then<ARF = never, AJF = never, ANF = never,
@@ -7529,7 +7529,7 @@ declare namespace JQuery {
          * @param doneFilter An optional function that is called when the Deferred is resolved.
          * @param failFilter An optional function that is called when the Deferred is rejected.
          * @param progressFilter An optional function that is called when progress notifications are sent to the Deferred.
-         * @see {@link https://api.jquery.com/deferred.then/}
+         * @see [deferred.then](https://api.jquery.com/deferred.then/)
          * @since 1.8
          */
         then<ARD = never, AJD = never, AND = never,
@@ -7552,7 +7552,7 @@ declare namespace JQuery {
          * Add handlers to be called when the Deferred object is rejected.
          *
          * @param failFilter A function that is called when the Deferred is rejected.
-         * @see {@link https://api.jquery.com/deferred.catch/}
+         * @see [deferred.catch](https://api.jquery.com/deferred.catch/)
          * @since 3.0
          */
         catch<ARF = never, AJF = never, ANF = never,
@@ -7613,7 +7613,7 @@ declare namespace JQuery {
     }
 
     /**
-     * @see {@link https://api.jquery.com/animate/#animate-properties-options}
+     * @see [animate](https://api.jquery.com/animate/)
      */
     interface EffectsOptions<TElement> {
         /**
@@ -7725,98 +7725,98 @@ declare namespace JQuery {
         /**
          * Indicates whether the META key was pressed when the event fired.
          *
-         * @see {@link https://api.jquery.com/event.metaKey/}
+         * @see [event.metaKey](https://api.jquery.com/event.metaKey/)
          * @since 1.0.4
          */
         metaKey: boolean;
         /**
          * The namespace specified when the event was triggered.
          *
-         * @see {@link https://api.jquery.com/event.namespace/}
+         * @see [event.namespace](https://api.jquery.com/event.namespace/)
          * @since 1.4.3
          */
         namespace: string;
         /**
          * The mouse position relative to the left edge of the document.
          *
-         * @see {@link https://api.jquery.com/event.pageX/}
+         * @see [event.pageX](https://api.jquery.com/event.pageX/)
          * @since 1.0.4
          */
         pageX: number;
         /**
          * The mouse position relative to the top edge of the document.
          *
-         * @see {@link https://api.jquery.com/event.pageY/}
+         * @see [event.pageY](https://api.jquery.com/event.pageY/)
          * @since 1.0.4
          */
         pageY: number;
         /**
          * The last value returned by an event handler that was triggered by this event, unless the value was undefined.
          *
-         * @see {@link https://api.jquery.com/event.result/}
+         * @see [event.result](https://api.jquery.com/event.result/)
          * @since 1.3
          */
         result: any;
         /**
          * The difference in milliseconds between the time the browser created the event and January 1, 1970.
          *
-         * @see {@link https://api.jquery.com/event.timeStamp/}
+         * @see [event.timeStamp](https://api.jquery.com/event.timeStamp/)
          * @since 1.2.6
          */
         timeStamp: number;
         /**
          * Describes the nature of the event.
          *
-         * @see {@link https://api.jquery.com/event.type/}
+         * @see [event.type](https://api.jquery.com/event.type/)
          * @since 1.0
          */
         type: string;
         /**
          * For key or mouse events, this property indicates the specific key or button that was pressed.
          *
-         * @see {@link https://api.jquery.com/event.which/}
+         * @see [event.which](https://api.jquery.com/event.which/)
          * @since 1.1.3
          */
         which: number;
         /**
          * Returns whether event.preventDefault() was ever called on this event object.
          *
-         * @see {@link https://api.jquery.com/event.isDefaultPrevented/}
+         * @see [event.isDefaultPrevented](https://api.jquery.com/event.isDefaultPrevented/)
          * @since 1.3
          */
         isDefaultPrevented(): boolean;
         /**
          * Returns whether event.stopImmediatePropagation() was ever called on this event object.
          *
-         * @see {@link https://api.jquery.com/event.isImmediatePropagationStopped/}
+         * @see [event.isImmediatePropagationStopped](https://api.jquery.com/event.isImmediatePropagationStopped/)
          * @since 1.3
          */
         isImmediatePropagationStopped(): boolean;
         /**
          * Returns whether event.stopPropagation() was ever called on this event object.
          *
-         * @see {@link https://api.jquery.com/event.isPropagationStopped/}
+         * @see [event.isPropagationStopped](https://api.jquery.com/event.isPropagationStopped/)
          * @since 1.3
          */
         isPropagationStopped(): boolean;
         /**
          * If this method is called, the default action of the event will not be triggered.
          *
-         * @see {@link https://api.jquery.com/event.preventDefault/}
+         * @see [event.preventDefault](https://api.jquery.com/event.preventDefault/)
          * @since 1.0
          */
         preventDefault(): void;
         /**
          * Keeps the rest of the handlers from being executed and prevents the event from bubbling up the DOM tree.
          *
-         * @see {@link https://api.jquery.com/event.stopImmediatePropagation/}
+         * @see [event.stopImmediatePropagation](https://api.jquery.com/event.stopImmediatePropagation/)
          * @since 1.3
          */
         stopImmediatePropagation(): void;
         /**
          * Prevents the event from bubbling up the DOM tree, preventing any parent handlers from being notified of the event.
          *
-         * @see {@link https://api.jquery.com/event.stopPropagation/}
+         * @see [event.stopPropagation](https://api.jquery.com/event.stopPropagation/)
          * @since 1.0
          */
         stopPropagation(): void;
@@ -7831,21 +7831,21 @@ declare namespace JQuery {
         /**
          * The current DOM element within the event bubbling phase.
          *
-         * @see {@link https://api.jquery.com/event.currentTarget/}
+         * @see [event.currentTarget](https://api.jquery.com/event.currentTarget/)
          * @since 1.3
          */
         currentTarget: TTarget;
         /**
          * An optional object of data passed to an event method when the current executing handler is bound.
          *
-         * @see {@link https://api.jquery.com/event.data/}
+         * @see [event.data](https://api.jquery.com/event.data/)
          * @since 1.1
          */
         data: TData;
         /**
          * The element where the currently-called jQuery event handler was attached.
          *
-         * @see {@link https://api.jquery.com/event.delegateTarget/}
+         * @see [event.delegateTarget](https://api.jquery.com/event.delegateTarget/)
          * @since 1.7
          */
         delegateTarget: TTarget;
@@ -7853,14 +7853,14 @@ declare namespace JQuery {
         /**
          * The other DOM element involved in the event, if any.
          *
-         * @see {@link https://api.jquery.com/event.relatedTarget/}
+         * @see [event.relatedTarget](https://api.jquery.com/event.relatedTarget/)
          * @since 1.1.4
          */
         relatedTarget: TTarget | null;
         /**
          * The DOM element that initiated the event.
          *
-         * @see {@link https://api.jquery.com/event.target/}
+         * @see [event.target](https://api.jquery.com/event.target/)
          * @since 1.0
          */
         target: TTarget;
@@ -8067,92 +8067,92 @@ interface JQueryParam {
 interface BaseJQueryEventObject extends Event {
     /**
      * The current DOM element within the event bubbling phase.
-     * @see {@link https://api.jquery.com/event.currentTarget/}
+     * @see [event.currentTarget](https://api.jquery.com/event.currentTarget/)
      */
     currentTarget: Element;
     /**
      * An optional object of data passed to an event method when the current executing handler is bound.
-     * @see {@link https://api.jquery.com/event.data/}
+     * @see [event.data](https://api.jquery.com/event.data/)
      */
     data: any;
     /**
      * The element where the currently-called jQuery event handler was attached.
-     * @see {@link https://api.jquery.com/event.delegateTarget/}
+     * @see [event.delegateTarget](https://api.jquery.com/event.delegateTarget/)
      */
     delegateTarget: Element;
     /**
      * Returns whether event.preventDefault() was ever called on this event object.
-     * @see {@link https://api.jquery.com/event.isDefaultPrevented/}
+     * @see [event.isDefaultPrevented](https://api.jquery.com/event.isDefaultPrevented/)
      */
     isDefaultPrevented(): boolean;
     /**
      * Returns whether event.stopImmediatePropagation() was ever called on this event object.
-     * @see {@link https://api.jquery.com/event.isImmediatePropagationStopped/}
+     * @see [event.isImmediatePropagationStopped](https://api.jquery.com/event.isImmediatePropagationStopped/)
      */
     isImmediatePropagationStopped(): boolean;
     /**
      * Returns whether event.stopPropagation() was ever called on this event object.
-     * @see {@link https://api.jquery.com/event.isPropagationStopped/}
+     * @see [event.isPropagationStopped](https://api.jquery.com/event.isPropagationStopped/)
      */
     isPropagationStopped(): boolean;
     /**
      * The namespace specified when the event was triggered.
-     * @see {@link https://api.jquery.com/event.namespace/}
+     * @see [event.namespace](https://api.jquery.com/event.namespace/)
      */
     namespace: string;
     /**
      * The browser's original Event object.
-     * @see {@link https://api.jquery.com/category/events/event-object/}
+     * @see [category](https://api.jquery.com/category/)
      */
     originalEvent: Event;
     /**
      * If this method is called, the default action of the event will not be triggered.
-     * @see {@link https://api.jquery.com/event.preventDefault/}
+     * @see [event.preventDefault](https://api.jquery.com/event.preventDefault/)
      */
     preventDefault(): any;
     /**
      * The other DOM element involved in the event, if any.
-     * @see {@link https://api.jquery.com/event.relatedTarget/}
+     * @see [event.relatedTarget](https://api.jquery.com/event.relatedTarget/)
      */
     relatedTarget: Element;
     /**
      * The last value returned by an event handler that was triggered by this event, unless the value was undefined.
-     * @see {@link https://api.jquery.com/event.result/}
+     * @see [event.result](https://api.jquery.com/event.result/)
      */
     result: any;
     /**
      * Keeps the rest of the handlers from being executed and prevents the event from bubbling up the DOM tree.
-     * @see {@link https://api.jquery.com/event.stopImmediatePropagation/}
+     * @see [event.stopImmediatePropagation](https://api.jquery.com/event.stopImmediatePropagation/)
      */
     stopImmediatePropagation(): void;
     /**
      * Prevents the event from bubbling up the DOM tree, preventing any parent handlers from being notified of the event.
-     * @see {@link https://api.jquery.com/event.stopPropagation/}
+     * @see [event.stopPropagation](https://api.jquery.com/event.stopPropagation/)
      */
     stopPropagation(): void;
     /**
      * The DOM element that initiated the event.
-     * @see {@link https://api.jquery.com/event.target/}
+     * @see [event.target](https://api.jquery.com/event.target/)
      */
     target: Element;
     /**
      * The mouse position relative to the left edge of the document.
-     * @see {@link https://api.jquery.com/event.pageX/}
+     * @see [event.pageX](https://api.jquery.com/event.pageX/)
      */
     pageX: number;
     /**
      * The mouse position relative to the top edge of the document.
-     * @see {@link https://api.jquery.com/event.pageY/}
+     * @see [event.pageY](https://api.jquery.com/event.pageY/)
      */
     pageY: number;
     /**
      * For key or mouse events, this property indicates the specific key or button that was pressed.
-     * @see {@link https://api.jquery.com/event.which/}
+     * @see [event.which](https://api.jquery.com/event.which/)
      */
     which: number;
     /**
      * Indicates whether the META key was pressed when the event fired.
-     * @see {@link https://api.jquery.com/event.metaKey/}
+     * @see [event.metaKey](https://api.jquery.com/event.metaKey/)
      */
     metaKey: boolean;
 }


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
-----------------------------------
This PR only applied a change to fix a bug noticed by Microsoft/TypeScript#16498, to make the link in JSDoc parsed correctly in VSCode.
This change is only a batch replacement base on regular expressions(`\{@link https?(:\/\/api\.jquery\.com\/)([^\/]+)\/[^\}]*\}` => `[$2](https$1$2/)`), so maybe there are some links using incorrect title.
This change also fix the link using `http` protocol to `https`.

Before the edit:
![Before the edit](https://user-images.githubusercontent.com/9762652/39125200-c48360b4-4730-11e8-9693-78603650fb2a.png)
After the edit:
![After the edit:](https://user-images.githubusercontent.com/9762652/39144265-dde3cf76-4762-11e8-9185-3ff33743b8da.png)
(Please forgive my poor English:)