### PR TITLE
[stripe-v3] Differentiate response types on "token", "source" StripePaymentRequest events

### DIFF
--- a/types/stripe-v3/index.d.ts
+++ b/types/stripe-v3/index.d.ts
@@ -255,8 +255,6 @@ declare namespace stripe {
         }
 
         interface StripePaymentResponse {
-            token?: Token;
-            source?: Source;
             complete: (status: string) => void;
             payerName?: string;
             payerEmail?: string;
@@ -266,11 +264,20 @@ declare namespace stripe {
             methodName: string;
         }
 
+        interface StripeTokenPaymentResponse extends StripePaymentResponse {
+            token: Token;
+        }
+
+        interface StripeSourcePaymentResponse extends StripePaymentResponse {
+            source: Source;
+        }
+
         interface StripePaymentRequest {
             canMakePayment(): Promise<{applePay?: boolean} | null>;
             show(): void;
             update(options: StripePaymentRequestUpdateOptions): void;
-            on(event: 'token' | 'source', handler: (response: StripePaymentResponse) => void): void;
+            on(event: 'token', handler: (response: StripeTokenPaymentResponse) => void): void;
+            on(event: 'source', handler: (response: StripeSourcePaymentResponse) => void): void;
             on(event: 'cancel', handler: () => void): void;
             on(event: 'shippingaddresschange', handler: (response: {updateWith: (options: UpdateDetails) => void, shippingAddress: ShippingAddress}) => void): void;
             on(event: 'shippingoptionchange', handler: (response: {updateWith: (options: UpdateDetails) => void, shippingOption: ShippingOption}) => void): void;

--- a/types/stripe-v3/stripe-v3-tests.ts
+++ b/types/stripe-v3/stripe-v3-tests.ts
@@ -118,7 +118,19 @@ describe("Stripe", () => {
             }
         });
         paymentRequest.on('token', ev => {
-            const body = JSON.stringify({token: ev.token!.id});
+            const body = JSON.stringify({token: ev.token.id});
+            // post to server...
+            Promise.resolve({ok: true})
+            .then(response => {
+                if (response.ok) {
+                    ev.complete('success');
+                } else {
+                    ev.complete('fail');
+                }
+            });
+        });
+        paymentRequest.on('source', ev => {
+            const body = JSON.stringify({token: ev.source.id});
             // post to server...
             Promise.resolve({ok: true})
             .then(response => {


### PR DESCRIPTION
"token" events will pass a Token objects as part of the StripePaymentResponse object, while "source" events will pass a Source object.

---

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [The PaymentResponse object](https://stripe.com/docs/stripe-js/reference#payment-response-object)
- [ ] Increase the version number in the header if appropriate.