### PR TITLE
Express: `Response` `set`: allow array value

### DIFF
--- a/types/express-serve-static-core/index.d.ts
+++ b/types/express-serve-static-core/index.d.ts
@@ -707,6 +707,7 @@ export interface Response extends http.ServerResponse, Express.Response {
      */
     set(field: any): Response;
     set(field: string, value?: string): Response;
+    set(field: string, value?: string[]): Response;
 
     header(field: any): Response;
     header(field: string, value?: string): Response;


### PR DESCRIPTION
The [docs are ambiguous as to whether this is supported or not](https://expressjs.com/en/4x/api.html#res.set), but it works, and it's required for some use cases, e.g.

``` ts
const setCookieHeaderValues = ['foo=1', 'bar=2']
res.set('set-cookie', setCookieHeaderValues)

// response example:
// set-cookie: foo=1
// set-cookie: bar=2
```

Related https://github.com/expressjs/express/issues/2845

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
