### PR TITLE
added new property to IndividualSeriesOptions

### DIFF
--- a/types/highcharts/index.d.ts
+++ b/types/highcharts/index.d.ts
@@ -5436,6 +5436,11 @@ declare namespace Highcharts {
          * @default undefined
          */
         description?: string;
+		
+		/**
+         * Individual data label for each point. The options are the same as the ones for plotOptions.series.dataLabels
+         */
+        dataLabels?: DataLabels;
 
         /**
          * An id for the series. This can be used after render time to get a pointer to the series object through


### PR DESCRIPTION
added property 'dataLabels' to IndividualSeriesOptions interface as shown in official docs
https://www.highcharts.com/demo/column-rotated-labels -> check view options

Please fill in this template.

If changing an existing definition:
- [ x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.highcharts.com/demo/column-rotated-labels

