### PR TITLE
Remove URL and URLSearchParams from nodeJS global

### DIFF
--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -2377,44 +2377,40 @@ declare module "url" {
         unicode?: boolean;
     }
 
-    global {
-        class URL {
-            constructor(input: string, base?: string | URL);
-            hash: string;
-            host: string;
-            hostname: string;
-            href: string;
-            readonly origin: string;
-            password: string;
-            pathname: string;
-            port: string;
-            protocol: string;
-            search: string;
-            readonly searchParams: URLSearchParams;
-            username: string;
-            toString(): string;
-            toJSON(): string;
-        }
-
-        class URLSearchParams implements Iterable<[string, string]> {
-            constructor(init?: URLSearchParams | string | { [key: string]: string | string[] | undefined } | Iterable<[string, string]> | Array<[string, string]>);
-            append(name: string, value: string): void;
-            delete(name: string): void;
-            entries(): IterableIterator<[string, string]>;
-            forEach(callback: (value: string, name: string) => void): void;
-            get(name: string): string | null;
-            getAll(name: string): string[];
-            has(name: string): boolean;
-            keys(): IterableIterator<string>;
-            set(name: string, value: string): void;
-            sort(): void;
-            toString(): string;
-            values(): IterableIterator<string>;
-            [Symbol.iterator](): IterableIterator<[string, string]>;
-        }
+    export class URL {
+        constructor(input: string, base?: string | URL);
+        hash: string;
+        host: string;
+        hostname: string;
+        href: string;
+        readonly origin: string;
+        password: string;
+        pathname: string;
+        port: string;
+        protocol: string;
+        search: string;
+        readonly searchParams: URLSearchParams;
+        username: string;
+        toString(): string;
+        toJSON(): string;
     }
 
-    export { URL, URLSearchParams };
+    export class URLSearchParams implements Iterable<[string, string]> {
+        constructor(init?: URLSearchParams | string | { [key: string]: string | string[] | undefined } | Iterable<[string, string]> | Array<[string, string]>);
+        append(name: string, value: string): void;
+        delete(name: string): void;
+        entries(): IterableIterator<[string, string]>;
+        forEach(callback: (value: string, name: string) => void): void;
+        get(name: string): string | null;
+        getAll(name: string): string[];
+        has(name: string): boolean;
+        keys(): IterableIterator<string>;
+        set(name: string, value: string): void;
+        sort(): void;
+        toString(): string;
+        values(): IterableIterator<string>;
+        [Symbol.iterator](): IterableIterator<[string, string]>;
+    }
 }
 
 declare module "dns" {


### PR DESCRIPTION
This reverts the change that adds URL and URLSearchParams to the global scope in NodeJS due to a collision with DOM types when both are used..

Fixes #25342.