### PR TITLE
[@types/ws] Remove dependency on node >= 10

### DIFF
--- a/types/ws/index.d.ts
+++ b/types/ws/index.d.ts
@@ -168,6 +168,12 @@ declare namespace WebSocket {
         maxPayload?: number;
     }
 
+    interface AddressInfo {
+        address: string;
+        family: string;
+        port: number;
+    }
+
     // WebSocket Server
     class Server extends events.EventEmitter {
         options: ServerOptions;
@@ -176,7 +182,7 @@ declare namespace WebSocket {
 
         constructor(options?: ServerOptions, callback?: () => void);
 
-        address(): net.AddressInfo | string;
+        address(): AddressInfo | string;
         close(cb?: (err?: Error) => void): void;
         handleUpgrade(request: http.IncomingMessage, socket: net.Socket,
             upgradeHead: Buffer, callback: (client: WebSocket) => void): void;


### PR DESCRIPTION
Removes a dependency on `net.AddressInfo`, which is only present in `@types/node@10` and creates a dependency that is not needed.  Version 5.x of `ws` requires node 4.5+ and should not have this dependency: https://github.com/websockets/ws/releases/tag/5.0.0

The error you receive when using types for node versions below 10 is:

```
node_modules/@types/ws/index.d.ts:179:24 - error TS2694: Namespace '"net"' has no exported member 'AddressInfo'.
```

Two related issues exist: #25890 (closed) and #26195 (open).  The appropriate interface for the return type of the `server.address()` function is in fact the same as `net.AddressInfo | string` (docs here: https://github.com/websockets/ws/blob/master/doc/ws.md#serveraddress) so I have extracted the interface and included it in this definition to remove the dependency on node >= 10 types.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/websockets/ws/releases/tag/5.0.0 and https://github.com/websockets/ws/blob/master/doc/ws.md#serveraddress
