### PR TITLE
[react] Change React StatelessComponent return type to ReactNode

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -2232,8 +2232,7 @@ declare namespace React {
 
 declare global {
     namespace JSX {
-        // tslint:disable-next-line:no-empty-interface
-        interface Element extends React.ReactElement<any> { }
+        type Element = React.ReactNode;
         interface ElementClass extends React.Component<any> {
             render(): React.ReactNode;
         }

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -324,7 +324,7 @@ declare namespace React {
 
     type SFC<P = {}> = StatelessComponent<P>;
     interface StatelessComponent<P = {}> {
-        (props: P & { children?: ReactNode }, context?: any): ReactElement<any> | null;
+        (props: P & { children?: ReactNode }, context?: any): ReactNode;
         propTypes?: ValidationMap<P>;
         contextTypes?: ValidationMap<any>;
         defaultProps?: Partial<P>;
@@ -332,7 +332,7 @@ declare namespace React {
     }
 
     interface RefForwardingComponent<T, P = {}> {
-        (props: P & { children?: ReactNode }, ref?: Ref<T>): ReactElement<any> | null;
+        (props: P & { children?: ReactNode }, ref?: Ref<T>): ReactNode;
         propTypes?: ValidationMap<P>;
         contextTypes?: ValidationMap<any>;
         defaultProps?: Partial<P>;

--- a/types/react/test/index.ts
+++ b/types/react/test/index.ts
@@ -154,8 +154,11 @@ const StatelessComponent3: React.SFC<SCProps> =
     // allows null return
     props => props.foo ? DOM.div(null, props.foo, props.children) : null;
 
-// allows null as props
-const StatelessComponent4: React.SFC = props => null;
+// allows any ReactNode as return type
+const StatelessComponent4: React.SFC = () => [1, "foo", null, false, true];
+
+// allows children as return
+const StatelessComponent5: React.SFC = ({children}) => children;
 
 // React.createFactory
 const factory: React.CFactory<Props, ModernComponent> =


### PR DESCRIPTION
Fixes #18051

The tests in `tsx.tsx` fail for some reason I can't explain:

```
JSX element type 'ReactNode' is not a constructor function for JSX elements.
  Type 'undefined' is not assignable to type 'ElementClass'.
```

`ReactNode` is definitely the correct return type for SFCs though (see linked Flow type definition). I've confirmed this in a real application. Also, the return type of `Component.render()` already _is_ `ReactNode` – SFCs aren't different in this regard.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/facebook/flow/blob/a38fec68986f66d2d189556988d6c97cbcc1458b/lib/react.js#L132
