### PR TITLE
Reactstrap: StatelessComponent -> Component where appropriate; update innerRefs.

### DIFF
--- a/types/reactstrap/lib/Button.d.ts
+++ b/types/reactstrap/lib/Button.d.ts
@@ -8,7 +8,7 @@ export interface ButtonProps extends React.HTMLProps<HTMLButtonElement> {
   color?: string;
   disabled?: boolean;
   tag?: React.ReactType;
-  innerRef?: string | ((instance: HTMLButtonElement) => any);
+  innerRef?: React.Ref<HTMLButtonElement>;
 
   onClick?: React.MouseEventHandler<any>;
   size?: any;

--- a/types/reactstrap/lib/Button.d.ts
+++ b/types/reactstrap/lib/Button.d.ts
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { CSSModule } from '../index';
 
 export interface ButtonProps extends React.HTMLProps<HTMLButtonElement> {
@@ -17,5 +18,5 @@ export interface ButtonProps extends React.HTMLProps<HTMLButtonElement> {
   cssModule?: CSSModule;
 }
 
-declare const Button: React.StatelessComponent<ButtonProps>;
+declare class Button extends React.Component<ButtonProps> {}
 export default Button;

--- a/types/reactstrap/lib/CardLink.d.ts
+++ b/types/reactstrap/lib/CardLink.d.ts
@@ -2,7 +2,7 @@ import { CSSModule } from '../index';
 
 export interface CardLinkProps extends React.HTMLAttributes<HTMLElement> {
   tag?: React.ReactType;
-  innerRef?: string | ((instance: HTMLButtonElement) => any);
+  innerRef?: React.Ref<HTMLAnchorElement>;
   className?: string;
   cssModule?: CSSModule;
   href?: string;

--- a/types/reactstrap/lib/Carousel.d.ts
+++ b/types/reactstrap/lib/Carousel.d.ts
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { CSSModule } from '../index';
 
 export interface CarouselProps extends React.HTMLProps<HTMLElement> {
@@ -14,5 +15,5 @@ export interface CarouselProps extends React.HTMLProps<HTMLElement> {
     cssModule?: CSSModule
 }
 
-declare const Carousel: React.StatelessComponent<CarouselProps>;
+declare class Carousel extends React.Component<CarouselProps> {}
 export default Carousel;

--- a/types/reactstrap/lib/CarouselItem.d.ts
+++ b/types/reactstrap/lib/CarouselItem.d.ts
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { CSSModule } from '../index';
 
 export interface Transition {
@@ -16,5 +17,5 @@ export interface CarouselItemProps extends React.HTMLProps<HTMLElement>, Transit
     slide?: boolean;
 }
 
-declare const CarouselItem: React.StatelessComponent<CarouselItemProps>;
+declare class CarouselItem extends React.Component<CarouselItemProps> {}
 export default CarouselItem;

--- a/types/reactstrap/lib/Collapse.d.ts
+++ b/types/reactstrap/lib/Collapse.d.ts
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { CSSModule } from '../index';
 
 export interface CollapseProps extends React.HTMLProps<HTMLElement> {
@@ -19,5 +20,5 @@ export interface CollapseProps extends React.HTMLProps<HTMLElement> {
   onExited?: () => void;
 }
 
-declare const Collapse: React.StatelessComponent<CollapseProps>;
+declare class Collapse extends React.Component<CollapseProps> {}
 export default Collapse;

--- a/types/reactstrap/lib/Dropdown.d.ts
+++ b/types/reactstrap/lib/Dropdown.d.ts
@@ -1,6 +1,7 @@
+import * as React from 'react';
 import { CSSModule } from '../index';
 
-export type Direction = 
+export type Direction =
   | "up"
   | "down"
   | "left"
@@ -30,5 +31,5 @@ export interface DropdownProps extends Props {
   /* intentionally blank */
 }
 
-declare const Dropdown: React.StatelessComponent<DropdownProps>;
+declare class Dropdown extends React.Component<DropdownProps> {}
 export default Dropdown;

--- a/types/reactstrap/lib/DropdownItem.d.ts
+++ b/types/reactstrap/lib/DropdownItem.d.ts
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { CSSModule } from '../index';
 
 export interface DropdownItemProps extends React.HTMLAttributes<HTMLElement> {
@@ -13,5 +14,5 @@ export interface DropdownItemProps extends React.HTMLAttributes<HTMLElement> {
   active?: boolean;
 }
 
-declare const DropdownItem: React.StatelessComponent<DropdownItemProps>;
+declare class DropdownItem extends React.Component<DropdownItemProps> {}
 export default DropdownItem;

--- a/types/reactstrap/lib/DropdownToggle.d.ts
+++ b/types/reactstrap/lib/DropdownToggle.d.ts
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { CSSModule } from '../index';
 
 export interface DropdownToggleProps extends React.HTMLAttributes<HTMLElement> {
@@ -16,5 +17,5 @@ export interface DropdownToggleProps extends React.HTMLAttributes<HTMLElement> {
   size?: string;
 }
 
-declare const DropdownToggle: React.StatelessComponent<DropdownToggleProps>;
+declare class DropdownToggle extends React.Component<DropdownToggleProps> {}
 export default DropdownToggle;

--- a/types/reactstrap/lib/Form.d.ts
+++ b/types/reactstrap/lib/Form.d.ts
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { CSSModule } from '../index';
 
 export interface FormProps extends React.HTMLProps<HTMLFormElement> {
@@ -8,5 +9,5 @@ export interface FormProps extends React.HTMLProps<HTMLFormElement> {
   cssModule?: CSSModule;
 }
 
-declare const Form: React.StatelessComponent<FormProps>;
+declare class Form extends React.Component<FormProps> {}
 export default Form;

--- a/types/reactstrap/lib/Form.d.ts
+++ b/types/reactstrap/lib/Form.d.ts
@@ -4,7 +4,7 @@ import { CSSModule } from '../index';
 export interface FormProps extends React.HTMLProps<HTMLFormElement> {
   inline?: boolean;
   tag?: React.ReactType;
-  innerRef?: string | ((instance: HTMLButtonElement) => any);
+  innerRef?: React.Ref<HTMLFormElement>;
   className?: string;
   cssModule?: CSSModule;
 }

--- a/types/reactstrap/lib/Input.d.ts
+++ b/types/reactstrap/lib/Input.d.ts
@@ -35,7 +35,7 @@ export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> 
   valid?: boolean;
   invalid?: boolean;
   tag?: React.ReactType;
-  innerRef?: string | ((instance: HTMLInputElement) => any);
+  innerRef?: React.Ref<HTMLInputElement>;
   plaintext?: boolean;
   addon?: boolean;
   className?: string;

--- a/types/reactstrap/lib/Modal.d.ts
+++ b/types/reactstrap/lib/Modal.d.ts
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { CSSModule } from '../index';
 import { FadeProps } from './Fade';
 
@@ -28,5 +29,5 @@ export interface ModalProps extends React.HTMLAttributes<HTMLElement> {
   role?: string;
 }
 
-declare const Modal: React.StatelessComponent<ModalProps>;
+declare class Modal extends React.Component<ModalProps> {}
 export default Modal;

--- a/types/reactstrap/lib/NavLink.d.ts
+++ b/types/reactstrap/lib/NavLink.d.ts
@@ -3,7 +3,7 @@ import { CSSModule } from '../index';
 
 export interface NavLinkProps extends React.HTMLProps<HTMLAnchorElement> {
   tag?: React.ReactType;
-  innerRef?: string | ((instance: HTMLButtonElement) => any);
+  innerRef?: React.Ref<HTMLAnchorElement>;
   disabled?: boolean;
   active?: boolean;
   className?: string;

--- a/types/reactstrap/lib/NavLink.d.ts
+++ b/types/reactstrap/lib/NavLink.d.ts
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { CSSModule } from '../index';
 
 export interface NavLinkProps extends React.HTMLProps<HTMLAnchorElement> {
@@ -11,5 +12,5 @@ export interface NavLinkProps extends React.HTMLProps<HTMLAnchorElement> {
   href?: string;
 }
 
-declare const NavLink: React.StatelessComponent<NavLinkProps>;
+declare class NavLink extends React.Component<NavLinkProps> {}
 export default NavLink;

--- a/types/reactstrap/lib/Popover.d.ts
+++ b/types/reactstrap/lib/Popover.d.ts
@@ -1,5 +1,4 @@
-/// <reference types='react' />
-
+import * as React from 'react';
 import { CSSModule } from '../index';
 import { Popper } from './Popper';
 
@@ -19,5 +18,5 @@ export interface PopoverProps extends React.HTMLAttributes<HTMLElement> {
   cssModule?: CSSModule;
 }
 
-declare const Popover: React.StatelessComponent<PopoverProps>;
+declare class Popover extends React.Component<PopoverProps> {}
 export default Popover;

--- a/types/reactstrap/lib/TabContent.d.ts
+++ b/types/reactstrap/lib/TabContent.d.ts
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { CSSModule } from '../index';
 
 export interface TabContentProps extends React.HTMLAttributes<HTMLElement> {
@@ -7,5 +8,5 @@ export interface TabContentProps extends React.HTMLAttributes<HTMLElement> {
   cssModule?: CSSModule;
 }
 
-declare const TabContent: React.StatelessComponent<TabContentProps>;
+declare class TabContent extends React.Component<TabContentProps> {}
 export default TabContent;

--- a/types/reactstrap/lib/Tooltip.d.ts
+++ b/types/reactstrap/lib/Tooltip.d.ts
@@ -1,5 +1,4 @@
-/// <reference types='react' />
-
+import * as React from 'react';
 import { CSSModule } from '../index';
 import {Popper} from './Popper';
 
@@ -23,5 +22,5 @@ export interface TooltipProps extends UncontrolledTooltipProps {
   isOpen?: boolean;
 }
 
-declare const Tooltip: React.StatelessComponent<TooltipProps>;
+declare class Tooltip extends React.Component<TooltipProps> {}
 export default Tooltip;

--- a/types/reactstrap/lib/Uncontrolled.d.ts
+++ b/types/reactstrap/lib/Uncontrolled.d.ts
@@ -1,12 +1,14 @@
+import * as React from 'react';
+
 import { UncontrolledAlertProps          } from './Alert';
 import { UncontrolledButtonDropdownProps } from './ButtonDropdown';
 import { UncontrolledDropdownProps       } from './Dropdown';
 import { UncontrolledTooltipProps        } from './Tooltip';
 
-export const UncontrolledAlert: React.StatelessComponent<UncontrolledAlertProps>;
-export const UncontrolledButtonDropdown: React.StatelessComponent<UncontrolledButtonDropdownProps>;
-export const UncontrolledDropdown: React.StatelessComponent<UncontrolledDropdownProps>;
-export const UncontrolledTooltip: React.StatelessComponent<UncontrolledTooltipProps>;
+export class UncontrolledAlert extends React.Component<UncontrolledAlertProps> {}
+export class UncontrolledButtonDropdown extends React.Component<UncontrolledButtonDropdownProps> {}
+export class UncontrolledDropdown extends React.Component<UncontrolledDropdownProps> {}
+export class UncontrolledTooltip extends React.Component<UncontrolledTooltipProps> {}
 
 export { UncontrolledAlertProps          } from './Alert';
 export { UncontrolledButtonDropdownProps } from './ButtonDropdown';

--- a/types/reactstrap/reactstrap-tests.tsx
+++ b/types/reactstrap/reactstrap-tests.tsx
@@ -3336,7 +3336,7 @@ const CSSModuleExample = (props: any) => {
 };
 
 class Example107 extends React.Component {
-  private input: HTMLInputElement;
+  private input: HTMLInputElement | null;
 
   render() {
     return <Input type="file" innerRef={(input) => { this.input = input; }} />;
@@ -3694,7 +3694,6 @@ const Example116 = (props: any) => {
 function Example117() {
     const ref = (e: any) => {};
 
-    <Input ref={ref}/>;
     <Button ref={ref}/>;
     <Carousel ref={ref} next={null as any} previous={null as any}/>;
     <CarouselItem ref={ref}/>;
@@ -3712,4 +3711,14 @@ function Example117() {
     <UncontrolledButtonDropdown ref={ref}/>;
     <UncontrolledDropdown ref={ref}/>;
     <UncontrolledTooltip ref={ref} target={null as any}/>;
+}
+
+function Example118() {
+    const ref: string | ((e: any) => void) | React.RefObject<any> = null as any;
+
+    <Button innerRef={ref}/>;
+    <CardLink innerRef={ref}/>;
+    <Form innerRef={ref}/>;
+    <Input innerRef={ref}/>;
+    <NavLink innerRef={ref}/>;
 }

--- a/types/reactstrap/reactstrap-tests.tsx
+++ b/types/reactstrap/reactstrap-tests.tsx
@@ -3691,8 +3691,25 @@ const Example116 = (props: any) => {
   );
 };
 
-class Example117 extends React.Component {
-  render() {
-    return <Input ref={e => { console.log(e); }}/>;
-  }
+function Example117() {
+    const ref = (e: any) => {};
+
+    <Input ref={ref}/>;
+    <Button ref={ref}/>;
+    <Carousel ref={ref} next={null as any} previous={null as any}/>;
+    <CarouselItem ref={ref}/>;
+    <Collapse ref={ref}/>;
+    <Dropdown ref={ref}/>;
+    <DropdownItem ref={ref}/>;
+    <DropdownToggle ref={ref}/>;
+    <Form ref={ref}/>;
+    <Input ref={ref}/>;
+    <Modal ref={ref}/>;
+    <NavLink ref={ref}/>;
+    <TabContent ref={ref}/>;
+    <Tooltip ref={ref} target={null as any}/>;
+    <UncontrolledAlert ref={ref}/>;
+    <UncontrolledButtonDropdown ref={ref}/>;
+    <UncontrolledDropdown ref={ref}/>;
+    <UncontrolledTooltip ref={ref} target={null as any}/>;
 }


### PR DESCRIPTION
(See also #24846 for prior work.)

Update Reactstrap to declare components that aren't stateless functional components
as regular components. This allows consumers to use ref-related APIs, namely, the
`ref` prop and `forwardRef`.

Previously, Typescript would outright deny passing `ref`, and any attempts to use
`forwardRef` would cause very confusing type errors claiming that the component class
you were trying to refer to didn't exist (?!).

Note that many components actually are implemented as stateless components, and as such
their typings haven't been changed.

I found the list of components needing this update by checking out current master
of reactstrap (1d20d6d52c258428df39429e09c84b0ddcac76ee), then

```sh
cd src
rg 'extends (React.)?Component' -l | grep -v '__tests__'
```

Additionally, this PR updates any declarations of `innerRef` to use `React.Ref<T>` so that the consumer can pass anything that their installed typings for React say is a legal ref, rather than re-declaring what a ref is. In particular, this now allows support for 16.3-style ref objects, which is necessary for `forwardRef` to type properly.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: first PR in this vein: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/24846 ; refs + stateless components: https://github.com/facebook/react/issues/4936
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.