### PR TITLE
Add missing fetch types compatible with TS 2.6+

### DIFF
--- a/types/react-native/globals.d.ts
+++ b/types/react-native/globals.d.ts
@@ -21,4 +21,95 @@ declare function requestAnimationFrame(callback: (time: number) => void): number
 
 declare function fetchBundle(bundleId: number, callback: (error?: Error | null) => void): void;
 
-declare function fetch(input: RequestInfo, init?: RequestInit): Promise<Response>;
+//
+// Fetch API
+//
+
+declare function fetch(input: Request | string, init?: RequestInit): Promise<Response>;
+
+interface Blob {}
+
+declare interface FormData {
+  append(name: string, value: any): void;
+}
+
+declare interface Body {
+  readonly bodyUsed: boolean;
+  arrayBuffer(): Promise<ArrayBuffer>;
+  blob(): Promise<Blob>;
+  json(): Promise<any>;
+  text(): Promise<string>;
+  formData(): Promise<FormData>;
+}
+
+declare interface Headers {
+  append(name: string, value: string): void;
+  delete(name: string): void;
+  forEach(callback: Function, thisArg?: any): void;
+  get(name: string): string | null;
+  has(name: string): boolean;
+  set(name: string, value: string): void;
+}
+
+declare var Headers: {
+  prototype: Headers;
+  new(init?: HeadersInit_): Headers;
+};
+
+type BodyInit_ = Blob | Int8Array | Int16Array | Int32Array | Uint8Array | Uint16Array | Uint32Array | Uint8ClampedArray | Float32Array | Float64Array | DataView | ArrayBuffer | FormData | string | null;
+
+declare interface RequestInit {
+  body?: BodyInit_;
+  credentials?: RequestCredentials_;
+  headers?: HeadersInit_;
+  integrity?: string;
+  keepalive?: boolean;
+  method?: string;
+  mode?: RequestMode_;
+  referrer?: string;
+  window?: any;
+}
+
+declare interface Request extends Object, Body {
+  readonly credentials: RequestCredentials_;
+  readonly headers: Headers;
+  readonly method: string;
+  readonly mode: RequestMode_;
+  readonly referrer: string;
+  readonly url: string;
+  clone(): Request;
+}
+
+declare var Request: {
+  prototype: Request;
+  new(input: Request | string, init?: RequestInit): Request;
+};
+
+declare interface ResponseInit {
+  headers?: HeadersInit_;
+  status?: number;
+  statusText?: string;
+}
+
+declare interface Response extends Object, Body {
+  readonly headers: Headers;
+  readonly ok: boolean;
+  readonly status: number;
+  readonly statusText: string;
+  readonly type: ResponseType_;
+  readonly url: string;
+  readonly redirected: boolean;
+  clone(): Response;
+}
+
+declare var Response: {
+  prototype: Response;
+  new(body?: BodyInit_, init?: ResponseInit): Response;
+  error: () => Response;
+  redirect: (url: string, status?: number) => Response;
+};
+
+type HeadersInit_ = Headers | string[][] | { [key: string]: string };
+type RequestCredentials_ = "omit" | "same-origin" | "include";
+type RequestMode_ = "navigate" | "same-origin" | "no-cors" | "cors";
+type ResponseType_ = "basic" | "cors" | "default" | "error" | "opaque" | "opaqueredirect";


### PR DESCRIPTION
This PR addresses the missing Fetch interfaces (see #19840): `RequestInfo`, `RequestInit`, and  `Response`.
It uses definitions taken from TypeScript 2.8 libraries. It's important to note that the type declaration for `body` on `RequestInit` changed between TypeScript 2.7 and 2.8. I chose the 2.8 declaration because that will be the declaration going forward, and it seems more correct to target the current and future declaration. This means that applications using TypeScript 2.6 and 2.7 might need to remove the "dom" library from `tsconfig.json` to fix compile errors. This is recommended anyway since the DOM API has never been available in React Native. 

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).


- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://facebook.github.io/react-native/docs/network.html
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.