### PR TITLE
Fix return type for RedisOptions.reconnectOnError

### DIFF
--- a/types/ioredis/index.d.ts
+++ b/types/ioredis/index.d.ts
@@ -798,7 +798,11 @@ declare namespace IORedis {
          * Fixed in: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/15858
          */
         retryStrategy?(times: number): number | false;
-        reconnectOnError?(error: Error): boolean;
+        /**
+         * 1/true means reconnect, 2 means reconnect and resend failed command. Returning false will ignore
+         * the error and do nothing.
+         */
+        reconnectOnError?(error: Error): boolean | 1 | 2;
         /**
          * By default, if there is no active connection to the Redis server, commands are added to a queue
          * and are executed once the connection is "ready" (when enableReadyCheck is true, "ready" means


### PR DESCRIPTION
As seen in the source https://github.com/luin/ioredis/blob/cf18554c142f461b3ad7ff716df596d7d1615828/lib/redis/parser.js#L50 the return values for the `reconnectOnError` functions should include `1` and `2`.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/luin/ioredis/blob/cf18554c142f461b3ad7ff716df596d7d1615828/lib/redis/parser.js#L50
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
