### PR TITLE
Add react-resize-detector definitions for refreshMode & refreshRate

### DIFF
--- a/types/react-resize-detector/index.d.ts
+++ b/types/react-resize-detector/index.d.ts
@@ -1,6 +1,6 @@
-// Type definitions for react-resize-detector 2.1
+// Type definitions for react-resize-detector 2.2
 // Project: https://github.com/maslianok/react-resize-detector
-// Definitions by: Matthew James <https://github.com/matthew-matvei>
+// Definitions by: Matthew James <https://github.com/matthew-matvei>, James Greenleaf <https://github.com/aMoniker>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.6
 
@@ -17,6 +17,10 @@ interface ReactResizeDetectorProps extends React.Props<ReactResizeDetector> {
     skipOnMount?: boolean;
     /** Id of the element we want to observe. If none provided, parentElement of the component will be used. Default: "" */
     resizableElementId?: string;
+    /** Possible values: throttle and debounce */
+    refreshMode?: 'throttle' | 'debounce';
+    /** Makes sense only when refreshMode is set. Default: 1000. */
+    refreshRate?: number;
 }
 
 declare class ReactResizeDetector extends React.PureComponent<ReactResizeDetectorProps> { }

--- a/types/react-resize-detector/react-resize-detector-tests.tsx
+++ b/types/react-resize-detector/react-resize-detector-tests.tsx
@@ -20,7 +20,9 @@ class App extends React.PureComponent {
                 handleWidth
                 handleHeight
                 skipOnMount
-                resizableElementId="someElement" />
+                resizableElementId="someElement"
+                refreshMode="throttle"
+                refreshRate={10} />
         </div>;
     }
 


### PR DESCRIPTION
Attributes `refreshMode` and `refreshRate` were added to `react-resize-detector` on March 5th and rolled into `v2.2`, but are not typed yet. This PR adds the types.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/maslianok/react-resize-detector/commit/7bb5ac6f86d6d6b066906959da05b76606301550>>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.