### PR TITLE
[@types/graphql] Switch void for more correct `undefined | null` typing

### DIFF
--- a/types/graphql/Maybe.d.ts
+++ b/types/graphql/Maybe.d.ts
@@ -1,3 +1,0 @@
-type Maybe<T> = null | undefined | T
-
-export default Maybe

--- a/types/graphql/Maybe.d.ts
+++ b/types/graphql/Maybe.d.ts
@@ -1,0 +1,3 @@
+type Maybe<T> = null | undefined | T
+
+export default Maybe

--- a/types/graphql/error/GraphQLError.d.ts
+++ b/types/graphql/error/GraphQLError.d.ts
@@ -2,6 +2,7 @@ import { getLocation } from "../language";
 import { ASTNode } from "../language/ast";
 import { Source } from "../language/source";
 import { SourceLocation } from "../language/location";
+import Maybe from "../Maybe";
 
 /**
  * A GraphQLError describes an Error found during the parse, validate, or
@@ -58,7 +59,7 @@ export class GraphQLError extends Error {
     /**
      * The original error thrown from a field resolver during execution.
      */
-    readonly originalError: Error | void;
+    readonly originalError: Maybe<Error>;
 
     /**
      * Extension fields to add to the formatted error.
@@ -68,10 +69,10 @@ export class GraphQLError extends Error {
     constructor(
         message: string,
         nodes?: ReadonlyArray<ASTNode> | ASTNode | undefined,
-        source?: Source | void,
-        positions?: ReadonlyArray<number> | void,
-        path?: ReadonlyArray<string | number> | void,
-        originalError?: Error | void,
-        extensions?: { [key: string]: any } | void
+        source?: Maybe<Source>,
+        positions?: Maybe<ReadonlyArray<number>>,
+        path?: Maybe<ReadonlyArray<string | number>>,
+        originalError?: Maybe<Error>,
+        extensions?: Maybe<{ [key: string]: any }>
     );
 }

--- a/types/graphql/error/GraphQLError.d.ts
+++ b/types/graphql/error/GraphQLError.d.ts
@@ -1,8 +1,8 @@
+import Maybe from "../tsutils/Maybe";
 import { getLocation } from "../language";
 import { ASTNode } from "../language/ast";
 import { Source } from "../language/source";
 import { SourceLocation } from "../language/location";
-import Maybe from "../Maybe";
 
 /**
  * A GraphQLError describes an Error found during the parse, validate, or

--- a/types/graphql/execution/execute.d.ts
+++ b/types/graphql/execution/execute.d.ts
@@ -17,6 +17,7 @@ import {
     FragmentDefinitionNode,
 } from "../language/ast";
 import { MaybePromise } from "../jsutils/MaybePromise";
+import Maybe from "../Maybe";
 
 /**
  * Data that must be available at all points during query execution.
@@ -51,9 +52,9 @@ export type ExecutionArgs = {
     document: DocumentNode;
     rootValue?: any;
     contextValue?: any;
-    variableValues?: { [key: string]: any } | void;
-    operationName?: string | void;
-    fieldResolver?: GraphQLFieldResolver<any, any> | void;
+    variableValues?: Maybe<{ [key: string]: any }>;
+    operationName?: Maybe<string>;
+    fieldResolver?: Maybe<GraphQLFieldResolver<any, any>>;
 };
 
 /**
@@ -74,9 +75,9 @@ export function execute(
     document: DocumentNode,
     rootValue?: any,
     contextValue?: any,
-    variableValues?: { [key: string]: any } | void,
-    operationName?: string | void,
-    fieldResolver?: GraphQLFieldResolver<any, any> | void
+    variableValues?: Maybe<{ [key: string]: any }>,
+    operationName?: Maybe<string>,
+    fieldResolver?: Maybe<GraphQLFieldResolver<any, any>>
 ): MaybePromise<ExecutionResult>;
 
 /**
@@ -101,7 +102,7 @@ export function addPath(
 export function assertValidExecutionArguments(
     schema: GraphQLSchema,
     document: DocumentNode,
-    rawVariableValues: { [key: string]: any } | void
+    rawVariableValues: Maybe<{ [key: string]: any }>
 ): void;
 
 /**
@@ -115,9 +116,9 @@ export function buildExecutionContext(
     document: DocumentNode,
     rootValue: any,
     contextValue: any,
-    rawVariableValues: { [key: string]: any } | void,
-    operationName: string | void,
-    fieldResolver: GraphQLFieldResolver<any, any> | void
+    rawVariableValues: Maybe<{ [key: string]: any }>,
+    operationName: Maybe<string>,
+    fieldResolver: Maybe<GraphQLFieldResolver<any, any>>
 ): ReadonlyArray<GraphQLError> | ExecutionContext;
 
 /**
@@ -181,4 +182,4 @@ export function getFieldDef(
     schema: GraphQLSchema,
     parentType: GraphQLObjectType,
     fieldName: string
-): GraphQLField<any, any> | void;
+): Maybe<GraphQLField<any, any>>;

--- a/types/graphql/execution/execute.d.ts
+++ b/types/graphql/execution/execute.d.ts
@@ -1,3 +1,4 @@
+import Maybe from "../tsutils/Maybe";
 import { GraphQLError, locatedError } from "../error";
 import { GraphQLSchema } from "../type/schema";
 import {
@@ -17,7 +18,6 @@ import {
     FragmentDefinitionNode,
 } from "../language/ast";
 import { MaybePromise } from "../jsutils/MaybePromise";
-import Maybe from "../Maybe";
 
 /**
  * Data that must be available at all points during query execution.

--- a/types/graphql/execution/values.d.ts
+++ b/types/graphql/execution/values.d.ts
@@ -1,9 +1,9 @@
+import Maybe from "../tsutils/Maybe";
 import { GraphQLError } from "../error";
 import { GraphQLInputType, GraphQLField, GraphQLArgument } from "../type/definition";
 import { GraphQLDirective } from "../type/directives";
 import { GraphQLSchema } from "../type/schema";
 import { FieldNode, DirectiveNode, VariableDefinitionNode } from "../language/ast";
-import Maybe from "../Maybe";
 
 interface CoercedVariableValues {
     errors: ReadonlyArray<GraphQLError> | undefined;

--- a/types/graphql/execution/values.d.ts
+++ b/types/graphql/execution/values.d.ts
@@ -3,6 +3,7 @@ import { GraphQLInputType, GraphQLField, GraphQLArgument } from "../type/definit
 import { GraphQLDirective } from "../type/directives";
 import { GraphQLSchema } from "../type/schema";
 import { FieldNode, DirectiveNode, VariableDefinitionNode } from "../language/ast";
+import Maybe from "../Maybe";
 
 interface CoercedVariableValues {
     errors: ReadonlyArray<GraphQLError> | undefined;
@@ -35,7 +36,7 @@ export function getVariableValues(
 export function getArgumentValues(
     def: GraphQLField<any, any> | GraphQLDirective,
     node: FieldNode | DirectiveNode,
-    variableValues?: { [key: string]: any } | void
+    variableValues?: Maybe<{ [key: string]: any }>
 ): { [key: string]: any };
 
 /**
@@ -54,5 +55,5 @@ export function getDirectiveValues(
     node: {
         readonly directives?: ReadonlyArray<DirectiveNode>;
     },
-    variableValues?: { [key: string]: any } | void
+    variableValues?: Maybe<{ [key: string]: any }>
 ): undefined | { [key: string]: any };

--- a/types/graphql/graphql.d.ts
+++ b/types/graphql/graphql.d.ts
@@ -1,8 +1,8 @@
+import Maybe from "./tsutils/Maybe";
 import { Source } from "./language/source";
 import { GraphQLFieldResolver } from "./type/definition";
 import { GraphQLSchema } from "./type/schema";
 import { ExecutionResult } from "./execution/execute";
-import Maybe from "./Maybe";
 
 /**
  * This is the primary entry point function for fulfilling GraphQL operations

--- a/types/graphql/graphql.d.ts
+++ b/types/graphql/graphql.d.ts
@@ -2,6 +2,7 @@ import { Source } from "./language/source";
 import { GraphQLFieldResolver } from "./type/definition";
 import { GraphQLSchema } from "./type/schema";
 import { ExecutionResult } from "./execution/execute";
+import Maybe from "./Maybe";
 
 /**
  * This is the primary entry point function for fulfilling GraphQL operations
@@ -38,9 +39,9 @@ export interface GraphQLArgs {
     source: Source | string;
     rootValue?: any;
     contextValue?: any;
-    variableValues?: { [key: string]: any } | void;
-    operationName?: string | void;
-    fieldResolver?: GraphQLFieldResolver<any, any> | void;
+    variableValues?: Maybe<{ [key: string]: any }>;
+    operationName?: Maybe<string>;
+    fieldResolver?: Maybe<GraphQLFieldResolver<any, any>>;
 }
 
 export function graphql(args: GraphQLArgs): Promise<ExecutionResult>;
@@ -49,9 +50,9 @@ export function graphql(
     source: Source | string,
     rootValue?: any,
     contextValue?: any,
-    variableValues?: { [key: string]: any } | void,
-    operationName?: string | void,
-    fieldResolver?: GraphQLFieldResolver<any, any> | void
+    variableValues?: Maybe<{ [key: string]: any }>,
+    operationName?: Maybe<string>,
+    fieldResolver?: Maybe<GraphQLFieldResolver<any, any>>
 ): Promise<ExecutionResult>;
 
 /**
@@ -66,7 +67,7 @@ export function graphqlSync(
     source: Source | string,
     rootValue?: any,
     contextValue?: any,
-    variableValues?: { [key: string]: any } | void,
-    operationName?: string | void,
-    fieldResolver?: GraphQLFieldResolver<any, any> | void
+    variableValues?: Maybe<{ [key: string]: any }>,
+    operationName?: Maybe<string>,
+    fieldResolver?: Maybe<GraphQLFieldResolver<any, any>>
 ): ExecutionResult;

--- a/types/graphql/index.d.ts
+++ b/types/graphql/index.d.ts
@@ -13,6 +13,7 @@
 //                 Dylan Stewart <https://github.com/dyst5422>
 //                 Alessio Dionisi <https://github.com/adnsio>
 //                 Divyendu Singh <https://github.com/divyenduz>
+//                 Brad Zacher <https://github.com/bradzacher>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 

--- a/types/graphql/language/visitor.d.ts
+++ b/types/graphql/language/visitor.d.ts
@@ -1,5 +1,6 @@
 import { ASTNode, ASTKindToNode } from "./ast";
 import { TypeInfo } from "../utilities/TypeInfo";
+import Maybe from "../Maybe";
 
 interface EnterLeave<T> {
     readonly enter?: T;
@@ -157,4 +158,4 @@ export function visitWithTypeInfo(typeInfo: TypeInfo, visitor: Visitor<ASTKindTo
  * Given a visitor instance, if it is leaving or not, and a node kind, return
  * the function the visitor runtime should call.
  */
