### PR TITLE
[expo]: Add missing interfaces/classes for AdMob module.

### DIFF
--- a/types/expo/expo-tests.tsx
+++ b/types/expo/expo-tests.tsx
@@ -3,6 +3,10 @@ import { Text } from 'react-native';
 
 import {
     Accelerometer,
+    AdMobAppEvent,
+    AdMobBanner,
+    AdMobInterstitial,
+    AdMobRewarded,
     Amplitude,
     Asset,
     AuthSession,
@@ -26,6 +30,7 @@ import {
     KeepAwake,
     LinearGradient,
     Permissions,
+    PublisherBanner,
     registerRootComponent,
     ScreenOrientation,
     SQLite,
@@ -46,6 +51,41 @@ Accelerometer.addListener((obj) => {
 });
 Accelerometer.removeAllListeners();
 Accelerometer.setUpdateInterval(1000);
+
+() => (
+    <AdMobBanner
+        bannerSize="leaderboard"
+        adUnitID="ca-app-pub-3940256099942544/6300978111"
+        testDeviceID="EMULATOR"
+        didFailToReceiveAdWithError={(error: string) => console.log(error)}
+        style={{ flex: 1 }}
+    />
+);
+
+() => (
+    <PublisherBanner
+        bannerSize="leaderboard"
+        adUnitID="ca-app-pub-3940256099942544/6300978111"
+        testDeviceID="EMULATOR"
+        didFailToReceiveAdWithError={(error: string) => console.log(error)}
+        onAdMobDispatchAppEvent={(event: AdMobAppEvent) => console.log(event)}
+        style={{ flex: 1 }}
+    />
+);
+
+AdMobInterstitial.setAdUnitID('ca-app-pub-3940256099942544/1033173712'); // Test ID, Replace with your-admob-unit-id
+AdMobInterstitial.setTestDeviceID('EMULATOR');
+async () => {
+    await AdMobInterstitial.requestAdAsync();
+    await AdMobInterstitial.showAdAsync();
+};
+
+AdMobRewarded.setAdUnitID('ca-app-pub-3940256099942544/1033173712'); // Test ID, Replace with your-admob-unit-id
+AdMobRewarded.setTestDeviceID('EMULATOR');
+async () => {
+    await AdMobRewarded.requestAdAsync();
+    await AdMobRewarded.showAdAsync();
+};
 
 Amplitude.initialize('key');
 Amplitude.setUserId('userId');

--- a/types/expo/index.d.ts
+++ b/types/expo/index.d.ts
@@ -93,12 +93,12 @@ export interface PublisherBannerProperties extends AdMobBannerProperties {
 }
 export class PublisherBanner extends Component<PublisherBannerProperties> { }
 
-export type AdMobInterstitialEvent =
+export type AdMobInterstitialEmptyEvent =
     | 'interstitialDidLoad'
-    | 'interstitialDidFailToLoad'
     | 'interstitialDidOpen'
     | 'interstitialDidClose'
     | 'interstitialWillLeaveApplication';
+export type AdMobInterstitialEvent = AdMobInterstitialEmptyEvent | 'interstitialDidFailToLoad';
 export namespace AdMobInterstitial {
     function setAdUnitID(id: string): void;
     function setTestDeviceID(id: string): void;
@@ -106,19 +106,20 @@ export namespace AdMobInterstitial {
     function showAdAsync(): Promise<void>;
     function dismissAdAsync(): Promise<void>;
     function getIsReadyAsync(): Promise<boolean>;
-    function addEventListener(event: AdMobInterstitialEvent, handler: () => void): EventSubscription;
-    function removeEventListener(event: AdMobInterstitialEvent, handler: () => void): void;
+    function addEventListener(event: 'interstitialDidFailToLoad', handler: (error: string) => void): void;
+    function addEventListener(event: AdMobInterstitialEmptyEvent, handler: () => void): void;
+    function removeEventListener(event: 'interstitialDidFailToLoad', handler: (error: string) => void): void;
+    function removeEventListener(event: AdMobInterstitialEmptyEvent, handler: () => void): void;
     function removeAllListeners(): void;
 }
 
-export type AdMobRewardedEvent =
-    | 'rewardedVideoDidRewardUser'
+export type AdMobRewardedEmptyEvent =
     | 'rewardedVideoDidLoad'
-    | 'rewardedVideoDidFailToLoad'
     | 'rewardedVideoDidOpen'
     | 'rewardedVideoDidStart'
     | 'rewardedVideoDidClose'
     | 'rewardedVideoWillLeaveApplication';
+export type AdMobRewardedEvent = AdMobRewardedEmptyEvent | 'rewardedVideoDidRewardUser' | 'rewardedVideoDidFailToLoad';
 export namespace AdMobRewarded {
     function setAdUnitID(id: string): void;
     function setTestDeviceID(id: string): void;
@@ -126,8 +127,12 @@ export namespace AdMobRewarded {
     function showAdAsync(): Promise<void>;
     function dismissAdAsync(): Promise<void>;
     function getIsReadyAsync(): Promise<boolean>;
-    function addEventListener(event: AdMobRewardedEvent, handler: () => void): EventSubscription;
-    function removeEventListener(event: AdMobRewardedEvent, handler: () => void): void;
+    function addEventListener(event: 'rewardedVideoDidRewardUser', handler: (type: string, amount: number) => void): void;
+    function addEventListener(event: 'rewardedVideoDidFailToLoad', handler: (error: string) => void): void;
+    function addEventListener(event: AdMobRewardedEmptyEvent, handler: () => void): void;
+    function removeEventListener(event: 'rewardedVideoDidRewardUser', handler: (type: string, amount: number) => void): void;
+    function removeEventListener(event: 'rewardedVideoDidFailToLoad', handler: (error: string) => void): void;
+    function removeEventListener(event: AdMobRewardedEmptyEvent, handler: () => void): void;
     function removeAllListeners(): void;
 }
 

--- a/types/expo/index.d.ts
+++ b/types/expo/index.d.ts
@@ -346,14 +346,14 @@ export namespace Audio {
         canRecord: false,
         isDoneRecording: false
     } | {
-            canRecord: true,
-            isRecording: boolean,
-            durationMillis: number
-        } | {
-            canRecord: false,
-            isDoneRecording: true,
-            durationMillis: number
-        };
+        canRecord: true,
+        isRecording: boolean,
+        durationMillis: number
+    } | {
+        canRecord: false,
+        isDoneRecording: true,
+        durationMillis: number
+    };
 
     const RECORDING_OPTIONS_PRESET_HIGH_QUALITY: RecordingOptions;
     const RECORDING_OPTIONS_PRESET_LOW_QUALITY: RecordingOptions;
@@ -497,17 +497,17 @@ export namespace AuthSession {
     type StartAsyncResponse = {
         type: 'cancel';
     } | {
-            type: 'dismissed';
-        } | {
-            type: 'success';
-            params: HashMap;
-            event: HashMap;
-        } | {
-            type: 'error';
-            params: HashMap;
-            errorCode: string;
-            event: HashMap;
-        };
+        type: 'dismissed';
+    } | {
+        type: 'success';
+        params: HashMap;
+        event: HashMap;
+    } | {
+        type: 'error';
+        params: HashMap;
+        errorCode: string;
+        event: HashMap;
+    };
 
     function startAsync(options: { authUrl: string; returnUrl?: string; }): Promise<StartAsyncResponse>;
     function dismiss(): void;
@@ -525,25 +525,25 @@ export type PlaybackStatus = {
     /** Populated exactly once when an error forces the object to unload. */
     error?: string;
 } | {
-        isLoaded: true;
-        androidImplementation?: string;
-        uri: string;
-        progressUpdateIntervalMillis: number;
-        durationMillis?: number;
-        positionMillis: number;
-        playableDurationMillis?: number;
-        shouldPlay: boolean;
-        isPlaying: boolean;
-        isBuffering: boolean;
-        rate: number;
-        shouldCorrectPitch: boolean;
-        volume: number;
-        isMuted: boolean;
-        isLooping: boolean;
+    isLoaded: true;
+    androidImplementation?: string;
+    uri: string;
+    progressUpdateIntervalMillis: number;
+    durationMillis?: number;
+    positionMillis: number;
+    playableDurationMillis?: number;
+    shouldPlay: boolean;
+    isPlaying: boolean;
+    isBuffering: boolean;
+    rate: number;
+    shouldCorrectPitch: boolean;
+    volume: number;
+    isMuted: boolean;
+    isLooping: boolean;
 
-        /** True exactly once when the track plays to finish. */
-        didJustFinish: boolean;
-    };
+    /** True exactly once when the track plays to finish. */
+    didJustFinish: boolean;
+};
 
 export interface PlaybackStatusToSet {
     androidImplementation?: string;
@@ -1107,8 +1107,8 @@ export namespace DocumentPicker {
         name: string;
         size: number;
     } | {
-            type: 'cancel';
-        };
+        type: 'cancel';
+    };
 
     function getDocumentAsync(options?: Options): Promise<Response>;
 }
@@ -1282,9 +1282,9 @@ export namespace FileSystem {
         modificationTime: number;
         md5?: Md5;
     } | {
-            exists: false;
-            isDirectory: false;
-        };
+        exists: false;
+        isDirectory: false;
+    };
 
     interface DownloadResult {
         uri: string;
@@ -1353,11 +1353,11 @@ export namespace Fingerprint {
     type FingerprintAuthenticationResult = {
         success: true
     } | {
-            success: false,
+        success: false,
 
-            /** Error code in the case where authentication fails. */
-            error: string
-        };
+        /** Error code in the case where authentication fails. */
+        error: string
+    };
 
     /** Determine whether the Fingerprint scanner is available on the device. */
     function hasHardwareAsync(): Promise<boolean>;
@@ -1417,20 +1417,20 @@ export namespace Google {
     type LogInResult = {
         type: 'cancel';
     } | {
-            type: 'success';
-            accessToken: string;
-            idToken?: string;
-            refreshToken?: string;
-            serverAuthCode?: string;
-            user: {
-                id: string;
-                name: string;
-                givenName: string;
-                familyName: string;
-                photoUrl?: string;
-                email?: string;
-            }
-        };
+        type: 'success';
+        accessToken: string;
+        idToken?: string;
+        refreshToken?: string;
+        serverAuthCode?: string;
+        user: {
+            id: string;
+            name: string;
+            givenName: string;
+            familyName: string;
+            photoUrl?: string;
+            email?: string;
+        }
+    };
 
     function logInAsync(config: LogInConfig): Promise<LogInResult>;
 }

