### PR TITLE
fetch-mock: Add missing sandbox() definition

### DIFF
--- a/types/fetch-mock/fetch-mock-tests.ts
+++ b/types/fetch-mock/fetch-mock-tests.ts
@@ -92,3 +92,9 @@ fetchMock.get("http://test.com", {
     body: 'abc',
     redirectUrl: "http://example.org"
 });
+
+const sandbox = fetchMock.sandbox();
+sandbox.get("http://test.com", {
+    body: 'abc',
+    redirectUrl: "http://example.org"
+});

--- a/types/fetch-mock/index.d.ts
+++ b/types/fetch-mock/index.d.ts
@@ -187,6 +187,14 @@ declare namespace fetchMock {
         mock(options: MockOptions): this;
 
         /**
+         * Returns a drop-in mock for fetch which can be passed to other mocking
+         * libraries. It implements the full fetch-mock api and maintains its
+         * own state independent of other instances, so tests can be run in
+         * parallel.
+         */
+        sandbox(): FetchMockSandbox;
+
+        /**
          * Replaces fetch() with a stub which records its calls, grouped by
          * route, and optionally returns a mocked Response object or passes the
          *  call through to fetch(). Shorthand for mock() limited to being
@@ -425,6 +433,14 @@ declare namespace fetchMock {
          * lot of array buffers, it can be useful to default to `false`
          */
         configure(opts: {}): void;
+    }
+
+    interface FetchMockSandbox extends FetchMockStatic {
+        /**
+         * Also callable as fetch(). Use `typeof fetch` in your code to define
+         * a field that accepts both `fetch()` and a fetch-mock sandbox.
+         */
+        (input?: string | Request , init?: RequestInit): Promise<Response>;
     }
 }
 


### PR DESCRIPTION
Fixes #20421

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://www.wheresrhys.co.uk/fetch-mock/api#sandbox
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.