### PR TITLE
Use default export in @types/prop-types

### DIFF
--- a/types/prop-types/index.d.ts
+++ b/types/prop-types/index.d.ts
@@ -28,3 +28,9 @@ export function oneOfType(types: Array<Validator<any>>): Requireable<any>;
 export function arrayOf(type: Validator<any>): Requireable<any>;
 export function objectOf(type: Validator<any>): Requireable<any>;
 export function shape(type: ValidationMap<any>): Requireable<any>;
+
+export default ({
+    Validator, Requireable, ValidationMap,
+    any, array, bool, func, number, object, string, node, element, symbol,
+    instanceOf, oneOf, oneOfType, arrayOf, objectOf, shape
+});


### PR DESCRIPTION
PropTypes are commonly used by importing default exported value.
This export will help to preserve existing codebases and to use @types.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.