### PR TITLE
"chartist" improvements: added "series" to the ILineChartOptions, files reformat, definitions change

### DIFF
--- a/types/chartist/chartist-tests.ts
+++ b/types/chartist/chartist-tests.ts
@@ -53,6 +53,59 @@ new Chartist.Line('.ct-chart', {
     ]
 });
 
+
+// This example was taken here: https://gionkunz.github.io/chartist-js/examples.html#example-line-series-override
+new Chartist.Line('.ct-chart', {
+    labels: ['1', '2', '3', '4', '5', '6', '7', '8'],
+    // Naming the series with the series object array notation
+    series: [{
+        name: 'series-1',
+        data: [5, 2, -4, 2, 0, -2, 5, -3]
+    }, {
+        name: 'series-2',
+        data: [4, 3, 5, 3, 1, 3, 6, 4]
+    }, {
+        name: 'series-3',
+        data: [2, 4, 3, 1, 4, 5, 3, 2]
+    }]
+}, {
+    fullWidth: true,
+    // Within the series options you can use the series names
+    // to specify configuration that will only be used for the
+    // specific series.
+    series: {
+        'series-1': {
+            lineSmooth: Chartist.Interpolation.step()
+        },
+        'series-2': {
+            lineSmooth: Chartist.Interpolation.simple(),
+            showArea: true
+        },
+        'series-3': {
+            showPoint: false
+        }
+    }
+}, [
+    // You can even use responsive configuration overrides to
+    // customize your series configuration even further!
+    ['screen and (max-width: 320px)', {
+        series: {
+            'series-1': {
+                lineSmooth: Chartist.Interpolation.none()
+            },
+            'series-2': {
+                lineSmooth: Chartist.Interpolation.none(),
+                showArea: false
+            },
+            'series-3': {
+                lineSmooth: Chartist.Interpolation.none(),
+                showPoint: true
+            }
+        }
+    }]
+]);
+
+
 var data = {
     series: [5, 3, 4]
 };

--- a/types/chartist/chartist-tests.ts
+++ b/types/chartist/chartist-tests.ts
@@ -1,429 +1,432 @@
 import Chartist = require("chartist");
+
 Chartist.escapingMap = {
-  '&': '&amp;',
-  '<': '&lt;',
-  '>': '&gt;',
-  '"': '&quot;',
-  '\'': '&#039;',
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    '\'': '&#039;',
 };
 
 Chartist.precision = 8;
 
 new Chartist.Line('.ct-chart', {
-  labels: ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday'],
-  series: [
-    [12, 9, 7, 8, 5],
-    [2, 1, 3.5, 7, 3],
-    [1, 3, 4, 5, 6]
-  ]
+    labels: ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday'],
+    series: [
+        [12, 9, 7, 8, 5],
+        [2, 1, 3.5, 7, 3],
+        [1, 3, 4, 5, 6]
+    ]
 }, {
     fullWidth: true,
     chartPadding: {
-      right: 40
+        right: 40
     }
-  });
+});
 
 var lineChart = new Chartist.Line('.ct-chart', {
-  labels: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
-  series: [
-    [5, 5, 10, 8, 7, 5, 4, null, null, null, 10, 10, 7, 8, 6, 9],
-    [10, 15, null, 12, null, 10, 12, 15, null, null, 12, null, 14, null, null, null],
-    [null, null, null, null, 3, 4, 1, 3, 4, 6, 7, 9, 5, null, null, null]
-  ]
+    labels: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
+    series: [
+        [5, 5, 10, 8, 7, 5, 4, null, null, null, 10, 10, 7, 8, 6, 9],
+        [10, 15, null, 12, null, 10, 12, 15, null, null, 12, null, 14, null, null, null],
+        [null, null, null, null, 3, 4, 1, 3, 4, 6, 7, 9, 5, null, null, null]
+    ]
 }, {
     fullWidth: true,
     chartPadding: {
-      right: 10
+        right: 10
     },
     low: 0
-  });
+});
 
 new Chartist.Line('.ct-chart', {
-  labels: ['1', '2', '3', '4', '5', '6'],
-  series: [
-    {
-      name: 'Fibonacci sequence',
-      data: [1, 2, 3, 5, 8, 13]
-    },
-    {
-      name: 'Golden section',
-      data: [1, 1.618, 2.618, 4.236, 6.854, 11.09]
-    }
-  ]
+    labels: ['1', '2', '3', '4', '5', '6'],
+    series: [
+        {
+            name: 'Fibonacci sequence',
+            data: [1, 2, 3, 5, 8, 13]
+        },
+        {
+            name: 'Golden section',
+            data: [1, 1.618, 2.618, 4.236, 6.854, 11.09]
+        }
+    ]
 });
 
 var data = {
-  series: [5, 3, 4]
+    series: [5, 3, 4]
 };
 
