### PR TITLE
[google-cloud__pubsub]Added new apiEndpoint options key for Google PubSub definition type

### DIFF
--- a/types/google-cloud__pubsub/index.d.ts
+++ b/types/google-cloud__pubsub/index.d.ts
@@ -1,6 +1,6 @@
-// Type definitions for @google-cloud/pubsub 0.14
+// Type definitions for @google-cloud/pubsub 0.18
 // Project: https://github.com/GoogleCloudPlatform/google-cloud-node/tree/master/packages/pubsub
-// Definitions by: Paul Huynh <https://github.com/pheromonez>
+// Definitions by: Paul Huynh <https://github.com/pheromonez>, LunaPg <https://github.com/LunaPg>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
@@ -13,9 +13,13 @@ declare namespace PubSub {
     // https://googlecloudplatform.github.io/google-cloud-node/#/docs/pubsub/0.14.1/pubsub/v1
     function v1(config?: GCloudConfiguration): any;
 
+    /**
+     * @version: Google PubSub 0.18.0
+     */
     interface GCloudConfiguration {
         projectId?: string;
         keyFilename?: string;
+        apiEndpoint?: string;
         email?: string;
         credentials?: {
             client_email?: string;

--- a/types/google-cloud__pubsub/index.d.ts
+++ b/types/google-cloud__pubsub/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for @google-cloud/pubsub 0.18
 // Project: https://github.com/GoogleCloudPlatform/google-cloud-node/tree/master/packages/pubsub
-// Definitions by: Paul Huynh <https://github.com/pheromonez>, LunaPg <https://github.com/LunaPg>
+// Definitions by: Paul Huynh <https://github.com/pheromonez>
+//                 LunaPg <https://github.com/LunaPg>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/googleapis/nodejs-pubsub/blob/master/src/index.js>>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
