### PR TITLE
fix(react-transition-group v1): support esModuleInterop

### DIFF
--- a/types/react-transition-group/v1/index.d.ts
+++ b/types/react-transition-group/v1/index.d.ts
@@ -11,13 +11,13 @@ export interface HTMLTransitionGroupProps<T> extends HTMLAttributes<T> {
     childFactory?(child: ReactElement<any>): ReactElement<any>;
 }
 
-import * as TransitionGroup from "./TransitionGroup";
+import TransitionGroup = require("./TransitionGroup");
 export {
     TransitionGroupProps,
     TransitionGroupChildLifecycle
 } from "./TransitionGroup";
 
-import * as CSSTransitionGroup from "./CSSTransitionGroup";
+import CSSTransitionGroup = require("./CSSTransitionGroup");
 export {
     CSSTransitionGroupProps,
     CSSTransitionGroupTransitionName


### PR DESCRIPTION
This change fixes support for `esModuleInterop` flag, so that the library can be imported via:

```ts
import { CSSTransitionGroup, TransitionGroup } from "react-transition-group";
```

This package was previously using `import * as TransitionGroup from "./TransitionGroup`, to import the class `TransitionGroup`. However after enabling `esModuleInterop` TypeScript complains when using `TransitionGroup` as a JSX tag:

```
TS2604: JSX element type 'CSSTransitionGroup' does not have any construct or call signatures.
```

This patch fixes the types.

----

Please fill in this template.

- [ ] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
