### PR TITLE
http-proxy/Add missing property boolean `selfHandleResponse`

### DIFF
--- a/types/http-proxy/index.d.ts
+++ b/types/http-proxy/index.d.ts
@@ -207,6 +207,8 @@ declare namespace Server {
     headers?: {[header: string]: string};
     /** Timeout (in milliseconds) when proxy receives no response from target. Default: 120000 (2 minutes) */
     proxyTimeout?: number;
+    /** If set to true, none of the webOutgoing passes are called and it's your responsibility to appropriately return the response by listening and acting on the proxyRes event */
+    selfHandleResponse?: boolean;
   }
 }
 


### PR DESCRIPTION
Add missing boolean property `selfHandleResponse` to ServerOptions interface

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: The official documentation for this library https://www.npmjs.com/package/http-proxy#options states that there is a boolean property called `selfHandleResponse` that is missing from the current type definition.
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.