### PR TITLE
[atom] support version 1.27

### DIFF
--- a/types/atom/atom-tests.ts
+++ b/types/atom/atom-tests.ts
@@ -1327,6 +1327,8 @@ function testMarkerLayer() {
     markers = markerLayer.findMarkers({ containsRange: [[0, 0], pos] });
     markers = markerLayer.findMarkers({ containsRange: [[0, 0], [0, 0]] });
 
+    str = markerLayer.getRole();
+
     // Marker creation
     marker = markerLayer.markRange(range);
     marker = markerLayer.markRange([pos, pos]);
@@ -1950,32 +1952,54 @@ function testSelection() {
     selection.insertText("Replacement", { autoDecreaseIndent: true });
     selection.insertText("Replacement", { normalizeLineEndings: true });
     selection.insertText("Replacement", { undo: "skip" });
+    selection.insertText("Replacement", { bypassReadOnly: true });
     selection.insertText("Replacement", { select: true, autoIndent: true,
         autoIndentNewline: true, autoDecreaseIndent: true, normalizeLineEndings: true,
-        undo: "skip", preserveTrailingLineIndentation: false });
+        undo: "skip", preserveTrailingLineIndentation: false, bypassReadOnly: false });
 
     selection.backspace();
+    selection.backspace({ bypassReadOnly: true });
     selection.deleteToPreviousWordBoundary();
+    selection.deleteToPreviousWordBoundary({ bypassReadOnly: false });
     selection.deleteToNextWordBoundary();
+    selection.deleteToNextWordBoundary({ bypassReadOnly: true });
     selection.deleteToBeginningOfWord();
+    selection.deleteToBeginningOfWord({ bypassReadOnly: false });
     selection.deleteToBeginningOfLine();
+    selection.deleteToBeginningOfLine({ bypassReadOnly: true });
     selection.delete();
+    selection.delete({ bypassReadOnly: false });
     selection.deleteToEndOfLine();
+    selection.deleteToEndOfLine({ bypassReadOnly: true });
     selection.deleteToEndOfWord();
+    selection.deleteToEndOfWord({ bypassReadOnly: false });
     selection.deleteToBeginningOfSubword();
+    selection.deleteToBeginningOfSubword({ bypassReadOnly: true });
     selection.deleteToEndOfSubword();
+    selection.deleteToEndOfSubword({ bypassReadOnly: false });
     selection.deleteSelectedText();
+    selection.deleteSelectedText({ bypassReadOnly: true });
     selection.deleteLine();
+    selection.deleteLine({ bypassReadOnly: false });
     selection.joinLines();
+    selection.joinLines({ bypassReadOnly: true });
     selection.outdentSelectedRows();
+    selection.outdentSelectedRows({ bypassReadOnly: false });
     selection.autoIndentSelectedRows();
+    selection.autoIndentSelectedRows({ bypassReadOnly: true });
     selection.toggleLineComments();
+    selection.toggleLineComments({ bypassReadOnly: false });
     selection.cutToEndOfLine();
+    selection.cutToEndOfLine(true);
+    selection.cutToEndOfLine(undefined, { bypassReadOnly: true });
     selection.cutToEndOfBufferLine();
+    selection.cutToEndOfBufferLine(true);
+    selection.cutToEndOfBufferLine(false, { bypassReadOnly: false });
 
     selection.cut();
     selection.cut(true);
     selection.cut(true, true);
+    selection.cut(undefined, undefined, { bypassReadOnly: true });
 
     selection.copy();
     selection.copy(true);
