### PR TITLE
Add missing parameter to gm's `define` method

### DIFF
--- a/types/gm/gm-tests.ts
+++ b/types/gm/gm-tests.ts
@@ -62,6 +62,7 @@ declare const font: string;
 declare const quality: number;
 declare const align: string;
 declare const depth: number;
+declare const defineValue: string;
 let readStream: stream.PassThrough;
 
 gm(src)
@@ -104,7 +105,7 @@ gm(src)
 	.crop(width, height, x, y, usePercent)
 	.cycle(factor)
 	.deconstruct()
-	.define()
+	.define(defineValue)
 	.delay(time)
 	.density(width, height)
 	.despeckle()

--- a/types/gm/index.d.ts
+++ b/types/gm/index.d.ts
@@ -123,7 +123,7 @@ declare namespace m {
         crop(width: number, height: number, x?: number, y?: number, percent?: boolean): State;
         cycle(amount: number): State;
         deconstruct(): State;
-        define(): State;
+        define(value: string): State;
         delay(milliseconds: number): State;
         density(width: number, height: number): State;
         despeckle(): State;

--- a/types/gm/index.d.ts
+++ b/types/gm/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for gm 1.17
+// Type definitions for gm 1.18
 // Project: https://github.com/aheckmann/gm
 // Definitions by: Joel Spadin <https://github.com/ChaosinaCan>, Maarten van Vliet <https://github.com/maartenvanvliet>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/aheckmann/gm/blob/c6a6c5a18a65e9b9344955a5cf9d7417db25dff3/lib/args.js#L199
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. (Already exists)

---

The [source code for GM](https://github.com/aheckmann/gm/blob/c6a6c5a18a65e9b9344955a5cf9d7417db25dff3/lib/args.js#L199) accepts a value for `.define()` although the GM documentation omits to state this.
