### PR TITLE
Added jest-axe typings

### DIFF
--- a/types/jest-axe/index.d.ts
+++ b/types/jest-axe/index.d.ts
@@ -1,8 +1,7 @@
-// Type definitions for expect-puppeteer 2.2
-// Project: https://github.com/smooth-code/jest-puppeteer/tree/master/packages/expect-puppeteer
+// Type definitions for jest-axe 2.2
+// Project: https://github.com/nickcolley/jest-axe
 // Definitions by: Josh Goldberg <https://github.com/JoshuaKGoldberg>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.4
 
 /// <reference types="jest" />
 

--- a/types/jest-axe/index.d.ts
+++ b/types/jest-axe/index.d.ts
@@ -41,7 +41,7 @@ export type JestAxe = (html: string, options?: AxeOptions) => Promise<AxeResults
  * @param options   Options to run aXe.
  * @returns New aXe verifier function.
  */
-export const configureAxe: (options?: AxeOptions) => JestAxe;
+export function configureAxe(options?: AxeOptions): JestAxe;
 
 /**
  * Results from asserting whether aXe verification passed.

--- a/types/jest-axe/index.d.ts
+++ b/types/jest-axe/index.d.ts
@@ -10,7 +10,7 @@ import { AxeResults, Result, RunOnly } from "axe-core";
 
 /**
  * Version of the aXe verifier with defaults set.
- * 
+ *
  * @remarks You can still pass additional options to this new instance;
  *          they will be merged with the defaults.
  */
@@ -29,7 +29,7 @@ export interface AxeOptions {
 
 /**
  * Runs aXe on HTML.
- * 
+ *
  * @param html   Raw HTML string to verify with aXe.
  * @param options   Options to run aXe.
  * @returns Promise for the results of running aXe.
@@ -38,7 +38,7 @@ export type JestAxe = (html: string, options?: AxeOptions) => Promise<AxeResults
 
 /**
  * Creates a new aXe verifier function.
- * 
+ *
  * @param options   Options to run aXe.
  * @returns New aXe verifier function.
  */

--- a/types/jest-axe/index.d.ts
+++ b/types/jest-axe/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/nickcolley/jest-axe
 // Definitions by: Josh Goldberg <https://github.com/JoshuaKGoldberg>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.4
 
 /// <reference types="jest" />
 

--- a/types/jest-axe/index.d.ts
+++ b/types/jest-axe/index.d.ts
@@ -1,0 +1,85 @@
+// Type definitions for expect-puppeteer 2.2
+// Project: https://github.com/smooth-code/jest-puppeteer/tree/master/packages/expect-puppeteer
+// Definitions by: Josh Goldberg <https://github.com/JoshuaKGoldberg>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.4
+
+/// <reference types="jest" />
+
+import { AxeResults, Result, RunOnly } from "axe-core";
+
+/**
+ * Version of the aXe verifier with defaults set.
+ * 
+ * @remarks You can still pass additional options to this new instance;
+ *          they will be merged with the defaults.
+ */
+export const axe: JestAxe;
+
+/**
+ * Core options to run aXe.
+ */
+export interface AxeOptions {
+    elementRef?: boolean;
+    iframes?: boolean;
+    rules?: object;
+    runOnly?: RunOnly;
+    selectors?: boolean;
+}
+
+/**
+ * Runs aXe on HTML.
+ * 
+ * @param html   Raw HTML string to verify with aXe.
+ * @param options   Options to run aXe.
+ * @returns Promise for the results of running aXe.
+ */
+export type JestAxe = (html: string, options?: AxeOptions) => Promise<AxeResults>;
+
+/**
+ * Creates a new aXe verifier function.
+ * 
+ * @param options   Options to run aXe.
+ * @returns New aXe verifier function.
+ */
+export const configureAxe: (options?: AxeOptions) => JestAxe;
+
+/**
+ * Results from asserting whether aXe verification passed.
+ */
+export interface AssertionsResult {
+    /**
+     * Actual checked aXe verification results.
+     */
+    actual: Result[];
+
+    /**
+     * @returns Message from the Jest assertion.
+     */
+    message(): string;
+
+    /**
+     * Whether the assertion passed.
+     */
+    pass: boolean;
+}
+
+/**
+ * Asserts an aXe-verified result has no violations.
+ *
+ * @param results   aXe verification result, if not running via expect().
+ * @returns Jest expectations for the aXe result.
+ */
+export type IToHaveNoViolations = (results?: Partial<AxeResults>) => AssertionsResult;
+
+export const toHaveNoViolations: {
+    toHaveNoViolations: IToHaveNoViolations;
+};
+
+declare global {
+    namespace jest {
+        interface Matchers<R> {
+            toHaveNoViolations: IToHaveNoViolations;
+        }
+    }
+}

--- a/types/jest-axe/jest-axe-tests.ts
+++ b/types/jest-axe/jest-axe-tests.ts
@@ -1,0 +1,17 @@
+import { configureAxe, axe, toHaveNoViolations, JestAxe } from "jest-axe";
+
+expect.extend(toHaveNoViolations);
+
+const newJestWithDefaults: JestAxe = configureAxe();
+
+const newJestWithOptions: JestAxe = configureAxe({
+    elementRef: false,
+    iframes: false,
+    rules: {},
+    runOnly: "rules",
+    selectors: false,
+});
+
+const sameJest: JestAxe = axe;
+
+expect("").toHaveNoViolations();

--- a/types/jest-axe/jest-axe-tests.ts
+++ b/types/jest-axe/jest-axe-tests.ts
@@ -8,7 +8,9 @@ const newJestWithOptions: JestAxe = configureAxe({
     elementRef: false,
     iframes: false,
     rules: {},
-    runOnly: "rules",
+    runOnly: {
+        type: "rules",
+    },
     selectors: false,
 });
 

--- a/types/jest-axe/package.json
+++ b/types/jest-axe/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "axe-core": "^2.6.1"
+    }
+}

--- a/types/jest-axe/tsconfig.json
+++ b/types/jest-axe/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "jest-axe-tests.ts"
+    ]
+}

--- a/types/jest-axe/tslint.json
+++ b/types/jest-axe/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

https://github.com/nickcolley/jest-axe/pull/4