### PR TITLE
Adding in generic arguments into promise-retry

### DIFF
--- a/types/promise-retry/index.d.ts
+++ b/types/promise-retry/index.d.ts
@@ -14,7 +14,7 @@ import { WrapOptions } from "retry";
  * @param attempt The number of the attempt.
  * @returns A Promise for anything (eg. a HTTP response).
  */
-type RetryableFn<ResponseType> = ((retry: (error: any) => never, attempt: number) => Promise<ResponseType>);
+type RetryableFn<ResolutionType> = ((retry: (error: any) => never, attempt: number) => Promise<ResolutionType>);
 /**
  * Wrap all functions of the object with retry. The params can be entered in either order, just like in the original library.
  *
@@ -22,6 +22,6 @@ type RetryableFn<ResponseType> = ((retry: (error: any) => never, attempt: number
  * @param options The options for how long/often to retry the function for.
  * @returns The Promise resolved by the input retryableFn, or rejected (if not retried) from its catch block.
  */
-declare function promiseRetry<ResponseType>(retryableFn: RetryableFn<ResponseType>, options?: WrapOptions): Promise<ResponseType>;
-declare function promiseRetry<ResponseType>(options: WrapOptions, retryableFn: RetryableFn<ResponseType>): Promise<ResponseType>;
+declare function promiseRetry<ResolutionType>(retryableFn: RetryableFn<ResolutionType>, options?: WrapOptions): Promise<ResolutionType>;
+declare function promiseRetry<ResolutionType>(options: WrapOptions, retryableFn: RetryableFn<ResolutionType>): Promise<ResolutionType>;
 export = promiseRetry;

--- a/types/promise-retry/index.d.ts
+++ b/types/promise-retry/index.d.ts
@@ -14,7 +14,7 @@ import { WrapOptions } from "retry";
  * @param attempt The number of the attempt.
  * @returns A Promise for anything (eg. a HTTP response).
  */
-type RetryableFn = ((retry: (error: any) => never, attempt: number) => Promise<any>);
+type RetryableFn<ResponseType> = ((retry: (error: any) => never, attempt: number) => Promise<ResponseType>);
 /**
  * Wrap all functions of the object with retry. The params can be entered in either order, just like in the original library.
  *
@@ -22,6 +22,6 @@ type RetryableFn = ((retry: (error: any) => never, attempt: number) => Promise<a
  * @param options The options for how long/often to retry the function for.
  * @returns The Promise resolved by the input retryableFn, or rejected (if not retried) from its catch block.
  */
-declare function promiseRetry(retryableFn: RetryableFn, options?: WrapOptions): Promise<any>;
-declare function promiseRetry(options: WrapOptions, retryableFn: RetryableFn): Promise<any>;
+declare function promiseRetry<ResponseType>(retryableFn: RetryableFn<ResponseType>, options?: WrapOptions): Promise<ResponseType>;
+declare function promiseRetry<ResponseType>(options: WrapOptions, retryableFn: RetryableFn<ResponseType>): Promise<ResponseType>;
 export = promiseRetry;


### PR DESCRIPTION
Simple extension to the promise-retry typings to allow typing of the returned Promise type.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

