### PR TITLE
Types for JQuery Focus Exit

### DIFF
--- a/types/jquery-focus-exit/index.d.ts
+++ b/types/jquery-focus-exit/index.d.ts
@@ -1,0 +1,20 @@
+// Type definitions for JQuery Focus Exit 1.0
+// Project: https://github.com/makeup-jquery/jquery-focus-exit
+// Definitions by: Anderson Friaça <https://github.com/AndersonFriaca>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
+
+/// <reference types="jquery" />
+
+export interface FocusElements {
+    lostFocus?: HTMLElement;
+    gainedFocus: HTMLElement;
+}
+
+declare global {
+    interface JQuery {
+        focusExit(options?: { debug: boolean }): JQuery;
+        on(event: 'focusExit', handler: ((event: JQuery.Event<HTMLElement>, data: FocusElements) => void)): JQuery;
+        one(event: 'focusin', handler: ((event: JQuery.Event<HTMLElement>) => void)): JQuery;
+    }
+}

--- a/types/jquery-focus-exit/jquery-focus-exit-tests.ts
+++ b/types/jquery-focus-exit/jquery-focus-exit-tests.ts
@@ -1,0 +1,8 @@
+$('.test').one('focusin', e => {
+  $(e.currentTarget).addClass('focusin');
+});
+
+$('.test').focusExit({debug: true}).on('focusExit', (e, data) => {
+  console.log(e, data);
+  $(e.currentTarget).removeClass('focusin');
+});

--- a/types/jquery-focus-exit/tsconfig.json
+++ b/types/jquery-focus-exit/tsconfig.json
@@ -1,0 +1,25 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "esModuleInterop": true
+    },
+    "files": [
+        "index.d.ts",
+        "jquery-focus-exit-tests.ts"
+    ]
+}

--- a/types/jquery-focus-exit/tslint.json
+++ b/types/jquery-focus-exit/tslint.json
@@ -1,0 +1,1 @@
+{"extends": "dtslint/dt.json"}


### PR DESCRIPTION
Types creation of [https://github.com/makeup-jquery/jquery-focus-exit](https://github.com/makeup-jquery/jquery-focus-exit)
NPM: [https://www.npmjs.com/package/jquery-focus-exit](https://www.npmjs.com/package/jquery-focus-exit)

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).


If adding a new definition:
- [X] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [X] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [X] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
