### PR TITLE
[ember] Ember.Application extends Ember.Engine

### DIFF
--- a/types/ember/index.d.ts
+++ b/types/ember/index.d.ts
@@ -390,7 +390,7 @@ declare module 'ember' {
         An instance of Ember.Application is the starting point for every Ember application. It helps to
         instantiate, initialize and coordinate the many objects that make up your app.
         **/
-        class Application extends Namespace {
+        class Application extends Engine {
             /**
             Call advanceReadiness after any asynchronous setup logic has completed.
             Each call to deferReadiness must be matched by a call to advanceReadiness
@@ -1056,11 +1056,17 @@ declare module 'ember' {
              */
             namespace: Application;
         }
+        interface Initializer<T> {
+            name: string;
+            before?: string[];
+            after?: string[];
+            initialize(application: T): void;
+        }
         /**
          * The `Engine` class contains core functionality for both applications and
          * engines.
          */
-        class Engine extends Namespace {
+        class Engine extends Namespace.extend(_RegistryProxyMixin) {
             /**
              * The goal of initializers should be to register dependencies and injections.
              * This phase runs once. Because these initializers may load code, they are
@@ -1069,14 +1075,14 @@ declare module 'ember' {
              * after all initializers and therefore after all code is loaded and the app is
              * ready.
              */
-            initializer(initializer: {}): any;
+            initializer(initializer: Initializer<Engine>): void;
             /**
              * Instance initializers run after all initializers have run. Because
              * instance initializers run after the app is fully set up. We have access
              * to the store, container, and other items. However, these initializers run
              * after code has loaded and are not allowed to defer readiness.
              */
-            instanceInitializer(instanceInitializer: any): any;
+            instanceInitializer(instanceInitializer: Initializer<EngineInstance>): void;
             /**
              * Set this to provide an alternate class to `Ember.DefaultResolver`
              */

--- a/types/ember/test/application.ts
+++ b/types/ember/test/application.ts
@@ -7,6 +7,20 @@ let App = Ember.Application.create({
     }
 });
 
+App.initializer({
+    name: 'my-initializer',
+    initialize(app) {
+        app.register('foo:bar', Ember.Object.extend({ foo: 'bar' }));
+    }
+});
+
+App.instanceInitializer({
+    name: 'my-instance-initializer',
+    initialize(app) {
+        app.lookup('foo:bar').get('foo');
+    }
+});
+
 let App2 = Ember.Application.create({
     customEvents: {
         mouseenter: null,


### PR DESCRIPTION
We had `Application` extending directly from `Namespace` before, meaning it didn't have `initializer` and `instanceInitializer` methods. This also improves the typings for those two methods (though this mostly doesn't matter, as people tend to use `ember-load-initializers` to make these calls implicitly anyway.)

`Ember.Application` is documented [here](https://emberjs.com/api/ember/3.1/classes/Application)

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://emberjs.com/api/ember/3.1/classes/Application