### PR TITLE
Update react-redux-i18n for react-redux 5.0.18 types

### DIFF
--- a/types/react-redux-i18n/index.d.ts
+++ b/types/react-redux-i18n/index.d.ts
@@ -21,7 +21,7 @@ declare module 'react-redux-i18n' {
 
   type TranslationObjects = { [lang: string]: SubTranslationObject };
 
-  type DispatchCallback<S> = {
+  type DispatchCallback<S extends redux.Action<any>> = {
     (dispatch?: redux.Dispatch<S>, getState?: () => S): any;
   }
 

--- a/types/react-redux-i18n/index.d.ts
+++ b/types/react-redux-i18n/index.d.ts
@@ -21,7 +21,7 @@ declare module 'react-redux-i18n' {
 
   type TranslationObjects = { [lang: string]: SubTranslationObject };
 
-  type DispatchCallback<S extends redux.Action<any>> = {
+  type DispatchCallback<S extends redux.Action> = {
     (dispatch?: redux.Dispatch<S>, getState?: () => S): any;
   }
 

--- a/types/react-redux-i18n/package.json
+++ b/types/react-redux-i18n/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "redux": "^3.6.0"
+        "redux": "^3.7.2"
     }
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.

Add constraint for S type parameter.