### PR TITLE
[Dygraphs]: Allow Date type for input data array

### DIFF
--- a/types/dygraphs/index.d.ts
+++ b/types/dygraphs/index.d.ts
@@ -6,7 +6,7 @@
 /// <reference types="google.visualization" />
 
 declare namespace dygraphs {
-    type DataArray = number[][];
+    type DataArray = (number|Date)[][];
 
     type Data = string | DataArray | google.visualization.DataTable;
 


### PR DESCRIPTION
**Package:** dygraphs
**Info:**  Per documentation at [1] for package  array of data might be numbers or Date objects. The **Date** was missing from array.

**[1]** http://dygraphs.com/data.html#array
