### PR TITLE
[notifyjs] Fix `notifyjs is not a module`

### DIFF
--- a/types/notifyjs/index.d.ts
+++ b/types/notifyjs/index.d.ts
@@ -1,118 +1,111 @@
-// Type definitions for notifyjs 1.2.8
+// Type definitions for notifyjs 3.0.0
 // Project: https://github.com/alexgibson/notify.js
 // Definitions by: soundTricker <https://github.com/soundTricker>
+//                 NateScarlet <https://github.com/NateScarlet>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare var Notify: {
-    new (title : string , options? : notifyjs.INotifyOption): notifyjs.INotify;
+export default class Notify {
+    constructor(title: string, options?: INotifyOption);
 
     /**
      * Check is permission is needed for the user to receive notifications.
      * @return true : needs permission, false : does not need
      */
-    needsPermission : boolean;
+    static needsPermission: boolean;
 
     /**
      * Asks the user for permission to display notifications
      * @param onPermissionGrantedCallback A callback for permission is granted.
      * @param onPermissionDeniedCallback  A callback for permission is denied.
      */
-    requestPermission(onPermissionGrantedCallback?: ()=> any, onPermissionDeniedCallback? : ()=> any) : void;
+    static requestPermission(onPermissionGrantedCallback?: () => any, onPermissionDeniedCallback?: () => any): void;
 
     /**
      * return true if the browser supports HTML5 Notification
      * @param true : the browser supports HTML5 Notification, false ; the browser does not supports HTML5 Notification.
      */
-    isSupported(): boolean;
+    static isSupported(): boolean;
 
     /**
      * shows the user's current permission level (granted, denied or default), returns null if notifications are not supported.
      * @return 'granted' : permission has been given, 'denied' : permission has been denied, 'default' : permission has not yet been set, null : notifications are not supported
      */
-    permissionLevel: string;
+    static permissionLevel: string;
+
+    /**
+     * Show the notification.
+     */
+    show(): void;
+
+    /**
+     * Remove all event listener.
+     */
+    destroy(): void;
+
+    /**
+     * Close the notification.
+     */
+    close(): void;
+    onShowNotification(e: Event): void;
+    onCloseNotification(): void;
+    onClickNotification(): void;
+    onErrorNotification(): void;
+    handleEvent(e: Event): void;
 }
 
