### PR TITLE
Add sourceTarget and propagatedFrom to LeafletEvent

### DIFF
--- a/types/leaflet/index.d.ts
+++ b/types/leaflet/index.d.ts
@@ -1190,6 +1190,8 @@ export class Handler extends Class {
 export interface LeafletEvent {
     type: string;
     target: any;
+    sourceTarget: any;
+    propagatedFrom: any;
 }
 
 export interface LeafletMouseEvent extends LeafletEvent {

--- a/types/leaflet/index.d.ts
+++ b/types/leaflet/index.d.ts
@@ -1192,6 +1192,7 @@ export interface LeafletEvent {
     target: any;
     sourceTarget: any;
     propagatedFrom: any;
+    layer: any;
 }
 
 export interface LeafletMouseEvent extends LeafletEvent {


### PR DESCRIPTION
I added these members.
According to https://leafletjs.com/reference-1.3.0.html#event
the base Event has members sourceTarget and propagatedFrom which were missing in the definition of the LeafletEvent interface.

