### PR TITLE
sinon: move incorrect xhr restore method

### DIFF
--- a/types/sinon/index.d.ts
+++ b/types/sinon/index.d.ts
@@ -271,7 +271,6 @@ declare namespace Sinon {
         getAllResponseHeaders(): any;
 
         // Methods
-        restore(): void;
         setResponseHeaders(headers: any): void;
         setResponseBody(body: string): void;
         respond(status: number, headers: any, body: string): void;
@@ -285,6 +284,7 @@ declare namespace Sinon {
         useFilters: boolean;
         addFilter(filter: (method: string, url: string, async: boolean, username: string, password: string) => boolean): void;
         onCreate(xhr: SinonFakeXMLHttpRequest): void;
+        restore(): void;
     }
 
     interface SinonFakeServer extends SinonFakeServerOptions {

--- a/types/sinon/sinon-tests.ts
+++ b/types/sinon/sinon-tests.ts
@@ -40,6 +40,7 @@ function testSandbox() {
 
     const xhr = sb.useFakeXMLHttpRequest();
     xhr.useFilters = true;
+    xhr.restore();
 
     const server = sb.useFakeServer();
     server.respondWith('foo');
@@ -98,7 +99,6 @@ function testXHR() {
     const headers = xhr.getAllResponseHeaders();
     const header = xhr.getResponseHeader('foo');
 
-    xhr.restore();
     xhr.setResponseHeaders({ 'Content-Type': 'text/html' });
     xhr.setResponseBody('foo');
     xhr.respond(200, { 'Content-Type': 'foo' }, 'bar');
@@ -107,6 +107,7 @@ function testXHR() {
     sinon.FakeXMLHttpRequest.useFilters = true;
     sinon.FakeXMLHttpRequest.addFilter((method, url, async, user, pass) => true);
     sinon.FakeXMLHttpRequest.onCreate = (xhr) => {};
+    sinon.FakeXMLHttpRequest.restore();
 }
 
 function testClock() {


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://sinonjs.org/releases/v5.0.10/fake-xhr-and-server/
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

---

Just some fixes to the fake XHR interface.

It seems `restore` is a static method, not an instance method after all. it has been wrong all along apparently (since <4).