### PR TITLE
@types/vision ViewHandlerOrReplyOptions.layout?: boolean | string

### DIFF
--- a/types/vision/index.d.ts
+++ b/types/vision/index.d.ts
@@ -72,7 +72,7 @@ declare namespace vision {
          * Disable layout when using Jade as it will handle including any layout files independently.
          * Defaults to false.
          */
-        layout?: boolean;
+        layout?: boolean | string;
         /** the root file path, or array of file paths, where layout templates are located (using the relativeTo prefix if present). Defaults to path. */
         layoutPath?: string | string[];
         /** the key used by the template engine to denote where primary template content should go. Defaults to 'content'. */


### PR DESCRIPTION
As we can see in the link bellow `ViewHandlerOrReplyOptions.layout` can be also a filename.
Example `return h.view('myview', null, { layout: 'another_layout' });`

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://hapijs.com/tutorials/views#user-content-layouts