--- a/types/expo/v23/expo-tests.tsx
+++ b/types/expo/v23/expo-tests.tsx
@@ -2,6 +2,10 @@ import * as React from 'react';
 
 import {
     Accelerometer,
+    AdMobAppEvent,
+    AdMobBanner,
+    AdMobInterstitial,
+    AdMobRewarded,
     Amplitude,
     Asset,
     AuthSession,
@@ -16,7 +20,8 @@ import {
     Facebook,
     FacebookAds,
     FileSystem,
-	ImagePicker
+    ImagePicker,
+    PublisherBanner
 } from 'expo';
 
 Accelerometer.addListener((obj) => {
@@ -26,6 +31,35 @@ Accelerometer.addListener((obj) => {
 });
 Accelerometer.removeAllListeners();
 Accelerometer.setUpdateInterval(1000);
+
+() => (
+    <AdMobBanner
+        bannerSize="leaderboard"
+        adUnitID="ca-app-pub-3940256099942544/6300978111"
+        testDeviceID="EMULATOR"
+        didFailToReceiveAdWithError={(error: string) => console.log(error)}
+        style={{ flex: 1 }}
+    />
+);
+
+() => (
+    <PublisherBanner
+        bannerSize="leaderboard"
+        adUnitID="ca-app-pub-3940256099942544/6300978111"
+        testDeviceID="EMULATOR"
+        didFailToReceiveAdWithError={(error: string) => console.log(error)}
+        admobDispatchAppEvent={(event: AdMobAppEvent) => console.log(event)}
+        style={{ flex: 1 }}
+    />
+);
+
+AdMobInterstitial.setAdUnitID('ca-app-pub-3940256099942544/1033173712'); // Test ID, Replace with your-admob-unit-id
+AdMobInterstitial.setTestDeviceID('EMULATOR');
+AdMobInterstitial.requestAd(() => AdMobInterstitial.showAd());
+
+AdMobRewarded.setAdUnitID('ca-app-pub-3940256099942544/1033173712'); // Test ID, Replace with your-admob-unit-id
+AdMobRewarded.setTestDeviceID('EMULATOR');
+AdMobRewarded.requestAd(() => AdMobRewarded.showAd());
 
 Amplitude.initialize('key');
 Amplitude.setUserId('userId');

--- a/types/expo/v23/index.d.ts
+++ b/types/expo/v23/index.d.ts
@@ -76,55 +76,42 @@ export interface PublisherBannerProperties extends AdMobBannerProperties {
 }
 export class PublisherBanner extends Component<PublisherBannerProperties> { }
 
-export type AdMobInterstitialEvent =
+export type AdMobInterstitialEmptyEvent =
     | 'interstitialDidLoad'
-    | 'interstitialDidFailToLoad'
     | 'interstitialDidOpen'
     | 'interstitialDidClose'
     | 'interstitialWillLeaveApplication';
+export type AdMobInterstitialEvent = AdMobInterstitialEmptyEvent | 'interstitialVideoDidFailToLoad';
 export namespace AdMobInterstitial {
     function setAdUnitID(id: string): void;
     function setTestDeviceID(id: string): void;
     function requestAd(callback?: () => void): void;
     function showAd(callback?: (error: string) => void): void;
     function isReady(callback: (isReady: boolean) => void): void;
-    function addEventListener(event: 'interstitialDidLoad', handler: () => void): void;
     function addEventListener(event: 'interstitialDidFailToLoad', handler: (error: string) => void): void;
-    function addEventListener(event: 'interstitialDidOpen', handler: () => void): void;
-    function addEventListener(event: 'interstitialDidClose', handler: () => void): void;
-    function addEventListener(event: 'interstitialWillLeaveApplication', handler: () => void): void;
-    function removeEventListener(event: 'interstitialDidLoad', handler: () => void): void;
+    function addEventListener(event: AdMobInterstitialEmptyEvent, handler: () => void): void;
     function removeEventListener(event: 'interstitialDidFailToLoad', handler: (error: string) => void): void;
-    function removeEventListener(event: 'interstitialDidOpen', handler: () => void): void;
-    function removeEventListener(event: 'interstitialDidClose', handler: () => void): void;
-    function removeEventListener(event: 'interstitialWillLeaveApplication', handler: () => void): void;
+    function removeEventListener(event: AdMobInterstitialEmptyEvent, handler: () => void): void;
     function removeAllListeners(): void;
 }
 
-export type AdMobRewardedEvent =
-    | 'rewardedVideoDidRewardUser'
+export type AdMobRewardedEmptyEvent =
     | 'rewardedVideoDidLoad'
-    | 'rewardedVideoDidFailToLoad'
     | 'rewardedVideoDidOpen'
     | 'rewardedVideoDidClose'
     | 'rewardedVideoWillLeaveApplication';
+export type AdMobRewardedEvent = AdMobRewardedEmptyEvent | 'rewardedVideoDidRewardUser' | 'rewardedVideoDidFailToLoad';
 export namespace AdMobRewarded {
     function setAdUnitID(id: string): void;
     function setTestDeviceID(id: string): void;
     function requestAd(callback?: () => void): void;
     function showAd(callback?: (error: string) => void): void;
     function addEventListener(event: 'rewardedVideoDidRewardUser', handler: (type: string, amount: number) => void): void;
-    function addEventListener(event: 'rewardedVideoDidLoad', handler: () => void): void;
     function addEventListener(event: 'rewardedVideoDidFailToLoad', handler: (error: string) => void): void;
-    function addEventListener(event: 'rewardedVideoDidOpen', handler: () => void): void;
-    function addEventListener(event: 'rewardedVideoDidClose', handler: () => void): void;
-    function addEventListener(event: 'rewardedVideoWillLeaveApplication', handler: () => void): void;
+    function addEventListener(event: AdMobRewardedEmptyEvent, handler: () => void): void;
     function removeEventListener(event: 'rewardedVideoDidRewardUser', handler: (type: string, amount: number) => void): void;
-    function removeEventListener(event: 'rewardedVideoDidLoad', handler: () => void): void;
     function removeEventListener(event: 'rewardedVideoDidFailToLoad', handler: (error: string) => void): void;
-    function removeEventListener(event: 'rewardedVideoDidOpen', handler: () => void): void;
-    function removeEventListener(event: 'rewardedVideoDidClose', handler: () => void): void;
-    function removeEventListener(event: 'rewardedVideoWillLeaveApplication', handler: () => void): void;
+    function removeEventListener(event: AdMobRewardedEmptyEvent, handler: () => void): void;
     function removeAllListeners(): void;
 }
 

--- a/types/expo/v23/index.d.ts
+++ b/types/expo/v23/index.d.ts
@@ -43,6 +43,92 @@ export namespace Accelerometer {
 }
 
 /**
+ * Admob
+ */
+export type AdMobBannerSize =
+    | 'banner'
+    | 'largeBanner'
+    | 'mediumRectangle'
+    | 'fullBanner'
+    | 'leaderboard'
+    | 'smartBannerPortrait'
+    | 'smartBannerLandscape';
+export interface AdMobBannerProperties extends ViewProperties {
+    bannerSize?: AdMobBannerSize;
+    adUnitID?: string;
+    testDeviceID?: string;
+    didFailToReceiveAdWithError?(errorDescription: string): void;
+    adViewDidReceiveAd?(): void;
+    adViewWillPresentScreen?(): void;
+    adViewWillDismissScreen?(): void;
+    adViewDidDismissScreen?(): void;
+    adViewWillLeaveApplication?(): void;
+}
+
+export class AdMobBanner extends Component<AdMobBannerProperties> { }
+
+export interface AdMobAppEvent {
+    name: string;
+    info: string;
+}
+export interface PublisherBannerProperties extends AdMobBannerProperties {
+    admobDispatchAppEvent?(event: AdMobAppEvent): void;
+}
+export class PublisherBanner extends Component<PublisherBannerProperties> { }
+
+export type AdMobInterstitialEvent =
+    | 'interstitialDidLoad'
+    | 'interstitialDidFailToLoad'
+    | 'interstitialDidOpen'
+    | 'interstitialDidClose'
+    | 'interstitialWillLeaveApplication';
+export namespace AdMobInterstitial {
+    function setAdUnitID(id: string): void;
+    function setTestDeviceID(id: string): void;
+    function requestAd(callback?: () => void): void;
+    function showAd(callback?: (error: string) => void): void;
+    function isReady(callback: (isReady: boolean) => void): void;
+    function addEventListener(event: 'interstitialDidLoad', handler: () => void): void;
+    function addEventListener(event: 'interstitialDidFailToLoad', handler: (error: string) => void): void;
+    function addEventListener(event: 'interstitialDidOpen', handler: () => void): void;
+    function addEventListener(event: 'interstitialDidClose', handler: () => void): void;
+    function addEventListener(event: 'interstitialWillLeaveApplication', handler: () => void): void;
+    function removeEventListener(event: 'interstitialDidLoad', handler: () => void): void;
+    function removeEventListener(event: 'interstitialDidFailToLoad', handler: (error: string) => void): void;
+    function removeEventListener(event: 'interstitialDidOpen', handler: () => void): void;
+    function removeEventListener(event: 'interstitialDidClose', handler: () => void): void;
+    function removeEventListener(event: 'interstitialWillLeaveApplication', handler: () => void): void;
+    function removeAllListeners(): void;
+}
+
+export type AdMobRewardedEvent =
+    | 'rewardedVideoDidRewardUser'
+    | 'rewardedVideoDidLoad'
+    | 'rewardedVideoDidFailToLoad'
+    | 'rewardedVideoDidOpen'
+    | 'rewardedVideoDidClose'
+    | 'rewardedVideoWillLeaveApplication';
+export namespace AdMobRewarded {
+    function setAdUnitID(id: string): void;
+    function setTestDeviceID(id: string): void;
+    function requestAd(callback?: () => void): void;
+    function showAd(callback?: (error: string) => void): void;
+    function addEventListener(event: 'rewardedVideoDidRewardUser', handler: (type: string, amount: number) => void): void;
+    function addEventListener(event: 'rewardedVideoDidLoad', handler: () => void): void;
+    function addEventListener(event: 'rewardedVideoDidFailToLoad', handler: (error: string) => void): void;
+    function addEventListener(event: 'rewardedVideoDidOpen', handler: () => void): void;
+    function addEventListener(event: 'rewardedVideoDidClose', handler: () => void): void;
+    function addEventListener(event: 'rewardedVideoWillLeaveApplication', handler: () => void): void;
+    function removeEventListener(event: 'rewardedVideoDidRewardUser', handler: (type: string, amount: number) => void): void;
+    function removeEventListener(event: 'rewardedVideoDidLoad', handler: () => void): void;
+    function removeEventListener(event: 'rewardedVideoDidFailToLoad', handler: (error: string) => void): void;
+    function removeEventListener(event: 'rewardedVideoDidOpen', handler: () => void): void;
+    function removeEventListener(event: 'rewardedVideoDidClose', handler: () => void): void;
+    function removeEventListener(event: 'rewardedVideoWillLeaveApplication', handler: () => void): void;
+    function removeAllListeners(): void;
+}
+
+/**
  * Amplitude
  */
 export namespace Amplitude {
@@ -92,17 +178,17 @@ export namespace AuthSession {
     function startAsync(options: { authUrl: string; returnUrl: string; }): Promise<{
         type: 'cancel';
     } | {
-        type: 'dismissed';
-    } | {
-        type: 'success';
-        params: HashMap;
-        event: HashMap;
-    } | {
-        type: 'error';
-        params: HashMap;
-        errorCode: string;
-        event: HashMap;
-    }>;
+            type: 'dismissed';
+        } | {
+            type: 'success';
+            params: HashMap;
+            event: HashMap;
+        } | {
+            type: 'error';
+            params: HashMap;
+            errorCode: string;
+            event: HashMap;
+        }>;
     function dismiss(): void;
     function getRedirectUrl(): string;
 }
@@ -115,23 +201,23 @@ export type PlaybackStatus = {
     androidImplementation?: string;
     error?: string;
 } | {
-    isLoaded: true;
-    androidImplementation?: string;
-    uri: string;
-    progressUpdateIntervalMillis: number;
-    durationMillis?: number;
-    positionMillis: number;
-    playableDurationMillis?: number;
-    shouldPlay: boolean;
-    isPlaying: boolean;
-    isBuffering: boolean;
-    rate: number;
-    shouldCorrectPitch: boolean;
-    volume: number;
-    isMuted: boolean;
-    isLooping: boolean;
-    didJustFinish: boolean;
-};
+        isLoaded: true;
+        androidImplementation?: string;
+        uri: string;
+        progressUpdateIntervalMillis: number;
+        durationMillis?: number;
+        positionMillis: number;
+        playableDurationMillis?: number;
+        shouldPlay: boolean;
+        isPlaying: boolean;
+        isBuffering: boolean;
+        rate: number;
+        shouldCorrectPitch: boolean;
+        volume: number;
+        isMuted: boolean;
+        isLooping: boolean;
+        didJustFinish: boolean;
+    };
 
 export interface PlaybackStatusToSet {
     androidImplementation?: string;
@@ -181,14 +267,14 @@ export namespace Audio {
         canRecord: false,
         isDoneRecording: false
     } | {
-        canRecord: true,
-        isRecording: boolean,
-        durationMillis: number
-    } | {
-        canRecord: false,
-        isDoneRecording: true,
-        durationMillis: number
-    };
+            canRecord: true,
+            isRecording: boolean,
+            durationMillis: number
+        } | {
+            canRecord: false,
+            isDoneRecording: true,
+            durationMillis: number
+        };
 
     interface AudioMode {
         playsInSilentModeIOS: boolean;
@@ -702,8 +788,8 @@ export namespace DocumentPicker {
         name: string;
         size: number;
     } | {
-        type: 'cancel';
-    };
+            type: 'cancel';
+        };
 
     function getDocumentAsync(options?: Options): Promise<Response>;
 }
@@ -803,9 +889,9 @@ export namespace FileSystem {
         modificationTime: number;
         md5?: Md5;
     } | {
-        exists: false;
-        isDirectory: false;
-    };
+            exists: false;
+            isDirectory: false;
+        };
 
     interface DownloadResult {
         uri: string;
@@ -919,20 +1005,20 @@ export namespace Google {
     type LogInResult = {
         type: 'cancel';
     } | {
-        type: 'success';
-        accessToken: string;
-        idToken?: string;
-        refreshToken?: string;
-        serverAuthCode?: string;
-        user: {
-            id: string;
-            name: string;
-            givenName: string;
-            familyName: string;
-            photoUrl?: string;
-            email?: string;
-        }
-    };
+            type: 'success';
+            accessToken: string;
+            idToken?: string;
+            refreshToken?: string;
+            serverAuthCode?: string;
+            user: {
+                id: string;
+                name: string;
+                givenName: string;
+                familyName: string;
+                photoUrl?: string;
+                email?: string;
+            }
+        };
 
     function logInAsync(config: LogInConfig): Promise<LogInResult>;
 }

