### PR TITLE
Jasmine: Adds negativeCompare to CustomMatcher

### DIFF
--- a/types/jasmine/index.d.ts
+++ b/types/jasmine/index.d.ts
@@ -221,6 +221,8 @@ declare namespace jasmine {
     interface CustomMatcher {
         compare<T>(actual: T, expected: T, ...args: any[]): CustomMatcherResult;
         compare(actual: any, ...expected: any[]): CustomMatcherResult;
+        negativeCompare?<T>(actual: T, expected: T, ...args: any[]): CustomMatcherResult;
+        negativeCompare?(actual: any, ...expected: any[]): CustomMatcherResult;
     }
 
     type CustomMatcherFactory = (util: MatchersUtil, customEqualityTesters: CustomEqualityTester[]) => CustomMatcher;

--- a/types/jasmine/jasmine-tests.ts
+++ b/types/jasmine/jasmine-tests.ts
@@ -968,7 +968,13 @@ var customMatchers: jasmine.CustomMatcherFactories = {
         return {
             compare: (actual: any, floor: number, ceiling: number): jasmine.CustomMatcherResult => {
                 const pass = actual >= floor && actual <= ceiling;
-                const message = `expected ${actual} ${pass ? 'not ' : ''} to be within range ${floor}-${ceiling}`;
+                const message = `expected ${actual} to be within range ${floor}-${ceiling}`;
+                return { message, pass };
+            },
+
+            negativeCompare: (actual: any, floor: number, ceiling: number): jasmine.CustomMatcherResult => {
+                const pass = actual < floor && actual > ceiling;
+                const message = `expected ${actual} not to be within range ${floor}-${ceiling}`;
                 return { message, pass };
             }
         };
@@ -1009,6 +1015,14 @@ describe("Custom matcher: 'toBeGoofy'", () => {
 
     it("can take many 'expected' parameters", () => {
         expect(2).toBeWithinRange(1, 3);
+    });
+
+    it("can use the custom negativeCompare method", () => {
+        const matcher = customMatchers["toBeWithinRange"](jasmine.matchersUtil, []);
+        const result = matcher.negativeCompare!(1, 2, 3);
+
+        expect(result.pass).toBe(false);
+        expect(result.message).toBe("expected 1 not to be within range 2-3");
     });
 
     it("can be negated", () => {


### PR DESCRIPTION
Jasmine allows a CustomMatcher to define an optional `negativeCompare` method,
to handle the `.not` assertions.

See https://jasmine.github.io/2.8/custom_matcher.html#section-Custom_negative_comparators

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://jasmine.github.io/2.8/custom_matcher.html#section-Custom_negative_comparators
- [x] Increase the version number in the header if appropriate: not needed
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`: not needed
