### PR TITLE
node: add `argv0` as one of options for `spawn` and `spawnSync`

### DIFF
--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -2178,6 +2178,7 @@ declare module "child_process" {
     }
 
     export interface SpawnOptions {
+        argv0?: string;
         cwd?: string;
         env?: any;
         stdio?: any;
@@ -2320,6 +2321,7 @@ declare module "child_process" {
     export function fork(modulePath: string, args?: ReadonlyArray<string>, options?: ForkOptions): ChildProcess;
 
     export interface SpawnSyncOptions {
+        argv0?: string;
         cwd?: string;
         input?: string | Buffer;
         stdio?: any;

--- a/types/node/node-tests.ts
+++ b/types/node/node-tests.ts
@@ -2097,8 +2097,10 @@ namespace child_process_tests {
         childProcess.exec("echo test");
         childProcess.exec("echo test", { windowsHide: true });
         childProcess.spawn("echo", ["test"], { windowsHide: true });
+        childProcess.spawn("echo", ["test"], { windowsHide: true, argv0: "echo-test" });
         childProcess.spawnSync("echo test");
         childProcess.spawnSync("echo test", {windowsVerbatimArguments: false});
+        childProcess.spawnSync("echo test", {windowsVerbatimArguments: false, argv0: "echo-test"});
     }
 
     {


### PR DESCRIPTION
It is documented for `spawn` in
https://nodejs.org/dist/latest-v10.x/docs/api/child_process.html#child_process_child_process_spawn_command_args_options

It's not documented for `spawnSync`, but since `spawnSync` uses the same
function (normalizeSpawnArguments) for normalizing the options, it
should be there too:

https://github.com/nodejs/node/blob/master/lib/child_process.js#L545

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
