### PR TITLE
Add type definition for parse5

### DIFF
--- a/notNeededPackages.json
+++ b/notNeededPackages.json
@@ -1003,12 +1003,6 @@
             "asOfVersion": "1.1.2"
         },
         {
-            "libraryName": "parse5",
-            "typingsPackageName": "parse5",
-            "sourceRepoURL": "https://github.com/inikulin/parse5",
-            "asOfVersion": "3.0.0"
-        },
-        {
             "libraryName": "pascal-case",
             "typingsPackageName": "pascal-case",
             "sourceRepoURL": "https://github.com/blakeembrey/pascal-case",

--- a/types/jsdom/index.d.ts
+++ b/types/jsdom/index.d.ts
@@ -7,7 +7,7 @@
 /// <reference types="node" />
 
 import { EventEmitter } from 'events';
-import { MarkupData } from 'parse5';
+import { ElementLocation } from 'parse5';
 import * as tough from 'tough-cookie';
 import { Script } from 'vm';
 
@@ -32,7 +32,7 @@ export class JSDOM {
     /**
      * The nodeLocation() method will find where a DOM node is within the source document, returning the parse5 location info for the node.
      */
-    nodeLocation(node: Node): MarkupData.ElementLocation | null;
+    nodeLocation(node: Node): ElementLocation | null;
 
     /**
      * The built-in vm module of Node.js allows you to create Script instances,

--- a/types/parse5-htmlparser2-tree-adapter/index.d.ts
+++ b/types/parse5-htmlparser2-tree-adapter/index.d.ts
@@ -1,0 +1,210 @@
+// Type definitions for parse5-htmlparser2-tree-adapter 5.0
+// Project: https://github.com/inikulin/parse5
+// Definitions by: Ivan Nikulin <https://github.com/inikulin>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.2
+
+import * as parse5 from "parse5";
+
+/**
+ * htmlparser2 tree adapter Node interface.
+ */
+export interface Node {
+    /**
+     * The type of the node. E.g. {@link Document} will have `type` equal to 'root'`.
+     */
+    type: string;
+    /**
+     * [DOM spec](https://dom.spec.whatwg.org/#dom-node-nodetype)-compatible node {@link type}.
+     */
+    nodeType: number;
+    /**
+     * Parent node.
+     */
+    parent: ParentNode;
+    /**
+     * Same as {@link parent}. [DOM spec](https://dom.spec.whatwg.org)-compatible alias.
+     */
+    parentNode: ParentNode;
+    /**
+     * Previous sibling.
+     */
+    prev: Node;
+    /**
+     * Same as {@link prev}. [DOM spec](https://dom.spec.whatwg.org)-compatible alias.
+     */
+    previousSibling: Node;
+    /**
+     * Next sibling.
+     */
+    next: Node;
+    /**
+     * Same as {@link next}. [DOM spec](https://dom.spec.whatwg.org)-compatible alias.
+     */
+    nextSibling: Node;
+}
+
+/**
+ * htmlparser2 tree adapter ParentNode interface.
+ */
+export interface ParentNode extends Node {
+    /**
+     * Child nodes.
+     */
+    children: Node[];
+    /**
+     * Same as {@link children}. [DOM spec](https://dom.spec.whatwg.org)-compatible alias.
+     */
+    childNodes: Node[];
+    /**
+     * First child of the node.
+     */
+    firstChild: Node;
+    /**
+     * Last child of the node.
+     */
+    lastChild: Node;
+}
+
+/**
+ * htmlparser2 tree adapter DocumentType interface.
+ */
+export interface DocumentType extends Node {
+    /**
+     * The type of the node.
+     */
+    type: "directive";
+    /**
+     * Node name.
+     */
+    name: "!doctype";
+    /**
+     * Serialized doctype {@link name}, {@link publicId} and {@link systemId}.
+     */
+    data: string;
+    /**
+     * Document type name.
+     */
+    "x-name": string;
+    /**
+     * Document type public identifier.
+     */
+    "x-publicId": string;
+    /**
+     * Document type system identifier.
+     */
+    "x-systemId": string;
+}
+
+/**
+ * htmlparser2 tree adapter Document interface.
+ */
+export interface Document extends ParentNode {
+    /**
+     * The type of the node.
+     */
+    type: "root";
+    /**
+     * The name of the node.
+     */
+    name: "root";
+    /**
+     * [Document mode](https://dom.spec.whatwg.org/#concept-document-limited-quirks).
+     */
+    "x-mode": parse5.DocumentMode;
+}
+
+/**
+ * htmlparser2 tree adapter DocumentFragment interface.
+ */
+export interface DocumentFragment extends ParentNode {
+    /**
+     * The type of the node.
+     */
+    type: "root";
+    /**
+     * The name of the node.
+     */
+    name: "root";
+}
+
+/**
+ * htmlparser2 tree adapter Element interface.
+ */
+export interface Element extends ParentNode {
+    /**
+     * The name of the node. Equals to element {@link tagName}.
+     */
+    name: string;
+    /**
+     * Element tag name.
+     */
+    tagName: string;
+    /**
+     * Element namespace.
+     */
+    namespace: string;
+    /**
+     * Element attributes.
+     */
+    attribs: { [name: string]: string };
+    /**
+     * Element attribute namespaces.
+     */
+    "x-attribsNamespace": { [name: string]: string };
+    /**
+     * Element attribute namespace-related prefixes.
+     */
+    "x-attribsPrefix": { [name: string]: string };
+    /**
+     * Element source code location info. Available if location info is enabled via ParserOptions.
+     */
+    sourceCodeLocation?: parse5.ElementLocation;
+}
+
+/**
+ * htmlparser2 tree adapter CommentNode interface.
+ */
+export interface CommentNode extends Node {
+    /**
+     * The name of the node.
+     */
+    name: "comment";
+    /**
+     * Comment text.
+     */
+    data: string;
+    /**
+     * Same as {@link data}. [DOM spec](https://dom.spec.whatwg.org)-compatible alias.
+     */
+    nodeValue: string;
+    /**
+     * Comment source code location info. Available if location info is enabled via ParserOptions.
+     */
+    sourceCodeLocation?: parse5.Location;
+}
+
+/**
+ * htmlparser2 tree adapter TextNode interface.
+ */
+export interface TextNode extends Node {
+    /**
+     * The name of the node.
+     */
+    name: "text";
+    /**
+     * Text content.
+     */
+    data: string;
+    /**
+     * Same as {@link data}. [DOM spec](https://dom.spec.whatwg.org)-compatible alias.
+     */
+    nodeValue: string;
+    /**
+     * Comment source code location info. Available if location info is enabled via ParserOptions.
+     */
+    sourceCodeLocation?: parse5.Location;
+}
+
+declare const treeAdapter: parse5.TreeAdapter;
+export default treeAdapter;

--- a/types/parse5-htmlparser2-tree-adapter/parse5-htmlparser2-tree-adapter-tests.ts
+++ b/types/parse5-htmlparser2-tree-adapter/parse5-htmlparser2-tree-adapter-tests.ts
@@ -1,0 +1,70 @@
+import { parse } from "parse5";
+import treeAdapter, {
+    Node,
+    ParentNode,
+    Document,
+    DocumentType,
+    Element,
+    TextNode,
+    CommentNode
+} from "parse5-htmlparser2-tree-adapter";
+
+// htmlparser2 AST
+const htmlparser2Document = parse("<html>", {
+    treeAdapter
+}) as Document;
+
+htmlparser2Document; // $ExpectType Document
+htmlparser2Document.name; // $ExpectType "root"
+htmlparser2Document.type; // $ExpectType "root"
+htmlparser2Document["x-mode"]; // $ExpectType DocumentMode
+
+const htmlparser2Node = htmlparser2Document as Node;
+
+htmlparser2Node.next; // $ExpectType Node
+htmlparser2Node.nextSibling; // $ExpectType Node
+htmlparser2Node.nodeType; // $ExpectType number
+htmlparser2Node.parent; // $ExpectType ParentNode
+htmlparser2Node.parentNode; // $ExpectType ParentNode
+htmlparser2Node.prev; // $ExpectType Node
+htmlparser2Node.previousSibling; // $ExpectType Node
+htmlparser2Node.type; // $ExpectType string
+
+const htmlparser2ParentNode = htmlparser2Document as ParentNode;
+
+htmlparser2ParentNode; // $ExpectType ParentNode
+htmlparser2ParentNode.childNodes[0]; // $ExpectType Node
+htmlparser2ParentNode.children[0]; // $ExpectType Node
+htmlparser2ParentNode.firstChild; // $ExpectType Node
+htmlparser2ParentNode.lastChild; // $ExpectType Node
+
+const htmlparser2Doctype = htmlparser2Document.childNodes[0] as DocumentType;
+
+htmlparser2Doctype; // $ExpectType DocumentType
+htmlparser2Doctype.data; // $ExpectType string
+htmlparser2Doctype.name; // $ExpectType "!doctype"
+htmlparser2Doctype["x-name"]; // $ExpectType string
+htmlparser2Doctype["x-publicId"]; // $ExpectType string
+htmlparser2Doctype["x-systemId"]; // $ExpectType string
+
+const htmlparser2Element = htmlparser2Document.childNodes[0] as Element;
+
+htmlparser2Element; // $ExpectType Element
+htmlparser2Element.attribs["someAttr"]; // $ExpectType string
+htmlparser2Element["x-attribsNamespace"]["someAttr"]; // $ExpectType string
+htmlparser2Element["x-attribsPrefix"]["someAttr"]; // $ExpectType string
+htmlparser2Element.namespace; // $ExpectType string
+htmlparser2Element.tagName; // $ExpectType string
+htmlparser2Element.sourceCodeLocation!; // $ExpectType ElementLocation
+
+const htmlparser2TextNode = htmlparser2Document.childNodes[0] as TextNode;
+
+htmlparser2TextNode.data; // $ExpectType string
+htmlparser2TextNode.nodeValue; // $ExpectType string
+htmlparser2TextNode.sourceCodeLocation!; // $ExpectType Location
+
+const htmlparser2CommentNode = htmlparser2Document.childNodes[0] as CommentNode;
+
+htmlparser2CommentNode.data; // $ExpectType string
+htmlparser2CommentNode.nodeValue; // $ExpectType string
+htmlparser2CommentNode.sourceCodeLocation!; // $ExpectType Location

--- a/types/parse5-htmlparser2-tree-adapter/tsconfig.json
+++ b/types/parse5-htmlparser2-tree-adapter/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "parse5-htmlparser2-tree-adapter-tests.ts"
+    ]
+}

