### PR TITLE
react-input-mask: Add exports namespace with all declared types

### DIFF
--- a/types/react-input-mask/index.d.ts
+++ b/types/react-input-mask/index.d.ts
@@ -6,8 +6,11 @@
 
 import * as React from "react";
 
-declare namespace reactInputMask {
-    interface ReactInputMaskProps extends React.InputHTMLAttributes<HTMLInputElement> {
+export = ReactInputMask;
+export as namespace ReactInputMask;
+
+declare namespace ReactInputMask {
+    interface Props extends React.InputHTMLAttributes<HTMLInputElement> {
         /**
          * Mask string. Format characters are:
          * * `9`: `0-9`
@@ -41,8 +44,7 @@ declare namespace reactInputMask {
          */
         inputRef?: React.Ref<HTMLInputElement>;
     }
-    class ReactInputMask extends React.Component<ReactInputMaskProps> {
-    }
 }
-declare var ReactInputMask: typeof reactInputMask.ReactInputMask;
-export default ReactInputMask;
+
+declare class ReactInputMask extends React.Component<ReactInputMask.Props> {
+}

--- a/types/react-input-mask/index.d.ts
+++ b/types/react-input-mask/index.d.ts
@@ -6,7 +6,7 @@
 
 import * as React from "react";
 
-export = ReactInputMask;
+export default ReactInputMask;
 export as namespace ReactInputMask;
 
 declare namespace ReactInputMask {

--- a/types/react-input-mask/index.d.ts
+++ b/types/react-input-mask/index.d.ts
@@ -6,9 +6,6 @@
 
 import * as React from "react";
 
-export default ReactInputMask;
-export as namespace ReactInputMask;
-
 declare namespace ReactInputMask {
     interface Props extends React.InputHTMLAttributes<HTMLInputElement> {
         /**
@@ -48,3 +45,5 @@ declare namespace ReactInputMask {
 
 declare class ReactInputMask extends React.Component<ReactInputMask.Props> {
 }
+
+export default ReactInputMask;


### PR DESCRIPTION
Unable use ReactInputMaskProps in own components because namespace not exported.