### PR TITLE
Add checkPropTypes definition to @types/prop-types

### DIFF
--- a/types/prop-types/index.d.ts
+++ b/types/prop-types/index.d.ts
@@ -28,3 +28,15 @@ export function oneOfType(types: Array<Validator<any>>): Requireable<any>;
 export function arrayOf(type: Validator<any>): Requireable<any>;
 export function objectOf(type: Validator<any>): Requireable<any>;
 export function shape(type: ValidationMap<any>): Requireable<any>;
+
+/**
+ * Assert that the values match with the type specs.
+ * Error messages are memorized and will only be shown once.
+ *
+ * @param typeSpecs Map of name to a ReactPropType
+ * @param values Runtime values that need to be type-checked
+ * @param location e.g. "prop", "context", "child context"
+ * @param componentName Name of the component for error messages.
+ * @param getStack Returns the component stack.
+ */
+export function checkPropTypes(typeSpecs: any, values: any, location: string, componentName: string, getStack?: () => any): void;

--- a/types/prop-types/prop-types-tests.ts
+++ b/types/prop-types/prop-types-tests.ts
@@ -25,3 +25,5 @@ const propTypes: PropTypes.ValidationMap<Props> = {
     node: PropTypes.node.isRequired,
     element: PropTypes.element.isRequired
 };
+
+PropTypes.checkPropTypes({xs: PropTypes.array}, {xs: []}, 'location', 'componentName');


### PR DESCRIPTION
I used the jsdoc as guide in


Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/facebook/prop-types/blob/master/checkPropTypes.js
- [x] Increase the version number in the header if appropriate. (seems N/A)