### PR TITLE
Add types for graphql-depth-limit

### DIFF
--- a/types/graphql-depth-limit/graphql-depth-limit-tests.ts
+++ b/types/graphql-depth-limit/graphql-depth-limit-tests.ts
@@ -1,0 +1,29 @@
+import graphqlDepthLimit = require('graphql-depth-limit');
+import {
+    GraphQLSchema,
+    DocumentNode,
+    buildSchema,
+    Source,
+    parse,
+    validate,
+    specifiedRules
+} from 'graphql';
+
+const schema: GraphQLSchema = buildSchema(`
+  # graphql schema goes here...
+`);
+const document: DocumentNode = parse(new Source(`
+  # graphql query goes here...
+`, 'GraphQL request'));
+
+validate(schema, document, [ graphqlDepthLimit(5) ]);
+
+validate(schema, document, [ ...specifiedRules, graphqlDepthLimit(10) ]);
+
+validate(schema, document, [ graphqlDepthLimit(
+    10,
+    { ignore: [ /_trusted$/, 'idontcare' ] },
+    (depths: any) => {
+        // do something....
+    },
+)]);

--- a/types/graphql-depth-limit/index.d.ts
+++ b/types/graphql-depth-limit/index.d.ts
@@ -1,0 +1,20 @@
+// Type definitions for graphql-depth-limit 1.1
+// Project: https://github.com/stems/graphql-depth-limit#readme
+// Definitions by: Siim Tiilen <https://github.com/eritikass>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.8
+
+declare var d: GraphqlDepthLimit.depthLimit;
+export = d;
+
+declare namespace GraphqlDepthLimit {
+    interface options {
+        ignore: Array<string | RegExp | ((queryDepths: any[]) => boolean)>;
+    }
+
+    type depthLimit = (
+        depthLimit: number,
+        options?: options,
+        callback?: (obj: any) => void,
+    ) => any;
+}

--- a/types/graphql-depth-limit/index.d.ts
+++ b/types/graphql-depth-limit/index.d.ts
@@ -4,17 +4,11 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
-declare var d: GraphqlDepthLimit.depthLimit;
-export = d;
+declare function depthLimit(depthLimit: number, options?: depthLimit.Options, callback?: (obj: any) => void): any;
+export = depthLimit;
 
-declare namespace GraphqlDepthLimit {
-    interface options {
+declare namespace depthLimit {
+    interface Options {
         ignore: Array<string | RegExp | ((queryDepths: any[]) => boolean)>;
     }
-
-    type depthLimit = (
-        depthLimit: number,
-        options?: options,
-        callback?: (obj: any) => void,
-    ) => any;
 }

--- a/types/graphql-depth-limit/tsconfig.json
+++ b/types/graphql-depth-limit/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "graphql-depth-limit-tests.ts"
+    ]
+}

--- a/types/graphql-depth-limit/tslint.json
+++ b/types/graphql-depth-limit/tslint.json
@@ -1,0 +1,6 @@
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "strict-export-declare-modifiers": false
+    }
+}

--- a/types/graphql-depth-limit/tslint.json
+++ b/types/graphql-depth-limit/tslint.json
@@ -1,6 +1,1 @@
-{
-    "extends": "dtslint/dt.json",
-    "rules": {
-        "strict-export-declare-modifiers": false
-    }
-}
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
# What does this pull request do?

This pull request is adding types for [graphql-depth-limit](https://github.com/stems/graphql-depth-limit) package. 

--------------

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
