### PR TITLE
update getHeaderProps types to match actual

### DIFF
--- a/types/react-table/index.d.ts
+++ b/types/react-table/index.d.ts
@@ -474,7 +474,7 @@ export namespace Column {
          * Default: (state, rowInfo, column, instance) => ({})
          * A function that returns props to decorate the `th` element of the column
          */
-        getHeaderProps: ReactTableFunction;
+        getHeaderProps: ComponentPropsGetterC;
     }
 
     /** Configuration of a columns footer section */


### PR DESCRIPTION
when `getHeaderProps` is called in `react-table`, it is called like `column.getHeaderProps(finalState, undefined, column, this)` (see https://github.com/react-tools/react-table/blob/master/src/index.js )

However, the type definition for `getHeaderProps` is ` ReactTableFunction = (value?: any) => void;`.

I updated it to match its actual type, `ComponentPropsGetterC = (finalState: any, rowInfo?: undefined, column?: Column, instance?: any) => object | undefined;`

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
