### PR TITLE
added type definitions for NPM package module-alias

### DIFF
--- a/types/module-alias/index.d.ts
+++ b/types/module-alias/index.d.ts
@@ -10,6 +10,9 @@ export = init;
  */
 declare function init(options?: string | init.Options): void;
 
+/**
+ * Exported functoins
+ */
 declare namespace init {
     function isPathMatchesAlias(path: string, alias: string): boolean;
 

--- a/types/module-alias/index.d.ts
+++ b/types/module-alias/index.d.ts
@@ -1,0 +1,44 @@
+// Type definitions for module-alias 2.0
+// Project: https://github.com/ilearnio/module-alias/
+// Definitions by: Kevin Ramharak <https://github.com/KevinRamharak>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped/
+
+export = init;
+
+/**
+ * Import aliases from package.json
+ */
+declare function init(options?: string | init.Options): void;
+
+declare namespace init {
+    function isPathMatchesAlias(path: string, alias: string): boolean;
+
+    /**
+     * Register a custom modules directory
+     */
+    function addPath(path: string): void;
+
+    /**
+     * Register a single alias
+     */
+    function addAlias(alias: string, path: string): void;
+
+    /**
+     * Register mutliple aliases
+     */
+    function addAliases(aliases: { [alias: string]: string }): void;
+
+    /**
+     * Reset any changes maded (resets all registered aliases
+     * and custom module directories)
+     * The function is undocumented and for testing purposes only
+     */
+    function reset(): void;
+
+    /**
+     * module intialis options type
+     */
+    interface Options {
+        base: string;
+    }
+}

--- a/types/module-alias/module-alias-tests.ts
+++ b/types/module-alias/module-alias-tests.ts
@@ -1,3 +1,12 @@
-import * as moduleAlias from 'module-alias';
+import moduleAlias = require('module-alias');
+
+moduleAlias('path'); // $ExpectType void
+moduleAlias({ base : 'path' }); // $ExpectType void
 
 moduleAlias.isPathMatchesAlias('./path', '@alias'); // $ExpectType boolean
+
+moduleAlias.addPath('path'); // $ExpectType void
+moduleAlias.addAliases({ alias : 'path', anotherAlias : 'anotherPath' }); // $ExpectType void
+moduleAlias.addAlias('@alias', 'somePath'); // $ExpectType void
+
+moduleAlias.reset(); // $ExpectType void

--- a/types/module-alias/module-alias-tests.ts
+++ b/types/module-alias/module-alias-tests.ts
@@ -1,0 +1,3 @@
+import * as moduleAlias from 'module-alias';
+
+moduleAlias.isPathMatchesAlias('./path', '@alias'); // $ExpectType boolean

--- a/types/module-alias/tsconfig.json
+++ b/types/module-alias/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "module-alias-tests.ts"
+    ]
+}

--- a/types/module-alias/tslint.json
+++ b/types/module-alias/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
