### PR TITLE
Improve coverage of AWS Lambda Statement type

### DIFF
--- a/types/aws-lambda/aws-lambda-tests.ts
+++ b/types/aws-lambda/aws-lambda-tests.ts
@@ -260,6 +260,46 @@ statement = {
     Resource: str
 };
 
+// $ExpectError
+statement = {
+    Effect: str,
+    Action: str,
+    Principal: 123
+};
+
+// Bad Resource
+// $ExpectError
+statement = {
+    Effect: str,
+    Action: str,
+    Resource: 123
+};
+
+// Bad Resource with valid Principal
+// $ExpectError
+statement = {
+    Effect: str,
+    Action: str,
+    Principal: { Service: str},
+    Resource: 123
+};
+
+// Bad principal with valid Resource
+// $ExpectError
+statement = {
+    Effect: str,
+    Action: str,
+    Principal: 123,
+    Resource: str
+};
+
+// No Effect
+// $ExpectError
+statement = {
+    Action: str,
+    Principal: str
+};
+
 statement = {
     Sid: str,
     Action: [str, str],

--- a/types/aws-lambda/aws-lambda-tests.ts
+++ b/types/aws-lambda/aws-lambda-tests.ts
@@ -279,6 +279,20 @@ statement = {
 };
 
 statement = {
+    Action: str,
+    Principal: str,
+    Effect: str
+};
+
+statement = {
+    Action: str,
+    NotPrincipal: {
+        Service: str
+    },
+    Effect: str
+};
+
+statement = {
     Effect: str,
     NotAction: str,
     NotResource: str

--- a/types/aws-lambda/index.d.ts
+++ b/types/aws-lambda/index.d.ts
@@ -482,9 +482,17 @@ export interface BaseStatement {
 }
 
 export type PrincipalValue = { [key: string]: string | string[]; } | string | string[];
+export interface MaybeStatementPrincipal {
+    Principal?: PrincipalValue;
+    NotPrincipal?: PrincipalValue;
+}
+export interface MaybeStatementResource {
+    Resource?: string | string[];
+    NotResource?: string | string[];
+}
 export type StatementAction = { Action: string | string[] } | { NotAction: string | string[] };
-export type StatementResource = { Resource: string | string[] } | { NotResource: string | string[] };
-export type StatementPrincipal = { Principal: PrincipalValue } | { NotPrincipal: PrincipalValue };
+export type StatementResource = MaybeStatementPrincipal & ({ Resource: string | string[] } | { NotResource: string | string[] });
+export type StatementPrincipal = MaybeStatementResource & ({ Principal: PrincipalValue } | { NotPrincipal: PrincipalValue });
 /**
  * API Gateway CustomAuthorizer AuthResponse.PolicyDocument.Statement.
  * http://docs.aws.amazon.com/apigateway/latest/developerguide/use-custom-authorizer.html#api-gateway-custom-authorizer-output

--- a/types/aws-lambda/index.d.ts
+++ b/types/aws-lambda/index.d.ts
@@ -473,19 +473,22 @@ export interface Condition {
  * https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-control-access-policy-language-overview.html
  * https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements.html
  */
-export type Statement = BaseStatement & StatementAction & StatementResource;
+export type Statement = BaseStatement & StatementAction & (StatementResource | StatementPrincipal);
 
 export interface BaseStatement {
     Effect: string;
     Sid?: string;
     Condition?: ConditionBlock;
-    Principal?: string | string[];
-    NotPrincipal?: string | string[];
 }
 
+export interface PrincipalBlock {
+    [key: string]: string | string[];
+}
+
+export type PrincipalValue = PrincipalBlock | string | string[];
 export type StatementAction = { Action: string | string[] } | { NotAction: string | string[] };
 export type StatementResource = { Resource: string | string[] } | { NotResource: string | string[] };
-
+export type StatementPrincipal = { Principal: PrincipalValue } | { NotPrincipal: PrincipalValue };
 /**
  * API Gateway CustomAuthorizer AuthResponse.PolicyDocument.Statement.
  * http://docs.aws.amazon.com/apigateway/latest/developerguide/use-custom-authorizer.html#api-gateway-custom-authorizer-output

--- a/types/aws-lambda/index.d.ts
+++ b/types/aws-lambda/index.d.ts
@@ -481,11 +481,7 @@ export interface BaseStatement {
     Condition?: ConditionBlock;
 }
 
-export interface PrincipalBlock {
-    [key: string]: string | string[];
-}
-
-export type PrincipalValue = PrincipalBlock | string | string[];
+export type PrincipalValue = { [key: string]: string | string[]; } | string | string[];
 export type StatementAction = { Action: string | string[] } | { NotAction: string | string[] };
 export type StatementResource = { Resource: string | string[] } | { NotResource: string | string[] };
 export type StatementPrincipal = { Principal: PrincipalValue } | { NotPrincipal: PrincipalValue };


### PR DESCRIPTION
This allows AWS policy statements which have only a Principal, and no Resource.  This is a critical use case which is described here:
https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_principal.html:

For example this is the typical statement required to allow an AWS Lambda function to assume a role:
```
{
  Effect: "Allow",
  Principal: { "Service": "lambda.amazonaws.com" },
  Action: "sts:AssumeRole"
}
```
The current Statement type declaration disallows statements like this which have no Resource restriction but have a Principal restriction. It also only allows `string` or `string[]` style principal values, which prevents forming a statement like the one above.

This PR fixes the problem, and prevents invalid documents missing both Resource and Principal.

# Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

## Select one of these and delete the others:

### If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
* This PR enables a critical use case explained here and above: https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_principal.html
- [ ] Increase the version number in the header if appropriate.
