### PR TITLE
[@types/jsforce] fixes Connection.query signature to accept the optio…

### DIFF
--- a/types/jsforce/connection.d.ts
+++ b/types/jsforce/connection.d.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from 'events';
 import { DescribeSObjectResult, DescribeGlobalResult } from './describe-result';
-import { Query, QueryResult } from './query';
+import { Query, QueryResult, ExecuteOptions } from './query';
 import { Record } from './record';
 import { RecordResult } from './record-result';
 import { SObject } from './salesforce-object';
@@ -93,8 +93,8 @@ export type ConnectionEvent = "refresh";
 export abstract class BaseConnection extends EventEmitter {
     _baseUrl(): string;
     request(info: RequestInfo | string, options?: Object, callback?: (err: Error, Object: object) => void): Promise<Object>;
-    query<T>(soql: string, callback?: (err: Error, result: QueryResult<T>) => void): Query<QueryResult<T>>;
-    queryMore<T>(locator: string, options?: object, callback?: (err: Error, result: QueryResult<T>) => void): Promise<QueryResult<T>>;
+    query<T>(soql: string, options?: ExecuteOptions, callback?: (err: Error, result: QueryResult<T>) => void): Query<QueryResult<T>>;
+    queryMore<T>(locator: string, options?: ExecuteOptions, callback?: (err: Error, result: QueryResult<T>) => void): Promise<QueryResult<T>>;
     create<T>(type: string, records: Record<T> | Array<Record<T>>, options?: Object,
         callback?: (err: Error, result: RecordResult | RecordResult[]) => void): Promise<(RecordResult | RecordResult[])>;
     insert<T>(type: string, records: Record<T> | Array<Record<T>>, options?: Object,

--- a/types/jsforce/jsforce-tests.ts
+++ b/types/jsforce/jsforce-tests.ts
@@ -30,6 +30,14 @@ const requestInfo: sf.RequestInfo = {
 };
 salesforceConnection.request(requestInfo);
 
+const queryOptions: sf.ExecuteOptions = {
+    autoFetch: true,
+    maxFetch: 5000,
+    headers: {},
+    scanAll: true
+};
+salesforceConnection.query('SELECT Id, Name FROM Account', queryOptions);
+
 // note the following should never compile:
 // salesforceConnection.sobject<DummyRecord>("Dummy").select(["lol"]);
 

--- a/types/jsforce/query.d.ts
+++ b/types/jsforce/query.d.ts
@@ -5,7 +5,8 @@ import { RecordResult } from './record-result';
 export interface ExecuteOptions {
     autoFetch?: boolean;
     maxFetch?: number;
-    scanAll?: number;
+    headers?: object;
+    scanAll?: boolean;
 }
 
 export interface QueryResult<T> {


### PR DESCRIPTION
…ns arg as ExecuteOptions type from Query.d.ts.  Modifies the Connection.queryMore options type to be ExecuteOptions as well.  Fixes the scanAll property on ExecuteOptions to be a boolean rather than number and add the headers property as optional.  Adds a test to jsforce-tests.ts for the changes.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/jsforce/jsforce/blob/master/lib/connection.js#L494
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
