### PR TITLE
swagger-jsdoc: use true typescript import statements instead of require

### DIFF
--- a/types/swagger-jsdoc/index.d.ts
+++ b/types/swagger-jsdoc/index.d.ts
@@ -6,8 +6,8 @@
 
 /* =================== USAGE ===================
 
-    import * as express from "express"
-    import swaggerJSDoc = require('swagger-jsdoc');
+    import * as express from 'express';
+    import { swaggerJSDoc } from 'swagger-jsdoc';
     const app = express()
 
     let options = {
@@ -27,7 +27,7 @@
       }
     };
 
-    var spec = swaggerJSDoc(options);
+    let spec = swaggerJSDoc(options);
 
     app.get('/api-docs.json', function(req, res) {
       res.setHeader('Content-Type', 'application/json');
@@ -37,6 +37,5 @@
  =============================================== */
 
 declare module "swagger-jsdoc" {
-    function swaggerJSDoc(options?: any): any;
-    export = swaggerJSDoc;
+    export function swaggerJSDoc(options?: any): any;
 }

--- a/types/swagger-jsdoc/index.d.ts
+++ b/types/swagger-jsdoc/index.d.ts
@@ -7,7 +7,7 @@
 /* =================== USAGE ===================
 
     import * as express from 'express';
-    import { swaggerJSDoc } from 'swagger-jsdoc';
+    import * as swaggerJSDoc from 'swagger-jsdoc';
     const app = express()
 
     let options = {
@@ -36,6 +36,9 @@
 
  =============================================== */
 
-declare module "swagger-jsdoc" {
-    export function swaggerJSDoc(options?: any): any;
-}
+ declare function swaggerJSDoc(options?: any): any;
+ declare namespace swaggerJSDoc {
+ 
+ }
+ 
+ export = swaggerJSDoc;

--- a/types/swagger-jsdoc/swagger-jsdoc-tests.ts
+++ b/types/swagger-jsdoc/swagger-jsdoc-tests.ts
@@ -1,5 +1,5 @@
-import express = require('express');
-import swaggerJSDoc = require('swagger-jsdoc');
+import * as express from 'express';
+import { swaggerJSDoc } from 'swagger-jsdoc';
 const app = express();
 
 let options = {
@@ -10,7 +10,6 @@ let options = {
         }
     }
 };
-
 
 let swaggerSpec = swaggerJSDoc(options);
 

--- a/types/swagger-jsdoc/swagger-jsdoc-tests.ts
+++ b/types/swagger-jsdoc/swagger-jsdoc-tests.ts
@@ -1,5 +1,5 @@
 import * as express from 'express';
-import { swaggerJSDoc } from 'swagger-jsdoc';
+import * as swaggerJSDoc from 'swagger-jsdoc';
 const app = express();
 
 let options = {


### PR DESCRIPTION
This module requires use of require('') style imports, which is not compliant to ES6 style imports.
The pull request fixes this by using TS export statement instead of export= .

Documentation and test has been adapted accordingly.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: https://palantir.github.io/tslint/rules/no-require-imports/
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

