### PR TITLE
[Sequelize] Add useMaster to FindOptions<T>

### DIFF
--- a/types/sequelize/index.d.ts
+++ b/types/sequelize/index.d.ts
@@ -3366,6 +3366,13 @@ declare namespace sequelize {
          * Throw EmptyResultError if a record is not found
          */
         rejectOnEmpty?: boolean;
+
+       /**
+         * Force the query to use the write pool
+         *
+         * Defaults to false
+         */
+        useMaster?: boolean;
     }
 
     type AnyFindOptions = FindOptions<any>;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:

In [this test](https://github.com/sequelize/sequelize/blob/5426912832978a942d02a55160a7ac2ba4ea70f9/test/integration/dialects/abstract/connection-manager.test.js#L134) you can see they're passing in `useMaster` to a select query.
Also [this issue](https://github.com/sequelize/sequelize/issues/3977) confirms the use of `useMaster` is allowed.


[`Model.findOne` uses `Model.findAll` which uses `QueryInterface.select`](https://github.com/sequelize/sequelize/blob/master/lib/model.js#L1714 )
[`QueryInterfaces.select` uses `Sequelize.query`](https://github.com/sequelize/sequelize/blob/master/lib/query-interface.js#L1116  ). 

I wasn't sure if we should extend `FindOptions` with `QueryOptions` or if I can just add `useMaster` in `FindOptions`. Maybe someone more experienced can suggest this?