### PR TITLE
Add all parser options to express-xml-bodyparser

### DIFF
--- a/types/express-xml-bodyparser/express-xml-bodyparser-tests.ts
+++ b/types/express-xml-bodyparser/express-xml-bodyparser-tests.ts
@@ -3,8 +3,54 @@ import xmlparser = require('express-xml-bodyparser');
 
 const app: express.Express = express();
 
+// xml-parser with no options
 app.use(xmlparser());
 
-app.post("/auth", xmlparser({explicitArray: false}), (req, res, next) => {
-    res.send("Success!");
-});
+// xml-parser with implicit default options
+app.use(xmlparser({}));
+
+// xml-parser with explicit default options
+app.use(xmlparser({
+    async: false,
+    explicitArray: true,
+    normalize: true,
+    normalizeTags: true,
+    trim: true
+}));
+
+// xml-parser with all options
+app.use(xmlparser({
+    async: true,
+    attrkey: 'attrkey',
+    attrNameProcessors: [(name => String.fromCharCode((42 + name.length) & 127))],
+    attrValueProcessors: [(name => String.fromCharCode((24 + name.length) & 127))],
+    charkey: 'charKey',
+    charsAsChildren: true,
+    childkey: 'childkey',
+    emptyTag: 'emptyTag',
+    explicitArray: true,
+    explicitCharkey: true,
+    explicitChildren: true,
+    explicitRoot: true,
+    ignoreAttrs: false,
+    includeWhiteChars: false,
+    mergeAttrs: true,
+    normalize: true,
+    normalizeTags: true,
+    strict: true,
+    tagNameProcessors: [(name) => name.toLocaleLowerCase()],
+    trim: true,
+    validator: () => false,
+    valueProcessors: [],
+    xmlns: true,
+}));
+
+// xml-parser as route middleware with custom options
+const routeMiddleware: express.Handler = xmlparser({ explicitArray: false, strict: false });
+const routeHandler: express.RequestHandler = (req: express.Request, res: express.Response, next: express.NextFunction) => {
+    res.send('Success!');
+};
+app.post('/auth', [routeMiddleware], routeHandler);
+
+// overriding mime-type regexp
+xmlparser.regexp = /text\/(stranger|things)/;

--- a/types/express-xml-bodyparser/index.d.ts
+++ b/types/express-xml-bodyparser/index.d.ts
@@ -1,23 +1,19 @@
 // Type definitions for express-xml-bodyparser 0.3
 // Project: https://github.com/macedigital/express-xml-bodyparser
-// Definitions by: Notice Maker <https://github.com/noticeMaker>
+// Definitions by:  Notice Maker <https://github.com/noticeMaker>
+//                  Matthias Adler <https://github.com/macedigital>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
-import { Request, Response, NextFunction } from 'express';
+import { Handler } from 'express';
 
-declare function xmlparser(options?: xmlparser.XmlparserOptions): (req: Request, res: Response, next: NextFunction) => void;
+import { Options as XmlParserOptions } from 'xml2js';
+
+declare function xmlparser(options?: XmlParserOptions): Handler;
 
 declare namespace xmlparser {
+    // @deprecated Will be removed in future versions
     let regexp: RegExp;
-
-    interface XmlparserOptions {
-        async?: boolean;
-        explicitArray?: boolean;
-        normalize?: boolean;
-        normalizeTags?: boolean;
-        trim?: boolean;
-    }
 }
 
 export = xmlparser;


### PR DESCRIPTION
All `xml2js` configuration options can be passed into the `express-xml-bodyparser` middleware,
not only a select few.

Add test to assert that it is possible to change regexp even though this potentially affects
all parser instances.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/Leonidas-from-XIV/node-xml2js#options>
- [ ] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

