### PR TITLE
node: Fix parameter type of TransformOptions transform callback

### DIFF
--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -5993,14 +5993,16 @@ declare module "stream" {
             uncork(): void;
         }
 
+        type TransformCallback = (err?: Error, data?: any) => void;
+
         export interface TransformOptions extends DuplexOptions {
-            transform?: (chunk: string | Buffer, encoding: string, callback: Function) => any;
-            flush?: (callback: Function) => any;
+            transform?: (chunk: any, encoding: string, callback: TransformCallback) => any;
+            flush?: (callback: TransformCallback) => any;
         }
 
         export class Transform extends Duplex {
             constructor(opts?: TransformOptions);
-            _transform(chunk: any, encoding: string, callback: Function): void;
+            _transform(chunk: any, encoding: string, callback: TransformCallback): void;
             destroy(error?: Error): void;
         }
 

--- a/types/node/v9/index.d.ts
+++ b/types/node/v9/index.d.ts
@@ -5499,14 +5499,16 @@ declare module "stream" {
             uncork(): void;
         }
 
+        type TransformCallback = (err?: Error, data?: any) => void;
+
         export interface TransformOptions extends DuplexOptions {
-            transform?: (chunk: string | Buffer, encoding: string, callback: Function) => any;
-            flush?: (callback: Function) => any;
+            transform?: (chunk: any, encoding: string, callback: TransformCallback) => any;
+            flush?: (callback: TransformCallback) => any;
         }
 
         export class Transform extends Duplex {
             constructor(opts?: TransformOptions);
-            _transform(chunk: any, encoding: string, callback: Function): void;
+            _transform(chunk: any, encoding: string, callback: TransformCallback): void;
             destroy(error?: Error): void;
         }
 


### PR DESCRIPTION
- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).


- [X] Provide a URL to documentation or source code which provides context for the suggested changes: 
[Transform constructor documentation](https://nodejs.org/api/stream.html#stream_transform_transform_chunk_encoding_callback)
- [ ] Increase the version number in the header if appropriate.  - N/A
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.  - N/A


----

This is needed to support transforms in Object Mode (i.e chunk is an object, not a Buffer or string).