### PR TITLE
select2: jQuery v1 and v2 type definition compatibility

### DIFF
--- a/types/select2/index.d.ts
+++ b/types/select2/index.d.ts
@@ -6,8 +6,35 @@
 // TypeScript Version: 2.3
 
 /// <reference types="jquery"/>
+/// <reference types="requirejs"/>
 
 export as namespace Select2;
+
+// --------------------------------------------------------------------------
+// For jQuery v1 and v2 backward compatibility
+// --------------------------------------------------------------------------
+
+export type Sub<O extends string, D extends string> =
+    {[K in O]: (Record<D, never> & Record<string, K>)[K]}[O];
+
+/**
+ * Same as jQuery v3 `JQuery.AjaxSettingsBase`.
+ */
+export type JQueryAjaxSettingsBase =
+    Pick<JQueryAjaxSettings, Sub<keyof JQueryAjaxSettings, "url">>;
+
+/**
+ * Same as jQuery v3 `JQuery.EventHandlerBase`.
+ */
+export type JQueryEventHandlerBase<TContext extends object, T> =
+    (this: TContext, t: T, ...args: any[]) => void | false;
+
+/**
+ * Same as jQuery v3 `JQuery.PlainObject`.
+ */
+export interface PlainObject<T = any> {
+    [key: string]: T;
+}
 
 // --------------------------------------------------------------------------
 // Some Interfaces
@@ -110,7 +137,7 @@ export interface Translation {
 
 export interface DataParams {
     data: OptionData; // TODO: must be data source
-    originalEvent: JQuery.Event;
+    originalEvent: BaseJQueryEventObject;
 }
 
 export interface IngParams {
@@ -118,7 +145,7 @@ export interface IngParams {
     prevented: boolean;
 }
 
-export interface Event<TElement, T> extends JQuery.Event<TElement, undefined> {
+export interface Event<TElement, T> extends BaseJQueryEventObject {
     params: T;
 }
 
@@ -133,10 +160,10 @@ export interface Trigger {
 // Ajax Option
 // --------------------------------------------------------------------------
 
-export interface AjaxOptions<Result = DataFormat | GroupedDataFormat, RemoteResult = any> extends JQuery.Ajax.AjaxSettingsBase<any> {
+export interface AjaxOptions<Result = DataFormat | GroupedDataFormat, RemoteResult = any> extends JQueryAjaxSettingsBase {
     delay?: number;
     url?: string | ((params: QueryOptions) => string);
-    data?: (params: QueryOptions) => JQuery.PlainObject;
+    data?: (params: QueryOptions) => PlainObject;
     transport?: (settings: JQueryAjaxSettings, success?: (data: RemoteResult) => undefined, failure?: () => undefined) => void;
     processResults?: (data: RemoteResult, params: QueryOptions) => ProcessedResult<Result>;
 }
@@ -195,6 +222,8 @@ export interface Options<Result = DataFormat | GroupedDataFormat, RemoteResult =
 // --------------------------------------------------------------------------
 
 export interface Select2Plugin<TElement extends Node = HTMLElement>  {
+    amd: { require: Require; };
+
     defaults: {
         set: (key: string, value: any) => void;
         reset: () => void;
@@ -230,13 +259,13 @@ declare global {
         trigger(events: Trigger): void;
 
         // TODO: events "change" and "change.select2"
-        on(events: "select2:closing", handler?: JQuery.EventHandlerBase<TElement, Event<TElement, IngParams>>): this;
-        on(events: "select2:close", handler?: JQuery.EventHandlerBase<TElement, Event<TElement, {}>>): this;
-        on(events: "select2:opening", handler?: JQuery.EventHandlerBase<TElement, Event<TElement, IngParams>>): this;
-        on(events: "select2:open", handler?: JQuery.EventHandlerBase<TElement, Event<TElement, {}>>): this;
-        on(events: "select2:selecting", handler?: JQuery.EventHandlerBase<TElement, Event<TElement, IngParams>>): this;
-        on(events: "select2:select", handler?: JQuery.EventHandlerBase<TElement, Event<TElement, DataParams>>): this;
-        on(events: "select2:unselecting", handler?: JQuery.EventHandlerBase<TElement, Event<TElement, IngParams>>): this;
-        on(events: "select2:unselect", handler?: JQuery.EventHandlerBase<TElement, Event<TElement, DataParams>>): this;
+        on(events: "select2:closing", handler?: JQueryEventHandlerBase<TElement, Event<TElement, IngParams>>): this;
+        on(events: "select2:close", handler?: JQueryEventHandlerBase<TElement, Event<TElement, {}>>): this;
+        on(events: "select2:opening", handler?: JQueryEventHandlerBase<TElement, Event<TElement, IngParams>>): this;
+        on(events: "select2:open", handler?: JQueryEventHandlerBase<TElement, Event<TElement, {}>>): this;
+        on(events: "select2:selecting", handler?: JQueryEventHandlerBase<TElement, Event<TElement, IngParams>>): this;
+        on(events: "select2:select", handler?: JQueryEventHandlerBase<TElement, Event<TElement, DataParams>>): this;
+        on(events: "select2:unselecting", handler?: JQueryEventHandlerBase<TElement, Event<TElement, IngParams>>): this;
+        on(events: "select2:unselect", handler?: JQueryEventHandlerBase<TElement, Event<TElement, DataParams>>): this;
     }
 }

--- a/types/select2/index.d.ts
+++ b/types/select2/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Boris Yankov <https://github.com/borisyankov>
 //                 denisname <https://github.com/denisname>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 /// <reference types="jquery"/>
 /// <reference types="requirejs"/>

--- a/types/select2/select2-tests.ts
+++ b/types/select2/select2-tests.ts
@@ -733,6 +733,13 @@ $(".js-example-rtl").select2({
 // =====================================================
 // See: https://select2.org/advanced
 
+$.fn.select2.amd.require(
+    ["select2/utils", "select2/selection/single", "select2/selection/placeholder"],
+    (Utils: any, SingleSelection: any, Placeholder: any) => {
+        const CustomSelectionAdapter = Utils.Decorate(SingleSelection, Placeholder);
+    }
+);
+
 // TODO (Adapters)
 
 // =====================================================


### PR DESCRIPTION
This follows the demand in #25196 for compatibility with jQuery v1 and v2 type definition. See #25548.
Add support for `$.fn.select2.amd`.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://select2.org/advanced/adapters-and-decorators#decorators
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
