### PR TITLE
pg (node-postgres): allow Client to have 0 parameters in constructor

### DIFF
--- a/types/pg/index.d.ts
+++ b/types/pg/index.d.ts
@@ -117,7 +117,7 @@ export class Pool extends events.EventEmitter {
 }
 
 export class ClientBase extends events.EventEmitter {
-    constructor(config: string | ClientConfig);
+    constructor(config?: string | ClientConfig);
 
     connect(): Promise<void>;
     connect(callback: (err: Error) => void): void;
@@ -147,7 +147,7 @@ export class ClientBase extends events.EventEmitter {
 }
 
 export class Client extends ClientBase {
-    constructor(config: string | ClientConfig);
+    constructor(config?: string | ClientConfig);
 
     end(): Promise<void>;
     end(callback: (err: Error) => void): void;

--- a/types/pg/pg-tests.ts
+++ b/types/pg/pg-tests.ts
@@ -179,3 +179,8 @@ pool.end().then(() => console.log('pool has ended'));
   await client.query('SELECT NOW()');
   client.release();
 })();
+
+// client constructor tests
+// client config object tested above
+let c = new Client(); // empty constructor allowed
+c = new Client('connectionString'); // connection string allowed


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:  
If no config is passed in then an empty object is defaulted [here](https://github.com/brianc/node-postgres/blob/8fb641ee91b0f8474559983520485e90c3a94d55/lib/client.js#L32)
Examples show it being empty as well: https://node-postgres.com/features/connecting  
- [x] Increase the version number in the header if appropriate.  
N/A
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.  
N/A
