### PR TITLE
[react-sortable-tree] Fix canDrop and onMoveNode type

### DIFF
--- a/types/react-sortable-tree/index.d.ts
+++ b/types/react-sortable-tree/index.d.ts
@@ -58,20 +58,19 @@ export interface OnVisibilityToggleData extends FullTree, TreeNode {
     expanded: boolean;
 }
 
-export interface PreviousAndNextLocation {
+interface PreviousAndNextLocation {
     prevTreeIndex: number;
     prevPath: number[];
-    prevParent: TreeItem | null;
     nextTreeIndex: number;
     nextPath: number[];
+}
+
+export interface OnDragPreviousAndNextLocation extends PreviousAndNextLocation {
+    prevParent: TreeItem | null;
     nextParent: TreeItem | null;
 }
 
-export interface OnMovePreviousAndNextLocation {
-    prevTreeIndex: number;
-    prevPath: number[];
-    nextTreeIndex: number;
-    nextPath: number[];
+export interface OnMovePreviousAndNextLocation extends PreviousAndNextLocation {
     nextParentNode: TreeItem | null;
 }
 
@@ -177,7 +176,7 @@ export interface ReactSortableTreeProps {
     onMoveNode?(data: NodeData & FullTree & OnMovePreviousAndNextLocation): void;
     onVisibilityToggle?(data: OnVisibilityToggleData): void;
     canDrag?: ((data: ExtendedNodeData) => boolean) | boolean;
-    canDrop?(data: PreviousAndNextLocation & NodeData): boolean;
+    canDrop?(data: OnDragPreviousAndNextLocation & NodeData): boolean;
     reactVirtualizedListProps?: ListProps;
     rowHeight?: ((info: Index) => number) | number;
     slideRegionSize?: number;

--- a/types/react-sortable-tree/index.d.ts
+++ b/types/react-sortable-tree/index.d.ts
@@ -57,12 +57,22 @@ export interface ExtendedNodeData extends NodeData {
 export interface OnVisibilityToggleData extends FullTree, TreeNode {
     expanded: boolean;
 }
+
 export interface PreviousAndNextLocation {
+    prevTreeIndex: number;
+    prevPath: number[];
+    prevParent: TreeItem | null;
+    nextTreeIndex: number;
+    nextPath: number[];
+    nextParent: TreeItem | null;
+}
+
+export interface OnMovePreviousAndNextLocation {
     prevTreeIndex: number;
     prevPath: number[];
     nextTreeIndex: number;
     nextPath: number[];
-    nextParentNode: TreeItem;
+    nextParentNode: TreeItem | null;
 }
 
 export type NodeRenderer = React.ComponentClass<NodeRendererProps>;
@@ -164,7 +174,7 @@ export interface ReactSortableTreeProps {
     searchFinishCallback?(matches: NodeData[]): void;
     generateNodeProps?(data: ExtendedNodeData): { [index: string]: any };
     getNodeKey?(data: TreeNode & TreeIndex): string | number;
-    onMoveNode?(data: NodeData & FullTree): void;
+    onMoveNode?(data: NodeData & FullTree & OnMovePreviousAndNextLocation): void;
     onVisibilityToggle?(data: OnVisibilityToggleData): void;
     canDrag?: ((data: ExtendedNodeData) => boolean) | boolean;
     canDrop?(data: PreviousAndNextLocation & NodeData): boolean;

--- a/types/react-sortable-tree/react-sortable-tree-tests.tsx
+++ b/types/react-sortable-tree/react-sortable-tree-tests.tsx
@@ -13,7 +13,8 @@ import SortableTree,
         OnVisibilityToggleData,
         PreviousAndNextLocation,
         PlaceholderRendererProps,
-        ThemeProps
+        ThemeProps,
+        OnMovePreviousAndNextLocation
     } from "react-sortable-tree";
 import { ListProps, ListRowRenderer } from "react-virtualized";
 
@@ -55,7 +56,7 @@ class Test extends React.Component {
                     searchFinishCallback={(matches: NodeData[]) => { const firstTitle = matches[0].node.title; }}
                     generateNodeProps={(data: ExtendedNodeData) => ({buttons: [data.node.title]}) }
                     getNodeKey={defaultGetNodeKey}
-                    onMoveNode={(data: NodeData & FullTree) => {}}
+                    onMoveNode={(data: NodeData & FullTree & OnMovePreviousAndNextLocation) => {}}
                     onVisibilityToggle={(data: OnVisibilityToggleData) => {}}
                     canDrag={true}
                     canDrop={(data: PreviousAndNextLocation & NodeData) => true}

--- a/types/react-sortable-tree/react-sortable-tree-tests.tsx
+++ b/types/react-sortable-tree/react-sortable-tree-tests.tsx
@@ -11,10 +11,10 @@ import SortableTree,
         ExtendedNodeData,
         FullTree,
         OnVisibilityToggleData,
-        PreviousAndNextLocation,
+        OnDragPreviousAndNextLocation,
+        OnMovePreviousAndNextLocation,
         PlaceholderRendererProps,
-        ThemeProps,
-        OnMovePreviousAndNextLocation
+        ThemeProps
     } from "react-sortable-tree";
 import { ListProps, ListRowRenderer } from "react-virtualized";
 
@@ -59,7 +59,7 @@ class Test extends React.Component {
                     onMoveNode={(data: NodeData & FullTree & OnMovePreviousAndNextLocation) => {}}
                     onVisibilityToggle={(data: OnVisibilityToggleData) => {}}
                     canDrag={true}
-                    canDrop={(data: PreviousAndNextLocation & NodeData) => true}
+                    canDrop={(data: OnDragPreviousAndNextLocation & NodeData) => true}
                     reactVirtualizedListProps={reactVirtualizedListProps}
                     rowHeight={62}
                     slideRegionSize={100}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/frontend-collective/react-sortable-tree#options
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