--- a/types/expo/v23/index.d.ts
+++ b/types/expo/v23/index.d.ts
@@ -165,17 +165,17 @@ export namespace AuthSession {
     function startAsync(options: { authUrl: string; returnUrl: string; }): Promise<{
         type: 'cancel';
     } | {
-            type: 'dismissed';
-        } | {
-            type: 'success';
-            params: HashMap;
-            event: HashMap;
-        } | {
-            type: 'error';
-            params: HashMap;
-            errorCode: string;
-            event: HashMap;
-        }>;
+        type: 'dismissed';
+    } | {
+        type: 'success';
+        params: HashMap;
+        event: HashMap;
+    } | {
+        type: 'error';
+        params: HashMap;
+        errorCode: string;
+        event: HashMap;
+    }>;
     function dismiss(): void;
     function getRedirectUrl(): string;
 }
@@ -188,23 +188,23 @@ export type PlaybackStatus = {
     androidImplementation?: string;
     error?: string;
 } | {
-        isLoaded: true;
-        androidImplementation?: string;
-        uri: string;
-        progressUpdateIntervalMillis: number;
-        durationMillis?: number;
-        positionMillis: number;
-        playableDurationMillis?: number;
-        shouldPlay: boolean;
-        isPlaying: boolean;
-        isBuffering: boolean;
-        rate: number;
-        shouldCorrectPitch: boolean;
-        volume: number;
-        isMuted: boolean;
-        isLooping: boolean;
-        didJustFinish: boolean;
-    };
+    isLoaded: true;
+    androidImplementation?: string;
+    uri: string;
+    progressUpdateIntervalMillis: number;
+    durationMillis?: number;
+    positionMillis: number;
+    playableDurationMillis?: number;
+    shouldPlay: boolean;
+    isPlaying: boolean;
+    isBuffering: boolean;
+    rate: number;
+    shouldCorrectPitch: boolean;
+    volume: number;
+    isMuted: boolean;
+    isLooping: boolean;
+    didJustFinish: boolean;
+};
 
 export interface PlaybackStatusToSet {
     androidImplementation?: string;
@@ -254,14 +254,14 @@ export namespace Audio {
         canRecord: false,
         isDoneRecording: false
     } | {
-            canRecord: true,
-            isRecording: boolean,
-            durationMillis: number
-        } | {
-            canRecord: false,
-            isDoneRecording: true,
-            durationMillis: number
-        };
+        canRecord: true,
+        isRecording: boolean,
+        durationMillis: number
+    } | {
+        canRecord: false,
+        isDoneRecording: true,
+        durationMillis: number
+    };
 
     interface AudioMode {
         playsInSilentModeIOS: boolean;
@@ -775,8 +775,8 @@ export namespace DocumentPicker {
         name: string;
         size: number;
     } | {
-            type: 'cancel';
-        };
+        type: 'cancel';
+    };
 
     function getDocumentAsync(options?: Options): Promise<Response>;
 }
