### PR TITLE
[@types/croppie] Added the method "get()" from the Croppie library

### DIFF
--- a/types/croppie/croppie-tests.ts
+++ b/types/croppie/croppie-tests.ts
@@ -22,4 +22,6 @@ c.result({ type: 'blob' }).then(blob => {
     x = blob;
 });
 
+c.get();
+
 c.destroy();

--- a/types/croppie/index.d.ts
+++ b/types/croppie/index.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: Connor Peet <https://github.com/connor4312>
 //                 dklmuc <https://github.com/dklmuc>
 //                 Sarun Intaralawan <https://github.com/sarunint>
+//                 Knut Erik Helgesen <https://github.com/knuthelgesen>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 export as namespace Croppie;
@@ -25,6 +26,8 @@ declare class Croppie {
     result(options: Croppie.ResultOptions & { type: 'blob' }): Promise<Blob>;
     result(options: Croppie.ResultOptions & { type: 'rawcanvas' }): Promise<HTMLCanvasElement>;
     result(options?: Croppie.ResultOptions): Promise<HTMLCanvasElement>;
+
+    get(): Croppie.CropData;
 
     rotate(degrees: 90 | 180 | 270 | -90 | -180 | -270): void;
 
@@ -58,5 +61,11 @@ declare namespace Croppie {
         mouseWheelZoom?: boolean;
         showZoomer?: boolean;
         viewport?: { width: number, height: number, type?: CropType };
+    }
+
+    interface CropData {
+        points?: number[];
+        orientation?: number;
+        zoom?: number;
     }
 }


### PR DESCRIPTION
Added the method "get()" from the Croppie library so it's possible to read crop data (points, zoom and orientation)
Added an interface for the crop data

The Croppie API has a method "get()" to read crop data. This method was missing from the definition, so I have added it to make it possible to read these data from Croppie and not only the image data.
The API is documented here: https://foliotek.github.io/Croppie/
See section on methods.


Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://foliotek.github.io/Croppie/
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
