### PR TITLE
[restangular] id property of element can be either a string or a number

### DIFF
--- a/types/restangular/index.d.ts
+++ b/types/restangular/index.d.ts
@@ -128,7 +128,7 @@ declare namespace restangular {
     getRestangularUrl(): string;
     getRequestedUrl(): string;
     route?: string;
-    id?: string;
+    id?: number | string;
     reqParams?: any;
   }
 


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: No real doc, but all examples or Restangular use `number` for their `id`s (https://github.com/mgonto/restangular)
- [x] Increase the version number in the header if appropriate (not appropriate)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. (no substantial changes)

**Notes**

Following this commit https://github.com/DefinitelyTyped/DefinitelyTyped/pull/9240/files/83dcde9de2c6259aeafab1c0c68929bea0f95a2d#r64597763, It is clear that this property should be typed `number | string`, not only `string`

cc @brendon-colburn 