### PR TITLE
Add 'external' to node v6, v7, and v8 MemoryUsage interface

### DIFF
--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -621,6 +621,7 @@ declare namespace NodeJS {
         rss: number;
         heapTotal: number;
         heapUsed: number;
+        external: number;
     }
 
     export interface CpuUsage {

--- a/types/node/v6/index.d.ts
+++ b/types/node/v6/index.d.ts
@@ -413,6 +413,7 @@ declare namespace NodeJS {
         rss: number;
         heapTotal: number;
         heapUsed: number;
+        external: number;
     }
 
     export interface CpuUsage {

--- a/types/node/v7/index.d.ts
+++ b/types/node/v7/index.d.ts
@@ -424,6 +424,7 @@ declare namespace NodeJS {
         rss: number;
         heapTotal: number;
         heapUsed: number;
+        external: number;
     }
 
     export interface CpuUsage {

--- a/types/node/v8/index.d.ts
+++ b/types/node/v8/index.d.ts
@@ -472,6 +472,7 @@ declare namespace NodeJS {
         rss: number;
         heapTotal: number;
         heapUsed: number;
+        external: number;
     }
 
     export interface CpuUsage {

--- a/types/node/v9/index.d.ts
+++ b/types/node/v9/index.d.ts
@@ -612,6 +612,7 @@ declare namespace NodeJS {
         rss: number;
         heapTotal: number;
         heapUsed: number;
+        external: number;
     }
 
     export interface CpuUsage {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://nodejs.org/api/process.html#process_process_memoryusage>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.


`process.memoryUsage()` returns a structure which includes the `external` field. This change adds `external` to the `MemoryUsage` interface, which is the type returned by `process.MemoryUsage()`.
