### PR TITLE
[react-fontawesome] Changing props from a type union to an interface

### DIFF
--- a/types/react-fontawesome/index.d.ts
+++ b/types/react-fontawesome/index.d.ts
@@ -11,7 +11,7 @@ import * as React from 'react';
 
 export = FontAwesome;
 
-interface Intermediate extends React.HTMLProps<HTMLElement> {
+interface Intermediate extends React.HTMLAttributes<HTMLElement> {
     size?: any;
 }
 

--- a/types/react-fontawesome/index.d.ts
+++ b/types/react-fontawesome/index.d.ts
@@ -11,7 +11,7 @@ import * as React from 'react';
 
 export = FontAwesome;
 
-interface Intermediate extends React.HTMLAttributes<HTMLElement> {
+interface Intermediate extends React.AllHTMLAttributes<HTMLElement> {
     size?: any;
 }
 

--- a/types/react-fontawesome/index.d.ts
+++ b/types/react-fontawesome/index.d.ts
@@ -11,12 +11,16 @@ import * as React from 'react';
 
 export = FontAwesome;
 
+interface Intermediate extends React.HTMLProps<HTMLElement> {
+    size?: any;
+}
+
 declare namespace FontAwesome {
     type FontAwesomeSize = 'lg' | '2x' | '3x' | '4x' | '5x';
     type FontAwesomeStack = '1x' | '2x';
     type FontAwesomeFlip = 'horizontal' | 'vertical';
 
-    type FontAwesomeProps = React.HTMLProps<FontAwesome> | {
+    interface FontAwesomeProps extends Intermediate {
         ariaLabel?: string;
         border?: boolean;
         cssModule?: any;
@@ -30,7 +34,7 @@ declare namespace FontAwesome {
         spin?: boolean;
         stack?: FontAwesomeStack;
         tag?: string;
-    };
+    }
 }
 
 declare class FontAwesome extends React.Component<FontAwesome.FontAwesomeProps> {}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: *(N/A)*
- [x] Increase the version number in the header if appropriate. *(N/A)*
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. *(N/A)*

This was done because some of the generics such as Pick<>, etc weren't working correctly due to the union.