### PR TITLE
fixes gl-texture2d with missing setPixels() method

### DIFF
--- a/types/gl-texture2d/gl-texture2d-tests.ts
+++ b/types/gl-texture2d/gl-texture2d-tests.ts
@@ -54,10 +54,19 @@ texture2d(gl, ndarray([1, 2, 3]));
 
 const texture = texture2d(gl, canvas);
 
-texture.bind();
-texture.bind(1);
 texture.dispose();
 texture.generateMipmap();
+
+texture.bind();
+texture.bind(1);
+
+texture.setPixels(canvas);
+texture.setPixels(video);
+texture.setPixels(image);
+texture.setPixels(imageData);
+texture.setPixels(ndarray([1, 2, 3]));
+texture.setPixels(canvas, [1,1]);
+texture.setPixels(canvas, [1,1], 0);
 
 texture.magFilter = 1;
 texture.minFilter = 1;

--- a/types/gl-texture2d/gl-texture2d-tests.ts
+++ b/types/gl-texture2d/gl-texture2d-tests.ts
@@ -65,8 +65,8 @@ texture.setPixels(video);
 texture.setPixels(image);
 texture.setPixels(imageData);
 texture.setPixels(ndarray([1, 2, 3]));
-texture.setPixels(canvas, [1,1]);
-texture.setPixels(canvas, [1,1], 0);
+texture.setPixels(canvas, [1, 1]);
+texture.setPixels(canvas, [1, 1], 0);
 
 texture.magFilter = 1;
 texture.minFilter = 1;

--- a/types/gl-texture2d/index.d.ts
+++ b/types/gl-texture2d/index.d.ts
@@ -29,7 +29,7 @@ declare class Texture {
     bind(id?: number): number;
     dispose(): void;
     generateMipmap(): void;
-    setPixels( data: InputType | RawObject | ndarray, offset?: [number, number], mipLevel?: GLenum): void;
+    setPixels(data: InputType | RawObject | ndarray, offset?: [number, number], mipLevel?: GLenum): void;
 }
 
 declare function texture2d(gl: WebGLRenderingContext, array: ndarray): Texture;

--- a/types/gl-texture2d/index.d.ts
+++ b/types/gl-texture2d/index.d.ts
@@ -29,6 +29,7 @@ declare class Texture {
     bind(id?: number): number;
     dispose(): void;
     generateMipmap(): void;
+    setPixels( data: InputType | RawObject | ndarray, offset?: [number, number], mipLevel?: GLenum): void;
 }
 
 declare function texture2d(gl: WebGLRenderingContext, array: ndarray): Texture;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [gl-texture2d texture.setPixel()](https://www.npmjs.com/package/gl-texture2d#texsetpixelsdata-offset-miplevel)
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
