### PR TITLE
README: Add a link about major version update

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -87,6 +87,7 @@ Primero, haz un [fork](https://guides.github.com/activities/forking/) en este re
 
 * `cd types/my-package-to-edit`
 * Haz cambios. Recuerda editar las pruebas.
+  Si realiza cambios importantes, no olvide [actualizar una versión principal](#quiero-actualizar-un-paquete-a-una-nueva-versión-principal).
 * También puede que quieras añadirte la sección "Definitions by" en el encabezado del paquete.
   - Esto hará que seas notificado (a través de tu nombre de usuario en GitHub) cada vez que alguien haga un pull request o issue sobre el paquete.
   - Haz esto añadiendo tu nombre al final de la línea, así como en `// Definitions by: Alice <https://github.com/alice>, Bob <https://github.com/bob>`.

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ First, [fork](https://guides.github.com/activities/forking/) this repository, in
 
 * `cd types/my-package-to-edit`
 * Make changes. Remember to edit tests.
+  If you make breaking changes, do not forget to [update a major version](#i-want-to-update-a-package-to-a-new-major-version).
 * You may also want to add yourself to "Definitions by" section of the package header.
   - This will cause you to be notified (via your GitHub username) whenever someone makes a pull request or issue about the package.
   - Do this by adding your name to the end of the line, as in `// Definitions by: Alice <https://github.com/alice>, Bob <https://github.com/bob>`.


### PR DESCRIPTION
Hi, 
This is a proposal of tiny README update. I think the [`Make a pull request`][make-a-pull-request] section should contain a link to the description about [a way of major version update][major-version-update] in FAQ.

Since the current `PULL_REQUEST_TEMPLATE.md` refers to only the `Make a pull request` section, new contributors could overlook that FAQ section when they create a pull request with some breaking changes (actually I missed it and it resulted in #25321).
This update could reduce such situations.

BTW  I don't know Spanish at all so I used Google Translate to edit `README.es.md`.

[make-a-pull-request]: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/e199aed403b6d0052546da0cc21c571c57d5c383#make-a-pull-request
[major-version-update]: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/e199aed403b6d0052546da0cc21c571c57d5c383#i-want-to-update-a-package-to-a-new-major-version

----

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).


