### PR TITLE
classnames: let classNames() to accept boolean, as the original implementation does

### DIFF
--- a/types/classnames/classnames-tests.ts
+++ b/types/classnames/classnames-tests.ts
@@ -38,3 +38,6 @@ const className = cx('foo', ['bar'], { baz: true }); // => "abc def xyz"
 
 // falsey values are just ignored
 cx(null, 'bar', undefined, 0, 1, { baz: null }, ''); // => 'bar 1'
+
+// true is just ignored
+cx(true || "foo");

--- a/types/classnames/index.d.ts
+++ b/types/classnames/index.d.ts
@@ -9,7 +9,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
-type ClassValue = string | number | ClassDictionary | ClassArray | undefined | null | false;
+type ClassValue = string | number | ClassDictionary | ClassArray | undefined | null | boolean;
 
 interface ClassDictionary {
 	[id: string]: boolean | undefined | null;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

---

ref. https://github.com/JedWatson/classnames/blob/master/index.js#L22

It just ignores an arg unless the arg is not string, number, array, nor object. That is, the original impl just ignores boolean.