### PR TITLE
source-map-support: retrieveSourceMap can return null

### DIFF
--- a/types/source-map-support/index.d.ts
+++ b/types/source-map-support/index.d.ts
@@ -24,7 +24,7 @@ export interface Options {
     overrideRetrieveFile?: boolean;
     overrideRetrieveSourceMap?: boolean;
     retrieveFile?(path: string): string;
-    retrieveSourceMap?(source: string): UrlAndMap;
+    retrieveSourceMap?(source: string): UrlAndMap | null;
 }
 
 export interface Position {

--- a/types/source-map-support/source-map-support-tests.ts
+++ b/types/source-map-support/source-map-support-tests.ts
@@ -6,11 +6,11 @@ function retrieveFile(path: string): string {
 	return "foo";
 }
 
-function retrieveSourceMap(source: string): sms.UrlAndMap {
-	return {
+function retrieveSourceMap(source: string): sms.UrlAndMap | null {
+	return source ? {
 		url: "http://foo",
 		map: "foo"
-	};
+	} : null;
 }
 
 const options: sms.Options = {
@@ -39,5 +39,5 @@ let p: sms.Position = {
 };
 p = sms.mapSourcePosition(p);
 
-let u: sms.UrlAndMap;
+let u: sms.UrlAndMap | null;
 u = retrieveSourceMap("foo");


### PR DESCRIPTION
to indicate no source map has been found for source, function should return null

see README: https://github.com/evanw/node-source-map-support#options