### PR TITLE
restify 7.2: Fixes Typings

### DIFF
--- a/types/restify/index.d.ts
+++ b/types/restify/index.d.ts
@@ -51,6 +51,8 @@ export interface ServerOptions {
     noWriteContinue?: boolean;
 
     rejectUnauthorized?: boolean;
+
+    ignoreTrailingSlash?: boolean;
 }
 
 export interface AddressInterface {

--- a/types/restify/index.d.ts
+++ b/types/restify/index.d.ts
@@ -1,12 +1,16 @@
-// Type definitions for restify 5.0
+// Type definitions for restify 7.2
 // Project: https://github.com/restify/node-restify
-// Definitions by: Bret Little <https://github.com/blittle>, Steve Hipwell <https://github.com/stevehipwell>, Leandro Almeida <https://github.com/leanazulyoro>
+// Definitions by:  Bret Little <https://github.com/blittle>
+//                  Steve Hipwell <https://github.com/stevehipwell>
+//                  Leandro Almeida <https://github.com/leanazulyoro>
+//                  Martin Wentzel <https://github.com/Junkern>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
 /// <reference types="node" />
 
 import http = require('http');
+import http2 = require('http2');
 import https = require('https');
 import Logger = require('bunyan');
 import url = require('url');
@@ -14,17 +18,13 @@ import spdy = require('spdy');
 import stream = require('stream');
 
 export interface ServerOptions {
-    ca?: string | Buffer | ReadonlyArray<string | Buffer>;
-
     certificate?: string | Buffer | ReadonlyArray<string | Buffer>;
 
+    dtrace?: boolean;
+
+    url?: string;
+
     key?: string | Buffer | ReadonlyArray<string | Buffer>;
-
-    passphrase?: string;
-
-    requestCert?: boolean;
-
-    ciphers?: string;
 
     formatters?: Formatters;
 
@@ -34,9 +34,11 @@ export interface ServerOptions {
 
     spdy?: spdy.ServerOptions;
 
-    version?: string;
+    http2?: http2.SecureServerOptions;
 
-    versions?: string[];
+    onceNext?: boolean;
+
+    strictNext?: boolean;
 
     handleUpgrades?: boolean;
 
@@ -45,8 +47,6 @@ export interface ServerOptions {
     handleUncaughtExceptions?: boolean;
 
     router?: Router;
-
-    socketio?: boolean;
 
     noWriteContinue?: boolean;
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://restify.com/docs/server-api/
- [x] Increase the version number in the header if appropriate.

Restify is now on version `7.2.0` and the typings are not up-to-date. Documentation is found here: http://restify.com/docs/server-api/

However, some sections are ambiguous, hence I made a issue over there (https://github.com/restify/node-restify/issues/1666) I will wait for the outcome there and then work those changes in here. Also I will.

Not sure if I should make a subfolder (https://github.com/DefinitelyTyped/DefinitelyTyped#i-want-to-update-a-package-to-a-new-major-version)