### PR TITLE
knockout: Add type params to the KnockoutBindingHandler type

### DIFF
--- a/types/knockout/index.d.ts
+++ b/types/knockout/index.d.ts
@@ -1,10 +1,10 @@
 // Type definitions for Knockout v3.4.0
 // Project: http://knockoutjs.com
-// Definitions by: Boris Yankov <https://github.com/borisyankov>, 
-//                 Igor Oleinikov <https://github.com/Igorbek>, 
-//                 Clément Bourgeois <https://github.com/moonpyk>, 
-//                 Matt Brooks <https://github.com/EnableSoftware>, 
-//                 Benjamin Eckardt <https://github.com/BenjaminEckardt>, 
+// Definitions by: Boris Yankov <https://github.com/borisyankov>,
+//                 Igor Oleinikov <https://github.com/Igorbek>,
+//                 Clément Bourgeois <https://github.com/moonpyk>,
+//                 Matt Brooks <https://github.com/EnableSoftware>,
+//                 Benjamin Eckardt <https://github.com/BenjaminEckardt>,
 //                 Mathias Lorenzen <https://github.com/ffMathy>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
@@ -150,10 +150,10 @@ interface KnockoutAllBindingsAccessor {
     has(name: string): boolean;
 }
 
-interface KnockoutBindingHandler {
+interface KnockoutBindingHandler<E extends Node = any, V = any, VM = any> {
     after?: Array<string>;
-    init?: (element: any, valueAccessor: () => any, allBindingsAccessor: KnockoutAllBindingsAccessor, viewModel: any, bindingContext: KnockoutBindingContext) => void | { controlsDescendantBindings: boolean; };
-    update?: (element: any, valueAccessor: () => any, allBindingsAccessor: KnockoutAllBindingsAccessor, viewModel: any, bindingContext: KnockoutBindingContext) => void;
+    init?: (element: E, valueAccessor: () => V, allBindingsAccessor: KnockoutAllBindingsAccessor, viewModel: VM, bindingContext: KnockoutBindingContext) => void | { controlsDescendantBindings: boolean; };
+    update?: (element: E, valueAccessor: () => V, allBindingsAccessor: KnockoutAllBindingsAccessor, viewModel: VM, bindingContext: KnockoutBindingContext) => void;
     options?: any;
     preprocess?: (value: string, name: string, addBindingCallback?: (name: string, value: string) => void) => string;
     [s: string]: any;
@@ -440,7 +440,7 @@ interface KnockoutStatic {
     contextFor(node: any): any;
     isSubscribable(instance: any): instance is KnockoutSubscribable<any>;
     toJSON(viewModel: any, replacer?: Function, space?: any): string;
-  
+
     toJS(viewModel: any): any;
 
     isObservable(instance: any): instance is KnockoutObservable<any>;
@@ -451,7 +451,7 @@ interface KnockoutStatic {
 
     isComputed(instance: any): instance is KnockoutComputed<any>;
     isComputed<T>(instance: KnockoutObservable<T> | T): instance is KnockoutComputed<T>;
-  
+
     dataFor(node: any): any;
     removeNode(node: Node): void;
     cleanNode(node: Node): Node;

--- a/types/knockout/test/index.ts
+++ b/types/knockout/test/index.ts
@@ -192,7 +192,7 @@ function test_bindings() {
             var value = ko.utils.unwrapObservable(valueAccessor());
             $(element).toggle(value);
         }
-    };
+    } as KnockoutBindingHandler<HTMLElement, KnockoutObservable<boolean> | boolean>;
     ko.bindingHandlers.hasFocus = {
         init: function (element, valueAccessor) {
             $(element).focus(function () {
@@ -211,7 +211,7 @@ function test_bindings() {
             else
                 element.blur();
         }
-    };
+    } as KnockoutBindingHandler<HTMLElement, KnockoutObservable<boolean>>;
     ko.bindingHandlers.allowBindings = {
         init: function (elem, valueAccessor) {
             var shouldAllowBindings = ko.utils.unwrapObservable(valueAccessor());


### PR DESCRIPTION
This adds some optional type parameters to the KnockoutBindingHandler type: which allows bindingHandlers to be written as:

```
interface MyBindingHandlerValue {
    foo: string;    
};

ko.bindingHandlers.myBindingHandler = {
    init(element, valueAccessor, allBindingsAccessor, viewModel, bindingContext) {
        const foo = valueAccessor().foo; //Properly typed as string
    },
    update(element, valueAccessor, allBindingsAccessor, viewModel, bindingContext) {
        //...
    }
} as KnockoutBindingHandler<HTMLElement, MyBindingHandlerValue>;
```

which I think is an improvement over the current alternative:

```
type MyBindingValueAccessor = () => {
    foo: string
};

ko.bindingHandlers.myBindingHandler = {
    init(element: HTMLElement, valueAccessor: MyBindingValueAccessor, allBindingsAccessor, viewModel, bindingContext) {
        const foo = valueAccessor().foo; //Properly typed as string
    },
    update(element: HTMLElement, valueAccessor: MyBindingValueAccessor, allBindingsAccessor, viewModel, bindingContext) {
        //...
    }
};
```

It allows you to provide the type for the value - rather than the value accessor - avoids duplication between `init` and `update`, and keeps the already long list of arguments from growing longer due to type annotations.

---

I considered having the default value of the `Element` param be `Node`, but it'd be a backwards incompatible change, and it's not a particularly helpful default since many (most?) bindingHandlers depend on `HTMLElement` features.  


---

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: N/A
- [X] Increase the version number in the header if appropriate.

