### PR TITLE
[@types/react-relay] QueryRendererProps["query"] can be null

### DIFF
--- a/types/react-relay/index.d.ts
+++ b/types/react-relay/index.d.ts
@@ -4,6 +4,7 @@
 //                 Matt Martin <https://github.com/voxmatt>
 //                 Eloy Durán <https://github.com/alloy>
 //                 Nicolas Pirotte <https://github.com/npirotte>
+//                 Cameron Knight <https://github.com/ckknight>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.6
 
@@ -76,7 +77,7 @@ export const graphql: GraphqlInterface;
 export interface QueryRendererProps {
     cacheConfig?: RelayRuntimeTypes.CacheConfig;
     environment: RelayRuntimeTypes.Environment;
-    query: RelayRuntimeTypes.GraphQLTaggedNode;
+    query?: RelayRuntimeTypes.GraphQLTaggedNode | null;
     render(readyState: ReadyState): React.ReactElement<any> | undefined | null;
     variables: RelayRuntimeTypes.Variables;
     rerunParamExperimental?: RelayRuntimeTypes.RerunParam;

--- a/types/react-relay/test/react-relay-tests.tsx
+++ b/types/react-relay/test/react-relay-tests.tsx
@@ -28,16 +28,16 @@ const modernEnvironment = new Environment({ network, store });
 // ~~~~~~~~~~~~~~~~~~~~~
 // Modern QueryRenderer
 // ~~~~~~~~~~~~~~~~~~~~~
-const MyQueryRenderer = (props: { name: string }) => (
+const MyQueryRenderer = (props: { name: string, show: boolean }) => (
     <QueryRenderer
         environment={modernEnvironment}
-        query={graphql`
+        query={props.show ? graphql`
             query ExampleQuery($pageID: ID!) {
                 page(id: $pageID) {
                     name
                 }
             }
-        `}
+        ` : null}
         variables={{
             pageID: "110798995619330",
         }}
@@ -46,6 +46,23 @@ const MyQueryRenderer = (props: { name: string }) => (
                 return <div>{error.message}</div>;
             } else if (props) {
                 return <div>{props.name} is great!</div>;
+            }
+            return <div>Loading</div>;
+        }}
+    />
+);
+
+const MyEmptyQueryRenderer = () => (
+    <QueryRenderer
+        environment={modernEnvironment}
+        // NOTE: let's intentionally leave out `query`
+        // query={undefined}
+        variables={{}}
+        render={({ error, props }) => {
+            if (error) {
+                return <div>{error.message}</div>;
+            } else if (props) {
+                throw new Error('This code path should never be hit');
             }
             return <div>Loading</div>;
         }}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - https://facebook.github.io/relay/docs/en/query-renderer.html "query: The graphql tagged query. Note: To enable compatibility mode, relay-compiler enforces the query to be named as \<FileName\>Query. __Optional, if not provided, an empty props object is passed to the render callback.__"
  - https://github.com/facebook/relay/blob/master/packages/react-relay/modern/ReactRelayQueryRenderer.js#L59
