### PR TITLE
Add typings for webpack-serve and webpack-hot-client

### DIFF
--- a/types/webpack-hot-client/index.d.ts
+++ b/types/webpack-hot-client/index.d.ts
@@ -1,0 +1,51 @@
+// Type definitions for webpack-hot-client 3.0
+// Project: https://github.com/webpack-contrib/webpack-hot-client
+// Definitions by: Ryan Clark <https://github.com/rynclark>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
+
+/// <reference types="node" />
+
+import * as webpack from 'webpack';
+import * as http from 'http';
+
+export = WebpackHotClient;
+
+declare function WebpackHotClient(
+  compiler: webpack.Compiler | webpack.MultiCompiler,
+  options: WebpackHotClient.Options
+): void;
+
+declare namespace WebpackHotClient {
+  interface WebpackHotHost {
+    /** Client hostname that is used in the browser by WebSockets */
+    client: string;
+    /** Server hostname */
+    server: string;
+  }
+
+  interface Options {
+    /** Automatically configure every entry */
+    allEntries?: boolean;
+    /** Auto configure the given webpack config with the hot configuration */
+    autoConfigure?: boolean;
+    /** Level of information for webpack-hot-client to output */
+    host?: WebpackHotHost | string;
+    /** Enable hot module reloading */
+    hmr?: boolean;
+    /** Enable HTTPS */
+    https?: boolean;
+    /** Level of information for webpack-hot-client to output */
+    logLevel?: 'trace' | 'debug' | 'info' | 'warn' | 'error';
+    /** Prepend timestamp to each log line */
+    logTime?: boolean;
+    /** Port that the WebSocket listens on */
+    port?: number;
+    /** Reload the page if a patch cannot be applied by webpack */
+    reload?: boolean;
+    /** Server instance for webpack-hot-client to connect to */
+    server?: http.Server;
+    /** Webpack stats configuration */
+    stats?: webpack.Options.Stats;
+  }
+}

--- a/types/webpack-hot-client/tsconfig.json
+++ b/types/webpack-hot-client/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "lib": [
+      "es6"
+    ],
+    "noImplicitAny": true,
+    "noImplicitThis": true,
+    "strictNullChecks": true,
+    "strictFunctionTypes": true,
+    "baseUrl": "../",
+    "typeRoots": [
+      "../"
+    ],
+    "types": [],
+    "noEmit": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "files": [
+    "index.d.ts",
+    "webpack-hot-client-tests.ts"
+  ]
+}

--- a/types/webpack-hot-client/tslint.json
+++ b/types/webpack-hot-client/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/webpack-hot-client/webpack-hot-client-tests.ts
+++ b/types/webpack-hot-client/webpack-hot-client-tests.ts
@@ -1,0 +1,6 @@
+import webpack = require('webpack');
+import hot = require('webpack-hot-client');
+
+const compiler = webpack();
+
+hot(compiler, { logLevel: 'info', reload: false });

