### PR TITLE
Reactstrap: Added missing 'to' type definition to reactstrap navlink interface

### DIFF
--- a/types/reactstrap/lib/NavLink.d.ts
+++ b/types/reactstrap/lib/NavLink.d.ts
@@ -9,6 +9,7 @@ export interface NavLinkProps extends React.HTMLProps<HTMLAnchorElement> {
   cssModule?: CSSModule;
   onClick?: React.MouseEventHandler<any>;
   href?: string;
+  to?: string;
 }
 
 declare const NavLink: React.StatelessComponent<NavLinkProps>;

--- a/types/reactstrap/lib/NavLink.d.ts
+++ b/types/reactstrap/lib/NavLink.d.ts
@@ -9,7 +9,7 @@ export interface NavLinkProps extends React.HTMLProps<HTMLAnchorElement> {
   cssModule?: CSSModule;
   onClick?: React.MouseEventHandler<any>;
   href?: string;
-  to?: string;
+  [others: string]: any;
 }
 
 declare const NavLink: React.StatelessComponent<NavLinkProps>;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/reactstrap/reactstrap/issues/298
This typing (to field in NavLink) didn't exist in the typings.
- [x] Increase the version number in the header if appropriate.
Not appropriate
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
Not appropriate

