### PR TITLE
Types for jquery-next-id

### DIFF
--- a/types/jquery-next-id/index.d.ts
+++ b/types/jquery-next-id/index.d.ts
@@ -1,0 +1,22 @@
+// Type definitions for jquery-next-id 1.0
+// Project: https://github.com/makeup-jquery/jquery-next-id
+// Definitions by: Anderson Friaça <https://github.com/AndersonFriaca>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
+
+/// <reference types="jquery" />
+
+export interface JQueryNextId {
+    (prefix?: string): JQuery;
+
+    defaults: {
+        prefix: string;
+        separator: string;
+    };
+}
+
+declare global {
+    interface JQuery {
+        nextId: JQueryNextId;
+    }
+}

--- a/types/jquery-next-id/jquery-next-id-tests.ts
+++ b/types/jquery-next-id/jquery-next-id-tests.ts
@@ -1,0 +1,6 @@
+$('div').nextId('my-prefix');
+
+$.fn.nextId.defaults = {
+  prefix: 'id',
+  separator: '-'
+};

--- a/types/jquery-next-id/tsconfig.json
+++ b/types/jquery-next-id/tsconfig.json
@@ -1,0 +1,25 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "esModuleInterop": true
+    },
+    "files": [
+        "index.d.ts",
+        "jquery-next-id-tests.ts"
+    ]
+}

--- a/types/jquery-next-id/tslint.json
+++ b/types/jquery-next-id/tslint.json
@@ -1,0 +1,1 @@
+{"extends": "dtslint/dt.json"}


### PR DESCRIPTION
Types creation of [https://github.com/makeup-jquery/jquery-next-id](https://github.com/makeup-jquery/jquery-next-id)
NPM: [https://www.npmjs.com/package/jquery-next-id](https://www.npmjs.com/package/jquery-next-id) 

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- [X] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [X] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [X] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
