### PR TITLE
[ArangoDB] Fix collection properties argument & index fields type

### DIFF
--- a/types/arangodb/arangodb-tests.ts
+++ b/types/arangodb/arangodb-tests.ts
@@ -47,6 +47,11 @@ bananas.ensureIndex({
     unique: true,
     fields: ["color", "shape.type"]
 });
+bananas.updateByExample(
+    bananas.any(),
+    { shape: { type: "round" } },
+    { mergeObjects: true }
+);
 
 const router = createRouter();
 module.context.use(router);

--- a/types/arangodb/arangodb-tests.ts
+++ b/types/arangodb/arangodb-tests.ts
@@ -34,9 +34,9 @@ interface Banana {
     };
 }
 
-const bananas = db._createDocumentCollection("bananas") as ArangoDB.Collection<
-    Banana
->;
+const bananas = db._createDocumentCollection("bananas", {
+    waitForSync: false
+}) as ArangoDB.Collection<Banana>;
 bananas.ensureIndex({
     type: "hash",
     unique: true,

--- a/types/arangodb/arangodb-tests.ts
+++ b/types/arangodb/arangodb-tests.ts
@@ -1,4 +1,4 @@
-import { db, aql } from "@arangodb";
+import { db, aql, query } from "@arangodb";
 import { md5 } from "@arangodb/crypto";
 import { createRouter } from "@arangodb/foxx";
 import sessionsMiddleware = require("@arangodb/foxx/sessions");
@@ -21,10 +21,10 @@ const admin = users.firstExample({ username: "admin" })!;
 users.update(admin, { password: md5("hunter2") });
 console.logLines("user", admin._key, admin.username);
 
-const query = aql`
+db._query(aql`
     FOR u IN ${users}
     RETURN u
-`;
+`);
 
 interface Banana {
     color: string;
@@ -81,4 +81,14 @@ router.use(
         storage: jwtStorage({ algorithm: "HS512", secret: "tacocat" }),
         transport: cookieTransport({ secret: "banana", algorithm: "sha256" })
     })
+);
+
+console.log(
+    query`
+        FOR u IN users
+        ${aql.literal(
+            Math.random() < 0.5 ? "FILTER u.admin" : "FILTER !u.admin"
+        )}
+        RETURN u
+    `.toArray()
 );

