### PR TITLE
fix(unzipper): update promise and buffer to be functions, not properties

### DIFF
--- a/types/unzipper/index.d.ts
+++ b/types/unzipper/index.d.ts
@@ -1,109 +1,115 @@
 // Type definitions for unzipper 0.8
 // Project: https://github.com/ZJONSSON/node-unzipper#readme
 // Definitions by: s73obrien <https://github.com/s73obrien>
+//                 Nate <https://github.com/natemara>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.2
 /// <reference types="node" />
 
 import { Readable, Stream, PassThrough, Duplex } from "stream";
 import { ClientRequest, RequestOptions } from "http";
 
 export interface PullStream extends Duplex {
-	stream(eof: number | string, includeEof: boolean): PassThrough;
-	pull(eof: number | string, includeEof: boolean): Promise<Buffer>;
+    stream(eof: number | string, includeEof: boolean): PassThrough;
+    pull(eof: number | string, includeEof: boolean): Promise<Buffer>;
 }
 
 export interface Entry extends PassThrough {
-	autodrain(): Promise<void>;
-	buffer: Promise<Buffer>;
-	path: string;
+    autodrain(): Promise<void>;
+    buffer(): Promise<Buffer>;
+    path: string;
 
-	props: {
-		path: string;
-	};
+    props: {
+        path: string;
+    };
 
-	type: string;
-	vars: {
-		signature?: number;
-		versionsNeededToExtract: number;
-		flags: number;
-		compressionMethod: number;
-		lastModifiedTime: number;
-		crc32: number;
-		compressedSize: number;
-		fileNameLength: number;
-		extraFieldLength: number;
-	};
+    type: string;
+    vars: {
+        signature?: number;
+        versionsNeededToExtract: number;
+        flags: number;
+        compressionMethod: number;
+        lastModifiedTime: number;
+        crc32: number;
+        compressedSize: number;
+        fileNameLength: number;
+        extraFieldLength: number;
+    };
 
-	extra: {
-		signature: number;
-		partsize: number;
-		uncompressedSize: number;
-		compressedSize: number;
-		offset: number;
-		disknum: number;
-	};
+    extra: {
+        signature: number;
+        partsize: number;
+        uncompressedSize: number;
+        compressedSize: number;
+        offset: number;
+        disknum: number;
+    };
 }
 
 export function unzip(
-	source: {
-		stream: Readable;
-		size: Promise<number>
-	},
-	offset: number,
-	_password: string): Entry;
+    source: {
+        stream: Readable;
+        size: Promise<number>;
+    },
+    offset: number,
+    _password: string
+): Entry;
 
 export namespace Open {
-	function file(filename: string): CentralDirectory;
-	function url(request: ClientRequest, opt: string | RequestOptions): CentralDirectory;
-	function s3(client: any, params: any): CentralDirectory;
+    function file(filename: string): CentralDirectory;
+    function url(
+        request: ClientRequest,
+        opt: string | RequestOptions
+    ): CentralDirectory;
+    function s3(client: any, params: any): CentralDirectory;
 }
 
 export function BufferStream(entry: Entry): Promise<Buffer>;
 
 export interface CentralDirectory {
-	signature: number;
-	diskNumber: number;
-	diskStart: number;
-	numberOfRecordsOnDisk: number;
-	numberOfRecords: number;
-	sizeOfCentralDirectory: number;
-	offsetToStartOfCentralDirectory: number;
-	commentLength: number;
-	files: [
-		{
-			signature: number;
-			versionMadeBy: number;
-			versionsNeededToExtract: number;
-			flags: number;
-			compressionMethod: number;
-			lastModifiedTime: number;
-			lastModifiedDate: number;
-			crc32: number;
-			compressedSize: number;
-			uncompressedSize: number;
-			fileNameLength: number;
-			extraFieldLength: number;
-			fileCommentLength: number;
-			diskNumber: number;
-			internalFileAttributes: number;
-			externalFileAttributes: number;
-			offsetToLocalFileHeader: number;
-			path: string;
-			comment: string;
-			stream: Entry;
-			buffer: Promise<Buffer>;
-		}
-	];
+    signature: number;
+    diskNumber: number;
+    diskStart: number;
+    numberOfRecordsOnDisk: number;
+    numberOfRecords: number;
+    sizeOfCentralDirectory: number;
+    offsetToStartOfCentralDirectory: number;
+    commentLength: number;
+    files: [
+        {
+            signature: number;
+            versionMadeBy: number;
+            versionsNeededToExtract: number;
+            flags: number;
+            compressionMethod: number;
+            lastModifiedTime: number;
+            lastModifiedDate: number;
+            crc32: number;
+            compressedSize: number;
+            uncompressedSize: number;
+            fileNameLength: number;
+            extraFieldLength: number;
+            fileCommentLength: number;
+            diskNumber: number;
+            internalFileAttributes: number;
+            externalFileAttributes: number;
+            offsetToLocalFileHeader: number;
+            path: string;
+            comment: string;
+            stream: Entry;
+            buffer: Promise<Buffer>;
+        }
+    ];
 }
 
 export class ParseOptions {
-	verbose?: boolean;
-	path?: string;
-	// more options?
+    verbose?: boolean;
+    path?: string;
+    // more options?
 }
 
 export type ParseStream = PullStream & {
-	promise: Promise<void>
+    promise(): Promise<void>;
 };
 
 export function Parse(opts?: ParseOptions): ParseStream;

