### PR TITLE
fix(prosemirror-*): replace void with undefined in return union types

### DIFF
--- a/types/prosemirror-collab/index.d.ts
+++ b/types/prosemirror-collab/index.d.ts
@@ -47,7 +47,7 @@ export function sendableSteps<S extends Schema = any>(
   steps: Array<Step<S>>;
   clientID: number | string;
   origins: Array<Transaction<S>>;
-} | null | void;
+} | null | undefined;
 /**
  * Get the version up to which the collab plugin has synced with the
  * central authority.

--- a/types/prosemirror-collab/prosemirror-collab-tests.ts
+++ b/types/prosemirror-collab/prosemirror-collab-tests.ts
@@ -10,3 +10,4 @@ plugin = collab.collab({ version: 1 });
 plugin = collab.collab({ clientID: 1 });
 
 const sendableSteps = collab.sendableSteps(state);
+sendableSteps!.clientID;

--- a/types/prosemirror-inputrules/index.d.ts
+++ b/types/prosemirror-inputrules/index.d.ts
@@ -42,7 +42,7 @@ export class InputRule<S extends Schema = any> {
         match: string[],
         start: number,
         end: number
-      ) => Transaction<S> | null | void)
+      ) => Transaction<S> | null)
   );
 }
 /**
@@ -81,7 +81,7 @@ export function undoInputRule<S extends Schema = any>(
 export function wrappingInputRule<S extends Schema = any>(
   regexp: RegExp,
   nodeType: NodeType<S>,
-  getAttrs?: { [key: string]: any } | ((p: string[]) => { [key: string]: any } | null | void),
+  getAttrs?: { [key: string]: any } | ((p: string[]) => { [key: string]: any } | null | undefined),
   joinPredicate?: (p1: string[], p2: ProsemirrorNode<S>) => boolean
 ): InputRule<S>;
 /**
@@ -95,7 +95,7 @@ export function wrappingInputRule<S extends Schema = any>(
 export function textblockTypeInputRule<S extends Schema = any>(
   regexp: RegExp,
   nodeType: NodeType<S>,
-  getAttrs?: { [key: string]: any } | ((p: string[]) => { [key: string]: any } | null | void)
+  getAttrs?: { [key: string]: any } | ((p: string[]) => { [key: string]: any } | null | undefined)
 ): InputRule<S>;
 /**
  * Converts double dashes to an emdash.

--- a/types/prosemirror-inputrules/prosemirror-inputrules-tests.ts
+++ b/types/prosemirror-inputrules/prosemirror-inputrules-tests.ts
@@ -1,5 +1,8 @@
 import * as inputrules from 'prosemirror-inputrules';
 import { NodeType } from 'prosemirror-model';
+import { Transaction } from 'prosemirror-state';
 
 const nodeType = new NodeType();
-const rule: inputrules.InputRule = inputrules.wrappingInputRule(/^\$/, nodeType);
+const rule1: inputrules.InputRule = inputrules.wrappingInputRule(/^\$/, nodeType);
+const rule2 = new inputrules.InputRule(/^$/, 'str');
+const rule3 = new inputrules.InputRule(/^$/, () => null);

--- a/types/prosemirror-model/index.d.ts
+++ b/types/prosemirror-model/index.d.ts
@@ -35,12 +35,12 @@ export class ContentMatch<S extends Schema = any> {
    * Match a node type and marks, returning a match after that node
    * if successful.
    */
-  matchType(type: NodeType<S>): ContentMatch<S> | null | void;
+  matchType(type: NodeType<S>): ContentMatch<S> | null | undefined;
   /**
    * Try to match a fragment. Returns the resulting match when
    * successful.
    */
-  matchFragment(frag: Fragment<S>, start?: number, end?: number): ContentMatch<S> | null | void;
+  matchFragment(frag: Fragment<S>, start?: number, end?: number): ContentMatch<S> | null | undefined;
   /**
    * Try to match the given fragment, and if that fails, see if it can
    * be made to match by inserting nodes in front of it. When
@@ -49,14 +49,14 @@ export class ContentMatch<S extends Schema = any> {
    * return a fragment if the resulting match goes to the end of the
    * content expression.
    */
