### PR TITLE
[react-native] Add missing style props to View

### DIFF
--- a/types/react-native-snap-carousel/index.d.ts
+++ b/types/react-native-snap-carousel/index.d.ts
@@ -14,7 +14,6 @@ import {
     NativeScrollEvent,
     StyleProp,
     ScrollViewProps,
-    ScrollViewStyle,
     ViewStyle,
     ImageProps,
     FlatListProps
@@ -180,11 +179,11 @@ export interface CarouselProps<T> extends React.Props<ScrollViewProps> {
     /**
      * Optional styles for Scrollview's global wrapper
      */
-    containerCustomStyle?: StyleProp<ScrollViewStyle>;
+    containerCustomStyle?: StyleProp<ViewStyle>;
     /**
      * Optional styles for Scrollview's items container
      */
-    contentContainerCustomStyle?: StyleProp<ScrollViewStyle>;
+    contentContainerCustomStyle?: StyleProp<ViewStyle>;
     /**
      * Value of the opacity effect applied to inactive slides
      */

--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -604,14 +604,6 @@ export interface FlexStyle {
     direction?: "inherit" | "ltr" | "rtl";
 }
 
-
-/**
- * Layout Prop Types
- * @see https://facebook.github.io/react-native/docs/layout-props.html
- * @see https://github.com/facebook/react-native/blob/master/Libraries/StyleSheet/LayoutPropTypes.js
- */
-export interface LayoutProps extends FlexStyle {}
-
 /**
  * @see ShadowPropTypesIOS.js
  */
@@ -1577,7 +1569,10 @@ export interface GestureResponderHandlers {
     onMoveShouldSetResponderCapture?: (event: GestureResponderEvent) => boolean;
 }
 
-// @see https://facebook.github.io/react-native/docs/view.html#style
+/**
+ * @see https://facebook.github.io/react-native/docs/view.html#style
+ * @see https://github.com/facebook/react-native/blob/master/Libraries/Components/View/ViewStylePropTypes.js
+ */
 export interface ViewStyle extends FlexStyle, ShadowStyleIOS, TransformsStyle {
     backfaceVisibility?: "visible" | "hidden";
     backgroundColor?: string;
@@ -1684,6 +1679,7 @@ export interface ViewPropsAndroid {
     renderToHardwareTextureAndroid?: boolean;
 }
 
+
 type Falsy = undefined | null | false;
 interface RecursiveArray<T> extends Array<T | RecursiveArray<T>> {}
 /** Keep a brand of 'T' so that calls to `StyleSheet.flatten` can take `RegisteredStyle<T>` and return `T`. */
@@ -1783,7 +1779,7 @@ type AccessibilityTraits =
  * @see https://facebook.github.io/react-native/docs/view.html#props
  */
 export interface ViewProps
-    extends ViewPropsAndroid, ViewPropsIOS, GestureResponderHandlers, Touchable, AccessibilityProps, LayoutProps {
+    extends ViewPropsAndroid, ViewPropsIOS, GestureResponderHandlers, Touchable, AccessibilityProps, ViewStyle {
     /**
      * This defines how far a touch event can start away from the view.
      * Typical interface guidelines recommend touch targets that are at least
@@ -3390,7 +3386,7 @@ export type ImageSourcePropType = ImageURISource | ImageURISource[] | ImageRequi
 /**
  * @see https://facebook.github.io/react-native/docs/image.html
  */
-export interface ImageProps extends ImagePropsIOS, ImagePropsAndroid, AccessibilityProps, LayoutProps {
+export interface ImageProps extends ImagePropsIOS, ImagePropsAndroid, AccessibilityProps, ViewStyle {
     /**
      * onLayout function
      *

--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -3494,6 +3494,14 @@ export interface ImagePropsBase extends ImagePropsIOS, ImagePropsAndroid, Access
      * A unique identifier for this element to be used in UI Automation testing scripts.
      */
     testID?: string;
+
+    /**
+     * Currently broken
+     * @see https://github.com/facebook/react-native/pull/19281
+     */
+    width?: never,
+    height?: never,
+    tintColor?: never,
 }
 
 export interface ImageProps extends ImagePropsBase {

--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -542,7 +542,7 @@ type FlexAlignType = "flex-start" | "flex-end" | "center" | "stretch" | "baselin
  * Flex Prop Types
  * @see https://facebook.github.io/react-native/docs/flexbox.html#proptypes
  * @see https://facebook.github.io/react-native/docs/layout-props.html
- * @see LayoutPropTypes.js
+ * @see https://github.com/facebook/react-native/blob/master/Libraries/StyleSheet/LayoutPropTypes.js
  */
 export interface FlexStyle {
     alignContent?: "flex-start" | "flex-end" | "center" | "stretch" | "space-between" | "space-around";
@@ -608,7 +608,7 @@ export interface FlexStyle {
 /**
  * Layout Prop Types
  * @see https://facebook.github.io/react-native/docs/layout-props.html
- * @see LayoutPropTypes.js
+ * @see https://github.com/facebook/react-native/blob/master/Libraries/StyleSheet/LayoutPropTypes.js
  */
 export interface LayoutProps extends FlexStyle {}
 
@@ -1578,32 +1578,43 @@ export interface GestureResponderHandlers {
 }
 
 // @see https://facebook.github.io/react-native/docs/view.html#style
-export interface ViewStyle extends FlexStyle, TransformsStyle {
+export interface ViewStyle extends FlexStyle, ShadowStyleIOS, TransformsStyle {
     backfaceVisibility?: "visible" | "hidden";
     backgroundColor?: string;
     borderBottomColor?: string;
+    borderBottomEndRadius?: number;
     borderBottomLeftRadius?: number;
     borderBottomRightRadius?: number;
+    borderBottomStartRadius?: number;
     borderBottomWidth?: number;
     borderColor?: string;
+    borderEndColor?: string;
     borderLeftColor?: string;
+    borderLeftWidth?: number;
     borderRadius?: number;
     borderRightColor?: string;
     borderRightWidth?: number;
+    borderStartColor?: string;
     borderStyle?: "solid" | "dotted" | "dashed";
     borderTopColor?: string;
+    borderTopEndRadius?: number;
     borderTopLeftRadius?: number;
     borderTopRightRadius?: number;
+    borderTopStartRadius?: number;
     borderTopWidth?: number;
-    display?: "none" | "flex";
+    borderWidth?: number;
     opacity?: number;
     overflow?: "visible" | "hidden";
-    shadowColor?: string;
-    shadowOffset?: { width: number; height: number };
-    shadowOpacity?: number;
-    shadowRadius?: number;
-    elevation?: number;
     testID?: string;
+    /**
+      * Sets the elevation of a view, using Android's underlying
+      * [elevation API](https://developer.android.com/training/material/shadows-clipping.html#Elevation).
+      * This adds a drop shadow to the item and affects z-order for overlapping views.
+      * Only supported on Android 5.0+, has no effect on earlier versions.
+      *
+      * @platform android
+      */
+    elevation?: number;
 }
 
 export interface ViewPropsIOS {
@@ -3230,8 +3241,9 @@ export interface ShadowStyleIOS {
 /**
  * Image style
  * @see https://facebook.github.io/react-native/docs/image.html#style
+ * @see https://github.com/facebook/react-native/blob/master/Libraries/Image/ImageStylePropTypes.js
  */
-export interface ImageStyle extends FlexStyle, TransformsStyle, ShadowStyleIOS {
+export interface ImageStyle extends FlexStyle, ShadowStyleIOS, TransformsStyle {
     resizeMode?: ImageResizeMode;
     backfaceVisibility?: "visible" | "hidden";
     borderBottomLeftRadius?: number;
@@ -5462,34 +5474,6 @@ export interface InteractionManagerStatic extends EventEmitterListener {
     setDeadline(deadline: number): void;
 }
 
-export interface ScrollViewStyle extends FlexStyle, TransformsStyle {
-    backfaceVisibility?: "visible" | "hidden";
-    backgroundColor?: string;
-    borderColor?: string;
-    borderTopColor?: string;
-    borderRightColor?: string;
-    borderBottomColor?: string;
-    borderLeftColor?: string;
-    borderRadius?: number;
-    borderTopLeftRadius?: number;
-    borderTopRightRadius?: number;
-    borderBottomLeftRadius?: number;
-    borderBottomRightRadius?: number;
-    borderStyle?: "solid" | "dotted" | "dashed";
-    borderWidth?: number;
-    borderTopWidth?: number;
-    borderRightWidth?: number;
-    borderBottomWidth?: number;
-    borderLeftWidth?: number;
-    opacity?: number;
-    overflow?: "visible" | "hidden";
-    shadowColor?: string;
-    shadowOffset?: { width: number; height: number };
-    shadowOpacity?: number;
-    shadowRadius?: number;
-    elevation?: number;
-}
-
 export interface ScrollResponderEvent extends NativeSyntheticEvent<NativeTouchEvent> {}
 
 interface ScrollResponderMixin extends SubscribableMixin {
@@ -6058,7 +6042,7 @@ export interface ScrollViewProps
     /**
      * Style
      */
-    style?: StyleProp<ScrollViewStyle>;
+    style?: StyleProp<ViewStyle>;
 
     /**
      * A RefreshControl component, used to provide pull-to-refresh

--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -3385,7 +3385,7 @@ export type ImageSourcePropType = ImageURISource | ImageURISource[] | ImageRequi
 /**
  * @see https://facebook.github.io/react-native/docs/image.html
  */
-export interface ImagePropsBase extends ImagePropsIOS, ImagePropsAndroid, AccessibilityProps, ViewStyle {
+export interface ImagePropsBase extends ImagePropsIOS, ImagePropsAndroid, AccessibilityProps, ImageStyle {
     /**
      * onLayout function
      *

--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -1599,7 +1599,6 @@ export interface ViewStyle extends FlexStyle, ShadowStyleIOS, TransformsStyle {
     borderTopWidth?: number;
     borderWidth?: number;
     opacity?: number;
-    overflow?: "visible" | "hidden";
     testID?: string;
     /**
       * Sets the elevation of a view, using Android's underlying
@@ -3386,7 +3385,7 @@ export type ImageSourcePropType = ImageURISource | ImageURISource[] | ImageRequi
 /**
  * @see https://facebook.github.io/react-native/docs/image.html
  */
-export interface ImageProps extends ImagePropsIOS, ImagePropsAndroid, AccessibilityProps, ViewStyle {
+export interface ImagePropsBase extends ImagePropsIOS, ImagePropsAndroid, AccessibilityProps, ViewStyle {
     /**
      * onLayout function
      *
@@ -3492,15 +3491,17 @@ export interface ImageProps extends ImagePropsIOS, ImagePropsAndroid, Accessibil
     loadingIndicatorSource?: ImageURISource;
 
     /**
+     * A unique identifier for this element to be used in UI Automation testing scripts.
+     */
+    testID?: string;
+}
+
+export interface ImageProps extends ImagePropsBase {
+    /**
      *
      * Style
      */
     style?: StyleProp<ImageStyle>;
-
-    /**
-     * A unique identifier for this element to be used in UI Automation testing scripts.
-     */
-    testID?: string;
 }
 
 declare class ImageComponent extends React.Component<ImageProps> {}
@@ -3513,7 +3514,7 @@ export class Image extends ImageBase {
     queryCache?(urls: string[]): Promise<Map<string, "memory" | "disk">>;
 }
 
-export interface ImageBackgroundProps extends ImageProps {
+export interface ImageBackgroundProps extends ImagePropsBase {
     style?: StyleProp<ViewStyle>;
     imageStyle?: StyleProp<ImageStyle>;
 }

--- a/types/react-native/test/index.tsx
+++ b/types/react-native/test/index.tsx
@@ -471,12 +471,13 @@ class StylePropsTest extends React.PureComponent {
             <View backgroundColor="lightgray" flex={1} overflow="scroll">
                 <Image
                     borderRadius={100}
-                    height={300}
+                    // height={200}
                     margin={20}
                     overflow="visible" // ps: must fail if "scroll"
                     source={{ uri }}
-                    tintColor="green"
-                    width={300}
+                    style={{ width: 200, height: 200, tintColor: 'green' }}
+                    // tintColor="green"
+                    // width={200}
                 />
             </View>
         );

--- a/types/react-native/test/index.tsx
+++ b/types/react-native/test/index.tsx
@@ -22,6 +22,7 @@ import {
     DataSourceAssetCallback,
     DeviceEventEmitterStatic,
     Dimensions,
+    Image,
     ImageStyle,
     InteractionManager,
     ListView,
@@ -458,6 +459,26 @@ class StatusBarTest extends React.Component {
                 barStyle="light-content"
                 translucent
             />
+        );
+    }
+}
+
+class StylePropsTest extends React.PureComponent {
+    render() {
+        const uri = 'https://seeklogo.com/images/T/typescript-logo-B29A3F462D-seeklogo.com.png'
+
+        return (
+            <View backgroundColor="lightgray" flex={1} overflow="scroll">
+                <Image
+                    borderRadius={100}
+                    height={300}
+                    margin={20}
+                    overflow="visible" // ps: must fail if "scroll"
+                    source={{ uri }}
+                    tintColor="green"
+                    width={300}
+                />
+            </View>
         );
     }
 }


### PR DESCRIPTION
Continuation of #25083 

React Native actually accepts the whole `ViewStyle` as props, not only the `FlexStyle`.

Before this PR, it wouldn't allow me to do `<View backgroundColor="#00FF00" />`, after it will.

> ~PS: I noticed an existing type error but I don't know how to fix it: `overflow` can have the `scroll` value, but it is currently not autocompleting that. If we add this the `ImageStyle` gives an error when trying to override it.~ (fixed)

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/facebook/react-native/blob/master/Libraries/Components/View/ViewStylePropTypes.js
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
