### PR TITLE
fix stream support in jszip typings, as the library supports this

### DIFF
--- a/types/jszip/index.d.ts
+++ b/types/jszip/index.d.ts
@@ -31,6 +31,7 @@ interface InputByType {
     uint8array: Uint8Array;
     arraybuffer: ArrayBuffer;
     blob: Blob;
+    stream: NodeJS.ReadableStream;
 }
 
 interface OutputByType {
@@ -44,7 +45,7 @@ interface OutputByType {
     nodebuffer: Buffer;
 }
 
-type InputFileFormat = InputByType[keyof InputByType] | NodeJS.ReadableStream;
+type InputFileFormat = InputByType[keyof InputByType];
 
 declare namespace JSZip {
     type InputType = keyof InputByType;

--- a/types/jszip/jszip-tests.ts
+++ b/types/jszip/jszip-tests.ts
@@ -112,7 +112,7 @@ function testJSZip() {
 		}).catch((e: any) => log(SEVERITY.ERROR, e));
 
 	newJszip.file("stream.txt").async('text').then((text: string) => {
-			if (text === "test string") {
+			if (text === "test stream") {
 		log(SEVERITY.INFO, "all ok");
 	} else {
 		log(SEVERITY.ERROR, "no matching file found");

--- a/types/jszip/jszip-tests.ts
+++ b/types/jszip/jszip-tests.ts
@@ -1,5 +1,7 @@
 import JSZip = require('jszip');
 
+import { Readable } from "stream";
+
 const SEVERITY = {
 	DEBUG: 0,
 	INFO: 1,
@@ -10,9 +12,12 @@ const SEVERITY = {
 
 function createTestZip(): JSZip {
 	const zip = new JSZip();
+	const stream = new Readable();
+	stream.push("test stream");
 	zip.file("test.txt", "test string");
 	zip.file("test", null, { dir: true });
 	zip.file("test/test.txt", "test string");
+	zip.file("stream.txt", stream);
 	return zip;
 }
 
@@ -103,6 +108,14 @@ function testJSZip() {
 		log(SEVERITY.INFO, "all ok");
 			} else {
 		log(SEVERITY.ERROR, "wrong number of files");
+	}
+		}).catch((e: any) => log(SEVERITY.ERROR, e));
+
+	newJszip.file("stream.txt").async('text').then((text: string) => {
+			if (text === "test string") {
+		log(SEVERITY.INFO, "all ok");
+	} else {
+		log(SEVERITY.ERROR, "no matching file found");
 	}
 		}).catch((e: any) => log(SEVERITY.ERROR, e));
 	}).catch((e: any) => { console.error(e); });


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [X] Provide a URL to documentation or source code which provides context for the suggested changes: 
* https://stuk.github.io/jszip/documentation/api_jszip/file_data.html
- [X] Increase the version number in the header if appropriate.
* this is a minor change, and should be portable back to the version number in the file
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
* N/A


Since @dt-bot is a bit slow today, I'll manually ping the original authors:
* @mzeiher
* @forabi