### PR TITLE
A fix for react-overlays typing for TypeScript 2.8.3+

### DIFF
--- a/types/react-overlays/index.d.ts
+++ b/types/react-overlays/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Aaron Beall <https://github.com/aaronbeall>
 //                 Vito Samson <https://github.com/vitosamson>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from "react";
 

--- a/types/react-overlays/lib/Modal.d.ts
+++ b/types/react-overlays/lib/Modal.d.ts
@@ -12,6 +12,11 @@ export = Modal;
 
 interface ModalProps extends TransitionCallbacks, PortalProps {
   className?: string;
+  
+  /**
+   * A style object for the Modal.
+   */
+  style?: Object;
 
   /**
    * Set the visibility of the Modal


### PR DESCRIPTION
- Adding property ModalProps.style?: Object as this declaration is required by TypeScript starting from at least 2.8.3;

- Updating TypeScript version to 2.8.

Ping @aaronbeall, @vitosamson

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
