### PR TITLE
Set redux-batched-subscribe semver limit to <4.0.0

### DIFF
--- a/types/redux-batched-subscribe/package.json
+++ b/types/redux-batched-subscribe/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "redux": ">=1.0.0"
+        "redux": ">=1.0.0 <4.0.0"
     }
 }


### PR DESCRIPTION
Redux 4.0.0 was [recently released](https://github.com/reactjs/redux/releases/latest) with breaking changes to their TypeScript types. While a better long-term fix is to update the typings here to work with the 4.0 changes, this PR at least lets existing projects using redux < 4.0.0 continue to build without erroring by ensuring that npm and yarn pull in the proper version of redux. (As an aside, I originally intended to make redux a `peerDependency` but the test suite prevents that)

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.) **Do I need to add any?**
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).


If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: reactjs/redux#2773, reactjs/redux#2679, reactjs/redux#2674, reactjs/redux#2563, reacjts/redux#2182 and possible a few more
- [X] Increase the version number in the header if appropriate. **No version header**
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. **N/A**