@@ -876,9 +876,9 @@ export namespace FileSystem {
         modificationTime: number;
         md5?: Md5;
     } | {
-            exists: false;
-            isDirectory: false;
-        };
+        exists: false;
+        isDirectory: false;
+    };
 
     interface DownloadResult {
         uri: string;
@@ -992,20 +992,20 @@ export namespace Google {
     type LogInResult = {
         type: 'cancel';
     } | {
-            type: 'success';
-            accessToken: string;
-            idToken?: string;
-            refreshToken?: string;
-            serverAuthCode?: string;
-            user: {
-                id: string;
-                name: string;
-                givenName: string;
-                familyName: string;
-                photoUrl?: string;
-                email?: string;
-            }
-        };
+        type: 'success';
+        accessToken: string;
+        idToken?: string;
+        refreshToken?: string;
+        serverAuthCode?: string;
+        user: {
+            id: string;
+            name: string;
+            givenName: string;
+            familyName: string;
+            photoUrl?: string;
+            email?: string;
+        }
+    };
 
     function logInAsync(config: LogInConfig): Promise<LogInResult>;
 }

--- a/types/expo/v24/index.d.ts
+++ b/types/expo/v24/index.d.ts
@@ -93,55 +93,42 @@ export interface PublisherBannerProperties extends AdMobBannerProperties {
 }
 export class PublisherBanner extends Component<PublisherBannerProperties> { }
 
-export type AdMobInterstitialEvent =
+export type AdMobInterstitialEmptyEvent =
     | 'interstitialDidLoad'
-    | 'interstitialDidFailToLoad'
     | 'interstitialDidOpen'
     | 'interstitialDidClose'
     | 'interstitialWillLeaveApplication';
+export type AdMobInterstitialEvent = AdMobInterstitialEmptyEvent | 'interstitialVideoDidFailToLoad';
 export namespace AdMobInterstitial {
     function setAdUnitID(id: string): void;
     function setTestDeviceID(id: string): void;
     function requestAd(callback?: () => void): void;
     function showAd(callback?: (error: string) => void): void;
     function isReady(callback: (isReady: boolean) => void): void;
-    function addEventListener(event: 'interstitialDidLoad', handler: () => void): void;
     function addEventListener(event: 'interstitialDidFailToLoad', handler: (error: string) => void): void;
-    function addEventListener(event: 'interstitialDidOpen', handler: () => void): void;
-    function addEventListener(event: 'interstitialDidClose', handler: () => void): void;
-    function addEventListener(event: 'interstitialWillLeaveApplication', handler: () => void): void;
-    function removeEventListener(event: 'interstitialDidLoad', handler: () => void): void;
+    function addEventListener(event: AdMobInterstitialEmptyEvent, handler: () => void): void;
     function removeEventListener(event: 'interstitialDidFailToLoad', handler: (error: string) => void): void;
-    function removeEventListener(event: 'interstitialDidOpen', handler: () => void): void;
-    function removeEventListener(event: 'interstitialDidClose', handler: () => void): void;
-    function removeEventListener(event: 'interstitialWillLeaveApplication', handler: () => void): void;
+    function removeEventListener(event: AdMobInterstitialEmptyEvent, handler: () => void): void;
     function removeAllListeners(): void;
 }
 
-export type AdMobRewardedEvent =
-    | 'rewardedVideoDidRewardUser'
+export type AdMobRewardedEmptyEvent =
     | 'rewardedVideoDidLoad'
-    | 'rewardedVideoDidFailToLoad'
     | 'rewardedVideoDidOpen'
     | 'rewardedVideoDidClose'
     | 'rewardedVideoWillLeaveApplication';
+export type AdMobRewardedEvent = AdMobRewardedEmptyEvent | 'rewardedVideoDidRewardUser' | 'rewardedVideoDidFailToLoad';
 export namespace AdMobRewarded {
     function setAdUnitID(id: string): void;
     function setTestDeviceID(id: string): void;
     function requestAd(callback?: () => void): void;
     function showAd(callback?: (error: string) => void): void;
     function addEventListener(event: 'rewardedVideoDidRewardUser', handler: (type: string, amount: number) => void): void;
-    function addEventListener(event: 'rewardedVideoDidLoad', handler: () => void): void;
     function addEventListener(event: 'rewardedVideoDidFailToLoad', handler: (error: string) => void): void;
-    function addEventListener(event: 'rewardedVideoDidOpen', handler: () => void): void;
-    function addEventListener(event: 'rewardedVideoDidClose', handler: () => void): void;
-    function addEventListener(event: 'rewardedVideoWillLeaveApplication', handler: () => void): void;
+    function addEventListener(event: AdMobRewardedEmptyEvent, handler: () => void): void;
     function removeEventListener(event: 'rewardedVideoDidRewardUser', handler: (type: string, amount: number) => void): void;
-    function removeEventListener(event: 'rewardedVideoDidLoad', handler: () => void): void;
     function removeEventListener(event: 'rewardedVideoDidFailToLoad', handler: (error: string) => void): void;
-    function removeEventListener(event: 'rewardedVideoDidOpen', handler: () => void): void;
-    function removeEventListener(event: 'rewardedVideoDidClose', handler: () => void): void;
-    function removeEventListener(event: 'rewardedVideoWillLeaveApplication', handler: () => void): void;
+    function removeEventListener(event: AdMobRewardedEmptyEvent, handler: () => void): void;
     function removeAllListeners(): void;
 }
 

