### PR TITLE
d3-array: strict histogram proposition [BREAKING CHANGE]

### DIFF
--- a/types/d3-array/d3-array-tests.ts
+++ b/types/d3-array/d3-array-tests.ts
@@ -70,6 +70,7 @@ const mixedObjectArray = [
 ];
 
 const mixedObjectOrUndefinedArray = [...mixedObjectArray, undefined];
+const mixedObjectArrayLike = mixedObjectArray as ArrayLike<MixedObject>;
 
 let typedArray = Uint8Array.from(numbersArray);
 let readonlyNumbersArray = numbersArray as ReadonlyArray<number>;
@@ -104,6 +105,34 @@ function accessorMixedObjectToStrOrUndefined(datum: MixedObject | undefined, ind
     return datum ? datum.str : undefined;
 }
 
+function accessorLikeMixedObjectToNum(datum: MixedObject, index: number, array: ArrayLike<MixedObject>): number {
+    return datum.num;
+}
+
+function accessorLikeMixedObjectToStr(datum: MixedObject, index: number, array: ArrayLike<MixedObject>): string {
+    return datum.str;
+}
+
+function accessorLikeMixedObjectToNumeric(datum: MixedObject, index: number, array: ArrayLike<MixedObject>): NumCoercible {
+    return datum.numeric;
+}
+
+function accessorLikeMixedObjectToDate(datum: MixedObject, index: number, array: ArrayLike<MixedObject>): Date {
+    return datum.date;
+}
+
+function accessorLikeMixedObjectToNumOrUndefined(datum: MixedObject | undefined, index: number, array: ArrayLike<MixedObject | undefined>): number | undefined | null {
+    return datum ? datum.num : undefined;
+}
+
+function accessorLikeMixedObjectToStrOrUndefined(datum: MixedObject | undefined, index: number, array: ArrayLike<MixedObject>): string | undefined | null {
+    return datum ? datum.str : undefined;
+}
+
+function accessorReadOnlyMixedObjectToNumOrUndefined(datum: MixedObject | undefined, index: number, array: ReadonlyArray<MixedObject | undefined>): number | undefined | null {
+    return datum ? datum.num : undefined;
+}
+
 // -----------------------------------------------------------------------------
 // Test Statistics
 // -----------------------------------------------------------------------------
@@ -133,7 +162,17 @@ numericOrUndefined = d3Array.max(mixedObjectArray, accessorMixedObjectToNumeric)
 dateOrUndefined = d3Array.max(mixedObjectArray, accessorMixedObjectToDate);
 numOrUndefined = d3Array.max(mixedObjectArray, accessorMixedObjectToNumOrUndefined);
 strOrUndefined = d3Array.max(mixedObjectArray, accessorMixedObjectToStrOrUndefined);
-numOrUndefined = d3Array.max(readonlyMixedObjectOrUndefinedArray, accessorMixedObjectToNumOrUndefined);
+numOrUndefined = d3Array.max(readonlyMixedObjectOrUndefinedArray, accessorReadOnlyMixedObjectToNumOrUndefined);
+
+numOrUndefined = d3Array.max(mixedObjectArrayLike, accessorLikeMixedObjectToNum);
+numOrUndefined = d3Array.max(mixedObjectArray, accessorLikeMixedObjectToNum);
+numOrUndefined = d3Array.max(mixedObjectArray, accessorReadOnlyMixedObjectToNumOrUndefined);
+// $ExpectError
+numOrUndefined = d3Array.max(mixedObjectArrayLike, accessorMixedObjectToNum);
+// $ExpectError
+numOrUndefined = d3Array.max(mixedObjectArrayLike, accessorReadOnlyMixedObjectToNumOrUndefined);
+// $ExpectError
+numOrUndefined = d3Array.max(readonlyNumbersArray, (d, i, a) => { a.push(3); return 0; });
 
 // min() -----------------------------------------------------------------------
 
@@ -160,7 +199,7 @@ numericOrUndefined = d3Array.min(mixedObjectArray, accessorMixedObjectToNumeric)
 dateOrUndefined = d3Array.min(mixedObjectArray, accessorMixedObjectToDate);
 numOrUndefined = d3Array.min(mixedObjectArray, accessorMixedObjectToNumOrUndefined);
 strOrUndefined = d3Array.min(mixedObjectArray, accessorMixedObjectToStrOrUndefined);
-numOrUndefined = d3Array.min(readonlyMixedObjectOrUndefinedArray, accessorMixedObjectToNumOrUndefined);
+numOrUndefined = d3Array.min(readonlyMixedObjectOrUndefinedArray, accessorReadOnlyMixedObjectToNumOrUndefined);
 
 // extent() --------------------------------------------------------------------
 
