### PR TITLE
[IBM_DB] Database callback return type fixes

### DIFF
--- a/types/ibm_db/index.d.ts
+++ b/types/ibm_db/index.d.ts
@@ -104,9 +104,9 @@ export class Database implements Options {
 
     rollbackTransactionSync(): Database;
 
-    columns(catalog: string | null, schema: string | null, table: string | null, column: string | null, cb: (error: Error, res: ODBCResult) => void): void;
+    columns(catalog: string | null, schema: string | null, table: string | null, column: string | null, cb: (error: Error, res: any[]) => void): void;
 
-    tables(catalog: string | null, schema: string | null, table: string | null, type: string | null, cb: (error: Error, res: ODBCResult) => void): void;
+    tables(catalog: string | null, schema: string | null, table: string | null, type: string | null, cb: (error: Error, res: any[]) => void): void;
 
     describe(obj: DescribeObject,  cb: (error: Error, res: any[]) => void): void;
 
@@ -187,6 +187,7 @@ export class ODBCStatement {
 
 export class ODBCResult {
     fetchMode: number;
+    fetchSync(): any[];
     fetchAllSync(): any[];
     moreResultsSync(): any[];
     closeSync(): void;


### PR DESCRIPTION
 * Change result type of `columns()` and `tables()` callback definition of `Database`.
    The code before calling a callback, fetches and returns data from `ODBCResult`, not the `ODBCResult` object itself.
 * Add missing `ODBCResult.fetchSync()` definition.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes:
    * https://github.com/ibmdb/node-ibm_db/blob/master/lib/odbc.js#L957
    * https://github.com/ibmdb/node-ibm_db/blob/master/lib/odbc.js#L980
    * https://github.com/ibmdb/node-ibm_db/blob/master/src/odbc_result.cpp#L322
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
