### PR TITLE
[spotify-web-playback-sdk] Fix incorrect enum declaration

### DIFF
--- a/types/spotify-web-playback-sdk/index.d.ts
+++ b/types/spotify-web-playback-sdk/index.d.ts
@@ -64,7 +64,12 @@ declare namespace Spotify {
         duration: number;
         paused: boolean;
         position: number;
-        repeat_mode: RepeatMode;
+        /**
+         * 0: NO_REPEAT
+         * 1: ONCE_REPEAT
+         * 2: FULL_REPEAT
+         */
+        repeat_mode: 0 | 1 | 2;
         shuffle: boolean;
         restrictions: PlaybackRestrictions;
         track_window: PlaybackTrackWindow;
@@ -80,12 +85,6 @@ declare namespace Spotify {
         name: string;
         getOAuthToken(cb: (token: string) => void): void;
         volume?: number;
-    }
-
-    enum RepeatMode {
-        NO_REPEAT = 0,
-        ONCE_REPEAT = 1,
-        FULL_REPEAT = 2,
     }
 
     type ErrorListener = (err: Error) => void;

--- a/types/spotify-web-playback-sdk/spotify-web-playback-sdk-tests.ts
+++ b/types/spotify-web-playback-sdk/spotify-web-playback-sdk-tests.ts
@@ -27,6 +27,7 @@ player.addListener("ready", (data) => {
 player.getCurrentState().then((playbackState: Spotify.PlaybackState | null) => {
     if (playbackState) {
         const { current_track, next_tracks } = playbackState.track_window;
+        const repeatMode: 0 | 1 | 2 = playbackState.repeat_mode;
 
         console.log("Currently Playing", current_track);
         console.log("Playing Next", next_tracks[0]);


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Increase the version number in the header if appropriate.
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

The enum was meant to be used as `const enum` (it doesn't actually exist), but since `const enum`s aren't allowed, we need to use a type here.
I'm correcting a declaration bug here, but one that is, strictly speaking, breaking backwards compatibility. Does that need a minor version number increase?