### PR TITLE
Add express-correlation-id and correlation-id packages

### DIFF
--- a/types/correlation-id/correlation-id-tests.ts
+++ b/types/correlation-id/correlation-id-tests.ts
@@ -1,0 +1,21 @@
+import { withId, bindId, getId } from "correlation-id";
+
+withId("my-id", () => {
+    const id: string = getId() || "";
+});
+
+withId(() => {
+    const id: string = getId() || "";
+});
+
+const x: string = bindId("my-id", (foo: string, bar: number): string => {
+    const id: string = getId() || "";
+
+    return foo + bar + id;
+})("foo", 12);
+
+const y: string = bindId((foo: string, bar: number): string => {
+    const id: string = getId() || "";
+
+    return foo + bar + id;
+})("foo", 12);

--- a/types/correlation-id/index.d.ts
+++ b/types/correlation-id/index.d.ts
@@ -6,7 +6,7 @@
 export function withId(id: string, work: () => void): void;
 export function withId(work: () => void): void;
 
-export function bindId<T extends Function>(id: string, work: T): T;
-export function bindId<T extends Function>(work: T): T;
+export function bindId<T extends (...p: any[]) => any>(id: string, work: T): T;
+export function bindId<T extends (...p: any[]) => any>(work: T): T;
 
 export function getId(): string | undefined;

--- a/types/correlation-id/index.d.ts
+++ b/types/correlation-id/index.d.ts
@@ -1,0 +1,12 @@
+// Type definitions for correlation-id 2.1
+// Project: https://github.com/toboid/correlation-id#readme
+// Definitions by: Nate <https://github.com/natemara>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export function withId(id: string, work: () => void): void;
+export function withId(work: () => void): void;
+
+export function bindId<T extends Function>(id: string, work: T): T;
+export function bindId<T extends Function>(work: T): T;
+
+export function getId(): string | undefined;

--- a/types/correlation-id/tsconfig.json
+++ b/types/correlation-id/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": ["index.d.ts", "correlation-id-tests.ts"]
+}

--- a/types/correlation-id/tslint.json
+++ b/types/correlation-id/tslint.json
@@ -1,29 +1,3 @@
 {
-    "extends": "dtslint/dt.json",
-    "rules": {
-        "ban-types": {
-            "options": [
-                [
-                    "Object",
-                    "Avoid using the `Object` type. Did you mean `object`?"
-                ],
-                [
-                    "Boolean",
-                    "Avoid using the `Boolean` type. Did you mean `boolean`?"
-                ],
-                [
-                    "Number",
-                    "Avoid using the `Number` type. Did you mean `number`?"
-                ],
-                [
-                    "String",
-                    "Avoid using the `String` type. Did you mean `string`?"
-                ],
-                [
-                    "Symbol",
-                    "Avoid using the `Symbol` type. Did you mean `symbol`?"
-                ]
-            ]
-        }
-    }
+    "extends": "dtslint/dt.json"
 }

--- a/types/correlation-id/tslint.json
+++ b/types/correlation-id/tslint.json
@@ -1,0 +1,29 @@
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "ban-types": {
+            "options": [
+                [
+                    "Object",
+                    "Avoid using the `Object` type. Did you mean `object`?"
+                ],
+                [
+                    "Boolean",
+                    "Avoid using the `Boolean` type. Did you mean `boolean`?"
+                ],
+                [
+                    "Number",
+                    "Avoid using the `Number` type. Did you mean `number`?"
+                ],
+                [
+                    "String",
+                    "Avoid using the `String` type. Did you mean `string`?"
+                ],
+                [
+                    "Symbol",
+                    "Avoid using the `Symbol` type. Did you mean `symbol`?"
+                ]
+            ]
+        }
+    }
+}

--- a/types/express-correlation-id/express-correlation-id-tests.ts
+++ b/types/express-correlation-id/express-correlation-id-tests.ts
@@ -1,0 +1,9 @@
+import * as express from "express";
+import correlator from "express-correlation-id";
+
+const app = express();
+app.use(correlator());
+app.use(correlator({}));
+app.use(correlator({ header: "x-correlation-id" }));
+
+const x: string = correlator.getId() || "";

--- a/types/express-correlation-id/index.d.ts
+++ b/types/express-correlation-id/index.d.ts
@@ -1,0 +1,14 @@
+// Type definitions for express-correlation-id 1.2
+// Project: https://github.com/toboid/express-correlation-id#readme
+// Definitions by: Nate <https://github.com/natemara>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.2
+
+import { RequestHandler } from "express-serve-static-core";
+
+declare const correlator: {
+    (options?: { header?: string }): RequestHandler;
+    getId(): string | undefined;
+};
+
+export default correlator;

--- a/types/express-correlation-id/tsconfig.json
+++ b/types/express-correlation-id/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": ["index.d.ts", "express-correlation-id-tests.ts"]
+}

--- a/types/express-correlation-id/tslint.json
+++ b/types/express-correlation-id/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
This adds definitions for the express-correlation-id and correlation-id packages.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
    - Note: I did use `Function` here: https://github.com/natemara/DefinitelyTyped/blob/c60e4b129485cd1fd8cbc073927eb45c5eaf733d/types/correlation-id/index.d.ts#L9, but I believe that this may be a rare acceptable use case for it. Because `bindId` is just a function decorator that returns a function with the same signature, I'm not sure how else to represent it.
    - I'm also not sure if this is a best practice for a function default export with extra properties https://github.com/natemara/DefinitelyTyped/blob/c60e4b129485cd1fd8cbc073927eb45c5eaf733d/types/express-correlation-id/index.d.ts#L9
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.