### PR TITLE
[BUGFIX] aws-lambda callbacks support string errors

### DIFF
--- a/types/aws-lambda/aws-lambda-tests.ts
+++ b/types/aws-lambda/aws-lambda-tests.ts
@@ -504,6 +504,7 @@ function callback(cb: AWSLambda.Callback) {
     cb();
     cb(null);
     cb(error);
+    cb(str); // https://docs.aws.amazon.com/apigateway/latest/developerguide/handle-errors-in-lambda-integration.html
     cb(null, anyObj);
     cb(null, bool);
     cb(null, str);

--- a/types/aws-lambda/index.d.ts
+++ b/types/aws-lambda/index.d.ts
@@ -661,9 +661,11 @@ export type Handler<TEvent = any, TResult = any> = (
  * http://docs.aws.amazon.com/lambda/latest/dg/nodejs-prog-model-handler.html
  *
  * @param error – an optional parameter that you can use to provide results of the failed Lambda function execution.
+ *                It can be a string for Lambda Proxy Integrations
+ *                https://docs.aws.amazon.com/apigateway/latest/developerguide/handle-errors-in-lambda-integration.html
  * @param result – an optional parameter that you can use to provide the result of a successful function execution. The result provided must be JSON.stringify compatible.
  */
-export type Callback<TResult = any> = (error?: Error | null, result?: TResult) => void;
+export type Callback<TResult = any> = (error?: Error | null | string, result?: TResult) => void;
 
 // Begin defining Handler and Callback types for each API trigger type.
 // Ordered by https://docs.aws.amazon.com/lambda/latest/dg/invoking-lambda-function.html


### PR DESCRIPTION
 As per https://docs.aws.amazon.com/apigateway/latest/developerguide/handle-errors-in-lambda-integration.html

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.aws.amazon.com/apigateway/latest/developerguide/handle-errors-in-lambda-integration.html
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

