### PR TITLE
Add redux-thunk typings

### DIFF
--- a/types/redux-action/redux-action-tests.ts
+++ b/types/redux-action/redux-action-tests.ts
@@ -11,7 +11,7 @@ const dispatch: Redux.Dispatch<any> = (...args: any[]): any => { };
 const actionCreator0 = ReduxAction.createAction<Payload>('get items');
 
 dispatch(actionCreator0(1))
-  .then(action => {
+  .then((action: any) => {
     const type: string = action.type;
     const payload: Payload = action.payload;
   });
@@ -19,7 +19,7 @@ dispatch(actionCreator0(1))
 const actionCreator1 = ReduxAction.createAction<Payload>();
 
 dispatch(actionCreator1(1))
-  .then(action => {
+  .then((action: any) => {
     const type: string = action.type;
     const payload: Payload = action.payload;
   });
@@ -27,7 +27,7 @@ dispatch(actionCreator1(1))
 const actionCreator2 = ReduxAction.createAction('get items', (name: string) => name);
 
 dispatch(actionCreator2(1))
-  .then(action => {
+  .then((action: any) => {
     const type: string = action.type;
     const payload: string = action.payload;
   });
@@ -35,7 +35,7 @@ dispatch(actionCreator2(1))
 const actionCreator3 = ReduxAction.createAction('get items', (name: string) => Promise.resolve(name));
 
 dispatch(actionCreator3(1))
-  .then(action => {
+  .then((action: any) => {
     const type: string = action.type;
     const payload: string = action.payload;
   });
@@ -43,7 +43,7 @@ dispatch(actionCreator3(1))
 const actionCreator4 = ReduxAction.createAction((name: string) => name);
 
 dispatch(actionCreator4(1))
-  .then(action => {
+  .then((action: any) => {
     const type: string = action.type;
     const payload: string = action.payload;
   });
@@ -51,7 +51,7 @@ dispatch(actionCreator4(1))
 const actionCreator5 = ReduxAction.createAction<number, string>((name: string) => 1);
 
 dispatch(actionCreator5('items'))
-  .then(action => {
+  .then((action: any) => {
     const type: string = action.type;
     const payload: number = action.payload;
   });
@@ -59,7 +59,7 @@ dispatch(actionCreator5('items'))
 const actionCreator6 = ReduxAction.createAction<number, string, boolean>((name: string) => 1);
 
 dispatch(actionCreator6('items', false))
-  .then(action => {
+  .then((action: any) => {
     const type: string = action.type;
     const payload: number = action.payload;
   });

--- a/types/redux-action/redux-action-tests.ts
+++ b/types/redux-action/redux-action-tests.ts
@@ -1,5 +1,4 @@
 import * as ReduxAction from 'redux-action';
-import * as ReduxThunk from 'redux-thunk';
 import * as Redux from 'redux';
 
 interface Payload {

--- a/types/redux-testkit/index.d.ts
+++ b/types/redux-testkit/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/wix/redux-testkit#readme
 // Definitions by: Andrey Kizimov <https://github.com/Bookler96>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.1
+// TypeScript Version: 2.3
 
 import * as Redux from 'redux';
 import { ThunkAction } from 'redux-thunk';
@@ -31,7 +31,7 @@ export function Selector(selector: (state: any, action: any) => any): {
 	execute(state: any, ...args: any[]): any;
 };
 
-export function Thunk(thunkFunc: ThunkAction<any, any, any>, extraArg?: any): ThunkTestkit & {
+export function Thunk(thunkFunc: ThunkAction<any, any, any, any>, extraArg?: any): ThunkTestkit & {
 	withState(state: any): ThunkTestkit;
 };
 

--- a/types/redux-testkit/package.json
+++ b/types/redux-testkit/package.json
@@ -2,6 +2,6 @@
 	"private": true,
 	"dependencies": {
 		"redux": "^3.6.0",
-		"redux-thunk": "^2.2.0"
+		"redux-thunk": "2.2.0"
 	}
 }

--- a/types/redux-thunk/index.d.ts
+++ b/types/redux-thunk/index.d.ts
@@ -1,0 +1,26 @@
+// Type definitions for redux-thunk 2.3
+// Project: https://github.com/reduxjs/redux-thunk
+// Definitions by: Daniel Lytkin <https://github.com/aikoven>, Zhongliang Wang <https://github.com/Cryrivers>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
+
+import { Middleware, Action, AnyAction } from "redux";
+
+export interface ThunkDispatch<S, E, A extends Action> {
+  <T extends A>(action: T): T;
+  <R>(asyncAction: ThunkAction<R, S, E, A>): R;
+}
+
+export type ThunkAction<R, S, E, A extends Action> = (
+  dispatch: ThunkDispatch<S, E, A>,
+  getState: () => S,
+  extraArgument: E
+) => R;
+
+export type ThunkMiddleware<S = {}, A extends Action = AnyAction, E = undefined> = Middleware<ThunkDispatch<S, E, A>, S, ThunkDispatch<S, E, A>>;
+
+declare const thunk: ThunkMiddleware & {
+  withExtraArgument<E>(extraArgument: E): ThunkMiddleware<{}, AnyAction, E>
+};
+
+export default thunk;

--- a/types/redux-thunk/package.json
+++ b/types/redux-thunk/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "redux": "^3.6.0"
+        "redux": "^4.0.0"
     }
 }

--- a/types/redux-thunk/redux-thunk-tests.ts
+++ b/types/redux-thunk/redux-thunk-tests.ts
@@ -1,0 +1,74 @@
+import { createStore, applyMiddleware } from 'redux';
+import thunk, { ThunkAction, ThunkMiddleware } from 'redux-thunk';
+
+interface State {
+  foo: string;
+}
+
+type Actions = { type: 'FOO' } | { type: 'BAR', result: number };
+
+type ThunkResult<R> = ThunkAction<R, State, undefined, Actions>;
+
+const initialState: State = {
+  foo: 'foo'
+};
+
+function fakeReducer(state: State = initialState, action: Actions): State {
+  return state;
+}
+
+const store = createStore(fakeReducer, applyMiddleware(thunk as ThunkMiddleware<State, Actions>));
+
+store.dispatch(dispatch => {
+  dispatch({ type: 'FOO' });
+  // typings:expect-error
+  dispatch({ type: 'BAR' }); // tslint:disable-line 
+  dispatch({ type: 'BAR', result: 5 });
+  // typings:expect-error
+  store.dispatch({ type: 'BAZ'}); // tslint:disable-line 
+});
+
+function testGetState(): ThunkResult<void> {
+  return (dispatch, getState) => {
+    const state = getState();
+    const foo: string = state.foo;
+    dispatch({ type: 'FOO' });
+    // typings:expect-error
+    dispatch({ type: 'BAR'}); // tslint:disable-line 
+    dispatch({ type: 'BAR', result: 5 });
+    // typings:expect-error
+    dispatch({ type: 'BAZ'}); // tslint:disable-line 
+    // Can dispatch another thunk action
+    dispatch(anotherThunkAction());
+  };
+}
+
+function anotherThunkAction(): ThunkResult<string> {
+  return (dispatch, getState) => {
+    dispatch({ type: 'FOO' });
+    return 'hello';
+  };
+}
+
+store.dispatch({ type: 'FOO' });
+// typings:expect-error
+store.dispatch({ type: 'BAR' }); // tslint:disable-line 
+store.dispatch({ type: 'BAR', result: 5 });
+// typings:expect-error
+store.dispatch({ type: 'BAZ'}); // tslint:disable-line 
+store.dispatch(testGetState());
+
+const storeThunkArg = createStore(
+  fakeReducer,
+  applyMiddleware(thunk.withExtraArgument('bar') as ThunkMiddleware<State, Actions, string>)
+);
+
+storeThunkArg.dispatch((dispatch, getState, extraArg) => {
+  const bar: string = extraArg;
+  store.dispatch({ type: 'FOO' });
+  // typings:expect-error
+  store.dispatch({ type: 'BAR' }); // tslint:disable-line 
+  store.dispatch({ type: 'BAR', result: 5 });
+  // typings:expect-error
+  store.dispatch({ type: 'BAZ'}); // tslint:disable-line 
+});

--- a/types/redux-thunk/tsconfig.json
+++ b/types/redux-thunk/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "redux-thunk-tests.ts"
+    ]
+}

--- a/types/redux-thunk/tslint.json
+++ b/types/redux-thunk/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

---

Note: We already have types on redux-thunk, but want to remove them in our next major release. I'm getting them into @types now so that we don't interrupt/break users when upgrading.

Also, apologies if I screwed something up. I had to make a small change to redux-action's typings, as they were importing our types without any actual usage of them. That was causing conflicts with our types of the same name.