-  fillBefore(after: Fragment<S>, toEnd?: boolean, startIndex?: number): Fragment<S> | null | void;
+  fillBefore(after: Fragment<S>, toEnd?: boolean, startIndex?: number): Fragment<S> | null | undefined;
   /**
    * Find a set of wrapping node types that would allow a node of the
    * given type to appear at this position. The result may be empty
    * (when it fits directly) and will be null when no such wrapping
    * exists.
    */
-  findWrapping(target: NodeType<S>): Array<NodeType<S>> | null | void;
+  findWrapping(target: NodeType<S>): Array<NodeType<S>> | null | undefined;
   /**
    * Get the _n_th outgoing edge from this node in the finite automaton
    * that describes the content expression.
@@ -89,7 +89,7 @@ export class Fragment<S extends Schema = any> {
       start: number,
       parent: ProsemirrorNode<S>,
       index: number
-    ) => boolean | null | void,
+    ) => boolean | null | undefined | void,
     startPos?: number
   ): void;
   /**
@@ -101,7 +101,7 @@ export class Fragment<S extends Schema = any> {
       node: ProsemirrorNode<S>,
       pos: number,
       parent: ProsemirrorNode<S>
-    ) => boolean | null | void
+    ) => boolean | null | undefined | void
   ): void;
   /**
    * Create a new fragment containing the combined content of this
@@ -141,7 +141,7 @@ export class Fragment<S extends Schema = any> {
   /**
    * Get the child node at the given index, if it exists.
    */
-  maybeChild(index: number): ProsemirrorNode<S> | null | void;
+  maybeChild(index: number): ProsemirrorNode<S> | null | undefined;
   /**
    * Call `f` for every child node, passing the node, its offset
    * into this parent node, and its index.
@@ -151,14 +151,14 @@ export class Fragment<S extends Schema = any> {
    * Find the first position at which this fragment and another
    * fragment differ, or `null` if they are the same.
    */
-  findDiffStart(other: Fragment<S>): number | null | void;
+  findDiffStart(other: Fragment<S>): number | null | undefined;
   /**
    * Find the first position, searching from the end, at which this
    * fragment and the given fragment differ, or `null` if they are the
    * same. Since this position will not be the same in both nodes, an
    * object with two separate positions is returned.
    */
-  findDiffEnd(other: ProsemirrorNode<S>): { a: number; b: number } | null | void;
+  findDiffEnd(other: ProsemirrorNode<S>): { a: number; b: number } | null | undefined;
   /**
    * Return a debugging string that describes this fragment.
    */
