### PR TITLE
Typing updates/fixes for react-radio-group

### DIFF
--- a/types/react-radio-group/index.d.ts
+++ b/types/react-radio-group/index.d.ts
@@ -6,17 +6,21 @@
 
 import * as React from 'react';
 
+// Omit taken from https://github.com/Microsoft/TypeScript/issues/12215#issuecomment-311923766
+export type Omit<T, K extends keyof T> = Pick<T, ({ [P in keyof T]: P } & { [P in K]: never } & { [x: string]: never, [x: number]: never })[keyof T]>;
+
 export namespace Radio {
-    type RadioProps = React.InputHTMLAttributes<HTMLInputElement>;
+    type RadioProps = Omit<React.InputHTMLAttributes<HTMLInputElement>, 'value' | 'name' | 'role' | 'type' | 'aria-checked'> & {
+        value: any;
+    };
 }
 export const Radio: React.ComponentClass<Radio.RadioProps>;
 
 export namespace RadioGroup {
-    interface RadioGroupProps {
-        name?: string;
-        selectedValue?: React.InputHTMLAttributes<HTMLInputElement>['value'];
-        onChange?: (value: React.InputHTMLAttributes<HTMLInputElement>['value']) => void;
-        Component?: string | React.ReactElement<React.HTMLProps<HTMLElement>>;
-    }
+    type RadioGroupProps = Omit<React.HTMLProps<any>, 'onChange'> & {
+        selectedValue?: any;
+        onChange?: (value: any) => void;
+        Component?: React.ReactType<Omit<React.HTMLProps<any>, 'onChange' | 'role'>>;
+    };
 }
 export const RadioGroup: React.ComponentClass<RadioGroup.RadioGroupProps>;

--- a/types/react-radio-group/react-radio-group-tests.tsx
+++ b/types/react-radio-group/react-radio-group-tests.tsx
@@ -1,23 +1,60 @@
 import * as React from 'react';
 import { Radio, RadioGroup } from "react-radio-group";
 
-class ReactRadioGroup extends React.Component<RadioGroup.RadioGroupProps, { selectedValue: React.InputHTMLAttributes<HTMLInputElement>['value'] }> {
+const DefaultComponent: React.SFC<React.HTMLProps<HTMLDivElement>> = ({ children, ...rest }) => {
+    return (
+        <div style={{ display: 'flex' }} {...rest}>
+            {children}
+        </div>
+    );
+};
+
+interface ReactRadioGroupState {
+    selectedValueA: any;
+    selectedValueB: any;
+}
+
+class ReactRadioGroup extends React.Component<RadioGroup.RadioGroupProps, ReactRadioGroupState> {
     state = {
-        selectedValue: 2,
+        selectedValueA: 2,
+        selectedValueB: true,
     };
 
-    handleChange: RadioGroup.RadioGroupProps['onChange'] = selectedValue => {
-        console.log(selectedValue);
-        this.setState({ selectedValue });
+    handleChange = (key: keyof ReactRadioGroupState) => (value: any) => {
+        console.log(key, value);
+        this.setState(state => {
+            return {
+                ...state,
+                [key]: value,
+            };
+        });
     }
 
     render() {
         return (
             <div>
-                <RadioGroup name="radioGroup" onChange={this.handleChange} selectedValue={this.state.selectedValue}>
+                <RadioGroup
+                    name="radioGroupA"
+                    onChange={this.handleChange('selectedValueA')}
+                    selectedValue={this.state.selectedValueA}
+                    Component={DefaultComponent}
+                    className="here-is-a-classname"
+                >
                     <Radio id="Option A" value="a" />
                     <Radio id="Option B" value={2} />
                     <Radio id="Option C" value={["hello"]} disabled />
+                </RadioGroup>
+                <RadioGroup
+                    name="radioGroupB"
+                    onChange={this.handleChange('selectedValueB')}
+                    selectedValue={this.state.selectedValueB}
+                    Component="span"
+                    style={{marginBottom: '10px'}}
+                >
+                    <Radio id="Option D" value={true} />
+                    <Radio id="Option E" value={null} />
+                    <Radio id="Option F" value={undefined} />
+                    <Radio id="Option G" value={{name: 'Mark'}} disabled />
                 </RadioGroup>
             </div>
         );


### PR DESCRIPTION
* Allow `value` of Radio component to be any
* Add most HTMLProps to RadioGroup component
* Fix typing for `Component` prop on RadioGroup to be a string or React component

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
