### PR TITLE
[react-native] Restore previous StatusBar exports

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -7538,7 +7538,7 @@ export interface StatusBarProps extends StatusBarPropsIOS, StatusBarPropsAndroid
     hidden?: boolean;
 }
 
-export class StatusBar extends React.Component<StatusBarProps> {
+export interface StatusBarStatic extends React.Component<StatusBarProps> {
     /**
      * The current height of the status bar on the device.
      * @platform android
@@ -8586,7 +8586,10 @@ export type PushNotificationIOS = PushNotificationIOSStatic;
 
 export const Settings: SettingsStatic;
 export type Settings = SettingsStatic;
-
+                                       
+export const StatusBar: StatusBarStatic;
+export type StatusBar = StatusBarStatic;
+                                       
 export const StatusBarIOS: StatusBarIOSStatic;
 export type StatusBarIOS = StatusBarIOSStatic;
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

After the merged [#25307](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/25307) PR, StatusBar became broken. This PR simply restores previous StatusBar exports in order to make it work correctly again.
