### PR TITLE
[unzip] Add stream.PassThrough as super interface

### DIFF
--- a/types/unzip/index.d.ts
+++ b/types/unzip/index.d.ts
@@ -4,6 +4,8 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 /// <reference types="node" />
 
+import stream = require('stream');
+
 export function Extract(options: { path: string }): NodeJS.WritableStream;
 export function Parse(): NodeJS.WritableStream;
 
@@ -24,7 +26,7 @@ export function Parse(): NodeJS.WritableStream;
  *  });
  * ```
  */
-export interface Entry {
+export interface Entry extends stream.PassThrough {
     path: string;
     type: 'Directory' | 'File';
     size: number;

--- a/types/unzip/index.d.ts
+++ b/types/unzip/index.d.ts
@@ -30,6 +30,5 @@ export interface Entry extends stream.PassThrough {
     path: string;
     type: 'Directory' | 'File';
     size: number;
-    pipe: (stream: NodeJS.WritableStream) => void;
     autodrain: () => void;
 }


### PR DESCRIPTION
The unzip entry interface actually extends stream.PassThrough as seen here: https://github.com/EvanOxfeld/node-unzip/blob/master/lib/entry.js#L8

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [no behavior change] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/EvanOxfeld/node-unzip/blob/master/lib/entry.js#L8
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