--- a/types/parse5-htmlparser2-tree-adapter/tslint.json
+++ b/types/parse5-htmlparser2-tree-adapter/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/parse5-parser-stream/index.d.ts
+++ b/types/parse5-parser-stream/index.d.ts
@@ -1,0 +1,92 @@
+// Type definitions for parse5-parser-stream 5.0
+// Project: https://github.com/inikulin/parse5
+// Definitions by: Ivan Nikulin <https://github.com/inikulin>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.2
+
+/// <reference types="node" />
+
+import * as stream from "stream";
+import * as parse5 from "parse5";
+
+/**
+ * Streaming HTML parser with scripting support.
+ * A [writable stream](https://nodejs.org/api/stream.html#stream_class_stream_writable).
+ *
+ * ** NOTE:** This API is available only for Node.js.
+ *
+ * @example
+ * ```js
+ *
+ * const parse5 = require('parse5');
+ * const http = require('http');
+ *
+ * // Fetch the page content and obtain it's <head> node
+ * http.get('http://inikulin.github.io/parse5/', res => {
+ *    const parser = new parse5.ParserStream();
+ *
+ *    parser.once('finish', () => {
+ *        console.log(parser.document.childNodes[1].childNodes[0].tagName); //> 'head'
+ *    });
+ *
+ *    res.pipe(parser);
+ * });
+ * ```
+ */
+export default class ParserStream<TDocument> extends stream.Writable {
+    /**
+     * @param options - Parsing options.
+     */
+    constructor(options?: parse5.ParserOptions);
+
+    /**
+     * The resulting document node.
+     */
+    document: TDocument;
+
+    /**
+     * Raised when parser encounters a `<script>` element.
+     * If this event has listeners, parsing will be suspended once it is emitted.
+     * So, if `<script>` has the `src` attribute, you can fetch it, execute and then resume parsing just like browsers do.
+     *
+     * @param listener.scriptElement - The script element that caused the event.
+     * @param listener.documentWrite - Write additional `html` at the current parsing position. Suitable for implementing the DOM `document.write` and `document.writeln` methods.
+     * @param listener.documentWrite.html - HTML to write.
+     * @param listener.resume - Resumes parsing.
+     *
+     * @example
+     * ```js
+     *
+     * const parse = require('parse5');
+     * const http = require('http');
+     *
+     * const parser = new parse5.ParserStream();
+     *
+     * parser.on('script', (scriptElement, documentWrite, resume) => {
+     *     const src = parse5.treeAdapters.default.getAttrList(scriptElement)[0].value;
+     *
+     *     http.get(src, res => {
+     *        // Fetch the script content, execute it with DOM built around `parser.document` and
+     *        // `document.write` implemented using `documentWrite`.
+     *        ...
+     *        // Then resume parsing.
+     *        resume();
+     *     });
+     * });
+     *
+     * parser.end('<script src="example.com/script.js"></script>');
+     * ```
+     */
+    on(
+        event: "script",
+        listener: (
+            scriptElement: parse5.Element,
+            documentWrite: (html: string) => void,
+            resume: () => void
+        ) => void
+    ): this;
+    /**
+     * WritableStream events
+     */
+    on(event: string, listener: (...params: any[]) => any): this;
+}