--- a/types/expo/v24/index.d.ts
+++ b/types/expo/v24/index.d.ts
@@ -60,6 +60,92 @@ export namespace Accelerometer {
 }
 
 /**
+ * Admob
+ */
+export type AdMobBannerSize =
+    | 'banner'
+    | 'largeBanner'
+    | 'mediumRectangle'
+    | 'fullBanner'
+    | 'leaderboard'
+    | 'smartBannerPortrait'
+    | 'smartBannerLandscape';
+export interface AdMobBannerProperties extends ViewProperties {
+    bannerSize?: AdMobBannerSize;
+    adUnitID?: string;
+    testDeviceID?: string;
+    didFailToReceiveAdWithError?(errorDescription: string): void;
+    adViewDidReceiveAd?(): void;
+    adViewWillPresentScreen?(): void;
+    adViewWillDismissScreen?(): void;
+    adViewDidDismissScreen?(): void;
+    adViewWillLeaveApplication?(): void;
+}
+
+export class AdMobBanner extends Component<AdMobBannerProperties> { }
+
+export interface AdMobAppEvent {
+    name: string;
+    info: string;
+}
+export interface PublisherBannerProperties extends AdMobBannerProperties {
+    admobDispatchAppEvent?(event: AdMobAppEvent): void;
+}
+export class PublisherBanner extends Component<PublisherBannerProperties> { }
+
+export type AdMobInterstitialEvent =
+    | 'interstitialDidLoad'
+    | 'interstitialDidFailToLoad'
+    | 'interstitialDidOpen'
+    | 'interstitialDidClose'
+    | 'interstitialWillLeaveApplication';
+export namespace AdMobInterstitial {
+    function setAdUnitID(id: string): void;
+    function setTestDeviceID(id: string): void;
+    function requestAd(callback?: () => void): void;
+    function showAd(callback?: (error: string) => void): void;
+    function isReady(callback: (isReady: boolean) => void): void;
+    function addEventListener(event: 'interstitialDidLoad', handler: () => void): void;
+    function addEventListener(event: 'interstitialDidFailToLoad', handler: (error: string) => void): void;
+    function addEventListener(event: 'interstitialDidOpen', handler: () => void): void;
+    function addEventListener(event: 'interstitialDidClose', handler: () => void): void;
+    function addEventListener(event: 'interstitialWillLeaveApplication', handler: () => void): void;
+    function removeEventListener(event: 'interstitialDidLoad', handler: () => void): void;
+    function removeEventListener(event: 'interstitialDidFailToLoad', handler: (error: string) => void): void;
+    function removeEventListener(event: 'interstitialDidOpen', handler: () => void): void;
+    function removeEventListener(event: 'interstitialDidClose', handler: () => void): void;
+    function removeEventListener(event: 'interstitialWillLeaveApplication', handler: () => void): void;
+    function removeAllListeners(): void;
+}
+
+export type AdMobRewardedEvent =
+    | 'rewardedVideoDidRewardUser'
+    | 'rewardedVideoDidLoad'
+    | 'rewardedVideoDidFailToLoad'
+    | 'rewardedVideoDidOpen'
+    | 'rewardedVideoDidClose'
+    | 'rewardedVideoWillLeaveApplication';
+export namespace AdMobRewarded {
+    function setAdUnitID(id: string): void;
+    function setTestDeviceID(id: string): void;
+    function requestAd(callback?: () => void): void;
+    function showAd(callback?: (error: string) => void): void;
+    function addEventListener(event: 'rewardedVideoDidRewardUser', handler: (type: string, amount: number) => void): void;
+    function addEventListener(event: 'rewardedVideoDidLoad', handler: () => void): void;
+    function addEventListener(event: 'rewardedVideoDidFailToLoad', handler: (error: string) => void): void;
+    function addEventListener(event: 'rewardedVideoDidOpen', handler: () => void): void;
+    function addEventListener(event: 'rewardedVideoDidClose', handler: () => void): void;
+    function addEventListener(event: 'rewardedVideoWillLeaveApplication', handler: () => void): void;
+    function removeEventListener(event: 'rewardedVideoDidRewardUser', handler: (type: string, amount: number) => void): void;
+    function removeEventListener(event: 'rewardedVideoDidLoad', handler: () => void): void;
+    function removeEventListener(event: 'rewardedVideoDidFailToLoad', handler: (error: string) => void): void;
+    function removeEventListener(event: 'rewardedVideoDidOpen', handler: () => void): void;
+    function removeEventListener(event: 'rewardedVideoDidClose', handler: () => void): void;
+    function removeEventListener(event: 'rewardedVideoWillLeaveApplication', handler: () => void): void;
+    function removeAllListeners(): void;
+}
+
+/**
  * Provides access to Amplitude mobile analytics which basically lets you log various events to the Cloud. This module wraps Amplitude’s iOS and Android SDKs.
  *
  * Note: Session tracking may not work correctly when running Experiences in the main Expo app. It will work correctly if you create a standalone app.
@@ -269,14 +355,14 @@ export namespace Audio {
         canRecord: false,
         isDoneRecording: false
     } | {
-        canRecord: true,
-        isRecording: boolean,
-        durationMillis: number
-    } | {
-        canRecord: false,
-        isDoneRecording: true,
-        durationMillis: number
-    };
+            canRecord: true,
+            isRecording: boolean,
+            durationMillis: number
+        } | {
+            canRecord: false,
+            isDoneRecording: true,
+            durationMillis: number
+        };
 
     const RECORDING_OPTIONS_PRESET_HIGH_QUALITY: RecordingOptions;
     const RECORDING_OPTIONS_PRESET_LOW_QUALITY: RecordingOptions;
@@ -420,17 +506,17 @@ export namespace AuthSession {
     type StartAsyncResponse = {
         type: 'cancel';
     } | {
-        type: 'dismissed';
-    } | {
-        type: 'success';
-        params: HashMap;
-        event: HashMap;
-    } | {
-        type: 'error';
-        params: HashMap;
-        errorCode: string;
-        event: HashMap;
-    };
+            type: 'dismissed';
+        } | {
+            type: 'success';
+            params: HashMap;
+            event: HashMap;
+        } | {
+            type: 'error';
+            params: HashMap;
+            errorCode: string;
+            event: HashMap;
+        };
 
     function startAsync(options: { authUrl: string; returnUrl?: string; }): Promise<StartAsyncResponse>;
     function dismiss(): void;
@@ -448,25 +534,25 @@ export type PlaybackStatus = {
     /** Populated exactly once when an error forces the object to unload. */
     error?: string;
 } | {
-    isLoaded: true;
-    androidImplementation?: string;
-    uri: string;
-    progressUpdateIntervalMillis: number;
-    durationMillis?: number;
-    positionMillis: number;
-    playableDurationMillis?: number;
-    shouldPlay: boolean;
-    isPlaying: boolean;
-    isBuffering: boolean;
-    rate: number;
-    shouldCorrectPitch: boolean;
-    volume: number;
-    isMuted: boolean;
-    isLooping: boolean;
+        isLoaded: true;
+        androidImplementation?: string;
+        uri: string;
+        progressUpdateIntervalMillis: number;
+        durationMillis?: number;
+        positionMillis: number;
+        playableDurationMillis?: number;
+        shouldPlay: boolean;
+        isPlaying: boolean;
+        isBuffering: boolean;
+        rate: number;
+        shouldCorrectPitch: boolean;
+        volume: number;
+        isMuted: boolean;
+        isLooping: boolean;
 
-    /** True exactly once when the track plays to finish. */
-    didJustFinish: boolean;
-};
+        /** True exactly once when the track plays to finish. */
+        didJustFinish: boolean;
+    };
 
 export interface PlaybackStatusToSet {
     androidImplementation?: string;
@@ -1022,8 +1108,8 @@ export namespace DocumentPicker {
         name: string;
         size: number;
     } | {
-        type: 'cancel';
-    };
+            type: 'cancel';
+        };
 
     function getDocumentAsync(options?: Options): Promise<Response>;
 }
@@ -1192,9 +1278,9 @@ export namespace FileSystem {
         modificationTime: number;
         md5?: Md5;
     } | {
-        exists: false;
-        isDirectory: false;
-    };
+            exists: false;
+            isDirectory: false;
+        };
 
     interface DownloadResult {
         uri: string;
@@ -1263,11 +1349,11 @@ export namespace Fingerprint {
     type FingerprintAuthenticationResult = {
         success: true
     } | {
-        success: false,
+            success: false,
 
-        /** Error code in the case where authentication fails. */
-        error: string
-    };
+            /** Error code in the case where authentication fails. */
+            error: string
+        };
 
     /** Determine whether the Fingerprint scanner is available on the device. */
     function hasHardwareAsync(): Promise<boolean>;
@@ -1327,20 +1413,20 @@ export namespace Google {
     type LogInResult = {
         type: 'cancel';
     } | {
-        type: 'success';
-        accessToken: string;
-        idToken?: string;
-        refreshToken?: string;
-        serverAuthCode?: string;
-        user: {
-            id: string;
-            name: string;
-            givenName: string;
-            familyName: string;
-            photoUrl?: string;
-            email?: string;
-        }
-    };
+            type: 'success';
+            accessToken: string;
+            idToken?: string;
+            refreshToken?: string;
+            serverAuthCode?: string;
+            user: {
+                id: string;
+                name: string;
+                givenName: string;
+                familyName: string;
+                photoUrl?: string;
+                email?: string;
+            }
+        };
 
     function logInAsync(config: LogInConfig): Promise<LogInResult>;
 }

--- a/types/expo/v24/index.d.ts
+++ b/types/expo/v24/index.d.ts
@@ -342,14 +342,14 @@ export namespace Audio {
         canRecord: false,
         isDoneRecording: false
     } | {
-            canRecord: true,
-            isRecording: boolean,
-            durationMillis: number
-        } | {
-            canRecord: false,
-            isDoneRecording: true,
-            durationMillis: number
-        };
+        canRecord: true,
+        isRecording: boolean,
+        durationMillis: number
+    } | {
+        canRecord: false,
+        isDoneRecording: true,
+        durationMillis: number
+    };
 
     const RECORDING_OPTIONS_PRESET_HIGH_QUALITY: RecordingOptions;
     const RECORDING_OPTIONS_PRESET_LOW_QUALITY: RecordingOptions;
@@ -493,17 +493,17 @@ export namespace AuthSession {
     type StartAsyncResponse = {
         type: 'cancel';
     } | {
-            type: 'dismissed';
-        } | {
-            type: 'success';
-            params: HashMap;
-            event: HashMap;
-        } | {
-            type: 'error';
-            params: HashMap;
-            errorCode: string;
-            event: HashMap;
-        };
+        type: 'dismissed';
+    } | {
+        type: 'success';
+        params: HashMap;
+        event: HashMap;
+    } | {
+        type: 'error';
+        params: HashMap;
+        errorCode: string;
+        event: HashMap;
+    };
 
     function startAsync(options: { authUrl: string; returnUrl?: string; }): Promise<StartAsyncResponse>;
     function dismiss(): void;
