### PR TITLE
Compatibility fix for keyof T in ts 2.9

### DIFF
--- a/types/aphrodite/index.d.ts
+++ b/types/aphrodite/index.d.ts
@@ -12,13 +12,7 @@ type FontFamily =
     | BaseCSSProperties['fontFamily']
     | CSS.FontFace;
 
-// Replace with Exclude once on 2.8+
-type Diff<T extends string, U extends string> = (
-    & { [P in T]: P }
-    & { [P in U]: never }
-    & { [x: string]: never }
-)[T];
-type Omit<T, K extends keyof T> = Pick<T, Diff<keyof T, K>>;
+type Omit<T, K extends keyof T> = Pick<T, ({ [P in keyof T]: P } & { [P in K]: never } & { [x: string]: never, [x: number]: never })[keyof T]>;
 
 type CSSProperties = Omit<BaseCSSProperties, 'fontFamily'> & {
     fontFamily?: FontFamily | FontFamily[];

--- a/types/dispatchr/addons/createStore.d.ts
+++ b/types/dispatchr/addons/createStore.d.ts
@@ -1,7 +1,6 @@
 import { StoreClass, Store } from '../index';
 
-type Diff<T extends string, U extends string> = ({ [P in T]: P } & { [P in U]: never } & { [x: string]: never })[T];
-type Omit<T, K extends keyof T> = Pick<T, Diff<keyof T, K>>;
+type Omit<T, K extends keyof T> = Pick<T, ({ [P in keyof T]: P } & { [P in K]: never } & { [x: string]: never, [x: number]: never })[keyof T]>;
 
 interface StoreOptions {
     storeName: string;

--- a/types/google-cloud__datastore/google-cloud__datastore-tests.ts
+++ b/types/google-cloud__datastore/google-cloud__datastore-tests.ts
@@ -14,8 +14,7 @@ interface TestEntity {
     name?: string;
     location?: string;
     symbol?: string;
-
-    [keySymbol: string]: any;
+    [Datastore.KEY]?: any;
 }
 
 const kind = 'Company';

--- a/types/google-cloud__datastore/index.d.ts
+++ b/types/google-cloud__datastore/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/googleapis/nodejs-datastore
 // Definitions by: Antoine Beauvais-Lacasse <https://github.com/beaulac>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.4
+// TypeScript Version: 2.7
 
 /// <reference types="node" />
 
@@ -36,7 +36,7 @@ declare module '@google-cloud/datastore' {
     class Datastore extends DatastoreRequest_ {
         constructor(options: InitOptions);
 
-        readonly KEY: KEY_SYMBOL;
+        readonly KEY: typeof Datastore.KEY;
         readonly MORE_RESULTS_AFTER_CURSOR: MoreResultsAfterCursor;
         readonly MORE_RESULTS_AFTER_LIMIT: MoreResultsAfterLimit;
         readonly NO_MORE_RESULTS: NoMoreResults;
@@ -81,7 +81,7 @@ declare module '@google-cloud/datastore' {
     }
 
     namespace Datastore {
-        const KEY: KEY_SYMBOL;
+        const KEY: unique symbol;
         const MORE_RESULTS_AFTER_CURSOR: MoreResultsAfterCursor;
         const MORE_RESULTS_AFTER_LIMIT: MoreResultsAfterLimit;
         const NO_MORE_RESULTS: NoMoreResults;
@@ -93,6 +93,8 @@ declare module '@google-cloud/datastore' {
 }
 
 declare module '@google-cloud/datastore/entity' {
+    import Datastore = require("@google-cloud/datastore");
+
     interface DatastoreInt {
         value: string;
     }
@@ -133,7 +135,7 @@ declare module '@google-cloud/datastore/entity' {
         parent?: DatastoreKey;
     }
 
-    type KEY_SYMBOL = symbol;
+    type KEY_SYMBOL = typeof Datastore.KEY;
 
     interface DatastorePayload<T> {
         key: DatastoreKey;

--- a/types/grid-styled/index.d.ts
+++ b/types/grid-styled/index.d.ts
@@ -5,10 +5,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.6
 
-export type Diff<T extends string, U extends string> = ({ [P in T]: P } &
-    { [P in U]: never } & { [x: string]: never })[T];
-
-export type Omit<T, K extends keyof T> = Pick<T, Diff<keyof T, K>>;
+export type Omit<T, K extends keyof T> = Pick<T, ({ [P in keyof T]: P } & { [P in K]: never } & { [x: string]: never, [x: number]: never })[keyof T]>;
 
 import { ComponentClass } from "react";
 import { StyledComponentClass } from "styled-components";

--- a/types/mirrorx/index.d.ts
+++ b/types/mirrorx/index.d.ts
@@ -11,8 +11,7 @@ import * as React from 'react';
 import { Connect } from 'react-redux';
 import { match } from "react-router";
 
-export type Diff<T extends string, U extends string> = ({[P in T]: P } & {[P in U]: never } & { [x: string]: never })[T];
-export type Omit<T, K extends keyof T> = Pick<T, Diff<keyof T, K>>;
+export type Omit<T, K extends keyof T> = Pick<T, ({ [P in keyof T]: P } & { [P in K]: never } & { [x: string]: never, [x: number]: never })[keyof T]>;
 
 export interface model {
   name: string;

--- a/types/react-autosuggest/index.d.ts
+++ b/types/react-autosuggest/index.d.ts
@@ -22,11 +22,7 @@ declare namespace Autosuggest {
      */
 
     /** @internal */
-    type Diff<T extends string, U extends string> = ({ [P in T]: P } &
-        { [P in U]: never } & { [x: string]: never })[T];
-
-    /** @internal */
-    type Omit<T, K extends keyof T> = Pick<T, Diff<keyof T, K>>;
+    type Omit<T, K extends keyof T> = Pick<T, ({ [P in keyof T]: P } & { [P in K]: never } & { [x: string]: never, [x: number]: never })[keyof T]>;
 
     interface SuggestionsFetchRequestedParams {
         value: string;

--- a/types/react-bootstrap-table/index.d.ts
+++ b/types/react-bootstrap-table/index.d.ts
@@ -1022,7 +1022,7 @@ export interface Options<TRow extends object = any> {
 	 * The function allows you to make further modifications to the cell value prior to it being saved. You need to
 	 * return the final cell value to use.
 	 */
-	onCellEdit?<K extends keyof TRow>(row: TRow, fieldName: K, value: TRow[K]): TRow[K];
+	onCellEdit?<K extends string & keyof TRow>(row: TRow, fieldName: K, value: TRow[K]): TRow[K];
 	/**
 	 * Custom message to show when the InsertModal save fails validation.
 	 * Default message is 'Form validate errors, please checking!'

--- a/types/react-bootstrap/index.d.ts
+++ b/types/react-bootstrap/index.d.ts
@@ -17,8 +17,7 @@
 
 import * as React from 'react';
 
-export type Diff<T extends string, U extends string> = ({ [P in T]: P } & { [P in U]: never } & { [x: string]: never })[T];
-export type Omit<T, K extends keyof T> = Pick<T, Diff<keyof T, K>>;
+export type Omit<T, K extends keyof T> = Pick<T, ({ [P in keyof T]: P } & { [P in K]: never } & { [x: string]: never, [x: number]: never })[keyof T]>;
 
 export type Sizes = 'xs' | 'xsmall' | 'sm' | 'small' | 'medium' | 'lg' | 'large';
 

--- a/types/react-dynamic-number/index.d.ts
+++ b/types/react-dynamic-number/index.d.ts
@@ -6,11 +6,7 @@
 
 import * as React from 'react';
 
-/**
- * remove Diff & Omit when in will be placed in TS from scratch
- */
-export type Diff<T extends string, U extends string> = ({[P in T]: P} & {[P in U]: never} & {[x: string]: never})[T];
-export type Omit<T, K extends keyof T> = {[P in Diff<keyof T, K>]: T[P]};
+export type Omit<T, K extends keyof T> = Pick<T, ({ [P in keyof T]: P } & { [P in K]: never } & { [x: string]: never, [x: number]: never })[keyof T]>;
 
 export type BaseInputProps = Partial<
   Omit<

--- a/types/react-geosuggest/index.d.ts
+++ b/types/react-geosuggest/index.d.ts
@@ -17,12 +17,7 @@ export default class Geosuggest extends Component<GeosuggestProps> {
 }
 
 // Replace with Exclude once on 2.8+
-export type Diff<T extends string, U extends string> = (
-    & { [P in T]: P }
-    & { [P in U]: never }
-    & { [x: string]: never }
-)[T];
-export type Omit<T, K extends keyof T> = Pick<T, Diff<keyof T, K>>;
+export type Omit<T, K extends keyof T> = Pick<T, ({ [P in keyof T]: P } & { [P in K]: never } & { [x: string]: never, [x: number]: never })[keyof T]>;
 
 export interface GeosuggestProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'style'> {
     placeholder?: string;

--- a/types/react-i18next/src/translate.d.ts
+++ b/types/react-i18next/src/translate.d.ts
@@ -20,8 +20,7 @@ export interface TranslateHocProps {
 }
 
 // Diff / Omit taken from https://github.com/Microsoft/TypeScript/issues/12215#issuecomment-311923766
-type Diff<T extends string, U extends string> = ({[P in T]: P } & {[P in U]: never } & { [x: string]: never })[T];
-type Omit<T, K extends string> = Pick<T, Diff<keyof T, K>>;
+type Omit<T, K extends keyof T> = Pick<T, ({ [P in keyof T]: P } & { [P in K]: never } & { [x: string]: never, [x: number]: never })[keyof T]>;
 
 type InjectedProps = InjectedI18nProps & InjectedTranslateProps;
 
@@ -32,11 +31,11 @@ export interface WrapperComponentClass<P = {}, PWrapped = {}> extends React.Comp
 // Injects props and removes them from the prop requirements.
 // Adds the new properties t (or whatever the translation function is called) and i18n if needed.
 export type InferableComponentEnhancerWithProps<TTranslateFunctionName extends string> =
-    <P extends {}>(component: React.ComponentClass<P> | React.StatelessComponent<P>) =>
+    <P extends { [key: string]: any }>(component: React.ComponentClass<P> | React.StatelessComponent<P>) =>
         React.ComponentClass<Omit<P, keyof InjectedI18nProps | TTranslateFunctionName> & TranslateHocProps>;
 
 export type InferableComponentEnhancerWithPropsAndRef<TTranslateFunctionName extends string> =
-    <P extends {}>(component: React.ComponentClass<P> | React.StatelessComponent<P>) =>
+    <P extends { [key: string]: any }>(component: React.ComponentClass<P> | React.StatelessComponent<P>) =>
         WrapperComponentClass<Omit<P, keyof InjectedI18nProps | TTranslateFunctionName>, P>;
 
 export interface Translate {

--- a/types/react-redux/index.d.ts
+++ b/types/react-redux/index.d.ts
@@ -30,8 +30,7 @@ type Dispatch<A extends Redux.Action = Redux.AnyAction> = Redux.Dispatch<A>;
 type ActionCreator<A> = Redux.ActionCreator<A>;
 
 // Diff / Omit taken from https://github.com/Microsoft/TypeScript/issues/12215#issuecomment-311923766
-type Diff<T extends string, U extends string> = ({ [P in T]: P } & { [P in U]: never } & { [x: string]: never })[T];
-type Omit<T, K extends keyof T> = Pick<T, Diff<keyof T, K>>;
+type Omit<T, K extends keyof T> = Pick<T, ({ [P in keyof T]: P } & { [P in K]: never } & { [x: string]: never, [x: number]: never })[keyof T]>;
 
 export interface DispatchProp<A extends Redux.Action = Redux.AnyAction> {
   dispatch?: Dispatch<A>;

--- a/types/react-relay/index.d.ts
+++ b/types/react-relay/index.d.ts
@@ -24,9 +24,7 @@ import * as RelayRuntimeTypes from "relay-runtime";
 
 // Taken from https://github.com/pelotom/type-zoo
 // tslint:disable-next-line:strict-export-declare-modifiers
-type Diff<T extends string, U extends string> = ({ [P in T]: P } & { [P in U]: never } & { [x: string]: never })[T];
-// tslint:disable-next-line:strict-export-declare-modifiers
-type Omit<T, K extends keyof T> = Pick<T, Diff<keyof T, K>>;
+type Omit<T, K extends keyof T> = Pick<T, ({ [P in keyof T]: P } & { [P in K]: never } & { [x: string]: never, [x: number]: never })[keyof T]>;
 
 export type RemoveRelayProp<P> = Omit<P & { relay: never }, "relay">;
 

--- a/types/react-router/index.d.ts
+++ b/types/react-router/index.d.ts
@@ -102,8 +102,7 @@ export interface match<P> {
 }
 
 // Diff / Omit taken from https://github.com/Microsoft/TypeScript/issues/12215#issuecomment-311923766
-export type Diff<T extends string, U extends string> = ({ [P in T]: P } & { [P in U]: never } & { [x: string]: never })[T];
-export type Omit<T, K extends keyof T> = Pick<T, Diff<keyof T, K>>;
+export type Omit<T, K extends keyof T> = Pick<T, ({ [P in keyof T]: P } & { [P in K]: never } & { [x: string]: never, [x: number]: never })[keyof T]>;
 
 export function matchPath<P>(pathname: string, props: RouteProps): match<P> | null;
 

--- a/types/recompose/index.d.ts
+++ b/types/recompose/index.d.ts
@@ -20,8 +20,7 @@ declare module 'recompose' {
     type predicateDiff<T> = (current: T, next: T) => boolean
 
     // Diff / Omit taken from https://github.com/Microsoft/TypeScript/issues/12215#issuecomment-311923766
-    type Diff<T extends string, U extends string> = ({ [P in T]: P } & { [P in U]: never } & { [x: string]: never })[T];
-    type Omit<T, K extends keyof T> = Pick<T, Diff<keyof T, K>>;
+    type Omit<T, K extends keyof T> = Pick<T, ({ [P in keyof T]: P } & { [P in K]: never } & { [x: string]: never, [x: number]: never })[keyof T]>;
 
     interface Observer<T>{
         next(props: T): void;

--- a/types/redux-form/index.d.ts
+++ b/types/redux-form/index.d.ts
@@ -39,8 +39,7 @@ export interface RegisteredFieldState {
     type: FieldType;
 }
 
-export type Diff<T extends string, U extends string> = ({ [P in T]: P } & { [P in U]: never } & { [x: string]: never })[T];
-export type Omit<T, K extends keyof T> = Pick<T, Diff<keyof T, K>>;
+export type Omit<T, K extends keyof T> = Pick<T, ({ [P in keyof T]: P } & { [P in K]: never } & { [x: string]: never, [x: number]: never })[keyof T]>;
 
 export * from "./lib/reduxForm";
 export * from "./lib/Field";


### PR DESCRIPTION
This is a backwards-compatibility fix for `keyof` in light of [recent changes](https://github.com/Microsoft/TypeScript/pull/23592) to the default behavior of `keyof` in 2.9. The goal of this change is to update existing definitions with a type compatible with both TS 2.9 *and* earlier versions of TS. The only change in this PR that could not be made backwards compatible is the definition of `Datastore.KEY` in `"google-cloud__datastore"` as TS 2.9 adds further restrictions when indexing using non-unique `symbol` types.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/Microsoft/TypeScript/pull/23592

