### PR TITLE
fix: fix createConnection return type

### DIFF
--- a/types/mongoose/index.d.ts
+++ b/types/mongoose/index.d.ts
@@ -103,7 +103,7 @@ declare module "mongoose" {
   export function createConnection(): Connection;
   export function createConnection(uri: string,
     options?: ConnectionOptions
-  ): Connection & Promise<Mongoose>;
+  ): Connection;
 
   /**
    * Disconnects all connections.
@@ -448,6 +448,8 @@ declare module "mongoose" {
 
     /** Expose the possible connection states. */
     static STATES: any;
+    then(res?: any, rej?: any): PromiseLike<any>;
+    catch(rej?: any): PromiseLike<any>;
   }
 
   /*

--- a/types/mongoose/index.d.ts
+++ b/types/mongoose/index.d.ts
@@ -103,7 +103,7 @@ declare module "mongoose" {
   export function createConnection(): Connection;
   export function createConnection(uri: string,
     options?: ConnectionOptions
-  ): Connection;
+  ): Connection & Promise<Mongoose>;
 
   /**
    * Disconnects all connections.
@@ -430,7 +430,7 @@ declare module "mongoose" {
     $format(arg: any): string;
     /** Debug print helper */
     $print(name: any, i: any, args: any[]): void;
-    /** Retreives information about this collections indexes. */
+    /** Retrieves information about this collections indexes. */
     getIndexes(): any;
   }
 

--- a/types/mongoose/mongoose-tests.ts
+++ b/types/mongoose/mongoose-tests.ts
@@ -43,6 +43,7 @@ mongoose.createConnection(connectUri, {
     native_parser: true
   }
 }).open('');
+mongoose.createConnection(connectUri).then(()=>{},()=>{});
 const dcWithCallback: null = mongoose.disconnect(cb);
 const dcPromise: Promise<void> = mongoose.disconnect();
 mongoose.get('test');

--- a/types/mongoose/mongoose-tests.ts
+++ b/types/mongoose/mongoose-tests.ts
@@ -43,7 +43,7 @@ mongoose.createConnection(connectUri, {
     native_parser: true
   }
 }).open('');
-mongoose.createConnection(connectUri).then(()=>{},()=>{});
+mongoose.createConnection(connectUri).then(()=>{}, () => {});
 const dcWithCallback: null = mongoose.disconnect(cb);
 const dcPromise: Promise<void> = mongoose.disconnect();
 mongoose.get('test');


### PR DESCRIPTION
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/Automattic/mongoose/blob/master/lib/index.js#L155>>
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