@@ -521,25 +521,25 @@ export type PlaybackStatus = {
     /** Populated exactly once when an error forces the object to unload. */
     error?: string;
 } | {
-        isLoaded: true;
-        androidImplementation?: string;
-        uri: string;
-        progressUpdateIntervalMillis: number;
-        durationMillis?: number;
-        positionMillis: number;
-        playableDurationMillis?: number;
-        shouldPlay: boolean;
-        isPlaying: boolean;
-        isBuffering: boolean;
-        rate: number;
-        shouldCorrectPitch: boolean;
-        volume: number;
-        isMuted: boolean;
-        isLooping: boolean;
+    isLoaded: true;
+    androidImplementation?: string;
+    uri: string;
+    progressUpdateIntervalMillis: number;
+    durationMillis?: number;
+    positionMillis: number;
+    playableDurationMillis?: number;
+    shouldPlay: boolean;
+    isPlaying: boolean;
+    isBuffering: boolean;
+    rate: number;
+    shouldCorrectPitch: boolean;
+    volume: number;
+    isMuted: boolean;
+    isLooping: boolean;
 
-        /** True exactly once when the track plays to finish. */
-        didJustFinish: boolean;
-    };
+    /** True exactly once when the track plays to finish. */
+    didJustFinish: boolean;
+};
 
 export interface PlaybackStatusToSet {
     androidImplementation?: string;
@@ -1095,8 +1095,8 @@ export namespace DocumentPicker {
         name: string;
         size: number;
     } | {
-            type: 'cancel';
-        };
+        type: 'cancel';
+    };
 
     function getDocumentAsync(options?: Options): Promise<Response>;
 }
@@ -1265,9 +1265,9 @@ export namespace FileSystem {
         modificationTime: number;
         md5?: Md5;
     } | {
-            exists: false;
-            isDirectory: false;
-        };
+        exists: false;
+        isDirectory: false;
+    };
 
     interface DownloadResult {
         uri: string;
@@ -1336,11 +1336,11 @@ export namespace Fingerprint {
     type FingerprintAuthenticationResult = {
         success: true
     } | {
-            success: false,
+        success: false,
 
-            /** Error code in the case where authentication fails. */
-            error: string
-        };
+        /** Error code in the case where authentication fails. */
+        error: string
+    };
 
     /** Determine whether the Fingerprint scanner is available on the device. */
     function hasHardwareAsync(): Promise<boolean>;
@@ -1400,20 +1400,20 @@ export namespace Google {
     type LogInResult = {
         type: 'cancel';
     } | {
-            type: 'success';
-            accessToken: string;
-            idToken?: string;
-            refreshToken?: string;
-            serverAuthCode?: string;
-            user: {
-                id: string;
-                name: string;
-                givenName: string;
-                familyName: string;
-                photoUrl?: string;
-                email?: string;
-            }
-        };
+        type: 'success';
+        accessToken: string;
+        idToken?: string;
+        refreshToken?: string;
+        serverAuthCode?: string;
+        user: {
+            id: string;
+            name: string;
+            givenName: string;
+            familyName: string;
+            photoUrl?: string;
+            email?: string;
+        }
+    };
 
     function logInAsync(config: LogInConfig): Promise<LogInResult>;
 }

