### PR TITLE
d3-polygon strict null check

### DIFF
--- a/types/d3-polygon/d3-polygon-tests.ts
+++ b/types/d3-polygon/d3-polygon-tests.ts
@@ -17,8 +17,7 @@ let containsFlag: boolean;
 let point: [number, number] = [15, 15];
 const polygon: Array<[number, number]> = [[10, 10], [20, 20], [10, 30]];
 const pointArray: Array<[number, number]> = [[10, 10], [20, 20], [10, 30], [15, 15]];
-let hull: Array<[number, number]>;
-let hullOrNoting: Array<[number, number]> | null;
+let hullOrNothing: Array<[number, number]> | null;
 
 // -----------------------------------------------------------------------------
 // Tests
@@ -28,9 +27,7 @@ num = d3Polygon.polygonArea(polygon);
 
 point = d3Polygon.polygonCentroid(polygon);
 
-hull = d3Polygon.polygonHull(pointArray)!;
-
-hullOrNoting = d3Polygon.polygonHull([]);
+hullOrNothing = d3Polygon.polygonHull(pointArray);
 
 containsFlag = d3Polygon.polygonContains(polygon, point);
 

--- a/types/d3-polygon/d3-polygon-tests.ts
+++ b/types/d3-polygon/d3-polygon-tests.ts
@@ -18,6 +18,7 @@ let point: [number, number] = [15, 15];
 const polygon: Array<[number, number]> = [[10, 10], [20, 20], [10, 30]];
 const pointArray: Array<[number, number]> = [[10, 10], [20, 20], [10, 30], [15, 15]];
 let hull: Array<[number, number]>;
+let hullOrNoting: Array<[number, number]> | null;
 
 // -----------------------------------------------------------------------------
 // Tests
@@ -27,7 +28,9 @@ num = d3Polygon.polygonArea(polygon);
 
 point = d3Polygon.polygonCentroid(polygon);
 
-hull = d3Polygon.polygonHull(pointArray);
+hull = d3Polygon.polygonHull(pointArray)!;
+
+hullOrNoting = d3Polygon.polygonHull([]);
 
 containsFlag = d3Polygon.polygonContains(polygon, point);
 

--- a/types/d3-polygon/index.d.ts
+++ b/types/d3-polygon/index.d.ts
@@ -3,11 +3,11 @@
 // Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-// Last module patch version validated against: 1.0.1
+// Last module patch version validated against: 1.0.3
 
 /**
- * Returns the signed area of the specified polygon. If the vertices of the polygon are in counterclockwise order (
- * assuming a coordinate system where the origin ⟨0,0⟩ is in the top-left corner), the returned area is positive;
+ * Returns the signed area of the specified polygon. If the vertices of the polygon are in counterclockwise order
+ * (assuming a coordinate system where the origin <0,0> is in the top-left corner), the returned area is positive;
  * otherwise it is negative, or zero.
  *
  * @param polygon Array of coordinates <x0, y0>, <x1, y1> and so on.
@@ -34,7 +34,7 @@ export function polygonHull(points: Array<[number, number]>): Array<[number, num
  * Returns true if and only if the specified point is inside the specified polygon.
  *
  * @param polygon Array of coordinates <x0, y0>, <x1, y1> and so on.
- * @param point Coordinates of point <x, y>
+ * @param point Coordinates of point <x, y>.
  */
 export function polygonContains(polygon: Array<[number, number]>, point: [number, number]): boolean;
 

--- a/types/d3-polygon/tsconfig.json
+++ b/types/d3-polygon/tsconfig.json
@@ -6,7 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
-        "strictNullChecks": false,
+        "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/d3-polygon/tslint.json
+++ b/types/d3-polygon/tslint.json
@@ -1,7 +1,3 @@
 {
-    "extends": "dtslint/dt.json",
-    "rules": {
-        "unified-signatures": false,
-        "callable-types": false
-    }
+    "extends": "dtslint/dt.json"
 }


### PR DESCRIPTION
Activate strict null check for d3-polygon. Type definition was already good. So I only change tests.

Nothing to say about strict function or TS 2.4. Definition is already good too.

Remove useless tslint rules exceptions.

Related: #23611

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/d3/d3-polygon
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
