### PR TITLE
S3rver: Add `declare namespace S3rver` to fix import

### DIFF
--- a/types/s3rver/index.d.ts
+++ b/types/s3rver/index.d.ts
@@ -28,4 +28,6 @@ interface S3rverOptions {
     directory: string;
 }
 
+declare namespace S3rver {}
+
 export = S3rver;


### PR DESCRIPTION
- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: N/A
- [X] Increase the version number in the header if appropriate.
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

---

With the current state of these typings, I'm not actually able to import this library, it fails with a `Module resolves to a non-module entity and cannot be imported using this construct.` error, when attempting to import it as `import * as S3rver from 's3rver'`.  

I'll admit I don't have the strongest understanding of `namespace` and modules, but I believe this is the "standard incantation" for imported libraries.