### PR TITLE
mapbox-gl: Added StyleFunction to SymbolLayout - icon-allow-overlap

### DIFF
--- a/types/mapbox-gl/index.d.ts
+++ b/types/mapbox-gl/index.d.ts
@@ -1020,7 +1020,7 @@ declare namespace mapboxgl {
         'symbol-placement'?: 'point' | 'line';
         'symbol-spacing'?: number | Expression;
         'symbol-avoid-edges'?: boolean;
-        'icon-allow-overlap'?: boolean;
+        'icon-allow-overlap'?: boolean | StyleFunction;
         'icon-ignore-placement'?: boolean;
         'icon-optional'?: boolean;
         'icon-rotation-alignment'?: 'map' | 'viewport' | 'auto';


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:   https://www.mapbox.com/mapbox-gl-js/style-spec#layout-symbol-icon-allow-overlap The documentation is wrong, icon-allow-overlap works just fine with style functions.
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.