### PR TITLE
[next] Add getInitialProps to next/document definition

### DIFF
--- a/types/next/document.d.ts
+++ b/types/next/document.d.ts
@@ -1,15 +1,46 @@
 import * as React from "react";
+import * as http from "http";
+
+export interface Context {
+    err?: Error;
+    req: http.IncomingMessage;
+    res: http.ServerResponse;
+    pathname: string;
+    query?: {
+        [key: string]:
+            | boolean
+            | boolean[]
+            | number
+            | number[]
+            | string
+            | string[];
+    };
+    asPath: string;
+
+    renderPage(
+        enhancer?: (page: React.Component) => React.ComponentType<any>
+    ): {
+        html?: string;
+        head: Array<React.ReactElement<any>>;
+        errorHtml: string;
+    };
+}
 
 export interface DocumentProps {
     __NEXT_DATA__?: any;
     dev?: boolean;
     chunks?: string[];
+    html?: string;
     head?: Array<React.ReactElement<any>>;
+    errorHtml?: string;
     styles?: Array<React.ReactElement<any>>;
+
     [key: string]: any;
 }
 
 export class Head extends React.Component<any> {}
 export class Main extends React.Component {}
 export class NextScript extends React.Component {}
-export default class extends React.Component<DocumentProps> {}
+export default class extends React.Component<DocumentProps> {
+    static getInitialProps(ctx: Context): DocumentProps;
+}


### PR DESCRIPTION
- add Document.getInitialProps

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/zeit/next.js/blob/v2.4.2/server/document.js#L7-L11, https://github.com/zeit/next.js/blob/v2.4.2/server/render.js#L58-L89
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
