### PR TITLE
feat(node9&10): add `TextDecoder` and `TextEncoder` for `util` module

### DIFF
--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -6233,7 +6233,7 @@ declare module "util" {
         );
         decode(
           input?:
-            | Int8Array
+            Int8Array
             | Int16Array
             | Int32Array
             | Uint8Array

--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -23,6 +23,7 @@
 //                 Mohsen Azimi <https://github.com/mohsen1>
 //                 Hoàng Văn Khải <https://github.com/KSXGitHub>
 //                 Alexander T. <https://github.com/a-tarasyuk>
+//                 Lishude <https://github.com/islishude>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /** inspector module types */
@@ -6219,6 +6220,38 @@ declare module "util" {
         export function isWeakMap(object: any): object is WeakMap<any, any>;
         export function isWeakSet(object: any): object is WeakSet<any>;
         export function isWebAssemblyCompiledModule(object: any): boolean;
+    }
+
+    export class TextDecoder {
+        readonly encoding: string;
+        readonly fatal: boolean;
+        readonly ignoreBOM: boolean;
+        constructor(
+          encoding?: string,
+          options?: { fatal?: boolean; ignoreBOM?: boolean }
+        );
+        decode(
+          input?:
+            | Int8Array
+            | Int16Array
+            | Int32Array
+            | Uint8Array
+            | Uint16Array
+            | Uint32Array
+            | Uint8ClampedArray
+            | Float32Array
+            | Float64Array
+            | DataView
+            | ArrayBuffer
+            | null,
+          options?: { stream?: boolean }
+        ): string;
+    }
+
+    export class TextEncoder {
+        readonly encoding: string;
+        constructor();
+        encode(input?: string): Uint8Array;
     }
 }
 

--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -6222,6 +6222,7 @@ declare module "util" {
         export function isWebAssemblyCompiledModule(object: any): boolean;
     }
 
