### PR TITLE
[angular-translate] Remove angular reference

### DIFF
--- a/types/angular-translate/index.d.ts
+++ b/types/angular-translate/index.d.ts
@@ -4,8 +4,6 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
-/// <reference types="angular" />
-
 declare var _: string;
 export = _;
 


### PR DESCRIPTION
This brings the definition in line with official AngularJS packages like
angular-sanitize, angular-cookies, and angular-route.

This reference was causing bizarre path issues when trying to run the
dgeni documentation tool on a project that included these types, and it
appears that the fix for that is to remove the reference, which
coincidentally matches what the official AngularJS packages do.


- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/angular-route/index.d.ts
https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/angular-sanitize/index.d.ts
https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/angular-cookies/index.d.ts
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.