### PR TITLE
[puppeteer] Add `Request.abort` errorCode argument

### DIFF
--- a/types/puppeteer/index.d.ts
+++ b/types/puppeteer/index.d.ts
@@ -604,6 +604,20 @@ export type ResourceType =
   | "manifest"
   | "other";
 
+export type ErrorCode =
+  | "aborted"
+  | "accessdenied"
+  | "addressunreachable"
+  | "connectionaborted"
+  | "connectionclosed"
+  | "connectionfailed"
+  | "connectionrefused"
+  | "connectionreset"
+  | "internetdisconnected"
+  | "namenotresolved"
+  | "timedout"
+  | "failed";
+
 export interface Overrides {
   url?: string;
   method?: HttpMethod;
@@ -618,7 +632,7 @@ export interface Request {
    * To use this, request interception should be enabled with `page.setRequestInterception`.
    * @throws An exception is immediately thrown if the request interception is not enabled.
    */
-  abort(): Promise<void>;
+  abort(errorCode?: ErrorCode): Promise<void>;
 
   /**
    * Continues request with optional request overrides.


### PR DESCRIPTION
the method `Request.abort` has a single argument `errorCode`
which can be one of the following values https://github.com/GoogleChrome/puppeteer/blob/master/lib/NetworkManager.js#L494