+    // TypeScript Version: 2.1
     export class TextDecoder {
         readonly encoding: string;
         readonly fatal: boolean;

--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -6222,7 +6222,6 @@ declare module "util" {
         export function isWebAssemblyCompiledModule(object: any): boolean;
     }
 
-    // TypeScript Version: 2.1
     export class TextDecoder {
         readonly encoding: string;
         readonly fatal: boolean;

--- a/types/node/node-tests.ts
+++ b/types/node/node-tests.ts
@@ -857,6 +857,35 @@ namespace util_tests {
 
         // util.isDeepStrictEqual
         util.isDeepStrictEqual({foo: 'bar'}, {foo: 'bar'});
+
+        // util.TextDecoder()
+        var td = new util.TextDecoder();
+        new util.TextDecoder("utf-8");
+        new util.TextDecoder("utf-8", { fatal: true });
+        new util.TextDecoder("utf-8", { fatal: true, ignoreBOM: true });
+        var ignoreBom: boolean = td.ignoreBOM;
+        var fatal: boolean = td.fatal;
+        var encoding: string = td.encoding;
+        td.decode(new Int8Array(1));
+        td.decode(new Int16Array(1));
+        td.decode(new Int32Array(1));
+        td.decode(new Uint8Array(1));
+        td.decode(new Uint16Array(1));
+        td.decode(new Uint32Array(1));
+        td.decode(new Uint8ClampedArray(1));
+        td.decode(new Float32Array(1));
+        td.decode(new Float64Array(1));
+        td.decode(new DataView(new Int8Array(1).buffer));
+        td.decode(new ArrayBuffer(1));
+        td.decode(null);
+        td.decode(null, { stream: true });
+        td.decode(new Int8Array(1), { stream: true });
+        var decode: string = td.decode(new Int8Array(1));
+
+        // util.TextEncoder()
+        var te = new util.TextEncoder();
+        var teEncoding: string = te.encoding;
+        var teEncodeRes: Uint8Array = te.encode("TextEncoder");
     }
 }
 

--- a/types/node/v8/index.d.ts
+++ b/types/node/v8/index.d.ts
@@ -5588,7 +5588,7 @@ declare module "util" {
         );
         decode(
           input?:
-            | Int8Array
+            Int8Array
             | Int16Array
             | Int32Array
             | Uint8Array

--- a/types/node/v9/index.d.ts
+++ b/types/node/v9/index.d.ts
@@ -5671,7 +5671,7 @@ declare module "util" {
         );
         decode(
           input?:
-            | Int8Array
+            Int8Array
             | Int16Array
             | Int32Array
             | Uint8Array

--- a/types/node/v9/index.d.ts
+++ b/types/node/v9/index.d.ts
@@ -24,6 +24,7 @@
 //                 Mohsen Azimi <https://github.com/mohsen1>
 //                 Hoàng Văn Khải <https://github.com/KSXGitHub>
 //                 Alexander T. <https://github.com/a-tarasyuk>
+//                 Lishude <https://github.com/islishude>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /** inspector module types */
@@ -5658,6 +5659,38 @@ declare module "util" {
     export function promisify(fn: Function): Function;
     export namespace promisify {
         const custom: symbol;
+    }
+
+    export class TextDecoder {
+        readonly encoding: string;
+        readonly fatal: boolean;
+        readonly ignoreBOM: boolean;
+        constructor(
+          encoding?: string,
+          options?: { fatal?: boolean; ignoreBOM?: boolean }
+        );
+        decode(
+          input?:
+            | Int8Array
+            | Int16Array
+            | Int32Array
+            | Uint8Array
+            | Uint16Array
+            | Uint32Array
+            | Uint8ClampedArray
+            | Float32Array
+            | Float64Array
+            | DataView
+            | ArrayBuffer
+            | null,
+          options?: { stream?: boolean }
+        ): string;
+    }
+
+    export class TextEncoder {
+        readonly encoding: string;
+        constructor();
+        encode(input?: string): Uint8Array;
     }
 }
 

--- a/types/node/v9/index.d.ts
+++ b/types/node/v9/index.d.ts
@@ -5660,7 +5660,7 @@ declare module "util" {
     export namespace promisify {
         const custom: symbol;
     }
-
+    // TypeScript Version: 2.1
     export class TextDecoder {
         readonly encoding: string;
         readonly fatal: boolean;

--- a/types/node/v9/index.d.ts
+++ b/types/node/v9/index.d.ts
@@ -5660,7 +5660,7 @@ declare module "util" {
     export namespace promisify {
         const custom: symbol;
     }
-    // TypeScript Version: 2.1
+
     export class TextDecoder {
         readonly encoding: string;
         readonly fatal: boolean;

--- a/types/node/v9/node-tests.ts
+++ b/types/node/v9/node-tests.ts
@@ -854,6 +854,35 @@ namespace util_tests {
 
         // util.isDeepStrictEqual
         util.isDeepStrictEqual({foo: 'bar'}, {foo: 'bar'});
+
+        // util.TextDecoder()
+        var td = new util.TextDecoder();
+        new util.TextDecoder("utf-8");
+        new util.TextDecoder("utf-8", { fatal: true });
+        new util.TextDecoder("utf-8", { fatal: true, ignoreBOM: true });
+        var ignoreBom: boolean = td.ignoreBOM;
+        var fatal: boolean = td.fatal;
+        var encoding: string = td.encoding;
+        td.decode(new Int8Array(1));
+        td.decode(new Int16Array(1));
+        td.decode(new Int32Array(1));
+        td.decode(new Uint8Array(1));
+        td.decode(new Uint16Array(1));
+        td.decode(new Uint32Array(1));
+        td.decode(new Uint8ClampedArray(1));
+        td.decode(new Float32Array(1));
+        td.decode(new Float64Array(1));
+        td.decode(new DataView(new Int8Array(1).buffer));
+        td.decode(new ArrayBuffer(1));
+        td.decode(null);
+        td.decode(null, { stream: true });
+        td.decode(new Int8Array(1), { stream: true });
+        var decode: string = td.decode(new Int8Array(1));
+
+        // util.TextEncoder()
+        var te = new util.TextEncoder();
+        var teEncoding: string = te.encoding;
+        var teEncodeRes: Uint8Array = te.encode("TextEncoder");
     }
 }
 


### PR DESCRIPTION
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://nodejs.org/dist/latest-v10.x/docs/api/>>
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
