### PR TITLE
fixing a bug where SharePoint type definitions would include an implicit any

### DIFF
--- a/types/sharepoint/index.d.ts
+++ b/types/sharepoint/index.d.ts
@@ -108,31 +108,29 @@ declare namespace SP {
 
     class PageContextInfo {
         constructor();
-        get_siteServerRelativeUrl(): string;
-        get_webServerRelativeUrl(): string;
-        get_webAbsoluteUrl(): string;
-        get_serverRequestPath(): string;
-        get_siteAbsoluteUrl(): string;
-        get_webTitle(): string;
-        get_tenantAppVersion(): string;
-        get_isAppWeb(): boolean;
-        get_webLogoUrl(): string;
-        get_webLanguage(): number;
-        get_currentLanguage(): number;
-        get_pageItemId(): number;
-        get_pageListId(): string;
-        get_webPermMasks(): { High: number; Low: number; };
-        get_currentCultureName(): string;
-        get_currentUICultureName(): string;
-        get_clientServerTimeDelta(): number;
-        get_userLoginName(): string;
-        get_webTemplate(): string;
+        static get_clientServerTimeDelta(): number;
+        static get_siteServerRelativeUrl(): string;
+        static get_webServerRelativeUrl(): string;
+        static get_webAbsoluteUrl(): string;
+        static get_serverRequestPath(): string;
+        static get_siteAbsoluteUrl(): string;
+        static get_webTitle(): string;
+        static get_tenantAppVersion(): string;
+        static get_isAppWeb(): boolean;
+        static get_webLogoUrl(): string;
+        static get_webLanguage(): number;
+        static get_currentLanguage(): number;
+        static get_pageItemId(): number;
+        static get_pageListId(): string;
+        static get_webPermMasks(): { High: number; Low: number; };
+        static get_currentCultureName(): string;
+        static get_currentUICultureName(): string;
+        static get_clientServerTimeDelta(): number;
+        static get_userLoginName(): string;
+        static get_webTemplate(): string;
+        static get_pagePersonalizationScope(): string;
+        static get_webPermMasks(): SP.ContextPermissions;
     }
-
-    interface PageContextInfoInstance {
-        get_pagePersonalizationScope(): string;
-    }
-
     class ContextPermissions {
         has(perm: number): boolean;
         hasPermissions(high: number, low: number): boolean;

--- a/types/sharepoint/index.d.ts
+++ b/types/sharepoint/index.d.ts
@@ -2157,15 +2157,11 @@ declare namespace SP {
     }
     let ClientObjectCollection: ClientObjectCollectionConstructor;
 
-    interface ClientObjectList<T> extends SP.ClientObjectCollection<T> {
-        new(context: SP.ClientRuntimeContext, objectPath: SP.ObjectPath, childItemType: any): ClientObjectList<T>;
+    class ClientObjectList<T> extends SP.ClientObjectCollection<T> {
+        constructor(context: SP.ClientRuntimeContext, objectPath: SP.ObjectPath, childItemType: any);
         fromJson(initValue: any): void;
         customFromJson(initValue: any): boolean;
     }
-    interface ClientObjectListConstructor {
-        new<T>(context: SP.ClientRuntimeContext, objectPath: SP.ObjectPath, childItemType: any): ClientObjectList<T>;
-    }
-    let ClientObjectList: ClientObjectListConstructor;
     class ClientObjectPrototype {
         retrieve(propertyNames?: string[]): void;
         retrieveObject(propertyName: string): SP.ClientObjectPrototype;
@@ -2209,8 +2205,8 @@ declare namespace SP {
     }
     class ClientRequestSucceededEventArgs extends SP.ClientRequestEventArgs {
     }
-    interface ClientRuntimeContext extends Sys.IDisposable {
-        new(serverRelativeUrlOrFullUrl: string): ClientRuntimeContext;
+    class ClientRuntimeContext implements Sys.IDisposable {
+        constructor(serverRelativeUrlOrFullUrl: string);
         get_url(): string;
         get_viaUrl(): string;
         set_viaUrl(value: string): void;

--- a/types/sharepoint/index.d.ts
+++ b/types/sharepoint/index.d.ts
@@ -2158,7 +2158,7 @@ declare namespace SP {
     let ClientObjectCollection: ClientObjectCollectionConstructor;
 
     interface ClientObjectList<T> extends SP.ClientObjectCollection<T> {
-        new(context: SP.ClientRuntimeContext, objectPath: SP.ObjectPath, childItemType: any);
+        new(context: SP.ClientRuntimeContext, objectPath: SP.ObjectPath, childItemType: any): ClientObjectList<T>;
         fromJson(initValue: any): void;
         customFromJson(initValue: any): boolean;
     }
@@ -2210,7 +2210,7 @@ declare namespace SP {
     class ClientRequestSucceededEventArgs extends SP.ClientRequestEventArgs {
     }
     interface ClientRuntimeContext extends Sys.IDisposable {
-        new(serverRelativeUrlOrFullUrl: string);
+        new(serverRelativeUrlOrFullUrl: string): ClientRuntimeContext;
         get_url(): string;
         get_viaUrl(): string;
         set_viaUrl(value: string): void;

--- a/types/sharepoint/index.d.ts
+++ b/types/sharepoint/index.d.ts
@@ -6,7 +6,7 @@
 //                 Tero Arvola <https://github.com/teroarvola>
 //                 Dennis George <https://github.com/dennispg>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.5
 
 /// <reference types="microsoft-ajax" />
 

--- a/types/sharepoint/index.d.ts
+++ b/types/sharepoint/index.d.ts
@@ -5309,11 +5309,11 @@ declare namespace Microsoft.SharePoint.Client.Search {
         }
 
         interface StringCollection extends SP.ClientObjectCollection<string> {
-            itemAt: (index: number) => string;
-            get_item: (index: number) => string;
-            get_childItemType: () => typeof String;
-            add: (property: string) => void;
-            clear: () => void;
+            itemAt(index: number): string;
+            get_item(index: number): string;
+            get_childItemType(): typeof String;
+            add(property: string): void;
+            clear(): void;
         }
         interface StringCollectionConstructor {
             new(context: SP.ClientContext): StringCollection;
@@ -5393,11 +5393,11 @@ declare namespace Microsoft.SharePoint.Client.Search {
             static queryPropertyValueToObject: (val: QueryPropertyValue) => any;
         }
         interface ReorderingRuleCollection extends SP.ClientObjectCollection<ReorderingRule> {
-            itemAt: (index: number) => ReorderingRule;
-            get_item: (index: number) => ReorderingRule;
-            get_childItemType: () => typeof ReorderingRule;
-            add: (property: ReorderingRule) => void;
-            clear: () => void;
+            itemAt(index: number): ReorderingRule;
+            get_item(index: number): ReorderingRule;
+            get_childItemType(): typeof ReorderingRule;
+            add(property: ReorderingRule): void;
+            clear(): void;
         }
 
         enum ReorderingRuleMatchType {
@@ -5424,11 +5424,11 @@ declare namespace Microsoft.SharePoint.Client.Search {
         }
 
         interface SortCollection extends SP.ClientObjectCollection<Sort> {
-            itemAt: (index: number) => Sort;
-            get_item: (index: number) => Sort;
-            get_childItemType: () => typeof Sort;
-            add: (strProperty: string, sortDirection: SortDirection) => void;
-            clear: () => void;
+            itemAt(index: number): Sort;
+            get_item(index: number): Sort;
+            get_childItemType(): typeof Sort;
+            add(strProperty: string, sortDirection: SortDirection): void;
+            clear(): void;
         }
 
         enum SortDirection {

--- a/types/sharepoint/index.d.ts
+++ b/types/sharepoint/index.d.ts
@@ -108,7 +108,6 @@ declare namespace SP {
 
     class PageContextInfo {
         constructor();
-        static get_clientServerTimeDelta(): number;
         static get_siteServerRelativeUrl(): string;
         static get_webServerRelativeUrl(): string;
         static get_webAbsoluteUrl(): string;
@@ -129,7 +128,6 @@ declare namespace SP {
         static get_userLoginName(): string;
         static get_webTemplate(): string;
         static get_pagePersonalizationScope(): string;
-        static get_webPermMasks(): SP.ContextPermissions;
     }
     class ContextPermissions {
         has(perm: number): boolean;

--- a/types/sharepoint/index.d.ts
+++ b/types/sharepoint/index.d.ts
@@ -106,8 +106,8 @@ declare namespace SP {
         static resizeImageToSquareLength(imgElement: HTMLImageElement, squareLength: number): void;
     }
 
-    interface PageContextInfo {
-        new(): PageContextInfoInstance;
+    class PageContextInfo {
+        constructor();
         get_siteServerRelativeUrl(): string;
         get_webServerRelativeUrl(): string;
         get_webAbsoluteUrl(): string;
@@ -132,7 +132,6 @@ declare namespace SP {
     interface PageContextInfoInstance {
         get_pagePersonalizationScope(): string;
     }
-    let PageContextInfo: PageContextInfo;
 
     class ContextPermissions {
         has(perm: number): boolean;
@@ -2139,7 +2138,8 @@ declare namespace SP {
         constructor();
     }
     /** Provides a base class for a collection of objects on a remote client. */
-    interface ClientObjectCollection<T> extends SP.ClientObject, IEnumerable<T> {
+    class ClientObjectCollection<T> extends SP.ClientObject implements IEnumerable<T> {
+        constructor();
         get_areItemsAvailable(): boolean;
         /** Gets the data for all of the items in the collection. */
         retrieveItems(): SP.ClientObjectPrototype;
@@ -2152,11 +2152,6 @@ declare namespace SP {
         getItemAtIndex(index: number): T;
         fromJson(obj: any): void;
     }
-    interface ClientObjectCollectionConstructor {
-        new<T>(): ClientObjectCollection<T>;
-    }
-    let ClientObjectCollection: ClientObjectCollectionConstructor;
-
     class ClientObjectList<T> extends SP.ClientObjectCollection<T> {
         constructor(context: SP.ClientRuntimeContext, objectPath: SP.ObjectPath, childItemType: any);
         fromJson(initValue: any): void;
@@ -2443,16 +2438,13 @@ declare namespace SP {
         assemblyVersion: string;
         wssMajorVersion: string;
     }
-    interface ClientContext extends SP.ClientRuntimeContext {
+    class ClientContext extends SP.ClientRuntimeContext {
+        constructor(serverRelativeUrlOrFullUrl?: string);
         get_web(): SP.Web;
         get_site(): SP.Site;
         get_serverVersion(): string;
+        static get_current(): SP.ClientContext;
     }
-    interface ClientContextConstructor {
-        new(serverRelativeUrlOrFullUrl?: string): ClientContext;
-        get_current(): SP.ClientContext;
-    }
-    let ClientContext: ClientContextConstructor;
     enum ULSTraceLevel {
         verbose,
     }
@@ -4398,18 +4390,15 @@ declare namespace SP {
         update(): void;
         deleteObject(): void;
     }
-    interface RoleDefinitionBindingCollectionConstructor {
-        new(context: SP.ClientRuntimeContext): SP.RoleDefinitionBindingCollection;
-        newObject(context: SP.ClientRuntimeContext): SP.RoleDefinitionBindingCollection;
-    }
-    interface RoleDefinitionBindingCollection extends SP.ClientObjectCollection<RoleDefinition> {
+    class RoleDefinitionBindingCollection extends SP.ClientObjectCollection<RoleDefinition> {
+        constructor(context: SP.ClientRuntimeContext);
         itemAt(index: number): SP.RoleDefinition;
         get_item(index: number): SP.RoleDefinition;
         add(roleDefinition: SP.RoleDefinition): void;
         remove(roleDefinition: SP.RoleDefinition): void;
         removeAll(): void;
+        static newObject(context: SP.ClientRuntimeContext): SP.RoleDefinitionBindingCollection;
     }
-    let RoleDefinitionBindingCollection: RoleDefinitionBindingCollectionConstructor;
     interface RoleDefinitionCollection extends SP.ClientObjectCollection<RoleDefinition> {
         itemAt(index: number): SP.RoleDefinition;
         get_item(index: number): SP.RoleDefinition;
@@ -5304,17 +5293,14 @@ declare namespace Microsoft.SharePoint.Client.Search {
             exportPopularQueries: (web: SP.Web, sourceId: SP.Guid) => SP.JsonObjectResult;
         }
 
-        interface StringCollection extends SP.ClientObjectCollection<string> {
+        class StringCollection extends SP.ClientObjectCollection<string> {
+            constructor(context: SP.ClientContext);
             itemAt(index: number): string;
             get_item(index: number): string;
             get_childItemType(): typeof String;
             add(property: string): void;
             clear(): void;
         }
-        interface StringCollectionConstructor {
-            new(context: SP.ClientContext): StringCollection;
-        }
-        let StringCollection: StringCollectionConstructor;
 
         class QueryPersonalizationData extends SP.ClientObject {
             // It's really empty;
@@ -6924,15 +6910,12 @@ declare namespace SP {
             getValidatedString(value: TaxonomyFieldValue): SP.StringResult;
         }
 
-        interface TaxonomyFieldValueCollection extends SP.ClientObjectCollection<TaxonomyFieldValue> {
+        class TaxonomyFieldValueCollection extends SP.ClientObjectCollection<TaxonomyFieldValue> {
+            constructor(context: SP.ClientContext, fieldValue: string, creatingField: SP.Field);
             itemAt(index: number): TaxonomyFieldValue;
             get_item(index: number): TaxonomyFieldValue;
             populateFromLabelGuidPairs(text: string): void;
         }
-        interface TaxonomyFieldValueCollectionConstructor {
-            new(context: SP.ClientContext, fieldValue: string, creatingField: SP.Field): TaxonomyFieldValueCollection;
-        }
-        let TaxonomyFieldValueCollection: TaxonomyFieldValueCollectionConstructor;
 
         class TaxonomyFieldValue extends SP.ClientValueObject {
             get_label(): string;

--- a/types/sharepoint/tslint.json
+++ b/types/sharepoint/tslint.json
@@ -8,6 +8,7 @@
         "no-any-union": false,
         "no-const-enum": false,
         "no-duplicate-imports": false,
+        "no-empty-interface": false,
         "no-inferrable-types": false,
         "no-namespace": false,
         "no-mergeable-namespace": false,


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: details bellow
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

The SharePoint type definitions had implicit anys because of the way some constructor definitions were implemented. Updated it to follow recommendations.