### PR TITLE
Add: null as a possible result for async find methods in loopback

### DIFF
--- a/types/loopback/index.d.ts
+++ b/types/loopback/index.d.ts
@@ -1490,7 +1490,7 @@ declare namespace l {
                         skip?: number;
                         where?: any;
                   }
-            ): Promise<T[]>;
+            ): Promise<T[] | null>;
 
             /**
              * Find object by ID with an optional filter for include/fields
@@ -1540,7 +1540,7 @@ declare namespace l {
                         fields?: string|any|any[];
                         include?: string|any|any[];
                   },
-            ): Promise<T>;
+            ): Promise<T | null>;
 
             /**
              * Find one model instance that matches `filter` specification.
@@ -1616,7 +1616,7 @@ declare namespace l {
                         skip?: number;
                         where?: any;
                   }
-            ): Promise<T>;
+            ): Promise<T | null>;
 
             /**
              * Finds one record matching the optional filter object. If not found, creates
@@ -1715,7 +1715,7 @@ declare namespace l {
                         skip?: number;
                         where?: any;
                   }
-            ): Promise<{instance: T, created: boolean}>;
+            ): Promise<{instance: T, created: boolean} | null>;
 
             /**
              * Get the `Change` model.

--- a/types/loopback/index.d.ts
+++ b/types/loopback/index.d.ts
@@ -1416,17 +1416,6 @@ declare namespace l {
             /**
              * Find all model instances that match `filter` specification.
              * See [Querying models](docs.strongloop.com/display/LB/Querying+models)
-             * @callback {() => void} callback Callback function called with `(err, returned-instances)` arguments.    Required.
-             * @param {Error} err Error object; see [Error object](docs.strongloop.com/display/LB/Error+object).
-             * @param {Array} models Model instances matching the filter, or null if none found
-             */
-            static find<T = any>(
-                  callback: CallbackWithResult<T[]>
-            ): void;
-
-            /**
-             * Find all model instances that match `filter` specification.
-             * See [Querying models](docs.strongloop.com/display/LB/Querying+models)
              * @options {any} [filter] Optional Filter JSON object; see below.
              * @property {string|any|Array} fields Identify fields to include in return result.
              * <br/>See [Fields filter](docs.strongloop.com/display/LB/Fields+filter).


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: `N/a.`
- [ ] Increase the version number in the header if appropriate: `N/a.`
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`: `N/a.`

**Explanation:**

 * In my previous PR, I accidentally did `Promise<T>` for all the find methods but the find methods actually return `null` instead of error-ing out when nothing is found.

 * There are two possible signatures for `find()` with an arity of 1 - it is possible to pass only a remote filter or to pass only a callback. I removed the callback one in favour of the promise-based one - not sure if this is the best call but promises are widely supported now so not sure if there is any value in keeping the callback one.
