### PR TITLE
[flowjs] Change type of IFlow.opts to IFlowOptions

### DIFF
--- a/types/flowjs/flowjs-tests.ts
+++ b/types/flowjs/flowjs-tests.ts
@@ -4,7 +4,7 @@
 var flowObject: flowjs.IFlow;
 var bool: boolean = flowObject.support;
 bool = flowObject.supportDirectory;
-var obj: Object = flowObject.opts;
+var flowOpts: flowjs.IFlowOptions = flowObject.opts;
 var flowFileArray: flowjs.IFlowFile[] = flowObject.files;
 
 flowObject.assignBrowse(<HTMLElement[]> [], false, false, {});

--- a/types/flowjs/index.d.ts
+++ b/types/flowjs/index.d.ts
@@ -7,7 +7,7 @@ declare namespace flowjs {
     interface IFlow {
         support: boolean;
         supportDirectory: boolean;
-        opts: Object;
+        opts: IFlowOptions;
         files: IFlowFile[];
 
         assignBrowse(domNodes: HTMLElement[], isDirectory: boolean, singleFile: boolean, attributes: Object): void;


### PR DESCRIPTION
This should be pretty straight-forward. Not sure why `IFlow.opts` was typed as `Object` when the definition of `IFlowOptions` is right there.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/flowjs/flow.js
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