--- a/types/parse5-parser-stream/parse5-parser-stream-tests.ts
+++ b/types/parse5-parser-stream/parse5-parser-stream-tests.ts
@@ -1,0 +1,32 @@
+import * as parse5 from "parse5";
+import ParserStream from "parse5-parser-stream";
+import { createReadStream } from "fs";
+
+const defaultAdapter = new Object() as parse5.TreeAdapter;
+let parser = new ParserStream<parse5.DefaultTreeDocument>();
+
+parser = new ParserStream<parse5.DefaultTreeDocument>({ sourceCodeLocationInfo: true });
+parser = new ParserStream<parse5.DefaultTreeDocument>({ treeAdapter: defaultAdapter });
+parser = new ParserStream<parse5.DefaultTreeDocument>({
+    sourceCodeLocationInfo: true,
+    treeAdapter: defaultAdapter
+});
+parser = new ParserStream<parse5.DefaultTreeDocument>({
+    sourceCodeLocationInfo: true,
+    treeAdapter: defaultAdapter
+});
+
+parser.document; // $ExpectType DefaultTreeDocument
+
+parser
+    .on(
+        "script",
+        (
+            element: parse5.Element,
+            documentWrite: (html: string) => void,
+            resume: () => {}
+        ) => {}
+    )
+    .on("finish", () => {});
+
+createReadStream("file").pipe(parser);

--- a/types/parse5-parser-stream/tsconfig.json
+++ b/types/parse5-parser-stream/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "parse5-parser-stream-tests.ts"
+    ]
+}

--- a/types/parse5-parser-stream/tslint.json
+++ b/types/parse5-parser-stream/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/parse5-plain-text-conversion-stream/index.d.ts
+++ b/types/parse5-plain-text-conversion-stream/index.d.ts
@@ -1,0 +1,33 @@
+// Type definitions for parse5-plain-text-conversion-stream 5.0
+// Project: https://github.com/inikulin/parse5
+// Definitions by: Ivan Nikulin <https://github.com/inikulin>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.2
+
+import ParserStream from "parse5-parser-stream";
+
+/**
+ * Converts plain text files into HTML document as required by [HTML specification](https://html.spec.whatwg.org/#read-text).
+ * A [writable stream](https://nodejs.org/api/stream.html#stream_class_stream_writable).
+ *
+ * ** NOTE:** This API is available only for Node.js.
+ *
+ * @example
+ * ```js
+ *
+ * const parse5 = require('parse5');
+ * const fs = require('fs');
+ *
+ * const file = fs.createReadStream('war_and_peace.txt');
+ * const converter = new parse5.PlainTextConversionStream();
+ *
+ * converter.once('finish', () => {
+ *     console.log(converter.document.childNodes[1].childNodes[0].tagName); //> 'head'
+ * });
+ *
+ * file.pipe(converter);
+ * ```
+ */
+export default class PlainTextConversionStream<TDocument> extends ParserStream<
+    TDocument
+> {}

--- a/types/parse5-plain-text-conversion-stream/parse5-plain-text-conversion-stream-tests.ts
+++ b/types/parse5-plain-text-conversion-stream/parse5-plain-text-conversion-stream-tests.ts
@@ -1,0 +1,27 @@
+import * as parse5 from "parse5";
+import PlainTextConversionStream from "parse5-plain-text-conversion-stream";
+import { createReadStream } from "fs";
+
+const defaultAdapter = new Object() as parse5.TreeAdapter;
+let converter = new PlainTextConversionStream<parse5.DefaultTreeDocument>();
+
+converter = new PlainTextConversionStream<parse5.DefaultTreeDocument>({
+    sourceCodeLocationInfo: true
+});
+converter = new PlainTextConversionStream<parse5.DefaultTreeDocument>({
+    treeAdapter: defaultAdapter
+});
+converter = new PlainTextConversionStream<parse5.DefaultTreeDocument>({
+    sourceCodeLocationInfo: true,
+    treeAdapter: defaultAdapter
+});
+converter = new PlainTextConversionStream<parse5.DefaultTreeDocument>({
+    sourceCodeLocationInfo: true,
+    treeAdapter: defaultAdapter
+});
+
+converter.document; // $ExpectType DefaultTreeDocument
+
+converter.on("finish", () => {});
+
+createReadStream("file").pipe(converter);

--- a/types/parse5-plain-text-conversion-stream/tsconfig.json
+++ b/types/parse5-plain-text-conversion-stream/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "parse5-plain-text-conversion-stream-tests.ts"
+    ]
+}

