### PR TITLE
fix(argparse): addArgument accepts strings

### DIFF
--- a/types/argparse/argparse-tests.ts
+++ b/types/argparse/argparse-tests.ts
@@ -20,6 +20,12 @@ simpleExample.addArgument(
         help: 'bar foo',
     }
 );
+simpleExample.addArgument(
+    'positional',
+    {
+        help: 'bar foo',
+    }
+);
 
 simpleExample.printHelp();
 console.log('-----------');

--- a/types/argparse/index.d.ts
+++ b/types/argparse/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/nodeca/argparse
 // Definitions by: Andrew Schurman <https://github.com/arcticwaters>
 //                 Tomasz Łaziuk <https://github.com/tlaziuk>
+//                 Sebastian Silbermann <https://github.com/eps1lon>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
@@ -34,7 +35,7 @@ export class SubParser {
 }
 
 export class ArgumentGroup {
-    addArgument(args: string[], options?: ArgumentOptions): void;
+    addArgument(args: string[] | string, options?: ArgumentOptions): void;
     addArgumentGroup(options?: ArgumentGroupOptions): ArgumentGroup;
     addMutuallyExclusiveGroup(options?: { required: boolean }): ArgumentGroup;
     setDefaults(options?: {}): void;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
  - [addArgument documentation](https://github.com/nodeca/argparse#addargument-method)
  - [responsible code](https://github.com/nodeca/argparse/blob/master/lib/action_container.js#L180-L185)
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

