### PR TITLE
node-fetch: Add URLSearchParams as valid body

### DIFF
--- a/types/node-fetch/index.d.ts
+++ b/types/node-fetch/index.d.ts
@@ -7,6 +7,7 @@
 /// <reference types="node" />
 
 import { Agent } from "http";
+import { URLSearchParams } from "url";
 
 export class Request extends Body {
     constructor(input: string | { href: string } | Request, init?: RequestInit);
@@ -164,7 +165,7 @@ export interface ResponseInit {
 }
 
 export type HeaderInit = Headers | string[];
-export type BodyInit = ArrayBuffer | ArrayBufferView | NodeJS.ReadableStream | string;
+export type BodyInit = ArrayBuffer | ArrayBufferView | NodeJS.ReadableStream | string | URLSearchParams;
 export type RequestInfo = string | Request;
 
 export default function fetch(


### PR DESCRIPTION
MDN includes URLSearchParams as a valid type for the body

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 

[MDN is clear](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch) that this is allowed:

> body: Any body that you want to add to your request: this can be a Blob, BufferSource, FormData, URLSearchParams, or USVString object. Note that a request using the GET or HEAD method cannot have a body.
- [ ] Increase the version number in the header if appropriate.

~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.~