-var sum = (a: number, b: number) => { return a + b };
+var sum = (a: number, b: number) => {
+    return a + b
+};
 
 new Chartist.Pie('.ct-chart', data, {
-  labelInterpolationFnc: (value: number) => {
-    return Math.round(value / data.series.reduce(sum) * 100) + '%';
-  }
+    labelInterpolationFnc: (value: number) => {
+        return Math.round(value / data.series.reduce(sum) * 100) + '%';
+    }
 });
 
 new Chartist.Pie('.ct-chart', {
-  series: [20, 10, 30, 40]
+    series: [20, 10, 30, 40]
 }, {
     donut: true,
     donutWidth: 60,
     startAngle: 270,
     total: 200,
     showLabel: false
-  });
+});
 
 // Animation Donut example
 var chart = new Chartist.Pie('.ct-chart', {
-  series: [10, 20, 50, 20, 5, 50, 15],
-  labels: [1, 2, 3, 4, 5, 6, 7]
+    series: [10, 20, 50, 20, 5, 50, 15],
+    labels: [1, 2, 3, 4, 5, 6, 7]
 }, {
     donut: true,
     showLabel: false
-  });
+});
 
 chart.on('draw', (data: any) => {
-  if (data.type === 'slice') {
-    // Get the total path length in order to use for dash array animation
-    var pathLength = data.element._node.getTotalLength();
+    if (data.type === 'slice') {
+        // Get the total path length in order to use for dash array animation
+        var pathLength = data.element._node.getTotalLength();
 
-    // Set a dasharray that matches the path length as prerequisite to animate dashoffset
-    data.element.attr({
-      'stroke-dasharray': pathLength + 'px ' + pathLength + 'px'
-    });
+        // Set a dasharray that matches the path length as prerequisite to animate dashoffset
+        data.element.attr({
+            'stroke-dasharray': pathLength + 'px ' + pathLength + 'px'
+        });
 
-    // Create animation definition while also assigning an ID to the animation for later sync usage
-    var animationDefinition: Chartist.IChartistAnimations = {
-      'stroke-dashoffset': {
-        id: 'anim' + data.index,
-        dur: 1000,
-        from: -pathLength + 'px',
-        to: '0px',
-        easing: Chartist.Svg.Easing.easeOutQuint,
-        // We need to use `fill: 'freeze'` otherwise our animation will fall back to initial (not visible)
-        fill: 'freeze'
-      }
-    };
+        // Create animation definition while also assigning an ID to the animation for later sync usage
+        var animationDefinition: Chartist.IChartistAnimations = {
+            'stroke-dashoffset': {
+                id: 'anim' + data.index,
+                dur: 1000,
+                from: -pathLength + 'px',
+                to: '0px',
+                easing: Chartist.Svg.Easing.easeOutQuint,
+                // We need to use `fill: 'freeze'` otherwise our animation will fall back to initial (not visible)
+                fill: 'freeze'
+            }
+        };
 
-    // If this was not the first slice, we need to time the animation so that it uses the end sync event of the previous animation
-    if (data.index !== 0) {
-      animationDefinition['stroke-dashoffset'].begin = 'anim' + (data.index - 1) + '.end';
+        // If this was not the first slice, we need to time the animation so that it uses the end sync event of the previous animation
+        if (data.index !== 0) {
+            animationDefinition['stroke-dashoffset'].begin = 'anim' + (data.index - 1) + '.end';
+        }
+
+        // We need to set an initial value before the animation starts as we are not in guided mode which would do that for us
+        data.element.attr({
+            'stroke-dashoffset': -pathLength + 'px'
+        });
+
+        // We can't use guided mode as the animations need to rely on setting begin manually
+        // See http://gionkunz.github.io/chartist-js/api-documentation.html#chartistsvg-function-animate
+        data.element.animate(animationDefinition, false);
     }
-
-    // We need to set an initial value before the animation starts as we are not in guided mode which would do that for us
-    data.element.attr({
-      'stroke-dashoffset': -pathLength + 'px'
-    });
-
-    // We can't use guided mode as the animations need to rely on setting begin manually
-    // See http://gionkunz.github.io/chartist-js/api-documentation.html#chartistsvg-function-animate
-    data.element.animate(animationDefinition, false);
-  }
 });
 
 new Chartist.Bar('.ct-chart', {
-  labels: ['XS', 'S', 'M', 'L', 'XL', 'XXL', 'XXXL'],
-  series: [20, 60, 120, 200, 180, 20, 10]
+    labels: ['XS', 'S', 'M', 'L', 'XL', 'XXL', 'XXXL'],
+    series: [20, 60, 120, 200, 180, 20, 10]
 }, {
     distributeSeries: true
-  });
+});
 
 new Chartist.Bar('.ct-chart', {
-  labels: ['Quarter 1', 'Quarter 2', 'Quarter 3', 'Quarter 4'],
-  series: [
-    [5, 4, 3, 7],
-    [3, 2, 9, 5],
-    [1, 5, 8, 4],
-    [2, 3, 4, 6],
-    [4, 1, 2, 1]
-  ]
+    labels: ['Quarter 1', 'Quarter 2', 'Quarter 3', 'Quarter 4'],
+    series: [
+        [5, 4, 3, 7],
+        [3, 2, 9, 5],
+        [1, 5, 8, 4],
+        [2, 3, 4, 6],
+        [4, 1, 2, 1]
+    ]
 }, {
     // Default mobile configuration
     stackBars: true,
     axisX: {
-      labelInterpolationFnc: (value: string) => {
-        return value.split(/\s+/).map((word: string) => {
-          return word[0];
-        }).join('');
-      }
+        labelInterpolationFnc: (value: string) => {
+            return value.split(/\s+/).map((word: string) => {
+                return word[0];
+            }).join('');
+        }
     },
     axisY: {
-      offset: 20
+        offset: 20
     }
-  }, [
+}, [
     // Options override for media > 400px
     ['screen and (min-width: 400px)', {
-      reverseData: true,
-      horizontalBars: true,
-      axisX: {
-        labelInterpolationFnc: Chartist.noop
-      },
-      axisY: {
-        offset: 60
-      }
+        reverseData: true,
+        horizontalBars: true,
+        axisX: {
+            labelInterpolationFnc: Chartist.noop
+        },
+        axisY: {
+            offset: 60
+        }
     }],
     // Options override for media > 800px
     ['screen and (min-width: 800px)', {
-      stackBars: false,
-      seriesBarDistance: 10
+        stackBars: false,
+        seriesBarDistance: 10
     }],
     // Options override for media > 1000px
     ['screen and (min-width: 1000px)', {
-      reverseData: false,
-      horizontalBars: false,
-      seriesBarDistance: 15
+        reverseData: false,
+        horizontalBars: false,
+        seriesBarDistance: 15
     }]
-  ]);
+]);
 
 new Chartist.Pie('.ct-chart', {
-  series: [{
-    value: 20,
-    name: 'Series 1',
-    className: 'my-custom-class-one',
-    meta: 'Meta One'
-  }, {
-      value: 10,
-      name: 'Series 2',
-      className: 'my-custom-class-two',
-      meta: 'Meta Two'
+    series: [{
+        value: 20,
+        name: 'Series 1',
+        className: 'my-custom-class-one',
+        meta: 'Meta One'
     }, {
-      value: 70,
-      name: 'Series 3',
-      className: 'my-custom-class-three',
-      meta: 'Meta Three'
+        value: 10,
+        name: 'Series 2',
+        className: 'my-custom-class-two',
+        meta: 'Meta Two'
+    }, {
+        value: 70,
+        name: 'Series 3',
+        className: 'my-custom-class-three',
+        meta: 'Meta Three'
     }]
 });
 
 new Chartist.Bar('.bar-chart', {
-  labels: ['foo', 'bar', 'foobar'],
-  series: [
-    {
-      data: [1],
-      className: 'graph-foo',
-    },
-    {
-      data: [10],
-      className: 'graph-foo',
-    },
-    {
-      data: [12],
-      className: 'graph-foo',
-    }]
-  }, {
+    labels: ['foo', 'bar', 'foobar'],
+    series: [
+        {
+            data: [1],
+            className: 'graph-foo',
+        },
+        {
+            data: [10],
+            className: 'graph-foo',
+        },
+        {
+            data: [12],
+            className: 'graph-foo',
+        }]
+}, {
     seriesBarDistance: 30,
     reverseData: true,
     horizontalBars: true,
     height: '115px',
     axisY: {
-      offset: 70,
-      showGrid: false,
+        offset: 70,
+        showGrid: false,
     },
     axisX: {
-      scaleMinSpace: 200
+        scaleMinSpace: 200
     }
-  });
+});
 
 new Chartist.Line('.ct-chart', {
-  labels: [1, 2, 3, 4, 5, 6, 7, 8],
-  series: [
-    [5, 9, 7, 8, 5, 3, 5, 4]
-  ]
+    labels: [1, 2, 3, 4, 5, 6, 7, 8],
+    series: [
+        [5, 9, 7, 8, 5, 3, 5, 4]
+    ]
 }, {
     ticks: [0, 4],
     low: 0,
     showArea: true,
     axisY: {
-      showLabel: true,
-      showGrid: false,
-      ticks: [1, 4],
-      type: Chartist.FixedScaleAxis
+        showLabel: true,
+        showGrid: false,
+        ticks: [1, 4],
+        type: Chartist.FixedScaleAxis
     }
-  });
+});
 
 new Chartist.Line('.ct-chart', {
-  labels: [1, 2, 3, 4, 5, 6, 7, 8],
-  series: [
-    [5, 9, 7, 8, 5, 3, 5, 4]
-  ]
+    labels: [1, 2, 3, 4, 5, 6, 7, 8],
+    series: [
+        [5, 9, 7, 8, 5, 3, 5, 4]
+    ]
 }, {
     ticks: [0, 4],
     low: 0,
     showArea: true,
     axisX: {
-      showGrid: false
+        showGrid: false
     },
     axisY: {
-      showLabel: true,
-      showGrid: false,
-      ticks: [1, 4],
-      type: Chartist.FixedScaleAxis
+        showLabel: true,
+        showGrid: false,
+        ticks: [1, 4],
+        type: Chartist.FixedScaleAxis
     }
-  });
+});
 
 var chart2 = new Chartist.Line('.ct-chart', {
-  labels: [1, 2, 3, 4, 5],
-  series: [
-    [12, 9, 7, 8, 5]
-  ]
+    labels: [1, 2, 3, 4, 5],
+    series: [
+        [12, 9, 7, 8, 5]
+    ]
 });
 
 // Listening for draw events that get emitted by the Chartist chart
 chart2.on('draw', (data: any) => {
-  // If the draw event was triggered from drawing a point on the line chart
-  if (data.type === 'point') {
-    // We are creating a new path SVG element that draws a triangle around the point coordinates
-    var triangle = new Chartist.Svg('path', {
-      d: ['M',
-        data.x,
-        data.y - 15,
-        'L',
-        data.x - 15,
-        data.y + 8,
-        'L',
-        data.x + 15,
-        data.y + 8,
-        'z'].join(' '),
-      style: 'fill-opacity: 1'
-    }, 'ct-area');
+    // If the draw event was triggered from drawing a point on the line chart
+    if (data.type === 'point') {
+        // We are creating a new path SVG element that draws a triangle around the point coordinates
+        var triangle = new Chartist.Svg('path', {
+            d: ['M',
+                data.x,
+                data.y - 15,
+                'L',
+                data.x - 15,
+                data.y + 8,
+                'L',
+                data.x + 15,
+                data.y + 8,
+                'z'].join(' '),
+            style: 'fill-opacity: 1'
+        }, 'ct-area');
 
-    // With data.element we get the Chartist SVG wrapper and we can replace the original point drawn by Chartist with our newly created triangle
-    data.element.replace(triangle);
-  }
+        // With data.element we get the Chartist SVG wrapper and we can replace the original point drawn by Chartist with our newly created triangle
+        data.element.replace(triangle);
+    }
 });
 
 // Create a simple bi-polar bar chart
 var biPolarChart = new Chartist.Bar('.ct-chart', {
-  labels: ['W1', 'W2', 'W3', 'W4', 'W5', 'W6', 'W7', 'W8', 'W9', 'W10'],
-  series: [
-    [1, 2, 4, 8, 6, -2, -1, -4, -6, -2]
-  ]
+    labels: ['W1', 'W2', 'W3', 'W4', 'W5', 'W6', 'W7', 'W8', 'W9', 'W10'],
+    series: [
+        [1, 2, 4, 8, 6, -2, -1, -4, -6, -2]
+    ]
 }, {
     high: 10,
     low: -10,
     axisX: {
-      labelInterpolationFnc: (value: any, index: number) => {
-        return index % 2 === 0 ? value : null;
-      }
+        labelInterpolationFnc: (value: any, index: number) => {
+            return index % 2 === 0 ? value : null;
+        }
     }
-  });
+});
 
 // Listen for draw events on the bar chart
 biPolarChart.on('draw', (data: any) => {
-  // If this draw event is of type bar we can use the data to create additional content
-  if (data.type === 'bar') {
-    // We use the group element of the current series to append a simple circle with the bar peek coordinates and a circle radius that is depending on the value
-    data.group.append(new Chartist.Svg('circle', {
-      cx: data.x2,
-      cy: data.y2,
-      r: Math.abs(Chartist.getMultiValue(data.value)) * 2 + 5
-    }, 'ct-slice-pie'));
-  }
+    // If this draw event is of type bar we can use the data to create additional content
+    if (data.type === 'bar') {
+        // We use the group element of the current series to append a simple circle with the bar peek coordinates and a circle radius that is depending on the value
+        data.group.append(new Chartist.Svg('circle', {
+            cx: data.x2,
+            cy: data.y2,
+            r: Math.abs(Chartist.getMultiValue(data.value)) * 2 + 5
+        }, 'ct-slice-pie'));
+    }
 });
 
 new Chartist.Bar('.ct-chart', {
-  labels: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'],
-  series: [
-    [5, 4, 3, 7, 5, 10, 3],
-    [3, 2, 9, 5, 4, 6, 4]
-  ]
+    labels: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'],
+    series: [
+        [5, 4, 3, 7, 5, 10, 3],
+        [3, 2, 9, 5, 4, 6, 4]
+    ]
 }, {
     axisX: {
-      // On the x-axis start means top and end means bottom
-      position: 'start'
+        // On the x-axis start means top and end means bottom
+        position: 'start'
     },
     axisY: {
-      // On the y-axis start means left and end means right
-      position: 'end'
+        // On the y-axis start means left and end means right
+        position: 'end'
     }
-  });
+});
 
 new Chartist.Line('.ct-chart', {
-  labels: [1, 2, 3, 4, 5],
-  series: [[1, 2, 8, 1, 7]]
+    labels: [1, 2, 3, 4, 5],
+    series: [[1, 2, 8, 1, 7]]
 }, {
     lineSmooth: Chartist.Interpolation.none({
-      fillHoles: false
+        fillHoles: false
     })
-  });
+});
 
 new Chartist.Line('.ct-chart', {
-  labels: [1, 2, 3, 4, 5],
-  series: [[1, 2, 8, 1, 7]]
+    labels: [1, 2, 3, 4, 5],
+    series: [[1, 2, 8, 1, 7]]
 }, {
     lineSmooth: Chartist.Interpolation.simple({
-      divisor: 2,
-      fillHoles: false
+        divisor: 2,
+        fillHoles: false
     })
-  });
+});
 
 new Chartist.Line('.ct-chart', {
-  labels: [1, 2, 3, 4, 5],
-  series: [[1, 2, 8, 1, 7]]
+    labels: [1, 2, 3, 4, 5],
+    series: [[1, 2, 8, 1, 7]]
 }, {
     lineSmooth: Chartist.Interpolation.cardinal({
-      tension: 1,
-      fillHoles: false
+        tension: 1,
+        fillHoles: false
     })
-  });
+});
 
 new Chartist.Line('.ct-chart', {
-  labels: [1, 2, 3, 4, 5],
-  series: [[1, 2, 8, 1, 7]]
+    labels: [1, 2, 3, 4, 5],
+    series: [[1, 2, 8, 1, 7]]
 }, {
     lineSmooth: Chartist.Interpolation.step({
-      postpone: true,
-      fillHoles: false
+        postpone: true,
+        fillHoles: false
     })
-  });
+});
 
 var overlappingBarsData: Chartist.IChartistData = {
-  labels: ['Jan', 'Feb', 'Mar', 'Apr', 'Mai', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'],
-  series: [
-    [5, 4, 3, 7, 5, 10, 3, 4, 8, 10, 6, 8],
-    [3, 2, 9, 5, 4, 6, 4, 6, 7, 8, 7, 4]
-  ]
+    labels: ['Jan', 'Feb', 'Mar', 'Apr', 'Mai', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'],
+    series: [
+        [5, 4, 3, 7, 5, 10, 3, 4, 8, 10, 6, 8],
+        [3, 2, 9, 5, 4, 6, 4, 6, 7, 8, 7, 4]
+    ]
 };
 
 var overlappingBarsOptions: Chartist.IBarChartOptions = {
-  seriesBarDistance: 10
+    seriesBarDistance: 10
 };
 
 var overlappingBarsResponsiveOptions: Array<Chartist.IResponsiveOptionTuple<Chartist.IBarChartOptions>> = [
-  ['screen and (max-width: 640px)', {
-    seriesBarDistance: 5,
-    axisX: {
-      labelInterpolationFnc: (value: any) => {
-        return value[0];
-      }
-    }
-  }]
+    ['screen and (max-width: 640px)', {
+        seriesBarDistance: 5,
+        axisX: {
+            labelInterpolationFnc: (value: any) => {
+                return value[0];
+            }
+        }
+    }]
 ];
 
 new Chartist.Bar('.ct-chart', overlappingBarsData, overlappingBarsOptions, overlappingBarsResponsiveOptions);
 
 new Chartist.Candle('.ct-chart', {
-  labels: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'],
-  series: [
-    [5, 4, 3, 7],
-    [3, 2, 9, 5],
-    [5, 4, 3, 7],
-    [3, 2, 9, 5],
-    [5, 4, 3, 7],
-    [3, 2, 9, 5],
-    [3, 2, 9, 5]
-  ]
+    labels: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'],
+    series: [
+        [5, 4, 3, 7],
+        [3, 2, 9, 5],
+        [5, 4, 3, 7],
+        [3, 2, 9, 5],
+        [5, 4, 3, 7],
+        [3, 2, 9, 5],
+        [3, 2, 9, 5]
+    ]
 }, {
-  axisX: {
-    labelOffset: {
-      x: -10,
-      y: 0
+    axisX: {
+        labelOffset: {
+            x: -10,
+            y: 0
+        }
+    },
+    axisY: {
+        showGrid: false,
+        labelInterpolationFnc: function (value: any) {
+            return value + 12000;
+        }
     }
-  },
-  axisY: {
-    showGrid: false,
-    labelInterpolationFnc: function (value: any) {
-      return value + 12000;
-    }
-  }
 });

--- a/types/chartist/index.d.ts
+++ b/types/chartist/index.d.ts
@@ -5,696 +5,712 @@
 
 declare namespace Chartist {
 
-  interface ChartistStatic {
-
-    /**
-     * Precision level used internally in Chartist for rounding. If you require more decimal places you can increase this number.
-     */
-    precision: number;
-
-    /**
-     * A map with characters to escape for strings to be safely used as attribute values.
-     */
-    escapingMap: IChartistEscapeMap;
-
-    Pie: IChartistPieChart;
-    Bar: IChartistBarChart;
-    Line: IChartistLineChart;
-    Candle: IChartistCandleChart;
-
-    FixedScaleAxis: IFixedScaleAxisStatic;
-    AutoScaleAxis: IAutoScaleAxisStatic;
-    StepAxis: IStepAxisStatic;
-
-    Svg: ChartistSvgStatic;
-    Interpolation: ChartistInterpolationStatic;
-
-    noop: Function;
-
-    alphaNumerate(n: number): string;
-    extend(target: Object, ...sources: Object[]): Object;
-
-    replaceAll(str: string, subStr: string, newSubStr: string): string;
-    ensureUnit(value: number, unit: string): string;
-    quantity(input: string | number): Object;
-
-    query(query: Node | string): Node;
-    times(length: number): Array<any>;
-    sum(previous: number, current: number): number;
-    mapMultiply(factor: number): (num: number) => number;
-    mapAdd(addend: number): (num: number) => number;
-    serialMap(arr: Array<any>, cb: Function): Array<any>;
-    roundWithPrecision(value: number, digits?: number): number;
-
-    getMultiValue(value: any, dimension?: any): number; // this method is not documented, but it is used in the examples
-
-    serialize(data: Object | string | number): string;
-    deserialize(data: string): Object | string | number;
-
-    createSvg(container: Node, width: string, height: string, className: string): Object; // TODO: Figure out if this is returning a ChartistSVGWrapper or an actual SVGElement
-
-    plugins: any;
-  }
-
-  interface IChartistEscapeMap {
-    [Key: string]: string;
-  }
-
-  interface IResponsiveOptionTuple<T extends IChartOptions> extends Array<string | T> {
-    0: string;
-    1: T;
-  }
-
-  // these have no other purpose than to help define the types that can be placed on
-  // a line chart axisX
-  // in the actual chartist library these are classes that project their options onto
-  // the parent class
-  interface IFixedScaleAxisStatic { }
-  interface IAutoScaleAxisStatic { }
-  interface IStepAxisStatic { }
-
-  // data formats are not well documented on all the ways they can be passed to the constructors
-  // this definition gives some intellisense, but does not protect the user from misuse
-  // TODO: come in and tidy this up and make it fit better
-  interface IChartistData {
-    labels?: Array<string> | Array<number> | Array<Date>;
-    series: Array<IChartistSeriesData> | Array<Array<IChartistData>> | Array<number> |  Array<Array<number>>;
-  }
-
-  interface IChartistSeriesData {
-    name?: string;
-    value?: number;
-    data?: Array<number>;
-    className?: string;
-    meta?: string; // I assume this could probably be a number as well?
-  }
-
-  interface IChartistBase<T extends IChartOptions> {
-    container: any;
-    data: IChartistData;
-    defaultOptions: T;
-    options: T;
-    responsiveOptions: Array<IResponsiveOptionTuple<T>>;
-
-    // this most likely doesn't need to be exposed to the user
-    eventEmitter: any;
-
-    supportsForeignObject: boolean;
-    supportsAnimations: boolean;
-    resizeListener: any;
-
-    plugins?: Array<any>; // all of these plugins seem to be functions with options, but keeping type any for now
-
-    update(data: Object, options?: T, override?: boolean): void;
-    detach(): void;
-
-    /**
-     * Use this function to register event handlers. The handler callbacks are synchronous and will run in the main thread rather than the event loop.
-     *
-     * @method on
-     * @param event {string} Name of the event. Check the examples for supported events.
-     * @param handler {Function} The handler function that will be called when an event with the given name was emitted. This function will receive a data argument which contains event data. See the example for more details.
-     */
-    on(event: string, handler: Function): IChartistBase<T>;
-
-    /**
-     * Use this function to un-register event handlers. If the handler function parameter is omitted all handlers for the given event will be un-registered.
-     *
-     * @method off
-     * @param event {string} Name of the event for which a handler should be removed
-     * @param handler {Function} The handler function that that was previously used to register a new event handler. This handler will be removed from the event handler list. If this parameter is omitted then all event handlers for the given event are removed from the list.
-     */
-    off(event: string, handler?: Function): IChartistBase<T>;
-  }
-
-  interface IChartistPieChart extends IChartistBase<IPieChartOptions> {
-    new (target: any, data: IChartistData, options?: IPieChartOptions, responsiveOptions?: Array<IResponsiveOptionTuple<IPieChartOptions>>): IChartistPieChart;
-  }
-
-  interface IChartistLineChart extends IChartistBase<ILineChartOptions> {
-    new (target: any, data: IChartistData, options?: ILineChartOptions, responsiveOptions?: Array<IResponsiveOptionTuple<ILineChartOptions>>): IChartistLineChart;
-  }
-
-  interface IChartistBarChart extends IChartistBase<IBarChartOptions> {
-    new (target: any, data: IChartistData, options?: IBarChartOptions, responsiveOptions?: Array<IResponsiveOptionTuple<IBarChartOptions>>): IChartistBarChart;
-  }
-
-  interface IChartistCandleChart extends IChartistBase<ICandleChartOptions> {
-    new (target: any, data: IChartistData, options?: ICandleChartOptions, responsiveOptions?: Array<IResponsiveOptionTuple<ICandleChartOptions>>): IChartistCandleChart;
-  }
-
-  interface IChartOptions {
-    /**
-     * If true the whole data is reversed including labels, the series order as well as the whole series data arrays.
-     */
-    reverseData?: boolean;
-
-    plugins?: Array<any>;
-  }
-
-  interface IPieChartOptions extends IChartOptions {
-    /**
-     * Specify a fixed width for the chart as a string (i.e. '100px' or '50%')
-     */
-    width?: number | string;
-
-    /**
-     * Specify a fixed height for the chart as a string (i.e. '100px' or '50%')
-     */
-    height?: number | string;
-
-    /**
-     * Padding of the chart drawing area to the container element and labels as a number or padding object {top: 5, right: 5, bottom: 5, left: 5}
-     */
-    chartPadding?: IChartPadding | number;
-
-    /**
-     * Override the class names that are used to generate the SVG structure of the chart
-     */
-    classNames?: IPieChartClasses;
-
-    /**
-     * The start angle of the pie chart in degrees where 0 points north. A higher value offsets the start angle clockwise.
-     */
-    startAngle?: number;
-
-    /**
-     * An optional total you can specify. By specifying a total value, the sum of the values in the series must be this total in order to draw a full pie. You can use this parameter to draw only parts of a pie or gauge charts.
-     */
-    total?: number;
-
-    /**
-     * If specified the donut CSS classes will be used and strokes will be drawn instead of pie slices.
-     */
-    donut?: boolean;
-    
-    /**
-     * If specified the donut segments will be drawn as shapes instead of strokes.
-     */
-    donutSolid?: boolean;
-
-    /**
-     * Specify the donut stroke width, currently done in javascript for convenience. May move to CSS styles in the future.
-     * This option can be set as number or string to specify a relative width (i.e. 100 or '30%').
-     */
-    donutWidth?: number | string;
-
-    /**
-     * Specify if a label should be shown or not
-     */
-    showLabel?: boolean;
-
-    /**
-     * Label position offset from the standard position which is half distance of the radius. This value can be either positive or negative. Positive values will position the label away from the center.
-     */
-    labelOffset?: number;
-
-    /**
-     * This option can be set to 'inside', 'outside' or 'center'. Positioned with 'inside' the labels will be placed on half the distance of the radius to the border of the Pie by respecting the 'labelOffset'. The 'outside' option will place the labels at the border of the pie and 'center' will place the labels in the absolute center point of the chart. The 'center' option only makes sense in conjunction with the 'labelOffset' option.
-     */
-    labelPosition?: string;
-
-    /**
-     * An interpolation function for the label value
-     */
-    labelInterpolationFnc?: Function;
-
-    /**
-     * Label direction can be 'neutral', 'explode' or 'implode'.  Default is 'neutral'.  The labels anchor will be positioned based on those settings as well as the fact if the labels are on the right or left side of the center of the chart. Usually explode is useful when labels are positioned far away from the center.
-     */
-    labelDirection?: string;
-
-    /**
-     * If true the whole data is reversed including labels, the series order as well as the whole series data arrays.
-     */
-    reverseData?: boolean;
-    
-    /**
-    * If true empty values will be ignored to avoid drawing unncessary slices and labels
-    */
-    ignoreEmptyValues?: boolean;
-  }
-
-  interface IChartPadding {
-    top?: number;
-    right?: number;
-    bottom?: number;
-    left?: number;
-  }
-
-  interface IPieChartClasses {
-    chartPie?: string;
-    chartDonut?: string;
-    series?: string;
-    slicePie?: string;
-    sliceDonut?: string;
-    label?: string;
-  }
-
-  interface IBarChartOptions extends IChartOptions {
-    axisX?: IBarChartAxis;
-    axisY?: IBarChartAxis;
-    width?: number | string;
-    height?: number | string;
-    high?: number;
-    low?: number;
-    ticks?: Array<string | number>;
-    onlyInteger?: boolean;
-    chartPadding?: IChartPadding;
-    seriesBarDistance?: number;
-
-    /**
-     * If set to true this property will cause the series bars to be stacked and form a total for each series point. This will also influence the y-axis and the overall bounds of the chart. In stacked mode the seriesBarDistance property will have no effect.
-     */
-    stackBars?: boolean;
-
-    horizontalBars?: boolean;
-    distributeSeries?: boolean;
-  }
-
-  interface IBarChartAxis {
-    offset?: number;
-    position?: string;
-    labelOffset?: {
-      x?: number;
-      y?: number;
-    };
-    showLabel?: boolean;
-    showGrid?: boolean;
-    labelInterpolationFnc?: Function;
-    scaleMinSpace?: number;
-    onlyInteger?: boolean;
-  }
-
-  interface IBarChartClasses {
-    chart?: string;
-    horizontalBars?: string;
-    label?: string;
-    labelGroup?: string;
-    series?: string;
-    bar?: string;
-    grid?: string;
-    gridGroup?: string;
-    vertical?: string;
-    horizontal?: string;
-    start?: string;
-    end?: string;
-  }
-
-  interface ILineChartOptions extends IChartOptions {
-    axisX?: IChartistStepAxis | IChartistFixedScaleAxis | IChartistAutoScaleAxis;
-    axisY?: IChartistStepAxis | IChartistFixedScaleAxis | IChartistAutoScaleAxis;
-    width?: number | string;
-    height?: number | string;
-    showLine?: boolean;
-    showPoint?: boolean;
-    showArea?: boolean;
-    areaBase?: number;
-    lineSmooth?: Function | boolean;
-    low?: number;
-    high?: number;
-    ticks?: Array<string | number>;
-    chartPadding?: IChartPadding;
-    fullWidth?: boolean;
-    classNames?: ILineChartClasses;
-  }
-
-  interface ILineChartAxis {
-    offset?: number;
-    position?: string;
-    labelOffset?: {
-      x?: number;
-      y?: number;
-    };
-    showLabel?: boolean;
-    showGrid?: boolean;
-    labelInterpolationFnc?: Function;
-  }
-
-  interface IChartistStepAxis extends ILineChartAxis {
-    type?: IStepAxisStatic;
-    ticks?: Array<string> | Array<number>;
-    stretch?: boolean;
-  }
-
-  interface IChartistFixedScaleAxis extends ILineChartAxis {
-    type?: IFixedScaleAxisStatic;
-    high?: number;
-    low?: number;
-    divisor?: number;
-    ticks?: Array<string> | Array<number>;
-  }
-
-  interface IChartistAutoScaleAxis extends ILineChartAxis {
-    high?: number;
-    low?: number;
-    scaleMinSpace?: number;
-    onlyInteger?: boolean;
-    referenceValue?: number;
-    type?: IAutoScaleAxisStatic;
-  }
-
-  interface ILineChartClasses {
-    /**
-     * Default is 'ct-chart-line'
-     */
-    chart?: string;
-    label?: string;
-    labelGroup?: string;
-    series?: string;
-    line?: string;
-    point?: string;
-    area?: string;
-    grid?: string;
-    gridGroup?: string;
-    gridBackground?: string;
-    vertical?: string;
-    horizontal?: string;
-    start?: string;
-    end?: string;
-  }
-
-  interface ICandleChartOptions extends IChartOptions {     
-       
-    /**       
-     * Options for X-Axis     
-     */       
-    axisX?: ICandleChartAxis;     
-      
-    /**       
-     * Options for Y-Axis     
-     */       
-    axisY?: ICandleChartAxis;     
-      
-    /**       
-     * Specify a fixed width for the chart as a string (i.e. '100px' or '50%')        
-     */       
-    width?: number | string;      
-      
-    /**       
-     * Specify a fixed height for the chart as a string (i.e. '100px' or '50%')       
-     */       
-    height?: number | string;     
-      
-    /**       
-     * Overriding the natural high of the chart allows you to zoom in or limit the charts highest displayed value     
-     */       
-    hight?: number | string;      
-      
-    /**       
-     * Overriding the natural low of the chart allows you to zoom in or limit the charts lowest displayed value       
-     */       
-    low?: number | string;        
-      
-    /**       
-     * Width of candle body in pixel (IMO is 2 px best minimum value)     
-     */       
-    candleWidth?: number | string;        
-      
-    /**       
-     * Width of candle wick in pixel (IMO is 1 px best minimum value)     
-     */       
-    candleWickWidth?: number | string;        
-      
-    /**       
-     * Use calculated x-axis step length, depending on the number of quotes to display, as candle width. Otherwise the candleWidth is being used.     
-     */       
-    useStepLengthAsCandleWidth?: boolean | string;        
-      
-    /**       
-     * Use 1/3 of candle body width as width for the candle wick, otherwise the candleWickWidth is being used.        
-     */       
-    useOneThirdAsCandleWickWidth?: boolean | string;      
-      
-    /**       
-     * Padding of the chart drawing area to the container element and labels as a number or padding object {top: 5, right: 5, bottom: 5, left: 5}     
-     */       
-    chartPadding?: IChartPadding | number;        
-      
-    /**       
-     * When set to true, the last grid line on the x-axis is not drawn and the chart elements will expand to the full available width of the chart. For the last label to be drawncorrectly you might need to add chart padding or offset the last label with a draw event handler.      
-     */       
-    fullWidth?: boolean | string;     
-       
-    /**       
-     * Override the class names that get used to generate the SVG structure of the chart      
-     */       
-    classNames?: ICandleChartClasses;     
-   }       
-       
-   interface ICandleChartAxis {        
-    /**       
-     * The offset of the chart drawing area to the border of the container        
-     */       
-    offset?: number;      
-    /**       
-     * Position where labels are placed. Can be set to `start` or `end` where `start` is equivalent to left or top on vertical axis and `end` is equivalent to right or bottom on horizontal axis.        
-     */       
-    position?: string;        
-    /**       
-     * Allows you to correct label positioning on this axis by positive or negative x and y offset.       
-     */       
-    labelOffset?: {       
-      x?: number;     
-      y?: number;     
-    };        
-    /**       
-     * If labels should be shown or not       
-     */       
-     showLabel?: boolean;      
-     /**       
-      * If the axis grid should be drawn or not        
-      */       
-     showGrid?: boolean;       
-     /**       
-      * Interpolation function that allows you to intercept the value from the axis label      
-      */       
-     labelInterpolationFnc?: Function;     
-    /**       
-      * Set the axis type to be used to project values on this axis. If not defined, Chartist.StepAxis will be used for the X-Axis, where the ticks option will be set to the labels in the data and the stretch option will be set to the global fullWidth option. This type can be changed to any axis constructor available (e.g. Chartist.FixedScaleAxis), where all axis options should be present here.      
-     */       
-     type?: any;       
-   }       
-       
-   interface ICandleChartClasses {     
-     chart?: string;       
-     label?: string;       
-     labelGroup?: string;      
-     series?: string;      
-     candlePositive?: string;      
-     candleNegative?: string,      
-     grid?: string,        
-     gridGroup?: string,       
-     gridBackground?: string,      
-     vertical?: string,        
-     horizontal?: string,      
-     start?: string,       
-     end?: string,     
-   }       
- 
-
-  interface ChartistSvgStatic {
-    new (name: HTMLElement | string, attributes: Object, className?: string, parent?: Object, insertFirst?: boolean): IChartistSvg;
-
-    Easing: ChartistEasingStatic;
-
-    /**
-     * This method checks for support of a given SVG feature like Extensibility, SVG-animation or the like. Check http://www.w3.org/TR/SVG11/feature for a detailed list.
-     */
-    isSupported(feature: string): boolean;
-  }
-
-  interface IChartistSvg {
-
-    /**
-     * Set attributes on the current SVG element of the wrapper you're currently working on.
-     */
-    attr(attributes: Object | string, ns: string): Object | string;
-
-    /**
-     * Create a new SVG element whose wrapper object will be selected for further operations. This way you can also create nested groups easily.
-     */
-    elem(name: string, attributes?: Object, className?: string, insertFirst?: boolean): IChartistSvg;
-
-    /**
-     * Returns the parent Chartist.SVG wrapper object
-     */
-    parent(): IChartistSvg;
-
-    /**
-     * This method returns a Chartist.Svg wrapper around the root SVG element of the current tree.
-     */
-    root(): IChartistSvg;
-
-    /**
-     * Find the first child SVG element of the current element that matches a CSS selector. The returned object is a Chartist.Svg wrapper.
-     */
-    querySelector(selector: string): IChartistSvg;
-
-    /**
-     * Find the all child SVG elements of the current element that match a CSS selector. The returned object is a Chartist.Svg.List wrapper.
-     */
-    querySelectorAll(selector: string): any; // this returns an svg wrapper list in the docs, need to see if that's just an array or a special list
-
-    /**
-     * This method creates a foreignObject (see https://developer.mozilla.org/en-US/docs/Web/SVG/Element/foreignObject) that allows to embed HTML content into a SVG graphic. With the help of foreignObjects you can enable the usage of regular HTML elements inside of SVG where they are subject for SVG positioning and transformation but the Browser will use the HTML rendering capabilities for the containing DOM.
-     */
-    foreignObject(content: any, attributes?: Object, className?: string, insertFirst?: boolean): IChartistSvg;
-
-    /**
-     * This method adds a new text element to the current Chartist.Svg wrapper.
-     */
-    text(t: string): IChartistSvg;
-
-    /**
-     * This method will clear all child nodes of the current wrapper object.
-     */
-    empty(): IChartistSvg;
-
-    /**
-     * This method will cause the current wrapper to remove itself from its parent wrapper. Use this method if you'd like to get rid of an element in a given DOM structure.
-     */
-    remove(): IChartistSvg;
-
-    /**
-     * This method will replace the element with a new element that can be created outside of the current DOM.
-     */
-    replace(): IChartistSvg;
-
-    /**
-     * This method will append an element to the current element as a child.
-     */
-    append(element: IChartistSvg, insertFirst?: boolean): IChartistSvg;
-
-    /**
-     * Returns an array of class names that are attached to the current wrapper element. This method can not be chained further.
-     */
-    classes(): Array<string>;
-
-    /**
-     * Adds one or a space separated list of classes to the current element and ensures the classes are only existing once.
-     *
-     * @method addClass
-     * @param names {string} A white space separated list of class names
-     */
-    addClass(names: string): IChartistSvg;
-
-    /**
-     * Removes one or a space separated list of classes from the current element.
-     *
-     * @method removeClass
-     * @param names {string} A white space separated list of class names
-     */
-    removeClass(names: string): IChartistSvg;
-
-    /**
-     * Removes all classes from the current element.
-     */
-    removeAllClasses(): IChartistSvg;
-
-    /**
-     * Get element height with fallback to svg BoundingBox or parent container dimensions
-     */
-    height(): number;
-
-    /**
-     * The animate function lets you animate the current element with SMIL animations. You can add animations for multiple attributes at the same time by using an animation definition object. This object should contain SMIL animation attributes.
-     */
-    animate(animations: IChartistAnimations, guided: boolean, eventEmitter: Object): IChartistSvg;
-
-    /**
-     * "Safe" way to get property value from svg BoundingBox. This is a workaround. Firefox throws an NS_ERROR_FAILURE error if getBBox() is called on an invisible node.
-     * THIS IS A WORKAROUND
-     */
-    getBBoxProperty(node: SVGElement, prop: string): string; // TODO: find a good example of this and add it to the tests, it might belong to static
-  }
-
-  interface IChartistAnimations {
-    [Key: string]: IChartistAnimationOptions;
-  }
-
-  interface IChartistAnimationOptions {
-    id?: string;
-    dur: string | number;
-    from: string | number;
-    to: string | number;
-    easing?: IChartistEasingDefinition | string;
-    fill?: string;
-    begin?: string;
-  }
-
-  interface IChartistEasingDefinition {
-    0: number;
-    1: number;
-    2: number;
-    3: number;
-  }
-
-  interface ChartistEasingStatic {
-    easeInSine: IChartistEasingDefinition;
-    easeOutSine: IChartistEasingDefinition;
-    easeInOutSine: IChartistEasingDefinition;
-    easeInQuad: IChartistEasingDefinition;
-    easeOutQuad: IChartistEasingDefinition;
-    easeInOutQuad: IChartistEasingDefinition;
-    easeInCubic: IChartistEasingDefinition;
-    easeOutCubic: IChartistEasingDefinition;
-    easeInOutCubic: IChartistEasingDefinition;
-    easeInQuart: IChartistEasingDefinition;
-    easeOutQuart: IChartistEasingDefinition;
-    easeInOutQuart: IChartistEasingDefinition;
-    easeInQuint: IChartistEasingDefinition;
-    easeOutQuint: IChartistEasingDefinition;
-    easeInOutQuint: IChartistEasingDefinition;
-    easeInExpo: IChartistEasingDefinition;
-    easeOutExpo: IChartistEasingDefinition;
-    easeInOutExpo: IChartistEasingDefinition;
-    easeInCirc: IChartistEasingDefinition;
-    easeOutCirc: IChartistEasingDefinition;
-    easeInOutCirc: IChartistEasingDefinition;
-    easeInBack: IChartistEasingDefinition;
-    easeOutBack: IChartistEasingDefinition;
-    easeInOutBack: IChartistEasingDefinition;
-  }
-
-  interface ChartistInterpolationStatic {
-
-    /**
-     * This interpolation function does not smooth the path and the result is only containing lines and no curves.
-     */
-    none(options?: IChartistInterpolationOptions): Function;
-
-    /**
-     * Simple smoothing creates horizontal handles that are positioned with a fraction of the length between two data points. You can use the divisor option to specify the amount of smoothing.
-     */
-    simple(options?: IChartistSimpleInterpolationOptions): Function;
-
-    /**
-     * Cardinal / Catmull-Rome spline interpolation is the default smoothing function in Chartist. It produces nice results where the splines will always meet the points. It produces some artifacts though when data values are increased or decreased rapidly. The line may not follow a very accurate path and if the line should be accurate this smoothing function does not produce the best results.
-     */
-    cardinal(options?: IChartistCardinalInterpolationOptions): Function;
-
-    /**
-     * Step interpolation will cause the line chart to move in steps rather than diagonal or smoothed lines. This interpolation will create additional points that will also be drawn when the showPoint option is enabled.
-     */
-    step(options?: IChartistStepInterpolationOptions): Function;
-  }
-
-  interface IChartistInterpolationOptions {
-    fillHoles?: boolean;
-  }
-
-  interface IChartistSimpleInterpolationOptions extends IChartistInterpolationOptions {
-    divisor?: number;
-  }
-
-  interface IChartistCardinalInterpolationOptions extends IChartistInterpolationOptions {
-    tension?: number;
-  }
-
-  interface IChartistStepInterpolationOptions extends IChartistInterpolationOptions {
-    postpone?: boolean;
-  }
+    interface ChartistStatic {
+
+        /**
+         * Precision level used internally in Chartist for rounding. If you require more decimal places you can increase this number.
+         */
+        precision: number;
+
+        /**
+         * A map with characters to escape for strings to be safely used as attribute values.
+         */
+        escapingMap: IChartistEscapeMap;
+
+        Pie: IChartistPieChart;
+        Bar: IChartistBarChart;
+        Line: IChartistLineChart;
+        Candle: IChartistCandleChart;
+
+        FixedScaleAxis: IFixedScaleAxisStatic;
+        AutoScaleAxis: IAutoScaleAxisStatic;
+        StepAxis: IStepAxisStatic;
+
+        Svg: ChartistSvgStatic;
+        Interpolation: ChartistInterpolationStatic;
+
+        noop: Function;
+
+        alphaNumerate(n: number): string;
+
+        extend(target: Object, ...sources: Object[]): Object;
+
+        replaceAll(str: string, subStr: string, newSubStr: string): string;
+
+        ensureUnit(value: number, unit: string): string;
+
+        quantity(input: string | number): Object;
+
+        query(query: Node | string): Node;
+
+        times(length: number): Array<any>;
+
+        sum(previous: number, current: number): number;
+
+        mapMultiply(factor: number): (num: number) => number;
+
+        mapAdd(addend: number): (num: number) => number;
+
+        serialMap(arr: Array<any>, cb: Function): Array<any>;
+
+        roundWithPrecision(value: number, digits?: number): number;
+
+        getMultiValue(value: any, dimension?: any): number; // this method is not documented, but it is used in the examples
+
+        serialize(data: Object | string | number): string;
+
+        deserialize(data: string): Object | string | number;
+
+        createSvg(container: Node, width: string, height: string, className: string): Object; // TODO: Figure out if this is returning a ChartistSVGWrapper or an actual SVGElement
+
+        plugins: any;
+    }
+
+    interface IChartistEscapeMap {
+        [Key: string]: string;
+    }
+
+    interface IResponsiveOptionTuple<T extends IChartOptions> extends Array<string | T> {
+        0: string;
+        1: T;
+    }
+
+    // these have no other purpose than to help define the types that can be placed on
+    // a line chart axisX
+    // in the actual chartist library these are classes that project their options onto
+    // the parent class
+    interface IFixedScaleAxisStatic {
+    }
+
+    interface IAutoScaleAxisStatic {
+    }
+
+    interface IStepAxisStatic {
+    }
+
+    // data formats are not well documented on all the ways they can be passed to the constructors
+    // this definition gives some intellisense, but does not protect the user from misuse
+    // TODO: come in and tidy this up and make it fit better
+    interface IChartistData {
+        labels?: Array<string> | Array<number> | Array<Date>;
+        series: Array<IChartistSeriesData> | Array<Array<IChartistData>> | Array<number> | Array<Array<number>>;
+    }
+
+    interface IChartistSeriesData {
+        name?: string;
+        value?: number;
+        data?: Array<number>;
+        className?: string;
+        meta?: string; // I assume this could probably be a number as well?
+    }
+
+    interface IChartistBase<T extends IChartOptions> {
+        container: any;
+        data: IChartistData;
+        defaultOptions: T;
+        options: T;
+        responsiveOptions: Array<IResponsiveOptionTuple<T>>;
+
+        // this most likely doesn't need to be exposed to the user
+        eventEmitter: any;
+
+        supportsForeignObject: boolean;
+        supportsAnimations: boolean;
+        resizeListener: any;
+
+        plugins?: Array<any>; // all of these plugins seem to be functions with options, but keeping type any for now
+
+        update(data: Object, options?: T, override?: boolean): void;
+
+        detach(): void;
+
+        /**
+         * Use this function to register event handlers. The handler callbacks are synchronous and will run in the main thread rather than the event loop.
+         *
+         * @method on
+         * @param event {string} Name of the event. Check the examples for supported events.
+         * @param handler {Function} The handler function that will be called when an event with the given name was emitted. This function will receive a data argument which contains event data. See the example for more details.
+         */
+        on(event: string, handler: Function): IChartistBase<T>;
+
+        /**
+         * Use this function to un-register event handlers. If the handler function parameter is omitted all handlers for the given event will be un-registered.
+         *
+         * @method off
+         * @param event {string} Name of the event for which a handler should be removed
+         * @param handler {Function} The handler function that that was previously used to register a new event handler. This handler will be removed from the event handler list. If this parameter is omitted then all event handlers for the given event are removed from the list.
+         */
+        off(event: string, handler?: Function): IChartistBase<T>;
+    }
+
+    interface IChartistPieChart extends IChartistBase<IPieChartOptions> {
+        new (target: any, data: IChartistData, options?: IPieChartOptions, responsiveOptions?: Array<IResponsiveOptionTuple<IPieChartOptions>>): IChartistPieChart;
+    }
+
+    interface IChartistLineChart extends IChartistBase<ILineChartOptions> {
+        new (target: any, data: IChartistData, options?: ILineChartOptions, responsiveOptions?: Array<IResponsiveOptionTuple<ILineChartOptions>>): IChartistLineChart;
+    }
+
+    interface IChartistBarChart extends IChartistBase<IBarChartOptions> {
+        new (target: any, data: IChartistData, options?: IBarChartOptions, responsiveOptions?: Array<IResponsiveOptionTuple<IBarChartOptions>>): IChartistBarChart;
+    }
+
+    interface IChartistCandleChart extends IChartistBase<ICandleChartOptions> {
+        new (target: any, data: IChartistData, options?: ICandleChartOptions, responsiveOptions?: Array<IResponsiveOptionTuple<ICandleChartOptions>>): IChartistCandleChart;
+    }
+
+    interface IChartOptions {
+        /**
+         * If true the whole data is reversed including labels, the series order as well as the whole series data arrays.
+         */
+        reverseData?: boolean;
+
+        plugins?: Array<any>;
+    }
+
+    interface IPieChartOptions extends IChartOptions {
+        /**
+         * Specify a fixed width for the chart as a string (i.e. '100px' or '50%')
+         */
+        width?: number | string;
+
+        /**
+         * Specify a fixed height for the chart as a string (i.e. '100px' or '50%')
+         */
+        height?: number | string;
+
+        /**
+         * Padding of the chart drawing area to the container element and labels as a number or padding object {top: 5, right: 5, bottom: 5, left: 5}
+         */
+        chartPadding?: IChartPadding | number;
+
+        /**
+         * Override the class names that are used to generate the SVG structure of the chart
+         */
+        classNames?: IPieChartClasses;
+
+        /**
+         * The start angle of the pie chart in degrees where 0 points north. A higher value offsets the start angle clockwise.
+         */
+        startAngle?: number;
+
+        /**
+         * An optional total you can specify. By specifying a total value, the sum of the values in the series must be this total in order to draw a full pie. You can use this parameter to draw only parts of a pie or gauge charts.
+         */
+        total?: number;
+
+        /**
+         * If specified the donut CSS classes will be used and strokes will be drawn instead of pie slices.
+         */
+        donut?: boolean;
+
+        /**
+         * If specified the donut segments will be drawn as shapes instead of strokes.
+         */
+        donutSolid?: boolean;
+
+        /**
+         * Specify the donut stroke width, currently done in javascript for convenience. May move to CSS styles in the future.
+         * This option can be set as number or string to specify a relative width (i.e. 100 or '30%').
+         */
+        donutWidth?: number | string;
+
+        /**
+         * Specify if a label should be shown or not
+         */
+        showLabel?: boolean;
+
+        /**
+         * Label position offset from the standard position which is half distance of the radius. This value can be either positive or negative. Positive values will position the label away from the center.
+         */
+        labelOffset?: number;
+
+        /**
+         * This option can be set to 'inside', 'outside' or 'center'. Positioned with 'inside' the labels will be placed on half the distance of the radius to the border of the Pie by respecting the 'labelOffset'. The 'outside' option will place the labels at the border of the pie and 'center' will place the labels in the absolute center point of the chart. The 'center' option only makes sense in conjunction with the 'labelOffset' option.
+         */
+        labelPosition?: string;
+
+        /**
+         * An interpolation function for the label value
+         */
+        labelInterpolationFnc?: Function;
+
+        /**
+         * Label direction can be 'neutral', 'explode' or 'implode'.  Default is 'neutral'.  The labels anchor will be positioned based on those settings as well as the fact if the labels are on the right or left side of the center of the chart. Usually explode is useful when labels are positioned far away from the center.
+         */
+        labelDirection?: string;
+
+        /**
+         * If true the whole data is reversed including labels, the series order as well as the whole series data arrays.
+         */
+        reverseData?: boolean;
+
+        /**
+         * If true empty values will be ignored to avoid drawing unncessary slices and labels
+         */
+        ignoreEmptyValues?: boolean;
+    }
+
+    interface IChartPadding {
+        top?: number;
+        right?: number;
+        bottom?: number;
+        left?: number;
+    }
+
+    interface IPieChartClasses {
+        chartPie?: string;
+        chartDonut?: string;
+        series?: string;
+        slicePie?: string;
+        sliceDonut?: string;
+        label?: string;
+    }
+
+    interface IBarChartOptions extends IChartOptions {
+        axisX?: IBarChartAxis;
+        axisY?: IBarChartAxis;
+        width?: number | string;
+        height?: number | string;
+        high?: number;
+        low?: number;
+        ticks?: Array<string | number>;
+        onlyInteger?: boolean;
+        chartPadding?: IChartPadding;
+        seriesBarDistance?: number;
+
+        /**
+         * If set to true this property will cause the series bars to be stacked and form a total for each series point. This will also influence the y-axis and the overall bounds of the chart. In stacked mode the seriesBarDistance property will have no effect.
+         */
+        stackBars?: boolean;
+
+        horizontalBars?: boolean;
+        distributeSeries?: boolean;
+    }
+
+    interface IBarChartAxis {
+        offset?: number;
+        position?: string;
+        labelOffset?: {
+            x?: number;
+            y?: number;
+        };
+        showLabel?: boolean;
+        showGrid?: boolean;
+        labelInterpolationFnc?: Function;
+        scaleMinSpace?: number;
+        onlyInteger?: boolean;
+    }
+
+    interface IBarChartClasses {
+        chart?: string;
+        horizontalBars?: string;
+        label?: string;
+        labelGroup?: string;
+        series?: string;
+        bar?: string;
+        grid?: string;
+        gridGroup?: string;
+        vertical?: string;
+        horizontal?: string;
+        start?: string;
+        end?: string;
+    }
+
+    interface ILineChartOptions extends IChartOptions {
+        axisX?: IChartistStepAxis | IChartistFixedScaleAxis | IChartistAutoScaleAxis;
+        axisY?: IChartistStepAxis | IChartistFixedScaleAxis | IChartistAutoScaleAxis;
+        width?: number | string;
+        height?: number | string;
+        showLine?: boolean;
+        showPoint?: boolean;
+        showArea?: boolean;
+        areaBase?: number;
+        lineSmooth?: Function | boolean;
+        low?: number;
+        high?: number;
+        ticks?: Array<string | number>;
+        chartPadding?: IChartPadding;
+        fullWidth?: boolean;
+        classNames?: ILineChartClasses;
+    }
+
+    interface ILineChartAxis {
+        offset?: number;
+        position?: string;
+        labelOffset?: {
+            x?: number;
+            y?: number;
+        };
+        showLabel?: boolean;
+        showGrid?: boolean;
+        labelInterpolationFnc?: Function;
+    }
+
+    interface IChartistStepAxis extends ILineChartAxis {
+        type?: IStepAxisStatic;
+        ticks?: Array<string> | Array<number>;
+        stretch?: boolean;
+    }
+
+    interface IChartistFixedScaleAxis extends ILineChartAxis {
+        type?: IFixedScaleAxisStatic;
+        high?: number;
+        low?: number;
+        divisor?: number;
+        ticks?: Array<string> | Array<number>;
+    }
+
+    interface IChartistAutoScaleAxis extends ILineChartAxis {
+        high?: number;
+        low?: number;
+        scaleMinSpace?: number;
+        onlyInteger?: boolean;
+        referenceValue?: number;
+        type?: IAutoScaleAxisStatic;
+    }
+
+    interface ILineChartClasses {
+        /**
+         * Default is 'ct-chart-line'
+         */
+        chart?: string;
+        label?: string;
+        labelGroup?: string;
+        series?: string;
+        line?: string;
+        point?: string;
+        area?: string;
+        grid?: string;
+        gridGroup?: string;
+        gridBackground?: string;
+        vertical?: string;
+        horizontal?: string;
+        start?: string;
+        end?: string;
+    }
+
+    interface ICandleChartOptions extends IChartOptions {
+
+        /**
+         * Options for X-Axis
+         */
+        axisX?: ICandleChartAxis;
+
+        /**
+         * Options for Y-Axis
+         */
+        axisY?: ICandleChartAxis;
+
+        /**
+         * Specify a fixed width for the chart as a string (i.e. '100px' or '50%')
+         */
+        width?: number | string;
+
+        /**
+         * Specify a fixed height for the chart as a string (i.e. '100px' or '50%')
+         */
+        height?: number | string;
+
+        /**
+         * Overriding the natural high of the chart allows you to zoom in or limit the charts highest displayed value
+         */
+        hight?: number | string;
+
+        /**
+         * Overriding the natural low of the chart allows you to zoom in or limit the charts lowest displayed value
+         */
+        low?: number | string;
+
+        /**
+         * Width of candle body in pixel (IMO is 2 px best minimum value)
+         */
+        candleWidth?: number | string;
+
+        /**
+         * Width of candle wick in pixel (IMO is 1 px best minimum value)
+         */
+        candleWickWidth?: number | string;
+
+        /**
+         * Use calculated x-axis step length, depending on the number of quotes to display, as candle width. Otherwise the candleWidth is being used.
+         */
+        useStepLengthAsCandleWidth?: boolean | string;
+
+        /**
+         * Use 1/3 of candle body width as width for the candle wick, otherwise the candleWickWidth is being used.
+         */
+        useOneThirdAsCandleWickWidth?: boolean | string;
+
+        /**
+         * Padding of the chart drawing area to the container element and labels as a number or padding object {top: 5, right: 5, bottom: 5, left: 5}
+         */
+        chartPadding?: IChartPadding | number;
+
+        /**
+         * When set to true, the last grid line on the x-axis is not drawn and the chart elements will expand to the full available width of the chart. For the last label to be drawncorrectly you might need to add chart padding or offset the last label with a draw event handler.
+         */
+        fullWidth?: boolean | string;
+
+        /**
+         * Override the class names that get used to generate the SVG structure of the chart
+         */
+        classNames?: ICandleChartClasses;
+    }
+
+    interface ICandleChartAxis {
+        /**
+         * The offset of the chart drawing area to the border of the container
+         */
+        offset?: number;
+        /**
+         * Position where labels are placed. Can be set to `start` or `end` where `start` is equivalent to left or top on vertical axis and `end` is equivalent to right or bottom on horizontal axis.
+         */
+        position?: string;
+        /**
+         * Allows you to correct label positioning on this axis by positive or negative x and y offset.
+         */
+        labelOffset?: {
+            x?: number;
+            y?: number;
+        };
+        /**
+         * If labels should be shown or not
+         */
+        showLabel?: boolean;
+        /**
+         * If the axis grid should be drawn or not
+         */
+        showGrid?: boolean;
+        /**
+         * Interpolation function that allows you to intercept the value from the axis label
+         */
+        labelInterpolationFnc?: Function;
+        /**
+         * Set the axis type to be used to project values on this axis. If not defined, Chartist.StepAxis will be used for the X-Axis, where the ticks option will be set to the labels in the data and the stretch option will be set to the global fullWidth option. This type can be changed to any axis constructor available (e.g. Chartist.FixedScaleAxis), where all axis options should be present here.
+         */
+        type?: any;
+    }
+
+    interface ICandleChartClasses {
+        chart?: string;
+        label?: string;
+        labelGroup?: string;
+        series?: string;
+        candlePositive?: string;
+        candleNegative?: string,
+        grid?: string,
+        gridGroup?: string,
+        gridBackground?: string,
+        vertical?: string,
+        horizontal?: string,
+        start?: string,
+        end?: string,
+    }
+
+
+    interface ChartistSvgStatic {
+        new (name: HTMLElement | string, attributes: Object, className?: string, parent?: Object, insertFirst?: boolean): IChartistSvg;
+
+        Easing: ChartistEasingStatic;
+
+        /**
+         * This method checks for support of a given SVG feature like Extensibility, SVG-animation or the like. Check http://www.w3.org/TR/SVG11/feature for a detailed list.
+         */
+        isSupported(feature: string): boolean;
+    }
+
+    interface IChartistSvg {
+
+        /**
+         * Set attributes on the current SVG element of the wrapper you're currently working on.
+         */
+        attr(attributes: Object | string, ns: string): Object | string;
+
+        /**
+         * Create a new SVG element whose wrapper object will be selected for further operations. This way you can also create nested groups easily.
+         */
+        elem(name: string, attributes?: Object, className?: string, insertFirst?: boolean): IChartistSvg;
+
+        /**
+         * Returns the parent Chartist.SVG wrapper object
+         */
+        parent(): IChartistSvg;
+
+        /**
+         * This method returns a Chartist.Svg wrapper around the root SVG element of the current tree.
+         */
+        root(): IChartistSvg;
+
+        /**
+         * Find the first child SVG element of the current element that matches a CSS selector. The returned object is a Chartist.Svg wrapper.
+         */
+        querySelector(selector: string): IChartistSvg;
+
+        /**
+         * Find the all child SVG elements of the current element that match a CSS selector. The returned object is a Chartist.Svg.List wrapper.
+         */
+        querySelectorAll(selector: string): any; // this returns an svg wrapper list in the docs, need to see if that's just an array or a special list
+
+        /**
+         * This method creates a foreignObject (see https://developer.mozilla.org/en-US/docs/Web/SVG/Element/foreignObject) that allows to embed HTML content into a SVG graphic. With the help of foreignObjects you can enable the usage of regular HTML elements inside of SVG where they are subject for SVG positioning and transformation but the Browser will use the HTML rendering capabilities for the containing DOM.
+         */
+        foreignObject(content: any, attributes?: Object, className?: string, insertFirst?: boolean): IChartistSvg;
+
+        /**
+         * This method adds a new text element to the current Chartist.Svg wrapper.
+         */
+        text(t: string): IChartistSvg;
+
+        /**
+         * This method will clear all child nodes of the current wrapper object.
+         */
+        empty(): IChartistSvg;
+
+        /**
+         * This method will cause the current wrapper to remove itself from its parent wrapper. Use this method if you'd like to get rid of an element in a given DOM structure.
+         */
+        remove(): IChartistSvg;
+
+        /**
+         * This method will replace the element with a new element that can be created outside of the current DOM.
+         */
+        replace(): IChartistSvg;
+
+        /**
+         * This method will append an element to the current element as a child.
+         */
+        append(element: IChartistSvg, insertFirst?: boolean): IChartistSvg;
+
+        /**
+         * Returns an array of class names that are attached to the current wrapper element. This method can not be chained further.
+         */
+        classes(): Array<string>;
+
+        /**
+         * Adds one or a space separated list of classes to the current element and ensures the classes are only existing once.
+         *
+         * @method addClass
+         * @param names {string} A white space separated list of class names
+         */
+        addClass(names: string): IChartistSvg;
+
+        /**
+         * Removes one or a space separated list of classes from the current element.
+         *
+         * @method removeClass
+         * @param names {string} A white space separated list of class names
+         */
+        removeClass(names: string): IChartistSvg;
+
+        /**
+         * Removes all classes from the current element.
+         */
+        removeAllClasses(): IChartistSvg;
+
+        /**
+         * Get element height with fallback to svg BoundingBox or parent container dimensions
+         */
+        height(): number;
+
+        /**
+         * The animate function lets you animate the current element with SMIL animations. You can add animations for multiple attributes at the same time by using an animation definition object. This object should contain SMIL animation attributes.
+         */
+        animate(animations: IChartistAnimations, guided: boolean, eventEmitter: Object): IChartistSvg;
+
+        /**
+         * "Safe" way to get property value from svg BoundingBox. This is a workaround. Firefox throws an NS_ERROR_FAILURE error if getBBox() is called on an invisible node.
+         * THIS IS A WORKAROUND
+         */
+        getBBoxProperty(node: SVGElement, prop: string): string; // TODO: find a good example of this and add it to the tests, it might belong to static
+    }
+
+    interface IChartistAnimations {
+        [Key: string]: IChartistAnimationOptions;
+    }
+
+    interface IChartistAnimationOptions {
+        id?: string;
+        dur: string | number;
+        from: string | number;
+        to: string | number;
+        easing?: IChartistEasingDefinition | string;
+        fill?: string;
+        begin?: string;
+    }
+
+    interface IChartistEasingDefinition {
+        0: number;
+        1: number;
+        2: number;
+        3: number;
+    }
+
+    interface ChartistEasingStatic {
+        easeInSine: IChartistEasingDefinition;
+        easeOutSine: IChartistEasingDefinition;
+        easeInOutSine: IChartistEasingDefinition;
+        easeInQuad: IChartistEasingDefinition;
+        easeOutQuad: IChartistEasingDefinition;
+        easeInOutQuad: IChartistEasingDefinition;
+        easeInCubic: IChartistEasingDefinition;
+        easeOutCubic: IChartistEasingDefinition;
+        easeInOutCubic: IChartistEasingDefinition;
+        easeInQuart: IChartistEasingDefinition;
+        easeOutQuart: IChartistEasingDefinition;
+        easeInOutQuart: IChartistEasingDefinition;
+        easeInQuint: IChartistEasingDefinition;
+        easeOutQuint: IChartistEasingDefinition;
+        easeInOutQuint: IChartistEasingDefinition;
+        easeInExpo: IChartistEasingDefinition;
+        easeOutExpo: IChartistEasingDefinition;
+        easeInOutExpo: IChartistEasingDefinition;
+        easeInCirc: IChartistEasingDefinition;
+        easeOutCirc: IChartistEasingDefinition;
+        easeInOutCirc: IChartistEasingDefinition;
+        easeInBack: IChartistEasingDefinition;
+        easeOutBack: IChartistEasingDefinition;
+        easeInOutBack: IChartistEasingDefinition;
+    }
+
+    interface ChartistInterpolationStatic {
+
+        /**
+         * This interpolation function does not smooth the path and the result is only containing lines and no curves.
+         */
+        none(options?: IChartistInterpolationOptions): Function;
+
+        /**
+         * Simple smoothing creates horizontal handles that are positioned with a fraction of the length between two data points. You can use the divisor option to specify the amount of smoothing.
+         */
+        simple(options?: IChartistSimpleInterpolationOptions): Function;
+
+        /**
+         * Cardinal / Catmull-Rome spline interpolation is the default smoothing function in Chartist. It produces nice results where the splines will always meet the points. It produces some artifacts though when data values are increased or decreased rapidly. The line may not follow a very accurate path and if the line should be accurate this smoothing function does not produce the best results.
+         */
+        cardinal(options?: IChartistCardinalInterpolationOptions): Function;
+
+        /**
+         * Step interpolation will cause the line chart to move in steps rather than diagonal or smoothed lines. This interpolation will create additional points that will also be drawn when the showPoint option is enabled.
+         */
+        step(options?: IChartistStepInterpolationOptions): Function;
+    }
+
+    interface IChartistInterpolationOptions {
+        fillHoles?: boolean;
+    }
+
+    interface IChartistSimpleInterpolationOptions extends IChartistInterpolationOptions {
+        divisor?: number;
+    }
+
+    interface IChartistCardinalInterpolationOptions extends IChartistInterpolationOptions {
+        tension?: number;
+    }
+
+    interface IChartistStepInterpolationOptions extends IChartistInterpolationOptions {
+        postpone?: boolean;
+    }
 }
 
 declare var Chartist: Chartist.ChartistStatic;

--- a/types/chartist/index.d.ts
+++ b/types/chartist/index.d.ts
@@ -333,6 +333,15 @@ declare namespace Chartist {
         chartPadding?: IChartPadding;
         fullWidth?: boolean;
         classNames?: ILineChartClasses;
+        series?: {
+            [key: string]: {
+                lineSmooth?: Function | boolean;
+                showLine?: boolean;
+                showPoint?: boolean;
+                showArea?: boolean;
+                areaBase?: number;
+            }
+        }
     }
 
     interface ILineChartAxis {

--- a/types/chartist/index.d.ts
+++ b/types/chartist/index.d.ts
@@ -1,9 +1,6 @@
 // Type definitions for Chartist v0.9.81
 // Project: https://github.com/gionkunz/chartist-js
-// Definitions by: Matt Gibbs <https://github.com/mtgibbs>,
-// Simon Pfeifer <https://github.com/psimonski>,
-// Cassey Lottman <https://github.com/clottman>,
-// Anastasiia Antonova <https://github.com/affilnost>,
+// Definitions by: Matt Gibbs <https://github.com/mtgibbs>, Simon Pfeifer <https://github.com/psimonski>, Cassey Lottman <https://github.com/clottman>, Anastasiia Antonova <https://github.com/affilnost>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare namespace Chartist {

--- a/types/chartist/index.d.ts
+++ b/types/chartist/index.d.ts
@@ -1,6 +1,9 @@
 // Type definitions for Chartist v0.9.81
 // Project: https://github.com/gionkunz/chartist-js
-// Definitions by: Matt Gibbs <https://github.com/mtgibbs>, Simon Pfeifer <https://github.com/psimonski>, Cassey Lottman <https://github.com/clottman>
+// Definitions by: Matt Gibbs <https://github.com/mtgibbs>,
+// Simon Pfeifer <https://github.com/psimonski>,
+// Cassey Lottman <https://github.com/clottman>,
+// Anastasiia Antonova <https://github.com/affilnost>,
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare namespace Chartist {


### PR DESCRIPTION
- [x] The package "chartist" was modified
- [x] Improvements made: added "series" to the ILineChartOptions, files reformat, definitions change
- [x] Changed the tests accordingly, tested

**Info**
The case shown here https://gionkunz.github.io/chartist-js/examples.html#example-line-series-override (press **Edit Example**) was not supported. To be precise, having "series" inside of "options" was not possible.
I added this test case, added support of "series" inside of "options" and tested everything. In addition, I reformatted the files with 4 spaces indentation and added myself into definitions.



- [x] URL to documentation which provides context for the suggested changes: https://gionkunz.github.io/chartist-js/examples.html#example-line-series-override
(press **Edit Example**)