### PR TITLE
[restangular] extendModel and extendCollection belongs to IProvider

### DIFF
--- a/types/restangular/index.d.ts
+++ b/types/restangular/index.d.ts
@@ -69,8 +69,8 @@ declare namespace restangular {
     setSelfLinkAbsoluteUrl(value: boolean): IProvider;
     setParentless(value: any): IProvider;
     setPlainByDefault(isPlain: boolean): IProvider;
-    extendModel(route: string, extender: (model: IElement) => any): void;
-    extendCollection(route: string, extender: (collection: ICollection) => any): void;
+    extendModel(route: string, extender: (model: IElement) => any): IProvider;
+    extendCollection(route: string, extender: (collection: ICollection) => any): IProvider;
   }
 
   interface ICustom {

--- a/types/restangular/index.d.ts
+++ b/types/restangular/index.d.ts
@@ -69,6 +69,8 @@ declare namespace restangular {
     setSelfLinkAbsoluteUrl(value: boolean): IProvider;
     setParentless(value: any): IProvider;
     setPlainByDefault(isPlain: boolean): IProvider;
+    extendModel(route: string, extender: (model: IElement) => any): void;
+    extendCollection(route: string, extender: (collection: ICollection) => any): void;
   }
 
   interface ICustom {
@@ -94,8 +96,6 @@ declare namespace restangular {
     restangularizeCollection(parent: any, element: any, route: string): ICollection;
     service(route: string, parent?: any): IScopedService;
     stripRestangular(element: any): any;
-    extendModel(route: string, extender: (model: IElement) => any): void;
-    extendCollection(route: string, extender: (collection: ICollection) => any): void;
   }
 
   interface IScopedService extends IService {

--- a/types/restangular/restangular-tests.ts
+++ b/types/restangular/restangular-tests.ts
@@ -27,6 +27,16 @@ myApp.config((RestangularProvider: restangular.IProvider) => {
       return elem;
   });
 
+  RestangularProvider.extendModel('accounts', function(model: any) {
+    model.prettifyAmount = function() {};
+    return model;
+  });
+
+  RestangularProvider.extendCollection('accounts', function(collection: any) {
+    collection.totalAmount = function() {};
+    return collection;
+  });
+
   RestangularProvider.setRestangularFields({
     id: "_id",
     route: "restangularRoute",


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [extendModel](https://github.com/mgonto/restangular#adding-custom-methods-to-models), [extendCollection](https://github.com/mgonto/restangular#adding-custom-methods-to-collections)
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

**Rationale**

`extendModel` is an alias for `Restangular.addElementTransformer(route, false, fn);`, and `extendCollection` is an alias for `Restangular.addElementTransformer(route, true, fn);`. The function [`addElementTransformer`](https://github.com/mgonto/restangular#addelementtransformer) is generally use with the provider in the doc (`RestangularProvider.addElementTransformer`), and sometimes in the Service `Restangular.addElementTransformer`.

The current version of the typings allows the use of `addElementTransformer` in both `IProvider` and `IService`.  
We also need to be able to call extendModel and extendCollection in the `IProvider`. Since `IService extends IProvider`, this will not cause any regression.

[Relevant portion of Restangular code](https://github.com/mgonto/restangular/blob/master/src/restangular.js#L477):

```
object.extendCollection = function(route, fn) {
  return object.addElementTransformer(route, true, fn);
};

object.extendModel = function(route, fn) {
  return object.addElementTransformer(route, false, fn);
};
```

Also changed the return type, it returns the object itself, not void.