### PR TITLE
moment-timezone: Fix type: .tz() can also return undefined as per the docs

### DIFF
--- a/types/moment-timezone/index.d.ts
+++ b/types/moment-timezone/index.d.ts
@@ -57,7 +57,7 @@ declare module "moment" {
     }
 
     interface Moment {
-        tz(): string;
+        tz(): string | undefined;
         tz(timezone: string): Moment;
         zoneAbbr(): string;
         zoneName(): string;

--- a/types/moment-timezone/moment-timezone-tests.ts
+++ b/types/moment-timezone/moment-timezone-tests.ts
@@ -83,3 +83,5 @@ moment.tz.guess(true);
 const zoneAbbr: string = moment.tz('America/Los_Angeles').zoneAbbr();
 
 const zoneName: string = moment.tz('America/Los_Angeles').zoneName();
+
+const zoneType: string | undefined = moment.tz('2013-11-18 11:55').tz();


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://momentjs.com/timezone/docs/#/using-timezones/converting-to-zone/
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
