### PR TITLE
Adds 'success' and 'errors' properties to BatchResultInfo.

### DIFF
--- a/types/jsforce/batch.d.ts
+++ b/types/jsforce/batch.d.ts
@@ -12,8 +12,10 @@ export interface BatchInfo {
 
 export interface BatchResultInfo {
     id: string;
-    batchId: string;
-    jobId: string;
+    batchId?: string;
+    jobId?: string;
+    success?: boolean;
+    errors?: string[];
 }
 
 export class Batch extends Writable {

--- a/types/jsforce/bulk.d.ts
+++ b/types/jsforce/bulk.d.ts
@@ -8,7 +8,7 @@ import { Batch, BatchResultInfo } from './batch';
 
 export interface BulkOptions {
     extIdField: string;
-    concurrencyMode: 'Serial' | 'Parallel';
+    concurrencyMode?: 'Serial' | 'Parallel';
 }
 
 type BulkLoadOperation =

--- a/types/jsforce/connection.d.ts
+++ b/types/jsforce/connection.d.ts
@@ -22,9 +22,10 @@ export interface PartialOAuth2Options {
 }
 
 export interface RequestInfo {
+    body?: string;
+    headers?: object;
     method?: string;
     url?: string;
-    headers?: object;
 }
 
 export interface ConnectionOptions extends PartialOAuth2Options {
@@ -56,6 +57,16 @@ export abstract class RestApi {
     put(path: string, body: object, options: object, callback: () => object): Promise<object>;
     patch(path: string, body: object, options: object, callback: () => object): Promise<object>;
     del(path: string, options: object, callback: () => object): Promise<object>;
+}
+
+export interface ExecuteAnonymousResult {
+    compiled: boolean;
+    compileProblem: string;
+    success: boolean;
+    line: number;
+    column: number;
+    exceptionMessage: string;
+    exceptionStackTrace: string;
 }
 
 export type ConnectionEvent = "refresh";
@@ -135,5 +146,5 @@ export class Tooling extends BaseConnection {
     _logger: any;
 
     // Specific to tooling
-    executeAnonymous(body: string, callback?: (err: Error, res: any) => void): Promise<any>;
+    executeAnonymous(body: string, callback?: (err: Error, res: any) => void): Promise<ExecuteAnonymousResult>;
 }

--- a/types/jsforce/job.d.ts
+++ b/types/jsforce/job.d.ts
@@ -19,6 +19,6 @@ export class Job extends EventEmitter {
     close(callback?: (err: Error, jobInfo: JobInfo) => void): Promise<JobInfo>;
     createBatch(): Batch;
     info(callback?: (err: Error, jobInfo: JobInfo) => void): Promise<JobInfo>;
-    list(callback?: (err: Error, jobInfo: BatchInfo) => void): Promise<BatchInfo>;
+    list(callback?: (err: Error, jobInfo: BatchInfo) => void): Promise<BatchInfo[]>;
     open(callback?: (err: Error, jobInfo: JobInfo) => void): Promise<JobInfo>;
 }


### PR DESCRIPTION
Changes 'concurrencyMode' property to be optional since 'Parallel' is the default.
Adds 'body' property to RequestInfo.
Adds the ExecuteAnonymousResult interface.
Changes Job.prototype.list() to return a BatchInfo[].
Adds tests.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
