### PR TITLE
types/he: version 1.1.1 updates, include `decimal` in EncodeOptions interface

### DIFF
--- a/types/he/he-tests.ts
+++ b/types/he/he-tests.ts
@@ -2,18 +2,18 @@ import he = require('he');
 
 function main() {
     var result: string;
-  
+
     result = he.encode('foo \xa9 bar \u2260 baz qux');
     // 'foo &#xA9; bar &#x2260; baz qux'
-  
+
     he.encode('foo \0 bar');
     // 'foo \0 bar'
-  
+
     // Passing an `options` object to `encode`, to explicitly disallow named references:
     he.encode('foo \xa9 bar \u2260 baz qux', {
         'useNamedReferences': false
     });
-    
+
     he.encode('foo \xa9 bar \u2260 baz qux', {
         'encodeEverything': true
     });
@@ -22,21 +22,43 @@ function main() {
         'encodeEverything': true,
         'useNamedReferences': true
     });
-    
+
     he.encode('\x01', {
         'strict': false
     });
-    // '&#x1;'  
-    
+    // '&#x1;'
+
     he.encode('foo © and & ampersand', {
         'allowUnsafeSymbols': true
     });
-    
+
+    // Using the global default setting (defaults to `false`):
+    he.encode('foo © bar ≠ baz 𝌆 qux');
+    // → 'foo &#xA9; bar &#x2260; baz &#x1D306; qux'
+
+    // Passing an `options` object to `encode`, to explicitly disable decimal escapes:
+    he.encode('foo © bar ≠ baz 𝌆 qux', {
+        'decimal': false
+    });
+    // → 'foo &#xA9; bar &#x2260; baz &#x1D306; qux'
+
+    // Passing an `options` object to `encode`, to explicitly enable decimal escapes:
+    he.encode('foo © bar ≠ baz 𝌆 qux', {
+        'decimal': true
+    });
+    // → 'foo &#169; bar &#8800; baz &#119558; qux'
+
+    // Passing an `options` object to `encode`, to explicitly allow named references and decimal escapes:
+    he.encode('foo © bar ≠ baz 𝌆 qux', {
+        'useNamedReferences': true,
+     'decimal': true
+    });
+
     // Override the global default setting:
     he.encode.options.useNamedReferences = true;
-    
+
     he.decode('foo &copy; bar &ne; baz &#x1D306; qux');
-    
+
     he.decode('foo&ampbar', {
         'isAttributeValue': false
     });

--- a/types/he/index.d.ts
+++ b/types/he/index.d.ts
@@ -1,6 +1,7 @@
-// Type definitions for he v0.5.0
+// Type definitions for he v1.1.1
 // Project: https://github.com/mathiasbynens/he
 // Definitions by: Simon Edwards <https://github.com/sedwards2009>
+//                 Robin Tregaskis <https://github.com/lokidokicoki>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 // he - "HTML Entities" - A high quality pair of HTML encode and decode functions.
@@ -17,6 +18,18 @@ export interface EncodeOptions {
     * be used instead. Set it to true to enable the use of named references.
     */
     useNamedReferences?: boolean;
+
+    /**
+     * The default value for the decimal option is false. If the option is
+     * enabled, encode will generally use decimal escapes (e.g. &#169;)
+     * rather than hexadecimal escapes (e.g. &#xA9;). Beside of this
+     * replacement, the basic behavior remains the same when combined with
+     * other options. For example: if both options useNamedReferences and
+     * decimal are enabled, named references (e.g. &copy;) are used over
+     * decimal escapes. HTML entities without a named reference are encoded
+     * using decimal escapes.
+     */
+    decimal?: boolean;
 
     /**
     * The default value for the encodeEverything option is false. This means


### PR DESCRIPTION
…eOptions interface

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/mathiasbynens/he#decimal
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

