### PR TITLE
[core-js] Change lpad/rpad to padStart/padEnd

### DIFF
--- a/types/core-js/index.d.ts
+++ b/types/core-js/index.d.ts
@@ -755,8 +755,8 @@ declare namespace core {
         raw(template: TemplateStringsArray, ...substitutions: any[]): string;
         startsWith(text: string, searchString: string, position?: number): boolean;
         at(text: string, index: number): string;
-        lpad(text: string, length: number, fillStr?: string): string;
-        rpad(text: string, length: number, fillStr?: string): string;
+        padStart(text: string, length: number, fillStr?: string): string;
+        padEnd(text: string, length: number, fillStr?: string): string;
         escapeHTML(text: string): string;
         unescapeHTML(text: string): string;
     };
@@ -1454,9 +1454,13 @@ declare module "core-js/fn/string/includes" {
     const includes: typeof core.String.includes;
     export = includes;
 }
-declare module "core-js/fn/string/lpad" {
-    const lpad: typeof core.String.lpad;
-    export = lpad;
+declare module "core-js/fn/string/pad-end" {
+    const padEnd: typeof core.String.padEnd;
+    export = padEnd;
+}
+declare module "core-js/fn/string/pad-start" {
+    const padStart: typeof core.String.padStart;
+    export = padStart;
 }
 declare module "core-js/fn/string/raw" {
     const raw: typeof core.String.raw;
@@ -1465,10 +1469,6 @@ declare module "core-js/fn/string/raw" {
 declare module "core-js/fn/string/repeat" {
     const repeat: typeof core.String.repeat;
     export = repeat;
-}
-declare module "core-js/fn/string/rpad" {
-    const rpad: typeof core.String.rpad;
-    export = rpad;
 }
 declare module "core-js/fn/string/starts-with" {
     const startsWith: typeof core.String.startsWith;
@@ -2273,9 +2273,13 @@ declare module "core-js/library/fn/string/includes" {
     const includes: typeof core.String.includes;
     export = includes;
 }
-declare module "core-js/library/fn/string/lpad" {
-    const lpad: typeof core.String.lpad;
-    export = lpad;
+declare module "core-js/library/fn/string/pad-end" {
+    const padEnd: typeof core.String.padEnd;
+    export = padEnd;
+}
+declare module "core-js/library/fn/string/pad-start" {
+    const padStart: typeof core.String.padStart;
+    export = padStart;
 }
 declare module "core-js/library/fn/string/raw" {
     const raw: typeof core.String.raw;
@@ -2284,10 +2288,6 @@ declare module "core-js/library/fn/string/raw" {
 declare module "core-js/library/fn/string/repeat" {
     const repeat: typeof core.String.repeat;
     export = repeat;
-}
-declare module "core-js/library/fn/string/rpad" {
-    const rpad: typeof core.String.rpad;
-    export = rpad;
 }
 declare module "core-js/library/fn/string/starts-with" {
     const startsWith: typeof core.String.startsWith;

--- a/types/core-js/index.d.ts
+++ b/types/core-js/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for core-js 0.9
+// Type definitions for core-js 2.5
 // Project: https://github.com/zloirock/core-js/
 // Definitions by: Ron Buckton <https://github.com/rbuckton>, Michel Felipe <https://github.com/mfdeveloper>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/zloirock/core-js/blob/167408c8467f2ee7934968fdf73e3a3f4eab7567/CHANGELOG.md#110---20150817>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

Not sure if we should keep the old lpad/rpad and just add padStart/padEnd to keep compatibility with <1.1.0. Thoughts? 
