### PR TITLE
Add types for `onSortOver` prop

### DIFF
--- a/types/react-sortable-hoc/index.d.ts
+++ b/types/react-sortable-hoc/index.d.ts
@@ -36,6 +36,8 @@ export interface SortEnd {
 
 export type SortEndHandler = (sort: SortEnd, event: SortEvent) => void;
 
+export type SortOverHandler = ({index, oldIndex, newIndex, collection}: SortOver, event: SortEvent) => void;
+
 export type ContainerGetter = (element: React.ReactElement<any>) => HTMLElement;
 
 export interface Dimensions {
@@ -55,6 +57,7 @@ export interface SortableContainerProps {
     onSortStart?: SortStartHandler;
     onSortMove?: SortMoveHandler;
     onSortEnd?: SortEndHandler;
+    onSortOver?: SortOverHandler;
     useDragHandle?: boolean;
     useWindowAsScrollContainer?: boolean;
     hideSortableGhost?: boolean;


### PR DESCRIPTION
https://github.com/clauderic/react-sortable-hoc/pull/278 added `onSortOver` prop. This PR adds the type definitions for the prop.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
