### PR TITLE
[@feathersjs/feathers] Make HookContext generic default to any

### DIFF
--- a/types/feathersjs__feathers/index.d.ts
+++ b/types/feathersjs__feathers/index.d.ts
@@ -45,9 +45,9 @@ export interface Paginated<T> {
 }
 
 // tslint:disable-next-line void-return
-export type Hook = <T>(hook: HookContext<T>) => (Promise<HookContext<T>> | void);
+export type Hook = (hook: HookContext) => (Promise<HookContext> | void);
 
-export interface HookContext<T> {
+export interface HookContext<T = any> {
     app?: Application;
     data?: T;
     error?: any;


### PR DESCRIPTION
`HookContext` and `Hook` should not have been generics in the first place. Defaulting to `HookContext<any>` now, to have a non-breaking solution.