### PR TITLE
[select2] rollback breaking changes in 4.0.45 (back to 4.0.44)

### DIFF
--- a/types/select2/index.d.ts
+++ b/types/select2/index.d.ts
@@ -1,242 +1,215 @@
 // Type definitions for Select2 4.0
 // Project: http://ivaynberg.github.com/select2/
 // Definitions by: Boris Yankov <https://github.com/borisyankov>
-//                 denisname <https://github.com/denisname>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
 /// <reference types="jquery"/>
 
-export as namespace Select2;
-
-// --------------------------------------------------------------------------
-// Some Interfaces
-// --------------------------------------------------------------------------
-
-export interface Select2 {
-    $container: JQuery;
-    $dropdown: JQuery;
-    $selection: JQuery;
-    $results: JQuery;
-    dropdown: any;
-    id: string;
-    options: { options: Options };
-    results: any;
-    selection: any;
-}
-
-export interface QueryOptions {
+interface Select2QueryOptions {
     term?: string;
     page?: number;
+    context?: any;
+    callback?: (result: { results: any; more?: boolean; context?: any; }) => void;
 }
 
-export interface SearchOptions {
-    term: string;
+type AjaxFunction =
+    (settings: JQueryAjaxSettings, success?: (data: any) => null, failure?: () => null) => JQueryXHR;
+
+interface Select2AjaxOptions extends JQueryAjaxSettings {
+    transport?: AjaxFunction;
+    /**
+     * Url to make request to, can be string or a function returning a string.
+     */
+    url?: any;
+    dataType?: string;
+    delay?: number;
+    headers?: any;
+    cache?: boolean;
+    data?: (params: Select2QueryOptions, page: number, context: any) => any;
+    results?: (term: any, page: number, context: any) => any;
+    processResults?: (data: any, params: any) => any;
+    templateResult?: (data: any) => any;
+    templateSelection?: (data: any) => any;
 }
 
-export interface DataFormat {
-    id: number | string;
+interface IdTextPair {
+    id: any;
     text: string;
-    selected?: boolean;
+}
+
+interface Select2Options {
+    amdBase?: string;
+    amdLanguageBase?: string;
+    width?: string;
+    dropdownAutoWidth?: boolean;
+    minimumInputLength?: number;
+    maximumInputLength?: number;
+    minimumResultsForSearch?: number;
+    maximumSelectionLength?: number;
+    placeholder?: string | IdTextPair;
+    separator?: string;
+    allowClear?: boolean;
+    multiple?: boolean;
     disabled?: boolean;
+    closeOnSelect?: boolean;
+    openOnEnter?: boolean;
+    id?: (object: any) => string;
+    matcher?: (term: string, text: string, option: any) => boolean;
+    formatSelection?: (object: any, container: JQuery, escapeMarkup: (markup: string) => string) => string;
+    formatResult?: (object: any, container: JQuery, query: any, escapeMarkup: (markup: string) => string) => string;
+    formatResultCssClass?: (object: any) => string;
+    formatNoMatches?: (term: string) => string;
+    formatSearching?: () => string;
+    formatInputTooShort?: (term: string, minLength: number) => string;
+    formatSelectionTooBig?: (maxSize: number) => string;
+    formatLoadMore?: (pageNumber: number) => string;
+    initSelection?: (element: JQuery, callback: (data: any) => void) => void;
+    tokenizer?: (input: string, selection: any[], selectCallback: () => void, options: Select2Options) => string;
+    tokenSeparators?: string[];
+    query?: (options: Select2QueryOptions) => void;
+    ajax?: Select2AjaxOptions;
+    data?: any;
+    tags?: any;
+    createTag?: any;
+    containerCss?: any;
+    containerCssClass?: any;
+    dropdownCss?: any;
+    dropdownCssClass?: any;
+    escapeMarkup?: (markup: string) => string;
+    theme?: string;
+    /**
+     * Template can return both plain string that will be HTML escaped and a jquery object that can render HTML
+     */
+    templateSelection?: (object: Select2SelectionObject, container: JQuery) => any;
+    templateResult?: (object: Select2SelectionObject) => any;
+    language?: string | string[] | {};
+    selectOnClose?: boolean;
+    sorter?: (data: any[]) => any[];
+    dropdownParent?: JQuery;
+    debug?: boolean;
+    dropdownAdapter?: any;
+    selectionAdapter?: any;
+    resultsAdapter?: any;
+    dataAdapter?: any;
 }
 
-export interface GroupedDataFormat {
-    text: string;
-    children?: DataFormat[];
-
-    id?: undefined;
+interface Select2JQueryEventObject extends JQueryEventObject {
+    val: any;
+    added: any;
+    removed: any;
+    choice: {
+        id: any;
+        text: string;
+    };
 }
 
-export interface ProcessedResult<Result = DataFormat | GroupedDataFormat> {
-    results: Result[];
-    pagination?: {more: boolean};
-}
-
-export interface LoadingData {
+interface Select2SelectionObject {
     loading: boolean;
-    text: string;
-
-    id?: undefined;
-    element?: undefined;
-}
-
-export interface OptGroupData {
-    children: OptionData[];
-    disabled: boolean;
-    element: HTMLOptGroupElement;
-    selected: boolean;
-    text: string;
-    title: string;
-
-    loading?: undefined;
-}
-
-export interface OptionData {
     disabled: boolean;
     element: HTMLOptionElement;
     id: string;
     selected: boolean;
     text: string;
     title: string;
-
-    loading?: undefined;
-    children?: undefined;
 }
 
-export interface IdTextPair {
-    id: string;
-    text: string;
+interface Select2Plugin {
+    amd: any;
 
-    loading?: undefined;
-    element?: undefined;
-}
+    (): JQuery;
+    (it: IdTextPair): JQuery;
 
-export interface TranslationArg {
-    input: string;
-    minimum: number;
-    maximum: number;
-}
-
-export interface Translation {
-    errorLoading?: () => string;
-    inputTooLong?: (arg: TranslationArg) => string;
-    inputTooShort?: (arg: TranslationArg) => string;
-    loadingMore?: () => string;
-    maximumSelected?: (arg: TranslationArg) => string;
-    noResults?: () => string;
-    searching?: () => string;
-}
-
-export interface DataParams {
-    data: OptionData; // TODO: must be data source
-    originalEvent: JQuery.Event;
-}
-
-export interface IngParams {
-    name: "select" | "open" | "close" | "unselect";
-    prevented: boolean;
-}
-
-export interface Event<TElement, T> extends JQuery.Event<TElement, undefined> {
-    params: T;
-}
-
-export interface Trigger {
-    type: "select2:select";
-    params: {
-        data: IdTextPair;
-    };
-}
-
-// --------------------------------------------------------------------------
-// Ajax Option
-// --------------------------------------------------------------------------
-
-export interface AjaxOptions<Result = DataFormat | GroupedDataFormat, RemoteResult = any> extends JQuery.Ajax.AjaxSettingsBase<any> {
-    delay?: number;
-    url?: string | ((params: QueryOptions) => string);
-    data?: (params: QueryOptions) => JQuery.PlainObject;
-    transport?: (settings: JQueryAjaxSettings, success?: (data: RemoteResult) => undefined, failure?: () => undefined) => void;
-    processResults?: (data: RemoteResult, params: QueryOptions) => ProcessedResult<Result>;
-}
-
-// --------------------------------------------------------------------------
-// Options
-// --------------------------------------------------------------------------
-
-export interface Options<Result = DataFormat | GroupedDataFormat, RemoteResult = any> {
-    ajax?: AjaxOptions<Result, RemoteResult>;
-    allowClear?: boolean;
-    amdBase?: string;
-    amdLanguageBase?: string;
-    closeOnSelect?: boolean;
-    containerCss?: any;
-    containerCssClass?: string;
-    data?: DataFormat[] | GroupedDataFormat[];
-    dataAdapter?: any;
-    debug?: boolean;
-    dir?: "ltr" | "rtl";
-    disabled?: boolean;
-    dropdownAdapter?: any;
-    dropdownAutoWidth?: boolean;
-    dropdownCss?: any;
-    dropdownCssClass?: string;
-    dropdownParent?: JQuery;
-    escapeMarkup?: (markup: string) => string;
-    initSelection?: (element: JQuery, callback: (data: any) => void) => void;
-    language?: string | Translation;
-    matcher?: (params: SearchOptions, data: OptGroupData | OptionData) => OptGroupData | OptionData | null;
-    maximumInputLength?: number;
-    maximumSelectionLength?: number;
-    minimumInputLength?: number;
-    minimumResultsForSearch?: number;
-    multiple?: boolean;
-    placeholder?: string | IdTextPair;
-    resultsAdapter?: any;
-    selectionAdapter?: any;
-    selectOnClose?: boolean;
-    sorter?: (data: Array<OptGroupData | OptionData | IdTextPair>) => Array<OptGroupData | OptionData | IdTextPair>;
-    tags?: boolean;
-    templateResult?: (result: LoadingData | Result) => string | JQuery | null;
-    templateSelection?: (selection: IdTextPair | LoadingData | Result) => string | JQuery;
-    theme?: string;
-    tokenizer?: (input: string, selection: any[], selectCallback: () => void, options: Options) => string;
-    tokenSeparators?: string[];
-    width?: string;
-
-    // Not in https://select2.org/configuration/options-api
-    createTag?: (params: SearchOptions) => IdTextPair | null;
-    insertTag?: (data: Array<OptionData | IdTextPair>, tag: IdTextPair) => void;
-}
-
-// --------------------------------------------------------------------------
-// jQuery And Select2 Plugin
-// --------------------------------------------------------------------------
-
-export interface Select2Plugin<TElement extends Node = HTMLElement>  {
-    defaults: {
-        set: (key: string, value: any) => void;
-        reset: () => void;
-    };
-
-    (): JQuery<TElement>;
-    // tslint:disable-next-line:no-unnecessary-generics
-    <Result = DataFormat | GroupedDataFormat, RemoteResult = any>(options: Options<Result, RemoteResult>): JQuery<TElement>;
-
+	/**
+	 * Get the id value of the current selection
+	 */
+    (method: 'val'): any;
+	/**
+	 * Set the id value of the current selection
+	 * @params value Value to set the id to
+	 * @params triggerChange Should a change event be triggered
+	 */
+    (method: 'val', value: any, triggerChange?: boolean): any;
 	/**
 	 * Get the data object of the current selection
 	 */
-    (method: "data"): OptionData[];
+    (method: 'data'): any;
+	/**
+	 * Set the data of the current selection
+	 * @params value Object to set the data to
+	 * @params triggerChange Should a change event be triggered
+	 */
+    (method: 'data', value: any, triggerChange?: boolean): any;
 	/**
 	 * Reverts changes to DOM done by Select2. Any selection done via Select2 will be preserved.
 	 */
-    (method: "destroy"): JQuery<TElement>;
+    (method: 'destroy'): JQuery;
 	/**
 	 * Opens the dropdown
 	 */
-    (method: "open"): JQuery<TElement>;
+    (method: 'open'): JQuery;
 	/**
 	 * Closes the dropdown
 	 */
-    (method: "close"): JQuery<TElement>;
+    (method: 'close'): JQuery;
+	/**
+	 * Enables or disables Select2 and its underlying form component
+	 * @param value True if it should be enabled false if it should be disabled
+	 */
+    (method: 'enable', value: boolean): JQuery;
+	/**
+	 * Toggles readonly mode on Select2 and its underlying form component
+	 * @param value True if it should be readonly false if it should be read write
+	 */
+    (method: 'readonly', value: boolean): JQuery;
+	/**
+	 * Retrieves the main container element that wraps all of DOM added by Select2
+	 */
+    (method: 'container'): JQuery;
+	/**
+	 * Notifies Select2 that a drag and drop sorting operation has started
+	 */
+    (method: 'onSortStart'): JQuery;
+	/**
+	 * Notifies Select2 that a drag and drop sorting operation has finished
+	 */
+    (method: 'onSortEnd'): JQuery;
+
+    (method: string): any;
+    (method: string, value: any, trigger?: boolean): any;
+    (options: Select2Options): JQuery;
 }
 
-declare global {
-    interface JQuery<TElement extends Node = HTMLElement> {
-        select2: Select2Plugin<TElement>;
-        data(key: "select2"): Select2;
+interface JQuery {
+    select2: Select2Plugin;
+    off(events?: "change", selector?: any, handler?: (eventObject: Select2JQueryEventObject) => any): JQuery;
 
-        trigger(events: Trigger): void;
+    on(events: "change", selector?: string, data?: any, handler?: (eventObject: Select2JQueryEventObject) => any): JQuery;
+    on(events: "change", selector?: string, handler?: (eventObject: Select2JQueryEventObject) => any): JQuery;
+    on(events: "change", handler?: (eventObject: Select2JQueryEventObject) => any): JQuery;
+    on(events: "select2:closing", handler?: (eventObject: Select2JQueryEventObject) => any): JQuery;
+    on(events: "select2:close", handler?: (eventObject: Select2JQueryEventObject) => any): JQuery;
+    on(events: "select2:opening", handler?: (eventObject: Select2JQueryEventObject) => any): JQuery;
+    on(events: "select2:open", handler?: (eventObject: Select2JQueryEventObject) => any): JQuery;
+    on(events: "select2:selecting", handler?: (eventObject: Select2JQueryEventObject) => any): JQuery;
+    on(events: "select2:select", handler?: (eventObject: Select2JQueryEventObject) => any): JQuery;
+    on(events: "select2:unselecting", handler?: (eventObject: Select2JQueryEventObject) => any): JQuery;
+    on(events: "select2:unselect", handler?: (eventObject: Select2JQueryEventObject) => any): JQuery;
+}
 
-        // TODO: events "change" and "change.select2"
-        on(events: "select2:closing", handler?: JQuery.EventHandlerBase<TElement, Event<TElement, IngParams>>): this;
-        on(events: "select2:close", handler?: JQuery.EventHandlerBase<TElement, Event<TElement, {}>>): this;
-        on(events: "select2:opening", handler?: JQuery.EventHandlerBase<TElement, Event<TElement, IngParams>>): this;
-        on(events: "select2:open", handler?: JQuery.EventHandlerBase<TElement, Event<TElement, {}>>): this;
-        on(events: "select2:selecting", handler?: JQuery.EventHandlerBase<TElement, Event<TElement, IngParams>>): this;
-        on(events: "select2:select", handler?: JQuery.EventHandlerBase<TElement, Event<TElement, DataParams>>): this;
-        on(events: "select2:unselecting", handler?: JQuery.EventHandlerBase<TElement, Event<TElement, IngParams>>): this;
-        on(events: "select2:unselect", handler?: JQuery.EventHandlerBase<TElement, Event<TElement, DataParams>>): this;
-    }
+declare class Select2 {
+    constructor(element: JQuery, options: Select2Options);
+    focus(): void;
+    destroy(): void;
+    // TODO: Don't use 'Function' as a type.
+    // tslint:disable-next-line:ban-types
+    on(event: string, callback: Function): void;
+    selection: any;
+    dropdown: any;
+    results: any;
+    $container: JQuery;
+    $dropdown: JQuery;
+    $selection: JQuery;
+    $results: JQuery;
+    options: { options: Select2Options };
 }

--- a/types/select2/select2-tests.ts
+++ b/types/select2/select2-tests.ts
@@ -1,776 +1,238 @@
-// =====================================================
-// Configuration -- Global defaults
-// =====================================================
-// See: https://select2.org/configuration/defaults
-
-$.fn.select2.defaults.set("theme", "classic");
-$.fn.select2.defaults.set("ajax--cache", false);
-$.fn.select2.defaults.reset();
-
-// =====================================================
-// Appearance
-// =====================================================
-// See: https://select2.org/appearance
-
-$(".js-example-responsive").select2({
-    width: "resolve"
+$("#e9").select2();
+$("#e2").select2({
+    placeholder: "Select a State",
+    allowClear: true
 });
-
-$(".js-example-theme-single").select2({
-    theme: "classic"
+$("#e2_2").select2({
+    placeholder: "Select a State"
 });
-
-// =====================================================
-// Data sources -- The Select2 data format
-// =====================================================
-// See: https://select2.org/data-sources/formats
-
-let dataFormat: Select2.DataFormat[];
-let groupedDataFormat: Select2.GroupedDataFormat[];
-
-dataFormat = [
-    {id: 1, text: "Option 1"},
-    {id: 2, text: "Option 2"},
-];
-
-dataFormat = [
-    {id: 1, text: "Option 1"},
-    {id: 2, text: "Option 2", selected: true},
-    {id: 3, text: "Option 3", disabled: true},
-];
-
-groupedDataFormat = [
-    {
-        text: "Group 1",
-        children : [
-            {id: 1, text: "Option 1.1"},
-            {id: 2, text: "Option 1.2"},
-        ]
-    },
-    {
-        text: "Group 2",
-        children : [
-            {id: 3, text: "Option 2.1"},
-            {id: 4, text: "Option 2.2"},
-        ]
-    }
-];
-
-// =====================================================
-// Data sources -- Ajax (remote data)
-// =====================================================
-// See: https://select2.org/data-sources/ajax
-
-// Request parameters
-
-$("#mySelect2").select2({
-    ajax: {
-        url: "https://api.github.com/orgs/select2/repos",
-        data: (params) => {
-            return {
-                search: params.term,
-                type: "public"
-            };
-        }
-    }
+$("#e2_3").select2({
+    placeholder: { id: "1", text: "Select options" }
 });
-
-// Transforming response data
-
-interface ServerResult {
-    items: Select2.DataFormat[];
+$("#e3").select2({
+    minimumInputLength: 2
+});
+function format(state: any) {
+    if (!state.id) return state.text;
+    return `<img class="flag" src="images/flags/${state.id.toLowerCase()}.png"/>` + state.text;
 }
-
-$("#mySelect2").select2({
-    ajax: {
-        url: "/example/api",
-        processResults: (data: ServerResult) => {
-            return {
-                results: data.items
-            };
+$("#e4").select2({
+    formatResult: format,
+    formatSelection: format
+});
+$("#e5").select2({
+    minimumInputLength: 1,
+    query(query) {
+        const data = { results: [] as IdTextPair[] };
+        for (let i = 1; i < 5; i++) {
+            let s = "";
+            for (let j = 0; j < i; j++) { s = s + query.term; }
+            data.results.push({ id: query.term + i, text: s });
         }
     }
 });
 
-// Pagination
-
-$("#mySelect2").select2({
-    ajax: {
-        url: "https://api.github.com/search/repositories",
-        data: (params) => {
-            return {
-                search: params.term,
-                page: params.page || 1
-            };
-        }
-    }
+$("#e19").select2({ maximumSelectionLength: 3 });
+$("#e10").select2({
+    data: [{ id: 0, text: 'enhancement' }, { id: 1, text: 'bug' }, { id: 2, text: 'duplicate' }, { id: 3, text: 'invalid' }, { id: 4, text: 'wontfix' }]
 });
 
-interface ServerPaginatedResult {
-    results: Select2.DataFormat[];
-    count_filtered: number;
-}
+const data = [{ id: 0, tag: 'enhancement' }, { id: 1, tag: 'bug' }, { id: 2, tag: 'duplicate' }, { id: 3, tag: 'invalid' }, { id: 4, tag: 'wontfix' }];
 
-$("#mySelect2").select2({
-    ajax: {
-        url: "/example/api",
-        processResults: (data: ServerPaginatedResult, params) => {
-            params.page = params.page || 1;
-            return {
-                results: data.results,
-                pagination: {
-                    more: (params.page * 10) < data.count_filtered
-                }
-            };
-        }
-    }
+$("#e10_2").select2({
+    data: { results: data, text: 'tag' },
+    formatSelection: format,
+    formatResult: format
 });
 
-// Rate-limiting requests
-
-$("#mySelect2").select2({
-    ajax: {
-        delay: 250
-    }
+$("#e10_3").select2({
+    data: {
+        results: data,
+        text: (item: {tag: string}) => {
+            console.log('called with', item);
+            return item.tag;
+    }},
+    formatSelection: format,
+    formatResult: format
 });
 
-// Dynamic URLs
-
-$("#mySelect2").select2({
+let movieFormatResult;
+let movieFormatSelection;
+$("#e6").select2({
+    placeholder: "Search for a movie",
+    minimumInputLength: 1,
     ajax: {
-        url: (params) => {
-            return "/some/url/" + params.term;
-        }
-    }
-});
-
-// Alternative transport methods
-
-declare let AjaxSettings2RequestInit: (s: JQueryAjaxSettings) => RequestInit;
-
-$("#mySelect2").select2({
-    ajax: {
-        transport: (params: JQueryAjaxSettings, success?: (data: any) => undefined, failure?: () => undefined) => {
-            const p = AjaxSettings2RequestInit(params);
-            fetch(params.url!, p)
-                .then(success)
-                .catch(failure);
-        }
-    }
-});
-
-// Additional examples
-
-interface GithubApiResult {
-    total_count: number;
-    incomplete_results: boolean;
-    items: GithubRepositories[];
-}
-
-interface GithubRepositories {
-    id: string;
-    name: string;
-    full_name: string;
-    owner: {
-        avatar_url: string
-        gravatar_id: string
-    };
-    description?: string;
-    stargazers_count: number;
-    watchers_count: number;
-    forks_count: number;
-
-    loading: undefined;
-}
-
-$(".js-example-data-ajax").select2<GithubRepositories, GithubApiResult>({
-    ajax: {
-        url: "https://api.github.com/search/repositories",
-        dataType: "json",
-        delay: 250,
-        data: (params: Select2.QueryOptions) => {
+        url: "http://api.rottentomatoes.com/api/public/v1.0/movies.json",
+        dataType: 'jsonp',
+        cache: false,
+        data(params, page) {
             return {
                 q: params.term,
-                page: params.page
+                page_limit: 10,
+                apikey: "ju6z9mjyajq2djue3gbvv26t"
             };
         },
-        processResults: (data: GithubApiResult, params: Select2.QueryOptions) => {
-            params.page = params.page || 1;
-
-            return {
-                results: data.items,
-                pagination: {
-                    more: (params.page * data.items.length) < data.total_count
-                }
-            };
-        },
-        cache: true
+        results(data, page) {
+            return { results: data.movies };
+        }
     },
-    placeholder: "Search for a repository",
-    escapeMarkup: (markup: string) => markup,
+    formatResult: movieFormatResult,
+    formatSelection: movieFormatSelection,
+    dropdownCssClass: "bigdrop"
+});
+
+let t: ArrayLike<string>;
+$("#e6").select2({
+    placeholder: "Search for a movie",
     minimumInputLength: 1,
-    templateResult: formatRepo,
-    templateSelection: formatRepoSelection
+    ajax: {
+        url: () => "http://api.rottentomatoes.com/api/public/v1.0/movies.json",
+        dataType: 'jsonp',
+        data(params, page) {
+            return {
+                q: params.term,
+                page_limit: 10,
+                apikey: "ju6z9mjyajq2djue3gbvv26t"
+            };
+        },
+        results(data, page) {
+            return { results: data.movies };
+        }
+    },
+    formatResult: movieFormatResult,
+    formatSelection: movieFormatSelection,
+    dropdownCssClass: "bigdrop"
+});
+$("#e6").select2({
+    placeholder: "Search for a movie",
+    minimumInputLength: 1,
+    ajax: {
+        url: "http://api.rottentomatoes.com/api/public/v1.0/movies.json",
+        type: 'GET',
+        dataType: 'jsonp',
+        cache: false,
+        data(params, page) {
+            return {
+                q: params.term,
+                page_limit: 10,
+                apikey: "ju6z9mjyajq2djue3gbvv26t"
+            };
+        },
+        results(data, page) {
+            return { results: data.movies };
+        }
+    },
+    formatResult: movieFormatResult,
+    formatSelection: movieFormatSelection,
+    dropdownCssClass: "bigdrop"
+});
+$("#e7").select2({
+    placeholder: "Search for a movie",
+    minimumInputLength: 3,
+    ajax: {
+        url: "http://api.rottentomatoes.com/api/public/v1.0/movies.json",
+        dataType: 'jsonp',
+        delay: 100,
+        data(params, aPage) {
+            return {
+                q: params.term,
+                page_limit: 10,
+                page: aPage,
+                apikey: "ju6z9mjyajq2djue3gbvv26t"
+            };
+        },
+        results(data, page) {
+            const moreValue = (page * 10) < data.total;
+            return { results: data.movies, more: moreValue };
+        }
+    },
+    formatResult: movieFormatResult,
+    formatSelection: movieFormatSelection,
+    dropdownCssClass: "bigdrop"
 });
 
-function formatRepo(obj: Select2.LoadingData | GithubRepositories) {
-    if (obj.loading) {
-        return obj.text;
-    }
-
-    const repo = obj as GithubRepositories;
-
-    let markup = '<div class="select2-result-repository clearfix">' +
-        `<div class="select2-result-repository__avatar"><img src="${repo.owner.avatar_url}"></div>` +
-        '<div class="select2-result-repository__meta">' +
-        `<div class="select2-result-repository__title"> ${repo.full_name} </div>`;
-
-    if (repo.description) {
-        markup += `<div class="select2-result-repository__description">${repo.description}</div>`;
-    }
-
-    markup += '<div class="select2-result-repository__statistics">' +
-        `<div class="select2-result-repository__forks"><i class="fa fa-flash"></i> ${repo.forks_count} Forks</div>` +
-        `<div class="select2-result-repository__stargazers"><i class="fa fa-star"></i> ${repo.stargazers_count} Stars</div>` +
-        `<div class="select2-result-repository__watchers"><i class="fa fa-eye"></i> ${repo.watchers_count} Watchers</div>` +
-        "</div>" +
-        "</div></div>";
-
-    return markup;
+function sort(elements: any) {
+    return elements.sort();
 }
+$("#e20").select2({
+    sorter: sort
+});
 
-function formatRepoSelection(repo: Select2.IdTextPair | Select2.LoadingData | GithubRepositories) {
-    return (repo as GithubRepositories).full_name ||
-        (repo as Select2.IdTextPair | Select2.LoadingData).text;
+$("#e8").select2();
+$("#e8_get").click(() => alert("Selected value is: " + $("#e8").select2("val")));
+$("#e8_set").click(() => $("#e8").select2("val", "CA"));
+$("#e8_cl").click(() => $("#e8").select2("val", ""));
+$("#e8_get2").click(() => alert("Selected data is: " + JSON.stringify($("#e8").select2("data"))));
+$("#e8_set2").click(() => $("#e8").select2("data", { id: "CA", text: "California" }));
+$("#e8_open").click(() => $("#e8").select2("open"));
+$("#e8_close").click(() => $("#e8").select2("close"));
+$("#e8_2").select2();
+$("#e8_2_get").click(() => alert("Selected value is: " + $("#e8_2").select2("val")));
+$("#e8_2_set").click(() => $("#e8_2").select2("val", ["CA", "MA"]));
+$("#e8_2_get2").click(() => alert("Selected value is: " + JSON.stringify($("#e8_2").select2("data"))));
+$("#e8_2_set2").click(() => $("#e8_2").select2("data", [{ id: "CA", text: "California" }, { id: "MA", text: "Massachusetts" }]));
+$("#e8_2_cl").click(() => $("#e8_2").select2("val", ""));
+$("#e8_2_open").click(() => $("#e8_2").select2("open"));
+$("#e8_2_close").click(() => $("#e8_2").select2("close"));
+$("#e11").select2({
+    placeholder: "Select report type",
+    allowClear: true,
+    data: [{ id: 0, text: 'story' }, { id: 1, text: 'bug' }, { id: 2, text: 'task' }]
+});
+$("#e11_2").select2({
+    multiple: true,
+    data: [{ id: 0, text: 'story' }, { id: 1, text: 'bug' }, { id: 2, text: 'task' }]
+});
+function log(e: string) {
+    const item = $(`<li>${e}</li>`);
+    $("#events_11").append(item);
+    item.animate({ opacity: 1 }, 10000, 'linear', () => item.animate({ opacity: 0 }, 2000, 'linear', () => item.remove()));
 }
-
-// =====================================================
-// Data sources -- Ajax (remote data)
-// =====================================================
-// See: https://select2.org/data-sources/ajax
-
-$(".js-example-data-array").select2({
-    data: dataFormat
-});
-
-$(".js-example-data-array").select2({
-    data: groupedDataFormat
-});
-
-// =====================================================
-// Dropdown
-// =====================================================
-// See: https://select2.org/dropdown
-
-// Templating
-
-function formatState(state: Select2.LoadingData | Select2.OptionData) {
-    const opt = state as Select2.OptionData;
-    if (!opt.id) {
-        return (state as Select2.LoadingData).text;
-    }
-    const baseUrl = "/user/pages/images/flags";
-    const $state = $(
-        `<span><img src="${baseUrl}/${opt.element.value.toLowerCase()}.png" class="img-flag"> ${opt.text}</span>`
-    );
-    return $state;
-}
-
-$(".js-example-templating").select2({
-    templateResult: formatState
-});
-
-// Automatic selection
-
-$("#mySelect2").select2({
-    selectOnClose: true
-});
-
-// Forcing the dropdown to remain open after selection
-
-$("#mySelect2").select2({
-    closeOnSelect: false
-});
-
-// Dropdown placement
-
-$("#mySelect2").select2({
-    dropdownParent: $("#myModal")
-});
-
-// =====================================================
-// Selections
-// =====================================================
-// See: https://select2.org/selections
-
-// Limiting the number of selections
-
-$(".js-example-basic-multiple-limit").select2({
-    maximumSelectionLength: 2
-});
-
-// Clearable selections
-
-$("select").select2({
-    placeholder: "This is my placeholder",
-    allowClear: true
-});
-
-// =====================================================
-// Dynamic option creation
-// =====================================================
-// See: https://select2.org/tagging
-
-$(".js-example-tags").select2({
-    tags: true
-});
-
-// Automatic tokenization into tags
-
-$(".js-example-tokenizer").select2({
-    tags: true,
+$("#e11")
+    // TS 0.9.5: correct overload not resolved https://typescript.codeplex.com/discussions/472172
+    .on("change", (e: Select2JQueryEventObject) => log(JSON.stringify({ val: e.val, added: e.added, removed: e.removed })))
+    .on("open", () => log("open"));
+$("#e11_2")
+    .on("change", (e: Select2JQueryEventObject) => log(JSON.stringify({ val: e.val, added: e.added, removed: e.removed })))
+    .on("open", () => log("open"));
+$("#e12").select2({ tags: ["red", "green", "blue"] });
+$("#e20").select2({
+    tags: ["red", "green", "blue"],
     tokenSeparators: [",", " "]
 });
+$("#e13").select2();
+$("#e13_ca").click(() => $("#e13").val("CA").trigger("change"));
+$("#e13_ak_co").click(() => $("#e13").val(["AK", "CO"]).trigger("change"));
+$("#e14").val(["AL", "AZ"]).select2();
+$("#e14_init").click(() => $("#e14").select2());
+$("#e14_destroy").click(() => $("#e14").select2("destroy"));
+$("#e15").select2({ tags: ["red", "green", "blue", "orange", "white", "black", "purple", "cyan", "teal"] });
+$("#e15").on("change", () => $("#e15_val").html($("#e15").val() as string));
 
-// Customizing tag creation
-
-$("select").select2({
-    tags: true,
-    createTag: (params) => {
-        const term = params.term.trim();
-
-        if (term === "") {
-            return null;
-        }
-
-        return {
-            id: term,
-            text: term,
-            newTag: true, // not for select2 use
-        };
+$("#e16").select2();
+$("#e16_2").select2();
+$("#e16_enable").click(() => $("#e16,#e16_2").select2("enable"));
+$("#e16_disable").click(() => $("#e16,#e16_2").select2("disable"));
+$("#e17").select2({
+    matcher: (term, text) => text.toUpperCase().indexOf(term.toUpperCase()) === 0
+});
+$("#e17_2").select2({
+    matcher: (term, text, opt) => {
+        return text.toUpperCase().indexOf(term.toUpperCase()) >= 0
+            || opt.attr("alt").toUpperCase().indexOf(term.toUpperCase()) >= 0;
     }
 });
-
-$("select").select2({
-    tags: true,
-    createTag: (params) => {
-        if (params.term.indexOf("@") === -1) {
-            return null;
-        }
-
-        return {
-            id: params.term,
-            text: params.term
-        };
-    }
-});
-
-// Customizing tag placement in the dropdown
-
-$("select").select2({
-    tags: true,
-    insertTag: (data, tag) => {
-        data.push(tag);
-    }
-});
-
-// =====================================================
-// Placeholders
-// =====================================================
-// See: https://select2.org/placeholders
-
-// Single select placeholders
-
-$(".js-example-placeholder-single").select2({
-    placeholder: "Select a state",
-    allowClear: true
-});
-
-// Multi-select placeholders
-
-$(".js-example-placeholder-multiple").select2({
-    placeholder: "Select a state"
-});
-
-// Default selection placeholders
-
-$("select").select2({
-    placeholder: {
-        id: "-1",
-        text: "Select an option"
-    }
-});
-
-// Customizing placeholder appearance
-
-$("select").select2({
-    templateSelection: (data: Select2.IdTextPair | Select2.LoadingData | Select2.OptionData) => {
-        if (data.id === "") {
-            return "Custom styled placeholder text";
-        }
-        return data.text;
-    }
-});
-
-// =====================================================
-// Search
-// =====================================================
-// See: https://select2.org/searching
-
-// Customizing how results are matched
-
-$(".js-example-matcher").select2({
-    matcher: (params, data) => {
-        if (params.term.trim() === "") {
-            return data;
-        }
-
-        if (typeof data.text === "undefined") {
-            return null;
-        }
-
-        if (data.text.indexOf(params.term) > -1) {
-            const modifiedData = {...data};
-            modifiedData.text += " (matched)";
-            return modifiedData;
-        }
-
-        return null;
-    }
-});
-
-// Matching grouped options
-
-function matchStart(params: Select2.SearchOptions, data: Select2.OptGroupData | Select2.OptionData) {
-    if (params.term.trim() === "") {
-        return data;
-    }
-
-    if (typeof data.children === "undefined") {
-        return null;
-    }
-
-    const filteredChildren: Select2.OptionData[] = [];
-    data.children.forEach((child, idx) => {
-        if (child.text.toUpperCase().indexOf(params.term.toUpperCase()) === 0) {
-            filteredChildren.push(child);
-        }
-    });
-
-    if (filteredChildren.length) {
-        const modifiedData = {...data};
-        modifiedData.children = filteredChildren;
-
-        return modifiedData;
-    }
-
-    return null;
-}
-
-$(".js-example-matcher-start").select2({
-    matcher: matchStart
-});
-
-// Minimum search term length
-
-$("select").select2({
-    minimumInputLength: 3
-});
-
-// Maximum search term length
-
-$("select").select2({
-    maximumInputLength: 20
-});
-
-// Limiting display of the search box to large result sets
-
-$("select").select2({
-    minimumResultsForSearch: 20
-});
-
-// Hiding the search box
-
-$("#js-example-basic-hide-search").select2({
-    minimumResultsForSearch: Infinity
-});
-
-$("#js-example-basic-hide-search-multi").select2();
-$("#js-example-basic-hide-search-multi").on("select2:opening select2:closing", function(event) {
-    const $searchfield = $(this).parent().find(".select2-search__field");
-    $searchfield.prop("disabled", true);
-});
-
-// =====================================================
-// Programmatic control -- Add, select, or clear items
-// =====================================================
-// See: https://select2.org/programmatic-control/add-select-clear-items
-
-// Preselecting options in an remotely-sourced (AJAX) Select2
-
-interface StudentAjaxResult {
-    id: string;
-    text: string;
-    full_name: string;
-}
-
-const studentSelect = $("#mySelect2");
-$.ajax({
-    type: "GET",
-    url: "/api/students/s/123"
-}).then((res: StudentAjaxResult) => {
-    const option = new Option(res.full_name, res.id, true, true);
-    studentSelect.append(option).trigger("change");
-
-    studentSelect.trigger({
-        type: "select2:select",
-        params: {
-            data: res
-        }
-    });
-});
-
-// =====================================================
-// Programmatic control -- Retrieving selections
-// =====================================================
-// See: https://select2.org/programmatic-control/retrieving-selections
-
-// Using the data method
-
-$("#mySelect2").select2("data");
-
-// Using a jQuery selector
-
-// TODO
-// $("#mySelect2").select2<GithubRepositories>({
-//     templateSelection: (data) => {
-//         $(data.element).attr("data-custom-attribute", (data as GithubRepositories).owner.gravatar_id);
-//         return data.text;
-//     }
-// });
-
-// =====================================================
-// Programmatic control -- Methods
-// =====================================================
-// See: https://select2.org/programmatic-control/methods
-
-// Opening the dropdown
-
-$("#mySelect2").select2("open");
-
-// Closing the dropdown
-
-$("#mySelect2").select2("close");
-
-// Destroying the Select2 control
-
-$("#mySelect2").select2("destroy");
-
-// Event unbinding
-
-$("#example").select2();
-
-$("#example").on("select2:select", (e) => {
-    console.log("select event");
-});
-
-$("#example").select2("destroy");
-
-$("#example").off("select2:select");
-
-// Examples
-
-const $example = $(".js-example-programmatic").select2();
-const $exampleMulti = $(".js-example-programmatic-multi").select2();
-
-$(".js-programmatic-set-val").on("click", () => {
-    $example.val("CA").trigger("change");
-});
-
-$(".js-programmatic-open").on("click", () => {
-    $example.select2("open");
-});
-
-$(".js-programmatic-close").on("click", () => {
-    $example.select2("close");
-});
-
-$(".js-programmatic-init").on("click", () => {
-    $example.select2();
-});
-
-$(".js-programmatic-destroy").on("click", () => {
-    $example.select2("destroy");
-});
-
-$(".js-programmatic-multi-set-val").on("click", () => {
-    $exampleMulti.val(["CA", "AL"]).trigger("change");
-});
-
-$(".js-programmatic-multi-clear").on("click", () => {
-    $exampleMulti.val([]).trigger("change");
-});
-
-// =====================================================
-// Programmatic control -- Events
-// =====================================================
-// See: https://select2.org/programmatic-control/events
-
-// Listening for events
-
-$("#mySelect2").on("select2:select", (e) => {
-    // Do something
-});
-
-// Event data
-
-$("#mySelect2").on("select2:select", (e) => {
-    const data = e.params.data;
-    console.log(data);
-});
-
-// Triggering events
-
-const triggerData = {
-    id: "1",
-    text: "Tyto alba",
-    genus: "Tyto",
-    species: "alba"
-};
-
-$("#mySelect2").trigger({
-    type: "select2:select",
-    params: {
-        data: triggerData
-    }
-});
-
-// Examples
-
-const $eventLog = $(".js-event-log");
-const $eventSelect = $(".js-example-events");
-
-$eventSelect.select2();
-
-$eventSelect.on("select2:open", (e) => { log("select2:open", e); });
-$eventSelect.on("select2:close", (e) => { log("select2:close", e); });
-$eventSelect.on("select2:select", (e) => { log("select2:select", e); });
-$eventSelect.on("select2:unselect", (e) => { log("select2:unselect", e); });
-$eventSelect.on("change", (e) => { log("change"); });
-
-function log(name: string, evt?: Select2.Event<HTMLElement, {} | Select2.IngParams | Select2.DataParams>) {
-    let args = "{}";
-    if (evt) {
-        args = JSON.stringify(evt.params, (key, value) => {
-            if (value && value.nodeName) return "[DOM node]";
-            if (value instanceof $.Event) return "[$.Event]";
-            return value;
-        });
-    }
-    const $e = $(`<li>${name} -> ${args}</li>`);
-    $eventLog.append($e);
-    $e.animate({ opacity: 1 }, 10000, "linear", () => {
-        $e.animate({ opacity: 0 }, 2000, "linear", () => {
-            $e.remove();
-        });
-    });
-}
-
-// =====================================================
-// Internationalization
-// =====================================================
-// See: https://select2.org/i18n
-
-// Language files
-
-$(".js-example-language").select2({
-    language: "es"
-});
-
-// Translation objects
-
-const fr: Select2.Translation = {
-    errorLoading: () => {
-        return "Les résultats ne peuvent pas être chargés.";
-    },
-    inputTooLong: (args) => {
-        const overChars = args.input.length - args.maximum;
-        return `Supprimez ${overChars} caractère${overChars > 1 ? "s" : ""}`;
-    },
-    inputTooShort: (args) => {
-        const remainingChars = args.minimum - args.input.length;
-        return `Saisissez au moins ${remainingChars} caractère${remainingChars > 1 ? "s" : ""}`;
-    },
-    loadingMore: () => {
-        return "Chargement de résultats supplémentaires…";
-    },
-    maximumSelected: (args) => {
-        return `Vous pouvez seulement sélectionner ${args.maximum}` +
-            ` élément${args.maximum > 1 ? "s" : ""}`;
-    },
-    noResults: () => {
-        return "Aucun résultat trouvé";
-    },
-    searching: () => {
-        return "Recherche en cours…";
-    }
-};
-
-$(".js-example-language").select2({
-    language: {
-        inputTooShort: () => "You must enter more characters..."
-    }
-});
-
-// RTL support
-
-$(".js-example-rtl").select2({
-    dir: "rtl"
-});
-
-// =====================================================
-// Advanced Features and Developer Guide
-// =====================================================
-// See: https://select2.org/advanced
-
-// TODO (Adapters)
-
-// =====================================================
-// Others
-// =====================================================
-// Code not from the official documentation
-
-$().data("select2").$container.on("keyup", "input", console.log);
-
-$(".js-multiple").select2({
-    multiple: false,
-});
-
-$(".js-states").select2({
-    sorter: (data) => {
-        return data.sort((a, b) => a.text > b.text ? 1 : 0);
-    }
-});
-
-$("#mySelect2").select2({
-    theme: "bootstrap",
-}).on("select2:closing", function() {
-    $(this).val("Bye");
-}).on("select2:close", function() {
-    $(this).trigger("change");
-});
-
-const selectedData: Select2.OptionData[] = $("#mySelect2").select2("data");
-// TODO
-// const selectedRepo: GithubRepositories[] = $(".js-example-data-ajax").select2("data") as GithubRepositories[];
-
-// jQuery Generic
-
-declare let select: HTMLSelectElement;
-const $select: JQuery<HTMLSelectElement> = $(select) as JQuery<HTMLSelectElement>;
-
-select = $select.select2().get(0);
-select = $select.select2({tags: true}).get(0);
-select = $select.select2("open").get(0);
-select = $select.select2("close").get(0);
-select = $select.select2("destroy").get(0);
+$("#e18,#e18_2").select2();
+alert("Selected value is: " + $("#e8").select2("val")); $("#e8").select2("val", { id: "CA", text: "Califoria" });
+
+$("#e8").select2("val");
+$("#e8").select2("val", "CA");
+$("#e8").select2("data");
+$("#e8").select2("data", { id: "CA", text: "Califoria" });
+$("#e8").select2("destroy");
+$("#e8").select2("open");
+$("#e8").select2("enable", false);
+$("#e8").select2("readonly", false);
+$("#e8").select2('container');
+$("#e8").select2('onSortStart');
+$("#e8").select2('onSortEnd');

--- a/types/select2/tsconfig.json
+++ b/types/select2/tsconfig.json
@@ -7,7 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
-        "strictNullChecks": true,
+        "strictNullChecks": false,
         "strictFunctionTypes": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/select2/tslint.json
+++ b/types/select2/tslint.json
@@ -1,6 +1,7 @@
 {
     "extends": "dtslint/dt.json",
     "rules": {
-        "unified-signatures": false
+        "unified-signatures": false,
+        "prefer-method-signature": false
     }
 }

--- a/types/select2/tslint.json
+++ b/types/select2/tslint.json
@@ -1,7 +1,6 @@
 {
     "extends": "dtslint/dt.json",
     "rules": {
-        "unified-signatures": false,
-        "quotemark": [true, "double", "avoid-escape", "avoid-template"]
+        "unified-signatures": false
     }
 }


### PR DESCRIPTION
This is a PR to rollback breaking changes in select2 typing introduced in #25196 PR. Please see discussion there for reasoning. I'm not saying that the definitions in PR are bad but that change breaks too much. 
So basically it's returning to the state of 4.0.44 version of `@types/select2` package. 