### PR TITLE
Jasmine - Make createSpyObj definitions consistent - same strict type for all methodNames arguments.

### DIFF
--- a/types/jasmine/index.d.ts
+++ b/types/jasmine/index.d.ts
@@ -130,6 +130,7 @@ declare function waits(timeout?: number): void;
 
 declare namespace jasmine {
     type Expected<T> = T | ObjectContaining<T> | Any | Spy;
+    type SpyObjMethodNames = string[] | {[methodName: string]: any};
 
     var clock: () => Clock;
 
@@ -144,12 +145,11 @@ declare namespace jasmine {
     function objectContaining<T>(sample: Partial<T>): ObjectContaining<T>;
     function createSpy(name?: string, originalFn?: Function): Spy;
 
-    function createSpyObj(baseName: string, methodNames: any[] | {[methodName: string]: any}): any;
-    function createSpyObj<T>(baseName: string, methodNames: any[] | {[methodName: string]: any}): SpyObj<T>;
+    function createSpyObj(baseName: string, methodNames: SpyObjMethodNames): any;
+    function createSpyObj<T>(baseName: string, methodNames: SpyObjMethodNames): SpyObj<T>;
 
-    function createSpyObj(baseName: string, methodNames: any): any;
-    function createSpyObj(methodNames: any[]): any;
-    function createSpyObj(methodNames: any): any;
+    function createSpyObj(methodNames: SpyObjMethodNames): any;
+    function createSpyObj<T>(methodNames: SpyObjMethodNames): SpyObj<T>;
 
     function pp(value: any): string;
 

--- a/types/jasmine/jasmine-tests.ts
+++ b/types/jasmine/jasmine-tests.ts
@@ -1109,18 +1109,22 @@ describe("createSpyObj", function () {
         expect(spyObj.method2.and.identity()).toEqual('BaseName.method2');
     });
 
-    it("should allow you to omit the baseName", function () {
+    it("should allow you to omit the baseName and takes only an object", function () {
+        var spyObj = jasmine.createSpyObj({ 'method1': 42, 'method2': 'special sauce' });
+
+        expect(spyObj.method1()).toEqual(42);
+        expect(spyObj.method1.and.identity()).toEqual('unknown.method1');
+
+        expect(spyObj.method2()).toEqual('special sauce');
+        expect(spyObj.method2.and.identity()).toEqual('unknown.method2');
+    });
+
+    it("should allow you to omit the baseName and takes only a list of methods", function () {
         var spyObj = jasmine.createSpyObj(['method1', 'method2']);
 
         expect(spyObj).toEqual({ method1: jasmine.any(Function), method2: jasmine.any(Function) });
         expect(spyObj.method1.and.identity()).toEqual('unknown.method1');
         expect(spyObj.method2.and.identity()).toEqual('unknown.method2');
-    });
-
-    it("should throw if you do not pass an array or object argument", function () {
-        expect(function () {
-            jasmine.createSpyObj('BaseName');
-        }).toThrow("createSpyObj requires a non-empty array or object of method names to create spies for");
     });
 
     it("should throw if you pass an empty array argument", function () {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://jasmine.github.io/api/2.6/jasmine.html (search for `createSpyObj`)
- [ ] Increase the version number in the header if appropriate.
  - Not sure what this means.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
  - Not substantial changes.