### PR TITLE
node: Add WHATWG URL API types for v6

### DIFF
--- a/types/node/v6/index.d.ts
+++ b/types/node/v6/index.d.ts
@@ -1957,8 +1957,54 @@ declare module "url" {
     }
 
     export function parse(urlStr: string, parseQueryString?: boolean, slashesDenoteHost?: boolean): Url;
+    export function format(URL: URL, options?: URLFormatOptions): string;
     export function format(urlObject: UrlObject | string): string;
     export function resolve(from: string, to: string): string;
+
+    export function domainToASCII(domain: string): string;
+    export function domainToUnicode(domain: string): string;
+
+    export interface URLFormatOptions {
+        auth?: boolean;
+        fragment?: boolean;
+        search?: boolean;
+        unicode?: boolean;
+    }
+
+    export class URLSearchParams implements Iterable<string[]> {
+        constructor(init?: URLSearchParams | string | { [key: string]: string | string[] } | Iterable<string[]> );
+        append(name: string, value: string): void;
+        delete(name: string): void;
+        entries(): Iterator<string[]>;
+        forEach(callback: (value: string, name: string) => void): void;
+        get(name: string): string | null;
+        getAll(name: string): string[];
+        has(name: string): boolean;
+        keys(): Iterator<string>;
+        set(name: string, value: string): void;
+        sort(): void;
+        toString(): string;
+        values(): Iterator<string>;
+        [Symbol.iterator](): Iterator<string[]>;
+    }
+
+    export class URL {
+        constructor(input: string, base?: string | URL);
+        hash: string;
+        host: string;
+        hostname: string;
+        href: string;
+        readonly origin: string;
+        password: string;
+        pathname: string;
+        port: string;
+        protocol: string;
+        search: string;
+        readonly searchParams: URLSearchParams;
+        username: string;
+        toString(): string;
+        toJSON(): string;
+    }
 }
 
 declare module "dns" {

--- a/types/node/v6/node-tests.ts
+++ b/types/node/v6/node-tests.ts
@@ -486,11 +486,112 @@ namespace url_tests {
             pathname: 'search',
             query: { q: "you're a lizard, gary" }
         });
+
+        const myURL = new url.URL('https://a:b@你好你好?abc#foo');
+        url.format(myURL, { fragment: false, unicode: true, auth: false });
     }
 
     {
         var helloUrl = url.parse('http://example.com/?hello=world', true)
         assert.equal(helloUrl.query.hello, 'world');
+    }
+
+    {
+        const ascii: string = url.domainToASCII('español.com');
+        const unicode: string = url.domainToUnicode('xn--espaol-zwa.com');
+    }
+
+    {
+        let myURL = new url.URL('https://theuser:thepwd@example.org:81/foo/path?query=string#bar');
+        assert.equal(myURL.hash, '#bar');
+        assert.equal(myURL.host, 'example.org:81');
+        assert.equal(myURL.hostname, 'example.org');
+        assert.equal(myURL.href, 'https://theuser:thepwd@example.org:81/foo/path?query=string#bar');
+        assert.equal(myURL.origin, 'https://example.org:81');
+        assert.equal(myURL.password, 'thepwd');
+        assert.equal(myURL.username, 'theuser');
+        assert.equal(myURL.pathname, '/foo/path');
+        assert.equal(myURL.port, "81");
+        assert.equal(myURL.protocol, "https:");
+        assert.equal(myURL.search, "?query=string");
+        assert.equal(myURL.toString(), 'https://theuser:thepwd@example.org:81/foo/path?query=string#bar');
+        assert(myURL.searchParams instanceof url.URLSearchParams);
+
+        myURL.host = 'example.org:82';
+        myURL.hostname = 'example.com';
+        myURL.href = 'http://other.com';
+        myURL.hash = 'baz';
+        myURL.password = "otherpwd";
+        myURL.username = "otheruser";
+        myURL.pathname = "/otherPath";
+        myURL.port = "82";
+        myURL.protocol = "http";
+        myURL.search = "a=b";
+        assert.equal(myURL.href, 'http://otheruser:otherpwd@other.com:82/otherPath?a=b#baz');
+
+        myURL = new url.URL('/foo', 'https://example.org/');
+        assert.equal(myURL.href, 'https://example.org/foo');
+        assert.equal(myURL.toJSON(), myURL.href);
+    }
+
+    {
+        const searchParams = new url.URLSearchParams('abc=123');
+
+        assert.equal(searchParams.toString(), 'abc=123');
+        searchParams.forEach((value: string, name: string): void => {
+            assert.equal(name, 'abc');
+            assert.equal(value, '123');
+        });
+
+        assert.equal(searchParams.get('abc'), '123');
+
+        searchParams.append('abc', 'xyz');
+
+        assert.deepEqual(searchParams.getAll('abc'), ['123', 'xyz']);
+
+        const entries = searchParams.entries();
+        assert.deepEqual(entries.next(), { value: ["abc", "123"], done: false});
+        assert.deepEqual(entries.next(), { value: ["abc", "xyz"], done: false});
+        assert.deepEqual(entries.next(), { value: undefined, done: true});
+
+        const keys = searchParams.keys();
+        assert.deepEqual(keys.next(), { value: "abc", done: false});
+        assert.deepEqual(keys.next(), { value: "abc", done: false});
+        assert.deepEqual(keys.next(), { value: undefined, done: true});
+
+        const values = searchParams.values();
+        assert.deepEqual(values.next(), { value: "123", done: false});
+        assert.deepEqual(values.next(), { value: "xyz", done: false});
+        assert.deepEqual(values.next(), { value: undefined, done: true});
+
+        searchParams.set('abc', 'b');
+        assert.deepEqual(searchParams.getAll('abc'), ['b']);
+
+        searchParams.delete('a');
+        assert(!searchParams.has('a'));
+        assert.equal(searchParams.get('a'), null);
+
+        searchParams.sort();
+    }
+
+    {
+        const searchParams = new url.URLSearchParams({
+            user: 'abc',
+            query: ['first', 'second']
+        });
+
+        assert.equal(searchParams.toString(), 'user=abc&query=first%2Csecond');
+        assert.deepEqual(searchParams.getAll('query'), ['first,second']);
+    }
+
+    {
+        // Using an array
+        let params = new url.URLSearchParams([
+            ['user', 'abc'],
+            ['query', 'first'],
+            ['query', 'second']
+        ]);
+        assert.equal(params.toString(), 'user=abc&query=first&query=second');
     }
 }
 


### PR DESCRIPTION
Added in Node 6.13.0. This copies the respective types (and tests) from the types for Node v7.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [Node v6.13.0 release notes](https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V6.md#6.13.0)
- [ ] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.