### PR TITLE
Fix parameterized type inference for async-retry

### DIFF
--- a/types/async-retry/async-retry-tests.ts
+++ b/types/async-retry/async-retry-tests.ts
@@ -10,12 +10,12 @@ const o: Options = {
   onRetry: (e: Error) => 42
 };
 
-retry(
+const hello: Promise<string> = retry(
   bail => 'hello',
   { retries: 3 }
 );
 
-retry(
+const answer: Promise<number> = retry(
   bail => Promise.resolve(42),
   { retries: 3 }
 );

--- a/types/async-retry/index.d.ts
+++ b/types/async-retry/index.d.ts
@@ -19,7 +19,7 @@ declare namespace AsyncRetry {
 		onRetry?: (e: Error) => any;
 	}
 
-	type RetryFunction<A> = (bail: (e: Error) => A, attempt: number) => A|Promise<A>;
+	type RetryFunction<A> = (bail: (e: Error) => void, attempt: number) => A|Promise<A>;
 }
 
 export = AsyncRetry;


### PR DESCRIPTION
The async-retry function has a generic type parameter `A` and TypeScript is unable to infer the concrete type when the `bail` function, whose type references the generic type, is specified. Reading the source and API documentation of async-retry, `bail` returns nothing so `void` is the right type here. This in turn fixes inference of the generic type parameter `A`.

Tested by adding some expected return types to the test file. The type checks (`npm run lint async-retry`) failed before this commit. With this commit, they pass.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/zeit/async-retry/blob/8b63aa41ce8d57d1adef32a57026bb89949500a0/lib/index.js#L14
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.