### PR TITLE
cucumber: Transform should support multiple matches and use World as this context

### DIFF
--- a/types/cucumber/cucumber-tests.ts
+++ b/types/cucumber/cucumber-tests.ts
@@ -164,6 +164,14 @@ function StepSampleWithoutDefineSupportCode() {
         useForSnippets: false
     });
 
+    defineParameterType({
+        regexp: /(one) (two)/,
+        transformer: (x, y) => x + y,
+        name: 'param',
+        preferForRegexpMatch: false,
+        useForSnippets: false
+    });
+
     Given('a {param} step', param => {
         assert.equal(param, 'PARTICULAR');
     });

--- a/types/cucumber/cucumber-tests.ts
+++ b/types/cucumber/cucumber-tests.ts
@@ -11,6 +11,7 @@ const Status = cucumber.Status;
 declare module "cucumber" {
     interface World {
         visit(url: string, callback: CallbackStepDefinition): void;
+        toInt(value: string): number;
     }
 }
 
@@ -21,6 +22,7 @@ function StepSampleWithoutDefineSupportCode() {
         this.visit = (url: string, callback: Callback) => {
             callback(null, 'pending');
         };
+        this.toInt = parseInt;
     });
 
     Before((scenarioResult: HookScenarioResult, callback: Callback) => {
@@ -167,6 +169,16 @@ function StepSampleWithoutDefineSupportCode() {
     defineParameterType({
         regexp: /(one) (two)/,
         transformer: (x, y) => x + y,
+        name: 'param',
+        preferForRegexpMatch: false,
+        useForSnippets: false
+    });
+
+    defineParameterType({
+        regexp: /123/,
+        transformer(val) {
+            return this.toInt(val);
+        },
         name: 'param',
         preferForRegexpMatch: false,
         useForSnippets: false

--- a/types/cucumber/index.d.ts
+++ b/types/cucumber/index.d.ts
@@ -129,7 +129,7 @@ export type GlobalHookCode = (callback?: CallbackStepDefinition) => void;
 
 export interface Transform {
     regexp: RegExp;
-    transformer(...arg: string[]): any;
+    transformer(this: World, ...arg: string[]): any;
     useForSnippets?: boolean;
     preferForRegexpMatch?: boolean;
     name?: string;

--- a/types/cucumber/index.d.ts
+++ b/types/cucumber/index.d.ts
@@ -129,7 +129,7 @@ export type GlobalHookCode = (callback?: CallbackStepDefinition) => void;
 
 export interface Transform {
     regexp: RegExp;
-    transformer(arg: string): any;
+    transformer(...arg: string[]): any;
     useForSnippets?: boolean;
     preferForRegexpMatch?: boolean;
     name?: string;


### PR DESCRIPTION
This PR fixes to things in the Cucumber definitions:

1. It sets the `this` context of the `transformer` function in the `Transform` interface to `World`.

The [documentation](https://github.com/cucumber/cucumber-js/blob/master/docs/support_files/api_reference.md#defineparametertypename-preferforregexpmatch-regexp-transformer-useforsnippets) also mentions this:

> transformer: An optional function which transforms the captured argument from a string into what is passed to the step definition. If no transform function is specified, the captured argument is left as a string. The function can be synchronous or return a Promise of the transformed value. **The value of this is the current world**, so the function can delegate to world functions. World delegation does not work with arrow functions.

2. The `transformer` function in the `Transform` interface can take more than one parameter, which is used when there is more then one match.