### PR TITLE
react-loadable: add correct type for `LoadingComponentProps.error`

### DIFF
--- a/types/react-loadable/index.d.ts
+++ b/types/react-loadable/index.d.ts
@@ -5,6 +5,7 @@
 //                 Ian Ker-Seymer <https://github.com/ianks>
 //                 Tomek Łaziuk <https://github.com/tlaziuk>
 //                 Ian Mobley <https://github.com/iMobs>
+//                 Wu Haotian <https://github.com/whtsky>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.6
 
@@ -15,7 +16,7 @@ declare namespace LoadableExport {
         isLoading: boolean;
         pastDelay: boolean;
         timedOut: boolean;
-        error: any;
+        error: Error | false;
     }
 
     type Options<Props, Exports extends object> = OptionsWithoutRender<Props> | OptionsWithRender<Props, Exports>;

--- a/types/react-loadable/test/index.tsx
+++ b/types/react-loadable/test/index.tsx
@@ -6,6 +6,7 @@ class LoadingComponent extends React.Component<Loadable.LoadingComponentProps> {
     return (
       <div>
         {this.props.error}
+        {this.props.error && this.props.error.message}
         {this.props.isLoading}
         {this.props.pastDelay}
         {this.props.timedOut}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/jamiebuilds/react-loadable#loading-error-states
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
