### PR TITLE
[openlayers] Add hidpi option and test for ImageArcGISRest source

### DIFF
--- a/types/openlayers/index.d.ts
+++ b/types/openlayers/index.d.ts
@@ -8,6 +8,7 @@
 //                 Dan Manastireanu <https://github.com/danmana>
 //                 Yair Tawil <https://github.com/yairtawil>
 //                 Pierre Marchand <https://github.com/pierremarc>
+//                 Hauke Stieler <https://github.com/hauke96>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // Definitions partially generated using tsd-jsdoc (https://github.com/englercj/tsd-jsdoc)
 
@@ -12087,6 +12088,7 @@ export namespace olx {
         interface ImageArcGISRestOptions {
             attributions?: ol.Attribution[];
             crossOrigin?: (string);
+            hidpi?: boolean;
             logo?: (string | LogoOptions);
             imageLoadFunction?: ol.ImageLoadFunctionType;
             params?: { [k: string]: any };

--- a/types/openlayers/openlayers-tests.ts
+++ b/types/openlayers/openlayers-tests.ts
@@ -719,6 +719,23 @@ const wmts: ol.source.WMTS = new ol.source.WMTS({
 });
 
 //
+// ol.source.ImageArcGISRest
+//
+const arcGISImageLoadFunction: ol.ImageLoadFunctionType = (image, url) => {};
+const imageArcGISRest: ol.source.ImageArcGISRest = new ol.source.ImageArcGISRest({
+    attributions: [attribution],
+    crossOrigin: stringValue,
+    hidpi: booleanValue,
+    logo: logoOptions,
+    imageLoadFunction: arcGISImageLoadFunction,
+    params: {},
+    projection: projectionLike,
+    ratio: numberValue,
+    resolutions: [numberValue, numberValue, numberValue, numberValue, numberValue],
+    url: stringValue
+});
+
+//
 // ol.coordinate
 //
 coordinate = ol.coordinate.add(coordinate, coordinate);


### PR DESCRIPTION
I added the missing `hidpi` option for the `ol.source.ImageArcGISRest` and created it in the test file.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [https://openlayers.org/en/latest/apidoc/ol.source.ImageArcGISRest.html#ImageArcGISRest](https://openlayers.org/en/latest/apidoc/ol.source.ImageArcGISRest.html#ImageArcGISRest)
- [x] Increase the version number in the header if appropriate. **I checked and 4.6 is still up to date**
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. **No substantial changed and file already exists**
