### PR TITLE
Be more permissive with returns and parameters in common-tags

### DIFF
--- a/types/common-tags/common-tags-tests.ts
+++ b/types/common-tags/common-tags-tests.ts
@@ -143,6 +143,10 @@ new commonTags.TemplateTag({
     onEndResult: endResult => `${endResult}!`
 });
 
+new commonTags.TemplateTag({
+    onEndResult: () => ({})
+})
+
 /* Tests Built-in Transformers */
 
 new commonTags.TemplateTag(commonTags.trimResultTransformer());

--- a/types/common-tags/common-tags-tests.ts
+++ b/types/common-tags/common-tags-tests.ts
@@ -163,6 +163,9 @@ new commonTags.TemplateTag(commonTags.replaceSubstitutionTransformer(/baz/g, 'ba
 new commonTags.TemplateTag(commonTags.replaceSubstitutionTransformer('foo', 'bar'));
 new commonTags.TemplateTag(commonTags.replaceSubstitutionTransformer(/baz/g, 'bar'));
 
+new commonTags.TemplateTag(commonTags.replaceStringTransformer('foo', 'bar'));
+new commonTags.TemplateTag(commonTags.replaceStringTransformer(/baz/g, 'bar'));
+
 new commonTags.TemplateTag(commonTags.inlineArrayTransformer());
 new commonTags.TemplateTag(commonTags.inlineArrayTransformer({}));
 new commonTags.TemplateTag(commonTags.inlineArrayTransformer({separator: 'foo'}));

--- a/types/common-tags/index.d.ts
+++ b/types/common-tags/index.d.ts
@@ -2,14 +2,15 @@
 // Project: https://github.com/declandewet/common-tags
 // Definitions by: Viktor Zozuliak <https://github.com/zuzusik>
 //                 Paul Wang <https://github.com/tzupengwang>
+//                 coolreader18 <https://github.com/coolreader18>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare module 'common-tags' {
-    type TemplateTag = (literals: TemplateStringsArray, ...placeholders: any[]) => string;
+    type TemplateTag = (literals: TemplateStringsArray, ...placeholders: any[]) => any;
 
     type TemplateTransformer = {
-        onSubstitution?: (substitution: string, resultSoFar: string) => string;
-        onEndResult?: (endResult : string) => string;
+        onSubstitution?: (substitution?: any, resultSoFar?: string) => string;
+        onEndResult?: (endResult?: string) => any;
     }
 
     /* Built-in Tags */

--- a/types/common-tags/index.d.ts
+++ b/types/common-tags/index.d.ts
@@ -55,13 +55,15 @@ declare module 'common-tags' {
     };
 
     /* Built-in Transformers */
-    export var trimResultTransformer: (side?: 'left'|'right') => TemplateTransformer;
+    export var trimResultTransformer: (side?: 'start'|'left'|'end'|'right') => TemplateTransformer;
 
     export var stripIndentTransformer: (type?: 'initial'|'all') => TemplateTransformer;
 
     export var replaceResultTransformer: (replaceWhat: string|RegExp, replaceWith: string) => TemplateTransformer;
 
     export var replaceSubstitutionTransformer: (replaceWhat: string|RegExp, replaceWith: string) => TemplateTransformer;
+
+    export var replaceStringTransformer: (replaceWhat: string|RegExp, replaceWith: string) => TemplateTransformer;
 
     export var inlineArrayTransformer: (opts?: {separator?: string, conjunction?: string}) => TemplateTransformer;
 

--- a/types/common-tags/index.d.ts
+++ b/types/common-tags/index.d.ts
@@ -9,7 +9,8 @@ declare module 'common-tags' {
     type TemplateTag = (literals: TemplateStringsArray, ...placeholders: any[]) => any;
 
     type TemplateTransformer = {
-        onSubstitution?: (substitution?: any, resultSoFar?: string) => string;
+        onString?: (str: string) => string;
+        onSubstitution?: (substitution: any, resultSoFar: string) => string;
         onEndResult?: (endResult?: string) => any;
     }
 

--- a/types/common-tags/index.d.ts
+++ b/types/common-tags/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for common-tags v1.4.0
+// Type definitions for common-tags v1.7.2
 // Project: https://github.com/declandewet/common-tags
 // Definitions by: Viktor Zozuliak <https://github.com/zuzusik>
 //                 Paul Wang <https://github.com/tzupengwang>


### PR DESCRIPTION
Let the `TemplateTag` type and `onEndResult` function return `any`, change the `onSubsitution` `substitution` parameter to be of type any, and make all the function parameters optional.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/declandewet/common-tags#class-is-in-session-templatetag
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.