@@ -166,7 +166,7 @@ export class Fragment<S extends Schema = any> {
   /**
    * Create a JSON-serializeable representation of this fragment.
    */
-  toJSON(): { [key: string]: any } | null | void;
+  toJSON(): { [key: string]: any } | null | undefined;
   /**
    * Deserialize a fragment from its JSON representation.
    */
@@ -326,7 +326,7 @@ export interface ParseRule<S extends Schema = any> {
    * Called with a DOM Element for `tag` rules, and with a string (the
    * style's value) for `style` rules.
    */
-  getAttrs?: ((p: Node | string) => { [key: string]: any } | false | null | void) | null;
+  getAttrs?: ((p: Node | string) => { [key: string]: any } | false | null | undefined) | null;
   /**
    * For `tag` rules that produce non-leaf nodes or marks, by default
    * the content of the DOM element is parsed as content of the mark
@@ -507,7 +507,7 @@ declare class ProsemirrorNode<S extends Schema = any> {
   /**
    * Get the child node at the given index, if it exists.
    */
-  maybeChild(index: number): ProsemirrorNode<S> | null | void;
+  maybeChild(index: number): ProsemirrorNode<S> | null | undefined;
   /**
    * Call `f` for every child node, passing the node, its offset
    * into this parent node, and its index.
@@ -529,7 +529,7 @@ declare class ProsemirrorNode<S extends Schema = any> {
       pos: number,
       parent: ProsemirrorNode<S>,
       index: number
-    ) => boolean | null | void,
+    ) => boolean | null | undefined | void,
     startPos?: number
   ): void;
   /**
@@ -541,7 +541,7 @@ declare class ProsemirrorNode<S extends Schema = any> {
       node: ProsemirrorNode<S>,
       pos: number,
       parent: ProsemirrorNode<S>
-    ) => boolean | null | void
+    ) => boolean | null | undefined | void
   ): void;
   /**
    * Concatenates all the text nodes found in this fragment and its
@@ -612,7 +612,7 @@ declare class ProsemirrorNode<S extends Schema = any> {
   /**
    * Find the node starting at the given position.
    */
-  nodeAt(pos: number): ProsemirrorNode<S> | null | void;
+  nodeAt(pos: number): ProsemirrorNode<S> | null | undefined;
   /**
    * Find the (direct) child node after the given offset, if any,
    * and return it along with its index and offset relative to this
@@ -769,7 +769,7 @@ export class Slice<S extends Schema = any> {
   /**
    * Convert a slice to a JSON-serializable representation.
    */
-  toJSON(): { [key: string]: any } | null | void;
+  toJSON(): { [key: string]: any } | null | undefined;
   /**
    * Deserialize a slice from its JSON representation.
    */
@@ -892,7 +892,7 @@ export class ResolvedPos<S extends Schema = any> {
    * its parent node or its parent node isn't a textblock (in which
    * case no marks should be preserved).
    */
-  marksAcross($end: ResolvedPos<S>): Array<Mark<S>> | null | void;
+  marksAcross($end: ResolvedPos<S>): Array<Mark<S>> | null | undefined;
   /**
    * The depth up to which this position and the given (non-resolved)
    * position share the same parent nodes.
@@ -910,7 +910,7 @@ export class ResolvedPos<S extends Schema = any> {
   blockRange(
     other?: ResolvedPos<S>,
     pred?: (p: ProsemirrorNode<S>) => boolean
-  ): NodeRange<S> | null | void;
+  ): NodeRange<S> | null | undefined;
   /**
    * Query whether the given position shares the same parent node.
    */
@@ -1061,7 +1061,7 @@ export class NodeType<S extends Schema = any> {
     attrs?: { [key: string]: any },
     content?: Fragment<S> | ProsemirrorNode<S> | Array<ProsemirrorNode<S>>,
     marks?: Array<Mark<S>>
-  ): ProsemirrorNode<S> | null | void;
+  ): ProsemirrorNode<S> | null | undefined;
   /**
    * Returns true if the given fragment is valid content for this node
    * type with the given attributes.
@@ -1113,7 +1113,7 @@ export class MarkType<S extends Schema = any> {
   /**
    * Tests whether there is a mark of this type in the given set.
    */
-  isInSet(set: Array<Mark<S>>): Mark<S> | null | void;
+  isInSet(set: Array<Mark<S>>): Mark<S> | null | undefined;
   /**
    * Queries whether a given mark type is
    * [excluded](#model.MarkSpec.excludes) by this one.

--- a/types/prosemirror-model/prosemirror-model-tests.ts
+++ b/types/prosemirror-model/prosemirror-model-tests.ts
@@ -37,6 +37,49 @@ export const nodeSpec: model.NodeSpec = {
     }
 };
 
-const node = new model.Node();
-node.nodesBetween(0, 1, () => {});
-node.descendants(() => {});
+// Verify that non-null assertion operator can be used.
+
+const res1_1 = new model.Node();
+res1_1.nodesBetween(0, 1, () => {});
+res1_1.nodesBetween(0, 1, () => null);
+res1_1.nodesBetween(0, 1, () => undefined);
+res1_1.nodesBetween(0, 1, () => true);
+res1_1.descendants(() => {});
+res1_1.descendants(() => null);
+res1_1.descendants(() => undefined);
+res1_1.descendants(() => true);
+const res1_2: model.Node = res1_1.maybeChild(0)!;
+const res1_3: model.Node = res1_1.nodeAt(0)!;
+const res1_4: object = res1_1.toJSON()!;
+
+const cm1 = new model.ContentMatch();
+const cm2: model.ContentMatch = cm1.matchType({} as any)!;
+const cm3: model.ContentMatch = cm1.matchFragment({} as any)!;
+const cm4: model.Fragment = cm1.fillBefore({} as any)!;
+const cm5: model.NodeType[] = cm1.findWrapping({} as any)!;
+
+const f1 = new model.Fragment();
+f1.nodesBetween(0, 0, () => {});
+f1.nodesBetween(0, 0, () => null);
+f1.nodesBetween(0, 0, () => undefined);
+f1.nodesBetween(0, 0, () => true);
+
+f1.descendants(() => {});
+f1.descendants(() => null);
+f1.descendants(() => undefined);
+f1.descendants(() => true);
+
+const res2_1: model.Node = f1.maybeChild(0)!;
+const res2_2: number = f1.findDiffStart(f1)!;
+const res2_3: { a: number, b: number } = f1.findDiffEnd({} as any)!;
+const res2_4: object = f1.toJSON()!;
+
+const res3_1 = new model.ResolvedPos();
+const res3_2: model.Mark[] = res3_1.marksAcross(res3_1)!;
+const res3_3: model.NodeRange = res3_1.blockRange(res3_1)!;
+
+const res4_1 = new model.NodeType();
+const res4_2: model.Node = res4_1.createAndFill()!;
+
+const res5_1 = new model.MarkType();
+const res5_2: model.Mark = res5_1.isInSet([])!;

--- a/types/prosemirror-model/prosemirror-model-tests.ts
+++ b/types/prosemirror-model/prosemirror-model-tests.ts
@@ -50,7 +50,6 @@ res1_1.descendants(() => undefined);
 res1_1.descendants(() => true);
 const res1_2: model.Node = res1_1.maybeChild(0)!;
 const res1_3: model.Node = res1_1.nodeAt(0)!;
-const res1_4: object = res1_1.toJSON()!;
 
 const cm1 = new model.ContentMatch();
 const cm2: model.ContentMatch = cm1.matchType({} as any)!;

--- a/types/prosemirror-state/index.d.ts
+++ b/types/prosemirror-state/index.d.ts
@@ -74,7 +74,7 @@ export interface PluginSpec<S extends Schema = any> {
     transactions: Transaction[],
     oldState: EditorState<S>,
     newState: EditorState<S>
-  ) => Transaction | null | void)
+  ) => Transaction | null | undefined)
   | null;
 }
 /**
@@ -147,11 +147,11 @@ export class PluginKey<S extends Schema = any> {
    * Get the active plugin with this key, if any, from an editor
    * state.
    */
-  get(state: EditorState<S>): Plugin<S> | null | void;
+  get(state: EditorState<S>): Plugin<S> | null | undefined;
   /**
    * Get the plugin's state from an editor state.
    */
-  getState(state: EditorState<S>): any | null | void;
+  getState(state: EditorState<S>): any | null | undefined;
 }
 /**
  * Superclass for editor selections. Every selection type should
@@ -263,7 +263,7 @@ export class Selection<S extends Schema = any> {
     $pos: ResolvedPos<S>,
     dir: number,
     textOnly?: boolean
-  ): Selection<S> | null | void;
+  ): Selection<S> | null | undefined;
   /**
    * Find a valid cursor or leaf node selection near the given
    * position. Searches forward first by default, but if `bias` is

--- a/types/prosemirror-state/index.d.ts
+++ b/types/prosemirror-state/index.d.ts
@@ -74,7 +74,7 @@ export interface PluginSpec<S extends Schema = any> {
     transactions: Transaction[],
     oldState: EditorState<S>,
     newState: EditorState<S>
-  ) => Transaction | null | undefined)
+  ) => Transaction | null | undefined | void)
   | null;
 }
 /**

--- a/types/prosemirror-state/prosemirror-state-tests.ts
+++ b/types/prosemirror-state/prosemirror-state-tests.ts
@@ -49,7 +49,6 @@ const res1_5: state.PluginSpec["appendTransaction"] = () => ({} as state.Transac
 
 const res2_1 = new state.PluginKey();
 const res2_2: state.Plugin = res2_1.get({} as state.EditorState)!;
-const res2_3: any = res2_1.getState({} as state.EditorState)!;
 
 const res3_1 = new state.Selection({} as any, {} as any);
 const res3_2: state.Selection = state.Selection.findFrom({} as model.ResolvedPos, 0)!;

--- a/types/prosemirror-state/prosemirror-state-tests.ts
+++ b/types/prosemirror-state/prosemirror-state-tests.ts
@@ -40,3 +40,16 @@ transaction = transaction.setNodeMarkup(0);
 transaction = transaction.split(0);
 transaction = transaction.join(0);
 transaction = transaction.step(step);
+
+const res1_1: state.PluginSpec["appendTransaction"] = null;
+const res1_2: state.PluginSpec["appendTransaction"] = () => {};
+const res1_3: state.PluginSpec["appendTransaction"] = () => null;
+const res1_4: state.PluginSpec["appendTransaction"] = () => undefined;
+const res1_5: state.PluginSpec["appendTransaction"] = () => ({} as state.Transaction);
+
+const res2_1 = new state.PluginKey();
+const res2_2: state.Plugin = res2_1.get({} as state.EditorState)!;
+const res2_3: any = res2_1.getState({} as state.EditorState)!;
+
+const res3_1 = new state.Selection({} as any, {} as any);
+const res3_2: state.Selection = state.Selection.findFrom({} as model.ResolvedPos, 0)!;

--- a/types/prosemirror-transform/index.d.ts
+++ b/types/prosemirror-transform/index.d.ts
@@ -403,7 +403,7 @@ export function replaceStep<S extends Schema = any>(
   from: number,
   to?: number,
   slice?: Slice<S>
-): Step<S> | null | void;
+): Step<S> | null | undefined;
 /**
  * A step object represents an atomic change. It generally applies
  * only to the document it was created for, since the positions
@@ -439,13 +439,13 @@ export class Step<S extends Schema = any> {
    * version of that step with its positions adjusted, or `null` if
    * the step was entirely deleted by the mapping.
    */
-  map(mapping: Mappable): Step<S> | null | void;
+  map(mapping: Mappable): Step<S> | null | undefined;
   /**
    * Try to merge this step with another one, to be applied directly
    * after it. Returns the merged step when possible, null if the
    * steps can't be merged.
    */
-  merge(other: Step<S>): Step<S> | null | void;
+  merge(other: Step<S>): Step<S> | null | undefined;
   /**
    * Create a JSON-serializeable representation of this step. When
    * defining this for a custom subclass, make sure the result object
@@ -504,7 +504,7 @@ export class StepResult<S extends Schema = any> {
  * can be lifted. Will not go across
  * [isolating](#model.NodeSpec.isolating) parent nodes.
  */
-export function liftTarget(range: NodeRange): number | null | void;
+export function liftTarget(range: NodeRange): number | null | undefined;
 /**
  * Try to find a valid way to wrap the content in the given range in a
  * node of the given type. May introduce extra nodes around and inside
@@ -515,7 +515,7 @@ export function findWrapping<S extends Schema = any>(
   range: NodeRange<S>,
   nodeType: NodeType<S>,
   attrs?: { [key: string]: any }
-): Array<{ type: NodeType<S>; attrs?: { [key: string]: any } | null }> | null | void;
+): Array<{ type: NodeType<S>; attrs?: { [key: string]: any } | null }> | null | undefined;
 /**
  * Check whether splitting at the given position is allowed.
  */
@@ -535,7 +535,7 @@ export function canJoin(doc: ProsemirrorNode, pos: number): boolean;
  * block before (or after if `dir` is positive). Returns the joinable
  * point, if any.
  */
-export function joinPoint(doc: ProsemirrorNode, pos: number, dir?: number): number | null | void;
+export function joinPoint(doc: ProsemirrorNode, pos: number, dir?: number): number | null | undefined;
 /**
  * Try to find a point where a node of the given type can be inserted
  * near `pos`, by searching up the node hierarchy when `pos` itself
@@ -546,4 +546,4 @@ export function insertPoint<S extends Schema = any>(
   doc: ProsemirrorNode<S>,
   pos: number,
   nodeType: NodeType<S>
-): number | null | void;
+): number | null | undefined;

--- a/types/prosemirror-transform/prosemirror-transform-tests.ts
+++ b/types/prosemirror-transform/prosemirror-transform-tests.ts
@@ -1,3 +1,17 @@
 import * as transform from 'prosemirror-transform';
 
 const stepmap = new transform.StepMap([]);
+
+// Verify non-null assertion operator can be used.
+
+const res1_1: transform.Step = transform.replaceStep({} as any, 0)!;
+const res1_2: transform.Step = res1_1.map({} as any)!;
+const res1_3: transform.Step = res1_1.merge({} as any)!;
+
+const res2_1: number = transform.liftTarget({} as any)!;
+
+const res3_1: any[] = transform.findWrapping({} as any, {} as any)!;
+
+const res4_1: number = transform.joinPoint({} as any, 0)!;
+
+const res5_1: number = transform.insertPoint({} as any, 0, {} as any)!;

--- a/types/prosemirror-view/index.d.ts
+++ b/types/prosemirror-view/index.d.ts
@@ -237,7 +237,7 @@ export class EditorView<S extends Schema = any> {
   posAtCoords(coords: {
     left: number;
     top: number;
-  }): { pos: number; inside: number } | null | void;
+  }): { pos: number; inside: number } | null | undefined;
   /**
    * Returns the viewport rectangle at a given document position. `left`
    * and `right` will be the same number, as this returns a flat
@@ -404,7 +404,7 @@ export interface EditorProps<S extends Schema = any> {
     view: EditorView<S>,
     anchor: ResolvedPos<S>,
     head: ResolvedPos<S>
-  ) => Selection<S> | null | void)
+  ) => Selection<S> | null | undefined)
   | null;
   /**
    * The [parser](#model.DOMParser) to use when reading editor changes
@@ -482,7 +482,7 @@ export interface EditorProps<S extends Schema = any> {
    * A set of [document decorations](#view.Decoration) to show in the
    * view.
    */
-  decorations?: ((state: EditorState<S>) => DecorationSet<S> | null | void) | null;
+  decorations?: ((state: EditorState<S>) => DecorationSet<S> | null | undefined) | null;
   /**
    * When this returns false, the content of the view is not directly
    * editable.
@@ -500,7 +500,7 @@ export interface EditorProps<S extends Schema = any> {
    */
   attributes?:
   | { [name: string]: string }
-  | ((p: EditorState<S>) => { [name: string]: string } | null | void)
+  | ((p: EditorState<S>) => { [name: string]: string } | null | undefined | void)
   | null;
   /**
    * Determines the distance (in pixels) between the cursor and the

--- a/types/prosemirror-view/prosemirror-view-tests.ts
+++ b/types/prosemirror-view/prosemirror-view-tests.ts
@@ -1,3 +1,15 @@
 import * as view from 'prosemirror-view';
+import * as state from 'prosemirror-state';
 
 const decoration = new view.Decoration();
+
+const res1_1 = new view.EditorView({} as any, {} as any);
+const res1_2: { pos: number, inside: number } = res1_1.posAtCoords({ left: 0, top: 0})!;
+
+const res2_1: view.EditorProps = {} as any;
+const res2_2: state.Selection = res2_1.createSelectionBetween!({} as any, {} as any, {} as any)!;
+const res2_3: view.DecorationSet = res2_1.decorations!({} as any)!;
+
+const res3_1: view.EditorProps["attributes"] = () => {};
+const res3_2: view.EditorProps["attributes"] = () => null;
+const res3_3: view.EditorProps["attributes"] = () => undefined;


### PR DESCRIPTION
This PR aims to allow the non-null assertion operator to be used on return values from various ProseMirror APIs. Prior to TypeScript 2.8, the non-null assertion operator could be used to remove `void` from a union type (see https://github.com/Microsoft/TypeScript/issues/23847#issuecomment-386194536), but this behaviour was actually a bug.

So basically this PR makes ProseMirror types compatible with 2.8 where the non-null assertion operator is used.

----

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: This relates to https://github.com/Microsoft/TypeScript/issues/23847#issuecomment-386194536
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
