### PR TITLE
[reactstrap] <Col> component types: Added missing "order" attribute to ColumnProps

### DIFF
--- a/types/reactstrap/lib/Col.d.ts
+++ b/types/reactstrap/lib/Col.d.ts
@@ -7,6 +7,7 @@ export type ColumnProps
     push?: string | number
     pull?: string | number
     offset?: string | number
+    order?: string | number
   };
 
 export interface ColProps extends React.HTMLProps<HTMLDivElement> {


### PR DESCRIPTION
reactstrap supports the order attribute in the props of the <Col> component.
This was still missing from the types.
See: https://reactstrap.github.io/components/layout/

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://reactstrap.github.io/components/layout/
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
