### PR TITLE
MySQL - Add typed array to dateStrings

### DIFF
--- a/types/mysql/index.d.ts
+++ b/types/mysql/index.d.ts
@@ -400,7 +400,7 @@ export interface ConnectionConfig extends ConnectionOptions {
      * Force date types (TIMESTAMP, DATETIME, DATE) to be returned as strings rather then inflated into JavaScript
      * Date objects. Can be true/false or an array of type names to keep as strings. (Default: false)
      */
-    dateStrings?: boolean | (('TIMESTAMP' | 'DATETIME' | 'DATE')[]);;
+    dateStrings?: boolean | Array<'TIMESTAMP' | 'DATETIME' | 'DATE'>;
 
     /**
      * This will print all incoming and outgoing packets on stdout.

--- a/types/mysql/index.d.ts
+++ b/types/mysql/index.d.ts
@@ -397,10 +397,10 @@ export interface ConnectionConfig extends ConnectionOptions {
     bigNumberStrings?: boolean;
 
     /**
-     * Force date types (TIMESTAMP, DATETIME, DATE) to be returned as strings rather then inflated into JavaScript Date
-     * objects. (Default: false)
+     * Force date types (TIMESTAMP, DATETIME, DATE) to be returned as strings rather then inflated into JavaScript
+     * Date objects. Can be true/false or an array of type names to keep as strings. (Default: false)
      */
-    dateStrings?: boolean;
+    dateStrings?: boolean | (('TIMESTAMP' | 'DATETIME' | 'DATE')[]);;
 
     /**
      * This will print all incoming and outgoing packets on stdout.

--- a/types/mysql/mysql-tests.ts
+++ b/types/mysql/mysql-tests.ts
@@ -429,3 +429,5 @@ connection.query({sql: '...', values: ['test']}, (err: Error, results: any) => {
 connection = mysql.createConnection("mysql://localhost/test?flags=-FOUND_ROWS");
 connection = mysql.createConnection({debug: true});
 connection = mysql.createConnection({debug: ['ComQueryPacket', 'RowDataPacket']});
+connection = mysql.createConnection({dateStrings: ['DATE']});
+connection = mysql.createConnection({dateStrings: true});


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: **https://github.com/mysqljs/mysql/commit/5cc6c6801ba91c5f15114ccf0fd55efd5317febb**
- [x] Increase the version number in the header if appropriate. **Existed since mysql version 2.12**
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. **Not making substantial changes**