-export function getVisitFn(visitor: Visitor<any>, kind: string, isLeaving: boolean): VisitFn<any> | void;
+export function getVisitFn(visitor: Visitor<any>, kind: string, isLeaving: boolean): Maybe<VisitFn<any>>;

--- a/types/graphql/language/visitor.d.ts
+++ b/types/graphql/language/visitor.d.ts
@@ -1,6 +1,6 @@
+import Maybe from "../tsutils/Maybe";
 import { ASTNode, ASTKindToNode } from "./ast";
 import { TypeInfo } from "../utilities/TypeInfo";
-import Maybe from "../Maybe";
 
 interface EnterLeave<T> {
     readonly enter?: T;

--- a/types/graphql/subscription/subscribe.d.ts
+++ b/types/graphql/subscription/subscribe.d.ts
@@ -1,8 +1,8 @@
+import Maybe from "../tsutils/Maybe";
 import { GraphQLSchema } from "../type/schema";
 import { DocumentNode } from "../language/ast";
 import { GraphQLFieldResolver } from "../type/definition";
 import { ExecutionResult } from "../execution/execute";
-import Maybe from "../Maybe";
 
 /**
  * Implements the "Subscribe" algorithm described in the GraphQL specification.

--- a/types/graphql/subscription/subscribe.d.ts
+++ b/types/graphql/subscription/subscribe.d.ts
@@ -2,6 +2,7 @@ import { GraphQLSchema } from "../type/schema";
 import { DocumentNode } from "../language/ast";
 import { GraphQLFieldResolver } from "../type/definition";
 import { ExecutionResult } from "../execution/execute";
+import Maybe from "../Maybe";
 
 /**
  * Implements the "Subscribe" algorithm described in the GraphQL specification.
@@ -28,10 +29,10 @@ export function subscribe(args: {
     document: DocumentNode;
     rootValue?: any;
     contextValue?: any;
-    variableValues?: { [key: string]: any } | void;
-    operationName?: string | void;
-    fieldResolver?: GraphQLFieldResolver<any, any> | void;
-    subscribeFieldResolver?: GraphQLFieldResolver<any, any> | void;
+    variableValues?: Maybe<{ [key: string]: any }>;
+    operationName?: Maybe<string>;
+    fieldResolver?: Maybe<GraphQLFieldResolver<any, any>>;
+    subscribeFieldResolver?: Maybe<GraphQLFieldResolver<any, any>>;
 }): Promise<AsyncIterator<ExecutionResult> | ExecutionResult>;
 
 export function subscribe(
@@ -39,10 +40,10 @@ export function subscribe(
     document: DocumentNode,
     rootValue?: any,
     contextValue?: any,
-    variableValues?: { [key: string]: any } | void,
-    operationName?: string | void,
-    fieldResolver?: GraphQLFieldResolver<any, any> | void,
-    subscribeFieldResolver?: GraphQLFieldResolver<any, any> | void
+    variableValues?: Maybe<{ [key: string]: any }>,
+    operationName?: Maybe<string>,
+    fieldResolver?: Maybe<GraphQLFieldResolver<any, any>>,
+    subscribeFieldResolver?: Maybe<GraphQLFieldResolver<any, any>>
 ): Promise<AsyncIterator<ExecutionResult> | ExecutionResult>;
 
 /**
@@ -69,6 +70,6 @@ export function createSourceEventStream(
     rootValue?: any,
     contextValue?: any,
     variableValues?: { [key: string]: any },
-    operationName?: string | void,
-    fieldResolver?: GraphQLFieldResolver<any, any> | void
+    operationName?: Maybe<string>,
+    fieldResolver?: Maybe<GraphQLFieldResolver<any, any>>
 ): Promise<AsyncIterable<any> | ExecutionResult>;

--- a/types/graphql/tsconfig.json
+++ b/types/graphql/tsconfig.json
@@ -7,7 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
-        "strictNullChecks": false,
+        "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/graphql/tsutils/Maybe.d.ts
+++ b/types/graphql/tsutils/Maybe.d.ts
@@ -1,0 +1,4 @@
+// Conveniently represents flow's "Maybe" type https://flow.org/en/docs/types/maybe/
+type Maybe<T> = null | undefined | T
+
+export default Maybe

--- a/types/graphql/type/definition.d.ts
+++ b/types/graphql/type/definition.d.ts
@@ -17,6 +17,7 @@ import {
     ValueNode,
 } from "../language/ast";
 import { GraphQLSchema } from "./schema";
+import Maybe from "../Maybe";
 
 /**
  * These are all of the possible kinds of types.
@@ -254,8 +255,8 @@ export type Thunk<T> = (() => T) | T;
  */
 export class GraphQLScalarType {
     name: string;
-    description: string | void;
-    astNode?: ScalarTypeDefinitionNode | void;
+    description: Maybe<string>;
+    astNode?: Maybe<ScalarTypeDefinitionNode>;
     constructor(config: GraphQLScalarTypeConfig<any, any>);
 
     // Serializes an internal value to include in a response.
@@ -265,7 +266,7 @@ export class GraphQLScalarType {
     parseValue(value: any): any;
 
     // Parses an externally provided literal value to use as an input.
-    parseLiteral(valueNode: ValueNode, variables?: { [key: string]: any } | void): any;
+    parseLiteral(valueNode: ValueNode, variables?: Maybe<{ [key: string]: any }>): any;
 
     toString(): string;
     toJSON(): string;
@@ -274,11 +275,11 @@ export class GraphQLScalarType {
 
 export interface GraphQLScalarTypeConfig<TInternal, TExternal> {
     name: string;
-    description?: string | void;
-    astNode?: ScalarTypeDefinitionNode | void;
-    serialize(value: any): TExternal | void;
-    parseValue?(value: any): TInternal | void;
-    parseLiteral?(valueNode: ValueNode, variables: { [key: string]: any } | void): TInternal | void;
+    description?: Maybe<string>;
+    astNode?: Maybe<ScalarTypeDefinitionNode>;
+    serialize(value: any): Maybe<TExternal>;
+    parseValue?(value: any): Maybe<TInternal>;
+    parseLiteral?(valueNode: ValueNode, variables: Maybe<{ [key: string]: any }>): Maybe<TInternal>;
 }
 
 /**
@@ -320,10 +321,10 @@ export interface GraphQLScalarTypeConfig<TInternal, TExternal> {
  */
 export class GraphQLObjectType {
     name: string;
-    description: string | void;
-    astNode: ObjectTypeDefinitionNode | void;
-    extensionASTNodes: ReadonlyArray<ObjectTypeExtensionNode> | void;
-    isTypeOf: GraphQLIsTypeOfFn<any, any> | void;
+    description: Maybe<string>;
+    astNode: Maybe<ObjectTypeDefinitionNode>;
+    extensionASTNodes: Maybe<ReadonlyArray<ObjectTypeExtensionNode>>;
+    isTypeOf: Maybe<GraphQLIsTypeOfFn<any, any>>;
 
     constructor(config: GraphQLObjectTypeConfig<any, any>);
     getFields(): GraphQLFieldMap<any, any>;
@@ -335,19 +336,19 @@ export class GraphQLObjectType {
 
 export interface GraphQLObjectTypeConfig<TSource, TContext> {
     name: string;
-    interfaces?: Thunk<GraphQLInterfaceType[] | void>;
+    interfaces?: Thunk<Maybe<GraphQLInterfaceType[]>>;
     fields: Thunk<GraphQLFieldConfigMap<TSource, TContext>>;
-    isTypeOf?: GraphQLIsTypeOfFn<TSource, TContext> | void;
-    description?: string | void;
-    astNode?: ObjectTypeDefinitionNode | void;
-    extensionASTNodes?: ReadonlyArray<ObjectTypeExtensionNode> | void;
+    isTypeOf?: Maybe<GraphQLIsTypeOfFn<TSource, TContext>>;
+    description?: Maybe<string>;
+    astNode?: Maybe<ObjectTypeDefinitionNode>;
+    extensionASTNodes?: Maybe<ReadonlyArray<ObjectTypeExtensionNode>>;
 }
 
 export type GraphQLTypeResolver<TSource, TContext> = (
     value: TSource,
     context: TContext,
     info: GraphQLResolveInfo
-) => MaybePromise<GraphQLObjectType | string | void>;
+) => MaybePromise<Maybe<GraphQLObjectType | string>>;
 
 export type GraphQLIsTypeOfFn<TSource, TContext> = (
     source: TSource,
@@ -385,9 +386,9 @@ export interface GraphQLFieldConfig<TSource, TContext, TArgs = { [argName: strin
     args?: GraphQLFieldConfigArgumentMap;
     resolve?: GraphQLFieldResolver<TSource, TContext, TArgs>;
     subscribe?: GraphQLFieldResolver<TSource, TContext, TArgs>;
-    deprecationReason?: string | void;
-    description?: string | void;
-    astNode?: FieldDefinitionNode | void;
+    deprecationReason?: Maybe<string>;
+    description?: Maybe<string>;
+    astNode?: Maybe<FieldDefinitionNode>;
 }
 
 export type GraphQLFieldConfigArgumentMap = { [key: string]: GraphQLArgumentConfig };
@@ -395,8 +396,8 @@ export type GraphQLFieldConfigArgumentMap = { [key: string]: GraphQLArgumentConf
 export interface GraphQLArgumentConfig {
     type: GraphQLInputType;
     defaultValue?: any;
-    description?: string | void;
-    astNode?: InputValueDefinitionNode | void;
+    description?: Maybe<string>;
+    astNode?: Maybe<InputValueDefinitionNode>;
 }
 
 export type GraphQLFieldConfigMap<TSource, TContext> = {
@@ -405,22 +406,22 @@ export type GraphQLFieldConfigMap<TSource, TContext> = {
 
 export interface GraphQLField<TSource, TContext, TArgs = { [key: string]: any }> {
     name: string;
-    description: string | void;
+    description: Maybe<string>;
     type: GraphQLOutputType;
     args: GraphQLArgument[];
     resolve?: GraphQLFieldResolver<TSource, TContext, TArgs>;
     subscribe?: GraphQLFieldResolver<TSource, TContext, TArgs>;
     isDeprecated?: boolean;
-    deprecationReason?: string | void;
-    astNode?: FieldDefinitionNode | void;
+    deprecationReason?: Maybe<string>;
+    astNode?: Maybe<FieldDefinitionNode>;
 }
 
 export interface GraphQLArgument {
     name: string;
     type: GraphQLInputType;
     defaultValue?: any;
-    description?: string | void;
-    astNode?: InputValueDefinitionNode | void;
+    description?: Maybe<string>;
+    astNode?: Maybe<InputValueDefinitionNode>;
 }
 
 export type GraphQLFieldMap<TSource, TContext> = {
@@ -447,10 +448,10 @@ export type GraphQLFieldMap<TSource, TContext> = {
  */
 export class GraphQLInterfaceType {
     name: string;
-    description: string | void;
-    astNode?: InterfaceTypeDefinitionNode | void;
-    extensionASTNodes: ReadonlyArray<InterfaceTypeExtensionNode> | void;
-    resolveType: GraphQLTypeResolver<any, any> | void;
+    description: Maybe<string>;
+    astNode?: Maybe<InterfaceTypeDefinitionNode>;
+    extensionASTNodes: Maybe<ReadonlyArray<InterfaceTypeExtensionNode>>;
+    resolveType: Maybe<GraphQLTypeResolver<any, any>>;
 
     constructor(config: GraphQLInterfaceTypeConfig<any, any>);
 
@@ -469,10 +470,10 @@ export interface GraphQLInterfaceTypeConfig<TSource, TContext> {
      * the default implementation will call `isTypeOf` on each implementing
      * Object type.
      */
-    resolveType?: GraphQLTypeResolver<TSource, TContext> | void;
-    description?: string | void;
-    astNode?: InterfaceTypeDefinitionNode | void;
-    extensionASTNodes?: ReadonlyArray<InterfaceTypeExtensionNode> | void;
+    resolveType?: Maybe<GraphQLTypeResolver<TSource, TContext>>;
+    description?: Maybe<string>;
+    astNode?: Maybe<InterfaceTypeDefinitionNode>;
+    extensionASTNodes?: Maybe<ReadonlyArray<InterfaceTypeExtensionNode>>;
 }
 
 /**
@@ -500,9 +501,9 @@ export interface GraphQLInterfaceTypeConfig<TSource, TContext> {
  */
 export class GraphQLUnionType {
     name: string;
-    description: string | void;
-    astNode?: UnionTypeDefinitionNode | void;
-    resolveType: GraphQLTypeResolver<any, any> | void;
+    description: Maybe<string>;
+    astNode?: Maybe<UnionTypeDefinitionNode>;
+    resolveType: Maybe<GraphQLTypeResolver<any, any>>;
 
     constructor(config: GraphQLUnionTypeConfig<any, any>);
 
@@ -521,9 +522,9 @@ export interface GraphQLUnionTypeConfig<TSource, TContext> {
      * the default implementation will call `isTypeOf` on each implementing
      * Object type.
      */
-    resolveType?: GraphQLTypeResolver<TSource, TContext> | void;
-    description?: string | void;
-    astNode?: UnionTypeDefinitionNode | void;
+    resolveType?: Maybe<GraphQLTypeResolver<TSource, TContext>>;
+    description?: Maybe<string>;
+    astNode?: Maybe<UnionTypeDefinitionNode>;
 }
 
 /**
@@ -549,15 +550,15 @@ export interface GraphQLUnionTypeConfig<TSource, TContext> {
  */
 export class GraphQLEnumType {
     name: string;
-    description: string | void;
-    astNode: EnumTypeDefinitionNode | void;
+    description: Maybe<string>;
+    astNode: Maybe<EnumTypeDefinitionNode>;
 
     constructor(config: GraphQLEnumTypeConfig);
     getValues(): GraphQLEnumValue[];
-    getValue(name: string): GraphQLEnumValue | void;
-    serialize(value: any): string | void;
-    parseValue(value: any): any;
-    parseLiteral(valueNode: ValueNode, _variables: { [key: string]: any } | void): any;
+    getValue(name: string): Maybe<GraphQLEnumValue>;
+    serialize(value: any): Maybe<string>;
+    parseValue(value: any): Maybe<any>;
+    parseLiteral(valueNode: ValueNode, _variables: Maybe<{ [key: string]: any }>): Maybe<any>;
     toString(): string;
     toJSON(): string;
     inspect(): string;
@@ -566,25 +567,25 @@ export class GraphQLEnumType {
 export interface GraphQLEnumTypeConfig {
     name: string;
     values: GraphQLEnumValueConfigMap;
-    description?: string | void;
-    astNode?: EnumTypeDefinitionNode | void;
+    description?: Maybe<string>;
+    astNode?: Maybe<EnumTypeDefinitionNode>;
 }
 
 export type GraphQLEnumValueConfigMap = { [key: string]: GraphQLEnumValueConfig };
 
 export interface GraphQLEnumValueConfig {
     value?: any;
-    deprecationReason?: string | void;
-    description?: string | void;
-    astNode?: EnumValueDefinitionNode | void;
+    deprecationReason?: Maybe<string>;
+    description?: Maybe<string>;
+    astNode?: Maybe<EnumValueDefinitionNode>;
 }
 
 export interface GraphQLEnumValue {
     name: string;
-    description: string | void;
+    description: Maybe<string>;
     isDeprecated?: boolean;
-    deprecationReason: string | void;
-    astNode?: EnumValueDefinitionNode | void;
+    deprecationReason: Maybe<string>;
+    astNode?: Maybe<EnumValueDefinitionNode>;
     value: any;
 }
 
@@ -610,8 +611,8 @@ export interface GraphQLEnumValue {
  */
 export class GraphQLInputObjectType {
     name: string;
-    description: string | void;
-    astNode: InputObjectTypeDefinitionNode | void;
+    description: Maybe<string>;
+    astNode: Maybe<InputObjectTypeDefinitionNode>;
     constructor(config: GraphQLInputObjectTypeConfig);
     getFields(): GraphQLInputFieldMap;
     toString(): string;
@@ -622,15 +623,15 @@ export class GraphQLInputObjectType {
 export interface GraphQLInputObjectTypeConfig {
     name: string;
     fields: Thunk<GraphQLInputFieldConfigMap>;
-    description?: string | void;
-    astNode?: InputObjectTypeDefinitionNode | void;
+    description?: Maybe<string>;
+    astNode?: Maybe<InputObjectTypeDefinitionNode>;
 }
 
 export interface GraphQLInputFieldConfig {
     type: GraphQLInputType;
     defaultValue?: any;
-    description?: string | void;
-    astNode?: InputValueDefinitionNode | void;
+    description?: Maybe<string>;
+    astNode?: Maybe<InputValueDefinitionNode>;
 }
 
 export type GraphQLInputFieldConfigMap = {
@@ -641,8 +642,8 @@ export interface GraphQLInputField {
     name: string;
     type: GraphQLInputType;
     defaultValue?: any;
-    description?: string | void;
-    astNode?: InputValueDefinitionNode | void;
+    description?: Maybe<string>;
+    astNode?: Maybe<InputValueDefinitionNode>;
 }
 
 export type GraphQLInputFieldMap = { [key: string]: GraphQLInputField };

--- a/types/graphql/type/definition.d.ts
+++ b/types/graphql/type/definition.d.ts
@@ -1,3 +1,4 @@
+import Maybe from "../tsutils/Maybe";
 import { MaybePromise } from "../jsutils/MaybePromise";
 import {
     ScalarTypeDefinitionNode,
@@ -17,7 +18,6 @@ import {
     ValueNode,
 } from "../language/ast";
 import { GraphQLSchema } from "./schema";
-import Maybe from "../Maybe";
 
 /**
  * These are all of the possible kinds of types.

--- a/types/graphql/type/directives.d.ts
+++ b/types/graphql/type/directives.d.ts
@@ -1,7 +1,7 @@
+import Maybe from "../tsutils/Maybe";
 import { GraphQLFieldConfigArgumentMap, GraphQLArgument } from "./definition";
 import { DirectiveDefinitionNode } from "../language/ast";
 import { DirectiveLocationEnum } from "../language/directiveLocation";
-import Maybe from "../Maybe";
 
 /**
  * Test if the given value is a GraphQL directive.

--- a/types/graphql/type/directives.d.ts
+++ b/types/graphql/type/directives.d.ts
@@ -1,6 +1,7 @@
 import { GraphQLFieldConfigArgumentMap, GraphQLArgument } from "./definition";
 import { DirectiveDefinitionNode } from "../language/ast";
 import { DirectiveLocationEnum } from "../language/directiveLocation";
+import Maybe from "../Maybe";
 
 /**
  * Test if the given value is a GraphQL directive.
@@ -13,20 +14,20 @@ export function isDirective(directive: any): directive is GraphQLDirective;
  */
 export class GraphQLDirective {
     name: string;
-    description: string | void;
+    description: Maybe<string>;
     locations: DirectiveLocationEnum[];
     args: GraphQLArgument[];
-    astNode: DirectiveDefinitionNode | void;
+    astNode: Maybe<DirectiveDefinitionNode>;
 
     constructor(config: GraphQLDirectiveConfig);
 }
 
 export interface GraphQLDirectiveConfig {
     name: string;
-    description?: string | void;
+    description?: Maybe<string>;
     locations: DirectiveLocationEnum[];
-    args?: GraphQLFieldConfigArgumentMap | void;
-    astNode?: DirectiveDefinitionNode | void;
+    args?: Maybe<GraphQLFieldConfigArgumentMap>;
+    astNode?: Maybe<DirectiveDefinitionNode>;
 }
 
 /**

--- a/types/graphql/type/schema.d.ts
+++ b/types/graphql/type/schema.d.ts
@@ -2,6 +2,7 @@ import { GraphQLObjectType } from "./definition";
 import { GraphQLType, GraphQLNamedType, GraphQLAbstractType } from "./definition";
 import { SchemaDefinitionNode } from "../language/ast";
 import { GraphQLDirective } from "./directives";
+import Maybe from "../Maybe";
 
 /**
  * Test if the given value is a GraphQL schema.
@@ -35,21 +36,21 @@ export function isSchema(schema: any): schema is GraphQLSchema;
  *
  */
 export class GraphQLSchema {
-    astNode: SchemaDefinitionNode | void;
+    astNode: Maybe<SchemaDefinitionNode>;
 
     constructor(config: GraphQLSchemaConfig);
 
-    getQueryType(): GraphQLObjectType | void;
-    getMutationType(): GraphQLObjectType | void;
-    getSubscriptionType(): GraphQLObjectType | void;
+    getQueryType(): Maybe<GraphQLObjectType>;
+    getMutationType(): Maybe<GraphQLObjectType>;
+    getSubscriptionType(): Maybe<GraphQLObjectType>;
     getTypeMap(): TypeMap;
-    getType(name: string): GraphQLNamedType | void;
+    getType(name: string): Maybe<GraphQLNamedType>;
     getPossibleTypes(abstractType: GraphQLAbstractType): ReadonlyArray<GraphQLObjectType>;
 
     isPossibleType(abstractType: GraphQLAbstractType, possibleType: GraphQLObjectType): boolean;
 
     getDirectives(): ReadonlyArray<GraphQLDirective>;
-    getDirective(name: string): GraphQLDirective | void;
+    getDirective(name: string): Maybe<GraphQLDirective>;
 }
 
 type TypeMap = { [key: string]: GraphQLNamedType };
@@ -72,14 +73,14 @@ export interface GraphQLSchemaValidationOptions {
      * This option is provided to ease adoption and may be removed in a future
      * major release.
      */
-    allowedLegacyNames?: ReadonlyArray<string> | void;
+    allowedLegacyNames?: Maybe<ReadonlyArray<string>>;
 }
 
 export interface GraphQLSchemaConfig extends GraphQLSchemaValidationOptions {
-    query: GraphQLObjectType | void;
-    mutation?: GraphQLObjectType | void;
-    subscription?: GraphQLObjectType | void;
-    types?: GraphQLNamedType[] | void;
-    directives?: GraphQLDirective[] | void;
-    astNode?: SchemaDefinitionNode | void;
+    query: Maybe<GraphQLObjectType>;
+    mutation?: Maybe<GraphQLObjectType>;
+    subscription?: Maybe<GraphQLObjectType>;
+    types?: Maybe<GraphQLNamedType[]>;
+    directives?: Maybe<GraphQLDirective[]>;
+    astNode?: Maybe<SchemaDefinitionNode>;
 }

--- a/types/graphql/type/schema.d.ts
+++ b/types/graphql/type/schema.d.ts
@@ -1,8 +1,8 @@
+import Maybe from "../tsutils/Maybe";
 import { GraphQLObjectType } from "./definition";
 import { GraphQLType, GraphQLNamedType, GraphQLAbstractType } from "./definition";
 import { SchemaDefinitionNode } from "../language/ast";
 import { GraphQLDirective } from "./directives";
-import Maybe from "../Maybe";
 
 /**
  * Test if the given value is a GraphQL schema.

--- a/types/graphql/utilities/TypeInfo.d.ts
+++ b/types/graphql/utilities/TypeInfo.d.ts
@@ -10,6 +10,7 @@ import {
 } from "../type/definition";
 import { GraphQLDirective } from "../type/directives";
 import { ASTNode, FieldNode } from "../language/ast";
+import Maybe from "../Maybe";
 
 /**
  * TypeInfo is a utility class which, given a GraphQL schema, can keep track
@@ -28,14 +29,15 @@ export class TypeInfo {
         initialType?: GraphQLType
     );
 
-    getType(): GraphQLOutputType | void;
-    getParentType(): GraphQLCompositeType | void;
-    getInputType(): GraphQLInputType | void;
-    getParentInputType(): GraphQLInputType | void;
-    getFieldDef(): GraphQLField<any, any> | void;
-    getDirective(): GraphQLDirective | void;
-    getArgument(): GraphQLArgument | void;
-    getEnumValue(): GraphQLEnumValue | void;
+    getType(): Maybe<GraphQLOutputType>;
+    getParentType(): Maybe<GraphQLCompositeType>;
+    getInputType(): Maybe<GraphQLInputType>;
+    getParentInputType(): Maybe<GraphQLInputType>;
+    getFieldDef(): GraphQLField<any, Maybe<any>>;
+    getDefaultValue(): Maybe<any>;
+    getDirective(): Maybe<GraphQLDirective>;
+    getArgument(): Maybe<GraphQLArgument>;
+    getEnumValue(): Maybe<GraphQLEnumValue>;
     enter(node: ASTNode): any;
     leave(node: ASTNode): any;
 }
@@ -44,4 +46,4 @@ type getFieldDef = (
     schema: GraphQLSchema,
     parentType: GraphQLType,
     fieldNode: FieldNode
-) => GraphQLField<any, any> | void;
+) => Maybe<GraphQLField<any, any>>;

--- a/types/graphql/utilities/TypeInfo.d.ts
+++ b/types/graphql/utilities/TypeInfo.d.ts
@@ -1,3 +1,4 @@
+import Maybe from "../tsutils/Maybe";
 import { GraphQLSchema } from "../type/schema";
 import {
     GraphQLOutputType,
@@ -10,7 +11,6 @@ import {
 } from "../type/definition";
 import { GraphQLDirective } from "../type/directives";
 import { ASTNode, FieldNode } from "../language/ast";
-import Maybe from "../Maybe";
 
 /**
  * TypeInfo is a utility class which, given a GraphQL schema, can keep track

--- a/types/graphql/utilities/astFromValue.d.ts
+++ b/types/graphql/utilities/astFromValue.d.ts
@@ -1,5 +1,6 @@
 import { ValueNode } from "../language/ast";
 import { GraphQLInputType } from "../type/definition";
+import Maybe from "../Maybe";
 
 /**
  * Produces a GraphQL Value AST given a JavaScript value.
@@ -18,4 +19,4 @@ import { GraphQLInputType } from "../type/definition";
  * | null          | NullValue            |
  *
  */
-export function astFromValue(value: any, type: GraphQLInputType): ValueNode | void;
+export function astFromValue(value: any, type: GraphQLInputType): Maybe<ValueNode>;

--- a/types/graphql/utilities/astFromValue.d.ts
+++ b/types/graphql/utilities/astFromValue.d.ts
@@ -1,6 +1,6 @@
+import Maybe from "../tsutils/Maybe";
 import { ValueNode } from "../language/ast";
 import { GraphQLInputType } from "../type/definition";
-import Maybe from "../Maybe";
 
 /**
  * Produces a GraphQL Value AST given a JavaScript value.

--- a/types/graphql/utilities/buildASTSchema.d.ts
+++ b/types/graphql/utilities/buildASTSchema.d.ts
@@ -1,3 +1,4 @@
+import Maybe from "../tsutils/Maybe";
 import {
     DocumentNode,
     Location,
@@ -13,7 +14,6 @@ import { Source } from "../language/source";
 import { GraphQLSchema, GraphQLSchemaValidationOptions } from "../type/schema";
 import { ParseOptions } from "../language/parser";
 import blockStringValue from "../language/blockStringValue";
-import Maybe from "../Maybe";
 
 interface BuildSchemaOptions extends GraphQLSchemaValidationOptions {
     /**

--- a/types/graphql/utilities/buildASTSchema.d.ts
+++ b/types/graphql/utilities/buildASTSchema.d.ts
@@ -13,6 +13,7 @@ import { Source } from "../language/source";
 import { GraphQLSchema, GraphQLSchemaValidationOptions } from "../type/schema";
 import { ParseOptions } from "../language/parser";
 import blockStringValue from "../language/blockStringValue";
+import Maybe from "../Maybe";
 
 interface BuildSchemaOptions extends GraphQLSchemaValidationOptions {
     /**
@@ -47,7 +48,7 @@ type TypeDefinitionsMap = { [key: string]: TypeDefinitionNode };
 type TypeResolver = (typeRef: NamedTypeNode) => GraphQLNamedType;
 
 export class ASTDefinitionBuilder {
-    constructor(typeDefinitionsMap: TypeDefinitionsMap, options: BuildSchemaOptions | void, resolveType: TypeResolver);
+    constructor(typeDefinitionsMap: TypeDefinitionsMap, options: Maybe<BuildSchemaOptions>, resolveType: TypeResolver);
 
     buildTypes(nodes: ReadonlyArray<NamedTypeNode | TypeDefinitionNode>): Array<GraphQLNamedType>;
 
@@ -69,7 +70,7 @@ export class ASTDefinitionBuilder {
  */
 export function getDescription(
     node: { readonly description?: StringValueNode; readonly loc?: Location },
-    options: BuildSchemaOptions | void
+    options: Maybe<BuildSchemaOptions>
 ): string | undefined;
 
 /**

--- a/types/graphql/utilities/getOperationAST.d.ts
+++ b/types/graphql/utilities/getOperationAST.d.ts
@@ -1,4 +1,5 @@
 import { DocumentNode, OperationDefinitionNode } from "../language/ast";
+import Maybe from "../Maybe";
 
 /**
  * Returns an operation AST given a document AST and optionally an operation
@@ -7,5 +8,5 @@ import { DocumentNode, OperationDefinitionNode } from "../language/ast";
  */
 export function getOperationAST(
     documentAST: DocumentNode,
-    operationName: string | void
-): OperationDefinitionNode | void;
+    operationName: Maybe<string>
+): Maybe<OperationDefinitionNode>;

--- a/types/graphql/utilities/getOperationAST.d.ts
+++ b/types/graphql/utilities/getOperationAST.d.ts
@@ -1,5 +1,5 @@
+import Maybe from "../tsutils/Maybe";
 import { DocumentNode, OperationDefinitionNode } from "../language/ast";
-import Maybe from "../Maybe";
 
 /**
  * Returns an operation AST given a document AST and optionally an operation

--- a/types/graphql/utilities/introspectionQuery.d.ts
+++ b/types/graphql/utilities/introspectionQuery.d.ts
@@ -1,5 +1,5 @@
+import Maybe from "../tsutils/Maybe";
 import { DirectiveLocationEnum } from "../language/directiveLocation";
-import Maybe from "../Maybe";
 
 export interface IntrospectionOptions {
     // Whether to include descriptions in the introspection result.

--- a/types/graphql/utilities/introspectionQuery.d.ts
+++ b/types/graphql/utilities/introspectionQuery.d.ts
@@ -1,4 +1,5 @@
 import { DirectiveLocationEnum } from "../language/directiveLocation";
+import Maybe from "../Maybe";
 
 export interface IntrospectionOptions {
     // Whether to include descriptions in the introspection result.
@@ -16,8 +17,8 @@ export interface IntrospectionQuery {
 
 export interface IntrospectionSchema {
     readonly queryType: IntrospectionNamedTypeRef<IntrospectionObjectType>;
-    readonly mutationType: IntrospectionNamedTypeRef<IntrospectionObjectType> | void;
-    readonly subscriptionType: IntrospectionNamedTypeRef<IntrospectionObjectType> | void;
+    readonly mutationType: Maybe<IntrospectionNamedTypeRef<IntrospectionObjectType>>;
+    readonly subscriptionType: Maybe<IntrospectionNamedTypeRef<IntrospectionObjectType>>;
     readonly types: ReadonlyArray<IntrospectionType>;
     readonly directives: ReadonlyArray<IntrospectionDirective>;
 }
@@ -42,13 +43,13 @@ export type IntrospectionInputType = IntrospectionScalarType | IntrospectionEnum
 export interface IntrospectionScalarType {
     readonly kind: "SCALAR";
     readonly name: string;
-    readonly description?: string | void;
+    readonly description?: Maybe<string>;
 }
 
 export interface IntrospectionObjectType {
     readonly kind: "OBJECT";
     readonly name: string;
-    readonly description?: string | void;
+    readonly description?: Maybe<string>;
     readonly fields: ReadonlyArray<IntrospectionField>;
     readonly interfaces: ReadonlyArray<IntrospectionNamedTypeRef<IntrospectionInterfaceType>>;
 }
@@ -56,7 +57,7 @@ export interface IntrospectionObjectType {
 export interface IntrospectionInterfaceType {
     readonly kind: "INTERFACE";
     readonly name: string;
-    readonly description?: string | void;
+    readonly description?: Maybe<string>;
     readonly fields: ReadonlyArray<IntrospectionField>;
     readonly possibleTypes: ReadonlyArray<IntrospectionNamedTypeRef<IntrospectionObjectType>>;
 }
@@ -64,21 +65,21 @@ export interface IntrospectionInterfaceType {
 export interface IntrospectionUnionType {
     readonly kind: "UNION";
     readonly name: string;
-    readonly description?: string | void;
+    readonly description?: Maybe<string>;
     readonly possibleTypes: ReadonlyArray<IntrospectionNamedTypeRef<IntrospectionObjectType>>;
 }
 
 export interface IntrospectionEnumType {
     readonly kind: "ENUM";
     readonly name: string;
-    readonly description?: string | void;
+    readonly description?: Maybe<string>;
     readonly enumValues: ReadonlyArray<IntrospectionEnumValue>;
 }
 
 export interface IntrospectionInputObjectType {
     readonly kind: "INPUT_OBJECT";
     readonly name: string;
-    readonly description?: string | void;
+    readonly description?: Maybe<string>;
     readonly inputFields: ReadonlyArray<IntrospectionInputValue>;
 }
 
@@ -114,30 +115,30 @@ export interface IntrospectionNamedTypeRef<T extends IntrospectionType = Introsp
 
 export interface IntrospectionField {
     readonly name: string;
-    readonly description?: string | void;
+    readonly description?: Maybe<string>;
     readonly args: ReadonlyArray<IntrospectionInputValue>;
     readonly type: IntrospectionOutputTypeRef;
     readonly isDeprecated: boolean;
-    readonly deprecationReason?: string | void;
+    readonly deprecationReason?: Maybe<string>;
 }
 
 export interface IntrospectionInputValue {
     readonly name: string;
-    readonly description?: string | void;
+    readonly description?: Maybe<string>;
     readonly type: IntrospectionInputTypeRef;
-    readonly defaultValue?: string | void;
+    readonly defaultValue?: Maybe<string>;
 }
 
 export interface IntrospectionEnumValue {
     readonly name: string;
-    readonly description?: string | void;
+    readonly description?: Maybe<string>;
     readonly isDeprecated: boolean;
-    readonly deprecationReason?: string | void;
+    readonly deprecationReason?: Maybe<string>;
 }
 
 export interface IntrospectionDirective {
     readonly name: string;
-    readonly description?: string | void;
+    readonly description?: Maybe<string>;
     readonly locations: ReadonlyArray<DirectiveLocationEnum>;
     readonly args: ReadonlyArray<IntrospectionInputValue>;
 }

--- a/types/graphql/utilities/valueFromAST.d.ts
+++ b/types/graphql/utilities/valueFromAST.d.ts
@@ -1,6 +1,6 @@
+import Maybe from "../tsutils/Maybe";
 import { GraphQLInputType } from "../type/definition";
 import { ValueNode, VariableNode, ListValueNode, ObjectValueNode } from "../language/ast";
-import Maybe from "../Maybe";
 
 /**
  * Produces a JavaScript value given a GraphQL Value AST.

--- a/types/graphql/utilities/valueFromAST.d.ts
+++ b/types/graphql/utilities/valueFromAST.d.ts
@@ -1,5 +1,6 @@
 import { GraphQLInputType } from "../type/definition";
 import { ValueNode, VariableNode, ListValueNode, ObjectValueNode } from "../language/ast";
+import Maybe from "../Maybe";
 
 /**
  * Produces a JavaScript value given a GraphQL Value AST.
@@ -22,7 +23,7 @@ import { ValueNode, VariableNode, ListValueNode, ObjectValueNode } from "../lang
  *
  */
 export function valueFromAST(
-    valueNode: ValueNode | void,
+    valueNode: Maybe<ValueNode>,
     type: GraphQLInputType,
-    variables?: { [key: string]: any } | void
+    variables?: Maybe<{ [key: string]: any }>
 ): any;

--- a/types/graphql/utilities/valueFromASTUntyped.d.ts
+++ b/types/graphql/utilities/valueFromASTUntyped.d.ts
@@ -1,5 +1,5 @@
+import Maybe from "../tsutils/Maybe";
 import { ValueNode } from "../language/ast";
-import Maybe from "../Maybe";
 
 /**
  * Produces a JavaScript value given a GraphQL Value AST.

--- a/types/graphql/utilities/valueFromASTUntyped.d.ts
+++ b/types/graphql/utilities/valueFromASTUntyped.d.ts
@@ -1,4 +1,5 @@
 import { ValueNode } from "../language/ast";
+import Maybe from "../Maybe";
 
 /**
  * Produces a JavaScript value given a GraphQL Value AST.
@@ -16,4 +17,4 @@ import { ValueNode } from "../language/ast";
  * | Null                 | null             |
  *
  */
-export function valueFromASTUntyped(valueNode: ValueNode, variables?: { [key: string]: any } | void): any;
+export function valueFromASTUntyped(valueNode: ValueNode, variables?: Maybe<{ [key: string]: any }>): any;

--- a/types/graphql/validation/ValidationContext.d.ts
+++ b/types/graphql/validation/ValidationContext.d.ts
@@ -1,3 +1,4 @@
+import Maybe from "../tsutils/Maybe";
 import { GraphQLError } from "../error";
 import {
     DocumentNode,
@@ -17,7 +18,6 @@ import {
 } from "../type/definition";
 import { GraphQLDirective } from "../type/directives";
 import { TypeInfo } from "../utilities/TypeInfo";
-import Maybe from "../Maybe";
 
 type NodeWithSelectionSet = OperationDefinitionNode | FragmentDefinitionNode;
 type VariableUsage = {

--- a/types/graphql/validation/ValidationContext.d.ts
+++ b/types/graphql/validation/ValidationContext.d.ts
@@ -17,9 +17,14 @@ import {
 } from "../type/definition";
 import { GraphQLDirective } from "../type/directives";
 import { TypeInfo } from "../utilities/TypeInfo";
+import Maybe from "../Maybe";
 
 type NodeWithSelectionSet = OperationDefinitionNode | FragmentDefinitionNode;
-type VariableUsage = { node: VariableNode; type: GraphQLInputType | void };
+type VariableUsage = {
+    readonly node: VariableNode;
+    readonly type: Maybe<GraphQLInputType>;
+    readonly defaultValue: Maybe<any>;
+};
 
 /**
  * An instance of this class is passed as the "this" context to all validators,
@@ -37,7 +42,7 @@ export default class ValidationContext {
 
     getDocument(): DocumentNode;
 
-    getFragment(name: string): FragmentDefinitionNode | void;
+    getFragment(name: string): Maybe<FragmentDefinitionNode>;
 
     getFragmentSpreads(node: SelectionSetNode): ReadonlyArray<FragmentSpreadNode>;
 
@@ -47,17 +52,17 @@ export default class ValidationContext {
 
     getRecursiveVariableUsages(operation: OperationDefinitionNode): ReadonlyArray<VariableUsage>;
 
-    getType(): GraphQLOutputType | void;
+    getType(): Maybe<GraphQLOutputType>;
 
-    getParentType(): GraphQLCompositeType | void;
+    getParentType(): Maybe<GraphQLCompositeType>;
 
-    getInputType(): GraphQLInputType | void;
+    getInputType(): Maybe<GraphQLInputType>;
 
-    getParentInputType(): GraphQLInputType | void;
+    getParentInputType(): Maybe<GraphQLInputType>;
 
-    getFieldDef(): GraphQLField<any, any> | void;
+    getFieldDef(): Maybe<GraphQLField<any, any>>;
 
-    getDirective(): GraphQLDirective | void;
+    getDirective(): Maybe<GraphQLDirective>;
 
-    getArgument(): GraphQLArgument | void;
+    getArgument(): Maybe<GraphQLArgument>;
 }

--- a/types/graphql/validation/rules/NoUndefinedVariables.d.ts
+++ b/types/graphql/validation/rules/NoUndefinedVariables.d.ts
@@ -1,7 +1,8 @@
 import ValidationContext from "../ValidationContext";
 import { ASTVisitor } from "../../language/visitor";
+import Maybe from "../../Maybe";
 
-export function undefinedVarMessage(varName: string, opName: string | void): string;
+export function undefinedVarMessage(varName: string, opName: Maybe<string>): string;
 
 /**
  * No undefined variables

--- a/types/graphql/validation/rules/NoUndefinedVariables.d.ts
+++ b/types/graphql/validation/rules/NoUndefinedVariables.d.ts
@@ -1,6 +1,6 @@
+import Maybe from "../../tsutils/Maybe";
 import ValidationContext from "../ValidationContext";
 import { ASTVisitor } from "../../language/visitor";
-import Maybe from "../../Maybe";
 
 export function undefinedVarMessage(varName: string, opName: Maybe<string>): string;
 

--- a/types/graphql/validation/rules/NoUnusedVariables.d.ts
+++ b/types/graphql/validation/rules/NoUnusedVariables.d.ts
@@ -1,6 +1,6 @@
+import Maybe from "../../tsutils/Maybe";
 import ValidationContext from "../ValidationContext";
 import { ASTVisitor } from "../../language/visitor";
-import Maybe from "../../Maybe";
 
 export function unusedVariableMessage(varName: string, opName: Maybe<string>): string;
 

--- a/types/graphql/validation/rules/NoUnusedVariables.d.ts
+++ b/types/graphql/validation/rules/NoUnusedVariables.d.ts
@@ -1,7 +1,8 @@
 import ValidationContext from "../ValidationContext";
 import { ASTVisitor } from "../../language/visitor";
+import Maybe from "../../Maybe";
 
-export function unusedVariableMessage(varName: string, opName: string | void): string;
+export function unusedVariableMessage(varName: string, opName: Maybe<string>): string;
 
 /**
  * No unused variables

--- a/types/graphql/validation/rules/SingleFieldSubscriptions.d.ts
+++ b/types/graphql/validation/rules/SingleFieldSubscriptions.d.ts
@@ -1,7 +1,8 @@
 import ValidationContext from "../ValidationContext";
 import { ASTVisitor } from "../../language/visitor";
+import Maybe from "../../Maybe";
 
-export function singleFieldOnlyMessage(name: string | void): string;
+export function singleFieldOnlyMessage(name: Maybe<string>): string;
 
 /**
  * Subscriptions must only include one field.

--- a/types/graphql/validation/rules/SingleFieldSubscriptions.d.ts
+++ b/types/graphql/validation/rules/SingleFieldSubscriptions.d.ts
@@ -1,6 +1,6 @@
+import Maybe from "../../tsutils/Maybe";
 import ValidationContext from "../ValidationContext";
 import { ASTVisitor } from "../../language/visitor";
-import Maybe from "../../Maybe";
 
 export function singleFieldOnlyMessage(name: Maybe<string>): string;
 


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:

As per the discussion on the end of https://github.com/DefinitelyTyped/DefinitelyTyped/pull/24566.

The last set of typings changed some of the return/argument types from `| undefined` to `| void`. Whilst this is technically correct in terms of javascript meaning, the void type is intended to mean something different in typescript, they ultimately are harder to work with.
I reviewed the changes, and the the types that were changed to `| void`, were all [`Maybe`](https://flow.org/en/docs/types/maybe/) types in flow.
I.e. flow: `const x : ?string`, typescript: `const x : string | null | undefined`.

This PR changes the types to be inline with the meaning listed in the source flow code.