### PR TITLE
react-router-redux: Relax redux version constraint

### DIFF
--- a/types/react-router-redux/package.json
+++ b/types/react-router-redux/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "redux": "^3.7.2"
+        "redux": ">= 3.7.2"
     }
 }


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Now that Redux 4.0.0 has been released, depending on it and `@types/react-router-redux` causes this definition use an outdated version of Redux leading to type errors. The actual package does not impose such version constraints for the used Redux version and works with ^4.0.0 so it makes sense to relax the version constraint.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
