### PR TITLE
Chrome: Add node to BookmarkRemoveInfo type

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -263,6 +263,7 @@ declare namespace chrome.bookmarks {
     export interface BookmarkRemoveInfo {
         index: number;
         parentId: string;
+        node: BookmarkTreeNode;
     }
 
     export interface BookmarkMoveInfo {


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] ~Add or edit tests to reflect the change. (Run with `npm test`.)~ (not covered by tests atm).
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.chrome.com/extensions/bookmarks#event-onRemoved
- [ ] ~Increase the version number in the header if appropriate.~
- [ ] ~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.~

A simple change - added a `node` property to the `BookmarkRemoveInfo` type (was introduced in Chrome 48).