### PR TITLE
Fixing chai-jest-snapshot export to match package

### DIFF
--- a/types/chai-jest-snapshot/chai-jest-snapshot-tests.ts
+++ b/types/chai-jest-snapshot/chai-jest-snapshot-tests.ts
@@ -1,4 +1,4 @@
-import chaiJestSnapshot from 'chai-jest-snapshot';
+import * as chaiJestSnapshot from 'chai-jest-snapshot';
 import { expect } from 'chai';
 
 chai.use(chaiJestSnapshot);

--- a/types/chai-jest-snapshot/index.d.ts
+++ b/types/chai-jest-snapshot/index.d.ts
@@ -40,4 +40,4 @@ interface ChaiJestSnapshot {
 }
 
 declare var ChaiJestSnapshot: ChaiJestSnapshot;
-export default ChaiJestSnapshot;
+export = ChaiJestSnapshot;


### PR DESCRIPTION
chai-jest-snapshots doesn't use `export default`, so
`import * as chaiJestSnapshots from 'chai-jest-snapshots'` gives compiler errors and
`import chaiJestSnapshots from 'chai-jest-snapshots'` gives runtime errors

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x]Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/suchipi/chai-jest-snapshot/blob/master/src/index.js#L70
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
