### PR TITLE
add Tycho + Ika to Ramda authors to get @'d in issues

### DIFF
--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -1,6 +1,8 @@
 // Type definitions for ramda 0.25
 // Project: https://github.com/donnut/typescript-ramda
 // Definitions by: Erwin Poeze <https://github.com/donnut>
+//                 Ika Tyang <https://github.com/ikatyang>
+//                 Tycho Grouwstra <https://github.com/tycho01>
 //                 Matt DeKrey <https://github.com/mdekrey>
 //                 Matt Dziuban <https://github.com/mrdziuban>
 //                 Stephen King <https://github.com/sbking>
@@ -18,6 +20,8 @@
 //                 Jack Leigh <https://github.com/leighman>
 //                 Keagan McClelland <https://github.com/CaptJakk>
 //                 Tomas Szabo <https://github.com/deftomat>
+//                 Tycho Grouwstra <https://github.com/tycho01>
+//                 Ika Tyang <https://github.com/ikatyang>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.6
 

--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -1,7 +1,7 @@
 // Type definitions for ramda 0.25
 // Project: https://github.com/donnut/typescript-ramda
 // Definitions by: Erwin Poeze <https://github.com/donnut>
-//                 Ika Tyang <https://github.com/ikatyang>
+//                 Ika <https://github.com/ikatyang>
 //                 Tycho Grouwstra <https://github.com/tycho01>
 //                 Matt DeKrey <https://github.com/mdekrey>
 //                 Matt Dziuban <https://github.com/mrdziuban>
@@ -20,8 +20,6 @@
 //                 Jack Leigh <https://github.com/leighman>
 //                 Keagan McClelland <https://github.com/CaptJakk>
 //                 Tomas Szabo <https://github.com/deftomat>
-//                 Tycho Grouwstra <https://github.com/tycho01>
-//                 Ika <https://github.com/ikatyang>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.6
 

--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -21,9 +21,11 @@
 //                 Keagan McClelland <https://github.com/CaptJakk>
 //                 Tomas Szabo <https://github.com/deftomat>
 //                 Tycho Grouwstra <https://github.com/tycho01>
-//                 Ika Tyang <https://github.com/ikatyang>
+//                 Ika <https://github.com/ikatyang>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.6
+
+// Note: feel free to cross-post Ramda typing challenges at https://github.com/types/npm-ramda/
 
 declare let R: R.Static;
 


### PR DESCRIPTION
I just realized people have been posting issues here, and I wasn't getting notifications to help me respond. Also adding @ikatyang, who is currently maintaining Ramda typings at https://github.com/types/npm-ramda/.