### PR TITLE
[@types/expect-puppeteer] Fix toMatchElement() definition

### DIFF
--- a/types/expect-puppeteer/expect-puppeteer-tests.ts
+++ b/types/expect-puppeteer/expect-puppeteer-tests.ts
@@ -13,8 +13,9 @@ const testGlobal = async (instance: ElementHandle | Page) => {
     await expect(instance).toMatch("selector");
     await expect(instance).toMatch("selector", { timeout: 777 });
 
-    await expect(instance).toMatchElement("selector", "value");
-    await expect(instance).toMatchElement("selector", "value", { polling: "mutation" });
+    await expect(instance).toMatchElement("selector");
+    await expect(instance).toMatchElement("selector", { polling: "raf", timeout: 777 });
+    await expect(instance).toMatchElement("selector", { polling: "mutation", text: "text" });
 
     await expect(instance).toSelect("selector", "valueOrText");
     await expect(instance).toSelect("selector", "valueOrText", { polling: "raf" });

--- a/types/expect-puppeteer/index.d.ts
+++ b/types/expect-puppeteer/index.d.ts
@@ -42,7 +42,7 @@ interface ExpectPuppeteer {
     toDisplayDialog(block: () => Promise<void>): Promise<void>;
     toFill(selector: string, value: string, options?: ExpectTimingActions): Promise<void>;
     toMatch(selector: string, options?: ExpectTimingActions): Promise<void>;
-    toMatchElement(selector: string, value: string, options?: ExpectTimingActions): Promise<void>;
+    toMatchElement(selector: string, options?: ExpectToClickOptions): Promise<void>;
     toSelect(selector: string, valueOrText: string, options?: ExpectTimingActions): Promise<void>;
     toUploadFile(selector: string, filePath: string, options?: ExpectTimingActions): Promise<void>;
 }
@@ -57,7 +57,7 @@ declare global {
             toDisplayDialog(block: () => Promise<void>): Promise<void>;
             toFill(selector: string, value: string, options?: ExpectTimingActions): Promise<void>;
             toMatch(selector: string, options?: ExpectTimingActions): Promise<void>;
-            toMatchElement(selector: string, value: string, options?: ExpectTimingActions): Promise<void>;
+            toMatchElement(selector: string, options?: ExpectToClickOptions): Promise<void>;
             toSelect(selector: string, valueOrText: string, options?: ExpectTimingActions): Promise<void>;
             toUploadFile(selector: string, filePath: string, options?: ExpectTimingActions): Promise<void>;
         }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/smooth-code/jest-puppeteer/tree/master/packages/expect-puppeteer#toMatchElement
- [x] Increase the version number in the header if appropriate.
not appropriate
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
already present

---
Related issue: #25035

Definition changed from:
```typescript
toMatchElement(selector: string, value: string, options?: ExpectTimingActions): Promise<void>;
```
to correct one:
```typescript
toMatchElement(selector: string, options?: ExpectToClickOptions): Promise<void>;
```

Tests updated as well
