### PR TITLE
react: change default type value of ComponentLifecycle snapshot to any

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -369,7 +369,7 @@ declare namespace React {
     // This should actually be something like `Lifecycle<P, S> | DeprecatedLifecycle<P, S>`,
     // as React will _not_ call the deprecated lifecycle methods if any of the new lifecycle
     // methods are present.
-    interface ComponentLifecycle<P, S, SS = never> extends NewLifecycle<P, S, SS>, DeprecatedLifecycle<P, S> {
+    interface ComponentLifecycle<P, S, SS = any> extends NewLifecycle<P, S, SS>, DeprecatedLifecycle<P, S> {
         /**
          * Called immediately after a compoment is mounted. Setting state here will trigger re-rendering.
          */


### PR DESCRIPTION
PR #24987 from a few weeks ago changed the snapshot type from `never` to `any` for Component and PureComponent, but did not change ComponentLifecycle in the same way. @jacobwgillespie 

As a result, a new class that extends both of these with the default snapshot type fails:

```typescript
export interface IMyInterface extends React.Component<any, any>, React.ComponentLifecycle<any, any> { ... }

Named property 'getSnapshotBeforeUpdate' of types 'Component<any, any, any>' and 'ComponentLifecycle<any, any, never>' are not identical.
```
eg. being used in the wild here: https://github.com/palantir/blueprint/blob/release/1.x/packages/core/src/components/hotkeys/hotkeysTarget.tsx#L13

This PR updates ComponentLifecycle to match Component and PureComponent.

I tried to add a test for this case, but receive a lint error that `Classes can only extend a single class.`. Presumably old versions of Typescript did not support this.

- [ x ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ x ] Test the change in your own code. (Compile and run.)
- [ x ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ x ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ x ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ x ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
