### PR TITLE
feat(types/shelljs-exec-proxy): types for new module

### DIFF
--- a/types/shelljs-exec-proxy/index.d.ts
+++ b/types/shelljs-exec-proxy/index.d.ts
@@ -1,0 +1,17 @@
+// Type definitions for shelljs-exec-proxy 0.1
+// Project: https://github.com/nfischer/shelljs-exec-proxy#readme
+// Definitions by: Nikita Volodin <https://github.com/qlonik>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.2
+
+import * as shelljs from 'shelljs';
+
+interface Exec {
+    (...command: string[]): shelljs.ExecOutputReturnValue;
+    [k: string]: Exec;
+}
+
+type ShelljsExecProxy = { [k: string]: Exec } & typeof shelljs;
+
+declare const shelljsExecProxy: ShelljsExecProxy;
+export = shelljsExecProxy;

--- a/types/shelljs-exec-proxy/shelljs-exec-proxy-tests.ts
+++ b/types/shelljs-exec-proxy/shelljs-exec-proxy-tests.ts
@@ -1,0 +1,9 @@
+import * as shell from 'shelljs-exec-proxy';
+
+shell.git.status(); // $ExpectType ExecOutputReturnValue
+shell.git.add('.'); // $ExpectType ExecOutputReturnValue
+shell.git.commit('-am', 'Fixed issue #1'); // $ExpectType ExecOutputReturnValue
+shell.git.push('origin', 'master'); // $ExpectType ExecOutputReturnValue
+
+shell.cd('string'); // $ExpectType void
+shell.cd(123); // $ExpectError

--- a/types/shelljs-exec-proxy/tsconfig.json
+++ b/types/shelljs-exec-proxy/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "shelljs-exec-proxy-tests.ts"
+    ]
+}

--- a/types/shelljs-exec-proxy/tslint.json
+++ b/types/shelljs-exec-proxy/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
*Note:* I'm not sure if I correctly referenced the dependency of this type. This type depends on `shelljs` definition. I imported it as `import * as shelljs from 'shelljs'` and didn't include `/// <reference type="..." />`. I also didn't add package.json with dependencies field, as i'm not sure if it is needed, or generated automatically.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
