### PR TITLE
[Ramda] Improved memoize definition

### DIFF
--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -1021,11 +1021,13 @@ declare namespace R {
         median(list: ReadonlyArray<number>): number;
 
         /**
+         * @deprecated since v0.25.0
+         *
          * Creates a new function that, when invoked, caches the result of calling fn for a given argument set and
          * returns the result. Subsequent calls to the memoized fn with the same argument set will not result in an
          * additional call to fn; instead, the cached result for that set of arguments will be returned.
          */
-        memoize<T = any>(fn: (...a: any[]) => T): (...a: any[]) => T;
+        memoize<T extends (...args: any[]) => any>(fn: T): T;
 
         /**
          * A customisable version of R.memoize. memoizeWith takes an additional function that will be applied to a given

--- a/types/ramda/ramda-tests.ts
+++ b/types/ramda/ramda-tests.ts
@@ -305,7 +305,7 @@ R.times(i, 5);
     function stringLength(str: string): number {
       return str.length;
     }
-    const memoStringLength = R.memoize<number>(stringLength);
+    const memoStringLength = R.memoize(stringLength);
     const isLong = memoStringLength('short') > 10; // false
 })();
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).


## More info
As discussed in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/24895, I've updated a `memoize` to properly infer a function's type. Also, I've added a *deprecated* annotation as a hint for people which want to use it. This function is [deprecated since 0.25.0](http://ramdajs.com/docs/#memoize).

However, this change could affect people, which using this function with current definition. They will need to remove/update a type parameter in their codebases. On the other side, it is correctly inferring a type now.