### PR TITLE
Revert "S3rver: Add `declare namespace S3rver` to fix import"

### DIFF
--- a/types/s3rver/index.d.ts
+++ b/types/s3rver/index.d.ts
@@ -28,6 +28,4 @@ interface S3rverOptions {
     directory: string;
 }
 
-declare namespace S3rver {}
-
 export = S3rver;


### PR DESCRIPTION
Reverts DefinitelyTyped/DefinitelyTyped#26040

This was an inappropriate hack. [Please read more here from the DefinitelyTyped REAMDE](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/fbba9f55beab742b9d1c0fa9ef714e0771ad9d05#should-i-add-an-empty-namespace-to-a-package-that-doesnt-export-a-module-to-use-es6-style-imports)
