### PR TITLE
open() is deprecated in mongoose >= 4.11.0

### DIFF
--- a/types/mongoose/index.d.ts
+++ b/types/mongoose/index.d.ts
@@ -190,6 +190,7 @@ declare module "mongoose" {
 
     /**
      * Opens the connection to MongoDB.
+     * @deprecated open() is deprecated in mongoose >= 4.11.0
      * @param mongodb://uri or the host to which you are connecting
      * @param database database name
      * @param port database port
@@ -199,6 +200,19 @@ declare module "mongoose" {
      *   Options passed take precedence over options included in connection strings.
      */
     open(connection_string: string, database?: string, port?: number,
+      options?: ConnectionOpenOptions, callback?: (err: any) => void): any;
+    
+     /**
+     * Opens the connection to MongoDB.
+     * @param mongodb://uri or the host to which you are connecting
+     * @param database database name
+     * @param port database port
+     * @param options Mongoose forces the db option forceServerObjectId false and cannot be overridden.
+     *   Mongoose defaults the server auto_reconnect options to true which can be overridden.
+     *   See the node-mongodb-native driver instance for options that it understands.
+     *   Options passed take precedence over options included in connection strings.
+     */
+    openUri(connection_string: string, database?: string, port?: number,
       options?: ConnectionOpenOptions, callback?: (err: any) => void): any;
 
     /** Helper for dropDatabase() */

--- a/types/mongoose/index.d.ts
+++ b/types/mongoose/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Mongoose 5.0.14
+// Type definitions for Mongoose 5.0.15
 // Project: http://mongoosejs.com/
 // Definitions by: horiuchi <https://github.com/horiuchi>
 //                 sindrenm <https://github.com/sindrenm>

--- a/types/mongoose/mongoose-tests.ts
+++ b/types/mongoose/mongoose-tests.ts
@@ -129,6 +129,12 @@ conn1.openSet('mongodb://localhost/test', 'db', {
   replset: null,
   mongos: true
 }, function (err) {}).then(cb).catch(cb);
+conn1.openUri('mongodb://localhost/test', 'myDb', 27017, {
+  replset: null,
+  config: {
+    autoIndex: false
+  }
+}, function (err) {}).open('');
 conn1.close().catch(function (err) {});
 conn1.collection('name').$format(999);
 conn1.model('myModel', new mongoose.Schema({}), 'myCol').find();


### PR DESCRIPTION
Breaking change in @Automattic/mongoose
 
https://github.com/Automattic/mongoose/commit/dda165eebdb241397e9990440dc8e9c1f733db76#diff-259dec4414a400a6e895f16ff1d0ca3b

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).


- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/Automattic/mongoose/commit/dda165eebdb241397e9990440dc8e9c1f733db76#diff-259dec4414a400a6e895f16ff1d0ca3b
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
