### PR TITLE
missing methods in the pki namespace

### DIFF
--- a/types/node-forge/index.d.ts
+++ b/types/node-forge/index.d.ts
@@ -43,7 +43,9 @@ declare module "node-forge" {
             privateKey: Key;
         }
 
+		function pemToDer(pem: PEM): util.ByteStringBuffer;
         function privateKeyToPem(key: Key, maxline?: number): PEM;
+		function privateKeyInfoToPem(key: Key, maxline?: number): PEM;
         function publicKeyToPem(key: Key, maxline?: number): PEM;
         function publicKeyFromPem(pem: PEM): Key;
         function privateKeyFromPem(pem: PEM): Key;

--- a/types/node-forge/index.d.ts
+++ b/types/node-forge/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for node-forge 0.7.2
+// Type definitions for node-forge 0.7.5
 // Project: https://github.com/digitalbazaar/forge
 // Definitions by: Seth Westphal <https://github.com/westy92>
 //                 Kay Schecker <https://github.com/flynetworks>

--- a/types/node-forge/node-forge-tests.ts
+++ b/types/node-forge/node-forge-tests.ts
@@ -8,6 +8,8 @@ let x: string = forge.ssh.privateKeyToOpenSSH(key);
 let pemKey: forge.pki.PEM = publicKeyPem;
 let publicKeyRsa = forge.pki.publicKeyFromPem(pemKey);
 let privateKeyRsa = forge.pki.privateKeyFromPem(privateKeyPem);
+let privateKeyRsa2 = forge.pki.privateKeyInfoToPem(privateKeyPem);
+let byteBufferString = forge.pki.pemToDer(privateKeyRsa);
 let cert = forge.pki.createCertificate();
 
 {


### PR DESCRIPTION
Added missing methods to pki namespace.

Had to utilize the privateKeyInfoToPem function defined in pki.js in node-forge, and wanted my IDE to acknowledge its existence.

Please fill in this template.

- [x ] Use a meaningful title for the pull request. Include the name of the package modified.
- [x ] Test the change in your own code. (Compile and run.)
- [x ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

I am not sure if I have followed all the conventions. I haven't ever created more than a single pull request for any project, and this one seemed fairly easy.

I did NOT resolve the entire pki namespace, nor did I resolve any other namespace.

I only added what I needed, and if that is selfish and undesired, then I pre-apologize.