### PR TITLE
[@type/elasticsearch] Change string type to any in connectionClass

### DIFF
--- a/types/elasticsearch/elasticsearch-tests.ts
+++ b/types/elasticsearch/elasticsearch-tests.ts
@@ -1,8 +1,20 @@
 import * as elasticsearch from "elasticsearch";
+import HttpConnector = require("elasticsearch/src/lib/connectors/http");
+
+class MyHttpConnector extends HttpConnector {
+  constructor(host: any, config: any) {
+    super(host, config);
+  }
+}
 
 let client = new elasticsearch.Client({
   host: 'localhost:9200',
   log: 'trace'
+});
+
+client = new elasticsearch.Client({
+  host: 'localhost:9200',
+  connectionClass: MyHttpConnector
 });
 
 client = new elasticsearch.Client({

--- a/types/elasticsearch/index.d.ts
+++ b/types/elasticsearch/index.d.ts
@@ -12,6 +12,8 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
+import HttpConnector = require("./src/lib/connectors/http");
+
 export class Client {
     constructor(params: ConfigOptions);
     cat: Cat;
@@ -111,7 +113,7 @@ export interface ConfigOptions {
     keepAlive?: boolean;
     maxSockets?: number;
     suggestCompression?: boolean;
-    connectionClass?: any;
+    connectionClass?: string | typeof HttpConnector;
     sniffedNodesProtocol?: string;
     ssl?: object;
     selector?: any;

--- a/types/elasticsearch/index.d.ts
+++ b/types/elasticsearch/index.d.ts
@@ -111,7 +111,7 @@ export interface ConfigOptions {
     keepAlive?: boolean;
     maxSockets?: number;
     suggestCompression?: boolean;
-    connectionClass?: string;
+    connectionClass?: any;
     sniffedNodesProtocol?: string;
     ssl?: object;
     selector?: any;

--- a/types/elasticsearch/src/lib/connectors/http.d.ts
+++ b/types/elasticsearch/src/lib/connectors/http.d.ts
@@ -1,0 +1,13 @@
+// HttpConnector for elasticsearch
+
+export = HttpConnector;
+
+declare class HttpConnector {
+    constructor(host: any, config: any);
+
+    // onStatusSet(handler: (status: any) => void): void;
+    createAgent(config: any): any;
+    makeAgentConfig(config: any): any;
+    makeReqParams(params: any): any;
+    request(params: any, callback: (error: any, response: any, status: any, headers: any) => void): void;
+}


### PR DESCRIPTION
`connectionClass` can not be `string` type. I use my custom `HttpConnector` for sending custom request.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/current/extending_core_components.html
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

