### PR TITLE
Add optional error to readAsTextAsync callback in adm-zip

### DIFF
--- a/types/adm-zip/adm-zip-tests.ts
+++ b/types/adm-zip/adm-zip-tests.ts
@@ -20,6 +20,9 @@ zip.extractAllTo(/*target path*/"/home/me/zipcontent/", /*overwrite*/true);
 // extracts everything and calls callback -> async extracction
 zip.extractAllToAsync(/*target path*/"/home/me/zipcontent/", /*overwrite*/true, (error: Error)=> {});
 
+// reads a file inzide the archive as text
+zip.readAsTextAsync(/*target path*/"some_folder/my_file.txt", (data: string, error: any)=> {});
+
 // creating archives
 var zip = new AdmZip();
 
@@ -39,16 +42,16 @@ function processZipEntry(zipEntry: AdmZip.IZipEntry) {
 //tests taken from examples at https://github.com/cthackers/adm-zip/wiki/ADM-ZIP
 import Zip = require("adm-zip");
 // loads and parses existing zip file local_file.zip
-var zip = new Zip("local_file.zip"); 
+var zip = new Zip("local_file.zip");
 // creates new in memory zip
 zip = new Zip();
 // loads and parses existing zip file local_file.zip
-zip = new Zip("local_file.zip"); 
+zip = new Zip("local_file.zip");
 // get all entries and iterate them
 zip.getEntries().forEach((entry) => {
     var entryName = entry.entryName;
     var decompressedData = zip.readFile(entry); // decompressed buffer of the entry
-    console.log(zip.readAsText(entry)); // outputs the decompressed content of the entry  
+    console.log(zip.readAsText(entry)); // outputs the decompressed content of the entry
 });
 
 // will extract the file myfile.txt from the archive to /home/user/folder/subfolder/myfile.txt

--- a/types/adm-zip/index.d.ts
+++ b/types/adm-zip/index.d.ts
@@ -65,14 +65,14 @@ declare class AdmZip {
      * @param callback Called with the resulting string.
      * @param encoding Optional. If no encoding is specified utf8 is used
      */
-    readAsTextAsync(fileName: string, callback: (data: string) => any, encoding?: string): void;
+    readAsTextAsync(fileName: string, callback: (data: string, err?: any) => any, encoding?: string): void;
     /**
      * Asynchronous readAsText
      * @param entry ZipEntry object
      * @param callback Called with the resulting string.
      * @param encoding Optional. If no encoding is specified utf8 is used
      */
-    readAsTextAsync(fileName: AdmZip.IZipEntry, callback: (data: string) => any, encoding?: string): void;
+    readAsTextAsync(fileName: AdmZip.IZipEntry, callback: (data: string, err?: any) => any, encoding?: string): void;
     /**
      * Remove the entry from the file or the entry and all its nested directories
      * and files if the given entry is a directory


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/cthackers/adm-zip/blob/master/zipEntry.js#L63
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
