### PR TITLE
[plotly.js] added typed array to scatter data

### DIFF
--- a/types/plotly.js/index.d.ts
+++ b/types/plotly.js/index.d.ts
@@ -347,6 +347,7 @@ export interface ModeBarButton {
 // Data
 
 export type Datum = string | number | Date;
+export type TypedArray = Int8Array | Uint8Array | Int16Array | Uint16Array | Int32Array | Uint32Array | Uint8ClampedArray | Float32Array | Float64Array;
 
 export type Dash = 'solid' | 'dot' | 'dash' | 'longdash' | 'dashdot' | 'longdashdot';
 
@@ -356,9 +357,9 @@ export type Color = string | Array<string | undefined | null> | Array<Array<stri
 // Bar Scatter
 export interface ScatterData {
 	type: 'bar' | 'pointcloud' | 'scatter' | 'scattergl' | 'scatter3d';
-	x: Datum[] | Datum[][];
-	y: Datum[] | Datum[][];
-	z: Datum[] | Datum[][] | Datum[][][];
+	x: Datum[] | Datum[][] | TypedArray;
+	y: Datum[] | Datum[][] | TypedArray;
+	z: Datum[] | Datum[][] | Datum[][][] | TypedArray;
 	xy: Float32Array;
 	xaxis: string;
 	yaxis: string;


### PR DESCRIPTION
Typed arrays were added as a possible scatter data type in version 1.35. This PR updates the type definition to allow the x, y, or z fields of the ScatterData interface to be populated by a typed array. 

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/plotly/plotly.js/pull/2388