### PR TITLE
angular-translate: Add optional fn parameter to onReady

### DIFF
--- a/types/angular-translate/index.d.ts
+++ b/types/angular-translate/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for Angular Translate (pascalprecht.translate module) 2.15
 // Project: https://github.com/PascalPrecht/angular-translate
-// Definitions by: Michel Salib <https://github.com/michelsalib>
+// Definitions by: Michel Salib <https://github.com/michelsalib>, Gabriel Gil <https://github.com/GabrielGil>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 

--- a/types/angular-translate/index.d.ts
+++ b/types/angular-translate/index.d.ts
@@ -69,7 +69,7 @@ declare module 'angular' {
             versionInfo(): string;
             loaderCache(): any;
             isReady(): boolean;
-            onReady(): angular.IPromise<void>;
+            onReady(fn?: () => void): angular.IPromise<void>;
             resolveClientLocale(): string;
             getAvailableLanguageKeys(): string[];
         }


### PR DESCRIPTION
**Angular translate**

The method onReady can accept an optional function to be executed when the `$translate` service is ready.

*Docs*: https://angular-translate.github.io/docs/#/api/pascalprecht.translate.$translate#methods_onready

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