--- a/types/unzipper/unzipper-tests.ts
+++ b/types/unzipper/unzipper-tests.ts
@@ -1,44 +1,43 @@
-import {
-	Parse,
-	Open,
-	Entry,
-	CentralDirectory
-} from 'unzipper';
+import { Parse, Open, Entry, CentralDirectory } from "unzipper";
 
-import { createReadStream } from 'fs';
+import { createReadStream } from "fs";
 
-import { get } from 'http';
+import { get } from "http";
 
-createReadStream(
-	'http://example.org/path/to/archive.zip'
-).pipe(
-	Parse()
-).on('entry', (entry: Entry) => {
-	entry.buffer.then((b1: Buffer) => {});
-	const s1: string = entry.path;
-	const s2: string = entry.type;
-	const o1: {
-		signature?: number;
-		versionsNeededToExtract: number;
-		flags: number;
-		compressionMethod: number;
-		lastModifiedTime: number;
-		crc32: number;
-		compressedSize: number;
-		fileNameLength: number;
-		extraFieldLength: number;
-	} = entry.vars;
+createReadStream("http://example.org/path/to/archive.zip")
+    .pipe(Parse())
+    .on("entry", (entry: Entry) => {
+        entry.buffer().then((b1: Buffer) => {});
+        const s1: string = entry.path;
+        const s2: string = entry.type;
+        const o1: {
+            signature?: number;
+            versionsNeededToExtract: number;
+            flags: number;
+            compressionMethod: number;
+            lastModifiedTime: number;
+            crc32: number;
+            compressedSize: number;
+            fileNameLength: number;
+            extraFieldLength: number;
+        } =
+            entry.vars;
 
-	const o2: {
-		signature: number;
-		partsize: number;
-		uncompressedSize: number;
-		compressedSize: number;
-		offset: number;
-		disknum: number;
-	} = entry.extra;
-});
+        const o2: {
+            signature: number;
+            partsize: number;
+            uncompressedSize: number;
+            compressedSize: number;
+            offset: number;
+            disknum: number;
+        } =
+            entry.extra;
+    })
+    .promise()
+    .then(() => {
+        console.log("Finished reading stream");
+    });
 
-const dir1: CentralDirectory = Open.file('Z:\\path\\to\\archive.zip');
-const dir2: CentralDirectory = Open.url(get('url/to/archive.zip'), {});
-const dir3: CentralDirectory = Open.s3('any', 'any');
+const dir1: CentralDirectory = Open.file("Z:\\path\\to\\archive.zip");
+const dir2: CentralDirectory = Open.url(get("url/to/archive.zip"), {});
+const dir3: CentralDirectory = Open.s3("any", "any");


### PR DESCRIPTION
Entry.buffer and Parse.promise were incorrectly labeled as properties, but they are functions. This can be verified by looking at the source code that I have linked below.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
    - https://github.com/ZJONSSON/node-unzipper/blob/master/lib/parse.js#L240
    - https://github.com/ZJONSSON/node-unzipper/blob/master/lib/parse.js#L89