### PR TITLE
Mention npx when talking about dts-gen in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Your package should have this structure:
 | tsconfig.json | This allows you to run `tsc` within the package. |
 | tslint.json | Enables linting. |
 
-Generate these by running `npm install -g dts-gen` and `dts-gen --dt --name my-package-name --template module`.
+Generate these by running `npx dts-gen --dt --name my-package-name --template module` if you have npm ≥ 5.2.0, `npm install -g dts-gen` and `dts-gen --dt --name my-package-name --template module` otherwise.
 See all options at [dts-gen](https://github.com/Microsoft/dts-gen).
 
 You may edit the `tsconfig.json` to add new files, to add `"target": "es6"` (needed for async functions), to add to `"lib"`, or to add the `"jsx"` compiler option.


### PR DESCRIPTION
npm 5.2.0 and up bundle the [npx package runner](https://medium.com/@maybekatz/introducing-npx-an-npm-package-runner-55f7d4bd282b), which lets you run tools like `dts-gen` without needing to install them globally. It might be a good idea to suggest this option in the README. (I’m unable to bring the es version up-to-date as I don’t speak Spanish, but if anyone can provide a translation I’ll update the PR.)