### PR TITLE
Add gulp-svgmin types

### DIFF
--- a/types/gulp-svgmin/gulp-svgmin-tests.ts
+++ b/types/gulp-svgmin/gulp-svgmin-tests.ts
@@ -1,0 +1,51 @@
+import svgmin = require("gulp-svgmin");
+import { basename, extname } from "path";
+
+// From tests
+
+svgmin({ plugins: [] });
+svgmin({ plugins: [{ removeDoctype: false }] });
+svgmin({ plugins: [{ removeDoctype: false }, { removeComments: false }] });
+
+// From examples given in README
+
+// $ExpectType Transform
+svgmin();
+
+// $ExpectType Transform
+svgmin({
+    plugins: [{
+        removeDoctype: false
+    }, {
+        removeComments: false
+    }, {
+        cleanupNumericValues: {
+            floatPrecision: 2
+        }
+    }, {
+        convertColors: {
+            names2hex: false,
+            rgb2hex: false
+        }
+    }]
+});
+
+// $ExpectType Transform
+svgmin({
+    js2svg: {
+        pretty: true
+    }
+});
+
+// $ExpectType Transform
+svgmin(function getOptions(file) {
+    const prefix = basename(file.relative, extname(file.relative));
+    return {
+        plugins: [{
+            cleanupIDs: {
+                prefix: prefix + '-',
+                minify: true
+            }
+        }]
+    };
+});

--- a/types/gulp-svgmin/index.d.ts
+++ b/types/gulp-svgmin/index.d.ts
@@ -1,0 +1,17 @@
+// Type definitions for gulp-svgmin 1.2
+// Project: https://github.com/ben-eb/gulp-svgmin
+// Definitions by: Aankhen <https://github.com/Aankhen>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.2
+// (required because svgo specifies 2.2)
+
+/// <reference types="node"/>
+
+import SVGO = require("svgo");
+import { Transform } from "stream";
+import * as File from "vinyl";
+
+export = GulpSvgmin;
+
+declare function GulpSvgmin(cb: (file: File) => SVGO.Options): Transform;
+declare function GulpSvgmin(options?: SVGO.Options): Transform;

--- a/types/gulp-svgmin/tsconfig.json
+++ b/types/gulp-svgmin/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "gulp-svgmin-tests.ts"
+    ]
+}

--- a/types/gulp-svgmin/tslint.json
+++ b/types/gulp-svgmin/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

