### PR TITLE
[react-router] Make definitions work with TypeScript 2.9

### DIFF
--- a/types/react-router-bootstrap/index.d.ts
+++ b/types/react-router-bootstrap/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/react-bootstrap/react-router-bootstrap
 // Definitions by: Vincent Lesierse <https://github.com/vlesierse>, Karol Janyst <https://github.com/LKay>, Olmo del Corral <https://github.com/olmobrutall>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 export { default as LinkContainer } from "react-router-bootstrap/lib/LinkContainer"
 export { default as IndexLinkContainer } from "react-router-bootstrap/lib/IndexLinkContainer"

--- a/types/react-router-config/index.d.ts
+++ b/types/react-router-config/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/ReactTraining/react-router/tree/master/packages/react-router-config
 // Definitions by: François Nguyen <https://github.com/lith-light-g>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from "react";
 import { RouteComponentProps, match } from "react-router";

--- a/types/react-router-dom/index.d.ts
+++ b/types/react-router-dom/index.d.ts
@@ -4,7 +4,7 @@
 //                 Huy Nguyen <https://github.com/huy-nguyen>
 //                 Philip Jackson <https://github.com/p-jackson>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import { match } from "react-router";
 import * as React from 'react';

--- a/types/react-router-native/index.d.ts
+++ b/types/react-router-native/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Eduard Zintz <https://github.com/ezintz>
 //                 Fernando Helwanger <https://github.com/fhelwanger>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 export {
   match,

--- a/types/react-router-navigation-core/index.d.ts
+++ b/types/react-router-navigation-core/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/LeoLeBras/react-router-navigation#readme
 // Definitions by: Kalle Ott <https://github.com/kaoDev>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 // High-level wrappers
 import { PureComponent, ReactNode, ComponentClass, ReactElement } from "react";

--- a/types/react-router-navigation/index.d.ts
+++ b/types/react-router-navigation/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/LeoLeBras/react-router-navigation#readme
 // Definitions by: Kalle Ott <https://github.com/kaoDev>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import { Component, ReactNode, ReactElement, ComponentClass } from "react";
 import { StyleProp, ViewProps, ViewStyle, TextStyle } from "react-native";

--- a/types/react-router-param-link/index.d.ts
+++ b/types/react-router-param-link/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/mtsg/react-router-param-link
 // Definitions by: Motosugi Murata <https://github.com/mtsg>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from "react";
 import { LinkProps } from "react-router-dom";

--- a/types/react-router/index.d.ts
+++ b/types/react-router/index.d.ts
@@ -18,7 +18,7 @@
 //                 Rahul Raina <https://github.com/rraina>
 //                 Maksim Sharipov <https://github.com/pret-a-porter>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from 'react';
 import * as H from 'history';
@@ -106,8 +106,8 @@ export interface match<P> {
   url: string;
 }
 
-// Diff / Omit taken from https://github.com/Microsoft/TypeScript/issues/12215#issuecomment-311923766
-export type Omit<T, K extends keyof T> = Pick<T, ({ [P in keyof T]: P } & { [P in K]: never } & { [x: string]: never, [x: number]: never })[keyof T]>;
+// Omit taken from https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-8.html
+export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 
 export function matchPath<P>(pathname: string, props: RouteProps): match<P> | null;
 

--- a/types/rrc/index.d.ts
+++ b/types/rrc/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/pshrmn/rrc#readme
 // Definitions by: Deividas Bakanas <https://github.com/DeividasBakanas>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from "react";
 import * as H from "history";


### PR DESCRIPTION
The legacy definition doesn't work with TypeScript 2.9.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://blogs.msdn.microsoft.com/typescript/2018/05/31/announcing-typescript-2-9/
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.