### PR TITLE
Fill in missing before* type definitions in types/angular-animate/index.d.ts

### DIFF
--- a/types/angular-animate/index.d.ts
+++ b/types/angular-animate/index.d.ts
@@ -20,8 +20,11 @@ declare module 'angular' {
 
         interface IAnimateCallbackObject {
             eventFn?: (element: JQuery, doneFunction: Function, options: IAnimationOptions) => any;
+            beforeSetClass?: (element: JQuery, addedClasses: string, removedClasses: string, doneFunction: Function, options: IAnimationOptions) => any;
             setClass?: (element: JQuery, addedClasses: string, removedClasses: string, doneFunction: Function, options: IAnimationOptions) => any;
+            beforeAddClass?: (element: JQuery, addedClasses: string, doneFunction: Function, options: IAnimationOptions) => any;
             addClass?: (element: JQuery, addedClasses: string, doneFunction: Function, options: IAnimationOptions) => any;
+            beforeRemoveClass?: (element: JQuery, removedClasses: string, doneFunction: Function, options: IAnimationOptions) => any;
             removeClass?: (element: JQuery, removedClasses: string, doneFunction: Function, options: IAnimationOptions) => any;
             enter?: (element: JQuery, doneFunction: Function, options: IAnimationOptions) => any;
             leave?: (element: JQuery, doneFunction: Function, options: IAnimationOptions) => any;


### PR DESCRIPTION
Fill in beforeAddClass, beforeRemoveClass, and beforeSetClass type definitions that are missing.
Reference to angular-1.5 externs: https://github.com/google/closure-compiler/blob/master/contrib/externs/angular-1.5.js#L220
Reference to ngAnimate/animateJs.js: https://github.com/angular/angular.js/blob/master/src/ngAnimate/animateJs.js#L232

Please fill in this template.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/google/closure-compiler/blob/master/contrib/externs/angular-1.5.js#L220
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
