### PR TITLE
[@types/react-native] Remove layoutProperties

### DIFF
--- a/types/react-native/legacy-properties.d.ts
+++ b/types/react-native/legacy-properties.d.ts
@@ -1,5 +1,4 @@
 import {
-    LayoutProps,
     TextProps,
     TextPropsIOS,
     TextPropsAndroid,
@@ -76,9 +75,6 @@ declare module "react-native" {
      * They have been renamed to *Props to match React Native documentation
      * The following lines ensure compatibility with *Properties and should be removed in the future
      */
-
-    /** @deprecated Use LayoutProps */
-    export type LayoutProperties = LayoutProps;
 
     /** @deprecated Use TextProps */
     export type TextProperties = TextProps;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

LayoutProps was remove from the index.d.ts of react-native.
https://github.com/DefinitelyTyped/DefinitelyTyped/commit/8cc6c8d931150740b3b8c0a1f446ad03f506521f#diff-054a3bd6f6ba9a4f60119c781c2a63f6

So there is a regression with LayoutProperties in the legacy-properties.d.ts.