### PR TITLE
@types/react-redux: fix augmenting Redux.Dispatch has no effect in react-redux

### DIFF
--- a/types/react-redux/index.d.ts
+++ b/types/react-redux/index.d.ts
@@ -8,6 +8,7 @@
 //                 Nicholas Boll <https://github.com/nicholasboll>
 //                 Dibyo Majumdar <https://github.com/mdibyo>
 //                 Prashant Deva <https://github.com/pdeva>
+//                 Stefan Knoch <https://github.com/ch1ll0ut1>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.6
 

--- a/types/react-redux/index.d.ts
+++ b/types/react-redux/index.d.ts
@@ -19,20 +19,17 @@
 // https://github.com/DefinitelyTyped/DefinitelyTyped/issues/20796
 
 import * as React from 'react';
-import * as Redux from 'redux';
+import { Action, AnyAction, Store, Dispatch } from 'redux';
 
 type ComponentClass<P> = React.ComponentClass<P>;
 type StatelessComponent<P> = React.StatelessComponent<P>;
 type Component<P> = React.ComponentType<P>;
 type ReactNode = React.ReactNode;
-type Store<S> = Redux.Store<S>;
-type Dispatch<A extends Redux.Action = Redux.AnyAction> = Redux.Dispatch<A>;
-type ActionCreator<A> = Redux.ActionCreator<A>;
 
 // Diff / Omit taken from https://github.com/Microsoft/TypeScript/issues/12215#issuecomment-311923766
 type Omit<T, K extends keyof T> = Pick<T, ({ [P in keyof T]: P } & { [P in K]: never } & { [x: string]: never, [x: number]: never })[keyof T]>;
 
-export interface DispatchProp<A extends Redux.Action = Redux.AnyAction> {
+export interface DispatchProp<A extends Action<any> = AnyAction> {
   dispatch?: Dispatch<A>;
 }
 
@@ -221,7 +218,7 @@ interface Options<State = {}, TStateProps = {}, TOwnProps = {}, TMergedProps = {
  * @param connectOptions If specified, further customizes the behavior of the connector. Additionally, any extra
  *     options will be passed through to your <code>selectorFactory</code> in the <code>factoryOptions</code> argument.
  */
-export declare function connectAdvanced<S, TProps, TOwnProps, TFactoryOptions = {}>(
+export declare function connectAdvanced<S extends Action<any>, TProps, TOwnProps, TFactoryOptions = {}>(
     selectorFactory: SelectorFactory<S, TProps, TOwnProps, TFactoryOptions>,
     connectOptions?: ConnectOptions & TFactoryOptions
 ): AdvancedComponentDecorator<TProps, TOwnProps>;
@@ -234,7 +231,7 @@ export declare function connectAdvanced<S, TProps, TOwnProps, TFactoryOptions = 
  * call, the component will not be re-rendered. It's the responsibility of <code>selector</code> to return that
  * previous object when appropriate.
  */
-export interface SelectorFactory<S, TProps, TOwnProps, TFactoryOptions> {
+export interface SelectorFactory<S extends Action<any>, TProps, TOwnProps, TFactoryOptions> {
     (dispatch: Dispatch, factoryOptions: TFactoryOptions): Selector<S, TProps, TOwnProps>
 }
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [] Provide a URL to documentation or source code which provides context for the suggested changes: Minor change
- [not needed] Increase the version number in the header if appropriate.
- [not needed] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.


Problem: Augmenting Redux.Dispatch has no effect to the Dispatch in connect()

// augmented redux Dispatch
connect(undefined, (dispatch: Dispatch) => {});

// inferred react-redux Dispatch
connect(undefined, (dispatch) => {});

This PR will make both statements above have the same type.