### PR TITLE
[Koa] Remove Context index signature

### DIFF
--- a/types/koa/index.d.ts
+++ b/types/koa/index.d.ts
@@ -659,8 +659,6 @@ declare namespace Application {
          * Default error handling.
          */
         onerror(err: Error): void;
-
-        [key: string]: any;
     }
 
     interface Request extends BaseRequest {

--- a/types/koa/koa-tests.ts
+++ b/types/koa/koa-tests.ts
@@ -1,8 +1,11 @@
 import Koa = require("koa");
 
 declare module 'koa' {
-    export interface Context {
+    export interface BaseContext {
         db(): void;
+    }
+    export interface Context {
+        user: {};
     }
 }
 
@@ -12,6 +15,7 @@ app.context.db = () => {};
 
 app.use(async ctx => {
     console.log(ctx.db);
+    ctx.user = {};
 });
 
 app.use((ctx, next) => {

--- a/types/koa/koa-tests.ts
+++ b/types/koa/koa-tests.ts
@@ -1,5 +1,11 @@
 import Koa = require("koa");
 
+declare module 'koa' {
+    export interface Context {
+        db(): void;
+    }
+}
+
 const app = new Koa();
 
 app.context.db = () => {};


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] ~~Provide a URL to documentation or source code which provides context for the suggested changes~~
- [ ] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.


-------------

In Koa, `Context` is passed through the various middleware and route functions as a kind of per-request state container. It can hold pretty much anything, which is why an index signature like `[key: string]: any` might seem to make sense.

However, by having this index signature, it effectively makes it impossible to strongly enforce types for the `context` object. Any mistyped property name will silently be treated as any by the index signature.

It is possible to create your own interface for the Context object within your app. This falls short in two ways though:

1. Anywhere you use the `app.context`. The `app` variable is typed as an `Application`, which brings along with it the `Context` type supplied in this package, rather than your own version.

2. There's no way to remove an index signature from a type, so your custom Context type definition must manually redefine all the various builtin properties normally supplied in this package's typedef.

As you can see, the index signature on Context causes some problems.

The stricter approach is to use module augmentation to add any properties necessary to the `Context` interface, rather than relying on an index signature, i.e.:

```ts
declare module 'koa' {
  export interface Context {
    myCustomProp: boolean;
  }
}
```

This allows you to strongly type your Context object in a way that doesn't open the door for silent `any`s to creep in.

And if that's too cumbersome for you, you can always add back the index signature yourself to restore the current behavior:

```ts
declare module 'koa' {
  export interface Context {
    [key: string]: any;
  }
}
```

I realize this may be an unpopular change, but unfortunately, since there's no way to _remove_ an index signature from a type, removing it here is the only way I can see to allow for enforcing types on Koa's `Context`.