### PR TITLE
react-transition-group: Allow component={null} on TransitionGroup

### DIFF
--- a/types/react-transition-group/TransitionGroup.d.ts
+++ b/types/react-transition-group/TransitionGroup.d.ts
@@ -3,7 +3,7 @@ import { TransitionActions, TransitionProps } from "./Transition";
 
 declare namespace TransitionGroup {
     interface IntrinsicTransitionGroupProps<T extends keyof JSX.IntrinsicElements = "div"> extends TransitionActions {
-        component?: T;
+        component?: T|null;
     }
 
     interface ComponentTransitionGroupProps<T extends ReactType> extends TransitionActions {

--- a/types/react-transition-group/index.d.ts
+++ b/types/react-transition-group/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for react-transition-group 2.0
 // Project: https://github.com/reactjs/react-transition-group
 // Definitions by: Karol Janyst <https://github.com/LKay>
+//                 Epskampie <https://github.com/Epskampie>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.6
 


### PR DESCRIPTION
The react-transition-group documentation [states](http://reactcommunity.org/react-transition-group/transition-group):

> \<TransitionGroup\> renders a \<div\> by default. You can change this behavior by providing a component prop. If you use React v16+ and would like to avoid a wrapping \<div\> element **you can pass in component={null}**

However, I'm getting an error when using `component={null}` . This PR fixes that. I had some problems reproducing the error in this repo, would appreciate pointers on how to do that. The error is: `Type 'null' is not assignable to type 'ReactElement<TransitionProps> | ReactElement<TransitionProps>[] | undefined'.`

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
http://reactcommunity.org/react-transition-group/transition-group

