### PR TITLE
[react-stripe-elements] - Allow options to be passed to StripeProvider

### DIFF
--- a/types/react-stripe-elements/index.d.ts
+++ b/types/react-stripe-elements/index.d.ts
@@ -27,7 +27,10 @@ export namespace ReactStripeElements {
 		error?: { decline_code?: string };
 	};
 
-    type StripeProviderProps = { apiKey: string; stripe?: never; } | { apiKey?: never; stripe: StripeProps | null; };
+	interface StripeProviderOptions {
+		stripeAccount?: string;
+	}
+	type StripeProviderProps = { apiKey: string; stripe?: never; options?: StripeProviderOptions } | { apiKey?: never; stripe: StripeProps | null; options?: StripeProviderOptions; };
 
 	interface StripeProps {
 		createSource(sourceData?: SourceOptions): Promise<SourceResponse>;

--- a/types/react-stripe-elements/react-stripe-elements-tests.tsx
+++ b/types/react-stripe-elements/react-stripe-elements-tests.tsx
@@ -195,3 +195,8 @@ const TestStripeProviderProps2: React.SFC<{
 const TestStripeProviderProps3: React.SFC<{
     stripe: StripeProps;
 }> = props => <StripeProvider stripe={null} />;
+
+/**
+ * StripeProvider should be able to accept an `options` prop
+ */
+const TestStripeProviderOptions: React.SFC = () => <StripeProvider apiKey="" options={{stripeAccount: ""}} />;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [Note the use of `options` from props.](https://github.com/stripe/react-stripe-elements/blob/master/src/components/Provider.js#L96)
[Original documentation.](https://stripe.com/docs/stripe-js/reference#including-stripejs)
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

### Motivation
This change allows passing an `options` prop to `StripeProvider`, which is needed for use cases related to Stripe Connect accounts. The original library already supports this behaviour (even though it is not documented).