### PR TITLE
[Ramda] curried function signature for R.uncurryN

### DIFF
--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -18,6 +18,7 @@
 //                 Jack Leigh <https://github.com/leighman>
 //                 Keagan McClelland <https://github.com/CaptJakk>
 //                 Tomas Szabo <https://github.com/deftomat>
+//                 Yulong Ruan <https://github.com/ruanyl>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.6
 
@@ -1909,6 +1910,7 @@ declare namespace R {
          * Returns a function of arity n from a (manually) curried function.
          */
         uncurryN<T>(len: number, fn: (a: any) => any): (...a: any[]) => T;
+        uncurryN<T>(len: number): (fn: (a: any) => any) => (...a: any[]) => T;
 
         /**
          * Builds a list from a seed value. Accepts an iterator function, which returns either false

--- a/types/ramda/ramda-tests.ts
+++ b/types/ramda/ramda-tests.ts
@@ -131,6 +131,12 @@ class F2 {
 };
 
 () => {
+    const addFour          = (a: number) => (b: number) => (c: number) => (d: number) => a + b + c + d;
+    const uncurriedAddFour = R.uncurryN<number>(4)(addFour);
+    const res: number      = uncurriedAddFour(1, 2, 3, 4); // => 10
+};
+
+() => {
     // coerceArray :: (a|[a]) -> [a]
     const coerceArray = R.unless(R.isArrayLike, R.of);
     const a: number[] = coerceArray([1, 2, 3]); // => [1, 2, 3]


### PR DESCRIPTION
signature of R.uncurryN can be:
uncurryN: Number -> (a -> b) -> (a -> c)

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
this failed on `TypeScript@next`, but it's not related to the changes I made in this commit.

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [R.uncurryN](https://github.com/ramda/ramda/blob/master/source/uncurryN.js#L12)
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