--- a/types/expo/v25/expo-tests.tsx
+++ b/types/expo/v25/expo-tests.tsx
@@ -32,7 +32,10 @@ import {
     Permissions,
     PublisherBanner,
     registerRootComponent,
-    ScreenOrientation
+    ScreenOrientation,
+    SQLite,
+    Calendar,
+    MailComposer
 } from 'expo';
 
 Accelerometer.addListener((obj) => {
@@ -320,14 +323,37 @@ async () => {
 };
 
 async () => {
+    // Video test
     const result = await ImagePicker.launchImageLibraryAsync({
-        mediaTypes: ImagePicker.MediaTypeOptions.Videos
+        mediaTypes: ImagePicker.MediaTypeOptions.Videos,
     });
 
     if (!result.cancelled) {
         result.uri;
         result.width;
         result.height;
+        result.duration;
+        result.type;
+    }
+};
+
+async () => {
+    // Image test
+    const result = await ImagePicker.launchImageLibraryAsync({
+        mediaTypes: ImagePicker.MediaTypeOptions.Images,
+        base64: true,
+        aspect: [4, 3],
+        quality: 1,
+        exif: true,
+    });
+
+    if (!result.cancelled) {
+        result.uri;
+        result.width;
+        result.height;
+        result.exif;
+        result.base64;
+        result.type;
     }
 };
 
@@ -583,3 +609,124 @@ class __TestEntry__ extends React.Component {
     }
 }
 registerRootComponent(__TestEntry__);
+
+Calendar.EntityTypes.EVENT === 'event';
+Calendar.EntityTypes.REMINDER === 'reminder';
+
+Calendar.CalendarType.LOCAL === 'local';
+Calendar.CalendarType.CALDAV === 'caldav';
+Calendar.CalendarType.EXCHANGE === 'exchange';
+Calendar.CalendarType.SUBSCRIBED === 'subscribed';
+Calendar.CalendarType.BIRTHDAYS === 'birthdays';
+
+async () => {
+    const result = await Calendar.getCalendarsAsync(Calendar.EntityTypes.EVENT);
+    result.length;
+
+    const calendar = result[0];
+    calendar.id === '';
+    calendar.title === '';
+    calendar.sourceId === '';
+    calendar.type === Calendar.CalendarType.BIRTHDAYS;
+    calendar.color === '';
+    calendar.entityType === Calendar.EntityTypes.EVENT;
+    calendar.allowsModifications === true;
+    calendar.allowedAvailabilities === [''];
+    calendar.isPrimary === true;
+    calendar.name === '';
+    calendar.ownerAccount === '';
+    calendar.timeZone === '';
+    calendar.allowedReminders === [''];
+    calendar.allowedAttendeeTypes === [''];
+    calendar.isVisible === false;
+    calendar.isSynced === false;
+    calendar.accessLevel === Calendar.CalendarAccessLevel.CONTRIBUTOR;
+
+    if (calendar.source) {
+        calendar.source.id === '';
+        calendar.source.type === '';
+        calendar.source.name === '';
+        calendar.source.isLocalAccount === false;
+    }
+
+    const id1 =  await Calendar.createCalendarAsync({
+        accessLevel: Calendar.CalendarAccessLevel.EDITOR
+    });
+
+    id1 === '';
+
+    const id2 = await Calendar.updateCalendarAsync('1234', {
+        isVisible: false
+    });
+
+    id2 === '';
+
+    const id3 = await Calendar.updateCalendarAsync('1234', null);
+
+    await Calendar.deleteCalendarAsync('1234');
+
+    const events = await Calendar.getEventsAsync(
+        ['123', '124'],
+        new Date(),
+        new Date()
+    );
+
+    const event1 = events[0];
+
+    event1.accessLevel === Calendar.EventAccessLevel.CONFIDENTIAL;
+    event1.alarms === [];
+    event1.allDay === true;
+    event1.availability === Calendar.Availability.FREE;
+    event1.calendarId === '';
+    event1.creationDate === '';
+    event1.endDate === '';
+    event1.endTimeZone === '';
+    event1.guestsCanInviteOthers === true;
+    event1.guestsCanModify === true;
+    event1.guestsCanSeeGuests === false;
+    event1.id === '';
+    event1.instanceId === '';
+    event1.isDetached === false;
+
+    const event2 = await Calendar.getEventAsync('123', {
+        futureEvents: true
+    });
+
+    const eventId1 = await Calendar.createEventAsync('123');
+
+    const eventId2 = await Calendar.updateEventAsync('1234');
+
+    await Calendar.deleteEventAsync('1234');
+
+    const attendees = await Calendar.getAttendeesForEventAsync('123');
+
+    const aId1 = await Calendar.createAttendeeAsync('123');
+
+    const aId2 = await Calendar.updateAttendeeAsync('123');
+
+    await Calendar.deleteAttendeeAsync('123');
+
+    const reminders = await Calendar.getRemindersAsync(['123']);
+
+    const reminder = await Calendar.getReminderAsync('123');
+
+    const remId1 = await Calendar.createReminderAsync('123');
+
+    const remId2 = await Calendar.updateReminderAsync('123');
+
+    await Calendar.deleteReminderAsync('123');
+
+    const sources = await Calendar.getSourcesAsync();
+
+    const source = await Calendar.getSourceAsync('123');
+
+    Calendar.openEventInCalendar('123');
+};
+
+async () => {
+    const result = await MailComposer.composeAsync({
+        subject: 'sss'
+    });
+
+    result.status === 'saved';
+};

--- a/types/expo/v25/index.d.ts
+++ b/types/expo/v25/index.d.ts
@@ -93,55 +93,42 @@ export interface PublisherBannerProperties extends AdMobBannerProperties {
 }
 export class PublisherBanner extends Component<PublisherBannerProperties> { }
 
-export type AdMobInterstitialEvent =
+export type AdMobInterstitialEmptyEvent =
     | 'interstitialDidLoad'
-    | 'interstitialDidFailToLoad'
     | 'interstitialDidOpen'
     | 'interstitialDidClose'
     | 'interstitialWillLeaveApplication';
+export type AdMobInterstitialEvent = AdMobInterstitialEmptyEvent | 'interstitialVideoDidFailToLoad';
 export namespace AdMobInterstitial {
     function setAdUnitID(id: string): void;
     function setTestDeviceID(id: string): void;
     function requestAd(callback?: () => void): void;
     function showAd(callback?: (error: string) => void): void;
     function isReady(callback: (isReady: boolean) => void): void;
-    function addEventListener(event: 'interstitialDidLoad', handler: () => void): void;
     function addEventListener(event: 'interstitialDidFailToLoad', handler: (error: string) => void): void;
-    function addEventListener(event: 'interstitialDidOpen', handler: () => void): void;
-    function addEventListener(event: 'interstitialDidClose', handler: () => void): void;
-    function addEventListener(event: 'interstitialWillLeaveApplication', handler: () => void): void;
-    function removeEventListener(event: 'interstitialDidLoad', handler: () => void): void;
+    function addEventListener(event: AdMobInterstitialEmptyEvent, handler: () => void): void;
     function removeEventListener(event: 'interstitialDidFailToLoad', handler: (error: string) => void): void;
-    function removeEventListener(event: 'interstitialDidOpen', handler: () => void): void;
-    function removeEventListener(event: 'interstitialDidClose', handler: () => void): void;
-    function removeEventListener(event: 'interstitialWillLeaveApplication', handler: () => void): void;
+    function removeEventListener(event: AdMobInterstitialEmptyEvent, handler: () => void): void;
     function removeAllListeners(): void;
 }
 
-export type AdMobRewardedEvent =
-    | 'rewardedVideoDidRewardUser'
+export type AdMobRewardedEmptyEvent =
     | 'rewardedVideoDidLoad'
-    | 'rewardedVideoDidFailToLoad'
     | 'rewardedVideoDidOpen'
     | 'rewardedVideoDidClose'
     | 'rewardedVideoWillLeaveApplication';
+export type AdMobRewardedEvent = AdMobRewardedEmptyEvent | 'rewardedVideoDidRewardUser' | 'rewardedVideoDidFailToLoad';
 export namespace AdMobRewarded {
     function setAdUnitID(id: string): void;
     function setTestDeviceID(id: string): void;
     function requestAd(callback?: () => void): void;
     function showAd(callback?: (error: string) => void): void;
     function addEventListener(event: 'rewardedVideoDidRewardUser', handler: (type: string, amount: number) => void): void;
-    function addEventListener(event: 'rewardedVideoDidLoad', handler: () => void): void;
     function addEventListener(event: 'rewardedVideoDidFailToLoad', handler: (error: string) => void): void;
-    function addEventListener(event: 'rewardedVideoDidOpen', handler: () => void): void;
-    function addEventListener(event: 'rewardedVideoDidClose', handler: () => void): void;
-    function addEventListener(event: 'rewardedVideoWillLeaveApplication', handler: () => void): void;
+    function addEventListener(event: AdMobRewardedEmptyEvent, handler: () => void): void;
     function removeEventListener(event: 'rewardedVideoDidRewardUser', handler: (type: string, amount: number) => void): void;
-    function removeEventListener(event: 'rewardedVideoDidLoad', handler: () => void): void;
     function removeEventListener(event: 'rewardedVideoDidFailToLoad', handler: (error: string) => void): void;
-    function removeEventListener(event: 'rewardedVideoDidOpen', handler: () => void): void;
-    function removeEventListener(event: 'rewardedVideoDidClose', handler: () => void): void;
-    function removeEventListener(event: 'rewardedVideoWillLeaveApplication', handler: () => void): void;
+    function removeEventListener(event: AdMobRewardedEmptyEvent, handler: () => void): void;
     function removeAllListeners(): void;
 }
 

--- a/types/expo/v25/index.d.ts
+++ b/types/expo/v25/index.d.ts
@@ -18,7 +18,8 @@ import {
     NativeEventEmitter,
     ViewProperties,
     ViewStyle,
-    Permission
+    Permission,
+    StyleProp
 } from 'react-native';
 
 export type Axis = number;
@@ -1627,11 +1628,12 @@ export class KeepAwake extends Component {
 /**
  * LinearGradient
  */
-export interface LinearGradientProps extends ViewProperties {
+export interface LinearGradientProps {
     colors: string[];
     start?: [number, number];
     end?: [number, number];
     locations?: number[];
+    style?: StyleProp<ViewStyle>;
 }
 
 export class LinearGradient extends Component<LinearGradientProps> { }

--- a/types/expo/v25/index.d.ts
+++ b/types/expo/v25/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for expo 26.0
+// Type definitions for expo 25.0
 // Project: https://github.com/expo/expo-sdk
 // Definitions by: Konstantin Kai <https://github.com/KonstantinKai>
 //                 Martynas Kadiša <https://github.com/martynaskadisa>
@@ -18,8 +18,7 @@ import {
     NativeEventEmitter,
     ViewProperties,
     ViewStyle,
-    Permission,
-    StyleProp
+    Permission
 } from 'react-native';
 
 export type Axis = number;
@@ -84,12 +83,13 @@ export interface AdMobBannerProperties extends ViewProperties {
 }
 
 export class AdMobBanner extends Component<AdMobBannerProperties> { }
+
 export interface AdMobAppEvent {
     name: string;
     info: string;
 }
 export interface PublisherBannerProperties extends AdMobBannerProperties {
-    onAdMobDispatchAppEvent?(event: AdMobAppEvent): void;
+    admobDispatchAppEvent?(event: AdMobAppEvent): void;
 }
 export class PublisherBanner extends Component<PublisherBannerProperties> { }
 
@@ -102,12 +102,19 @@ export type AdMobInterstitialEvent =
 export namespace AdMobInterstitial {
     function setAdUnitID(id: string): void;
     function setTestDeviceID(id: string): void;
-    function requestAdAsync(): Promise<void>;
-    function showAdAsync(): Promise<void>;
-    function dismissAdAsync(): Promise<void>;
-    function getIsReadyAsync(): Promise<boolean>;
-    function addEventListener(event: AdMobInterstitialEvent, handler: () => void): EventSubscription;
-    function removeEventListener(event: AdMobInterstitialEvent, handler: () => void): void;
+    function requestAd(callback?: () => void): void;
+    function showAd(callback?: (error: string) => void): void;
+    function isReady(callback: (isReady: boolean) => void): void;
+    function addEventListener(event: 'interstitialDidLoad', handler: () => void): void;
+    function addEventListener(event: 'interstitialDidFailToLoad', handler: (error: string) => void): void;
+    function addEventListener(event: 'interstitialDidOpen', handler: () => void): void;
+    function addEventListener(event: 'interstitialDidClose', handler: () => void): void;
+    function addEventListener(event: 'interstitialWillLeaveApplication', handler: () => void): void;
+    function removeEventListener(event: 'interstitialDidLoad', handler: () => void): void;
+    function removeEventListener(event: 'interstitialDidFailToLoad', handler: (error: string) => void): void;
+    function removeEventListener(event: 'interstitialDidOpen', handler: () => void): void;
+    function removeEventListener(event: 'interstitialDidClose', handler: () => void): void;
+    function removeEventListener(event: 'interstitialWillLeaveApplication', handler: () => void): void;
     function removeAllListeners(): void;
 }
 
@@ -116,18 +123,25 @@ export type AdMobRewardedEvent =
     | 'rewardedVideoDidLoad'
     | 'rewardedVideoDidFailToLoad'
     | 'rewardedVideoDidOpen'
-    | 'rewardedVideoDidStart'
     | 'rewardedVideoDidClose'
     | 'rewardedVideoWillLeaveApplication';
 export namespace AdMobRewarded {
     function setAdUnitID(id: string): void;
     function setTestDeviceID(id: string): void;
-    function requestAdAsync(): Promise<void>;
-    function showAdAsync(): Promise<void>;
-    function dismissAdAsync(): Promise<void>;
-    function getIsReadyAsync(): Promise<boolean>;
-    function addEventListener(event: AdMobRewardedEvent, handler: () => void): EventSubscription;
-    function removeEventListener(event: AdMobRewardedEvent, handler: () => void): void;
+    function requestAd(callback?: () => void): void;
+    function showAd(callback?: (error: string) => void): void;
+    function addEventListener(event: 'rewardedVideoDidRewardUser', handler: (type: string, amount: number) => void): void;
+    function addEventListener(event: 'rewardedVideoDidLoad', handler: () => void): void;
+    function addEventListener(event: 'rewardedVideoDidFailToLoad', handler: (error: string) => void): void;
+    function addEventListener(event: 'rewardedVideoDidOpen', handler: () => void): void;
+    function addEventListener(event: 'rewardedVideoDidClose', handler: () => void): void;
+    function addEventListener(event: 'rewardedVideoWillLeaveApplication', handler: () => void): void;
+    function removeEventListener(event: 'rewardedVideoDidRewardUser', handler: (type: string, amount: number) => void): void;
+    function removeEventListener(event: 'rewardedVideoDidLoad', handler: () => void): void;
+    function removeEventListener(event: 'rewardedVideoDidFailToLoad', handler: (error: string) => void): void;
+    function removeEventListener(event: 'rewardedVideoDidOpen', handler: () => void): void;
+    function removeEventListener(event: 'rewardedVideoDidClose', handler: () => void): void;
+    function removeEventListener(event: 'rewardedVideoWillLeaveApplication', handler: () => void): void;
     function removeAllListeners(): void;
 }
 
@@ -1626,12 +1640,11 @@ export class KeepAwake extends Component {
 /**
  * LinearGradient
  */
-export interface LinearGradientProps {
+export interface LinearGradientProps extends ViewProperties {
     colors: string[];
     start?: [number, number];
     end?: [number, number];
     locations?: number[];
-    style?: StyleProp<ViewStyle>;
 }
 
 export class LinearGradient extends Component<LinearGradientProps> { }
@@ -1695,7 +1708,7 @@ export namespace Location {
     function getHeadingAsync(): Promise<HeadingStatus>;
     function watchHeadingAsync(callback: (status: HeadingStatus) => void): EventSubscription;
     function geocodeAsync(address: string): Promise<Coords>;
-    function reverseGeocodeAsync(location: LocationProps): Promise<GeocodeData[]>;
+    function reverseGeocodeAsync(location: LocationProps): Promise<GeocodeData>;
     function setApiKey(key: string): void;
 }
 
@@ -1947,7 +1960,6 @@ export interface SvgCommonProps {
     fill?: string;
     fillOpacity?: number | string;
     fillRule?: 'nonzero' | 'evenodd';
-    opacity?: number | string;
     stroke?: string;
     strokeWidth?: number | string;
     strokeOpacity?: number | string;
@@ -2058,7 +2070,7 @@ export interface SvgStopProps extends SvgCommonProps {
     stopOpacity?: string;
 }
 
-export class Svg extends Component<{ width: number, height: number, viewBox?: string }> {
+export class Svg extends Component<{ width: number, height: number }> {
     static Circle: ComponentClass<SvgCircleProps>;
     static ClipPath: ComponentClass<SvgCommonProps>;
     static Defs: ComponentClass;

--- a/types/expo/v25/index.d.ts
+++ b/types/expo/v25/index.d.ts
@@ -342,14 +342,14 @@ export namespace Audio {
         canRecord: false,
         isDoneRecording: false
     } | {
-            canRecord: true,
-            isRecording: boolean,
-            durationMillis: number
-        } | {
-            canRecord: false,
-            isDoneRecording: true,
-            durationMillis: number
-        };
+        canRecord: true,
+        isRecording: boolean,
+        durationMillis: number
+    } | {
+        canRecord: false,
+        isDoneRecording: true,
+        durationMillis: number
+    };
 
     const RECORDING_OPTIONS_PRESET_HIGH_QUALITY: RecordingOptions;
     const RECORDING_OPTIONS_PRESET_LOW_QUALITY: RecordingOptions;
@@ -493,17 +493,17 @@ export namespace AuthSession {
     type StartAsyncResponse = {
         type: 'cancel';
     } | {
-            type: 'dismissed';
-        } | {
-            type: 'success';
-            params: HashMap;
-            event: HashMap;
-        } | {
-            type: 'error';
-            params: HashMap;
-            errorCode: string;
-            event: HashMap;
-        };
+        type: 'dismissed';
+    } | {
+        type: 'success';
+        params: HashMap;
+        event: HashMap;
+    } | {
+        type: 'error';
+        params: HashMap;
+        errorCode: string;
+        event: HashMap;
+    };
 
     function startAsync(options: { authUrl: string; returnUrl?: string; }): Promise<StartAsyncResponse>;
     function dismiss(): void;
@@ -521,25 +521,25 @@ export type PlaybackStatus = {
     /** Populated exactly once when an error forces the object to unload. */
     error?: string;
 } | {
-        isLoaded: true;
-        androidImplementation?: string;
-        uri: string;
-        progressUpdateIntervalMillis: number;
-        durationMillis?: number;
-        positionMillis: number;
-        playableDurationMillis?: number;
-        shouldPlay: boolean;
-        isPlaying: boolean;
-        isBuffering: boolean;
-        rate: number;
-        shouldCorrectPitch: boolean;
-        volume: number;
-        isMuted: boolean;
-        isLooping: boolean;
+    isLoaded: true;
+    androidImplementation?: string;
+    uri: string;
+    progressUpdateIntervalMillis: number;
+    durationMillis?: number;
+    positionMillis: number;
+    playableDurationMillis?: number;
+    shouldPlay: boolean;
+    isPlaying: boolean;
+    isBuffering: boolean;
+    rate: number;
+    shouldCorrectPitch: boolean;
+    volume: number;
+    isMuted: boolean;
+    isLooping: boolean;
 
-        /** True exactly once when the track plays to finish. */
-        didJustFinish: boolean;
-    };
+    /** True exactly once when the track plays to finish. */
+    didJustFinish: boolean;
+};
 
 export interface PlaybackStatusToSet {
     androidImplementation?: string;
@@ -1103,8 +1103,8 @@ export namespace DocumentPicker {
         name: string;
         size: number;
     } | {
-            type: 'cancel';
-        };
+        type: 'cancel';
+    };
 
     function getDocumentAsync(options?: Options): Promise<Response>;
 }
@@ -1278,9 +1278,9 @@ export namespace FileSystem {
         modificationTime: number;
         md5?: Md5;
     } | {
-            exists: false;
-            isDirectory: false;
-        };
+        exists: false;
+        isDirectory: false;
+    };
 
     interface DownloadResult {
         uri: string;
@@ -1349,11 +1349,11 @@ export namespace Fingerprint {
     type FingerprintAuthenticationResult = {
         success: true
     } | {
-            success: false,
+        success: false,
 
-            /** Error code in the case where authentication fails. */
-            error: string
-        };
+        /** Error code in the case where authentication fails. */
+        error: string
+    };
 
     /** Determine whether the Fingerprint scanner is available on the device. */
     function hasHardwareAsync(): Promise<boolean>;
@@ -1413,20 +1413,20 @@ export namespace Google {
     type LogInResult = {
         type: 'cancel';
     } | {
-            type: 'success';
-            accessToken: string;
-            idToken?: string;
-            refreshToken?: string;
-            serverAuthCode?: string;
-            user: {
-                id: string;
-                name: string;
-                givenName: string;
-                familyName: string;
-                photoUrl?: string;
-                email?: string;
-            }
-        };
+        type: 'success';
+        accessToken: string;
+        idToken?: string;
+        refreshToken?: string;
+        serverAuthCode?: string;
+        user: {
+            id: string;
+            name: string;
+            givenName: string;
+            familyName: string;
+            photoUrl?: string;
+            email?: string;
+        }
+    };
 
     function logInAsync(config: LogInConfig): Promise<LogInResult>;
 }

--- a/types/expo/v25/tsconfig.json
+++ b/types/expo/v25/tsconfig.json
@@ -1,0 +1,33 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "dom",
+            "es6"
+        ],
+        "jsx": "react",
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../..",
+        "typeRoots": [
+            "../.."
+        ],
+        "paths": {
+            "expo": [
+                "expo/v25"
+            ],
+            "expo/*": [
+                "expo/v25/*"
+            ]
+        },
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "expo-tests.tsx"
+    ]
+}

--- a/types/expo/v25/tsconfig.json
+++ b/types/expo/v25/tsconfig.json
@@ -10,9 +10,9 @@
         "noImplicitThis": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
-        "baseUrl": "../..",
+        "baseUrl": "../../",
         "typeRoots": [
-            "../.."
+            "../../"
         ],
         "paths": {
             "expo": [

--- a/types/expo/v25/tslint.json
+++ b/types/expo/v25/tslint.json
@@ -1,0 +1,7 @@
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "void-return": false,
+        "max-line-length": false
+    }
+}


### PR DESCRIPTION
This module has existed since SDK v21.0.0, but had not been added to the
typescript definitions. The interface changed in SDK v26.0.0, so a split
between v25 and v26 was required.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes:
https://docs.expo.io/versions/v23.0.0/
https://docs.expo.io/versions/v24.0.0/
https://docs.expo.io/versions/v25.0.0/
https://docs.expo.io/versions/v26.0.0/
- [X] Increase the version number in the header if appropriate.
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