@@ -187,7 +226,7 @@ mixedOrUndefinedExtent = d3Array.extent(mixedObjectArray, accessorMixedObjectToN
 dateMixedOrUndefined = d3Array.extent(mixedObjectArray, accessorMixedObjectToDate);
 numOrUndefinedExtent = d3Array.extent(mixedObjectArray, accessorMixedObjectToNumOrUndefined);
 strOrUndefinedExtent = d3Array.extent(mixedObjectArray, accessorMixedObjectToStrOrUndefined);
-numOrUndefinedExtent = d3Array.extent(readonlyMixedObjectOrUndefinedArray, accessorMixedObjectToNumOrUndefined);
+numOrUndefinedExtent = d3Array.extent(readonlyMixedObjectOrUndefinedArray, accessorReadOnlyMixedObjectToNumOrUndefined);
 
 // mean() ----------------------------------------------------------------------
 
@@ -202,7 +241,7 @@ numOrUndefined = d3Array.mean(readonlyNumbersOrUndefinedArray);
 
 numOrUndefined = d3Array.mean(mixedObjectArray, accessorMixedObjectToNum);
 numOrUndefined = d3Array.mean(mixedObjectOrUndefinedArray, accessorMixedObjectToNumOrUndefined);
-numOrUndefined = d3Array.mean(readonlyMixedObjectOrUndefinedArray, accessorMixedObjectToNumOrUndefined);
+numOrUndefined = d3Array.mean(readonlyMixedObjectOrUndefinedArray, accessorReadOnlyMixedObjectToNumOrUndefined);
 
 // median() --------------------------------------------------------------------
 
@@ -217,7 +256,7 @@ numOrUndefined = d3Array.median(readonlyNumbersOrUndefinedArray);
 
 numOrUndefined = d3Array.median(mixedObjectArray, accessorMixedObjectToNum);
 numOrUndefined = d3Array.median(mixedObjectOrUndefinedArray, accessorMixedObjectToNumOrUndefined);
-numOrUndefined = d3Array.median(readonlyMixedObjectOrUndefinedArray, accessorMixedObjectToNumOrUndefined);
+numOrUndefined = d3Array.median(readonlyMixedObjectOrUndefinedArray, accessorReadOnlyMixedObjectToNumOrUndefined);
 
 // quantile() ------------------------------------------------------------------
 
@@ -232,7 +271,7 @@ numOrUndefined = d3Array.quantile(readonlyNumbersOrUndefinedArray, 0.5);
 
 numOrUndefined = d3Array.quantile(mixedObjectArray, 0.5, accessorMixedObjectToNum);
 numOrUndefined = d3Array.quantile(mixedObjectOrUndefinedArray, 0.5, accessorMixedObjectToNumOrUndefined);
-numOrUndefined = d3Array.quantile(readonlyMixedObjectOrUndefinedArray, 0.5, accessorMixedObjectToNumOrUndefined);
+numOrUndefined = d3Array.quantile(readonlyMixedObjectOrUndefinedArray, 0.5, accessorReadOnlyMixedObjectToNumOrUndefined);
 
 // sum() -----------------------------------------------------------------------
 
@@ -247,7 +286,7 @@ numOrUndefined = d3Array.sum(readonlyNumbersOrUndefinedArray);
 
 numOrUndefined = d3Array.sum(mixedObjectArray, accessorMixedObjectToNum);
 numOrUndefined = d3Array.sum(mixedObjectOrUndefinedArray, accessorMixedObjectToNumOrUndefined);
-numOrUndefined = d3Array.sum(readonlyMixedObjectOrUndefinedArray, accessorMixedObjectToNumOrUndefined);
+numOrUndefined = d3Array.sum(readonlyMixedObjectOrUndefinedArray, accessorReadOnlyMixedObjectToNumOrUndefined);
 
 // deviation() -----------------------------------------------------------------
 
@@ -262,7 +301,7 @@ numOrUndefined = d3Array.deviation(readonlyNumbersOrUndefinedArray);
 
 numOrUndefined = d3Array.deviation(mixedObjectArray, accessorMixedObjectToNum);
 numOrUndefined = d3Array.deviation(mixedObjectOrUndefinedArray, accessorMixedObjectToNumOrUndefined);
-numOrUndefined = d3Array.deviation(readonlyMixedObjectOrUndefinedArray, accessorMixedObjectToNumOrUndefined);
+numOrUndefined = d3Array.deviation(readonlyMixedObjectOrUndefinedArray, accessorReadOnlyMixedObjectToNumOrUndefined);
 
 // variance() ------------------------------------------------------------------
 
@@ -277,7 +316,7 @@ numOrUndefined = d3Array.variance(readonlyNumbersOrUndefinedArray);
 
 numOrUndefined = d3Array.variance(mixedObjectArray, accessorMixedObjectToNum);
 numOrUndefined = d3Array.variance(mixedObjectOrUndefinedArray, accessorMixedObjectToNumOrUndefined);
-numOrUndefined = d3Array.variance(readonlyMixedObjectOrUndefinedArray, accessorMixedObjectToNumOrUndefined);
+numOrUndefined = d3Array.variance(readonlyMixedObjectOrUndefinedArray, accessorReadOnlyMixedObjectToNumOrUndefined);
 
 // -----------------------------------------------------------------------------
 // Test Searching Arrays

--- a/types/d3-array/d3-array-tests.ts
+++ b/types/d3-array/d3-array-tests.ts
@@ -167,8 +167,8 @@ numOrUndefined = d3Array.max(readonlyMixedObjectOrUndefinedArray, accessorReadOn
 numOrUndefined = d3Array.max(mixedObjectArrayLike, accessorLikeMixedObjectToNum);
 numOrUndefined = d3Array.max(mixedObjectArray, accessorLikeMixedObjectToNum);
 numOrUndefined = d3Array.max(mixedObjectArray, accessorReadOnlyMixedObjectToNumOrUndefined);
-// $ExpectError
-numOrUndefined = d3Array.max(mixedObjectArrayLike, accessorMixedObjectToNum);
+// // $ExpectError
+// numOrUndefined = d3Array.max(mixedObjectArrayLike, accessorMixedObjectToNum);
 // $ExpectError
 numOrUndefined = d3Array.max(mixedObjectArrayLike, accessorReadOnlyMixedObjectToNumOrUndefined);
 // $ExpectError

--- a/types/d3-array/d3-array-tests.ts
+++ b/types/d3-array/d3-array-tests.ts
@@ -882,3 +882,8 @@ num = d3Array.thresholdScott(readonlyNumbersArray, -1, 234);
 num = d3Array.thresholdSturges(numbersArray);
 num = d3Array.thresholdSturges(typedArray);
 num = d3Array.thresholdSturges(readonlyNumbersArray);
+
+// Deprecated ==================================================================
+
+const histDeprecatedNumber: d3Array.HistogramGenerator<MixedObject, number> = d3Array.histogram<MixedObject, number>();
+const histDeprecatedDate: d3Array.HistogramGenerator<MixedObject, Date> = d3Array.histogram<MixedObject, Date>();

--- a/types/d3-array/d3-array-tests.ts
+++ b/types/d3-array/d3-array-tests.ts
@@ -167,6 +167,17 @@ numOrUndefined = d3Array.max(readonlyMixedObjectOrUndefinedArray, accessorReadOn
 numOrUndefined = d3Array.max(mixedObjectArrayLike, accessorLikeMixedObjectToNum);
 numOrUndefined = d3Array.max(mixedObjectArray, accessorLikeMixedObjectToNum);
 numOrUndefined = d3Array.max(mixedObjectArray, accessorReadOnlyMixedObjectToNumOrUndefined);
+
+numOrUndefined = d3Array.max(mixedObjectArray, (d) => {
+    const l: MixedObject = d;
+    return l.num;
+});
+
+strOrUndefined = d3Array.max(mixedObjectArray, (d) => {
+    const l: MixedObject = d;
+    return l.str;
+});
+
 // // $ExpectError
 // numOrUndefined = d3Array.max(mixedObjectArrayLike, accessorMixedObjectToNum);
 // $ExpectError

--- a/types/d3-array/d3-array-tests.ts
+++ b/types/d3-array/d3-array-tests.ts
@@ -81,27 +81,27 @@ const readonlyDateArray = dateArray as ReadonlyArray<Date>;
 const readonlyMixedObjectArray = mixedObjectArray as ReadonlyArray<MixedObject>;
 const readonlyMixedObjectOrUndefinedArray = mixedObjectOrUndefinedArray as ReadonlyArray<MixedObject | undefined>;
 
-function accessorMixedObjectToNum(datum: MixedObject, index: number, array: MixedObject[]): number {
+function accessorMixedObjectToNum(datum: MixedObject, index: number, array: ArrayLike<MixedObject>): number {
     return datum.num;
 }
 
-function accessorMixedObjectToStr(datum: MixedObject, index: number, array: MixedObject[]): string {
+function accessorMixedObjectToStr(datum: MixedObject, index: number, array: ArrayLike<MixedObject>): string {
     return datum.str;
 }
 
-function accessorMixedObjectToNumeric(datum: MixedObject, index: number, array: MixedObject[]): NumCoercible {
+function accessorMixedObjectToNumeric(datum: MixedObject, index: number, array: ArrayLike<MixedObject>): NumCoercible {
     return datum.numeric;
 }
 
-function accessorMixedObjectToDate(datum: MixedObject, index: number, array: MixedObject[]): Date {
+function accessorMixedObjectToDate(datum: MixedObject, index: number, array: ArrayLike<MixedObject>): Date {
     return datum.date;
 }
 
-function accessorMixedObjectToNumOrUndefined(datum: MixedObject | undefined, index: number, array: Array<MixedObject | undefined>): number | undefined | null {
+function accessorMixedObjectToNumOrUndefined(datum: MixedObject | undefined, index: number, array: ArrayLike<MixedObject | undefined>): number | undefined | null {
     return datum ? datum.num : undefined;
 }
 
-function accessorMixedObjectToStrOrUndefined(datum: MixedObject | undefined, index: number, array: MixedObject[]): string | undefined | null {
+function accessorMixedObjectToStrOrUndefined(datum: MixedObject | undefined, index: number, array: ArrayLike<MixedObject>): string | undefined | null {
     return datum ? datum.str : undefined;
 }
 
@@ -129,7 +129,7 @@ function accessorLikeMixedObjectToStrOrUndefined(datum: MixedObject | undefined,
     return datum ? datum.str : undefined;
 }
 
-function accessorReadOnlyMixedObjectToNumOrUndefined(datum: MixedObject | undefined, index: number, array: ReadonlyArray<MixedObject | undefined>): number | undefined | null {
+function accessorReadOnlyMixedObjectToNumOrUndefined(datum: MixedObject | undefined, index: number, array: ArrayLike<MixedObject | undefined>): number | undefined | null {
     return datum ? datum.num : undefined;
 }
 
@@ -178,10 +178,6 @@ strOrUndefined = d3Array.max(mixedObjectArray, (d) => {
     return l.str;
 });
 
-// // $ExpectError
-// numOrUndefined = d3Array.max(mixedObjectArrayLike, accessorMixedObjectToNum);
-// $ExpectError
-numOrUndefined = d3Array.max(mixedObjectArrayLike, accessorReadOnlyMixedObjectToNumOrUndefined);
 // $ExpectError
 numOrUndefined = d3Array.max(readonlyNumbersArray, (d, i, a) => { a.push(3); return 0; });
 

--- a/types/d3-array/d3-array-tests.ts
+++ b/types/d3-array/d3-array-tests.ts
@@ -733,7 +733,7 @@ histoMixedObject_DateOrUndefined = histoMixedObject_DateOrUndefined.domain((valu
 
 // thresholds(...) -------------------------------------------------------------
 
-type thresholdsWithUndefinedCont = d3Array.ThresholdCountGenerator<number | undefined>;
+type thresholdsWithUndefinedCont = d3Array.ThresholdCountGenerator;
 type thresholdsWithUndefinedArray = d3Array.ThresholdArrayGenerator<number | undefined>;
 
 let thresholds: d3Array.ThresholdCountGenerator<number> | d3Array.ThresholdArrayGenerator<number>;

--- a/types/d3-array/d3-array-tests.ts
+++ b/types/d3-array/d3-array-tests.ts
@@ -695,37 +695,37 @@ type valueAccessor<D, V> = (d: D, i: number, data: D[]) => V;
 
 // number - number
 const valueFnNumber_Number: valueAccessor<number, number> = histoNumber_Number.value();
-histoNumber_Number = histoNumber_Number.value((d: number, i: number, data: number[]) => {
+histoNumber_Number = histoNumber_Number.value((d: number, i: number, data: ArrayLike<number>) => {
     return d - num;
 });
 
 // MixedObject - number | undefined
 const valueFnMixedObject_NumberOrUndefined: valueAccessor<MixedObject, number | undefined> = histoMixed_NumberOrUndefined.value();
-histoMixed_NumberOrUndefined = histoMixed_NumberOrUndefined.value((d: MixedObject, i: number, data: MixedObject[]) => {
+histoMixed_NumberOrUndefined = histoMixed_NumberOrUndefined.value((d: MixedObject, i: number, data: ArrayLike<MixedObject>) => {
     return d.str === "NA" ? undefined : d.num;
 });
 
 // MixedObject | undefined - number | undefined
 const valueFnMixedOrUndefined_NumberOrUndefined: valueAccessor<MixedObject | undefined, number | undefined> = histoMixedOrUndefined_NumberOrUndefined.value();
-histoMixedOrUndefined_NumberOrUndefined = histoMixedOrUndefined_NumberOrUndefined.value((d: MixedObject | undefined, i: number, data: Array<MixedObject | undefined>) => {
+histoMixedOrUndefined_NumberOrUndefined = histoMixedOrUndefined_NumberOrUndefined.value((d: MixedObject | undefined, i: number, data: ArrayLike<MixedObject | undefined>) => {
     return d ? d.num : undefined;
 });
 
 // MixedObject | undefined - number
 const valueFnMixedOrUndefined_Number: valueAccessor<MixedObject | undefined, number> = histoMixedOrUndefined_Number.value();
-histoMixedOrUndefined_Number = histoMixedOrUndefined_Number.value((d: MixedObject | undefined, i: number, data: Array<MixedObject | undefined>) => {
+histoMixedOrUndefined_Number = histoMixedOrUndefined_Number.value((d: MixedObject | undefined, i: number, data: ArrayLike<MixedObject | undefined>) => {
     return d ? d.num : 0;
 });
 
 // MixedObject - Date
 const valueFnMixedObject_Date: valueAccessor<MixedObject, Date> = histoMixedObject_Date.value();
-histoMixedObject_Date = histoMixedObject_Date.value((d: MixedObject, i: number, data: MixedObject[]) => {
+histoMixedObject_Date = histoMixedObject_Date.value((d: MixedObject, i: number, data: ArrayLike<MixedObject>) => {
     return d.date;
 });
 
 // MixedObject - Date | undefined
 const valueFnMixedObject_DateOrUndefined: valueAccessor<MixedObject, Date | undefined> = histoMixedObject_DateOrUndefined.value();
-histoMixedObject_DateOrUndefined = histoMixedObject_DateOrUndefined.value((d: MixedObject, i: number, data: MixedObject[]) => {
+histoMixedObject_DateOrUndefined = histoMixedObject_DateOrUndefined.value((d: MixedObject, i: number, data: ArrayLike<MixedObject>) => {
     return d.date;
 });
 
@@ -773,13 +773,14 @@ histoMixedObject_DateOrUndefined = histoMixedObject_DateOrUndefined.domain((valu
 // thresholds(...) -------------------------------------------------------------
 
 type thresholdsWithUndefinedCont = d3Array.ThresholdCountGenerator;
-type thresholdsWithUndefinedArray = d3Array.ThresholdArrayGenerator<number | undefined>;
+type thresholdsWithUndefinedArray = d3Array.ThresholdNumberArrayGenerator<number | undefined>;
 
-let thresholds: d3Array.ThresholdCountGenerator<number> | d3Array.ThresholdArrayGenerator<number>;
+let thresholds: d3Array.ThresholdCountGenerator<number> | d3Array.ThresholdNumberArrayGenerator<number>;
 let thresholdsWithUndefined: thresholdsWithUndefinedCont | thresholdsWithUndefinedArray;
-const thresholdsArray: d3Array.ThresholdArrayGenerator<number> = (x) => [5, 10, 20];
-let thresholdsDate: d3Array.ThresholdArrayGenerator<Date>;
-let thresholdsDateOrUndefined: d3Array.ThresholdArrayGenerator<Date | undefined>;
+const thresholdsArray: d3Array.ThresholdNumberArrayGenerator<number> = (x: ArrayLike<number>) => [5, 10, 20];
+
+let thresholdsDate: d3Array.ThresholdDateArrayGenerator<Date>;
+let thresholdsDateOrUndefined: d3Array.ThresholdDateArrayGenerator<Date | undefined>;
 
 // number - number
 thresholds = histoNumber_Number.thresholds();
@@ -801,7 +802,7 @@ histoMixedOrUndefined_NumberOrUndefined = histoMixedOrUndefined_NumberOrUndefine
 histoMixedOrUndefined_NumberOrUndefined = histoMixedOrUndefined_NumberOrUndefined.thresholds(d3Array.thresholdScott);
 
 // MixedObject | undefined - number
-thresholdsWithUndefined = histoMixedOrUndefined_Number.thresholds();
+thresholds = histoMixedOrUndefined_Number.thresholds();
 histoMixedOrUndefined_Number = histoMixedOrUndefined_Number.thresholds(5);
 histoMixedOrUndefined_Number = histoMixedOrUndefined_Number.thresholds([5, 10, 20]);
 histoMixedOrUndefined_Number = histoMixedOrUndefined_Number.thresholds(d3Array.thresholdSturges);
@@ -810,7 +811,8 @@ histoMixedOrUndefined_Number = histoMixedOrUndefined_Number.thresholds(d3Array.t
 thresholdsDate = histoMixedObject_Date.thresholds();
 histoMixedObject_Date = histoMixedObject_Date.thresholds([new Date(2015, 11, 15), new Date(2016, 6, 1), new Date(2016, 8, 30)]);
 histoMixedObject_Date = histoMixedObject_Date.thresholds(timeScale.ticks(timeYear));
-histoMixedObject_Date = histoMixedObject_Date.thresholds((values: Date[], min: Date, max: Date) => {
+histoMixedObject_Date = histoMixedObject_Date.thresholds((values: ArrayLike<Date>) => [new Date(2015, 11, 15), new Date(2016, 6, 1), new Date(2016, 8, 30)]);
+histoMixedObject_Date = histoMixedObject_Date.thresholds((values: ArrayLike<Date>, min: Date, max: Date) => {
     const thresholds: Date[] = [values[0], values[2], values[4]];
     return thresholds;
 });
@@ -821,8 +823,8 @@ histoMixedObject_Date = histoMixedObject_Date.thresholds(d3Array.thresholdScott)
 thresholdsDateOrUndefined = histoMixedObject_DateOrUndefined.thresholds();
 histoMixedObject_DateOrUndefined = histoMixedObject_DateOrUndefined.thresholds([new Date(2015, 11, 15), new Date(2016, 6, 1), new Date(2016, 8, 30)]);
 histoMixedObject_DateOrUndefined = histoMixedObject_DateOrUndefined.thresholds(timeScale.ticks(timeYear));
-histoMixedObject_DateOrUndefined = histoMixedObject_DateOrUndefined.thresholds((values: Date[], min: Date, max: Date) => {
-    const thresholds: Date[] = [values[0], values[2], values[4]];
+histoMixedObject_DateOrUndefined = histoMixedObject_DateOrUndefined.thresholds((values: ArrayLike<Date | undefined>, min: Date, max: Date) => {
+    const thresholds: Date[] = [values[0]!, new Date(2015, 11, 15), values[values.length]!];
     return thresholds;
 });
 

--- a/types/d3-array/d3-array-tests.ts
+++ b/types/d3-array/d3-array-tests.ts
@@ -615,11 +615,33 @@ const timeScale = scaleTime();
 
 // Create histogram generator ==================================================
 
-let histoNumber_Number: d3Array.HistogramGenerator<number, number>;
+// number - number
+let histoNumber_Number: d3Array.HistogramGeneratorNumber<number, number>;
 histoNumber_Number = d3Array.histogram();
+histoNumber_Number = d3Array.histogram<number, number>();
 
-let histoMixedObject_Date: d3Array.HistogramGenerator<MixedObject, Date>;
+// MixedObject - number | undefined
+let histoMixed_NumberOrUndefined: d3Array.HistogramGeneratorNumber<MixedObject, number | undefined>;
+histoMixed_NumberOrUndefined = d3Array.histogram<MixedObject, number | undefined>();
+
+// MixedObject | undefined - number | undefined
+let histoMixedOrUndefined_NumberOrUndefined: d3Array.HistogramGeneratorNumber<MixedObject | undefined, number | undefined>;
+histoMixedOrUndefined_NumberOrUndefined = d3Array.histogram<MixedObject | undefined, number | undefined>();
+
+// MixedObject | undefined - number
+let histoMixedOrUndefined_Number: d3Array.HistogramGeneratorNumber<MixedObject | undefined, number>;
+histoMixedOrUndefined_Number = d3Array.histogram<MixedObject | undefined, number>();
+
+// MixedObject - Date
+let histoMixedObject_Date: d3Array.HistogramGeneratorDate<MixedObject, Date>;
 histoMixedObject_Date = d3Array.histogram<MixedObject, Date>();
+
+// MixedObject - Date | undefined
+let histoMixedObject_DateOrUndefined: d3Array.HistogramGeneratorDate<MixedObject, Date | undefined>;
+histoMixedObject_DateOrUndefined = d3Array.histogram<MixedObject, Date | undefined>();
+
+let defaultHistogram: d3Array.HistogramGeneratorNumber<number, number>;
+defaultHistogram = d3Array.histogram();
 
 // Configure histogram generator ===============================================
 
@@ -656,7 +678,7 @@ histoNumber_Number = histoNumber_Number.domain(d3Array.extent);
 let domainAccessorFn: (values: number[]) => [number, number] | [undefined, undefined];
 domainAccessorFn = histoNumber_Number.domain();
 
-let dateDomainAccessorFn: (values: Date[]) => [Date, Date] | [undefined, undefined];
+let dateDomainAccessorFn: (values: Date[]) => [Date, Date];
 dateDomainAccessorFn = histoMixedObject_Date.domain();
 
 // thresholds(...) -------------------------------------------------------------

--- a/types/d3-array/index.d.ts
+++ b/types/d3-array/index.d.ts
@@ -25,8 +25,6 @@ export interface Numeric {
     valueOf(): number;
 }
 
-export type AnArray<T> = T[] | ReadonlyArray<T> | ArrayLike<T>;
-
 // --------------------------------------------------------------------------------------
 // Descriptive Statistics
 // --------------------------------------------------------------------------------------
@@ -44,12 +42,12 @@ export function max<T extends Numeric>(array: ArrayLike<T>): T | undefined;
 /**
  * Return the maximum value in the array using natural order and a projection function to map values to strings.
  */
-export function max<K extends AnArray<any>>(array: K, accessor: (datum: K[0], index: number, array: K) => string | undefined | null): string | undefined;
+export function max<T>(array: ArrayLike<T>, accessor: (datum: T, index: number, array: ArrayLike<T>) => string | undefined | null): string | undefined;
 
 /**
  * Return the maximum value in the array using natural order and a projection function to map values to easily-sorted values.
  */
-export function max<U extends Numeric, K extends AnArray<any>>(array: K, accessor: (datum: K[0], index: number, array: K) => U | undefined | null): U | undefined;
+export function max<T, U extends Numeric>(array: ArrayLike<T>, accessor: (datum: T, index: number, array: ArrayLike<T>) => U | undefined | null): U | undefined;
 
 /**
  * Return the minimum value in the array using natural order.
@@ -64,12 +62,12 @@ export function min<T extends Numeric>(array: ArrayLike<T>): T | undefined;
 /**
  * Return the minimum value in the array using natural order.
  */
-export function min<K extends AnArray<any>>(array: K, accessor: (datum: K[0], index: number, array: K) => string | undefined | null): string | undefined;
+export function min<T>(array: ArrayLike<T>, accessor: (datum: T, index: number, array: ArrayLike<T>) => string | undefined | null): string | undefined;
 
 /**
  * Return the minimum value in the array using natural order.
  */
-export function min<T, U extends Numeric, K extends AnArray<T>>(array: K, accessor: (datum: T, index: number, array: K) => U | undefined | null): U | undefined;
+export function min<T, U extends Numeric>(array: ArrayLike<T>, accessor: (datum: T, index: number, array: ArrayLike<T>) => U | undefined | null): U | undefined;
 
 /**
  * Return the min and max simultaneously.
@@ -84,12 +82,12 @@ export function extent<T extends Numeric>(array: ArrayLike<T>): [T, T] | [undefi
 /**
  * Return the min and max simultaneously.
  */
-export function extent<K extends AnArray<any>>(array: K, accessor: (datum: K[0], index: number, array: K) => string | undefined | null): [string, string] | [undefined, undefined];
+export function extent<T>(array: ArrayLike<T>, accessor: (datum: T, index: number, array: ArrayLike<T>) => string | undefined | null): [string, string] | [undefined, undefined];
 
 /**
  * Return the min and max simultaneously.
  */
-export function extent<T, U extends Numeric, K extends AnArray<T>>(array: K, accessor: (datum: T, index: number, array: K) => U | undefined | null): [U, U] | [undefined, undefined];
+export function extent<T, U extends Numeric>(array: ArrayLike<T>, accessor: (datum: T, index: number, array: ArrayLike<T>) => U | undefined | null): [U, U] | [undefined, undefined];
 
 /**
  * Return the mean of an array of numbers
@@ -99,7 +97,7 @@ export function mean<T extends Numeric>(array: ArrayLike<T | undefined | null>):
 /**
  * Return the mean of an array of numbers
  */
-export function mean<K extends AnArray<any>>(array: K, accessor: (datum: K[0], index: number, array: K) => number | undefined | null): number | undefined;
+export function mean<T>(array: ArrayLike<T>, accessor: (datum: T, index: number, array: ArrayLike<T>) => number | undefined | null): number | undefined;
 
 /**
  * Return the median of an array of numbers
@@ -109,14 +107,14 @@ export function median<T extends Numeric>(array: ArrayLike<T | undefined | null>
 /**
  * Return the median of an array of numbers
  */
-export function median<K extends AnArray<any>>(array: K, accessor: (element: K[0], i: number, array: K) => number | undefined | null): number | undefined;
+export function median<T>(array: ArrayLike<T>, accessor: (element: T, i: number, array: ArrayLike<T>) => number | undefined | null): number | undefined;
 
 /**
  * Returns the p-quantile of an array of numbers
  */
 export function quantile<T extends Numeric>(array: ArrayLike<T | undefined | null>, p: number): number | undefined;
 
-export function quantile<K extends AnArray<any>>(array: K, p: number, accessor: (element: K[0], i: number, array: K) => number | undefined | null): number | undefined;
+export function quantile<T>(array: ArrayLike<T>, p: number, accessor: (element: T, i: number, array: ArrayLike<T>) => number | undefined | null): number | undefined;
 
 /**
  * Compute the sum of an array of numbers.
@@ -126,7 +124,7 @@ export function sum<T extends Numeric>(array: ArrayLike<T | undefined | null>): 
 /**
  * Compute the sum of an array, using the given accessor to convert values to numbers.
  */
-export function sum<K extends AnArray<any>>(array: K, accessor: (datum: K[0], index: number, array: K) => number | undefined | null): number;
+export function sum<T>(array: ArrayLike<T>, accessor: (datum: T, index: number, array: ArrayLike<T>) => number | undefined | null): number;
 
 /**
  * Compute the standard deviation, defined as the square root of the bias-corrected variance, of the given array of numbers.
@@ -137,7 +135,7 @@ export function deviation<T extends Numeric>(array: ArrayLike<T | undefined | nu
  * Compute the standard deviation, defined as the square root of the bias-corrected variance, of the given array,
  * using the given accessor to convert values to numbers.
  */
-export function deviation<K extends AnArray<any>>(array: K, accessor: (datum: K[0], index: number, array: K) => number | undefined | null): number | undefined;
+export function deviation<T>(array: ArrayLike<T>, accessor: (datum: T, index: number, array: ArrayLike<T>) => number | undefined | null): number | undefined;
 
 /**
  * Compute an unbiased estimator of the population variance of the given array of numbers.
@@ -148,7 +146,7 @@ export function variance<T extends Numeric>(array: ArrayLike<T | undefined | nul
  * Compute an unbiased estimator of the population variance of the given array,
  * using the given accessor to convert values to numbers.
  */
-export function variance<K extends AnArray<any>>(array: K, accessor: (datum: K[0], index: number, array: K) => number | undefined | null): number | undefined;
+export function variance<T>(array: ArrayLike<T>, accessor: (datum: T, index: number, array: ArrayLike<T>) => number | undefined | null): number | undefined;
 
 // --------------------------------------------------------------------------------------
 // Searching Arrays

--- a/types/d3-array/index.d.ts
+++ b/types/d3-array/index.d.ts
@@ -5,6 +5,7 @@
 //                 Tom Wanzek <https://github.com/tomwanzek>
 //                 denisname <https://github.com/denisname>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
 
 // Last module patch version validated against: 1.2.1
 

--- a/types/d3-array/index.d.ts
+++ b/types/d3-array/index.d.ts
@@ -334,12 +334,20 @@ export interface Bin<Datum, Value extends number | Date | undefined> extends Arr
 /**
  * Type definition for threshold generator which returns the count of recommended thresholds
  */
-export type ThresholdCountGenerator<Value extends number | undefined = number | undefined> = (values: ArrayLike<Value>, min?: number, max?: number) => number;
+export type ThresholdCountGenerator<Value extends number | undefined = number | undefined> =
+    (values: ArrayLike<Value>, min: number, max: number) => number;
 
 /**
- * Type definition for threshold generator which returns an array of recommended thresholds
+ * Type definition for threshold generator which returns an array of recommended numbers thresholds
  */
-export type ThresholdArrayGenerator<Value extends number | Date | undefined> = (values: ArrayLike<Value>, min?: Value, max?: Value) => Value[];
+export type ThresholdNumberArrayGenerator<Value extends number | undefined> =
+    (values: ArrayLike<Value>, min: number, max: number) => Value[];
+
+/**
+ * Type definition for threshold generator which returns an array of recommended dates thresholds
+ */
+export type ThresholdDateArrayGenerator<Value extends Date | undefined> =
+    (values: ArrayLike<Value>, min: Date, max: Date) => Value[];
 
 /**
  * @deprecated Use `HistogramGeneratorNumber<Datum, Value>` for `number` values and `HistogramGeneratorDate<Datum, Value> for `Date` values.
@@ -354,7 +362,6 @@ export interface HistogramGenerator<Datum, Value extends number | Date | undefin
     domain(domain: [Value, Value]): this;
     domain(domainAccessor: (values: ArrayLike<Value>) => [Value, Value] | [undefined, undefined]): this;
 
-    thresholds(): ThresholdCountGenerator | ThresholdArrayGenerator<Value>;
     /**
      * Set the array of values to be used as thresholds in determining the bins.
      *
@@ -365,25 +372,13 @@ export interface HistogramGenerator<Datum, Value extends number | Date | undefin
      * be of the same type as the materialized values of the histogram.
      */
     thresholds(thresholds: ArrayLike<Value>): this;
-    /**
-     * Set a threshold accessor function, which returns the array of values to be used as
-     * thresholds in determining the bins.
-     *
-     * Any threshold values outside the domain are ignored. The first bin.x0 is always equal to the minimum domain value,
-     * and the last bin.x1 is always equal to the maximum domain value.
-     *
-     * @param thresholds A function which accepts as arguments the array of materialized values, and
-     * optionally the domain minimum and maximum. The function calcutates and returns the array of values to be used as
-     * thresholds in determining the bins.
-     */
-    thresholds(thresholds: ThresholdArrayGenerator<Value>): this;
 }
 
 export interface HistogramCommon<Datum, Value extends number | Date | undefined> {
     (data: ArrayLike<Datum>): Array<Bin<Datum, Value>>;
 
-    value(): (d: Datum, i: number, data: Datum[]) => Value;
-    value(valueAccessor: (d: Datum, i: number, data: Datum[]) => Value): this;
+    value(): (d: Datum, i: number, data: ArrayLike<Datum>) => Value;
+    value(valueAccessor: (d: Datum, i: number, data: ArrayLike<Datum>) => Value): this;
 }
 
 export interface HistogramGeneratorDate<Datum, Value extends Date | undefined> extends HistogramCommon<Datum, Date> {
@@ -391,7 +386,7 @@ export interface HistogramGeneratorDate<Datum, Value extends Date | undefined> e
     domain(domain: [Date, Date]): this;
     domain(domainAccessor: (values: ArrayLike<Value>) => [Date, Date]): this;
 
-    thresholds(): ThresholdArrayGenerator<Value>;
+    thresholds(): ThresholdDateArrayGenerator<Value>;
     /**
      * Set the array of values to be used as thresholds in determining the bins.
      *
@@ -413,7 +408,7 @@ export interface HistogramGeneratorDate<Datum, Value extends Date | undefined> e
      * optionally the domain minimum and maximum. The function calcutates and returns the array of values to be used as
      * thresholds in determining the bins.
      */
-    thresholds(thresholds: ThresholdArrayGenerator<Value>): this;
+    thresholds(thresholds: ThresholdDateArrayGenerator<Value>): this;
 }
 
 export interface HistogramGeneratorNumber<Datum, Value extends number | undefined> extends HistogramCommon<Datum, Value> {
@@ -421,7 +416,7 @@ export interface HistogramGeneratorNumber<Datum, Value extends number | undefine
     domain(domain: [number, number]): this;
     domain(domainAccessor: (values: ArrayLike<Value>) => [number, number] | [undefined, undefined]): this;
 
-    thresholds(): ThresholdCountGenerator<Value> | ThresholdArrayGenerator<Value>;
+    thresholds(): ThresholdCountGenerator<Value> | ThresholdNumberArrayGenerator<Value>;
     /**
      * Divide the domain uniformly into approximately count bins. IMPORTANT: This threshold
      * setting approach only works, when the materialized values are numbers!
@@ -466,7 +461,7 @@ export interface HistogramGeneratorNumber<Datum, Value extends number | undefine
      * optionally the domain minimum and maximum. The function calcutates and returns the array of values to be used as
      * thresholds in determining the bins.
      */
-    thresholds(thresholds: ThresholdArrayGenerator<Value>): this;
+    thresholds(thresholds: ThresholdNumberArrayGenerator<Value>): this;
 }
 
 export function histogram(): HistogramGeneratorNumber<number, number>;

--- a/types/d3-array/index.d.ts
+++ b/types/d3-array/index.d.ts
@@ -322,12 +322,50 @@ export interface Bin<Datum, Value extends number | Date | undefined> extends Arr
 /**
  * Type definition for threshold generator which returns the count of recommended thresholds
  */
-export type ThresholdCountGenerator<Value extends number | undefined> = (values: ArrayLike<Value>, min?: number, max?: number) => number;
+export type ThresholdCountGenerator<Value extends number | undefined = number | undefined> = (values: ArrayLike<Value>, min?: number, max?: number) => number;
 
 /**
  * Type definition for threshold generator which returns an array of recommended thresholds
  */
 export type ThresholdArrayGenerator<Value extends number | Date | undefined> = (values: ArrayLike<Value>, min?: Value, max?: Value) => Value[];
+
+/**
+ * @deprecated Use `HistogramGeneratorNumber<Datum, Value>` for `number` values and `HistogramGeneratorDate<Datum, Value> for `Date` values.
+ */
+export interface HistogramGenerator<Datum, Value extends number | Date | undefined> {
+    (data: ArrayLike<Datum>): Array<Bin<Datum, Value>>;
+
+    value(): (d: Datum, i: number, data: ArrayLike<Datum>) => Value;
+    value(valueAccessor: (d: Datum, i: number, data: ArrayLike<Datum>) => Value): this;
+
+    domain(): (values: ArrayLike<Value>) => [Value, Value] | [undefined, undefined];
+    domain(domain: [Value, Value]): this;
+    domain(domainAccessor: (values: ArrayLike<Value>) => [Value, Value] | [undefined, undefined]): this;
+
+    thresholds(): ThresholdCountGenerator | ThresholdArrayGenerator<Value>;
+    /**
+     * Set the array of values to be used as thresholds in determining the bins.
+     *
+     * Any threshold values outside the domain are ignored. The first bin.x0 is always equal to the minimum domain value,
+     * and the last bin.x1 is always equal to the maximum domain value.
+     *
+     * @param thresholds Array of threshold values used for binning. The elements must
+     * be of the same type as the materialized values of the histogram.
+     */
+    thresholds(thresholds: ArrayLike<Value>): this;
+    /**
+     * Set a threshold accessor function, which returns the array of values to be used as
+     * thresholds in determining the bins.
+     *
+     * Any threshold values outside the domain are ignored. The first bin.x0 is always equal to the minimum domain value,
+     * and the last bin.x1 is always equal to the maximum domain value.
+     *
+     * @param thresholds A function which accepts as arguments the array of materialized values, and
+     * optionally the domain minimum and maximum. The function calcutates and returns the array of values to be used as
+     * thresholds in determining the bins.
+     */
+    thresholds(thresholds: ThresholdArrayGenerator<Value>): this;
+}
 
 export interface HistogramCommon<Datum, Value extends number | Date | undefined> {
     (data: ArrayLike<Datum>): Array<Bin<Datum, Value>>;
@@ -422,6 +460,12 @@ export interface HistogramGeneratorNumber<Datum, Value extends number | undefine
 export function histogram(): HistogramGeneratorNumber<number, number>;
 export function histogram<Datum, Value extends number | undefined>(): HistogramGeneratorNumber<Datum, Value>;
 export function histogram<Datum, Value extends Date | undefined>(): HistogramGeneratorDate<Datum, Value>;
+
+/**
+ * @deprecated Do not use Value generic which mixes number and Date types. Use either number or Date 
+ * (in combination with undefined, as applicable) to obtain a type-specific histogram generator.
+ */
+export function histogram<Datum, Value extends number | Date | undefined>(): HistogramGenerator<Datum, Value>;
 
 // --------------------------------------------------------------------------------------
 // Histogram Thresholds

--- a/types/d3-array/index.d.ts
+++ b/types/d3-array/index.d.ts
@@ -44,12 +44,12 @@ export function max<T extends Numeric>(array: ArrayLike<T>): T | undefined;
 /**
  * Return the maximum value in the array using natural order and a projection function to map values to strings.
  */
-export function max<T, K extends AnArray<T>>(array: K, accessor: (datum: T, index: number, array: K) => string | undefined | null): string | undefined;
+export function max<K extends AnArray<any>>(array: K, accessor: (datum: K[0], index: number, array: K) => string | undefined | null): string | undefined;
 
 /**
  * Return the maximum value in the array using natural order and a projection function to map values to easily-sorted values.
  */
-export function max<T, U extends Numeric, K extends AnArray<T>>(array: K, accessor: (datum: T, index: number, array: K) => U | undefined | null): U | undefined;
+export function max<U extends Numeric, K extends AnArray<any>>(array: K, accessor: (datum: K[0], index: number, array: K) => U | undefined | null): U | undefined;
 
 /**
  * Return the minimum value in the array using natural order.
@@ -64,7 +64,7 @@ export function min<T extends Numeric>(array: ArrayLike<T>): T | undefined;
 /**
  * Return the minimum value in the array using natural order.
  */
-export function min<T, K extends AnArray<T>>(array: K, accessor: (datum: T, index: number, array: K) => string | undefined | null): string | undefined;
+export function min<K extends AnArray<any>>(array: K, accessor: (datum: K[0], index: number, array: K) => string | undefined | null): string | undefined;
 
 /**
  * Return the minimum value in the array using natural order.
@@ -84,7 +84,7 @@ export function extent<T extends Numeric>(array: ArrayLike<T>): [T, T] | [undefi
 /**
  * Return the min and max simultaneously.
  */
-export function extent<T, K extends AnArray<T>>(array: K, accessor: (datum: T, index: number, array: K) => string | undefined | null): [string, string] | [undefined, undefined];
+export function extent<K extends AnArray<any>>(array: K, accessor: (datum: K[0], index: number, array: K) => string | undefined | null): [string, string] | [undefined, undefined];
 
 /**
  * Return the min and max simultaneously.
@@ -99,7 +99,7 @@ export function mean<T extends Numeric>(array: ArrayLike<T | undefined | null>):
 /**
  * Return the mean of an array of numbers
  */
-export function mean<T, K extends AnArray<T>>(array: K, accessor: (datum: T, index: number, array: K) => number | undefined | null): number | undefined;
+export function mean<K extends AnArray<any>>(array: K, accessor: (datum: K[0], index: number, array: K) => number | undefined | null): number | undefined;
 
 /**
  * Return the median of an array of numbers
@@ -109,14 +109,14 @@ export function median<T extends Numeric>(array: ArrayLike<T | undefined | null>
 /**
  * Return the median of an array of numbers
  */
-export function median<T, K extends AnArray<T>>(array: K, accessor: (element: T, i: number, array: K) => number | undefined | null): number | undefined;
+export function median<K extends AnArray<any>>(array: K, accessor: (element: K[0], i: number, array: K) => number | undefined | null): number | undefined;
 
 /**
  * Returns the p-quantile of an array of numbers
  */
 export function quantile<T extends Numeric>(array: ArrayLike<T | undefined | null>, p: number): number | undefined;
 
-export function quantile<T, K extends AnArray<T>>(array: K, p: number, accessor: (element: T, i: number, array: K) => number | undefined | null): number | undefined;
+export function quantile<K extends AnArray<any>>(array: K, p: number, accessor: (element: K[0], i: number, array: K) => number | undefined | null): number | undefined;
 
 /**
  * Compute the sum of an array of numbers.
@@ -126,7 +126,7 @@ export function sum<T extends Numeric>(array: ArrayLike<T | undefined | null>): 
 /**
  * Compute the sum of an array, using the given accessor to convert values to numbers.
  */
-export function sum<T, K extends AnArray<T>>(array: K, accessor: (datum: T, index: number, array: K) => number | undefined | null): number;
+export function sum<K extends AnArray<any>>(array: K, accessor: (datum: K[0], index: number, array: K) => number | undefined | null): number;
 
 /**
  * Compute the standard deviation, defined as the square root of the bias-corrected variance, of the given array of numbers.
@@ -137,7 +137,7 @@ export function deviation<T extends Numeric>(array: ArrayLike<T | undefined | nu
  * Compute the standard deviation, defined as the square root of the bias-corrected variance, of the given array,
  * using the given accessor to convert values to numbers.
  */
-export function deviation<T, K extends AnArray<T>>(array: K, accessor: (datum: T, index: number, array: K) => number | undefined | null): number | undefined;
+export function deviation<K extends AnArray<any>>(array: K, accessor: (datum: K[0], index: number, array: K) => number | undefined | null): number | undefined;
 
 /**
  * Compute an unbiased estimator of the population variance of the given array of numbers.
@@ -148,7 +148,7 @@ export function variance<T extends Numeric>(array: ArrayLike<T | undefined | nul
  * Compute an unbiased estimator of the population variance of the given array,
  * using the given accessor to convert values to numbers.
  */
-export function variance<T, K extends AnArray<T>>(array: K, accessor: (datum: T, index: number, array: K) => number | undefined | null): number | undefined;
+export function variance<K extends AnArray<any>>(array: K, accessor: (datum: K[0], index: number, array: K) => number | undefined | null): number | undefined;
 
 // --------------------------------------------------------------------------------------
 // Searching Arrays

--- a/types/d3-array/index.d.ts
+++ b/types/d3-array/index.d.ts
@@ -463,7 +463,7 @@ export function histogram<Datum, Value extends number | undefined>(): HistogramG
 export function histogram<Datum, Value extends Date | undefined>(): HistogramGeneratorDate<Datum, Value>;
 
 /**
- * @deprecated Do not use Value generic which mixes number and Date types. Use either number or Date 
+ * @deprecated Do not use Value generic which mixes number and Date types. Use either number or Date
  * (in combination with undefined, as applicable) to obtain a type-specific histogram generator.
  */
 export function histogram<Datum, Value extends number | Date | undefined>(): HistogramGenerator<Datum, Value>;

--- a/types/d3-array/index.d.ts
+++ b/types/d3-array/index.d.ts
@@ -25,7 +25,7 @@ export interface Numeric {
     valueOf(): number;
 }
 
-export type AnArray<T> = Array<T> | ReadonlyArray<T> | ArrayLike<T>;
+export type AnArray<T> = T[] | ReadonlyArray<T> | ArrayLike<T>;
 
 // --------------------------------------------------------------------------------------
 // Descriptive Statistics

--- a/types/d3-array/index.d.ts
+++ b/types/d3-array/index.d.ts
@@ -25,6 +25,8 @@ export interface Numeric {
     valueOf(): number;
 }
 
+export type AnArray<T> = Array<T> | ReadonlyArray<T> | ArrayLike<T>;
+
 // --------------------------------------------------------------------------------------
 // Descriptive Statistics
 // --------------------------------------------------------------------------------------
@@ -42,12 +44,12 @@ export function max<T extends Numeric>(array: ArrayLike<T>): T | undefined;
 /**
  * Return the maximum value in the array using natural order and a projection function to map values to strings.
  */
-export function max<T>(array: ArrayLike<T>, accessor: (datum: T, index: number, array: ArrayLike<T>) => string | undefined | null): string | undefined;
+export function max<T, K extends AnArray<T>>(array: K, accessor: (datum: T, index: number, array: K) => string | undefined | null): string | undefined;
 
 /**
  * Return the maximum value in the array using natural order and a projection function to map values to easily-sorted values.
  */
-export function max<T, U extends Numeric>(array: ArrayLike<T>, accessor: (datum: T, index: number, array: ArrayLike<T>) => U | undefined | null): U | undefined;
+export function max<T, U extends Numeric, K extends AnArray<T>>(array: K, accessor: (datum: T, index: number, array: K) => U | undefined | null): U | undefined;
 
 /**
  * Return the minimum value in the array using natural order.
@@ -62,12 +64,12 @@ export function min<T extends Numeric>(array: ArrayLike<T>): T | undefined;
 /**
  * Return the minimum value in the array using natural order.
  */
-export function min<T>(array: ArrayLike<T>, accessor: (datum: T, index: number, array: ArrayLike<T>) => string | undefined | null): string | undefined;
+export function min<T, K extends AnArray<T>>(array: K, accessor: (datum: T, index: number, array: K) => string | undefined | null): string | undefined;
 
 /**
  * Return the minimum value in the array using natural order.
  */
-export function min<T, U extends Numeric>(array: ArrayLike<T>, accessor: (datum: T, index: number, array: ArrayLike<T>) => U | undefined | null): U | undefined;
+export function min<T, U extends Numeric, K extends AnArray<T>>(array: K, accessor: (datum: T, index: number, array: K) => U | undefined | null): U | undefined;
 
 /**
  * Return the min and max simultaneously.
@@ -82,30 +84,39 @@ export function extent<T extends Numeric>(array: ArrayLike<T>): [T, T] | [undefi
 /**
  * Return the min and max simultaneously.
  */
-export function extent<T>(array: ArrayLike<T>, accessor: (datum: T, index: number, array: ArrayLike<T>) => string | undefined | null): [string, string] | [undefined, undefined];
+export function extent<T, K extends AnArray<T>>(array: K, accessor: (datum: T, index: number, array: K) => string | undefined | null): [string, string] | [undefined, undefined];
 
 /**
  * Return the min and max simultaneously.
  */
-export function extent<T, U extends Numeric>(array: ArrayLike<T>, accessor: (datum: T, index: number, array: ArrayLike<T>) => U | undefined | null): [U, U] | [undefined, undefined];
+export function extent<T, U extends Numeric, K extends AnArray<T>>(array: K, accessor: (datum: T, index: number, array: K) => U | undefined | null): [U, U] | [undefined, undefined];
 
 /**
  * Return the mean of an array of numbers
  */
 export function mean<T extends Numeric>(array: ArrayLike<T | undefined | null>): number | undefined;
-export function mean<T>(array: ArrayLike<T>, accessor: (datum: T, index: number, array: ArrayLike<T>) => number | undefined | null): number | undefined;
+
+/**
+ * Return the mean of an array of numbers
+ */
+export function mean<T, K extends AnArray<T>>(array: K, accessor: (datum: T, index: number, array: K) => number | undefined | null): number | undefined;
 
 /**
  * Return the median of an array of numbers
  */
 export function median<T extends Numeric>(array: ArrayLike<T | undefined | null>): number | undefined;
-export function median<T>(array: ArrayLike<T>, accessor: (element: T, i: number, array: ArrayLike<T>) => number | undefined | null): number | undefined;
+
+/**
+ * Return the median of an array of numbers
+ */
+export function median<T, K extends AnArray<T>>(array: K, accessor: (element: T, i: number, array: K) => number | undefined | null): number | undefined;
 
 /**
  * Returns the p-quantile of an array of numbers
  */
 export function quantile<T extends Numeric>(array: ArrayLike<T | undefined | null>, p: number): number | undefined;
-export function quantile<T>(array: ArrayLike<T>, p: number, accessor: (element: T, i: number, array: ArrayLike<T>) => number | undefined | null): number | undefined;
+
+export function quantile<T, K extends AnArray<T>>(array: K, p: number, accessor: (element: T, i: number, array: K) => number | undefined | null): number | undefined;
 
 /**
  * Compute the sum of an array of numbers.
@@ -115,7 +126,7 @@ export function sum<T extends Numeric>(array: ArrayLike<T | undefined | null>): 
 /**
  * Compute the sum of an array, using the given accessor to convert values to numbers.
  */
-export function sum<T>(array: ArrayLike<T>, accessor: (datum: T, index: number, array: ArrayLike<T>) => number | undefined | null): number;
+export function sum<T, K extends AnArray<T>>(array: K, accessor: (datum: T, index: number, array: K) => number | undefined | null): number;
 
 /**
  * Compute the standard deviation, defined as the square root of the bias-corrected variance, of the given array of numbers.
@@ -126,7 +137,7 @@ export function deviation<T extends Numeric>(array: ArrayLike<T | undefined | nu
  * Compute the standard deviation, defined as the square root of the bias-corrected variance, of the given array,
  * using the given accessor to convert values to numbers.
  */
-export function deviation<T>(array: ArrayLike<T>, accessor: (datum: T, index: number, array: ArrayLike<T>) => number | undefined | null): number | undefined;
+export function deviation<T, K extends AnArray<T>>(array: K, accessor: (datum: T, index: number, array: K) => number | undefined | null): number | undefined;
 
 /**
  * Compute an unbiased estimator of the population variance of the given array of numbers.
@@ -137,7 +148,7 @@ export function variance<T extends Numeric>(array: ArrayLike<T | undefined | nul
  * Compute an unbiased estimator of the population variance of the given array,
  * using the given accessor to convert values to numbers.
  */
-export function variance<T>(array: ArrayLike<T>, accessor: (datum: T, index: number, array: ArrayLike<T>) => number | undefined | null): number | undefined;
+export function variance<T, K extends AnArray<T>>(array: K, accessor: (datum: T, index: number, array: K) => number | undefined | null): number | undefined;
 
 // --------------------------------------------------------------------------------------
 // Searching Arrays

--- a/types/d3-array/index.d.ts
+++ b/types/d3-array/index.d.ts
@@ -1,9 +1,12 @@
 // Type definitions for D3JS d3-array module 1.2
 // Project: https://github.com/d3/d3-array
-// Definitions by: Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>, Tom Wanzek <https://github.com/tomwanzek>
+// Definitions by: Alex Ford <https://github.com/gustavderdrache>
+//                 Boris Yankov <https://github.com/borisyankov>
+//                 Tom Wanzek <https://github.com/tomwanzek>
+//                 denisname <https://github.com/denisname>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-// Last module patch version validated against: 1.2.0
+// Last module patch version validated against: 1.2.1
 
 // --------------------------------------------------------------------------
 // Shared Types and Interfaces
@@ -312,8 +315,8 @@ export function zip<T>(...arrays: Array<ArrayLike<T>>): T[][];
 // --------------------------------------------------------------------------------------
 
 export interface Bin<Datum, Value extends number | Date> extends Array<Datum> {
-    x0: Value;
-    x1: Value;
+    x0: Value | undefined;
+    x1: Value | undefined;
 }
 
 /**
@@ -328,11 +331,14 @@ export type ThresholdArrayGenerator<Value extends number | Date> = (values: Arra
 
 export interface HistogramGenerator<Datum, Value extends number | Date> {
     (data: ArrayLike<Datum>): Array<Bin<Datum, Value>>;
+
     value(): (d: Datum, i: number, data: ArrayLike<Datum>) => Value;
     value(valueAccessor: (d: Datum, i: number, data: ArrayLike<Datum>) => Value): this;
-    domain(): (values: ArrayLike<Value>) => [Value, Value];
+
+    domain(): (values: ArrayLike<Value>) => [Value, Value] | [undefined, undefined];
     domain(domain: [Value, Value]): this;
-    domain(domainAccessor: (values: ArrayLike<Value>) => [Value, Value]): this;
+    domain(domainAccessor: (values: ArrayLike<Value>) => [Value, Value] | [undefined, undefined]): this;
+
     thresholds(): ThresholdCountGenerator | ThresholdArrayGenerator<Value>;
     /**
      * Divide the domain uniformly into approximately count bins. IMPORTANT: This threshold

--- a/types/d3-array/index.d.ts
+++ b/types/d3-array/index.d.ts
@@ -322,7 +322,7 @@ export interface Bin<Datum, Value extends number | Date | undefined> extends Arr
 /**
  * Type definition for threshold generator which returns the count of recommended thresholds
  */
-export type ThresholdCountGenerator = (values: ArrayLike<number>, min?: number, max?: number) => number;
+export type ThresholdCountGenerator<Value extends number | undefined> = (values: ArrayLike<Value>, min?: number, max?: number) => number;
 
 /**
  * Type definition for threshold generator which returns an array of recommended thresholds
@@ -331,7 +331,7 @@ export type ThresholdArrayGenerator<Value extends number | Date | undefined> = (
 
 export interface HistogramCommon<Datum, Value extends number | Date | undefined> {
     (data: ArrayLike<Datum>): Array<Bin<Datum, Value>>;
-    
+
     value(): (d: Datum, i: number, data: Datum[]) => Value;
     value(valueAccessor: (d: Datum, i: number, data: Datum[]) => Value): this;
 }
@@ -341,7 +341,7 @@ export interface HistogramGeneratorDate<Datum, Value extends Date | undefined> e
     domain(domain: [Date, Date]): this;
     domain(domainAccessor: (values: ArrayLike<Value>) => [Date, Date]): this;
 
-    thresholds(): ThresholdCountGenerator | ThresholdArrayGenerator<Value>;
+    thresholds(): ThresholdArrayGenerator<Value>;
     /**
      * Set the array of values to be used as thresholds in determining the bins.
      *
@@ -371,7 +371,7 @@ export interface HistogramGeneratorNumber<Datum, Value extends number | undefine
     domain(domain: [number, number]): this;
     domain(domainAccessor: (values: ArrayLike<Value>) => [number, number] | [undefined, undefined]): this;
 
-    thresholds(): ThresholdCountGenerator | ThresholdArrayGenerator<Value>;
+    thresholds(): ThresholdCountGenerator<Value> | ThresholdArrayGenerator<Value>;
     /**
      * Divide the domain uniformly into approximately count bins. IMPORTANT: This threshold
      * setting approach only works, when the materialized values are numbers!
@@ -394,7 +394,7 @@ export interface HistogramGeneratorNumber<Datum, Value extends number | undefine
      * optionally the domain minimum and maximum. The function calcutates and returns the suggested
      * number of bins.
      */
-    thresholds(count: ThresholdCountGenerator): this;
+    thresholds(count: ThresholdCountGenerator<Value>): this;
     /**
      * Set the array of values to be used as thresholds in determining the bins.
      *
@@ -427,8 +427,8 @@ export function histogram<Datum, Value extends Date | undefined>(): HistogramGen
 // Histogram Thresholds
 // --------------------------------------------------------------------------------------
 
-export function thresholdFreedmanDiaconis(values: ArrayLike<number>, min: number, max: number): number; // of type ThresholdCountGenerator
+export function thresholdFreedmanDiaconis(values: ArrayLike<number | undefined>, min: number, max: number): number; // of type ThresholdCountGenerator
 
-export function thresholdScott(values: ArrayLike<number>, min: number, max: number): number; // of type ThresholdCountGenerator
+export function thresholdScott(values: ArrayLike<number | undefined>, min: number, max: number): number; // of type ThresholdCountGenerator
 
-export function thresholdSturges(values: ArrayLike<number>): number; // of type ThresholdCountGenerator
+export function thresholdSturges(values: ArrayLike<number | undefined>): number; // of type ThresholdCountGenerator

--- a/types/d3-array/tsconfig.json
+++ b/types/d3-array/tsconfig.json
@@ -8,7 +8,7 @@
         "noImplicitAny": true,
         "noImplicitThis": true,
         "strictNullChecks": true,
-        "strictFunctionTypes": false,
+        "strictFunctionTypes": true,
         "baseUrl": "../",
         "typeRoots": [
             "../"

--- a/types/d3-chord/index.d.ts
+++ b/types/d3-chord/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/d3/d3-chord/
 // Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
 
 // Last module patch version validated against: 1.0.3
 

--- a/types/d3-contour/d3-contour-tests.ts
+++ b/types/d3-contour/d3-contour-tests.ts
@@ -10,7 +10,7 @@ import * as d3Contour from 'd3-contour';
 import {
     range,
     thresholdSturges,
-    ThresholdArrayGenerator,
+    ThresholdNumberArrayGenerator,
     ThresholdCountGenerator
 } from 'd3-array';
 import { geoPath } from 'd3-geo';
@@ -39,13 +39,13 @@ function goldsteinPrice(x: number, y: number) {
 
 let size: [number, number];
 let boolFlag: boolean;
-const thresholdArrayGen: ThresholdArrayGenerator<number> = (values: ArrayLike<number>, min?: number, max?: number) => {
+const thresholdArrayGen: ThresholdNumberArrayGenerator<number> = (values: ArrayLike<number>, min?: number, max?: number) => {
     let thresholds: number[];
     thresholds = [values[1], values[2], values[4]];
     return thresholds;
 };
 
-let thresholdGenerator: ThresholdArrayGenerator<number> | ThresholdCountGenerator<number>;
+let thresholdGenerator: ThresholdNumberArrayGenerator<number> | ThresholdCountGenerator<number>;
 let pathStringMaybe: string | null;
 let num: number;
 

--- a/types/d3-contour/d3-contour-tests.ts
+++ b/types/d3-contour/d3-contour-tests.ts
@@ -45,7 +45,7 @@ const thresholdArrayGen: ThresholdArrayGenerator<number> = (values: ArrayLike<nu
     return thresholds;
 };
 
-let thresholdGenerator: ThresholdArrayGenerator<number> | ThresholdCountGenerator;
+let thresholdGenerator: ThresholdArrayGenerator<number> | ThresholdCountGenerator<number>;
 let pathStringMaybe: string | null;
 let num: number;
 

--- a/types/d3-contour/index.d.ts
+++ b/types/d3-contour/index.d.ts
@@ -7,7 +7,7 @@
 // Last module patch version validated against: 1.2.0
 
 import { MultiPolygon } from 'geojson';
-import { ThresholdArrayGenerator, ThresholdCountGenerator } from 'd3-array';
+import { ThresholdNumberArrayGenerator, ThresholdCountGenerator } from 'd3-array';
 
 /**
  * An extended GeoJSON MultiPolygon representing a contour.
@@ -78,7 +78,7 @@ export interface Contours {
     /**
      * Returns the current threshold generator, which by default implements Sturges’ formula.
      */
-    thresholds(): ThresholdCountGenerator<number> | ThresholdArrayGenerator<number>;
+    thresholds(): ThresholdCountGenerator<number> | ThresholdNumberArrayGenerator<number>;
     /**
      * Sets the threshold generator to use the specified count and returns this contour generator.
      * The input values’ extent will be uniformly divided into approximately count bins.
@@ -110,7 +110,7 @@ export interface Contours {
      * @param thresholds A threshold generator function. The threshold generator function is passed the array of input values
      * as its argument and returns either an array of calculated thresholds, or the count of thresholds to use.
      */
-    thresholds(thresholds: ThresholdCountGenerator<number> | ThresholdArrayGenerator<number>): this;
+    thresholds(thresholds: ThresholdCountGenerator<number> | ThresholdNumberArrayGenerator<number>): this;
 }
 
 /**
@@ -196,7 +196,7 @@ export interface ContourDensity<Datum = [number, number]> {
     /**
      * Returns the current threshold generator, which by default generates about twenty nicely-rounded density thresholds.
      */
-    thresholds(): ThresholdCountGenerator<number> | ThresholdArrayGenerator<number>;
+    thresholds(): ThresholdCountGenerator<number> | ThresholdNumberArrayGenerator<number>;
     /**
      * Sets the threshold generator to use the specified count and returns this density contour estimator.
      * Approximately count uniformly-spaced nicely-rounded thresholds will be generated.
@@ -228,7 +228,7 @@ export interface ContourDensity<Datum = [number, number]> {
      * @param thresholds A threshold generator function. The threshold generator function is passed the array of input values
      * as its argument and returns either an array of calculated thresholds, or the count of thresholds to use.
      */
-    thresholds(thresholds: ThresholdCountGenerator<number> | ThresholdArrayGenerator<number>): this;
+    thresholds(thresholds: ThresholdCountGenerator<number> | ThresholdNumberArrayGenerator<number>): this;
 
     /**
      * Returns the current bandwidth, which defaults to 20.4939….

--- a/types/d3-contour/index.d.ts
+++ b/types/d3-contour/index.d.ts
@@ -78,7 +78,7 @@ export interface Contours {
     /**
      * Returns the current threshold generator, which by default implements Sturges’ formula.
      */
-    thresholds(): ThresholdCountGenerator | ThresholdArrayGenerator<number>;
+    thresholds(): ThresholdCountGenerator<number> | ThresholdArrayGenerator<number>;
     /**
      * Sets the threshold generator to use the specified count and returns this contour generator.
      * The input values’ extent will be uniformly divided into approximately count bins.
@@ -110,7 +110,7 @@ export interface Contours {
      * @param thresholds A threshold generator function. The threshold generator function is passed the array of input values
      * as its argument and returns either an array of calculated thresholds, or the count of thresholds to use.
      */
-    thresholds(thresholds: ThresholdCountGenerator | ThresholdArrayGenerator<number>): this;
+    thresholds(thresholds: ThresholdCountGenerator<number> | ThresholdArrayGenerator<number>): this;
 }
 
 /**
@@ -196,7 +196,7 @@ export interface ContourDensity<Datum = [number, number]> {
     /**
      * Returns the current threshold generator, which by default generates about twenty nicely-rounded density thresholds.
      */
-    thresholds(): ThresholdCountGenerator | ThresholdArrayGenerator<number>;
+    thresholds(): ThresholdCountGenerator<number> | ThresholdArrayGenerator<number>;
     /**
      * Sets the threshold generator to use the specified count and returns this density contour estimator.
      * Approximately count uniformly-spaced nicely-rounded thresholds will be generated.
@@ -228,7 +228,7 @@ export interface ContourDensity<Datum = [number, number]> {
      * @param thresholds A threshold generator function. The threshold generator function is passed the array of input values
      * as its argument and returns either an array of calculated thresholds, or the count of thresholds to use.
      */
-    thresholds(thresholds: ThresholdCountGenerator | ThresholdArrayGenerator<number>): this;
+    thresholds(thresholds: ThresholdCountGenerator<number> | ThresholdArrayGenerator<number>): this;
 
     /**
      * Returns the current bandwidth, which defaults to 20.4939….


### PR DESCRIPTION
**Breaking Changes**

The `ThresholdArrayGenerator` interface has been **removed** and replaced by two disticts interfaces. For numbers thresholds use `ThresholdNumberArrayGenerator` and for dates thresholds use `ThresholdDateArrayGenerator`.

The `HistogramGenerator` interface is **deprecated**. Use `HistogramGeneratorDate` for `Date` values and `HistogramGeneratorNumber` for `Number` values.

All but one of `thresholds()` methods in `HistogramGenerator` have been **removed**. If you need them, update your code to use `HistogramGeneratorDate` and `HistogramGeneratorNumber`.

-----------------------------

Initial commit:

This pull request make histogram ready for strict null check (related: #14494). The changes are to be discussed... Strict function types and TS 2.3 are kept for another pull request.
Some backward incompatibilities are brought with this pull request. But, we can add some default generics...

Changes are made according to the following `d3.histogram` behaviours.

* The `histogram()` function accept an array containing `undefined`. Those will be filtered out.
* The `value` method may return `undefined`. This is useful to filter some values.
* The properties `Bin#x0` and `Bin#x1`may be undefined when histogram is computed on empty list or list with only `undefined`.
* Finally, for `domain`, we need a union with `[undefined, undefined]` to allow using `d3.extent` as domain.
Although this is useless when domain is `Date`. So we may want to divide `HistogramGenerator` in `HistogramGeneratorNumber` and `HistogramGeneratorDate` with different `domain` definition.
This also allows to remove `thresholds(count: ThresholdCountGenerator): this` from the _Date histogram_.

What are your thoughts ?

Related: #23611.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: see d3 api and source code
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
