### PR TITLE
[react-native] Add missing GlobalFetch / RequestInfo definitions

### DIFF
--- a/types/react-native/globals.d.ts
+++ b/types/react-native/globals.d.ts
@@ -25,7 +25,11 @@ declare function fetchBundle(bundleId: number, callback: (error?: Error | null) 
 // Fetch API
 //
 
-declare function fetch(input: Request | string, init?: RequestInit): Promise<Response>;
+declare interface GlobalFetch {
+  fetch(input: RequestInfo, init?: RequestInit): Promise<Response>;
+}
+
+declare function fetch(input: RequestInfo, init?: RequestInit): Promise<Response>;
 
 interface Blob {}
 
@@ -84,6 +88,8 @@ declare var Request: {
   prototype: Request;
   new(input: Request | string, init?: RequestInit): Request;
 };
+
+declare type RequestInfo = Request | string;
 
 declare interface ResponseInit {
   headers?: HeadersInit_;

--- a/types/react-native/test/globals.tsx
+++ b/types/react-native/test/globals.tsx
@@ -1,3 +1,26 @@
 const fetchCopy: GlobalFetch['fetch'] = fetch;
 
-const requestInfoAsString: RequestInfo = 'request';
+const myHeaders = new Headers();
+myHeaders.append('Content-Type', 'image/jpeg');
+
+const myInit: RequestInit = {
+  method: 'GET',
+  headers: myHeaders,
+  mode: 'cors',
+};
+
+const myRequest = new Request('flowers.jpg');
+
+fetch(myRequest, myInit).then((response) => {
+  console.log(response.type);
+  console.log(response.url);
+  console.log(response.status);
+  console.log(response.ok);
+  console.log(response.statusText);
+  console.log(response.headers);
+
+  return response.blob();
+}).then((blob) => {
+  const init = { status: 200, statusText: 'SuperSmashingGreat!' }
+  const myResponse = new Response(blob, init);
+})

--- a/types/react-native/test/globals.tsx
+++ b/types/react-native/test/globals.tsx
@@ -1,0 +1,3 @@
+const fetchCopy: GlobalFetch['fetch'] = fetch;
+
+const requestInfoAsString: RequestInfo = 'request';

--- a/types/react-native/tsconfig.json
+++ b/types/react-native/tsconfig.json
@@ -20,6 +20,7 @@
     "files": [
         "index.d.ts",
         "test/index.tsx",
+        "test/globals.tsx",
         "test/animated.tsx",
         "test/init-example.tsx",
         "test/ART.tsx",


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://facebook.github.io/react-native/docs/network.html
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

In the continuation of https://github.com/DefinitelyTyped/DefinitelyTyped/pull/25255 