### PR TITLE
react-redux: Fix Provider typing problem discussed in #25321

### DIFF
--- a/types/next-redux-wrapper/index.d.ts
+++ b/types/next-redux-wrapper/index.d.ts
@@ -13,32 +13,32 @@
  *~ workarounds for this limitation of ES6 modules.
  */
 
-import * as React from 'react';
 import { IncomingMessage, ServerResponse } from 'http';
+import { ComponentType } from 'react';
 import {
-    Store, Component,
     MapDispatchToPropsParam, MapStateToPropsParam,
     MergeProps, Options as ConnectOptions
 } from 'react-redux';
+import { Store } from 'redux';
 
 export = nextReduxWrapper;
 
 declare function nextReduxWrapper<TInitialState = any, TStateProps = any, TDispatchProps = any, TOwnProps = any, TMergedProps = any>(
     options: nextReduxWrapper.Options<TInitialState, TStateProps, TDispatchProps, TOwnProps, TMergedProps>
-): (Component: Component<TOwnProps & TMergedProps>) => nextReduxWrapper.NextReduxWrappedComponent<TOwnProps>;
+): (ComponentType: ComponentType<TOwnProps & TMergedProps>) => nextReduxWrapper.NextReduxWrappedComponent<TOwnProps>;
 declare function nextReduxWrapper<TInitialState = any, TStateProps = any, TDispatchProps = any, TOwnProps = any, TMergedProps = any>(
     createStore: nextReduxWrapper.NextStoreCreator<TInitialState, TStateProps, TDispatchProps, TOwnProps, TMergedProps>,
     mapStateToProps?: MapStateToPropsParam<TStateProps, TOwnProps, any>,
     mapDispatchToProps?: MapDispatchToPropsParam<TDispatchProps, TOwnProps>,
     mergeProps?: MergeProps<TStateProps, TDispatchProps, TOwnProps, TMergedProps>,
     options?: ConnectOptions
-): (Component: Component<TOwnProps & TMergedProps>) => nextReduxWrapper.NextReduxWrappedComponent<TOwnProps>;
+): (ComponentType: ComponentType<TOwnProps & TMergedProps>) => nextReduxWrapper.NextReduxWrappedComponent<TOwnProps>;
 
 declare namespace nextReduxWrapper {
     interface NextPageComponentMethods {
         getInitialProps(props: any): Promise<any>;
     }
-    type NextReduxWrappedComponent<P> = Component<P> & NextPageComponentMethods;
+    type NextReduxWrappedComponent<P> = ComponentType<P> & NextPageComponentMethods;
 
     type NextStoreCreator<TInitialState, TStateProps, TDispatchProps, TOwnProps, TMergedProps> = (
         initialState: TInitialState,

--- a/types/react-intl-redux/index.d.ts
+++ b/types/react-intl-redux/index.d.ts
@@ -20,4 +20,4 @@ interface IntlAction extends Action {
 export function intlReducer(state: IntlState, action: IntlAction): IntlState
 export function updateIntl (opts: IntlState): IntlAction
 export class IntlProvider extends ReactIntlProvider {}
-export class Provider extends ReduxProvider {}
+export class Provider<A extends IntlAction> extends ReduxProvider<A> {}

--- a/types/react-intl-redux/react-intl-redux-tests.tsx
+++ b/types/react-intl-redux/react-intl-redux-tests.tsx
@@ -1,6 +1,7 @@
 import * as React from "react"
 import { render } from "react-dom"
 import { Provider, IntlProvider, IntlState, IntlAction, intlReducer, updateIntl } from "react-intl-redux"
+import { createStore } from 'redux'
 
 var action: IntlAction = updateIntl({ locale : "en", messages : {} })
 var state: IntlState = intlReducer({ locale : "en", messages : {} }, action)
@@ -13,7 +14,7 @@ render(
 )
 
 render(
-    <Provider>
+    <Provider store={createStore(intlReducer)}>
         <div>Test</div>
     </Provider>,
     document.getElementById("main")

--- a/types/react-intl-redux/react-intl-redux-tests.tsx
+++ b/types/react-intl-redux/react-intl-redux-tests.tsx
@@ -1,7 +1,7 @@
 import * as React from "react"
 import { render } from "react-dom"
 import { Provider, IntlProvider, IntlState, IntlAction, intlReducer, updateIntl } from "react-intl-redux"
-import { createStore } from 'redux'
+import { createStore } from "redux"
 
 var action: IntlAction = updateIntl({ locale : "en", messages : {} })
 var state: IntlState = intlReducer({ locale : "en", messages : {} }, action)

--- a/types/react-redux/index.d.ts
+++ b/types/react-redux/index.d.ts
@@ -1,5 +1,5 @@
 // Type definitions for react-redux 6.0.0
-// Project: https://github.com/rackt/react-redux
+// Project: https://github.com/reactjs/react-redux
 // Definitions by: Qubo <https://github.com/tkqubo>,
 //                 Thomas Hasner <https://github.com/thasner>,
 //                 Kenzie Togami <https://github.com/kenzierocks>,
@@ -26,27 +26,31 @@
 // to update this type definitions for redux@4.x from redux@3.x.
 // https://github.com/DefinitelyTyped/DefinitelyTyped/issues/25321
 
-import * as React from 'react';
-import * as Redux from 'redux';
+import {
+    Component,
+    ComponentClass,
+    ComponentType,
+    ReactNode,
+    StatelessComponent
+} from 'react';
 
-type ComponentClass<P> = React.ComponentClass<P>;
-type StatelessComponent<P> = React.StatelessComponent<P>;
-type Component<P> = React.ComponentType<P>;
-type ReactNode = React.ReactNode;
-type Store<S> = Redux.Store<S>;
-type Dispatch<A extends Redux.Action = Redux.AnyAction> = Redux.Dispatch<A>;
-type ActionCreator<A> = Redux.ActionCreator<A>;
+import {
+    Action,
+    ActionCreator,
+    AnyAction,
+    Dispatch,
+    Store
+} from 'redux';
 
 // Diff / Omit taken from https://github.com/Microsoft/TypeScript/issues/12215#issuecomment-311923766
 type Omit<T, K extends keyof T> = Pick<T, ({ [P in keyof T]: P } & { [P in K]: never } & { [x: string]: never, [x: number]: never })[keyof T]>;
 
-
-export interface DispatchProp<A extends Redux.Action = Redux.AnyAction> {
-  dispatch: Dispatch<A>;
+export interface DispatchProp<A extends Action = AnyAction> {
+    dispatch: Dispatch<A>;
 }
 
 interface AdvancedComponentDecorator<TProps, TOwnProps> {
-    (component: Component<TProps>): ComponentClass<TOwnProps>;
+    (component: ComponentType<TProps>): ComponentClass<TOwnProps>;
 }
 
 /**
@@ -71,8 +75,8 @@ type Shared<
 // render. Also adds new prop requirements from TNeedsProps.
 export interface InferableComponentEnhancerWithProps<TInjectedProps, TNeedsProps> {
     <P extends Shared<TInjectedProps, P>>(
-        component: Component<P>
-    ): ComponentClass<Omit<P, keyof Shared<TInjectedProps, P>> & TNeedsProps> & {WrappedComponent: Component<P>}
+        component: ComponentType<P>
+    ): ComponentClass<Omit<P, keyof Shared<TInjectedProps, P>> & TNeedsProps> & {WrappedComponent: ComponentType<P>}
 }
 
 // Injects props and removes them from the prop requirements.
@@ -313,18 +317,17 @@ export interface ConnectOptions {
     withRef?: boolean
 }
 
-export interface ProviderProps {
+export interface ProviderProps<A extends Action> {
     /**
      * The single Redux store in your application.
      */
-    store?: Store<any>;
-    children?: ReactNode;
+    store: Store<any, A>;
 }
 
 /**
  * Makes the Redux store available to the connect() calls in the component hierarchy below.
  */
-export class Provider extends React.Component<ProviderProps, {}> { }
+export class Provider<A extends Action> extends Component<ProviderProps<A>> { }
 
 /**
  * Creates a new <Provider> which will set the Redux Store on the passed key of the context. You probably only need this

--- a/types/react-redux/index.d.ts
+++ b/types/react-redux/index.d.ts
@@ -30,7 +30,6 @@ import {
     Component,
     ComponentClass,
     ComponentType,
-    ReactNode,
     StatelessComponent
 } from 'react';
 

--- a/types/react-redux/react-redux-tests.tsx
+++ b/types/react-redux/react-redux-tests.tsx
@@ -1,7 +1,7 @@
 import { Component, ReactElement } from 'react';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
-import { Store, Dispatch, AnyAction, ActionCreator, createStore, bindActionCreators, ActionCreatorsMapObject } from 'redux';
+import { Store, Dispatch, AnyAction, ActionCreator, createStore, bindActionCreators, ActionCreatorsMapObject, Reducer } from 'redux';
 import { Connect, connect, createProvider, Provider, DispatchProp, MapStateToProps, Options } from 'react-redux';
 import objectAssign = require('object-assign');
 
@@ -965,4 +965,20 @@ namespace TestWithoutTOwnPropsDecoratedInference {
     }
     const ConnectedWithPickedOwnProps = connect(mapStateToPropsForPicked)(AllPropsComponent);
     <ConnectedWithPickedOwnProps own="blah" />
+}
+
+// https://github.com/DefinitelyTyped/DefinitelyTyped/issues/25321#issuecomment-387659500
+namespace ProviderAcceptsStoreWithCustomAction {
+    const reducer: Reducer<
+        { foo: number } | undefined,
+        { type: "foo"; payload: number }
+    > = state => state;
+
+    const store = createStore(reducer);
+
+    const Whatever = () => (
+        <Provider store={store}>
+            <div>Whatever</div>
+        </Provider>
+    );
 }


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/25321#issuecomment-387659500
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

---

Main objective: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/25321#issuecomment-387659500

Also replaced React and Redux type aliasing with just direct imports, renamed `Component` to `ComponentType` (since that's what it's named in React typings), made `store` a required prop (as per [Provider's propTypes](https://github.com/reactjs/react-redux/blob/57128d5a20d15f43513acd13251465966426d956/src/components/Provider.js#L48-L51)) and got rid of the `children` prop. Tried to make it required first, but that breaks `React.ComponentFactory` scenarios, where children are passed as separate variadic arguments ([`react-redux-toastr`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/8cd6bba3b37232c14c4f111c1c95f406fda6895e/types/react-redux-toastr/react-redux-toastr-tests.ts#L13) in particular), so gave up quickly and removed it altogether, since `children?: ReactNode` is the implied default.

Getting some `RangeError: Maximum call stack size exceeded` errors when testing/linting, but I'm not sure what to do about that. It's happening to others too: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/25664#issuecomment-388202246