--- a/types/arangodb/arangodb-tests.ts
+++ b/types/arangodb/arangodb-tests.ts
@@ -35,7 +35,12 @@ interface Banana {
 }
 
 const bananas = db._createDocumentCollection("bananas", {
-    waitForSync: false
+    waitForSync: false,
+    keyOptions: {
+        type: "autoincrement",
+        increment: 11,
+        offset: 23
+    }
 }) as ArangoDB.Collection<Banana>;
 bananas.ensureIndex({
     type: "hash",

--- a/types/arangodb/arangodb-tests.ts
+++ b/types/arangodb/arangodb-tests.ts
@@ -26,10 +26,21 @@ const query = aql`
     RETURN u
 `;
 
-db._createDocumentCollection("bananas").ensureIndex({
+interface Banana {
+    color: string;
+    shape: {
+        type: string;
+        coords: string[];
+    };
+}
+
+const bananas = db._createDocumentCollection("bananas") as ArangoDB.Collection<
+    Banana
+>;
+bananas.ensureIndex({
     type: "hash",
     unique: true,
-    fields: ["color", "shape"]
+    fields: ["color", "shape.type"]
 });
 
 const router = createRouter();

--- a/types/arangodb/index.d.ts
+++ b/types/arangodb/index.d.ts
@@ -538,6 +538,8 @@ declare namespace ArangoDB {
 
     type DocumentLike = ObjectWithId | ObjectWithKey;
 
+    type Patch<T> = { [K in keyof T]?: T[K] | Patch<T[K]> };
+
     interface DocumentMetadata {
         _key: string;
         _id: string;
@@ -590,6 +592,7 @@ declare namespace ArangoDB {
         keepNull?: boolean;
         waitForSync?: boolean;
         limit?: number;
+        mergeObjects?: boolean;
     }
 
     interface RemoveOptions {
@@ -724,24 +727,24 @@ declare namespace ArangoDB {
         ): InsertResult<T>;
         update(
             selector: string | DocumentLike,
-            data: Partial<Document<T>>,
+            data: Patch<Document<T>>,
             options?: UpdateOptions
         ): UpdateResult<T>;
         update(
             selectors: ReadonlyArray<string | DocumentLike>,
-            data: ReadonlyArray<Partial<Document<T>>>,
+            data: ReadonlyArray<Patch<Document<T>>>,
             options?: UpdateOptions
         ): Array<UpdateResult<T>>;
         updateByExample(
             example: Partial<Document<T>>,
-            newValue: Partial<Document<T>>,
+            newValue: Patch<Document<T>>,
             keepNull?: boolean,
             waitForSync?: boolean,
             limit?: number
         ): number;
         updateByExample(
             example: Partial<Document<T>>,
-            newValue: Partial<Document<T>>,
+            newValue: Patch<Document<T>>,
             options?: UpdateByExampleOptions
         ): number;
     }

--- a/types/arangodb/index.d.ts
+++ b/types/arangodb/index.d.ts
@@ -766,6 +766,10 @@ declare namespace ArangoDB {
         options?: QueryOptions;
     }
 
+    interface AqlLiteral {
+        toAQL: () => string;
+    }
+
     interface Cursor<T = any> {
         toArray(): T[];
         hasNext(): boolean;
@@ -1348,6 +1352,13 @@ declare namespace Foxx {
 
 declare module "@arangodb" {
     function aql(strings: TemplateStringsArray, ...args: any[]): ArangoDB.Query;
+    namespace aql {
+        function literal(value: any): ArangoDB.AqlLiteral;
+    }
+    function query(
+        strings: TemplateStringsArray,
+        ...args: any[]
+    ): ArangoDB.Cursor;
     function time(): number;
     const db: ArangoDB.Database & {
         [key: string]: ArangoDB.Collection | undefined;

--- a/types/arangodb/index.d.ts
+++ b/types/arangodb/index.d.ts
@@ -488,7 +488,7 @@ declare namespace ArangoDB {
 
     interface IndexDescription<T> {
         type: IndexType;
-        fields: ReadonlyArray<keyof T>;
+        fields: ReadonlyArray<keyof T | string>;
         sparse?: boolean;
         unique?: boolean;
         deduplicate?: boolean;
@@ -497,7 +497,7 @@ declare namespace ArangoDB {
     interface Index<T extends object = any> {
         id: string;
         type: IndexType;
-        fields: Array<keyof T>;
+        fields: Array<keyof T | string>;
         sparse: boolean;
         unique: boolean;
         deduplicate: boolean;

--- a/types/arangodb/index.d.ts
+++ b/types/arangodb/index.d.ts
@@ -91,6 +91,7 @@ declare namespace ArangoDB {
     type EngineType = "mmfiles" | "rocksdb";
     type IndexType = "hash" | "skiplist" | "fulltext" | "geo1" | "geo2";
     type ViewType = "arangosearch";
+    type KeyGeneratorType = "traditional" | "autoincrement";
     type ErrorName =
         | "ERROR_NO_ERROR"
         | "ERROR_FAILED"
@@ -463,12 +464,29 @@ declare namespace ArangoDB {
         replicationFactor?: number;
     }
 
+    interface CreateCollectionOptions {
+        waitForSync?: boolean;
+        journalSize?: number;
+        isVolatile?: boolean;
+        isSystem?: boolean;
+        keyOptions?: {
+            type?: KeyGeneratorType;
+            allowUserKeys?: boolean;
+            increment?: number;
+            offset?: number;
+        };
+        numberOfShards?: number;
+        shardKeys?: string[];
+        replicationFactor?: number;
+    }
+
     interface CollectionProperties {
         waitForSync: boolean;
         journalSize: number;
+        isSystem: boolean;
         isVolatile: boolean;
         keyOptions?: {
-            type: string;
+            type: KeyGeneratorType;
             allowUserKeys: boolean;
             increment?: number;
             offset?: number;
@@ -862,14 +880,14 @@ declare namespace ArangoDB {
         // Collection
         _collection(name: string): Collection;
         _collections(): Collection[];
-        _create(name: string, properties?: CollectionProperties): Collection;
+        _create(name: string, properties?: CreateCollectionOptions): Collection;
         _createDocumentCollection(
             name: string,
-            properties?: CollectionProperties
+            properties?: CreateCollectionOptions
         ): Collection;
         _createEdgeCollection(
             name: string,
-            properties?: CollectionProperties
+            properties?: CreateCollectionOptions
         ): Collection;
         _drop(name: string): void;
         _truncate(name: string): void;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [Index field type](https://docs.arangodb.com/3.3/Manual/Indexing/Hash.html#unique-hash-indexes), [Collection properties](https://docs.arangodb.com/3.3/Manual/DataModeling/Collections/DatabaseMethods.html#create) & [Update mergeObjects option](https://docs.arangodb.com/3.3/Manual/DataModeling/Documents/DocumentMethods.html#update-by-example)
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

---

Apologies for the noise. These somehow slipped through because our documentation isn't very clear on some of these. The dotted index fields in particular only popped up in an example and doesn't seem to be explicitly mentioned.

EDIT: Missed another one: document.updateByExample can take an optional mergeObjects option too and the update methods then should take a patch value rather than a partial.