-declare namespace notifyjs {
+/**
+ * Interface for the Notify's optional parameter.
+ */
+interface INotifyOption {
 
     /**
-     * Interface for Web Notifications API Wrapper.
+     * notification message body
      */
-     interface INotify {
-        /**
-         * Show the notification.
-         */
-        show() : void;
-
-        /**
-         * Remove all event listener.
-         */
-        destroy() : void;
-
-        /**
-         * Close the notification.
-         */
-        close() : void;
-        onShowNotification(e : Event) : void;
-        onCloseNotification() : void;
-        onClickNotification() : void;
-        onErrorNotification() : void;
-        handleEvent(e : Event) : void;
-    }
+    body?: string;
 
     /**
-     * Interface for the Notify's optional parameter.
+     * path for icon to display in notification
      */
-    interface INotifyOption {
+    icon?: string;
 
-        /**
-         * notification message body
-         */
-        body? : string;
+    /**
+     * unique identifier to stop duplicate notifications
+     */
+    tag?: string;
 
-        /**
-         * path for icon to display in notification
-         */
-        icon? : string;
+    /**
+    * number of seconds to close the notification automatically
+    */
+    timeout?: number;
 
-        /**
-         * unique identifier to stop duplicate notifications
-         */
-        tag? : string;
+    /**
+     * callback when notification is shown
+     */
+    notifyShow?(e: Event): any;
+    /**
+     * callback when notification is closed
+     */
+    notifyClose?: Function;
+    /**
+     * callback when notification is clicked
+     */
+    notifyClick?: Function;
+    /**
+     * callback when notification throws an error
+     */
+    notifyError?: Function;
+    /**
+     *  callback when user has granted permission
+     */
+    permissionGranted?: Function;
+    /**
+     * callback when user has denied permission
+     */
+    permissionDenied?: Function;
 
-         /**
-         * number of seconds to close the notification automatically
-         */
-        timeout? : number;
-
-        /**
-         * callback when notification is shown
-         */
-        notifyShow? (e : Event): any;
-        /**
-         * callback when notification is closed
-         */
-        notifyClose? : Function;
-        /**
-         * callback when notification is clicked
-         */
-        notifyClick? : Function;
-        /**
-         * callback when notification throws an error
-         */
-        notifyError? : Function;
-        /**
-         *  callback when user has granted permission
-         */
-        permissionGranted? : Function;
-        /**
-         * callback when user has denied permission
-         */
-        permissionDenied?: Function;
-
-        /**
-         * whether we expect for user interaction or not
-         * in case value is true the timeout for closing the notification won't be set
-         */
-        requireInteraction?: boolean;
-    }
+    /**
+     * whether we expect for user interaction or not
+     * in case value is true the timeout for closing the notification won't be set
+     */
+    requireInteraction?: boolean;
 }

--- a/types/notifyjs/index.d.ts
+++ b/types/notifyjs/index.d.ts
@@ -4,7 +4,7 @@
 //                 NateScarlet <https://github.com/NateScarlet>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-export default class Notify {
+declare class Notify {
     constructor(title: string, options?: INotifyOption);
 
     /**
@@ -109,3 +109,4 @@ interface INotifyOption {
      */
     requireInteraction?: boolean;
 }
+export = Notify

--- a/types/notifyjs/notifyjs-tests.ts
+++ b/types/notifyjs/notifyjs-tests.ts
@@ -1,27 +1,27 @@
-
+import Notify from 'notifyjs';
 
 function test_Notify_constructor() {
     //Min
     var n = new Notify("hoge")
     n.show();
-    
+
     //With option
-    n = new Notify("hoge", {body : "fuga"});
+    n = new Notify("hoge", { body: "fuga" });
     n.show();
-    
+
     //With Full option
     n = new Notify("hoge", {
-        body : "fuga",
-        icon : "./logo.png",
-        tag  : "user",
+        body: "fuga",
+        icon: "./logo.png",
+        tag: "user",
         timeout: 2,
-        notifyShow : (e:Event)=> console.log("notifyShow", e),
-        notifyClose : ()=> console.log("notifyClose"),
-        notifyClick : ()=> console.log("notifyClick"),
-        notifyError : ()=> console.log("notifyError"),
-        permissionGranted : ()=> console.log("permissionGranted"),
-        permissionDenied : ()=> console.log("permissionDenied"),
-        requireInteraction:true
+        notifyShow: (e: Event) => console.log("notifyShow", e),
+        notifyClose: () => console.log("notifyClose"),
+        notifyClick: () => console.log("notifyClick"),
+        notifyError: () => console.log("notifyError"),
+        permissionGranted: () => console.log("permissionGranted"),
+        permissionDenied: () => console.log("permissionDenied"),
+        requireInteraction: true
     });
     n.show();
 
@@ -30,8 +30,8 @@ function test_Notify_constructor() {
 function test_Notify_static_methods() {
     Notify.needsPermission;
     Notify.requestPermission();
-    Notify.requestPermission(()=> console.log("onPermissionGrantedCallback"));
-    Notify.requestPermission(()=> console.log("onPermissionGrantedCallback"), ()=> console.log("onPermissionDeniedCallback"));
+    Notify.requestPermission(() => console.log("onPermissionGrantedCallback"));
+    Notify.requestPermission(() => console.log("onPermissionGrantedCallback"), () => console.log("onPermissionDeniedCallback"));
     Notify.isSupported();
     Notify.permissionLevel;
 }

--- a/types/notifyjs/tsconfig.json
+++ b/types/notifyjs/tsconfig.json
@@ -15,7 +15,8 @@
         ],
         "types": [],
         "noEmit": true,
-        "forceConsistentCasingInFileNames": true
+        "forceConsistentCasingInFileNames": true,
+        "allowSyntheticDefaultImports": true
     },
     "files": [
         "index.d.ts",


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/alexgibson/notify.js/blob/30583643edea073fbc980a6c91113a3476d4c3a5/README.md>
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
