### PR TITLE
@types/recharts: XAxis and YAxis "label" prop should accept LabelProps object

### DIFF
--- a/types/recharts/index.d.ts
+++ b/types/recharts/index.d.ts
@@ -892,7 +892,7 @@ export interface XAxisProps extends EventAttributes {
     interval?: AxisInterval;
     reversed?: boolean;
     // see label section at http://recharts.org/#/en-US/api/XAxis
-    label?: string | number | Label;
+    label?: string | number | LabelProps;
 }
 
 export class XAxis extends React.Component<XAxisProps> { }
@@ -943,7 +943,7 @@ export interface YAxisProps extends EventAttributes {
     interval?: AxisInterval;
     reversed?: boolean;
     // see label section at http://recharts.org/#/en-US/api/YAxis
-    label?: string | number | Label;
+    label?: string | number | LabelProps;
 }
 
 export class YAxis extends React.Component<YAxisProps> { }

--- a/types/recharts/recharts-tests.tsx
+++ b/types/recharts/recharts-tests.tsx
@@ -136,12 +136,8 @@ class Component extends React.Component<{}, ComponentState> {
                 </ResponsiveContainer>
                 <ResponsiveContainer>
                     <LineChart width={500} height={300} data={data}>
-                        <XAxis dataKey="name">
-                            <Label>X axis - name</Label>
-                        </XAxis>
-                        <YAxis>
-                            <Label>Y axis</Label>
-                        </YAxis>
+                        <XAxis dataKey="name" label={{ value: "X axis - name" }} />
+                        <YAxis label={{ value: "Y axis" }} />
                         <CartesianGrid stroke="#eee" strokeDasharray="5 5"  />
                         <Line type="monotone" dataKey="uv" stroke="#8884d8" onClick={ this.clickHandler } />
                         <Line type="monotone" dataKey="pv" stroke="#82ca9d" />


### PR DESCRIPTION
According to docs(http://recharts.org/en-US/api/Label), one can provide `label` prop for XAxis and YAxis in a form of Label's props object:
```ts
<BarChart data={data}>
  <CartesianGrid strokeDasharray="3 3" />
  <XAxis dataKey="name">
    <Label value="Pages of my website" offset={0} position="insideBottom" />
  </XAxis>
  <YAxis label={{ value: 'pv of page', angle: -90, position: 'insideLeft' }} />
  <Bar dataKey="pv" fill="#8884d8">
    <LabelList dataKey="name" position="top" />
  </Bar>
</BarChart>
```

Previously, typings stated that you can provide object of `Label` type, which didn't make sense since it's react component. 

I also suspect that the `label` prop should be unified across all the types, because looks like in the recharts lib for the most of components it's controlled by the same method `renderCallByParent` which is basically trying to figure out how is label defined(as children, as object, as bool etc)
https://github.com/recharts/recharts/blob/db0f3f254f12d59583052e77a43822163c476c9f/src/component/Label.js#L380