### PR TITLE
Mongoose: Add force close Connection#close variant

### DIFF
--- a/types/mongoose/index.d.ts
+++ b/types/mongoose/index.d.ts
@@ -236,6 +236,9 @@ declare module "mongoose" {
     /** Closes the connection */
     close(callback?: (err: any) => void): Promise<void>;
 
+    /** Closes the connection */
+    close(force?: boolean, callback?: (err: any) => void): Promise<void>;
+
     /**
      * Retrieves a collection, creating it if not cached.
      * Not typically needed by applications. Just talk to your collection through your model.

--- a/types/mongoose/mongoose-tests.ts
+++ b/types/mongoose/mongoose-tests.ts
@@ -135,7 +135,10 @@ conn1.openUri('mongodb://localhost/test', 'myDb', 27017, {
     autoIndex: false
   }
 }, function (err) {}).open('');
-conn1.close().catch(function (err) {});
+conn1.close().then(function () {}).catch(function (err) {});
+conn1.close(true).then(function () {}).catch(function (err) {});
+conn1.close(function (err) {});
+conn1.close(true, function (err) {});
 conn1.collection('name').$format(999);
 conn1.model('myModel', new mongoose.Schema({}), 'myCol').find();
 conn1.models.myModel.findOne().exec();


### PR DESCRIPTION
`Connection#close` [accepts an optional boolean argument](http://mongoosejs.com/docs/api.html#connection_Connection-close) `force` in addition to the `callback` argument. This goes back
all the way to the mongoose tag `v4.11.14` (f9e0525fa2f7c8e254f3f949cab6273469b3df30).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/Automattic/mongoose/blob/5fbff008a6458b017ab786e874f343e55c81f831/lib/connection.js#L520
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

