### PR TITLE
Add ReactCreatableSelectProps

### DIFF
--- a/types/react-virtualized-select/index.d.ts
+++ b/types/react-virtualized-select/index.d.ts
@@ -5,7 +5,7 @@
 // TypeScript Version: 2.6
 
 import * as React from "react";
-import { ReactSelectProps, ReactAsyncSelectProps, LoadOptionsHandler, OptionValues } from "react-select";
+import { ReactSelectProps, ReactAsyncSelectProps, ReactCreatableSelectProps, LoadOptionsHandler, OptionValues } from "react-select";
 import { ListProps } from "react-virtualized";
 
 export interface VirtualizedOptionRenderOptions<T> {
@@ -29,8 +29,8 @@ export interface AdditionalVirtualizedSelectProps<TValue> {
     selectComponent?: React.ComponentClass<any> | React.StatelessComponent<any>;
 }
 
-type VirtualizedSelectProps<TValue = OptionValues> = (ReactAsyncSelectProps<TValue> & AdditionalVirtualizedSelectProps<TValue> & { async: true }) |
-    ReactSelectProps<TValue> & AdditionalVirtualizedSelectProps<TValue>;
+type VirtualizedSelectProps<TValue = OptionValues> = (ReactCreatableSelectProps<TValue> & ReactAsyncSelectProps<TValue> & AdditionalVirtualizedSelectProps<TValue> & { async: true }) |
+    ReactCreatableSelectProps<TValue> & ReactSelectProps<TValue> & AdditionalVirtualizedSelectProps<TValue>;
 
 declare class VirtualizedSelect<TValue = OptionValues> extends React.PureComponent<VirtualizedSelectProps<TValue>> {}
 export default VirtualizedSelect;

--- a/types/react-virtualized-select/react-virtualized-select-tests.tsx
+++ b/types/react-virtualized-select/react-virtualized-select-tests.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import Select from "react-select";
+import Select, * as ReactSelect from "react-select";
 import VirtualizedSelect from "react-virtualized-select";
 
 /*Example TValue.*/
@@ -9,6 +9,9 @@ interface Example {
 
 /*Example generic class.*/
 class ExampleSelectAsync extends VirtualizedSelect<Example> {
+}
+
+class ExampleSelectCreatable extends VirtualizedSelect<Example> {
 }
 
 <div>
@@ -23,7 +26,10 @@ class ExampleSelectAsync extends VirtualizedSelect<Example> {
 	  maxHeight={0}
 	  optionHeight={0}
 	  optionRenderer={() => <div/>}
-	  selectComponent={Select}
-	  loadOptions={(input: string) => Promise.resolve([{name: 'Hi'}])}
+      selectComponent={Select}
+      loadOptions={(input: string) => Promise.resolve([{name: 'Hi'}])}
+	/>
+	<ExampleSelectCreatable selectComponent={ReactSelect.Creatable}
+	  isValidNewOption={(arg: {label: string}) => arg.label.length > 1}
 	/>
 </div>;

--- a/types/react-virtualized-select/react-virtualized-select-tests.tsx
+++ b/types/react-virtualized-select/react-virtualized-select-tests.tsx
@@ -4,7 +4,7 @@ import VirtualizedSelect from "react-virtualized-select";
 
 /*Example TValue.*/
 interface Example {
-	name: string;
+    name: string;
 }
 
 /*Example generic class.*/
@@ -15,21 +15,22 @@ class ExampleSelectCreatable extends VirtualizedSelect<Example> {
 }
 
 <div>
-	<VirtualizedSelect
-	  maxHeight={0}
-	  optionHeight={0}
-	  optionRenderer={() => <div/>}
-	  selectComponent={Select}
-	  options={[]}
-	/>
-	<ExampleSelectAsync async={true}
-	  maxHeight={0}
-	  optionHeight={0}
-	  optionRenderer={() => <div/>}
+    <VirtualizedSelect
+      maxHeight={0}
+      optionHeight={0}
+      optionRenderer={() => <div/>}
+      selectComponent={Select}
+      options={[]}
+    />
+    <ExampleSelectAsync async={true}
+      maxHeight={0}
+      optionHeight={0}
+      optionRenderer={() => <div/>}
       selectComponent={Select}
       loadOptions={(input: string) => Promise.resolve([{name: 'Hi'}])}
-	/>
-	<ExampleSelectCreatable selectComponent={ReactSelect.Creatable}
-	  isValidNewOption={(arg: {label: string}) => arg.label.length > 1}
-	/>
+    />
+    <ExampleSelectCreatable
+      selectComponent={ReactSelect.Creatable}
+      isValidNewOption={(arg: {label: string}) => arg.label.length > 1}
+    />
 </div>;


### PR DESCRIPTION
react-virtualized-select allows picking the actual component via the selectComponent property, so it is possible to use Select.Creatable to create a react-select component that allows creating new options on the fly. However, we're lacking the corresponding props in TS.

This PR adds the props to the Typescript definition.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
