### PR TITLE
@types/cordova Replaced "CordovaPlugins" with "any"

### DIFF
--- a/types/cordova/index.d.ts
+++ b/types/cordova/index.d.ts
@@ -26,10 +26,8 @@ interface Cordova {
     /** Access a Cordova module by name. */
     require(moduleName: string): any;
     /** Namespace for Cordova plugin functionality */
-    plugins:CordovaPlugins;
+    plugins: any;
 }
-
-interface CordovaPlugins {}
 
 interface Document {
     addEventListener(type: "deviceready", listener: (ev: Event) => any, useCapture?: boolean): void;


### PR DESCRIPTION
Otherwise, calling window.cordova.plugins.anyinstalledplugin will throw an error at compile time.