### PR TITLE
[read-package-tree] Add the missing `name` field

### DIFF
--- a/types/read-package-tree/index.d.ts
+++ b/types/read-package-tree/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for read-package-tree 5.1
+// Type definitions for read-package-tree 5.2
 // Project: https://github.com/npm/read-package-tree
 // Definitions by: Melvin Groenhoff <https://github.com/mgroenhoff>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/read-package-tree/index.d.ts
+++ b/types/read-package-tree/index.d.ts
@@ -9,6 +9,7 @@ declare function rpt(root: string, filterWith: (node: rpt.Node, kidName: string)
 declare namespace rpt {
     class Node {
         id: number;
+        name: string;
         package: any;
         children: Node[];
         parent: Node | null;


### PR DESCRIPTION
The returned object in `read-package-tree` includes the `name` field:

https://github.com/npm/read-package-tree/blob/5245c6e50d7f46ae65191782622ec75bbe80561d/rpt.js#L51-L55

For some reason, type definitions didn’t include that field. This PR fixes that.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/npm/read-package-tree/blob/5245c6e50d7f46ae65191782622ec75bbe80561d/rpt.js#L51-L55
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
