### PR TITLE
oauth2-server: Remove User "id" property from types.

### DIFF
--- a/types/oauth2-server/index.d.ts
+++ b/types/oauth2-server/index.d.ts
@@ -327,7 +327,6 @@ declare namespace OAuth2Server {
      * A user object is completely transparent to oauth2-server and is simply used as input to model functions.
      */
     interface User {
-        id: string;
         [key: string]: any;
     }
 


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/oauthjs/node-oauth2-server/blob/e1f741fdad191ee47e7764b80a8403c1ea2804d4/docs/misc/migrating-v2-to-v3.rst#model-specification
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

From above link:

> - getUser(username, password) should return an object:
>   - No longer requires that id be returned.
> - getUserFromClient(client) should return an object:
>   - No longer requires that id be returned.

Ergo, the User "object" simply needs to be an object with no additional structure.
