### PR TITLE
[react-redux] Fixed the typings for inferred types with functional components

### DIFF
--- a/types/react-redux/index.d.ts
+++ b/types/react-redux/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-redux 6.0.0
+// Type definitions for react-redux 6.0.1
 // Project: https://github.com/rackt/react-redux
 // Definitions by: Qubo <https://github.com/tkqubo>,
 //                 Thomas Hasner <https://github.com/thasner>,
@@ -54,7 +54,7 @@ interface AdvancedComponentDecorator<TProps, TOwnProps> {
  * - it is present in both DecorationTargetProps and InjectedProps
  * - DecorationTargetProps[P] extends InjectedProps[P]
  * ie: decorated component can accept more types than decorator is injecting
- * 
+ *
  * For decoration, inject props or ownProps are all optionnaly
  * required by the decorated (right hand side) component.
  * But any property required by the decorated component must extend the injected property
@@ -70,9 +70,12 @@ type Shared<
 // Will not pass through the injected props if they are passed in during
 // render. Also adds new prop requirements from TNeedsProps.
 export interface InferableComponentEnhancerWithProps<TInjectedProps, TNeedsProps> {
-    <P extends Shared<TInjectedProps, P>>(
-        component: Component<P>
-    ): ComponentClass<Omit<P, keyof Shared<TInjectedProps, P>> & TNeedsProps> & {WrappedComponent: Component<P>}
+	(
+		component: StatelessComponent<TInjectedProps>
+	): ComponentClass<TNeedsProps> & {WrappedComponent: StatelessComponent<TInjectedProps>}
+	<P extends Shared<TInjectedProps, P>>(
+		component: Component<P>
+	): ComponentClass<Omit<P, keyof Shared<TInjectedProps, P>> & TNeedsProps> & {WrappedComponent: Component<P>}
 }
 
 // Injects props and removes them from the prop requirements.

--- a/types/react-redux/react-redux-tests.tsx
+++ b/types/react-redux/react-redux-tests.tsx
@@ -813,23 +813,42 @@ namespace TestControlledComponentWithoutDispatchProp {
 }
 
 namespace TestDispatchToPropsAsObject {
-    const onClick: ActionCreator<{}> = () => ({});
-    const mapStateToProps = (state: any) => {
-        return {
-            title: state.app.title as string,
-        };
-    };
-    const dispatchToProps = {
-        onClick,
-    };
+	const onClick: ActionCreator<{}> = () => ({});
+	const mapStateToProps = (state: any) => {
+		return {
+			title: state.app.title as string,
+		};
+	};
+	const dispatchToProps = {
+		onClick,
+	};
 
-    type Props = { title: string; } & typeof dispatchToProps;
-    const HeaderComponent: React.StatelessComponent<Props> = (props) => {
-        return <h1>{props.title}</h1>;
-    }
+	type Props = { title: string; } & typeof dispatchToProps;
+	const HeaderComponent: React.StatelessComponent<Props> = (props) => {
+		return <h1>{props.title}</h1>;
+	}
 
-    const Header = connect(mapStateToProps, dispatchToProps)(HeaderComponent);
-    <Header />
+	const Header = connect(mapStateToProps, dispatchToProps)(HeaderComponent);
+	<Header />
+}
+
+namespace TestInferredFunctionalComponent {
+
+	const Header = connect(
+		(
+			{ app: { title }}: { app: { title: string }},
+			{ extraText }: { extraText: string }
+		) => ({
+			title,
+			extraText
+		}),
+		(dispatch) => ({
+			onClick: () => dispatch({ type: 'test' })
+		})
+	)(({ title, extraText, onClick }) => {
+		return <h1 onClick={onClick}>{title} {extraText}</h1>;
+	});
+	<Header extraText='text'/>
 }
 
 namespace TestWrappedComponent {
@@ -933,7 +952,7 @@ namespace TestWithoutTOwnPropsDecoratedInference {
     // This should compile
     React.createElement(ConnectedWithOwnPropsClass, { own: 'string', forwarded: 'string' });
     React.createElement(ConnectedWithOwnPropsClass, { own: 'string', forwarded: 'string' });
-    
+
     // This should not compile, it is missing ForwardedProps
     React.createElement(ConnectedWithOwnPropsClass, { own: 'string' }); // $ExpectError
     React.createElement(ConnectedWithOwnPropsStateless, { own: 'string' }); // $ExpectError


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: (Could not find one)
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. (Already there)

Before the latest version of the types you could use inferred types with functional components, allowing for a very terse syntax (See the new test). Unfortunately the latest types cause the errors similar to the following when using this syntax
```
ERROR: 844:7   expect  TypeScript@next compile error: 
Type '{ children?: ReactNode; }' has no property 'title' and no string index signature.
ERROR: 844:14  expect  TypeScript@next compile error: 
Type '{ children?: ReactNode; }' has no property 'onClick' and no string index signature.
```

This fixes the inferred types, allowing for this syntax to work again