### PR TITLE
[react-transition-group] missing props definition of property 'component' in TransitionGroup

### DIFF
--- a/types/react-transition-group/TransitionGroup.d.ts
+++ b/types/react-transition-group/TransitionGroup.d.ts
@@ -14,6 +14,7 @@ declare namespace TransitionGroup {
         (IntrinsicTransitionGroupProps<T> & JSX.IntrinsicElements[T]) | (ComponentTransitionGroupProps<V>) & {
         children?: ReactElement<TransitionProps> | Array<ReactElement<TransitionProps>>;
         childFactory?(child: ReactElement<any>): ReactElement<any>;
+        [prop: string]: any;
     };
 }
 

--- a/types/react-transition-group/react-transition-group-tests.tsx
+++ b/types/react-transition-group/react-transition-group-tests.tsx
@@ -4,18 +4,18 @@ import Transition, { UNMOUNTED, EXITED, ENTERING, ENTERED, EXITING } from "react
 import TransitionGroup = require("react-transition-group/TransitionGroup");
 import Components = require("react-transition-group");
 
-interface IContainerProps {
+interface ContainerProps {
     theme: string;
     children?: Element[];
 }
 
-const Container: React.StatelessComponent<IContainerProps> = (props: IContainerProps) => {
+const Container: React.StatelessComponent<ContainerProps> = (props: ContainerProps) => {
     return (
         <div data-theme={props.theme}>
             {props.children}
         </div>
     );
-}
+};
 
 const Test: React.StatelessComponent = () => {
     function handleEnter(node: HTMLElement, isAppearing: boolean) {}

--- a/types/react-transition-group/react-transition-group-tests.tsx
+++ b/types/react-transition-group/react-transition-group-tests.tsx
@@ -4,6 +4,19 @@ import Transition, { UNMOUNTED, EXITED, ENTERING, ENTERED, EXITING } from "react
 import TransitionGroup = require("react-transition-group/TransitionGroup");
 import Components = require("react-transition-group");
 
+interface IContainerProps {
+    theme: string;
+    children?: Element[];
+}
+
+const Container: React.StatelessComponent<IContainerProps> = (props: IContainerProps) => {
+    return (
+        <div data-theme={props.theme}>
+            {props.children}
+        </div>
+    );
+}
+
 const Test: React.StatelessComponent = () => {
     function handleEnter(node: HTMLElement, isAppearing: boolean) {}
 
@@ -15,7 +28,8 @@ const Test: React.StatelessComponent = () => {
 
     return (
         <TransitionGroup
-            component="ul"
+            component={Container}
+            theme="test"
             className="animated-list"
             childFactory={ (child: React.ReactElement<any>) => child }
         >


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

Like the code change in the test file, props that will be applied on the component from the property 'component' of TransitionGroup are supposed to be available to declare on TransitionGroup itself. 
