### PR TITLE
fix(prettier): printer.embed is optional

### DIFF
--- a/types/prettier/index.d.ts
+++ b/types/prettier/index.d.ts
@@ -406,7 +406,11 @@ export namespace doc {
         function printDocToDebug(doc: Doc): string;
     }
     namespace printer {
-        function printDocToString(doc: Doc, options: Options): string;
+        function printDocToString(doc: Doc, options: Options): {
+            formatted: string;
+            cursorNodeStart?: number;
+            cursorNodeText?: string;
+        };
         interface Options {
             /**
              * Specify the line length that the printer will wrap on.

--- a/types/prettier/index.d.ts
+++ b/types/prettier/index.d.ts
@@ -9,7 +9,7 @@ export type Doc = doc.builders.Doc;
 
 // https://github.com/prettier/prettier/blob/master/src/common/fast-path.js
 export interface FastPath {
-    getName(): string | null;
+    getName(): null | number | string;
     getValue(): any;
     getNode(count?: number): any;
     getParentNode(count?: number): any;

--- a/types/prettier/index.d.ts
+++ b/types/prettier/index.d.ts
@@ -9,6 +9,7 @@ export type Doc = doc.builders.Doc;
 
 // https://github.com/prettier/prettier/blob/master/src/common/fast-path.js
 export interface FastPath {
+    stack: any[];
     getName(): null | number | string;
     getValue(): any;
     getNode(count?: number): any;

--- a/types/prettier/index.d.ts
+++ b/types/prettier/index.d.ts
@@ -131,12 +131,12 @@ export interface Printer {
         options: ParserOptions,
         print: (path: FastPath) => Doc,
     ): Doc;
-    embed(
+    embed?: (
         path: FastPath,
         print: (path: FastPath) => Doc,
         textToDoc: (text: string, options: Options) => Doc,
         options: ParserOptions,
-    ): Doc | null;
+    ) => Doc | null;
     insertPragma?: (text: string) => string;
     /**
      * @returns `null` if you want to remove this node


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/prettier/prettier/blob/1.12.1/src/main/multiparser.js#L7-L8>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.