### PR TITLE
Make the IControllerService typings more specific.

### DIFF
--- a/types/angular-desktop-notification/index.d.ts
+++ b/types/angular-desktop-notification/index.d.ts
@@ -101,7 +101,7 @@ declare module 'angular' {
              * Note: This property is not currently supported in any browser.
              * Ref: https://developer.mozilla.org/en-US/docs/Web/API/Notification/vibrate
              */
-            vibrate?: boolean;
+            vibrate?: any;
 
             /**
              * The onclick property of the Notification interface specifies an event listener to receive click events.

--- a/types/angular-mocks/index.d.ts
+++ b/types/angular-mocks/index.d.ts
@@ -97,7 +97,7 @@ declare module 'angular' {
   interface IControllerService {
     // Although the documentation doesn't state this, locals are optional
     <T>(controllerConstructor: new (...args: any[]) => T, locals?: any, bindings?: any): T;
-    <T>(controllerConstructor: Function, locals?: any, bindings?: any): T;
+    <T>(controllerConstructor: (...args: any[]) => T, locals?: any, bindings?: any): T;
     <T>(controllerName: string, locals?: any, bindings?: any): T;
   }
 

--- a/types/angular/index.d.ts
+++ b/types/angular/index.d.ts
@@ -1390,10 +1390,9 @@ declare namespace angular {
 
     interface IControllerService {
         // Although the documentation doesn't state this, locals are optional
-        <T>(controllerConstructor: new (...args: any[]) => T, locals?: any, later?: boolean, ident?: string): T;
-        <T>(controllerConstructor: Function, locals?: IControllerLocals, later?: boolean, ident?: string): T;
-        <T>(controllerConstructor: Function, locals?: any, later?: boolean, ident?: string): T;
-        <T>(controllerName: string, locals?: any, later?: boolean, ident?: string): T;
+        <T>(controllerConstructor: new (...args: any[]) => T, locals?: any): T;
+        <T>(controllerConstructor: (...args: any[]) => T, locals?: any): T;
+        <T>(controllerName: string, locals?: any): T;
     }
 
     interface IControllerProvider extends IServiceProvider {


### PR DESCRIPTION
Tighten the IControllerService typings by replacing the generic Function type with the more specific (...args: any[]) => T, which specifies a function which returns a generic type matching the controller required.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.angularjs.org/api/ng/service/$controller
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
