### PR TITLE
Add src to media in reactstrap

### DIFF
--- a/types/reactstrap/lib/Media.d.ts
+++ b/types/reactstrap/lib/Media.d.ts
@@ -13,6 +13,7 @@ export interface MediaProps extends React.HTMLAttributes<HTMLElement> {
   right?: boolean;
   tag?: React.ReactType;
   top?: boolean;
+  src?: string;
   href?: string;
   alt?: string;
 }


### PR DESCRIPTION
I extended the type definition of the Media component of reactstrap.