### PR TITLE
 fix(node): add support for `Buffer.from(uint8Array)`

### DIFF
--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -376,6 +376,10 @@ declare var Buffer: {
      */
     from(arrayBuffer: ArrayBuffer, byteOffset?: number, length?: number): Buffer;
     /**
+     * Copies the passed buffer data onto a new Buffer instance.
+     */
+    from(buffer: Uint8Array): Buffer;
+    /**
      * Creates a new Buffer using the passed {data}
      * @param data data to create a new Buffer
      */

--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -376,14 +376,10 @@ declare var Buffer: {
      */
     from(arrayBuffer: ArrayBuffer, byteOffset?: number, length?: number): Buffer;
     /**
-     * Copies the passed buffer data onto a new Buffer instance.
-     */
-    from(buffer: Uint8Array): Buffer;
-    /**
      * Creates a new Buffer using the passed {data}
      * @param data data to create a new Buffer
      */
-    from(data: any[] | string | Buffer | ArrayBuffer /*| TypedArray*/): Buffer;
+    from(data: any[] | string | Buffer | ArrayBuffer | Uint8Array /*| TypedArray*/): Buffer;
     /**
      * Creates a new Buffer containing the given JavaScript string {str}.
      * If provided, the {encoding} parameter identifies the character encoding.

--- a/types/node/node-tests.ts
+++ b/types/node/node-tests.ts
@@ -432,10 +432,13 @@ function bufferTests() {
         // String
         const buf3: Buffer = Buffer.from('this is a tést');
         // ArrayBuffer
-        const arr: Uint16Array = new Uint16Array(2);
-        arr[0] = 5000;
-        arr[1] = 4000;
-        const buf4: Buffer = Buffer.from(arr.buffer);
+        const arrUint16: Uint16Array = new Uint16Array(2);
+        arrUint16[0] = 5000;
+        arrUint16[1] = 4000;
+        const buf4: Buffer = Buffer.from(arrUint16.buffer);
+        const arrUint8: Uint8Array = new Uint8Array(2);
+        const buf5: Buffer = Buffer.from(arrUint8);
+        const buf6: Buffer = Buffer.from(buf1);
     }
 
     // Class Method: Buffer.from(arrayBuffer[, byteOffset[, length]])


### PR DESCRIPTION
These changes were originally proposed in #25412. I've implemented the review suggestions (consolidate the overloads of `Buffer.from` into one).

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/api/buffer.html#buffer_class_method_buffer_from_buffer
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
