### PR TITLE
[react-virtualized] Use React.ReactNode instead of string for label

### DIFF
--- a/types/react-virtualized/dist/es/Table.d.ts
+++ b/types/react-virtualized/dist/es/Table.d.ts
@@ -1,4 +1,4 @@
-import { Validator, Requireable, PureComponent, Component } from "react";
+import { Validator, ReactNode, Requireable, PureComponent, Component } from "react";
 import { CellMeasurerCache } from "./CellMeasurer";
 import {
     Index,
@@ -67,7 +67,7 @@ export type TableHeaderProps = {
     columnData?: any;
     dataKey: string;
     disableSort?: boolean;
-    label?: string;
+    label?: ReactNode;
     sortBy?: string;
     sortDirection?: SortDirectionType;
 };
@@ -141,7 +141,7 @@ export type ColumnProps = {
     /** Optional id to set on the column header; used for aria-describedby */
     id?: string;
     /** Header label for this column */
-    label?: string;
+    label?: ReactNode;
     /** Maximum width of column; this property will only be used if :flexGrow is > 0. */
     maxWidth?: number;
     /** Minimum width of column. */


### PR DESCRIPTION
Based on the [official API documentation](https://github.com/bvaughn/react-virtualized/blob/master/docs/Column.md) it seems that `label` is actually a ReactNode and not a `string`.

And because ReactNode includes string, this is not a breaking change.

-----

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
