### PR TITLE
Fix parameters for `generateAuthorizationCode` in oauth2-server

### DIFF
--- a/types/oauth2-server/index.d.ts
+++ b/types/oauth2-server/index.d.ts
@@ -239,7 +239,7 @@ declare namespace OAuth2Server {
          * Invoked to generate a new authorization code.
          *
          */
-        generateAuthorizationCode?(callback?: Callback<string>): Promise<string>;
+        generateAuthorizationCode?(client: Client, user: User, scope: string, callback?: Callback<string>): Promise<string>;
 
         /**
          * Invoked to retrieve an existing authorization code previously saved through Model#saveAuthorizationCode().

--- a/types/oauth2-server/oauth2-server-tests.ts
+++ b/types/oauth2-server/oauth2-server-tests.ts
@@ -2,37 +2,37 @@ import express = require("express");
 import OAuth2Server = require("oauth2-server");
 
 const oauth2Model: OAuth2Server.AuthorizationCodeModel = {
-        getClient: async (clientId: string, clientSecret: string): Promise<OAuth2Server.Client | OAuth2Server.Falsey> => {
-            return undefined;
-        },
-        saveToken: async (token: OAuth2Server.Token, client: OAuth2Server.Client, user: OAuth2Server.User): Promise<OAuth2Server.Token> => {
-            return token;
-        },
-        getAccessToken: async (accessToken: string): Promise<OAuth2Server.Token> => {
-            return {
-                accessToken,
-                client: {id: "testClient", grants: ["access_token"]},
-                user: {id: "testUser"}
-            };
-        },
-        verifyScope: async (token: OAuth2Server.Token, scope: string): Promise<boolean> => {
-            return true;
-        },
-        getAuthorizationCode: async (authorizationCode: string): Promise<OAuth2Server.AuthorizationCode> => {
-            return {
-                authorizationCode,
-                expiresAt: new Date(),
-                redirectUri: "www.test.com",
-                client: {id: "testClient", grants: ["access_token"]},
-                user: {id: "testUser"}
-            };
-        },
-        saveAuthorizationCode: async (code: OAuth2Server.AuthorizationCode, client: OAuth2Server.Client, user: OAuth2Server.User): Promise<OAuth2Server.AuthorizationCode> => {
-            return code;
-        },
-        revokeAuthorizationCode: async (code: OAuth2Server.AuthorizationCode): Promise<boolean> => {
-            return true;
-        }
+    getClient: async (clientId: string, clientSecret: string): Promise<OAuth2Server.Client | OAuth2Server.Falsey> => {
+        return undefined;
+    },
+    saveToken: async (token: OAuth2Server.Token, client: OAuth2Server.Client, user: OAuth2Server.User): Promise<OAuth2Server.Token> => {
+        return token;
+    },
+    getAccessToken: async (accessToken: string): Promise<OAuth2Server.Token> => {
+        return {
+            accessToken,
+            client: { id: "testClient", grants: ["access_token"] },
+            user: { id: "testUser" }
+        };
+    },
+    verifyScope: async (token: OAuth2Server.Token, scope: string): Promise<boolean> => {
+        return true;
+    },
+    getAuthorizationCode: async (authorizationCode: string): Promise<OAuth2Server.AuthorizationCode> => {
+        return {
+            authorizationCode,
+            expiresAt: new Date(),
+            redirectUri: "www.test.com",
+            client: { id: "testClient", grants: ["access_token"] },
+            user: { id: "testUser" }
+        };
+    },
+    saveAuthorizationCode: async (code: OAuth2Server.AuthorizationCode, client: OAuth2Server.Client, user: OAuth2Server.User): Promise<OAuth2Server.AuthorizationCode> => {
+        return code;
+    },
+    revokeAuthorizationCode: async (code: OAuth2Server.AuthorizationCode): Promise<boolean> => {
+        return true;
+    }
 };
 
 const oauth2Server = new OAuth2Server({

--- a/types/oauth2-server/oauth2-server-tests.ts
+++ b/types/oauth2-server/oauth2-server-tests.ts
@@ -2,6 +2,13 @@ import express = require("express");
 import OAuth2Server = require("oauth2-server");
 
 const oauth2Model: OAuth2Server.AuthorizationCodeModel = {
+    generateAuthorizationCode: async (client, user, scope) => {
+        return JSON.stringify({
+            client,
+            user,
+            scope,
+        });
+    },
     getClient: async (clientId: string, clientSecret: string): Promise<OAuth2Server.Client | OAuth2Server.Falsey> => {
         return undefined;
     },


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes:
  - https://oauth2-server.readthedocs.io/en/latest/model/spec.html#generateauthorizationcode-client-user-scope-callback
  - https://github.com/oauthjs/node-oauth2-server/blob/5f48a5ce060e22ae8032ea78a781518d5a7cd411/lib/handlers/authorize-handler.js#L138
- [X] Increase the version number in the header if appropriate.
  - No change seemed necessary for this
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
  - No change seemed necessary for this