### PR TITLE
[shelljs] Add missing `chmod` types

### DIFF
--- a/types/shelljs/index.d.ts
+++ b/types/shelljs/index.d.ts
@@ -2,6 +2,7 @@
 // Project: http://shelljs.org
 // Definitions by: Niklas Mollenhauer <https://github.com/nikeee>
 //                 Vojtech Jasny <https://github.com/voy>
+//                 George Kalpakas <https://github.com/gkalpak>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node"/>
@@ -385,10 +386,30 @@ export function chmod(octalMode: number, file: string): void;
  * Alters the permissions of a file or directory by either specifying the absolute permissions in octal form or expressing the changes in symbols. This command tries to mimic the POSIX behavior as much as possible. Notable exceptions:
  * - In symbolic modes, 'a-r' and '-r' are identical. No consideration is given to the umask.
  * - There is no "quiet" option since default behavior is to run silent.
+ * @param options   Available options: -v (output a diagnostic for every file processed), -c (like -v but report only when a change is made), -R (change files and directories recursively)
+ * @param octalMode The access mode. Octal.
+ * @param file      The file to use.
+ */
+export function chmod(options: string, octalMode: number, file: string): void;
+
+/**
+ * Alters the permissions of a file or directory by either specifying the absolute permissions in octal form or expressing the changes in symbols. This command tries to mimic the POSIX behavior as much as possible. Notable exceptions:
+ * - In symbolic modes, 'a-r' and '-r' are identical. No consideration is given to the umask.
+ * - There is no "quiet" option since default behavior is to run silent.
  * @param mode      The access mode. Can be an octal string or a symbolic mode string.
  * @param file      The file to use.
  */
 export function chmod(mode: string, file: string): void;
+
+/**
+ * Alters the permissions of a file or directory by either specifying the absolute permissions in octal form or expressing the changes in symbols. This command tries to mimic the POSIX behavior as much as possible. Notable exceptions:
+ * - In symbolic modes, 'a-r' and '-r' are identical. No consideration is given to the umask.
+ * - There is no "quiet" option since default behavior is to run silent.
+ * @param options   Available options: -v (output a diagnostic for every file processed), -c (like -v but report only when a change is made), -R (change files and directories recursively)
+ * @param mode      The access mode. Can be an octal string or a symbolic mode string.
+ * @param file      The file to use.
+ */
+export function chmod(options: string, mode: string, file: string): void;
 
 // Non-Unix commands
 

--- a/types/shelljs/shelljs-tests.ts
+++ b/types/shelljs/shelljs-tests.ts
@@ -116,6 +116,8 @@ shell.set('-f');
 shell.chmod(755, "/Users/brandon");
 shell.chmod("755", "/Users/brandon"); // same as above
 shell.chmod("u+x", "/Users/brandon");
+shell.chmod("-cR", 755, "/Users/brandon");
+shell.chmod("-Rv", "u+x", "/Users/brandon");
 
 shell.exit(0);
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://documentup.com/shelljs/shelljs#chmodoptions-octal_mode--octal_string-file
