### PR TITLE
Add type definitions for base64-arraybuffer

### DIFF
--- a/types/base64-arraybuffer/base64-arraybuffer-tests.ts
+++ b/types/base64-arraybuffer/base64-arraybuffer-tests.ts
@@ -1,0 +1,4 @@
+import { encode, decode } from 'base64-arraybuffer';
+
+encode(new Float32Array([1, 2, 3]).buffer); // $ExpectType string
+decode('AACAPwAAAEAAAEBA'); // $ExpectType ArrayBuffer

--- a/types/base64-arraybuffer/index.d.ts
+++ b/types/base64-arraybuffer/index.d.ts
@@ -1,0 +1,7 @@
+// Type definitions for base64-arraybuffer 0.1.5
+// Project: https://github.com/niklasvh/base64-arraybuffer
+// Definitions by: Ben Cook <https://github.com/jbencook>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export function encode(arraybuffer: ArrayBuffer): string;
+export function decode(base64: string): ArrayBuffer;

--- a/types/base64-arraybuffer/index.d.ts
+++ b/types/base64-arraybuffer/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for base64-arraybuffer 0.1.5
+// Type definitions for base64-arraybuffer 0.1
 // Project: https://github.com/niklasvh/base64-arraybuffer
 // Definitions by: Ben Cook <https://github.com/jbencook>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/base64-arraybuffer/tsconfig.json
+++ b/types/base64-arraybuffer/tsconfig.json
@@ -7,6 +7,7 @@
         "noImplicitAny": true,
         "noImplicitThis": true,
         "strictNullChecks": true,
+        "strictFunctionTypes": true,
         "baseUrl": "../",
         "typeRoots": [
             "../"

--- a/types/base64-arraybuffer/tsconfig.json
+++ b/types/base64-arraybuffer/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "base64-arraybuffer-tests.ts"
+    ]
+}

--- a/types/base64-arraybuffer/tslint.json
+++ b/types/base64-arraybuffer/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.