### PR TITLE
[urijs] Bugfix: segment(number) can also return undefined.

### DIFF
--- a/types/urijs/index.d.ts
+++ b/types/urijs/index.d.ts
@@ -105,7 +105,7 @@ declare namespace uri {
         search(qry: Object): URI;
         segment(): string[];
         segment(segments: string[]): URI;
-        segment(position: number): string;
+        segment(position: number): string | undefined;
         segment(position: number, level: string): URI;
         segment(segment: string): URI;
         segmentCoded(): string[];

--- a/types/urijs/urijs-tests.ts
+++ b/types/urijs/urijs-tests.ts
@@ -45,6 +45,9 @@ URI('http://example.org/foo/hello.html').segment('bar');
 URI('http://example.org/foo/hello.html').segment(0, 'bar');
 URI('http://example.org/foo/hello.html').segment(['foo', 'bar', 'foobar.html']);
 
+URI('http://example.org/foo/hello.html').segment(0);
+URI('http://example.org/foo/hello.html').segment(100);
+
 URI('http://example.org/foo/hello.html').segmentCoded('foo bar');
 URI('http://example.org/foo/hello.html').segmentCoded(0, 'foo bar');
 URI('http://example.org/foo/hello.html').segmentCoded(['foo bar', 'bar foo', 'foo bar.html']);


### PR DESCRIPTION
Try it out on https://medialize.github.io/URI.js/docs.html

> const uri = new URI("http://example.org/foo/hello.html");
>
> uri.segment(0)
> => "foo"
>
> uri.segment(5)
> => undefined

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://medialize.github.io/URI.js/docs.html
