### PR TITLE
[esprima] Add tolerant TokenizeOption property

### DIFF
--- a/types/esprima/esprima-tests.ts
+++ b/types/esprima/esprima-tests.ts
@@ -29,6 +29,7 @@ program = esprima.parseScript('answer = 42 // TODO: why', { comment: true, range
 // Tokenizing
 token = esprima.tokenize('code')[0];
 token = esprima.tokenize('code', {range: true})[0];
+token = esprima.tokenize('/E\/\w*/.exec("e")', { tolerant: true })[0];
 
 // Syntax Delegate
 esprima.parseScript('answer = 42', {}, (node) => {

--- a/types/esprima/index.d.ts
+++ b/types/esprima/index.d.ts
@@ -30,6 +30,7 @@ export interface ParseOptions {
 }
 
 export interface TokenizeOptions {
+    tolerant?: boolean;
     range?: boolean;
     loc?: boolean;
     comment?: boolean;


### PR DESCRIPTION
Like the `tolerant` option for `ParseOptions`, `tolerant` is sometimes needed to continue tokenizing through errors instead of immediately throwing (see test case for example). The option is [definitely there and supported]((https://github.com/jquery/esprima/blob/529a5f2bcb56bddf9a1b978826646a123a75784e/src/tokenizer.ts#L97)), and I could find no discussion on purposefully hiding it for the types package, so this PR exposes it.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [esprima `tokenizer.ts`](https://github.com/jquery/esprima/blob/529a5f2bcb56bddf9a1b978826646a123a75784e/src/tokenizer.ts#L97)

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
