### PR TITLE
[Cucumber]: Update property name to uri under SourceLocation to match Cucumber API

### DIFF
--- a/types/cucumber/index.d.ts
+++ b/types/cucumber/index.d.ts
@@ -81,7 +81,7 @@ export interface HookScenarioResult {
 
 export interface SourceLocation {
     line: number;
-    url: string;
+    uri: string;
 }
 
 export interface ScenarioResult {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
CucumberJS API reference for `After` hook that passes uri property and not url in the object parameter for the callback function of the hook`: {sourceLocation: {line, uri}`<<https://github.com/cucumber/cucumber-js/blob/a33145c0dc35455a157654496c29db789f0ffc35/docs/support_files/api_reference.md#afteroptions-fn>>