### PR TITLE
[ArangoDB] Update geo index type

### DIFF
--- a/types/arangodb/arangodb-tests.ts
+++ b/types/arangodb/arangodb-tests.ts
@@ -1,4 +1,4 @@
-import { db, aql, query } from "@arangodb";
+import { aql, db, query } from "@arangodb";
 import { md5 } from "@arangodb/crypto";
 import { createRouter } from "@arangodb/foxx";
 import sessionsMiddleware = require("@arangodb/foxx/sessions");
@@ -52,6 +52,10 @@ bananas.updateByExample(
     { shape: { type: "round" } },
     { mergeObjects: true }
 );
+bananas.ensureIndex({
+    type: "geo",
+    fields: ["latLng"]
+});
 
 const router = createRouter();
 module.context.use(router);

--- a/types/arangodb/index.d.ts
+++ b/types/arangodb/index.d.ts
@@ -89,7 +89,7 @@ declare namespace ArangoDB {
         | "network authentication required";
     type EdgeDirection = "any" | "inbound" | "outbound";
     type EngineType = "mmfiles" | "rocksdb";
-    type IndexType = "hash" | "skiplist" | "fulltext" | "geo1" | "geo2";
+    type IndexType = "hash" | "skiplist" | "fulltext" | "geo";
     type ViewType = "arangosearch";
     type KeyGeneratorType = "traditional" | "autoincrement";
     type ErrorName =


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/arangodb/arangodb/blob/8d5a30cca67b8b889ef734cca27db44381df05e3/CHANGELOG#L4
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

---

The index type for creating indexes was actually always simply "geo", this is a bug in the definition. The result index type is now also simply "geo" as of 3.4 and was "geo1" or "geo2" previously. The typings explicitly cover 3.4+ so this is not a breaking change.