--- a/types/webpack-serve/index.d.ts
+++ b/types/webpack-serve/index.d.ts
@@ -1,0 +1,93 @@
+// Type definitions for webpack-serve 1.0
+// Project: https://github.com/webpack-contrib/webpack-serve
+// Definitions by: Ryan Clark <https://github.com/rynclark>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
+
+/// <reference types="node" />
+
+import * as koa from 'koa';
+import * as webpack from 'webpack';
+import * as webpackDevMiddleware from 'webpack-dev-middleware';
+import * as webpackHotClient from 'webpack-hot-client';
+import * as https from 'https';
+
+export = WebpackServe;
+
+declare module 'webpack' {
+  interface Configuration {
+    serve: WebpackServe.Options;
+  }
+}
+
+declare function WebpackServe(
+  { config }: { config: WebpackServe.Options }
+): Promise<WebpackServe.Instance>;
+
+declare namespace WebpackServe {
+  interface WebpackServeOpen {
+    /** Name of the browser to open */
+    app: string;
+    /** Path on the server to open */
+    path: string;
+  }
+
+  interface WebpackServeMiddleware {
+    /** Function to call to add koa-static */
+    content: () => koa.Middleware;
+    /** Function to call to add the webpack-dev-middleware */
+    webpack: () => webpackDevMiddleware.WebpackDevMiddleware;
+  }
+
+  interface Instance {
+    /** Subscriber function for events */
+    on(event: 'build-started', listener: (args: { compiler: webpack.Compiler }) => void): this;
+    on(event: 'build-finished', listener: (args: { compiler: webpack.Compiler, stats: webpack.Stats }) => void): this;
+    on(event: 'compiler-error' | 'compiler-warning', listener: (args: { compiler: webpack.Compiler, stats: any }) => void): this;
+    on(event: 'listening', listener: (args: { server: koa, options: Options }) => void): this;
+
+    /** Close webpack-serve */
+    close: () => void;
+  }
+
+  interface ListenersObject {
+    'build-started': (args: { compiler: webpack.Compiler }) => void;
+    'build-finished': (args: { compiler: webpack.Compiler, stats: webpack.Stats }) => void;
+    'compiler-error': (args: { compiler: webpack.Compiler, stats: any }) => void;
+    'compiler-warning': (args: { compiler: webpack.Compiler, stats: any }) => void;
+    'listening': (args: { server: koa, options: Options }) => void;
+  }
+
+  interface Options {
+    /** Addon to webpack-serve that allows access to the Koa server instance */
+    add?: (app: koa, middleware: WebpackServeMiddleware, options: Options) => void;
+    /** Copy the server URL to the clipboard when the server is started */
+    clipboard?: boolean;
+    /** Custom instance of a webpack compiler */
+    compiler?: webpack.Compiler;
+    /** Webpack configuration for creating a new webpack compiler instance */
+    config?: webpack.Configuration;
+    /** A path or array of paths where content will be served from */
+    content?: string | string[];
+    /** Options for webpack-dev-middleware */
+    dev?: webpackDevMiddleware.Options;
+    /** The host the server will listen on */
+    host?: string;
+    /** Options for webpack-hot-client */
+    hot?: webpackHotClient.Options | boolean;
+    /** Enable HTTP2 support */
+    http2?: boolean;
+    /** Configuration object for the server to use HTTPS */
+    https?: https.ServerOptions;
+    /** Level of information for webpack-serve to output */
+    logLevel?: 'trace' | 'debug' | 'info' | 'warn' | 'error';
+    /** Prepend timestamp to each log line */
+    logTime?: boolean;
+    /** Object of subscribers to webpack-serve bus events */
+    on?: ListenersObject;
+    /** Open the browser when started */
+    open?: WebpackServeOpen | boolean;
+    /** Port that the server listens on */
+    port?: number;
+  }
+}

--- a/types/webpack-serve/tsconfig.json
+++ b/types/webpack-serve/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "lib": [
+      "es6"
+    ],
+    "noImplicitAny": true,
+    "noImplicitThis": true,
+    "strictNullChecks": true,
+    "strictFunctionTypes": true,
+    "baseUrl": "../",
+    "typeRoots": [
+      "../"
+    ],
+    "types": [],
+    "noEmit": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "files": [
+    "index.d.ts",
+    "webpack-serve-tests.ts"
+  ]
+}

--- a/types/webpack-serve/tslint.json
+++ b/types/webpack-serve/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/webpack-serve/webpack-serve-tests.ts
+++ b/types/webpack-serve/webpack-serve-tests.ts
@@ -1,0 +1,22 @@
+import webpack = require('webpack');
+import serve = require('webpack-serve');
+
+const compiler = webpack();
+
+const server = serve({
+  config: {
+    http2: true,
+    dev: {
+      publicPath: '/',
+      logLevel: 'info'
+    },
+    host: 'localhost'
+  }
+});
+
+server
+  .then((server) => {
+    server.on('listening', () => {
+      server.close();
+    });
+  });


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

This adds typings for `webpack-serve` and `webpack-hot-client` (the types for `webpack-serve` depend on typings for `webpack-hot-client`).

The `webpack-serve` typings add the `serve` property to `webpack` to enable type checking now that it's allowed to be part of the config.