### PR TITLE
react-data-grid: add missing GridProps selectAllRenderer androwActionsCell

### DIFF
--- a/types/react-data-grid/index.d.ts
+++ b/types/react-data-grid/index.d.ts
@@ -204,6 +204,16 @@ declare namespace AdazzleReactDataGrid {
             }
         }
         /**
+         * A custom formatter for the select all checkbox cell
+         * @default react-data-grid/src/formatters/SelectAll.js
+         */
+        selectAllRenderer?: React.ReactElement<any> | React.ComponentClass<any> | React.StatelessComponent<any>;
+        /**
+         * A custom formatter for select row column
+         * @default AdazzleReactDataGridPlugins.Editors.CheckboxEditor
+         */
+        rowActionsCell?: React.ReactElement<any> | React.ComponentClass<any> | React.StatelessComponent<any>;
+        /**
          * An event function called when a row is clicked.
          * Clicking the header row will trigger a call with -1 for the rowIdx.
          * @param rowIdx zero index number of row clicked

--- a/types/react-data-grid/index.d.ts
+++ b/types/react-data-grid/index.d.ts
@@ -207,12 +207,12 @@ declare namespace AdazzleReactDataGrid {
          * A custom formatter for the select all checkbox cell
          * @default react-data-grid/src/formatters/SelectAll.js
          */
-        selectAllRenderer?: React.ReactElement<any> | React.ComponentClass<any> | React.StatelessComponent<any>;
+        selectAllRenderer?: React.ComponentClass<any> | React.StatelessComponent<any>;
         /**
          * A custom formatter for select row column
          * @default AdazzleReactDataGridPlugins.Editors.CheckboxEditor
          */
-        rowActionsCell?: React.ReactElement<any> | React.ComponentClass<any> | React.StatelessComponent<any>;
+        rowActionsCell?: React.ComponentClass<any> | React.StatelessComponent<any>;
         /**
          * An event function called when a row is clicked.
          * Clicking the header row will trigger a call with -1 for the rowIdx.

--- a/types/react-data-grid/react-data-grid-tests.tsx
+++ b/types/react-data-grid/react-data-grid-tests.tsx
@@ -31,6 +31,35 @@ class CustomFilterHeaderCell extends React.Component<any, any> {
    }
 }
 
+class CustomRowSelectorCell extends ReactDataGridPlugins.Editors.CheckboxEditor {
+    render(){
+        return super.render();
+    }
+}
+
+export interface ICustomSelectAllProps {
+    onChange: any;
+    inputRef: any;
+}
+
+class CustomSelectAll extends React.Component<ICustomSelectAllProps> {
+    render() {
+        return (
+            <div className='react-grid-checkbox-container checkbox-align'>
+                <input
+                    className='react-grid-checkbox'
+                    type='checkbox'
+                    name='select-all-checkbox'
+                    id='select-all-checkbox'
+                    ref={this.props.inputRef}
+                    onChange={this.props.onChange}
+                />
+                <label htmlFor='select-all-checkbox' className='react-grid-checkbox-label'></label>
+            </div>
+        );
+    }
+}
+
 faker.locale = 'en_GB';
 
 function createFakeRowObjectData(index:number):Object {
@@ -327,6 +356,8 @@ class Example extends React.Component<any, any> {
                         keys: {rowKey: 'id', values: selectedRows}
                     }
                 }}
+                rowActionsCell={CustomRowSelectorCell}
+                selectAllRenderer={CustomSelectAll}
                 onRowClick={this.onRowClick}
             />
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/adazzle/react-data-grid/pull/953 (Added selectAllRenderer prop)
https://github.com/adazzle/react-data-grid/pull/427/commits/28c320ca8f352a8d0183d5ccb454ef9160ad3053 (Added rowActionsCell prop)

