### PR TITLE
Type Defentions for Ajv-Errors

### DIFF
--- a/types/ajv-errors/ajv-errors-tests.ts
+++ b/types/ajv-errors/ajv-errors-tests.ts
@@ -1,0 +1,5 @@
+import * as Ajv from "ajv";
+import AjvErrors = require("ajv-errors");
+
+const ajv = new Ajv({allErrors: true, jsonPointers: true});
+AjvErrors(ajv);

--- a/types/ajv-errors/index.d.ts
+++ b/types/ajv-errors/index.d.ts
@@ -1,0 +1,18 @@
+// Type definitions for ajv-errors 1.0
+// Project: https://github.com/afshawnlotfi/types-ajv-errors
+// Definitions by: Afshawn Lotfi <https://github.com/afshawnlotfi>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import { Ajv } from "ajv";
+
+/**
+ *
+ * @param ajv Ajv Main Class
+ * https://github.com/epoberezkin/ajv
+ * @param options Optional options for Ajv Errors
+ * https://github.com/epoberezkin/ajv-errors#options
+ *
+ */
+
+export = AjvErrors;
+declare function AjvErrors(ajv: Ajv, options?: {}): Ajv;

--- a/types/ajv-errors/index.d.ts
+++ b/types/ajv-errors/index.d.ts
@@ -1,5 +1,5 @@
 // Type definitions for ajv-errors 1.0
-// Project: https://github.com/afshawnlotfi/types-ajv-errors
+// Project: https://github.com/epoberezkin/ajv-errors
 // Definitions by: Afshawn Lotfi <https://github.com/afshawnlotfi>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 

--- a/types/ajv-errors/index.d.ts
+++ b/types/ajv-errors/index.d.ts
@@ -1,5 +1,5 @@
 // Type definitions for ajv-errors 1.0
-// Project: https://github.com/epoberezkin/ajv-errors
+// Project: https://github.com/afshawnlotfi/types-ajv-errors
 // Definitions by: Afshawn Lotfi <https://github.com/afshawnlotfi>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 

--- a/types/ajv-errors/tsconfig.json
+++ b/types/ajv-errors/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+ 	"strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "ajv-errors-tests.ts"
+    ]
+}

--- a/types/ajv-errors/tslint.json
+++ b/types/ajv-errors/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/karma-fixture/index.d.ts
+++ b/types/karma-fixture/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for karma-fixture 0.2.6
 // Project: https://github.com/billtrik/karma-fixture
 // Definitions by: Ezekiel Victor <https://github.com/evictor>
+//                 Afshawn Lotfi <https://github.com/afshawnlotfi>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare namespace fixture {

--- a/types/karma-fixture/index.d.ts
+++ b/types/karma-fixture/index.d.ts
@@ -25,3 +25,6 @@ declare namespace fixture {
 
   export function setBase(fixtureBasePath: string): void;
 }
+
+export = fixture;
+export as namespace fixture;


### PR DESCRIPTION
Hello, I have implemented typings for ajv-errors:
[https://github.com/epoberezkin/ajv-errors](https://github.com/epoberezkin/ajv-errors)

- [x] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`