--- a/types/parse5-plain-text-conversion-stream/tslint.json
+++ b/types/parse5-plain-text-conversion-stream/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/parse5-sax-parser/index.d.ts
+++ b/types/parse5-sax-parser/index.d.ts
@@ -1,0 +1,192 @@
+// Type definitions for parse5-sax-parser 5.0
+// Project: https://github.com/inikulin/parse5
+// Definitions by: Ivan Nikulin <https://github.com/inikulin>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.2
+
+/// <reference types="node" />
+
+import * as stream from "stream";
+import * as parse5 from "parse5";
+
+export interface StartTagToken {
+    /**
+     * Tag name.
+     */
+    tagName: string;
+    /**
+     * List of attributes.
+     */
+    attrs: parse5.Attribute[];
+    /**
+     * Indicates if the tag is self-closing.
+     */
+    selfClosing: boolean;
+    /**
+     * Start tag source code location info. Available if location info is enabled via {@link SAXParserOptions}.
+     */
+    sourceCodeLocation?: parse5.StartTagLocation;
+}
+
+export interface EndTagToken {
+    /**
+     * Tag name.
+     */
+    tagName: string;
+    /**
+     * End tag source code location info. Available if location info is enabled via {@link SAXParserOptions}.
+     */
+    sourceCodeLocation?: parse5.Location;
+}
+
+export interface CommentToken {
+    /**
+     * Comment text.
+     */
+    text: string;
+    /**
+     * Comment source code location info. Available if location info is enabled via {@link SAXParserOptions}.
+     */
+    sourceCodeLocation?: parse5.Location;
+}
+
+export interface TextToken {
+    /**
+     * Text content.
+     */
+    text: string;
+    /**
+     * Text content source code location info. Available if location info is enabled via {@link SAXParserOptions}.
+     */
+    sourceCodeLocation?: parse5.Location;
+}
+
+export interface DoctypeToken {
+    /**
+     * Document type name.
+     */
+    name: string;
+    /**
+     * Document type public identifier.
+     */
+    publicId: string;
+    /**
+     * Document type system identifier.
+     */
+    systemId: string;
+    /**
+     * Document type declaration source code location info. Available if location info is enabled via {@link SAXParserOptions}.
+     */
+    sourceCodeLocation?: parse5.Location;
+}
+
+export interface SAXParserOptions {
+    /**
+     * Enables source code location information for the tokens.
+     * When enabled, each token event handler will receive {@link Location} (or {@link StartTagLocation})
+     * object as its last argument.
+     */
+    sourceCodeLocationInfo?: boolean;
+}
+
+/**
+ * Streaming [SAX](https://en.wikipedia.org/wiki/Simple_API_for_XML)-style HTML parser.
+ * A [transform stream](https://nodejs.org/api/stream.html#stream_class_stream_transform)
+ * (which means you can pipe *through* it, see example).
+ *
+ * ** NOTE:** This API is available only for Node.js.
+ *
+ * @example
+ * ```js
+ *
+ * const parse5 = require('parse5');
+ * const http = require('http');
+ * const fs = require('fs');
+ *
+ * const file = fs.createWriteStream('/home/google.com.html');
+ * const parser = new parse5.SAXParser();
+ *
+ * parser.on('text', text => {
+ *    // Handle page text content
+ *    ...
+ * });
+ *
+ * http.get('http://google.com', res => {
+ *    // SAXParser is the Transform stream, which means you can pipe
+ *    // through it. So, you can analyze page content and, e.g., save it
+ *    // to the file at the same time:
+ *    res.pipe(parser).pipe(file);
+ * });
+ * ```
+ */
+export default class SAXParser extends stream.Transform {
+    /**
+     * @param options - Parsing options.
+     */
+    constructor(options?: SAXParserOptions);
+
+    /**
+     * Raised when the parser encounters a start tag.
+     *
+     * @param listener.startTag - Start tag token.
+     */
+    on(event: "startTag", listener: (startTag: StartTagToken) => void): this;
+
+    /**
+     * Raised when parser encounters an end tag.
+     *
+     * @param listener.endTag - End tag token.
+     */
+    on(event: "endTag", listener: (endTag: EndTagToken) => void): this;
+    /**
+     * Raised when parser encounters text content.
+     *
+     * @param listener.text - Text token.
+     */
+    on(event: "text", listener: (text: TextToken) => void): this;
+    /**
+     * Raised when parser encounters a comment.
+     *
+     * @param listener.comment - Comment content.
+     */
+    on(event: "comment", listener: (comment: CommentToken) => void): this;
+    /**
+     * Raised when parser encounters a [document type declaration](https://en.wikipedia.org/wiki/Document_type_declaration).
+     *
+     * @param listener.doctype - Document type token.
+     */
+    on(event: "doctype", listener: (doctype: DoctypeToken) => void): this;
+    /**
+     * TransformStream events
+     */
+    on(event: string, listener: (...params: any[]) => any): this;
+
+    /**
+     * Stops parsing. Useful if you want the parser to stop consuming CPU time once you've obtained the desired info
+     * from the input stream. Doesn't prevent piping, so that data will flow through the parser as usual.
+     *
+     * @example
+     * ```js
+     *
+     * const parse5 = require('parse5');
+     * const http = require('http');
+     * const fs = require('fs');
+     *
+     * const file = fs.createWriteStream('google.com.html');
+     * const parser = new parse5.SAXParser();
+     *
+     * parser.on('doctype', (name, publicId, systemId) => {
+     *    // Process doctype info ans stop parsing
+     *    ...
+     *    parser.stop();
+     * });
+     *
+     * http.get('http://google.com', res => {
+     *    // Despite the fact that parser.stop() was called whole
+     *    // content of the page will be written to the file
+     *    res.pipe(parser).pipe(file);
+     * });
+     * ```
+     */
+    stop(): void;
+}

--- a/types/parse5-sax-parser/parse5-sax-parser-tests.ts
+++ b/types/parse5-sax-parser/parse5-sax-parser-tests.ts
@@ -1,0 +1,45 @@
+import SAXParser, {
+    StartTagToken,
+    EndTagToken,
+    CommentToken,
+    TextToken,
+    DoctypeToken
+} from "parse5-sax-parser";
+import { createReadStream, createWriteStream } from "fs";
+
+let sax = new SAXParser();
+
+sax = new SAXParser({ sourceCodeLocationInfo: true });
+
+sax.stop();
+
+sax
+    .on("startTag", (startTag: StartTagToken) => {
+        startTag.tagName; // $ExpectType string
+        startTag.attrs; // $ExpectType Attribute[]
+        startTag.selfClosing; // $ExpectType boolean
+        startTag.sourceCodeLocation!; // $ExpectType StartTagLocation
+    })
+    .on("endTag", (endTag: EndTagToken) => {
+        endTag.tagName; // $ExpectType string
+        endTag.sourceCodeLocation!; // $ExpectType Location
+    })
+    .on("comment", (comment: CommentToken) => {
+        comment.text; // $ExpectType string
+        comment.sourceCodeLocation!; // $ExpectType Location
+    })
+    .on("text", (text: TextToken) => {
+        text.text; // $ExpectType string
+        text.sourceCodeLocation!; // $ExpectType Location
+    })
+    .on("doctype", (doctype: DoctypeToken) => {
+        doctype.name; // $ExpectType string
+        doctype.publicId; // $ExpectType string
+        doctype.systemId; // $ExpectType string
+        doctype.sourceCodeLocation!; // $ExpectType Location
+    })
+    .on("finish", () => {});
+
+createReadStream("file1")
+    .pipe(sax)
+    .pipe(createWriteStream("file2"));

--- a/types/parse5-sax-parser/tsconfig.json
+++ b/types/parse5-sax-parser/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "parse5-sax-parser-tests.ts"
+    ]
+}

--- a/types/parse5-sax-parser/tslint.json
+++ b/types/parse5-sax-parser/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/parse5-serializer-stream/index.d.ts
+++ b/types/parse5-serializer-stream/index.d.ts
@@ -1,0 +1,41 @@
+// Type definitions for parse5-serializer-stream 5.0
+// Project: https://github.com/inikulin/parse5
+// Definitions by: Ivan Nikulin <https://github.com/inikulin>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.2
+
+/// <reference types="node" />
+
+import * as stream from "stream";
+import * as parse5 from "parse5";
+
+/**
+ * Streaming AST node to an HTML serializer.
+ * A [readable stream](https://nodejs.org/api/stream.html#stream_class_stream_readable).
+ *
+ * ** NOTE:** This API is available only for Node.js.
+ *
+ * @example
+ * ```js
+ *
+ * const parse5 = require('parse5');
+ * const fs = require('fs');
+ *
+ * const file = fs.createWriteStream('/home/index.html');
+ *
+ * // Serializes the parsed document to HTML and writes it to the file.
+ * const document = parse5.parse('<body>Who is John Galt?</body>');
+ * const serializer = new parse5.SerializerStream(document);
+ *
+ * serializer.pipe(file);
+ * ```
+ */
+export default class SerializerStream extends stream.Readable {
+    /**
+     * Streaming AST node to an HTML serializer. A readable stream.
+     *
+     * @param node - Node to serialize.
+     * @param options - Serialization options.
+     */
+    constructor(node: parse5.Node, options?: parse5.SerializerOptions);
+}

