### PR TITLE
[svgo] Export Options type

### DIFF
--- a/types/svgo/index.d.ts
+++ b/types/svgo/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/svg/svgo
 // Definitions by: Bradley Ayers <https://github.com/bradleyayers>
 //                 Gilad Gray <https://github.com/giladgray>
+//                 Aankhen <https://github.com/Aankhen>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
@@ -288,29 +289,6 @@ interface Svg2JsOptions {
     position?: boolean;
 }
 
-interface Options {
-    /** Output as Data URI string. */
-    datauri?: "base64" | "enc" | "unenc";
-
-    /** Precision of floating point numbers. Will be passed to each plugin that suppors this param. */
-    floatPrecision?: number;
-
-    /** Use full set of plugins. */
-    full?: boolean;
-
-    /** Options for rendering optimized SVG from AST. */
-    js2svg?: Js2SvgOptions;
-
-    /**
-     * Individual plugin configurations.
-     * For specific options, see plugin source in https://github.com/svg/svgo/tree/master/plugins.
-     */
-    plugins?: PluginConfig[];
-
-    /** Options for parsing original SVG into AST. */
-    svg2js?: Svg2JsOptions;
-}
-
 interface SvgInfo {
     path?: string;
 }
@@ -321,8 +299,33 @@ interface OptimizedSvg {
 }
 
 declare class SVGO {
-    constructor(options?: Options);
+    constructor(options?: SVGO.Options);
     optimize(svgString: string, info?: SvgInfo): Promise<OptimizedSvg>;
+}
+
+declare namespace SVGO {
+    interface Options {
+        /** Output as Data URI string. */
+        datauri?: "base64" | "enc" | "unenc";
+
+        /** Precision of floating point numbers. Will be passed to each plugin that suppors this param. */
+        floatPrecision?: number;
+
+        /** Use full set of plugins. */
+        full?: boolean;
+
+        /** Options for rendering optimized SVG from AST. */
+        js2svg?: Js2SvgOptions;
+
+        /**
+         * Individual plugin configurations.
+         * For specific options, see plugin source in https://github.com/svg/svgo/tree/master/plugins.
+         */
+        plugins?: PluginConfig[];
+
+        /** Options for parsing original SVG into AST. */
+        svg2js?: Svg2JsOptions;
+    }
 }
 
 export = SVGO;

--- a/types/svgo/svgo-tests.ts
+++ b/types/svgo/svgo-tests.ts
@@ -8,7 +8,9 @@ svgo = new SVGO({ plugins: [{ cleanupAttrs: {} }] });
 svgo = new SVGO({ datauri: "base64" });
 svgo = new SVGO({ floatPrecision: 2 });
 svgo = new SVGO({ full: true });
-svgo = new SVGO({
+
+// SVGO options
+const options: SVGO.Options = {
     plugins: [],
     datauri: "enc",
     floatPrecision: 2,
@@ -20,7 +22,9 @@ svgo = new SVGO({
     svg2js: {
         trim: true,
     }
-});
+};
+
+svgo = new SVGO(options);
 
 // SVGO instance methods
 svgo.optimize(`<?xml version="1.0" encoding="utf-8"?><svg></svg>`, { path: "filepath" })


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/Aankhen/DefinitelyTyped/blob/fde2cd7646cc2be813cf4797c703273cf9c08817/types/svgo/svgo-tests.ts#L13>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

I was writing definitions for [gulp-svgmin](https://www.npmjs.com/package/gulp-svgmin) and found myself needing to reuse `svgo`’s `Options` type, but only the class is exported. I created a namespace declaration and moved the `Options` type into it. I’m not sure whether this was the right approach, and whether, having created the namespace, I should also move all the other declarations into it; I decided to be conservative. Any guidance would be appreciated.