### PR TITLE
[Plotly.js] Added missing hoverinfo type permutations

### DIFF
--- a/types/plotly.js/index.d.ts
+++ b/types/plotly.js/index.d.ts
@@ -386,13 +386,28 @@ export interface ScatterData {
 	'marker.colorbar': {}; // TODO
 	mode: 'lines' | 'markers' | 'text' | 'lines+markers' | 'text+markers' | 'text+lines' | 'text+lines+markers' | 'none';
 	hoveron: 'points' | 'fills';
-	hoverinfo: 'text';
+    hoverinfo: 'all' | 'none' | 'skip' |
+               'x' | 'x+text' | 'x+name' |
+               'x+y' | 'x+y+text' | 'x+y+name' |
+               'x+y+z' | 'x+y+z+text' | 'x+y+z+name' |
+               'y+x' | 'y+x+text' | 'y+x+name' |
+               'y+z' | 'y+z+text' | 'y+z+name' |
+               'y+x+z' | 'y+x+z+text' | 'y+x+z+name' |
+               'z+x' | 'z+x+text' | 'z+x+name' |
+               'z+y+x' | 'z+y+x+text' | 'z+y+x+name' |
+               'z+x+y' | 'z+x+y+text' | 'z+x+y+name';
 	fill: 'none' | 'tozeroy' | 'tozerox' | 'tonexty' | 'tonextx' | 'toself' | 'tonext';
 	fillcolor: string;
 	legendgroup: string;
 	name: string;
 	connectgaps: boolean;
 }
+
+/*
+Any combination of "x", "y", "z", "text", "name" joined with a "+" OR "all" or "none" or "skip".
+examples: "x", "y", "x+y", "x+y+z", "all"
+default: "all"
+*/
 
 export interface ScatterMarker {
 	symbol: string | string[]; // Drawing.symbolList

--- a/types/plotly.js/index.d.ts
+++ b/types/plotly.js/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for plotly.js 1.36
+// Type definitions for plotly.js 1.37
 // Project: https://plot.ly/javascript/
 // Definitions by: Chris Gervang <https://github.com/chrisgervang>
 // 				Martin Duparc <https://github.com/martinduparc>

--- a/types/plotly.js/index.d.ts
+++ b/types/plotly.js/index.d.ts
@@ -386,7 +386,7 @@ export interface ScatterData {
 	'marker.colorbar': {}; // TODO
 	mode: 'lines' | 'markers' | 'text' | 'lines+markers' | 'text+markers' | 'text+lines' | 'text+lines+markers' | 'none';
 	hoveron: 'points' | 'fills';
-    hoverinfo: 'all' | 'none' | 'skip' |
+    hoverinfo: 'all' | 'name' | 'none' | 'skip' | 'text' |
                'x' | 'x+text' | 'x+name' |
                'x+y' | 'x+y+text' | 'x+y+name' |
                'x+y+z' | 'x+y+z+text' | 'x+y+z+name' |

--- a/types/plotly.js/index.d.ts
+++ b/types/plotly.js/index.d.ts
@@ -386,7 +386,7 @@ export interface ScatterData {
 	'marker.colorbar': {}; // TODO
 	mode: 'lines' | 'markers' | 'text' | 'lines+markers' | 'text+markers' | 'text+lines' | 'text+lines+markers' | 'none';
 	hoveron: 'points' | 'fills';
-    hoverinfo: 'all' | 'name' | 'none' | 'skip' | 'text' |
+	hoverinfo: 'all' | 'name' | 'none' | 'skip' | 'text' |
                'x' | 'x+text' | 'x+name' |
                'x+y' | 'x+y+text' | 'x+y+name' |
                'x+y+z' | 'x+y+z+text' | 'x+y+z+name' |
@@ -403,12 +403,11 @@ export interface ScatterData {
 	connectgaps: boolean;
 }
 
-/*
-Any combination of "x", "y", "z", "text", "name" joined with a "+" OR "all" or "none" or "skip".
-examples: "x", "y", "x+y", "x+y+z", "all"
-default: "all"
-*/
-
+/**
+ * Any combination of "x", "y", "z", "text", "name" joined with a "+" OR "all" or "none" or "skip".
+ * examples: "x", "y", "x+y", "x+y+z", "all"
+ * default: "all"
+ */
 export interface ScatterMarker {
 	symbol: string | string[]; // Drawing.symbolList
 	color: Color | number[];


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://plot.ly/javascript/reference/#scattergl-hoverinfo>>
- [x] Increase the version number in the header if appropriate.
