### PR TITLE
add types for deglob

### DIFF
--- a/types/deglob/deglob-tests.ts
+++ b/types/deglob/deglob-tests.ts
@@ -1,0 +1,21 @@
+/// <reference types="node" />
+
+import deglob = require('deglob');
+
+deglob(['**/*.js'], (err, files) => {
+  files.forEach(file => {
+    console.log('found file ' + file);
+  });
+});
+
+const opts = {
+  cwd: 'foo',
+  useGitIgnore: false,
+  usePackageJson: false
+};
+
+deglob(['**/*.js'], opts, (err, files) => {
+  files.forEach(file => {
+    console.log('found file ' + file);
+  });
+});

--- a/types/deglob/index.d.ts
+++ b/types/deglob/index.d.ts
@@ -1,0 +1,22 @@
+// Type definitions for deglob v 2.1
+// Project: https://github.com/standard/deglob
+// Definitions by: Saad Quadri <https://github.com/saadq>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+type Callback = (err: Error | null, files: string[]) => void;
+
+declare function deglob(patterns: string[], cb: Callback): void;
+declare function deglob(patterns: string[], opts: deglob.Options, cb: Callback): void;
+
+declare namespace deglob {
+  interface Options {
+    useGitIgnore?: boolean;
+    usePackageJson?: boolean;
+    configKey?: string;
+    gitIgnoreFile?: string;
+    ignore?: string[];
+    cwd?: string;
+  }
+}
+
+export = deglob;

--- a/types/deglob/tsconfig.json
+++ b/types/deglob/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "deglob-tests.ts"
+    ]
+}

--- a/types/deglob/tslint.json
+++ b/types/deglob/tslint.json
@@ -1,0 +1,3 @@
+{
+  "extends": "dtslint/dt.json"
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
