### PR TITLE
added missing formatOutOfCountryCallingNumber function to definitions of google-libphonenumber

### DIFF
--- a/types/google-libphonenumber/index.d.ts
+++ b/types/google-libphonenumber/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for libphonenumber v7.4.3
 // Project: https://github.com/googlei18n/libphonenumber, https://github.com/seegno/google-libphonenumber
 // Definitions by: Leon Yu <https://github.com/leonyu>
+//		   Roman Jurkov <https://github.com/winfinit>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare namespace libphonenumber {
@@ -112,6 +113,7 @@ declare namespace libphonenumber {
     export class PhoneNumberUtil {
         static getInstance(): PhoneNumberUtil
         format(phoneNumber: PhoneNumber, format: PhoneNumberFormat): string;
+	formatOutOfCountryCallingNumber(phoneNumber: PhoneNumber, regionDialingFrom?: string): string;
         getNddPrefixForRegion(regionCode?: string, stripNonDigits?: boolean): string | undefined;
         getNumberType(phoneNumber: PhoneNumber): PhoneNumberType;
         getCountryCodeForRegion(supportedRegion:string):string;

--- a/types/google-libphonenumber/index.d.ts
+++ b/types/google-libphonenumber/index.d.ts
@@ -113,7 +113,7 @@ declare namespace libphonenumber {
     export class PhoneNumberUtil {
         static getInstance(): PhoneNumberUtil
         format(phoneNumber: PhoneNumber, format: PhoneNumberFormat): string;
-	formatOutOfCountryCallingNumber(phoneNumber: PhoneNumber, regionDialingFrom?: string): string;
+        formatOutOfCountryCallingNumber(phoneNumber: PhoneNumber, regionDialingFrom?: string): string;
         getNddPrefixForRegion(regionCode?: string, stripNonDigits?: boolean): string | undefined;
         getNumberType(phoneNumber: PhoneNumber): PhoneNumberType;
         getCountryCodeForRegion(supportedRegion:string):string;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/googlei18n/libphonenumber/blob/master/javascript/i18n/phonenumbers/phonenumberutil.js#L2031>>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.