--- a/types/parse5-serializer-stream/parse5-serializer-stream-tests.ts
+++ b/types/parse5-serializer-stream/parse5-serializer-stream-tests.ts
@@ -1,0 +1,16 @@
+import { parse, TreeAdapter } from "parse5";
+import SerializerStream from "parse5-serializer-stream";
+import { createReadStream, createWriteStream } from "fs";
+
+const document = parse("<html>");
+const defaultAdapter = new Object() as TreeAdapter;
+let serializer = new SerializerStream(document);
+
+serializer = new SerializerStream(document, {
+    treeAdapter: defaultAdapter
+});
+serializer = new SerializerStream(document, {
+    treeAdapter: defaultAdapter
+});
+
+serializer.pipe(createWriteStream("file"));

--- a/types/parse5-serializer-stream/tsconfig.json
+++ b/types/parse5-serializer-stream/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "parse5-serializer-stream-tests.ts"
+    ]
+}

--- a/types/parse5-serializer-stream/tslint.json
+++ b/types/parse5-serializer-stream/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/parse5/index.d.ts
+++ b/types/parse5/index.d.ts
@@ -1,0 +1,601 @@
+// Type definitions for parse5 5.0
+// Project: https://github.com/inikulin/parse5
+// Definitions by: Ivan Nikulin <https://github.com/inikulin>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.2
+
+export interface Location {
+    /**
+     * One-based line index of the first character
+     */
+    startLine: number;
+    /**
+     * One-based column index of the first character
+     */
+    startCol: number;
+    /**
+     * One-based line index of the last character
+     */
+    endLine: number;
+    /**
+     * One-based column index of the last character
+     */
+    endCol: number;
+    /**
+     * Zero-based first character index
+     */
+    startOffset: number;
+    /**
+     * Zero-based last character index
+     */
+    endOffset: number;
+}
+
+export interface AttributesLocation {
+    [attributeName: string]: Location;
+}
+
+export interface StartTagLocation extends Location {
+    /**
+     * Start tag attributes' location info
+     */
+    attrs: AttributesLocation;
+}
+
+export interface ElementLocation extends StartTagLocation {
+    /**
+     * Element's start tag location info.
+     */
+    startTag: StartTagLocation;
+    /**
+     * Element's end tag location info.
+     */
+    endTag: Location;
+}
+
+export interface ParserOptions {
+    /**
+     * The [scripting flag](https://html.spec.whatwg.org/multipage/parsing.html#scripting-flag). If set
+     * to `true`, `noscript` element content will be parsed as text.
+     *
+     *  **Default:** `true`
+     */
+    scriptingEnabled?: boolean;
+    /**
+     * Enables source code location information. When enabled, each node (except the root node)
+     * will have a `sourceCodeLocation` property. If the node is not an empty element, `sourceCodeLocation` will
+     * be a {@link ElementLocation} object, otherwise it will be {@link Location}.
+     * If the element was implicitly created by the parser (as part of
+     * [tree correction](https://html.spec.whatwg.org/multipage/syntax.html#an-introduction-to-error-handling-and-strange-cases-in-the-parser)),
+     * its `sourceCodeLocation` property will be `undefined`.
+     *
+     * **Default:** `false`
+     */
+    sourceCodeLocationInfo?: boolean;
+    /**
+     * Specifies the resulting tree format.
+     *
+     * **Default:** `treeAdapters.default`
+     */
+    treeAdapter?: TreeAdapter;
+}
+
+export interface SerializerOptions {
+    /***
+     * Specifies input tree format.
+     *
+     * **Default:** `treeAdapters.default`
+     */
+    treeAdapter?: TreeAdapter;
+}
+
+/**
+ * [Document mode](https://dom.spec.whatwg.org/#concept-document-limited-quirks).
+ */
+export type DocumentMode = "no-quirks" | "quirks" | "limited-quirks";
+
+// Default tree adapter
+
+/**
+ * Element attribute.
+ */
+export interface Attribute {
+    /**
+     * The name of the attribute.
+     */
+    name: string;
+    /**
+     * The value of the attribute.
+     */
+    value: string;
+    /**
+     * The namespace of the attribute.
+     */
+    namespace?: string;
+    /**
+     * The namespace-related prefix of the attribute.
+     */
+    prefix?: string;
+}
+
+/**
+ * Default tree adapter Node interface.
+ */
+export interface DefaultTreeNode {
+    /**
+     * The name of the node. E.g. {@link Document} will have `nodeName` equal to '#document'`.
+     */
+    nodeName: string;
+}
+
+/**
+ * Default tree adapter ParentNode interface.
+ */
+export interface DefaultTreeParentNode {
+    /**
+     * Child nodes.
+     */
+    childNodes: DefaultTreeNode[];
+}
+
+/**
+ * Default tree adapter DocumentType interface.
+ */
+export interface DefaultTreeDocumentType extends DefaultTreeNode {
+    /**
+     * The name of the node.
+     */
+    nodeName: "#documentType";
+    /**
+     * Document type name.
+     */
+    name: string;
+    /**
+     * Document type public identifier.
+     */
+    publicId: string;
+    /**
+     * Document type system identifier.
+     */
+    systemId: string;
+}
+
+/**
+ * Default tree adapter Document interface.
+ */
+export interface DefaultTreeDocument extends DefaultTreeParentNode {
+    /**
+     * The name of the node.
+     */
+    nodeName: "#document";
+    /**
+     * [Document mode](https://dom.spec.whatwg.org/#concept-document-limited-quirks).
+     */
+    mode: DocumentMode;
+}
+
+/**
+ * Default tree adapter DocumentFragment interface.
+ */
+export interface DefaultTreeDocumentFragment extends DefaultTreeParentNode {
+    /**
+     * The name of the node.
+     */
+    nodeName: "#document-fragment";
+}
+
+/**
+ * Default tree adapter Element interface.
+ */
+export interface DefaultTreeElement extends DefaultTreeParentNode {
+    /**
+     * The name of the node. Equals to element {@link tagName}.
+     */
+    nodeName: string;
+    /**
+     * Element tag name.
+     */
+    tagName: string;
+    /**
+     * Element namespace.
+     */
+    namespaceURI: string;
+    /**
+     * List of element attributes.
+     */
+    attrs: Attribute[];
+    /**
+     * Parent node.
+     */
+    parentNode: DefaultTreeParentNode;
+    /**
+     * Element source code location info. Available if location info is enabled via {@link ParserOptions}.
+     */
+    sourceCodeLocation?: ElementLocation;
+}
+
+/**
+ * Default tree adapter CommentNode interface.
+ */
+export interface DefaultTreeCommentNode extends DefaultTreeNode {
+    /**
+     * The name of the node.
+     */
+    nodeName: "#comment";
+    /**
+     * Comment text.
+     */
+    data: string;
+    /**
+     * Parent node.
+     */
+    parentNode: DefaultTreeParentNode;
+    /**
+     * Comment source code location info. Available if location info is enabled via {@link ParserOptions}.
+     */
+    sourceCodeLocation?: Location;
+}
+
+/**
+ * Default tree adapter TextNode interface.
+ */
+export interface DefaultTreeTextNode extends DefaultTreeNode {
+    /**
+     * The name of the node.
+     */
+    nodeName: "#text";
+    /**
+     * Text content.
+     */
+    value: string;
+    /**
+     * Parent node.
+     */
+    parentNode: DefaultTreeParentNode;
+    /**
+     * Text node source code location info. Available if location info is enabled via {@link ParserOptions}.
+     */
+    sourceCodeLocation?: Location;
+}
+
+// Generic node intefaces
+/**
+ * Generic Node interface.
+ * Cast to the actual AST interface (e.g. {@link parse5.DefaultTreeNode}) to get access to the properties.
+ */
+export type Node = DefaultTreeNode | object;
+/**
+ * Generic ParentNode interface.
+ * Cast to the actual AST interface (e.g. {@link parse5.DefaultTreeParentNode}) to get access to the properties.
+ */
+export type ParentNode = DefaultTreeParentNode | object;
+/**
+ * Generic DocumentType interface.
+ * Cast to the actual AST interface (e.g. {@link parse5.DefaultTreeDocumentType}) to get access to the properties.
+ */
+export type DocumentType = DefaultTreeDocumentType | object;
+/**
+ * Generic Document interface.
+ * Cast to the actual AST interface (e.g. {@link parse5.DefaultTreeDocument}) to get access to the properties.
+ */
+export type Document = DefaultTreeDocument | object;
+/**
+ * Generic DocumentFragment interface.
+ * Cast to the actual AST interface (e.g. {@link parse5.DefaultTreeDocumentFragment}) to get access to the properties.
+ */
+export type DocumentFragment = DefaultTreeDocumentFragment | object;
+/**
+ * Generic Element interface.
+ * Cast to the actual AST interface (e.g. {@link parse5.DefaultTreeElement}) to get access to the properties.
+ */
+export type Element = DefaultTreeElement | object;
+/**
+ * Generic TextNode interface.
+ * Cast to the actual AST interface (e.g. {@link parse5.DefaultTreeTextNode}) to get access to the properties.
+ */
+export type TextNode = DefaultTreeTextNode | object;
+/**
+ * Generic CommentNode interface.
+ * Cast to the actual AST interface (e.g. {@link parse5.Default.CommentNode}) to get access to the properties.
+ */
+export type CommentNode = DefaultTreeCommentNode | object;
+
+/**
+ * Tree adapter is a set of utility functions that provides minimal required abstraction layer beetween parser and a specific AST format.
+ * Note that `TreeAdapter` is not designed to be a general purpose AST manipulation library. You can build such library
+ * on top of existing `TreeAdapter` or use one of the existing libraries from npm.
+ *
+ * @see [default implementation](https://github.com/inikulin/parse5/blob/master/lib/tree_adapters/default.js)
+ */
+export interface TreeAdapter {
+    /**
+     * Creates a document node.
+     */
+    createDocument(): Document;
+    /**
+     * Creates a document fragment node.
+     */
+    createDocumentFragment(): DocumentFragment;
+    /**
+     * Creates an element node.
+     *
+     * @param tagName - Tag name of the element.
+     * @param namespaceURI - Namespace of the element.
+     * @param attrs - Attribute name-value pair array. Foreign attributes may contain `namespace` and `prefix` fields as well.
+     */
+    createElement(
+        tagName: string,
+        namespaceURI: string,
+        attrs: Attribute[]
+    ): Element;
+    /**
+     * Creates a comment node.
+     *
+     * @param data - Comment text.
+     */
+    createCommentNode(data: string): CommentNode;
+    /**
+     * Appends a child node to the given parent node.
+     *
+     * @param parentNode - Parent node.
+     * @param newNode -  Child node.
+     */
+    appendChild(parentNode: ParentNode, newNode: Node): void;
+    /**
+     * Inserts a child node to the given parent node before the given reference node.
+     *
+     * @param parentNode - Parent node.
+     * @param newNode -  Child node.
+     * @param referenceNode -  Reference node.
+     */
+    insertBefore(
+        parentNode: ParentNode,
+        newNode: Node,
+        referenceNode: Node
+    ): void;
+    /**
+     * Sets the `<template>` element content element.
+     *
+     * @param templateElement - `<template>` element.
+     * @param contentElement -  Content element.
+     */
+    setTemplateContent(
+        templateElement: Element,
+        contentElement: DocumentFragment
+    ): void;
+    /**
+     * Returns the `<template>` element content element.
+     *
+     * @param templateElement - `<template>` element.
+     */
+    getTemplateContent(templateElement: Element): DocumentFragment;
+    /**
+     * Sets the document type. If the `document` already contains a document type node, the `name`, `publicId` and `systemId`
+     * properties of this node will be updated with the provided values. Otherwise, creates a new document type node
+     * with the given properties and inserts it into the `document`.
+     *
+     * @param document - Document node.
+     * @param name -  Document type name.
+     * @param publicId - Document type public identifier.
+     * @param systemId - Document type system identifier.
+     */
+    setDocumentType(
+        document: Document,
+        name: string,
+        publicId: string,
+        systemId: string
+    ): void;
+    /**
+     * Sets the [document mode](https://dom.spec.whatwg.org/#concept-document-limited-quirks).
+     *
+     * @param document - Document node.
+     * @param mode - Document mode.
+     */
+    setDocumentMode(document: Document, mode: DocumentMode): void;
+    /**
+     * Returns [document mode](https://dom.spec.whatwg.org/#concept-document-limited-quirks).
+     *
+     * @param document - Document node.
+     */
+    getDocumentMode(document: Document): DocumentMode;
+    /**
+     * Removes a node from its parent.
+     *
+     * @param node - Node to remove.
+     */
+    detachNode(node: Node): void;
+    /**
+     * Inserts text into a node. If the last child of the node is a text node, the provided text will be appended to the
+     * text node content. Otherwise, inserts a new text node with the given text.
+     *
+     * @param parentNode - Node to insert text into.
+     * @param text - Text to insert.
+     */
+    insertText(parentNode: ParentNode, text: string): void;
+    /**
+     * Inserts text into a sibling node that goes before the reference node. If this sibling node is the text node,
+     * the provided text will be appended to the text node content. Otherwise, inserts a new sibling text node with
+     * the given text before the reference node.
+     *
+     * @param parentNode - Node to insert text into.
+     * @param text - Text to insert.
+     * @param referenceNode - Node to insert text before.
+     */
+    insertTextBefore(
+        parentNode: ParentNode,
+        text: string,
+        referenceNode: Node
+    ): void;
+    /**
+     * Copies attributes to the given element. Only attributes that are not yet present in the element are copied.
+     *
+     * @param recipient - Element to copy attributes into.
+     * @param attrs - Attributes to copy.
+     */
+    adoptAttributes(recipient: Element, attrs: Attribute[]): void;
+    /**
+     * Returns the first child of the given node.
+     *
+     * @param node - Node.
+     */
+    getFirstChild(node: ParentNode): Node;
+    /**
+     * Returns the given node's children in an array.
+     *
+     * @param node - Node.
+     */
+    getChildNodes(node: ParentNode): Node[];
+    /**
+     * Returns the given node's parent.
+     *
+     * @param node - Node.
+     */
+    getParentNode(node: Node): ParentNode;
+    /**
+     * Returns the given element's attributes in an array, in the form of name-value pairs.
+     * Foreign attributes may contain `namespace` and `prefix` fields as well.
+     *
+     * @param element - Element.
+     */
+    getAttrList(element: Element): Attribute[];
+    /**
+     * Returns the given element's tag name.
+     *
+     * @param element - Element.
+     */
+    getTagName(element: Element): string;
+    /**
+     * Returns the given element's namespace.
+     *
+     * @param element - Element.
+     */
+    getNamespaceURI(element: Element): string;
+    /**
+     * Returns the given text node's content.
+     *
+     * @param textNode - Text node.
+     */
+    getTextNodeContent(textNode: TextNode): string;
+    /**
+     * Returns the given comment node's content.
+     *
+     * @param commentNode - Comment node.
+     */
+    getCommentNodeContent(commentNode: CommentNode): string;
+    /**
+     * Returns the given document type node's name.
+     *
+     * @param doctypeNode - Document type node.
+     */
+    getDocumentTypeNodeName(doctypeNode: DocumentType): string;
+    /**
+     * Returns the given document type node's public identifier.
+     *
+     * @param doctypeNode - Document type node.
+     */
+    getDocumentTypeNodePublicId(doctypeNode: DocumentType): string;
+    /**
+     * Returns the given document type node's system identifier.
+     *
+     * @param doctypeNode - Document type node.
+     */
+    getDocumentTypeNodeSystemId(doctypeNode: DocumentType): string;
+    /**
+     * Determines if the given node is a text node.
+     *
+     * @param node - Node.
+     */
+    isTextNode(node: Node): boolean;
+    /**
+     * Determines if the given node is a comment node.
+     *
+     * @param node - Node.
+     */
+    isCommentNode(node: Node): boolean;
+    /**
+     * Determines if the given node is a document type node.
+     *
+     * @param node - Node.
+     */
+    isDocumentTypeNode(node: Node): boolean;
+    /**
+     * Determines if the given node is an element.
+     *
+     * @param node - Node.
+     */
+    isElementNode(node: Node): boolean;
+}
+
+/**
+ * Parses an HTML string.
+ *
+ * @param html - Input HTML string.
+ * @param options - Parsing options.
+ *
+ * @example
+ * ```js
+ *
+ * const parse5 = require('parse5');
+ *
+ * const document = parse5.parse('<!DOCTYPE html><html><head></head><body>Hi there!</body></html>');
+ *
+ * console.log(document.childNodes[1].tagName); //> 'html'
+ * ```
+ */
+export function parse(html: string, options?: ParserOptions): Document;
+
+/**
+ * Parses an HTML fragment.
+ *
+ * @param fragmentContext - Parsing context element. If specified, given fragment will be parsed as if it was set to the context element's `innerHTML` property.
+ * @param html - Input HTML fragment string.
+ * @param options - Parsing options.
+ *
+ * @example
+ * ```js
+ *
+ * const parse5 = require('parse5');
+ *
+ * const documentFragment = parse5.parseFragment('<table></table>');
+ *
+ * console.log(documentFragment.childNodes[0].tagName); //> 'table'
+ *
+ * // Parses the html fragment in the context of the parsed <table> element.
+ * const trFragment = parser.parseFragment(documentFragment.childNodes[0], '<tr><td>Shake it, baby</td></tr>');
+ *
+ * console.log(trFragment.childNodes[0].childNodes[0].tagName); //> 'td'
+ * ```
+ */
+export function parseFragment(
+    fragmentContext: Element,
+    html: string,
+    options?: ParserOptions
+): DocumentFragment;
+export function parseFragment(
+    html: string,
+    options?: ParserOptions
+): DocumentFragment;
+
+/**
+ * Serializes an AST node to an HTML string.
+ *
+ * @param node - Node to serialize.
+ * @param options - Serialization options.
+ *
+ * @example
+ * ```js
+ *
+ * const parse5 = require('parse5');
+ *
+ * const document = parse5.parse('<!DOCTYPE html><html><head></head><body>Hi there!</body></html>');
+ *
+ * // Serializes a document.
+ * const html = parse5.serialize(document);
+ *
+ * // Serializes the <html> element content.
+ * const str = parse5.serialize(document.childNodes[1]);
+ *
+ * console.log(str); //> '<head></head><body>Hi there!</body>'
+ * ```
+ */
+export function serialize(node: Node, options?: SerializerOptions): string;

