### PR TITLE
package.json reformat: 4 spaces indentation according to the .editorconfig

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,27 +1,27 @@
 {
-  "private": true,
-  "name": "definitely-typed",
-  "version": "0.0.2",
-  "homepage": "https://github.com/DefinitelyTyped/DefinitelyTyped",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/DefinitelyTyped/DefinitelyTyped.git"
-  },
-  "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/DefinitelyTyped/DefinitelyTyped/issues"
-  },
-  "engines": {
-    "node": ">=7.8.0"
-  },
-  "scripts": {
-    "compile-scripts": "tsc -p scripts",
-    "not-needed": "node scripts/not-needed.js",
-    "test": "node node_modules/types-publisher/bin/tester/test.js --run-from-definitely-typed",
-    "lint": "dtslint types"
-  },
-  "devDependencies": {
-    "dtslint": "github:Microsoft/dtslint#production",
-    "types-publisher": "Microsoft/types-publisher#production"
-  }
+    "private": true,
+    "name": "definitely-typed",
+    "version": "0.0.2",
+    "homepage": "https://github.com/DefinitelyTyped/DefinitelyTyped",
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/DefinitelyTyped/DefinitelyTyped.git"
+    },
+    "license": "MIT",
+    "bugs": {
+        "url": "https://github.com/DefinitelyTyped/DefinitelyTyped/issues"
+    },
+    "engines": {
+        "node": ">=7.8.0"
+    },
+    "scripts": {
+        "compile-scripts": "tsc -p scripts",
+        "not-needed": "node scripts/not-needed.js",
+        "test": "node node_modules/types-publisher/bin/tester/test.js --run-from-definitely-typed",
+        "lint": "dtslint types"
+    },
+    "devDependencies": {
+        "dtslint": "github:Microsoft/dtslint#production",
+        "types-publisher": "Microsoft/types-publisher#production"
+    }
 }


### PR DESCRIPTION
We should always use 4 spaces, including .json files, because
- it's written in .editorconfig (after this commit https://github.com/DefinitelyTyped/DefinitelyTyped/commit/d94fa4a42e4988bb3bef20668df5ac2768f34a0f)
- it's written in "Common Mistakes"  https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes
> Formatting: Either use all tabs, or always use 4 spaces.

Therefore formatted package.json to use 4 spaces indentation.