### PR TITLE
[React-navigation] Add NavigationContainerComponent in case you use ref of NavigationContainer

### DIFF
--- a/types/react-navigation/index.d.ts
+++ b/types/react-navigation/index.d.ts
@@ -598,9 +598,17 @@ export interface NavigationContainerProps {
   style?: StyleProp<ViewStyle>;
 }
 
+export interface NavigationContainerComponent extends React.Component<
+  NavigationContainerProps & NavigationNavigatorProps<any>
+  > {
+  dispatch: NavigationDispatch;
+}
+
 export interface NavigationContainer extends React.ComponentClass<
   NavigationContainerProps & NavigationNavigatorProps<any>
-> {
+  > {
+  new(props: NavigationContainerProps & NavigationNavigatorProps<any>, context?: any): NavigationContainerComponent;
+
   router: NavigationRouter<any, any>;
   screenProps: { [key: string]: any };
   navigationOptions: any;

--- a/types/react-navigation/react-navigation-tests.tsx
+++ b/types/react-navigation/react-navigation-tests.tsx
@@ -33,10 +33,12 @@ import {
     addNavigationHelpers,
     HeaderBackButton,
     Header,
+    NavigationContainer,
     NavigationParams,
     NavigationPopAction,
     NavigationPopToTopAction,
     NavigationScreenComponent,
+    NavigationContainerComponent,
 } from 'react-navigation';
 
 // Constants
@@ -411,3 +413,23 @@ const popToTopAction: NavigationPopToTopAction = NavigationActions.popToTop({
     key: "foo",
     immediate: true
 });
+
+class Page1 extends React.Component { }
+
+const RootNavigator: NavigationContainer = SwitchNavigator({
+    default: { getScreen: () => Page1 },
+});
+
+class Page2 extends React.Component {
+    navigatorRef: NavigationContainerComponent | null;
+
+    componentDidMount() {
+        if (this.navigatorRef) {
+            this.navigatorRef.dispatch(NavigationActions.navigate({ routeName: 'default' }));
+        }
+    }
+
+    render() {
+        return <RootNavigator ref={(instance: NavigationContainerComponent | null): void => { this.navigatorRef = instance; }} />;
+    }
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>

When you follow this guide : https://reactnavigation.org/docs/navigating-without-navigation-prop.html
You use the NavigationContainer ref which is a Component with a public dispatch function
