### PR TITLE
[video.js] Adds missing 'one' method to the player and fixes some indentation problems.

### DIFF
--- a/types/video.js/index.d.ts
+++ b/types/video.js/index.d.ts
@@ -94,6 +94,9 @@ declare namespace videojs {
 		name(): string;
 		options(obj: any): any;
 		player(): Player;
+		off(eventName?: string, callback?: (eventObject: Event) => void): void;
+		on(eventName: string, callback: (eventObject: Event) => void): void;
+		one(eventName: string, callback: (eventObject: Event) => void): void;
 		ready(callback: (this: this) => void): this;
 		removeAttribute(attribute: string): void;
 		removeChild(component: Component): void;
@@ -125,9 +128,6 @@ declare namespace videojs {
 		languageSwitch(options: any): void;
 		loop(value?: boolean): string;
 		muted(muted?: boolean): boolean;
-		off(eventName?: string, callback?: (eventObject: Event) => void): void;
-		on(eventName: string, callback: (eventObject: Event) => void): void;
-		one(eventName: string, callback: (eventObject: Event) => void): void;
 		pause(): Player;
 		paused(): boolean;
 		play(): Player;

--- a/types/video.js/index.d.ts
+++ b/types/video.js/index.d.ts
@@ -5,6 +5,7 @@
 //                 Sean Bennett <https://github.com/SWBennett06>
 //                 Christoph Wagner <https://github.com/IgelCampus>
 //                 Gio Freitas <https://github.com/giofreitas>
+//                 Grzegorz Błaszczyk <https://github.com/gjanblaszczyk>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 // The Video.js API allows you to interact with the video through
@@ -109,8 +110,8 @@ declare namespace videojs {
 	}
 
 	class Player extends Component {
-        autoplay(value?: boolean): string;
-		addRemoteTextTrack(options: {}): HTMLTrackElement;
+		autoplay(value?: boolean): string;
+		addRemoteTextTrack(options: {}, manualCleanup?: boolean): HTMLTrackElement;
 		buffered(): TimeRanges;
 		bufferedPercent(): number;
 		cancelFullScreen(): Player;
@@ -122,16 +123,17 @@ declare namespace videojs {
 		height(): number;
 		height(num: number): void;
 		languageSwitch(options: any): void;
-        loop(value?: boolean): string;
-        muted(muted?: boolean): boolean;
+		loop(value?: boolean): string;
+		muted(muted?: boolean): boolean;
 		off(eventName?: string, callback?: (eventObject: Event) => void): void;
 		on(eventName: string, callback: (eventObject: Event) => void): void;
+		one(eventName: string, callback: (eventObject: Event) => void): void;
 		pause(): Player;
 		paused(): boolean;
 		play(): Player;
 		playbackRate(rate?: number): number;
 		poster(val?: string): string | Player;
-        preload(value?: boolean): string;
+		preload(value?: boolean): string;
 		removeRemoteTextTrack(track: HTMLTrackElement): void;
 		requestFullScreen(): Player;
 		size(width: number, height: number): Player;

--- a/types/video.js/index.d.ts
+++ b/types/video.js/index.d.ts
@@ -92,11 +92,11 @@ declare namespace videojs {
 		initChildren(): void;
 		localize(key: string, tokens?: string[], defaultValue?: string): string;
 		name(): string;
-		options(obj: any): any;
-		player(): Player;
 		off(eventName?: string, callback?: (eventObject: Event) => void): void;
 		on(eventName: string, callback: (eventObject: Event) => void): void;
 		one(eventName: string, callback: (eventObject: Event) => void): void;
+		options(obj: any): any;
+		player(): Player;
 		ready(callback: (this: this) => void): this;
 		removeAttribute(attribute: string): void;
 		removeChild(component: Component): void;


### PR DESCRIPTION
- Add missing 'one' method to the player declaration
- Add manualCleanup parameter to the addRemoteTextTrack method
- Fix some indentation problems

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: 

-` addRemoteTextTrack(options:{}, manualCleanup?: boolean): HTMLTrackElement; `<<http://docs.videojs.com/player.js.html#line3310>>
-`one(eventName: string, callback: (eventObject: Event) => void): void;` <<http://docs.videojs.com/event-target.js.html#line111>>


