### PR TITLE
Expand google-map-react options spec to cover all valid options

### DIFF
--- a/types/google-map-react/google-map-react-tests.tsx
+++ b/types/google-map-react/google-map-react-tests.tsx
@@ -1,9 +1,20 @@
-import GoogleMapReact, { BootstrapURLKeys } from 'google-map-react';
+import GoogleMapReact, { BootstrapURLKeys, MapOptions } from 'google-map-react';
 import * as React from 'react';
 
 const center = { lat: 0, lng: 0 };
 
 const key: BootstrapURLKeys = { key: 'my-google-maps-key' };
 const client: BootstrapURLKeys = { client: 'my-client-identifier', v: '3.28' , language: 'en' };
+const options: MapOptions = {
+    zoomControl: false,
+    gestureHandling: 'cooperative',
+    styles: [
+        {
+            featureType: "administrative",
+            elementType: "all",
+            stylers: [ {saturation: "-100"} ]
+        }
+    ],
+};
 
-<GoogleMapReact center={center} zoom={3} bootstrapURLKeys={client}/>;
+<GoogleMapReact center={center} zoom={3} bootstrapURLKeys={client} options={options} />;

--- a/types/google-map-react/index.d.ts
+++ b/types/google-map-react/index.d.ts
@@ -8,15 +8,48 @@ import * as React from 'react';
 
 export type BootstrapURLKeys = ({ key: string; } | { client: string; v: string; }) & { language?: string };
 
-export interface Options {
-  styles?: any[];
-  scrollwheel?: boolean;
-  panControl?: boolean;
+export interface MapTypeStyle {
+  elementType: string;
+  featureType: string;
+  stylers: any[];
+}
+
+export interface MapOptions {
+  // Any options from https://developers.google.com/maps/documentation/javascript/reference/3/#MapOptions
+  // excluding 'zoom' and 'center' which get set via props.
+  backgroundColor?: string;
+  clickableIcons?: boolean;
+  disableDefaultUI?: boolean;
+  disableDoubleClickZoom?: boolean;
+  draggable?: boolean;
+  draggableCursor?: string;
+  draggingCursor?: string;
+  fullscreenControl?: boolean;
+  fullscreenControlOptions?: {position: number};
+  gestureHandling?: string;
+  heading?: number;
+  keyboardShortcuts?: boolean;
   mapTypeControl?: boolean;
-  minZoomOverride?: boolean;
+  mapTypeControlOptions?: any;
+  mapTypeId?: string;
   minZoom?: number;
   maxZoom?: number;
-  gestureHandling?: string;
+  noClear?: boolean;
+  panControl?: boolean;
+  panControlOptions?: {position: number};
+  rotateControl?: boolean;
+  rotateControlOptions?: {position: number};
+  scaleControl?: boolean;
+  scaleControlOptions?: any;
+  scrollwheel?: boolean;
+  streetView?: any;
+  streetViewControl?: boolean;
+  streetViewControlOptions?: {position: number};
+  styles?: MapTypeStyle[];
+  tilt?: number;
+  zoomControl?: boolean;
+  zoomControlOptions?: {position: number};
+  minZoomOverride?: boolean; // Not a standard option; specific to google-map-react: https://github.com/google-map-react/google-map-react/pull/154
 }
 
 export interface Maps {
@@ -87,7 +120,7 @@ export interface Props {
   defaultZoom?: number;
   zoom?: number;
   hoverDistance?: number;
-  options?: Options | ((maps: Maps) => Options);
+  options?: MapOptions | ((maps: Maps) => MapOptions);
   margin?: any[];
   debounced?: boolean;
   draggable?: boolean;


### PR DESCRIPTION
This fixes [the definitions](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/google-map-react) for [google-map-react](https://github.com/google-map-react/google-map-react) so that the `options` parameter will accept all of [the valid map options](https://developers.google.com/maps/documentation/javascript/reference/3/#MapOptions) and not just a subset of them.

This was necessary because I wanted to set the `zoomControl` option, and the previous definitions were flagging it as a type error, even though it works and affects the map.

---------------

PR template:

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developers.google.com/maps/documentation/javascript/reference/3/#MapOptions and https://github.com/google-map-react/google-map-react/blob/4faeeef56d61cfcec6ea2dc6966a4fd29d079175/src/google_map.js#L532-L565
- [ ] Increase the version number in the header if appropriate. n/a, should apply to all versions of google-map-react
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. n/a