@@ -1983,6 +2007,7 @@ function testSelection() {
 
     selection.fold();
     selection.indentSelectedRows();
+    selection.indentSelectedRows({ bypassReadOnly: false });
 
     // Managing multiple selections
     selection.addSelectionBelow();
@@ -2143,6 +2168,8 @@ function testTextBuffer() {
         num = nextRow;
     }
 
+    bool = buffer.hasAstral();
+
     // Mutating Text
     range = buffer.setText("Test");
     buffer.setTextViaDiff("Test");
@@ -2232,9 +2259,13 @@ function testTextBuffer() {
 
     // History
     bool = buffer.undo();
+    bool = buffer.undo({ selectionsMarkerLayer: markerLayer });
     bool = buffer.redo();
+    bool = buffer.redo({ selectionsMarkerLayer: markerLayer });
 
-    num = buffer.transact<number>(500, (): number => 42);
+    num = buffer.transact(500, (): number => 42);
+    num = buffer.transact({ groupingInterval: 500, selectionsMarkerLayer: markerLayer },
+        (): number => 42);
 
     buffer.clearUndoStack();
     num = buffer.createCheckpoint();
@@ -2434,6 +2465,8 @@ function testTextEditor() {
 
     // Mutating Text
     editor.setText("Test");
+    editor.setText("Test", {});
+    editor.setText("Text", { bypassReadOnly: true });
 
     range = editor.setTextInBufferRange(range, "Test");
     range = editor.setTextInBufferRange([pos, pos], "Test");
@@ -2443,7 +2476,7 @@ function testTextEditor() {
     range = editor.setTextInBufferRange(range, "Test", {});
     range = editor.setTextInBufferRange([pos, pos], "Test", { normalizeLineEndings: true });
     range = editor.setTextInBufferRange(range, "Test", { normalizeLineEndings: true,
-        undo: "skip" });
+        undo: "skip", bypassReadOnly: false });
 
     editor.insertText("Test");
     editor.insertText("Test", {});
@@ -2455,27 +2488,45 @@ function testTextEditor() {
     editor.insertText("Test", { undo: "skip" });
     editor.insertText("Text", { autoDecreaseIndent: false, autoIndent: false,
         autoIndentNewline: false, normalizeLineEndings: false, select: false,
-        undo: "skip", preserveTrailingLineIndentation: true });
+        undo: "skip", preserveTrailingLineIndentation: true, bypassReadOnly: true });
 
     editor.insertNewline();
+    editor.insertNewline({ bypassReadOnly: false });
     editor.delete();
+    editor.delete({ bypassReadOnly: true });
     editor.backspace();
+    editor.backspace({ bypassReadOnly: false });
     editor.mutateSelectedText((selection, index) => { selection.clear(); });
     editor.transpose();
+    editor.transpose({ bypassReadOnly: true });
     editor.upperCase();
+    editor.upperCase({ bypassReadOnly: false });
     editor.lowerCase();
+    editor.lowerCase({ bypassReadOnly: true });
     editor.toggleLineCommentsInSelection();
+    editor.toggleLineCommentsInSelection({ bypassReadOnly: false });
     editor.insertNewlineBelow();
+    editor.insertNewlineBelow({ bypassReadOnly: true });
     editor.insertNewlineAbove();
+    editor.insertNewlineAbove({ bypassReadOnly: false });
     editor.deleteToBeginningOfWord();
+    editor.deleteToBeginningOfWord({ bypassReadOnly: true });
     editor.deleteToPreviousWordBoundary();
+    editor.deleteToPreviousWordBoundary({ bypassReadOnly: false });
     editor.deleteToNextWordBoundary();
+    editor.deleteToNextWordBoundary({ bypassReadOnly: true });
     editor.deleteToBeginningOfSubword();
+    editor.deleteToBeginningOfSubword({ bypassReadOnly: false });
     editor.deleteToEndOfSubword();
+    editor.deleteToEndOfSubword({ bypassReadOnly: true });
     editor.deleteToBeginningOfLine();
+    editor.deleteToBeginningOfLine({ bypassReadOnly: false });
     editor.deleteToEndOfLine();
+    editor.deleteToEndOfLine({ bypassReadOnly: true });
     editor.deleteToEndOfWord();
+    editor.deleteToEndOfWord({ bypassReadOnly: false });
     editor.deleteLine();
+    editor.deleteLine({ bypassReadOnly: true });
 
     // History
     editor.undo();
@@ -2923,9 +2974,12 @@ function testTextEditor() {
     editor.setIndentationForBufferRow(42, 42, { preserveLeadingWhitespace: true });
 
     editor.indentSelectedRows();
+    editor.indentSelectedRows({ bypassReadOnly: false });
     editor.outdentSelectedRows();
+    editor.outdentSelectedRows({ bypassReadOnly: true });
     num = editor.indentLevelForLine("Test");
     editor.autoIndentSelectedRows();
+    editor.autoIndentSelectedRows({ bypassReadOnly: false });
 
     // Grammars
     grammar = editor.getGrammar();
@@ -2942,6 +2996,7 @@ function testTextEditor() {
     // Clipboard Operations
     editor.copySelectedText();
     editor.cutSelectedText();
+    editor.cutSelectedText({ bypassReadOnly: true });
 
     editor.pasteText();
     editor.pasteText({});
@@ -2951,11 +3006,14 @@ function testTextEditor() {
     editor.pasteText({ normalizeLineEndings: true });
     editor.pasteText({ select: true });
     editor.pasteText({ undo: "skip" });
+    editor.pasteText({ bypassReadOnly: false });
     editor.pasteText({ autoIndentNewline: true, autoIndent: true, autoDecreaseIndent: true,
-        normalizeLineEndings: true, select: true, undo: "skip" });
+        normalizeLineEndings: true, select: true, undo: "skip", bypassReadOnly: true });
 
     editor.cutToEndOfLine();
+    editor.cutToEndOfLine({ bypassReadOnly: false });
     editor.cutToEndOfBufferLine();
+    editor.cutToEndOfBufferLine({ bypassReadOnly: true });
 
     // Folds
     editor.foldCurrentRow();

--- a/types/atom/atom-tests.ts
+++ b/types/atom/atom-tests.ts
@@ -1327,7 +1327,8 @@ function testMarkerLayer() {
     markers = markerLayer.findMarkers({ containsRange: [[0, 0], pos] });
     markers = markerLayer.findMarkers({ containsRange: [[0, 0], [0, 0]] });
 
-    str = markerLayer.getRole();
+    const role = markerLayer.getRole();
+    if (role) str = role;
 
     // Marker creation
     marker = markerLayer.markRange(range);

--- a/types/atom/atom-tests.ts
+++ b/types/atom/atom-tests.ts
@@ -1740,6 +1740,10 @@ function testProject() {
     subscription = project.onDidAddBuffer(buffer => buffer.id);
     subscription = project.observeBuffers(buffer => buffer.getUri());
 
+    subscription = project.onDidReplace(projectSpec => {
+        if (projectSpec != null) str = projectSpec.originPath;
+    });
+
     // Accessing the git repository
     repositories = project.getRepositories();
 

--- a/types/atom/index.d.ts
+++ b/types/atom/index.d.ts
@@ -1005,7 +1005,7 @@ export interface MarkerLayer {
     findMarkers(params: FindMarkerOptions): Marker[];
 
     /** Get the role of the marker layer e.g. "atom.selection". */
-    getRole(): string;
+    getRole(): string | undefined;
 
     // Marker Creation
     /** Create a marker with the given range. */

--- a/types/atom/index.d.ts
+++ b/types/atom/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Atom 1.26
+// Type definitions for Atom 1.27
 // Project: https://github.com/atom/atom
 // Definitions by: GlenCFL <https://github.com/GlenCFL>
 //                 smhxx <https://github.com/smhxx>
@@ -7,7 +7,7 @@
 // TypeScript Version: 2.3
 
 // NOTE: only those classes exported within this file should be retain that status below.
-// https://github.com/atom/atom/blob/v1.26.0/exports/atom.js
+// https://github.com/atom/atom/blob/v1.27.0/exports/atom.js
 
 /// <reference types="node" />
 
@@ -1004,6 +1004,9 @@ export interface MarkerLayer {
     /** Find markers in the layer conforming to the given parameters. */
     findMarkers(params: FindMarkerOptions): Marker[];
 
+    /** Get the role of the marker layer e.g. "atom.selection". */
+    getRole(): string;
+
     // Marker Creation
     /** Create a marker with the given range. */
     markRange(range: RangeCompatible, options?: { reversed?: boolean, invalidate?:
@@ -1525,29 +1528,29 @@ export class TextEditor {
 
     // Mutating Text
     /** Replaces the entire contents of the buffer with the given string. */
-    setText(text: string): void;
+    setText(text: string, options?: ReadonlyEditOptions): void;
 
     /** Set the text in the given Range in buffer coordinates. */
     setTextInBufferRange(range: RangeCompatible, text: string, options?:
-        TextEditOptions): Range;
+        TextEditOptions & ReadonlyEditOptions): Range;
 
     /* For each selection, replace the selected text with the given text. */
-    insertText(text: string, options?: TextInsertionOptions): Range|false;
+    insertText(text: string, options?: TextInsertionOptions & ReadonlyEditOptions): Range|false;
 
     /** For each selection, replace the selected text with a newline. */
-    insertNewline(): void;
+    insertNewline(options?: ReadonlyEditOptions): void;
 
     /**
      *  For each selection, if the selection is empty, delete the character following
      *  the cursor. Otherwise delete the selected text.
      */
-    delete(): void;
+    delete(options?: ReadonlyEditOptions): void;
 
     /**
      *  For each selection, if the selection is empty, delete the character preceding
      *  the cursor. Otherwise delete the selected text.
      */
-    backspace(): void;
+    backspace(options?: ReadonlyEditOptions): void;
 
     /**
      *  Mutate the text of all the selections in a single transaction.
@@ -1561,89 +1564,89 @@ export class TextEditor {
      *  If the selection is empty, the characters preceding and following the cursor
      *  are swapped. Otherwise, the selected characters are reversed.
      */
-    transpose(): void;
+    transpose(options?: ReadonlyEditOptions): void;
 
     /**
      *  Convert the selected text to upper case.
      *  For each selection, if the selection is empty, converts the containing word
      *  to upper case. Otherwise convert the selected text to upper case.
      */
-    upperCase(): void;
+    upperCase(options?: ReadonlyEditOptions): void;
 
     /**
      *  Convert the selected text to lower case.
      *  For each selection, if the selection is empty, converts the containing word
      *  to upper case. Otherwise convert the selected text to upper case.
      */
-    lowerCase(): void;
+    lowerCase(options?: ReadonlyEditOptions): void;
 
     /**
      *  Toggle line comments for rows intersecting selections.
      *  If the current grammar doesn't support comments, does nothing.
      */
-    toggleLineCommentsInSelection(): void;
+    toggleLineCommentsInSelection(options?: ReadonlyEditOptions): void;
 
     /** For each cursor, insert a newline at beginning the following line. */
-    insertNewlineBelow(): void;
+    insertNewlineBelow(options?: ReadonlyEditOptions): void;
 
     /** For each cursor, insert a newline at the end of the preceding line. */
-    insertNewlineAbove(): void;
+    insertNewlineAbove(options?: ReadonlyEditOptions): void;
 
     /**
      *  For each selection, if the selection is empty, delete all characters of the
      *  containing word that precede the cursor. Otherwise delete the selected text.
      */
-    deleteToBeginningOfWord(): void;
+    deleteToBeginningOfWord(options?: ReadonlyEditOptions): void;
 
     /**
      *  Similar to ::deleteToBeginningOfWord, but deletes only back to the previous
      *  word boundary.
      */
-    deleteToPreviousWordBoundary(): void;
+    deleteToPreviousWordBoundary(options?: ReadonlyEditOptions): void;
 
     /** Similar to ::deleteToEndOfWord, but deletes only up to the next word boundary. */
-    deleteToNextWordBoundary(): void;
+    deleteToNextWordBoundary(options?: ReadonlyEditOptions): void;
 
     /**
      *  For each selection, if the selection is empty, delete all characters of the
      *  containing subword following the cursor. Otherwise delete the selected text.
      */
-    deleteToBeginningOfSubword(): void;
+    deleteToBeginningOfSubword(options?: ReadonlyEditOptions): void;
 
     /**
      *  For each selection, if the selection is empty, delete all characters of the
      *  containing subword following the cursor. Otherwise delete the selected text.
      */
-    deleteToEndOfSubword(): void;
+    deleteToEndOfSubword(options?: ReadonlyEditOptions): void;
 
     /**
      *  For each selection, if the selection is empty, delete all characters of the
      *  containing line that precede the cursor. Otherwise delete the selected text.
      */
-    deleteToBeginningOfLine(): void;
+    deleteToBeginningOfLine(options?: ReadonlyEditOptions): void;
 
     /**
      *  For each selection, if the selection is not empty, deletes the selection
      *  otherwise, deletes all characters of the containing line following the cursor.
      *  If the cursor is already at the end of the line, deletes the following newline.
      */
-    deleteToEndOfLine(): void;
+    deleteToEndOfLine(options?: ReadonlyEditOptions): void;
 
     /**
      *  For each selection, if the selection is empty, delete all characters of the
      *  containing word following the cursor. Otherwise delete the selected text.
      */
-    deleteToEndOfWord(): void;
+    deleteToEndOfWord(options?: ReadonlyEditOptions): void;
 
     /** Delete all lines intersecting selections. */
-    deleteLine(): void;
+    deleteLine(options?: ReadonlyEditOptions): void;
 
     // History
     /** Undo the last change. */
-    undo(): void;
+    undo(options?: ReadonlyEditOptions): void;
 
     /** Redo the last change. */
-    redo(): void;
+    redo(options?: ReadonlyEditOptions): void;
 
     /**
      *  Batch multiple operations as a single undo/redo step.
@@ -2284,10 +2287,10 @@ export class TextEditor {
         { preserveLeadingWhitespace?: boolean }): void;
 
     /** Indent rows intersecting selections by one level. */
-    indentSelectedRows(): void;
+    indentSelectedRows(options?: ReadonlyEditOptions): void;
 
     /** Outdent rows intersecting selections by one level. */
-    outdentSelectedRows(): void;
+    outdentSelectedRows(options?: ReadonlyEditOptions): void;
 
     /**
      *  Get the indentation level of the given line of text.
@@ -2298,7 +2301,7 @@ export class TextEditor {
     indentLevelForLine(line: string): number;
 
     /** Indent rows intersecting selections based on the grammar's suggested indent level. */
-    autoIndentSelectedRows(): void;
+    autoIndentSelectedRows(options?: ReadonlyEditOptions): void;
 
     // Grammars
     /** Get the current Grammar of this editor. */
@@ -2328,7 +2331,7 @@ export class TextEditor {
     copySelectedText(): void;
 
     /** For each selection, cut the selected text. */
-    cutSelectedText(): void;
+    cutSelectedText(options?: ReadonlyEditOptions): void;
 
     /**
      *  For each selection, replace the selected text with the contents of the clipboard.
@@ -2336,19 +2339,19 @@ export class TextEditor {
      *  each selection will be replaced with the content of the corresponding clipboard
      *  selection text.
      */
-    pasteText(options?: TextInsertionOptions): void;
+    pasteText(options?: TextInsertionOptions & ReadonlyEditOptions): void;
 
     /**
      *  For each selection, if the selection is empty, cut all characters of the
      *  containing screen line following the cursor. Otherwise cut the selected text.
      */
-    cutToEndOfLine(): void;
+    cutToEndOfLine(options?: ReadonlyEditOptions): void;
 
     /**
      *  For each selection, if the selection is empty, cut all characters of the
      *  containing buffer line following the cursor. Otherwise cut the selected text.
      */
-    cutToEndOfBufferLine(): void;
+    cutToEndOfBufferLine(options?: ReadonlyEditOptions): void;
 
     // Folds
     /**
@@ -3322,7 +3325,7 @@ export class Directory {
     /** Returns a boolean, always false. */
     isFile(): this is File;
 
-    /** Returns a roolean, always true. */
+    /** Returns a boolean, always true. */
     isDirectory(): this is Directory;
 
     /** Returns a boolean indicating whether or not this is a symbolic link. */
@@ -4716,107 +4719,107 @@ export interface Selection {
 
     // Modifying the selected text
     /** Replaces text at the current selection. */
-    insertText(text: string, options?: TextInsertionOptions): void;
+    insertText(text: string, options?: TextInsertionOptions & ReadonlyEditOptions): void;
 
     /**
      *  Removes the first character before the selection if the selection is empty
      *  otherwise it deletes the selection.
      */
-    backspace(): void;
+    backspace(options?: ReadonlyEditOptions): void;
 
     /**
      *  Removes the selection or, if nothing is selected, then all characters from
      *  the start of the selection back to the previous word boundary.
      */
-    deleteToPreviousWordBoundary(): void;
+    deleteToPreviousWordBoundary(options?: ReadonlyEditOptions): void;
 
     /**
      *  Removes the selection or, if nothing is selected, then all characters from
      *  the start of the selection up to the next word boundary.
      */
-    deleteToNextWordBoundary(): void;
+    deleteToNextWordBoundary(options?: ReadonlyEditOptions): void;
 
     /**
      *  Removes from the start of the selection to the beginning of the current
      *  word if the selection is empty otherwise it deletes the selection.
      */
-    deleteToBeginningOfWord(): void;
+    deleteToBeginningOfWord(options?: ReadonlyEditOptions): void;
 
     /**
      *  Removes from the beginning of the line which the selection begins on all
      *  the way through to the end of the selection.
      */
-    deleteToBeginningOfLine(): void;
+    deleteToBeginningOfLine(options?: ReadonlyEditOptions): void;
 
     /**
      *  Removes the selection or the next character after the start of the selection
      *  if the selection is empty.
      */
-    delete(): void;
+    delete(options?: ReadonlyEditOptions): void;
 
     /**
      *  If the selection is empty, removes all text from the cursor to the end of
      *  the line. If the cursor is already at the end of the line, it removes the following
      *  newline. If the selection isn't empty, only deletes the contents of the selection.
      */
-    deleteToEndOfLine(): void;
+    deleteToEndOfLine(options?: ReadonlyEditOptions): void;
 
     /**
      *  Removes the selection or all characters from the start of the selection to
      *  the end of the current word if nothing is selected.
      */
-    deleteToEndOfWord(): void;
+    deleteToEndOfWord(options?: ReadonlyEditOptions): void;
 
     /**
      *  Removes the selection or all characters from the start of the selection to
      *  the end of the current word if nothing is selected.
      */
-    deleteToBeginningOfSubword(): void;
+    deleteToBeginningOfSubword(options?: ReadonlyEditOptions): void;
 
     /**
      *  Removes the selection or all characters from the start of the selection to
      *  the end of the current word if nothing is selected.
      */
-    deleteToEndOfSubword(): void;
+    deleteToEndOfSubword(options?: ReadonlyEditOptions): void;
 
     /** Removes only the selected text. */
-    deleteSelectedText(): void;
+    deleteSelectedText(options?: ReadonlyEditOptions): void;
 
     /**
      *  Removes the line at the beginning of the selection if the selection is empty
      *  unless the selection spans multiple lines in which case all lines are removed.
      */
-    deleteLine(): void;
+    deleteLine(options?: ReadonlyEditOptions): void;
 
     /**
      *  Joins the current line with the one below it. Lines will be separated by a single space.
      *  If there selection spans more than one line, all the lines are joined together.
      */
-    joinLines(): void;
+    joinLines(options?: ReadonlyEditOptions): void;
 
     /** Removes one level of indent from the currently selected rows. */
-    outdentSelectedRows(): void;
+    outdentSelectedRows(options?: ReadonlyEditOptions): void;
 
     /**
      *  Sets the indentation level of all selected rows to values suggested by the
      *  relevant grammars.
      */
-    autoIndentSelectedRows(): void;
+    autoIndentSelectedRows(options?: ReadonlyEditOptions): void;
 
     /**
      *  Wraps the selected lines in comments if they aren't currently part of a comment.
      *  Removes the comment if they are currently wrapped in a comment.
      */
-    toggleLineComments(): void;
+    toggleLineComments(options?: ReadonlyEditOptions): void;
 
     /** Cuts the selection until the end of the screen line. */
-    cutToEndOfLine(): void;
+    cutToEndOfLine(maintainClipboard?: boolean, options?: ReadonlyEditOptions): void;
 
     /** Cuts the selection until the end of the buffer line. */
-    cutToEndOfBufferLine(): void;
+    cutToEndOfBufferLine(maintainClipboard?: boolean, options?: ReadonlyEditOptions): void;
 
     /** Copies the selection to the clipboard and then deletes it. */
-    cut(maintainClipboard?: boolean, fullLine?: boolean): void;
+    cut(maintainClipboard?: boolean, fullLine?: boolean, options?: ReadonlyEditOptions): void;
 
     /** Copies the current selection to the clipboard. */
     copy(maintainClipboard?: boolean, fullLine?: boolean): void;
@@ -4825,7 +4828,7 @@ export interface Selection {
     fold(): void;
 
     /** If the selection spans multiple rows, indent all of them. */
-    indentSelectedRows(): void;
+    indentSelectedRows(options?: ReadonlyEditOptions): void;
 
     // Managing multiple selections
     /** Moves the selection down one row. */
@@ -5134,6 +5137,12 @@ export class TextBuffer {
      */
     nextNonBlankRow(startRow: number): number|null;
 
+    /**
+     *  Return true if the buffer contains any astral-plane Unicode characters that
+     *  are encoded as surrogate pairs.
+     */
+    hasAstral(): boolean;
+
     // Mutating Text
     /** Replace the entire contents of the buffer with the given text. */
     setText(text: string): Range;
@@ -5172,7 +5181,7 @@ export class TextBuffer {
 
     // Markers
     /** Create a layer to contain a set of related markers. */
-    addMarkerLayer(options?: { maintainHistory?: boolean, persistent?: boolean }):
+    addMarkerLayer(options?: { maintainHistory?: boolean, persistent?: boolean, role?: string }):
         MarkerLayer;
 
     /**
@@ -5210,16 +5219,18 @@ export class TextBuffer {
      *  Undo the last operation. If a transaction is in progress, aborts it.
      *  @return A boolean of whether or not a change was made.
      */
-    undo(): boolean;
+    undo(options?: { selectionsMarkerLayer?: MarkerLayer }): boolean;
 
     /**
      *  Redo the last operation.
      *  @return A boolean of whether or not a change was made.
      */
-    redo(): boolean;
+    redo(options?: { selectionsMarkerLayer?: MarkerLayer }): boolean;
 
     /** Batch multiple operations as a single undo/redo step. */
-    transact<T>(groupingInterval: number, fn: () => T): T;
+    transact<T>(optionsOrInterval: number | { groupingInterval?: number,
+        selectionsMarkerLayer?: MarkerLayer }, fn: () => T): T;
+    /** Batch multiple operations as a single undo/redo step. */
     transact<T>(fn: () => T): T;
 
     /**
@@ -5237,20 +5248,22 @@ export class TextBuffer {
      *  `::revertToCheckpoint` and `::groupChangesSinceCheckpoint`.
      *  @return A checkpoint ID value.
      */
-    createCheckpoint(): number;
+    createCheckpoint(options?: { selectionsMarkerLayer?: MarkerLayer }): number;
 
     /**
      *  Revert the buffer to the state it was in when the given checkpoint was created.
      *  @return A boolean indicating whether the operation succeeded.
      */
-    revertToCheckpoint(checkpoint: number): boolean;
+    revertToCheckpoint(checkpoint: number, options?: { selectionsMarkerLayer: MarkerLayer }):
+        boolean;
 
     /**
      *  Group all changes since the given checkpoint into a single transaction for
      *  purposes of undo/redo.
      *  @return A boolean indicating whether the operation succeeded.
      */
-    groupChangesSinceCheckpoint(checkpoint: number): boolean;
+    groupChangesSinceCheckpoint(checkpoint: number, options?:
+        { selectionsMarkerLayer: MarkerLayer }): boolean;
 
     /**
      *  Group the last two text changes for purposes of undo/redo.
@@ -5828,7 +5841,7 @@ export interface TextEditorObservedEvent {
 // information under certain contexts.
 
 // NOTE: the config schema with these defaults can be found here:
-//   https://github.com/atom/atom/blob/v1.26.0/src/config-schema.js
+//   https://github.com/atom/atom/blob/v1.27.0/src/config-schema.js
 /**
  *  Allows you to strongly type Atom configuration variables. Additional key:value
  *  pairings merged into this interface will result in configuration values under
@@ -6411,6 +6424,11 @@ export interface ProcessOptions extends NodeProcessOptions {
      *  created.
      */
     autoStart?: boolean;
+}
+
+export interface ReadonlyEditOptions {
+    /** Whether the readonly protections on the text editor should be ignored. */
+    bypassReadOnly?: boolean;
 }
 
 export interface ScanContextOptions {


### PR DESCRIPTION
- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: [Atom v1.27 Release Page](https://github.com/atom/atom/releases/tag/v1.27.0)
[Atom v1.27 Blog Post](http://blog.atom.io/2018/05/15/atom-1-27.html)
[Atom v1.27 Documentation](https://atom.io/docs/api/v1.27.0/)
- [X] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

This modifies the `@types/atom` definitions in order to fully support Atom version 1.27.

There are a few pull requests with undocumented changes, which I have left off. I am willing to add these if any reviewers request it.
- https://github.com/atom/atom/pull/16428
  - Pane.increaseSize() and Pane.decreaseSize()
- https://github.com/atom/atom/pull/16845
  - Project.onDidReplace()