--- a/types/parse5/parse5-tests.ts
+++ b/types/parse5/parse5-tests.ts
@@ -1,0 +1,191 @@
+import * as parse5 from "parse5";
+
+// Shorthands
+// parse
+const document = parse5.parse("<html>");
+
+document; // $ExpectType Document
+
+const defaultAdapter = new Object() as parse5.TreeAdapter;
+
+parse5.parse("<html>", {}); // $ExpectType Document
+parse5.parse("<html>", { sourceCodeLocationInfo: true }); // $ExpectType Document
+parse5.parse("<html>", { treeAdapter: defaultAdapter }); // $ExpectType Document
+
+let opt = {
+    sourceCodeLocationInfo: true,
+    scriptingEnabled: false,
+    treeAdapter: defaultAdapter
+};
+
+parse5.parse("<html>", opt); // $ExpectType Document
+
+opt = {
+    sourceCodeLocationInfo: true,
+    scriptingEnabled: false,
+    treeAdapter: defaultAdapter
+};
+
+parse5.parse("<html>", opt); // $ExpectType Document
+
+// parseFragment
+const fragment = parse5.parseFragment("<div>");
+
+fragment; // $ExpectType DocumentFragment
+
+parse5.parseFragment("<div>", {});
+parse5.parseFragment("<div>", { sourceCodeLocationInfo: true });
+parse5.parseFragment("<div>", { treeAdapter: defaultAdapter });
+parse5.parseFragment("<div>", {
+    sourceCodeLocationInfo: true,
+    treeAdapter: defaultAdapter
+});
+parse5.parseFragment("<div>", {
+    sourceCodeLocationInfo: true,
+    treeAdapter: defaultAdapter
+});
+
+const element = (parse5.parseFragment(
+    "<div>"
+) as parse5.DefaultTreeDocumentFragment).childNodes[0] as parse5.Element;
+
+parse5.parseFragment(element, "<div>");
+parse5.parseFragment(element, "<div>", {});
+parse5.parseFragment(element, "<div>", { sourceCodeLocationInfo: true });
+parse5.parseFragment(element, "<div>", {
+    treeAdapter: defaultAdapter
+});
+parse5.parseFragment(element, "<div>", {
+    sourceCodeLocationInfo: true,
+    treeAdapter: defaultAdapter
+});
+parse5.parseFragment(element, "<div>", {
+    sourceCodeLocationInfo: true,
+    treeAdapter: defaultAdapter
+});
+
+// serialize
+const html = parse5.serialize(element);
+
+html; // $ExpectType string
+
+parse5.serialize(element, { treeAdapter: defaultAdapter });
+parse5.serialize(element, { treeAdapter: defaultAdapter });
+
+// Location info
+const loc = (element as parse5.DefaultTreeElement).sourceCodeLocation!;
+
+loc.startLine; // $ExpectType number
+loc.startCol; // $ExpectType number
+loc.endLine; // $ExpectType number
+loc.endCol; // $ExpectType number
+loc.startOffset; // $ExpectType number
+loc.endOffset; // $ExpectType number
+
+loc.startTag.startLine; // $ExpectType number
+loc.startTag.startCol; // $ExpectType number
+loc.startTag.endLine; // $ExpectType number
+loc.startTag.endCol; // $ExpectType number
+loc.startTag.startOffset; // $ExpectType number
+loc.startTag.endOffset; // $ExpectType number
+
+loc.startTag.attrs["someAttr"].startLine; // $ExpectType number
+loc.startTag.attrs["someAttr"].startCol; // $ExpectType number
+loc.startTag.attrs["someAttr"].endLine; // $ExpectType number
+loc.startTag.attrs["someAttr"].endCol; // $ExpectType number
+loc.startTag.attrs["someAttr"].startOffset; // $ExpectType number
+loc.startTag.attrs["someAttr"].endOffset; // $ExpectType number
+
+loc.endTag.startLine; // $ExpectType number
+loc.endTag.startCol; // $ExpectType number
+loc.endTag.endLine; // $ExpectType number
+loc.endTag.endCol; // $ExpectType number
+loc.endTag.startOffset; // $ExpectType number
+loc.endTag.endOffset; // $ExpectType number
+
+// Default AST
+const defaultDocument = document as parse5.DefaultTreeDocument;
+
+defaultDocument.nodeName; // $ExpectType "#document"
+defaultDocument.mode; // $ExpectType DocumentMode
+
+const defaultDoctype = document as parse5.DefaultTreeDocumentType;
+
+defaultDoctype.name; // $ExpectType string
+defaultDoctype.publicId; // $ExpectType string
+defaultDoctype.systemId; // $ExpectType string
+
+const defaultDocumentFragment = fragment as parse5.DefaultTreeDocumentFragment;
+
+defaultDocumentFragment.nodeName; // $ExpectType "#document-fragment"
+
+const defaultElement = defaultDocument
+    .childNodes[0] as parse5.DefaultTreeElement;
+
+defaultElement.sourceCodeLocation!; // $ExpectType ElementLocation
+defaultElement.namespaceURI; // $ExpectType string
+defaultElement.nodeName; // $ExpectType string
+defaultElement.tagName; // $ExpectType string
+defaultElement.parentNode; // $ExpectType DefaultTreeParentNode
+
+const defaultAttr = defaultElement.attrs[0];
+
+defaultAttr.name; // $ExpectType string
+defaultAttr.namespace!; // $ExpectType string
+defaultAttr.prefix!; // $ExpectType string
+defaultAttr.value; // $ExpectType string
+
+const defaultTextNode = defaultDocumentFragment
+    .childNodes[0] as parse5.DefaultTreeTextNode;
+
+defaultTextNode.sourceCodeLocation!; // $ExpectType Location
+defaultTextNode.nodeName; // $ExpectType "#text"
+defaultTextNode.value; // $ExpectType string
+defaultTextNode.parentNode; // $ExpectType DefaultTreeParentNode
+
+const defaultCommentNode = defaultDocumentFragment
+    .childNodes[0] as parse5.DefaultTreeCommentNode;
+
+defaultCommentNode.sourceCodeLocation!; // $ExpectType Location
+defaultCommentNode.nodeName; // $ExpectType "#comment"
+defaultCommentNode.data; // $ExpectType string
+defaultCommentNode.parentNode; // $ExpectType DefaultTreeParentNode
+
+const adapter = defaultAdapter;
+
+adapter.createDocument(); // $ExpectType Document
+adapter.createDocumentFragment(); // $ExpectType DocumentFragment
+adapter.createElement("div", "namespace", [{ name: "someAttr", value: "42" }]); // $ExpectType Element
+adapter.createCommentNode("foo"); // $ExpectType CommentNode
+
+adapter.appendChild(document, element);
+adapter.insertBefore(document, element, element);
+adapter.setTemplateContent(element, fragment);
+
+adapter.getTemplateContent(element); // $ExpectType DocumentFragment
+
+adapter.setDocumentType(document, "name", "publicId", "systemId");
+adapter.setDocumentMode(document, "quirks");
+
+adapter.getDocumentMode(document); // $ExpectType DocumentMode
+
+adapter.detachNode(element);
+adapter.insertText(element, "text");
+adapter.insertTextBefore(document, "text", element);
+adapter.adoptAttributes(element, [{ name: "someAttr", value: "42" }]);
+
+adapter.getFirstChild(element); // $ExpectType Node
+adapter.getChildNodes(element)[0]; // $ExpectType Node
+adapter.getParentNode(element); // $ExpectType ParentNode
+adapter.getAttrList(element)[0]; // $ExpectType Attribute
+adapter.getTagName(element); // $ExpectType string
+adapter.getNamespaceURI(element); // $ExpectType string
+adapter.getTextNodeContent(defaultTextNode); // $ExpectType string
+adapter.getCommentNodeContent(defaultCommentNode); // $ExpectType string
+adapter.getDocumentTypeNodeName(defaultDoctype); // $ExpectType string
+adapter.getDocumentTypeNodePublicId(defaultDoctype); // $ExpectType string
+adapter.getDocumentTypeNodeSystemId(defaultDoctype); // $ExpectType string
+adapter.isTextNode(element); // $ExpectType boolean
+adapter.isCommentNode(element); // $ExpectType boolean
+adapter.isDocumentTypeNode(element); // $ExpectType boolean
+adapter.isElementNode(element); // $ExpectType boolean

--- a/types/parse5/tsconfig.json
+++ b/types/parse5/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "parse5-tests.ts"
+    ]
+}

--- a/types/parse5/tslint.json
+++ b/types/parse5/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

-----

Starting from `5.0.0` parse5 will no longer provide its own type definitions and will be split into separate packages  (see https://github.com/inikulin/parse5/issues/235).