### PR TITLE
[eslint] create NodeListener and extend RuleListener

### DIFF
--- a/types/eslint/eslint-tests.ts
+++ b/types/eslint/eslint-tests.ts
@@ -336,6 +336,7 @@ rule = {
             onCodePathSegmentStart(segment, node) {},
             onCodePathSegmentEnd(segment, node) {},
             onCodePathSegmentLoop(fromSegment, toSegment, node) {},
+            IfStatement(node) {},
             'Program:exit'() {},
         };
     },

--- a/types/eslint/index.d.ts
+++ b/types/eslint/index.d.ts
@@ -241,7 +241,10 @@ export namespace Rule {
         meta?: RuleMetaData;
     }
 
-    interface RuleListener {
+    type NodeTypes = ESTree.Node['type'];
+    type NodeListener = { [T in NodeTypes]?: (node: ESTree.Node) => void };
+
+    interface RuleListener extends NodeListener {
         onCodePathStart?(codePath: CodePath, node: ESTree.Node): void;
 
         onCodePathEnd?(codePath: CodePath, node: ESTree.Node): void;


### PR DESCRIPTION
I've created a new type `NodeListener` and extend the `RuleListener` with it. This way I get the code completion when implementing a rule:

<img width="777" alt="screen shot 2018-04-29 at 17 55 20" src="https://user-images.githubusercontent.com/2317341/39408439-8b527adc-4bd6-11e8-9153-64d81b1db547.png">

Right now each handler has the same shape `(node: ESTree.Node) => void`. Would be great to find a way to infer the specific node type for each property, i.e.

```typescript
{
  Identifier: (node: ESTree.Identifier) => void,
  IfStatement: (node: ESTree.IfStatement) => void,
  // etc
}
```

Suggestions are welcome!