### PR TITLE
Add array overload to showdown

### DIFF
--- a/types/showdown/index.d.ts
+++ b/types/showdown/index.d.ts
@@ -321,6 +321,7 @@ declare namespace Showdown {
          * @param name
          */
         addExtension(extension: ShowdownExtension, name: string): void;
+        addExtension(extension: ShowdownExtension[], name: string): void;
 
         /**
          * Use a global registered extension with THIS converter

--- a/types/showdown/showdown-tests.ts
+++ b/types/showdown/showdown-tests.ts
@@ -17,6 +17,11 @@ var preloadedExtensions = [ 'my-ext' ],
 var configuredConverter = new showdown.Converter();
     configuredConverter.addExtension({type: 'output', filter: (text, converter)=>{return text.replace('#', '*')}}, 'myext');
 
+configuredConverter.addExtension([
+  {type: 'output', filter: (text, converter)=>{return text.replace('#', '*')}},
+  {type: 'output', filter: (text, converter)=>{return text.replace('#', '*')}}
+], 'myext');
+
 console.log(showdown.helper);
 
 console.log(converter.makeHtml(exampleMarkdown));


### PR DESCRIPTION
Uses two overloads so that the non-array variant still gets a contextual type