### PR TITLE
postman-collection: Fix return type of PropertyList.get

### DIFF
--- a/types/postman-collection/index.d.ts
+++ b/types/postman-collection/index.d.ts
@@ -103,7 +103,7 @@ export class PropertyList<TElement> extends PropertyBase<PropertyBaseDefinition>
 
     find(rule: (item: TElement) => boolean, context: any): TElement;
 
-    get(key: string): TElement | undefined;
+    get(key: string): any;
 
     has(item: string | TElement, value?: any): boolean;
 

--- a/types/postman-collection/postman-collection-tests.ts
+++ b/types/postman-collection/postman-collection-tests.ts
@@ -99,7 +99,7 @@ pList.eachParent((el: any) => {}); // $ExpectType void
 pList.eachParent((el: any) => {}, pList); // $ExpectType void
 pList.filter((el) => true, pList); // $ExpectType Certificate[]
 pList.find((el) => true, pList); // $ExpectType Certificate
-pList.get("string"); // $ExpectType Certificate | undefined
+pList.get("string"); // $ExpectType any
 pList.has("string"); // $ExpectType boolean
 pList.has("string", null); // $ExpectType boolean
 pList.has(certificate); // $ExpectType boolean


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
https://github.com/postmanlabs/postman-collection/blob/fea5a446df28e7c71e8a87f6b9d1537e23525b1e/lib/collection/property-list.js#L381
This was a mistake on my understanding of the source code on the original submission
- [x] Increase the version number in the header if appropriate.  
N/A
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.  
N/A


