### PR TITLE
d3-timer Activate strictNullChecks

### DIFF
--- a/types/d3-hsv/d3-hsv-tests.ts
+++ b/types/d3-hsv/d3-hsv-tests.ts
@@ -48,6 +48,7 @@ cHSV = cHSV.darker();
 cHSV = cHSV.darker(0.2);
 displayable = cHSV.displayable();
 cString = cHSV.toString();
+cString = cHSV.hex();
 console.log('Channels = (h : %d, s: %d, v: %d)', cHSV.h, cHSV.s, cHSV.v);
 console.log('Opacity = %d', cHSV.opacity);
 

--- a/types/d3-hsv/index.d.ts
+++ b/types/d3-hsv/index.d.ts
@@ -68,12 +68,6 @@ export interface HSVColor extends Color {
      * Returns the RGB equivalent of this color.
      */
     rgb(): RGBColor;
-
-    /**
-     * Returns a hexadecimal string representing this color.
-     * If this color is not displayable, a suitable displayable color is returned instead. For example, RGB channel values greater than 255 are clamped to 255.
-     */
-    hex(): string;
 }
 
 export const hsv: HSVColorFactory;

--- a/types/d3-timer/index.d.ts
+++ b/types/d3-timer/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-// Last module patch version validated against: 1.0.2
+// Last module patch version validated against: 1.0.7
 
 /**
  * Returns the current time as defined by performance.now if available, and Date.now if not.
@@ -44,7 +44,7 @@ export interface Timer {
 export function timer(callback: (elapsed: number) => void, delay?: number, time?: number): Timer;
 
 /**
- * Immediately invoke any eligible timer callbacks
+ * Immediately invoke any eligible timer callbacks.
  */
 export function timerFlush(): void;
 

--- a/types/d3-timer/tsconfig.json
+++ b/types/d3-timer/tsconfig.json
@@ -7,7 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
-        "strictNullChecks": false,
+        "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",
         "typeRoots": [


### PR DESCRIPTION
Activate strictNullChecks in d3-timer. As nothing accepts or returns `undefined` or `null`, I made no changes in the code. For strictFunctionTypes and TS 2.3, I have nothing to add neither.

This is just a really small pull request. So I take the opportunity to correct the omission to remove `hex(.)` of `d3-hsv` in #25586.

Related: #23611.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/d3/d3-timer
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
