### PR TITLE
recharts: Add tickMargin to XAxisProps and YAxisProps

### DIFF
--- a/types/recharts/index.d.ts
+++ b/types/recharts/index.d.ts
@@ -885,6 +885,8 @@ export interface XAxisProps extends EventAttributes {
     tickLine?: boolean | object;
     minTickGap?: number;
     tickSize?: number;
+    // The margin between tick line and the label
+    tickMargin?: number;
     interval?: AxisInterval;
     reversed?: boolean;
     // see label section at http://recharts.org/#/en-US/api/XAxis
@@ -934,6 +936,8 @@ export interface YAxisProps extends EventAttributes {
     tickLine?: boolean | object;
     minTickGap?: number;
     tickSize?: number;
+    // The margin between tick line and the label
+    tickMargin?: number;
     interval?: AxisInterval;
     reversed?: boolean;
     // see label section at http://recharts.org/#/en-US/api/YAxis


### PR DESCRIPTION
Recharts supports an optional `tickMargin` prop on `XAxis` and `YAxis` components, which defines the margin between the tick line and the tick itself (the label).

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [YAxis](http://recharts.org/en-US/api/YAxis) [XAxis](http://recharts.org/en-US/api/XAxis)
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.