### PR TITLE
[run-parallel-limit] New typings for package

### DIFF
--- a/types/run-parallel-limit/index.d.ts
+++ b/types/run-parallel-limit/index.d.ts
@@ -1,0 +1,21 @@
+// Type definitions for run-parallel-limit 1.0
+// Project: https://github.com/feross/run-parallel-limit
+// Definitions by: mrmlnc <https://github.com/mrmlnc>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.1
+
+declare namespace RunParallelLimit {
+    type TaskCallback<T> = (err: Error | null, results?: T) => void;
+    type Task<T> = (callback: TaskCallback<T>) => void;
+    type TaskObj<T> = Record<string, Task<T>>;
+
+    type Callback<T> = (err: Error, results: T) => void;
+}
+
+declare function RunParallelLimit<T>(tasks: Array<RunParallelLimit.Task<T>>, limit: number): T[];
+declare function RunParallelLimit<T>(tasks: Array<RunParallelLimit.Task<T>>, limit: number, callback: RunParallelLimit.Callback<T[]>): void;
+
+declare function RunParallelLimit<T>(tasks: RunParallelLimit.TaskObj<T>, limit: number): Record<string, T>;
+declare function RunParallelLimit<T>(tasks: RunParallelLimit.TaskObj<T>, limit: number, callback: RunParallelLimit.Callback<Record<string, T>>): void;
+
+export = RunParallelLimit;

--- a/types/run-parallel-limit/run-parallel-limit-tests.ts
+++ b/types/run-parallel-limit/run-parallel-limit-tests.ts
@@ -1,0 +1,52 @@
+import rpl = require('run-parallel-limit');
+
+const tasks: Array<rpl.Task<string>> = [
+    (callback) => () => callback(null, 'string'),
+    (callback) => () => callback(new Error('boom')),
+
+    // $ExpectError
+    (callback) => () => callback(null, 1)
+];
+
+const justTaskCallback: rpl.TaskCallback<string> = (err, result) => {
+    // $ExpectType Error | null
+    err;
+
+    // $ExpectType string | undefined
+    result;
+};
+
+justTaskCallback(null, 'string');
+justTaskCallback(new Error('boom'));
+// $ExpectError
+justTaskCallback(null, 1);
+
+rpl(tasks, 5, (err, results) => {
+    // $ExpectType Error
+    err;
+
+    // $ExpectType string[]
+    results;
+});
+
+// $ExpectType string[]
+const results = rpl(tasks, 5);
+
+const tasksObj: rpl.TaskObj<string> = {
+    one: (callback) => () => callback(null, 'string'),
+    two: (callback) => () => callback(new Error('boom')),
+
+    // $ExpectError
+    three: (callback) => () => callback(1)
+};
+
+rpl(tasksObj, 5, (err, results) => {
+    // $ExpectType Error
+    err;
+
+    // $ExpectType Record<string, string>
+    results;
+});
+
+// $ExpectType Record<string, string>
+const resultsObj = rpl(tasksObj, 5);

--- a/types/run-parallel-limit/tsconfig.json
+++ b/types/run-parallel-limit/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "run-parallel-limit-tests.ts"
+    ]
+}

--- a/types/run-parallel-limit/tslint.json
+++ b/types/run-parallel-limit/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.