### PR TITLE
added 2 missing defs (domain+request) in amazon-product-api for IItemLookupOptions

### DIFF
--- a/types/amazon-product-api/index.d.ts
+++ b/types/amazon-product-api/index.d.ts
@@ -33,6 +33,8 @@ interface IItemLookupOptions {
     searchIndex?: string;
     truncateReviewsAt?: number;
     variationPage?: string;
+    domain?: string;
+    request?: Function;
 }
 
 interface IBrowseNodeLookupOptions {


### PR DESCRIPTION
If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
- [x] added missing types in dt.s