### PR TITLE
[ramda] Improve R.evolve

### DIFF
--- a/types/ramda/ramda-tests.ts
+++ b/types/ramda/ramda-tests.ts
@@ -1307,19 +1307,55 @@ type Pair = KeyValuePair<string, number>;
 };
 
 () => {
-    const a1 = R.evolve({elapsed: R.add(1), remaining: R.add(-1)}, {name: "Tomato", elapsed: 100, remaining: 1400});
-    const a2 = R.evolve({elapsed: R.add(1), remaining: R.add(-1)})({name: "Tomato", elapsed: 100, remaining: 1400});
-};
+    // No type transformation
 
-() => {
-    // const tomato = {firstName: 'Tomato ', data: {elapsed: 100, remaining: 1400}, id:123};
-    // const transformations = {
-    //     firstName: R.trim,
-    //     lastName: R.trim, // Will not get invoked.
-    //     data: {elapsed: R.add(1), remaining: R.add(-1)}
-    // };
-    // const a = R.evolve(transformations, tomato); // => {firstName: 'Tomato', data: {elapsed: 101, remaining: 1399}, id:123}
-    // const b = R.evolve(transformations)(tomato); // => {firstName: 'Tomato', data: {elapsed: 101, remaining: 1399}, id:123}
+    const a1 = R.evolve({ elapsed: R.add(1), remaining: R.add(-1) }, { name: "Tomato", elapsed: 100, remaining: 1400 });
+
+    const a1Test: { elapsed: number, remaining: number, name: string } = a1;
+
+    const a2 = R.evolve({ elapsed: R.add(1), remaining: R.add(-1) })({ name: "Tomato", elapsed: 100, remaining: 1400 });
+
+    const a2Test: { elapsed: number, remaining: number, name: string } = a2;
+
+    // Object doesn't have all evolver keys
+
+    const a3 = R.evolve({ age: R.add(1), name: R.trim }, { name: "Potato", elapsed: 100 });
+
+    const a3Test: { name: string, elapsed: number } = a3;
+
+    // Flat transformation
+
+    const ex0 = R.evolve({ a: parseInt }, { a: '10', b: 1 });
+
+    const ex0Test: { a: number, b: number } = ex0;
+
+    // Nested transformation:
+
+    const ex1 = R.evolve(
+        { a: { b: R.toString, d: { e: R.toString } } },
+        { a: { b: 1, c: null, d: { e: 2 } } },
+    );
+
+    const ex1Test: { a: { b: string, c: null, d: { e: string } } } = ex1;
+
+    // Mapping a nested object with a single function
+
+    const ex2 = R.evolve(
+        { a: (obj: { foo: string }) => ({ bar: 1, baz: 2 }) },
+        { a: { foo: 'a', skipped: 3 }, b: null },
+    );
+
+    const ex2Test: { a: { bar: number, baz: number }, b: null } = ex2;
+
+    // Nested curried:
+
+    const ex3 = R.evolve(
+        { a: { b: R.toString, d: { e: R.toString } } },
+    )(
+        { a: { b: 1, c: null, d: { e: 2 } } }
+    );
+
+    const ex3Test: { a: { b: string, c: null, d: { e: string } } } = ex3;
 };
 
 () => {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Now `R.evolve` can transform a type of an object according to a supplied transformer function. Works well with currying. Previously only type preserving transformations were allowed.