### PR TITLE
[react-native-sqlite-storage] Added promise support 

### DIFF
--- a/types/react-native-sqlite-storage/index.d.ts
+++ b/types/react-native-sqlite-storage/index.d.ts
@@ -10,8 +10,8 @@ export function enablePromise(enablePromise: boolean): void;
 
 export function openDatabase(params: DatabaseParams): Promise<SQLiteDatabase>;
 export function openDatabase(params: DatabaseParams, success?: () => void, error?: (e: SQLError) => void): SQLiteDatabase;
-export function deleteDatabase(params: DatabaseParams, success?: () => void, error?: (err: SQLError) => void): void;
 export function deleteDatabase(params: DatabaseParams): Promise<void>;
+export function deleteDatabase(params: DatabaseParams, success?: () => void, error?: (err: SQLError) => void): void;
 export type Location = 'default' | 'Library' | 'Documents';
 export interface DatabaseOptionalParams {
     createFromLocation?: number | string;

--- a/types/react-native-sqlite-storage/index.d.ts
+++ b/types/react-native-sqlite-storage/index.d.ts
@@ -61,14 +61,12 @@ export interface SQLError {
 export type StatementCallback = (transaction: Transaction, resultSet: ResultSet) => void;
 export type StatementErrorCallback = (transaction: Transaction, error: SQLError) => void;
 export interface Transaction {
-    executeSql(sqlStatement: string, arguments?: any[]): Promise<TransactionResultSetPromise>;
+    executeSql(sqlStatement: string, arguments?: any[]): Promise<[Transaction, ResultSet]>;
     executeSql(sqlStatement: string, arguments?: any[], callback?: StatementCallback, errorCallback?: StatementErrorCallback): void;
 }
 
 export type TransactionCallback = (transaction: Transaction) => void;
 export type TransactionErrorCallback = (error: SQLError) => void;
-export type ResultSetPromise = [ResultSet];
-export type TransactionResultSetPromise = [Transaction, ResultSet];
 
 export interface SQLiteDatabase {
     transaction(scope: (tx: Transaction) => void): Promise<Transaction>;
@@ -77,7 +75,7 @@ export interface SQLiteDatabase {
     readTransaction(scope: (tx: Transaction) => void, error?: TransactionErrorCallback, success?: TransactionCallback): void;
     close(): Promise<void>;
     close(success: () => void, error: (err: SQLError) => void): void;
-    executeSql(statement: string, params?: any[]): Promise<ResultSetPromise>;
+    executeSql(statement: string, params?: any[]): Promise<[ResultSet]>;
     executeSql(statement: string, params?: any[], success?: StatementCallback, error?: StatementErrorCallback): void;
 
     attach(nameToAttach: string, alias: string): Promise<void>;

--- a/types/react-native-sqlite-storage/index.d.ts
+++ b/types/react-native-sqlite-storage/index.d.ts
@@ -61,14 +61,14 @@ export interface SQLError {
 export type StatementCallback = (transaction: Transaction, resultSet: ResultSet) => void;
 export type StatementErrorCallback = (transaction: Transaction, error: SQLError) => void;
 export interface Transaction {
-    executeSql(sqlStatement: string, arguments?: any[]): Promise<TransactionStatementPromise>;
+    executeSql(sqlStatement: string, arguments?: any[]): Promise<TransactionResultSetPromise>;
     executeSql(sqlStatement: string, arguments?: any[], callback?: StatementCallback, errorCallback?: StatementErrorCallback): void;
 }
 
 export type TransactionCallback = (transaction: Transaction) => void;
 export type TransactionErrorCallback = (error: SQLError) => void;
-export type StatementPromise = [ResultSet];
-export type TransactionStatementPromise = [Transaction, ResultSet];
+export type ResultSetPromise = [ResultSet];
+export type TransactionResultSetPromise = [Transaction, ResultSet];
 
 export interface SQLiteDatabase {
     transaction(scope: (tx: Transaction) => void): Promise<Transaction>;
@@ -77,7 +77,7 @@ export interface SQLiteDatabase {
     readTransaction(scope: (tx: Transaction) => void, error?: TransactionErrorCallback, success?: TransactionCallback): void;
     close(): Promise<void>;
     close(success: () => void, error: (err: SQLError) => void): void;
-    executeSql(statement: string, params?: any[]): Promise<StatementPromise>;
+    executeSql(statement: string, params?: any[]): Promise<ResultSetPromise>;
     executeSql(statement: string, params?: any[], success?: StatementCallback, error?: StatementErrorCallback): void;
 
     attach(nameToAttach: string, alias: string): Promise<void>;

--- a/types/react-native-sqlite-storage/index.d.ts
+++ b/types/react-native-sqlite-storage/index.d.ts
@@ -1,11 +1,17 @@
 // Type definitions for react-native-sqlite-storage 3.3
 // Project: https://github.com/andpor/react-native-sqlite-storage
 // Definitions by: Sergei Dryganets <https://github.com/dryganets>
+//                 Deividi Cavarzan <https://github.com/cavarzan>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.4
 
+export function DEBUG(isDebug: boolean): void;
+export function enablePromise(enablePromise: boolean): void;
+
+export function openDatabase(params: DatabaseParams): Promise<SQLiteDatabase>;
 export function openDatabase(params: DatabaseParams, success?: () => void, error?: (e: SQLError) => void): SQLiteDatabase;
 export function deleteDatabase(params: DatabaseParams, success?: () => void, error?: (err: SQLError) => void): void;
+export function deleteDatabase(params: DatabaseParams): Promise<void>;
 export type Location = 'default' | 'Library' | 'Documents';
 export interface DatabaseOptionalParams {
     createFromLocation?: number | string;
@@ -55,17 +61,28 @@ export interface SQLError {
 export type StatementCallback = (transaction: Transaction, resultSet: ResultSet) => void;
 export type StatementErrorCallback = (transaction: Transaction, error: SQLError) => void;
 export interface Transaction {
+    executeSql(sqlStatement: string, arguments?: any[]): Promise<TransactionStatementPromise>;
     executeSql(sqlStatement: string, arguments?: any[], callback?: StatementCallback, errorCallback?: StatementErrorCallback): void;
 }
 
 export type TransactionCallback = (transaction: Transaction) => void;
 export type TransactionErrorCallback = (error: SQLError) => void;
+export type StatementPromise = [ResultSet];
+export type TransactionStatementPromise = [Transaction, ResultSet];
 
 export interface SQLiteDatabase {
+    transaction(scope: (tx: Transaction) => void): Promise<Transaction>;
     transaction(scope: (tx: Transaction) => void, error?: TransactionErrorCallback, success?: TransactionCallback): void;
+    readTransaction(scope: (tx: Transaction) => void): Promise<TransactionCallback>;
     readTransaction(scope: (tx: Transaction) => void, error?: TransactionErrorCallback, success?: TransactionCallback): void;
+    close(): Promise<void>;
     close(success: () => void, error: (err: SQLError) => void): void;
+    executeSql(statement: string, params?: any[]): Promise<StatementPromise>;
     executeSql(statement: string, params?: any[], success?: StatementCallback, error?: StatementErrorCallback): void;
+
+    attach(nameToAttach: string, alias: string): Promise<void>;
     attach(nameToAttach: string, alias: string, success?: () => void, error?: (err: SQLError) => void): void;
+
+    dettach(alias: string): Promise<void>;
     dettach(alias: string, success?: () => void, error?: (err: SQLError) => void): void;
 }

--- a/types/react-native-sqlite-storage/react-native-sqlite-storage-tests.ts
+++ b/types/react-native-sqlite-storage/react-native-sqlite-storage-tests.ts
@@ -1,16 +1,40 @@
 import * as sqlite from 'react-native-sqlite-storage';
 
-const db = sqlite.openDatabase({name: 'test.db', location: 'default'}, () => {
-    db.transaction((tx) => {
-        tx.executeSql('SELECT * FROM Employees a, Departments b WHERE a.department = b.department_id', [], (tx, results) => {
-            // Get rows with Web SQL Database spec compliance.
-            const len = results.rows.length;
-            for (let i = 0; i < len; i++) {
-              const row = results.rows.item(i);
-              const log = `Employee name: ${row.name}, Dept Name: ${row.deptName}`;
-            }
-          });
-      });
-}, (err) => {
-    // log error
+const db = sqlite.openDatabase(
+    { name: 'test.db', location: 'default' },
+    () => {
+        db.transaction((tx) => {
+            tx.executeSql('SELECT * FROM Employees a, Departments b WHERE a.department = b.department_id', [], (tx, results) => {
+                // Get rows with Web SQL Database spec compliance.
+                const len = results.rows.length;
+                for (let i = 0; i < len; i++) {
+                    const row = results.rows.item(i);
+                    const log = `Employee name: ${row.name}, Dept Name: ${row.deptName}`;
+                }
+            });
+        });
+    },
+    (err) => {
+        // log error
+    }
+);
+
+sqlite.openDatabase({ name: 'test.db', location: 'default' }).then((db) => {
+    db
+        .transaction((tx) => {
+            tx
+                .executeSql('SELECT * FROM Employees a, Departments b WHERE a.department = b.department_id', [])
+                .then((result: sqlite.TransactionStatementPromise) => {
+                    // handle result
+                });
+        })
+        .then(() => {
+            // handle transaction finished
+        })
+        .catch((e: sqlite.SQLError) => {
+            // log error
+        });
+    db.executeSql('SELECT * FROM Employees a, Departments b WHERE a.department = b.department_id', []).then((result: sqlite.StatementPromise) => {
+        // handle result
+    });
 });

--- a/types/react-native-sqlite-storage/react-native-sqlite-storage-tests.ts
+++ b/types/react-native-sqlite-storage/react-native-sqlite-storage-tests.ts
@@ -24,7 +24,7 @@ sqlite.openDatabase({ name: 'test.db', location: 'default' }).then((db) => {
         .transaction((tx) => {
             tx
                 .executeSql('SELECT * FROM Employees a, Departments b WHERE a.department = b.department_id', [])
-                .then((result: sqlite.TransactionStatementPromise) => {
+                .then((result: sqlite.TransactionResultSetPromise) => {
                     // handle result
                 });
         })
@@ -34,7 +34,7 @@ sqlite.openDatabase({ name: 'test.db', location: 'default' }).then((db) => {
         .catch((e: sqlite.SQLError) => {
             // log error
         });
-    db.executeSql('SELECT * FROM Employees a, Departments b WHERE a.department = b.department_id', []).then((result: sqlite.StatementPromise) => {
+    db.executeSql('SELECT * FROM Employees a, Departments b WHERE a.department = b.department_id', []).then((result: sqlite.ResultSetPromise) => {
         // handle result
     });
 });

--- a/types/react-native-sqlite-storage/react-native-sqlite-storage-tests.ts
+++ b/types/react-native-sqlite-storage/react-native-sqlite-storage-tests.ts
@@ -24,7 +24,7 @@ sqlite.openDatabase({ name: 'test.db', location: 'default' }).then((db) => {
         .transaction((tx) => {
             tx
                 .executeSql('SELECT * FROM Employees a, Departments b WHERE a.department = b.department_id', [])
-                .then((result: sqlite.TransactionResultSetPromise) => {
+                .then((result: [sqlite.Transaction, sqlite.ResultSet]) => {
                     // handle result
                 });
         })
@@ -34,7 +34,7 @@ sqlite.openDatabase({ name: 'test.db', location: 'default' }).then((db) => {
         .catch((e: sqlite.SQLError) => {
             // log error
         });
-    db.executeSql('SELECT * FROM Employees a, Departments b WHERE a.department = b.department_id', []).then((result: sqlite.ResultSetPromise) => {
+    db.executeSql('SELECT * FROM Employees a, Departments b WHERE a.department = b.department_id', []).then((result: [sqlite.ResultSet]) => {
         // handle result
     });
 });


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/andpor/react-native-sqlite-storage/blob/master/test/index.ios.promise.js 
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

## Motivation

react-native-sqlite-storage provides out-of-the-box support for promises by using `enablePromise` method call. This provides an behavior that all methods replaces the success and error callbacks into a promise.

Both strategies can be used (callbacks or promises), this PR will won't make any breaking changes into the current version and current usage.

