### PR TITLE
[ember] `initializer` and `instanceInitializer` are static methods

### DIFF
--- a/types/ember/index.d.ts
+++ b/types/ember/index.d.ts
@@ -1075,14 +1075,14 @@ declare module 'ember' {
              * after all initializers and therefore after all code is loaded and the app is
              * ready.
              */
-            initializer(initializer: Initializer<Engine>): void;
+            static initializer(initializer: Initializer<Engine>): void;
             /**
              * Instance initializers run after all initializers have run. Because
              * instance initializers run after the app is fully set up. We have access
              * to the store, container, and other items. However, these initializers run
              * after code has loaded and are not allowed to defer readiness.
              */
-            instanceInitializer(instanceInitializer: Initializer<EngineInstance>): void;
+            static instanceInitializer(instanceInitializer: Initializer<EngineInstance>): void;
             /**
              * Set this to provide an alternate class to `Ember.DefaultResolver`
              */

--- a/types/ember/test/application.ts
+++ b/types/ember/test/application.ts
@@ -1,27 +1,33 @@
 import Ember from 'ember';
 import { assertType } from "./lib/assert";
 
-let App = Ember.Application.create({
-    customEvents: {
-        paste: 'paste'
-    }
+let BaseApp = Ember.Application.extend({
+    modulePrefix: 'my-app'
 });
 
-App.initializer({
+BaseApp.initializer({
     name: 'my-initializer',
     initialize(app) {
         app.register('foo:bar', Ember.Object.extend({ foo: 'bar' }));
     }
 });
 
-App.instanceInitializer({
+BaseApp.instanceInitializer({
     name: 'my-instance-initializer',
     initialize(app) {
         app.lookup('foo:bar').get('foo');
     }
 });
 
-let App2 = Ember.Application.create({
+let App1 = BaseApp.create({
+    rootElement: '#app-one',
+    customEvents: {
+        paste: 'paste'
+    }
+});
+
+let App2 = BaseApp.create({
+    rootElement: '#app-two',
     customEvents: {
         mouseenter: null,
         mouseleave: null


### PR DESCRIPTION
The structure of the `Engine`/`Application` class hierarchy in Ember is a little fuzzy because instances of the `Application` class typically have capitalized identifiers as though they were classes themselves. They're also totally different from instances of `ApplicationInstance`, which use lower case identifiers and are a whole separate thing. It turns out, though, that `initializer` and `instanceInitializer` are defined [in a `reopenClass` call](https://github.com/emberjs/ember.js/blob/v3.1.2/packages/ember-application/lib/system/engine.js#L307), so they're effectively static methods.

Combined with the fact that [they aren't explicitly documented as static](https://emberjs.com/api/ember/3.1/classes/Engine/methods/initializer?anchor=initializer) and the fact that nearly everyone uses `ember-load-initializers` rather than calling these methods directly, it turns out we've had those declarations wrong essentially forever 🙂

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/emberjs/ember.js/blob/v3.1.2/packages/ember-application/lib/system/engine.js#L307