### PR TITLE
allowFontScaling for react-native

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -801,12 +801,6 @@ export interface TextStyle extends TextStyleIOS, TextStyleAndroid, ViewStyle {
 
 export interface TextPropsIOS {
     /**
-     * Specifies whether fonts should scale to respect Text Size accessibility setting on iOS. The
-     * default is `true`.
-     */
-    allowFontScaling?: boolean;
-
-    /**
      * Specifies whether font should be scaled down automatically to fit given style constraints.
      */
     adjustsFontSizeToFit?: boolean;
@@ -843,6 +837,12 @@ export interface TextPropsAndroid {
 
 // https://facebook.github.io/react-native/docs/text.html#props
 export interface TextProps extends TextPropsIOS, TextPropsAndroid, AccessibilityProps {
+    /**
+     * Specifies whether fonts should scale to respect Text Size accessibility settings.
+     * The default is `true`.
+     */
+    allowFontScaling?: boolean;
+
     /**
      * This can be one of the following values:
      *
@@ -1090,9 +1090,7 @@ export interface TextInputProps
     extends ViewProps, TextInputIOSProps, TextInputAndroidProps, AccessibilityProps {
     /**
      * Specifies whether fonts should scale to respect Text Size accessibility settings.
-     * The default is true.
-     *
-     * https://facebook.github.io/react-native/docs/textinput.html#allowfontscaling
+     * The default is `true`.
      */
     allowFontScaling?: boolean;
 

--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -1089,6 +1089,14 @@ export type ReturnKeyTypeOptions = ReturnKeyType | ReturnKeyTypeAndroid | Return
 export interface TextInputProps
     extends ViewProps, TextInputIOSProps, TextInputAndroidProps, AccessibilityProps {
     /**
+     * Specifies whether fonts should scale to respect Text Size accessibility settings.
+     * The default is true.
+     *
+     * https://facebook.github.io/react-native/docs/textinput.html#allowfontscaling
+     */
+    allowFontScaling?: boolean;
+
+    /**
      * Can tell TextInput to automatically capitalize certain characters.
      *      characters: all characters,
      *      words: first letter of each word


### PR DESCRIPTION
This change:

1. Adds the `allowFontScaling` prop to `TextInputProps`.
2. Moves `allowFontScaling` from `TextPropsIOS` to `TextProps` as it is not only for iOS, as per docs.

Thank you!


- [✓] Use a meaningful title for the pull request. Include the name of the package modified.
- [✓] Test the change in your own code. (Compile and run.)
- [✓] Add or edit tests to reflect the change. (Run with `npm test`.)
- [✓] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [✓] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [✓] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Changed an existing definition:
- [✓] Provide a URL to documentation or source code which provides context for the suggested changes: 
    For TextInput: https://facebook.github.io/react-native/docs/textinput.html#allowfontscaling
    For Text: https://facebook.github.io/react-native/docs/text.html#allowfontscaling
- [✓] Increase the version number in the header if appropriate.
- [✓] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.