### PR TITLE
ejs: Add support for the async option

### DIFF
--- a/types/ejs/ejs-tests.ts
+++ b/types/ejs/ejs-tests.ts
@@ -3,7 +3,7 @@
 import ejs = require("ejs");
 import { readFileSync as read } from 'fs';
 import LRU = require("lru-cache");
-import { TemplateFunction, Options } from "ejs";
+import { TemplateFunction, AsyncTemplateFunction, Options } from "ejs";
 
 const fileName = 'test.ejs';
 const people = ['geddy', 'neil', 'alex'];
@@ -12,6 +12,8 @@ const template = '<%= people.join(", "); %>';
 const options = { filename: fileName };
 let result: string;
 let ejsFunction: TemplateFunction;
+let asyncResult: Promise<string>;
+let ejsAsyncFunction: AsyncTemplateFunction;
 
 const SimpleCallback = (err: any, html?: string) => {
     if (err) {
@@ -44,10 +46,18 @@ ejsFunction = ejs.compile('<%= it.people.join(", "); %>', { _with: false, locals
 ejsFunction = ejs.compile(template, { rmWhitespace: true });
 const customEscape = (str: string) => !str ? '' : str.toUpperCase();
 ejsFunction = ejs.compile(template, { escape: customEscape });
+ejsFunction = ejs.compile(template, { async: false });
+
+ejsAsyncFunction = ejs.compile(template, { async: true });
+ejsAsyncFunction = ejs.compile(template, { client: true, async: true });
 
 result = ejsFunction();
 result = ejsFunction({});
 result = ejsFunction(data);
+
+asyncResult = ejsAsyncFunction();
+asyncResult = ejsAsyncFunction({});
+asyncResult = ejsAsyncFunction(data);
 
 /** @see https://github.com/mde/ejs/tree/v2.5.7#custom-fileloader */
 ejs.fileLoader = (path: string) => "";

--- a/types/ejs/index.d.ts
+++ b/types/ejs/index.d.ts
@@ -2,7 +2,7 @@
 // Project: http://ejs.co/
 // Definitions by: Ben Liddicott <https://github.com/benliddicott>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.4
+// TypeScript Version: 2.8
 
 export interface Data {
     [name: string]: any;
@@ -28,14 +28,22 @@ export function resolveInclude(name: string, filename: string, isDir: boolean): 
 /**
  * Compile the given `str` of ejs into a template function.
  */
-export function compile(template: string, opts?: Options): (TemplateFunction);
+export function compile(template: string, opts?: Options & { async: false }): TemplateFunction;
+export function compile(template: string, opts: Options & { async: true }): AsyncTemplateFunction;
+export function compile(template: string, opts: Options & { async: boolean }): TemplateFunction | AsyncTemplateFunction;
+export function compile(template: string, opts: Exclude<Options, { async: any }>): TemplateFunction;
+export function compile(template: string, opts?: Options): TemplateFunction | AsyncTemplateFunction;
 /**
  * Render the given `template` of ejs.
  *
  * If you would like to include options but not data, you need to explicitly
  * call this function with `data` being an empty object or `null`.
  */
-export function render(template: string, data?: Data, opts?: Options): string;
+export function render(template: string, data?: Data, opts?: Options & { async: false }): string;
+export function render(template: string, data: Data, opts: Options & { async: true }): Promise<string>;
+export function render(template: string, data: Data, opts: Options & { async: boolean }): string | Promise<string>;
+export function render(template: string, data: Data, opts: Exclude<Options, { async: any }>): string;
+export function render(template: string, data?: Data, opts?: Options): string | Promise<string>;
 
 export type RenderFileCallback<T> = (err: Error, str?: string) => T;
 
@@ -55,6 +63,7 @@ export function renderFile<T>(path: string, data: Data, opts: Options, cb: Rende
 export function clearCache(): void;
 
 export type TemplateFunction = (data?: Data) => string;
+export type AsyncTemplateFunction = (data?: Data) => Promise<string>;
 export interface Options {
     /** Compiled functions are cached, requires `filename` */
     cache?: boolean;
@@ -95,6 +104,8 @@ export interface Options {
      * (By default escapes XML).
      */
     escape?(str: string): string;
+    /** Whether or not to use a Promise */
+    async?: boolean;
 }
 
 export function escapeRegexChars(s: string): string;

--- a/types/ejs/index.d.ts
+++ b/types/ejs/index.d.ts
@@ -2,7 +2,7 @@
 // Project: http://ejs.co/
 // Definitions by: Ben Liddicott <https://github.com/benliddicott>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.8
+// TypeScript Version: 2.4
 
 export interface Data {
     [name: string]: any;
@@ -30,8 +30,7 @@ export function resolveInclude(name: string, filename: string, isDir: boolean): 
  */
 export function compile(template: string, opts?: Options & { async: false }): TemplateFunction;
 export function compile(template: string, opts: Options & { async: true }): AsyncTemplateFunction;
-export function compile(template: string, opts: Options & { async: boolean }): TemplateFunction | AsyncTemplateFunction;
-export function compile(template: string, opts: Exclude<Options, { async: any }>): TemplateFunction;
+export function compile(template: string, opts: Options & { async?: never }): TemplateFunction;
 export function compile(template: string, opts?: Options): TemplateFunction | AsyncTemplateFunction;
 /**
  * Render the given `template` of ejs.
@@ -40,9 +39,8 @@ export function compile(template: string, opts?: Options): TemplateFunction | As
  * call this function with `data` being an empty object or `null`.
  */
 export function render(template: string, data?: Data, opts?: Options & { async: false }): string;
-export function render(template: string, data: Data, opts: Options & { async: true }): Promise<string>;
-export function render(template: string, data: Data, opts: Options & { async: boolean }): string | Promise<string>;
-export function render(template: string, data: Data, opts: Exclude<Options, { async: any }>): string;
+export function render(template: string, data: Data | undefined, opts: Options & { async: true }): Promise<string>;
+export function render(template: string, data: Data | undefined, opts: Options & { async?: never }): string;
 export function render(template: string, data?: Data, opts?: Options): string | Promise<string>;
 
 export type RenderFileCallback<T> = (err: Error, str?: string) => T;

--- a/types/ejs/index.d.ts
+++ b/types/ejs/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for ejs.js 2.5
+// Type definitions for ejs.js 2.6
 // Project: http://ejs.co/
 // Definitions by: Ben Liddicott <https://github.com/benliddicott>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/mem-fs-editor/index.d.ts
+++ b/types/mem-fs-editor/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/SBoudrias/mem-fs-editor#readme
 // Definitions by: My Food Bag <https://github.com/MyFoodBag>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.4
+// TypeScript Version: 2.8
 
 /// <reference types="node" />
 

--- a/types/mem-fs-editor/index.d.ts
+++ b/types/mem-fs-editor/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/SBoudrias/mem-fs-editor#readme
 // Definitions by: My Food Bag <https://github.com/MyFoodBag>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.8
+// TypeScript Version: 2.4
 
 /// <reference types="node" />
 


### PR DESCRIPTION
- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/mde/ejs/pull/343
- [X] Increase the version number in the header if appropriate.
- [ ] ~~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.~~ (Already present.)

I won't mince words here: This is ugly. But it works, and preserves backwards compatibility, as far as I can tell. If anyone has a better idea for how to do this, in particular one that doesn't require 2.8, please do it or post about it here.