### PR TITLE
[@types/mem-fs-editor] Fixed JSON parsing and other fixes

### DIFF
--- a/types/mem-fs-editor/index.d.ts
+++ b/types/mem-fs-editor/index.d.ts
@@ -17,11 +17,13 @@ export function create(store: Store): memFsEditor.Editor;
 export namespace memFsEditor {
     type Contents = string|Buffer;
 
-    type ReplacerFunc = (key: string, value: any) => string|null|undefined;
+    type ReplacerFunc = (key: string, value: any) => any;
 
     type Space = string|number;
 
     type ProcessFunc = (contents: Buffer) => Contents;
+
+    type Callback = (err: any) => any;
 
     interface CopyOptions {
         process?: ProcessFunc;
@@ -29,18 +31,19 @@ export namespace memFsEditor {
     }
 
     interface Editor {
-        read: (filepath: string, options?: { raw: boolean, defaults: string }) => string;
-        readJSON: (filepath: string, defaults?: string) => string;
-        write: (filepath: string, contents: Contents) => void;
-        writeJSON: (filepath: string, contents: object, replacer?: ReplacerFunc, space?: Space) => void;
-        append: (filepath: string, contents: Contents, options?: { trimEnd: boolean, separator: string }) => void;
-        extendJSON: (filepath: string, contents: object, replacer?: ReplacerFunc, space?: Space) => void;
-        delete: (filepath: string, options?: { globOptions: GlobOptions }) => void;
-        copy: (from: string, to: string, options?: CopyOptions) => void;
-        copyTpl: (from: string, to: string, context: object, templateOptions?: TemplateOptions, copyOptions?: CopyOptions) => void;
-        move: (from: string, to: string, options?: { globOptions: GlobOptions }) => void;
-        exists: (filepath: string) => boolean;
-        commit: (filters: ReadonlyArray<Transform>, callback: () => void) => void;
+        read(filepath: string, options?: { raw: boolean, defaults: string }): string;
+        readJSON(filepath: string, defaults?: any): any;
+        write(filepath: string, contents: Contents): void;
+        writeJSON(filepath: string, contents: any, replacer?: ReplacerFunc, space?: Space): void;
+        append(filepath: string, contents: Contents, options?: { trimEnd: boolean, separator: string }): void;
+        extendJSON(filepath: string, contents: object, replacer?: ReplacerFunc, space?: Space): void;
+        delete(filepath: string, options?: { globOptions: GlobOptions }): void;
+        copy(from: string, to: string, options?: CopyOptions): void;
+        copyTpl(from: string, to: string, context: object, templateOptions?: TemplateOptions, copyOptions?: CopyOptions): void;
+        move(from: string, to: string, options?: { globOptions: GlobOptions }): void;
+        exists(filepath: string): boolean;
+        commit(callback: Callback): void;
+        commit(filters: ReadonlyArray<Transform>, callback: Callback): void;
     }
 
     const prototype: {

--- a/types/mem-fs-editor/mem-fs-editor-tests.ts
+++ b/types/mem-fs-editor/mem-fs-editor-tests.ts
@@ -1,3 +1,5 @@
+import { Transform } from 'stream';
+
 import memFs = require('mem-fs');
 import editor = require('mem-fs-editor');
 
@@ -16,3 +18,17 @@ fs.copy('template.js', 'template.tpl', {
 fs.copyTpl('template.tpl', 'output.js', {
     foo: 'bar'
 });
+
+const obj = fs.readJSON('template.json');
+fs.writeJSON('template.json', obj);
+fs.extendJSON('template.json', {qwer: 'asdf'});
+
+fs.writeJSON('template.json', 'qwer'); // should not be an error, because the parameter is passed to JSON.stringify and it accepts the string
+// fs.extendJSON('template.json', 'qwer'); // should be an error, because it does not make sense to extend a json with string
+
+// should accept both versions of commit - with filters and without:
+const cb = (err: any) => ({adsf: 'adsf'});
+fs.commit(cb);
+
+const filters: Transform[] = [];
+fs.commit(filters, cb);


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
https://github.com/SBoudrias/mem-fs-editor#readjsonfilepath-defaults
https://github.com/SBoudrias/mem-fs-editor/blob/master/lib/index.js

- [x] Increase the version number in the header if appropriate.
not appropriate
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
not needed I think

---

There were several quirks about the type definitions:
- readJSON returning `string` instead of `any`
- readJSON accepting `defaults` as `string` instead of `any`
- writeJSON accepting `contents` as `object` instead of `any` - this argument is passed to JSON.stringify so I put the same types here
- extendJSON is ok to accept `contents` as `object` because it does not make sense to extend another json with, ie, string
- methods on the interface being properties, not actual functions - it prevented to define override for `commit` method
- callback argument not accepting `err` parameter.

All of the above should be fixed in this PR.