### PR TITLE
express-session: add strictNullCheck

### DIFF
--- a/types/express-session/express-session-tests.ts
+++ b/types/express-session/express-session-tests.ts
@@ -11,7 +11,7 @@ app.use(session({
   secret: 'keyboard cat',
   name: 'connect.sid',
   store: new session.MemoryStore(),
-  cookie: { path: '/', httpOnly: true, secure: false, maxAge: null },
+  cookie: { path: '/', httpOnly: true, secure: false },
   genid: (req: express.Request): string => '',
   rolling: false,
   resave: true,
@@ -30,7 +30,7 @@ app.use((req, res, next) => {
     sess.views++;
     res.setHeader('Content-Type', 'text/html');
     res.write(`<p>views: ${sess.views}</p>`);
-    res.write(`<p>expires in: ${(sess.cookie.maxAge / 1000)}s</p>`);
+    res.write(`<p>expires in: ${((sess.cookie.maxAge || 0) / 1000)}s</p>`);
     res.end();
   } else {
     sess.views = 1;
@@ -41,26 +41,28 @@ app.use((req, res, next) => {
 // Custom Session Store
 
 class MyStore extends session.Store {
-  private sessions: { [sid: string]: string };
+  private sessions: { [sid: string]: string | undefined };
 
   constructor() {
     super();
     this.sessions = {};
   }
 
-  get = (sid: string, callback: (err: any, session: Express.SessionData) => void): void => {
-    callback(null, JSON.parse(this.sessions[sid]));
+  get = (sid: string, callback: (err: any, session?: Express.SessionData | null) => void): void => {
+    const sessionString: string | undefined = this.sessions[sid];
+    const sessionData: Express.SessionData | null = sessionString ? JSON.parse(sessionString) : null;
+    callback(null, sessionData);
   }
 
-  set = (sid: string, session: Express.Session, callback: (err: any) => void): void => {
+  set = (sid: string, session: Express.Session, callback?: (err?: any) => void): void => {
     this.sessions[sid] = JSON.stringify(session);
-    callback(null);
+    if (callback) callback();
   }
 
-  destroy = (sid: string, callback: (err: any) => void): void => {
+  destroy = (sid: string, callback?: (err?: any) => void): void => {
     this.sessions[sid] = undefined;
     this.sessions = JSON.parse(JSON.stringify(this.sessions));
-    callback(null);
+    if (callback) callback();
   }
 }
 

--- a/types/express-session/index.d.ts
+++ b/types/express-session/index.d.ts
@@ -87,6 +87,7 @@ declare namespace session {
     all: (callback: (err: any, obj?: { [sid: string]: Express.SessionData; } | null) => void) => void;
     length: (callback: (err: any, length?: number | null) => void) => void;
     clear: (callback?: (err?: any) => void) => void;
+    touch: (sid: string, session: Express.Session, callback?: (err?: any) => void) => void;
   }
 
   class MemoryStore implements BaseMemoryStore {
@@ -96,6 +97,7 @@ declare namespace session {
     all: (callback: (err: any, obj?: { [sid: string]: Express.Session; } | null) => void) => void;
     length: (callback: (err: any, length?: number | null) => void) => void;
     clear: (callback?: (err?: any) => void) => void;
+    touch: (sid: string, session: Express.Session, callback?: (err?: any) => void) => void;
   }
 }
 

--- a/types/express-session/index.d.ts
+++ b/types/express-session/index.d.ts
@@ -67,35 +67,35 @@ declare namespace session {
   }
 
   interface BaseMemoryStore {
-    get: (sid: string, callback: (err: any, session: Express.SessionData) => void) => void;
-    set: (sid: string, session: Express.Session, callback: (err: any) => void) => void;
-    destroy: (sid: string, callback: (err: any) => void) => void;
-    length?: (callback: (err: any, length: number) => void) => void;
-    clear?: (callback: (err: any) => void) => void;
+    get: (sid: string, callback: (err: any, session?: Express.SessionData | null) => void) => void;
+    set: (sid: string, session: Express.Session, callback?: (err?: any) => void) => void;
+    destroy: (sid: string, callback?: (err?: any) => void) => void;
+    length?: (callback: (err: any, length?: number | null) => void) => void;
+    clear?: (callback?: (err?: any) => void) => void;
   }
 
   abstract class Store extends node.EventEmitter {
     constructor(config?: any);
 
-    regenerate: (req: express.Request, fn: (err: any) => any) => void;
-    load: (sid: string, fn: (err: any, session: Express.Session) => any) => void;
+    regenerate: (req: express.Request, fn: (err?: any) => any) => void;
+    load: (sid: string, fn: (err: any, session?: Express.Session | null) => any) => void;
     createSession: (req: express.Request, sess: Express.SessionData) => void;
 
-    get: (sid: string, callback: (err: any, session: Express.SessionData) => void) => void;
-    set: (sid: string, session: Express.Session, callback: (err: any) => void) => void;
-    destroy: (sid: string, callback: (err: any) => void) => void;
-    all: (callback: (err: any, obj: { [sid: string]: Express.SessionData; }) => void) => void;
-    length: (callback: (err: any, length: number) => void) => void;
-    clear: (callback: (err: any) => void) => void;
+    get: (sid: string, callback: (err: any, session?: Express.SessionData | null) => void) => void;
+    set: (sid: string, session: Express.Session, callback?: (err?: any) => void) => void;
+    destroy: (sid: string, callback?: (err?: any) => void) => void;
+    all: (callback: (err: any, obj?: { [sid: string]: Express.SessionData; } | null) => void) => void;
+    length: (callback: (err: any, length?: number | null) => void) => void;
+    clear: (callback?: (err?: any) => void) => void;
   }
 
   class MemoryStore implements BaseMemoryStore {
-    get: (sid: string, callback: (err: any, session: Express.SessionData) => void) => void;
-    set: (sid: string, session: Express.Session, callback: (err: any) => void) => void;
-    destroy: (sid: string, callback: (err: any) => void) => void;
-    all: (callback: (err: any, obj: { [sid: string]: Express.Session; }) => void) => void;
-    length: (callback: (err: any, length: number) => void) => void;
-    clear: (callback: (err: any) => void) => void;
+    get: (sid: string, callback: (err: any, session?: Express.SessionData | null) => void) => void;
+    set: (sid: string, session: Express.Session, callback?: (err?: any) => void) => void;
+    destroy: (sid: string, callback?: (err?: any) => void) => void;
+    all: (callback: (err: any, obj?: { [sid: string]: Express.Session; } | null) => void) => void;
+    length: (callback: (err: any, length?: number | null) => void) => void;
+    clear: (callback?: (err?: any) => void) => void;
   }
 }
 

--- a/types/express-session/tsconfig.json
+++ b/types/express-session/tsconfig.json
@@ -6,7 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
-        "strictNullChecks": false,
+        "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",
         "typeRoots": [


### PR DESCRIPTION
I wanted to create my own store, extending session.Store, but faced some problems:

- <s>Store methods are declared as class properties whereas in the source code, we can see that they are declared as prototype. It means that overloading these methods require to create a member function. This is not the case for most implementations.</s> EDIT: Actually, I cannot change this as it will break compatibility for already existing store definitions.

- Callback methods are not mandatory for most of the methods. If you enable strictNullCheck, you cannot avoid giving a callback.

- Last parameter of the callbacks is not mandatory: there either is an error and value is not given, or there is no value to give and callback may be called without any parameter. This is what most implementations are doing.

- Parameters can be null. If there is an error, the callback may be called with a non-null error parameter and the value set to null. There even can be a null result if the required session was not found.

- The touch method was not described.

I made some small modifications to reflect this. I will have no time to do more, but please feel free to ask me any question on these changes.