### PR TITLE
[@types/react] fix multiline comments

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -1054,8 +1054,7 @@ declare namespace React {
         /** Indicates whether the element, or another grouping element it controls, is currently expanded or collapsed. */
         'aria-expanded'?: boolean | 'false' | 'true';
         /**
-         * Identifies the next element (or elements) in an alternate reading order of content which, at the user's discretion,
-         * allows assistive technology to override the general default of reading in document source order.
+         * Identifies the next element (or elements) in an alternate reading order of content which, at the user's discretion, allows assistive technology to override the general default of reading in document source order.
          */
         'aria-flowto'?: string;
         /**
@@ -1100,14 +1099,12 @@ declare namespace React {
         /** Indicates whether the element's orientation is horizontal, vertical, or unknown/ambiguous. */
         'aria-orientation'?: 'horizontal' | 'vertical';
         /**
-         * Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship
-         * between DOM elements where the DOM hierarchy cannot be used to represent the relationship.
+         * Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship between DOM elements where the DOM hierarchy cannot be used to represent the relationship.
          * @see aria-controls.
          */
         'aria-owns'?: string;
         /**
-         * Defines a short hint (a word or short phrase) intended to aid the user with data entry when the control has no value.
-         * A hint could be a sample value or a brief description of the expected format.
+         * Defines a short hint (a word or short phrase) intended to aid the user with data entry when the control has no value. A hint could be a sample value or a brief description of the expected format.
          */
         'aria-placeholder'?: string;
         /**

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -994,8 +994,7 @@ declare namespace React {
         /** Indicates whether assistive technologies will present all, or only parts of, the changed region based on the change notifications defined by the aria-relevant attribute. */
         'aria-atomic'?: boolean | 'false' | 'true';
         /**
-         * Indicates whether inputting text could trigger display of one or more predictions of the user's intended value for an input and specifies how predictions would be
-         * presented if they are made.
+         * Indicates whether inputting text could trigger display of one or more predictions of the user's intended value for an input and specifies how predictions would be presented if they are made.
          */
         'aria-autocomplete'?: 'none' | 'inline' | 'list' | 'both';
         /** Indicates an element is being modified and that assistive technologies MAY want to wait until the modifications are complete before exposing them to the user. */


### PR DESCRIPTION
multiline comments break things downstream with typescript docgen prop inference, and is unnecessary to be multiline. so i suggest removing these three multilines.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

just changing a comment. low impact PR.