### PR TITLE
[redux-form] Add missing properties in InitializeOptions and Reset

### DIFF
--- a/types/redux-form/v6/lib/actionTypes.d.ts
+++ b/types/redux-form/v6/lib/actionTypes.d.ts
@@ -20,6 +20,7 @@ export interface ActionTypes {
     INITIALIZE: string;
     REGISTER_FIELD: string;
     RESET: string;
+    RESET_SECTION: string;
     SET_SUBMIT_FAILED: string;
     SET_SUBMIT_SUCCEEDED: string;
     START_ASYNC_VALIDATION: string;

--- a/types/redux-form/v6/lib/actions.d.ts
+++ b/types/redux-form/v6/lib/actions.d.ts
@@ -115,6 +115,11 @@ export function registerField(form: string, name: string, type: FieldType): Form
 export function reset(form: string): FormAction;
 
 /**
+ * Resets the values in the form sections back to the values past in with the most recent initialize action. 
+ */
+export function resetSection(form: string, ...sections: string[]): FormAction;
+
+/**
  * Flips the asyncValidating flag true
  */
 export function startAsyncValidation(form: string): FormAction;

--- a/types/redux-form/v6/lib/actions.d.ts
+++ b/types/redux-form/v6/lib/actions.d.ts
@@ -84,14 +84,22 @@ export function destroy(...form: string[]): FormAction;
 export function focus(form: string, field: string): FormAction;
 
 /**
- * Sets the initial values in the form with which future data values will be compared to calculate dirty and pristine.
- * The data parameter may contain deep nested array and object values that match the shape of your form fields.
- * If the keepDirty parameter is true, the values of the currently dirty fields will be retained to avoid overwriting
- * user edits.
+ * Sets the initial values in the form with which future data values will be compared to calculate dirty and pristine. 
+ * 
+ * If the keepDirty parameter is true, the values of currently dirty fields will be retained to avoid overwriting user edits.
+ * 
+ * If the keepSubmitSucceeded parameter is true, it will not clear the submitSucceeded flag if it is set.
+ * 
+ * If the updateUnregisteredFields parameter is true, it will update every initialValue if still pristine instead of only 
+ * registered fields. Highly recommended, defaults to false because of non-breaking backwards compatibility.
+ * 
+ * If the keepValues parameter is true, it will keep the old values and initial values.
  */
 interface InitializeOptions {
     keepDirty: boolean;
     keepSubmitSucceeded: boolean;
+    updateUnregisteredFields: boolean;
+    keepValues: boolean;
 }
 
 export function initialize(form: string, data: any, keepDirty?: boolean | InitializeOptions, options?: InitializeOptions): FormAction;

--- a/types/redux-form/v6/lib/reduxForm.d.ts
+++ b/types/redux-form/v6/lib/reduxForm.d.ts
@@ -519,6 +519,11 @@ export interface StrictFormProps<FormData extends DataShape, P, S> {
     reset(): void;
 
     /**
+     * Resets the form sections to the initialValues. It will be pristine after reset.
+     */
+    resetSection(...sections: string[]) : void;
+
+    /**
      * Whether or not your form is currently submitting. This prop will only
      * work if you have passed an onSubmit function that returns a promise. It
      * will be true until the promise is resolved or rejected.


### PR DESCRIPTION
Fixes #25534 

This adds missing properties from the InitializeOptions action as well as new resetSection method/action introduced in 7.3.0 

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: 
  - Initialize: https://redux-form.com/7.3.0/docs/api/actioncreators.md/#-code-initialize-form-string-data-object-keepdirty-boolean-options-keepdirty-boolean-keepsubmitsucceeded-boolean-updateunregisteredfields-boolean-keepvalues-boolean-code-  
  - resetSection method: https://redux-form.com/7.3.0/docs/api/reduxform.md/#-code-resetsection-sections-string-void-code-
  - resetSection action creator: https://redux-form.com/7.3.0/docs/api/actioncreators.md/#-code-resetsection-form-string-sections-string-code-
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

