### PR TITLE
Event Stream: Make split argument optional

### DIFF
--- a/types/event-stream/index.d.ts
+++ b/types/event-stream/index.d.ts
@@ -36,7 +36,7 @@ export declare function mapSync(syncFunction: Function):  MapStream;
  * 
  * @param matcher
  */
-export declare function split(matcher: string | RegExp):  MapStream;
+export declare function split(matcher?: string | RegExp):  MapStream;
 
 /**
  * Create a through stream that emits separator between each chunk, just like Array#join


### PR DESCRIPTION
Simple change to make an argument optional.
As you can see in the [documentation](https://www.npmjs.com/package/event-stream) in npm, `es.split()` does not require an argument.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.