### PR TITLE
[shallowequal] Update shallowequal exports to allow '* as' imports.

### DIFF
--- a/types/shallowequal/index.d.ts
+++ b/types/shallowequal/index.d.ts
@@ -3,7 +3,8 @@
 // Definitions by: Sean Kelley <https://github.com/seansfkelley>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare module 'shallowequal' {
-  function shallowEqual(objA: any, objB: any, compare?: (objA: any, objB: any, indexOrKey?: number | string) => boolean, compareContext?: any): boolean;
-  export = shallowEqual;
-}
+declare function shallowEqual(objA: any, objB: any, compare?: (objA: any, objB: any, indexOrKey?: number | string) => boolean, compareContext?: any): boolean;
+
+declare namespace shallowEqual { }
+
+export = shallowEqual;

--- a/types/shallowequal/shallowequal-tests.ts
+++ b/types/shallowequal/shallowequal-tests.ts
@@ -1,10 +1,15 @@
-import shallowEqual = require('shallowequal');
+import shallowEqual_require = require('shallowequal');
+import * as shallowEqual_splat from 'shallowequal';
 
 const a = {}, b = {};
 function compare(a: any, b: any, indexOrKey?: number | string) {
   return false;
 }
 
-shallowEqual(a, b);
-shallowEqual(a, b, compare);
-shallowEqual(a, b, compare, {});
+shallowEqual_require(a, b);
+shallowEqual_require(a, b, compare);
+shallowEqual_require(a, b, compare, {});
+
+shallowEqual_splat(a, b);
+shallowEqual_splat(a, b, compare);
+shallowEqual_splat(a, b, compare, {});


### PR DESCRIPTION
Follows the pattern from `classnames` so that `shallowequal` can be imported both with `import = require` and `import * as` import styles. This should make it work with both `module: commonjs` and `module: es2015` options.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [ ] ~~Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>~~ n/a
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
