### PR TITLE
[@types/three] Fix Three.ParametricGeometry arguments

### DIFF
--- a/types/three/test/webgl/webgl_geometries.ts
+++ b/types/three/test/webgl/webgl_geometries.ts
@@ -96,6 +96,17 @@
         object.position.set(0, 0, -200);
         scene.add(object);
 
+
+        object = new THREE.Mesh(
+            new THREE.ParametricGeometry(
+                (u:number, v:number, dest:THREE.Vector3):void => {
+                    dest.set(u, v, 0);
+                },
+                25,
+                25
+            )
+        );
+
         object = new THREE.AxesHelper(50);
         object.position.set(200, 0, -200);
         scene.add(object);

--- a/types/three/three-core.d.ts
+++ b/types/three/three-core.d.ts
@@ -7096,10 +7096,10 @@ export class OctahedronGeometry extends PolyhedronGeometry {
 }
 
 export class ParametricGeometry extends Geometry {
-    constructor(func: (u: number, v: number) => Vector3, slices: number, stacks: number);
+    constructor(func: (u: number, v: number, dest:Vector3) => void, slices: number, stacks: number);
 
     parameters: {
-        func: (u: number, v: number) => Vector3;
+        func: (u: number, v: number, dest:Vector3) => void;
         slices: number;
         stacks: number;
     };


### PR DESCRIPTION
This fixes the `ParametricGeometry` arguments.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://threejs.org/docs/#api/geometries/ParametricGeometry
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
