### PR TITLE
node: Type spawn's args as a ReadonlyArray of string

### DIFF
--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -2101,7 +2101,7 @@ declare module "child_process" {
         windowsHide?: boolean;
     }
 
-    export function spawn(command: string, args?: string[], options?: SpawnOptions): ChildProcess;
+    export function spawn(command: string, args?: ReadonlyArray<string>, options?: SpawnOptions): ChildProcess;
 
     export interface ExecOptions {
         cwd?: string;

--- a/types/node/v0/index.d.ts
+++ b/types/node/v0/index.d.ts
@@ -881,7 +881,7 @@ declare module "child_process" {
         unref(): void;
     }
 
-    export function spawn(command: string, args?: string[], options?: {
+    export function spawn(command: string, args?: ReadonlyArray<string>, options?: {
         cwd?: string;
         stdio?: any;
         custom?: any;

--- a/types/node/v4/index.d.ts
+++ b/types/node/v4/index.d.ts
@@ -1240,7 +1240,7 @@ declare module "child_process" {
         gid?: number;
         shell?: boolean | string;
     }
-    export function spawn(command: string, args?: string[], options?: SpawnOptions): ChildProcess;
+    export function spawn(command: string, args?: ReadonlyArray<string>, options?: SpawnOptions): ChildProcess;
 
     export interface ExecOptions {
         cwd?: string;

--- a/types/node/v6/index.d.ts
+++ b/types/node/v6/index.d.ts
@@ -1787,7 +1787,7 @@ declare module "child_process" {
         gid?: number;
         shell?: boolean | string;
     }
-    export function spawn(command: string, args?: string[], options?: SpawnOptions): ChildProcess;
+    export function spawn(command: string, args?: ReadonlyArray<string>, options?: SpawnOptions): ChildProcess;
 
     export interface ExecOptions {
         cwd?: string;

--- a/types/node/v7/index.d.ts
+++ b/types/node/v7/index.d.ts
@@ -1847,7 +1847,7 @@ declare module "child_process" {
         gid?: number;
         shell?: boolean | string;
     }
-    export function spawn(command: string, args?: string[], options?: SpawnOptions): ChildProcess;
+    export function spawn(command: string, args?: ReadonlyArray<string>, options?: SpawnOptions): ChildProcess;
 
     export interface ExecOptions {
         cwd?: string;

--- a/types/node/v8/index.d.ts
+++ b/types/node/v8/index.d.ts
@@ -2091,7 +2091,7 @@ declare module "child_process" {
         windowsHide?: boolean;
     }
 
-    export function spawn(command: string, args?: string[], options?: SpawnOptions): ChildProcess;
+    export function spawn(command: string, args?: ReadonlyArray<string>, options?: SpawnOptions): ChildProcess;
 
     export interface ExecOptions {
         cwd?: string;

--- a/types/node/v9/index.d.ts
+++ b/types/node/v9/index.d.ts
@@ -2091,7 +2091,7 @@ declare module "child_process" {
         windowsHide?: boolean;
     }
 
-    export function spawn(command: string, args?: string[], options?: SpawnOptions): ChildProcess;
+    export function spawn(command: string, args?: ReadonlyArray<string>, options?: SpawnOptions): ChildProcess;
 
     export interface ExecOptions {
         cwd?: string;


### PR DESCRIPTION
At the moment, this snippet:

```ts
const spawnArgs: ReadonlyArray<string> = ['foo', 'bar'];
spawn('foobar', spawnArgs);
```

fails with:

```
Argument of type 'ReadonlyArray<string>' is not assignable to parameter of type 'string[] | undefined'.
  Type 'ReadonlyArray<string>' is not assignable to type 'string[]'.
```

Looking at https://github.com/nodejs/node/blob/master/lib/child_process.js#L514-L535 and https://github.com/nodejs/node/blob/master/lib/internal/child_process.js#L286, it _looks_ like there is no mutation of the array. I am no expert so I'd be happy to be proven wrong, I just couldn't find sufficient evidence that a `ReadonlyArray` wouldn't be fine.
This is not a breaking change because passing a `string[]` is still valid.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes (see above)
- ~Increase the version number in the header if appropriate.~
- ~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.~
