### PR TITLE
Add missing Expo Updates module

### DIFF
--- a/types/expo/expo-tests.tsx
+++ b/types/expo/expo-tests.tsx
@@ -36,7 +36,8 @@ import {
     SQLite,
     Calendar,
     MailComposer,
-    Location
+    Location,
+    Updates
 } from 'expo';
 
 const reverseGeocode: Promise<Location.GeocodeData[]> = Location.reverseGeocodeAsync({
@@ -743,4 +744,37 @@ async () => {
     });
 
     result.status === 'saved';
+};
+
+async () => {
+    const updateEventListener: Updates.UpdateEventListener = ({ type, manifest, message }) => {
+        switch (type) {
+            case Updates.EventType.DOWNLOAD_STARTED:
+            case Updates.EventType.DOWNLOAD_PROGRESS:
+            case Updates.EventType.DOWNLOAD_FINISHED:
+            case Updates.EventType.NO_UPDATE_AVAILABLE:
+            case Updates.EventType.ERROR:
+                return true;
+        }
+    };
+
+    Updates.reload();
+
+    Updates.reloadFromCache();
+
+    Updates.addListener(updateEventListener);
+
+    const updateCheckResult = await Updates.checkForUpdateAsync();
+
+    if (updateCheckResult.isAvailable) {
+        console.log(updateCheckResult.manifest);
+    }
+
+    Updates.fetchUpdateAsync(updateEventListener);
+
+    const bundleFetchResult = await Updates.fetchUpdateAsync();
+
+    if (bundleFetchResult.isNew) {
+        console.log(bundleFetchResult.manifest);
+    }
 };

--- a/types/expo/index.d.ts
+++ b/types/expo/index.d.ts
@@ -2764,3 +2764,91 @@ export namespace MailComposer {
     ): Promise<{ status: 'sent' | 'saved' | 'cancelled' }>;
 }
 // #endregion
+
+export namespace Updates {
+    namespace EventType {
+        /** A new update is available and has started downloading. */
+        type DownloadStart = 'downloadStart';
+        /** A new update is currently being downloaded and will be stored in the device's cache. */
+        type DownloadProgress = 'downloadProgress';
+        /** A new update has finished downloading and is now stored in the device's cache. */
+        type DownloadFinished = 'downloadFinished';
+        /** No updates are available, and the most up-to-date bundle of this experience is already running. */
+        type NoUpdateAvailable = 'noUpdateAvailable';
+        /** An error occurred trying to fetch the latest update. */
+        type Error = 'error';
+
+        /** A new update is available and has started downloading. */
+        const DOWNLOAD_STARTED: DownloadStart;
+        /** A new update is currently being downloaded and will be stored in the device's cache. */
+        const DOWNLOAD_PROGRESS: DownloadProgress;
+        /** A new update has finished downloading and is now stored in the device's cache. */
+        const DOWNLOAD_FINISHED: DownloadFinished;
+        /** No updates are available, and the most up-to-date bundle of this experience is already running. */
+        const NO_UPDATE_AVAILABLE: NoUpdateAvailable;
+        /** An error occurred trying to fetch the latest update. */
+        const ERROR: Error;
+    }
+
+    interface UpdateCheck {
+        /** True if an update is available, false if you're already running the most up-to-date JS bundle. */
+        isAvailable: boolean;
+        /** If `isAvailable` is true, the manifest of the available update. Undefined otherwise. */
+        manifest?: Constants.Manifest;
+    }
+
+    interface UpdateBundle {
+        /** True if the fetched bundle is new (i.e. a different version that the what's currently running). */
+        isNew: boolean;
+        /** Manifest of the fetched update. */
+        manifest: Constants.Manifest;
+    }
+
+    /** An object that is passed into each event listener when a new version is available. */
+    interface UpdateEvent {
+        /** Type of the event */
+        type: EventType.DownloadStart
+            | EventType.DownloadProgress
+            | EventType.DownloadFinished
+            | EventType.NoUpdateAvailable
+            | EventType.Error;
+        /** If `type === Expo.Updates.EventType.DOWNLOAD_FINISHED`, the manifest of the newly downloaded update. Undefined otherwise. */
+        manifest?: Constants.Manifest;
+        /** If `type === Expo.Updates.EventType.ERROR`, the error message. Undefined otherwise. */
+        message?: string;
+    }
+
+    type UpdateEventListener = (event: UpdateEvent) => any;
+
+    /**
+     * Invokes a callback when updates-related events occur,
+     * either on the initial app load or as a result of a call to `Expo.Updates.fetchUpdateAsync`.
+     */
+    function addListener(listener: UpdateEventListener): EventSubscription;
+
+    /**
+     * Check if a new published version of your project is available.
+     * Does not actually download the update.
+     * Rejects if `updates.enabled` is `false` in app.json.
+     */
+    function checkForUpdateAsync(): Promise<UpdateCheck>;
+
+    /**
+     * Downloads the most recent published version of your experience to the device's local cache.
+     * Rejects if `updates.enabled` is `false` in app.json.
+     */
+    function fetchUpdateAsync(listener?: UpdateEventListener): Promise<UpdateBundle>;
+
+    /**
+     * Immediately reloads the current experience.
+     * This will use your app.json updates configuration to fetch and load the newest available JS supported by the device's Expo environment.
+     * This is useful for triggering an update of your experience if you have published a new version.
+     */
+    function reload(): void;
+
+    /**
+     * Immediately reloads the current experience using the most recent cached version.
+     * This is useful for triggering an update of your experience if you have published and already downloaded a new version.
+     */
+    function reloadFromCache(): void;
+}


### PR DESCRIPTION
Expo has created the [Updates module since SDK 26](https://docs.expo.io/versions/v26.0.0/sdk/updates) to modify the update mechanism, [source](https://github.com/expo/expo-sdk/blob/master/src/Updates.js).

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.expo.io/versions/v26.0.0/sdk/updates
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
