### PR TITLE
In react/index.d.ts, add default type annotation <T = Element> to SyntheticEvent and EventHandler types

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -547,7 +547,7 @@ declare namespace React {
     // Event System
     // ----------------------------------------------------------------------
 
-    interface SyntheticEvent<T> {
+    interface SyntheticEvent<T = Element> {
         bubbles: boolean;
         /**
          * A reference to the element on which the event listener is registered.
@@ -575,40 +575,40 @@ declare namespace React {
         type: string;
     }
 
-    interface ClipboardEvent<T> extends SyntheticEvent<T> {
+    interface ClipboardEvent<T = Element> extends SyntheticEvent<T> {
         clipboardData: DataTransfer;
         nativeEvent: NativeClipboardEvent;
     }
 
-    interface CompositionEvent<T> extends SyntheticEvent<T> {
+    interface CompositionEvent<T = Element> extends SyntheticEvent<T> {
         data: string;
         nativeEvent: NativeCompositionEvent;
     }
 
-    interface DragEvent<T> extends MouseEvent<T> {
+    interface DragEvent<T = Element> extends MouseEvent<T> {
         dataTransfer: DataTransfer;
         nativeEvent: NativeDragEvent;
     }
 
-    interface FocusEvent<T> extends SyntheticEvent<T> {
+    interface FocusEvent<T = Element> extends SyntheticEvent<T> {
         nativeEvent: NativeFocusEvent;
         relatedTarget: EventTarget;
         target: EventTarget & T;
     }
 
     // tslint:disable-next-line:no-empty-interface
-    interface FormEvent<T> extends SyntheticEvent<T> {
+    interface FormEvent<T = Element> extends SyntheticEvent<T> {
     }
 
-    interface InvalidEvent<T> extends SyntheticEvent<T> {
+    interface InvalidEvent<T = Element> extends SyntheticEvent<T> {
         target: EventTarget & T;
     }
 
-    interface ChangeEvent<T> extends SyntheticEvent<T> {
+    interface ChangeEvent<T = Element> extends SyntheticEvent<T> {
         target: EventTarget & T;
     }
 
-    interface KeyboardEvent<T> extends SyntheticEvent<T> {
+    interface KeyboardEvent<T = Element> extends SyntheticEvent<T> {
         altKey: boolean;
         charCode: number;
         ctrlKey: boolean;
@@ -630,7 +630,7 @@ declare namespace React {
         which: number;
     }
 
-    interface MouseEvent<T> extends SyntheticEvent<T> {
+    interface MouseEvent<T = Element> extends SyntheticEvent<T> {
         altKey: boolean;
         button: number;
         buttons: number;
@@ -651,7 +651,7 @@ declare namespace React {
         shiftKey: boolean;
     }
 
-    interface TouchEvent<T> extends SyntheticEvent<T> {
+    interface TouchEvent<T = Element> extends SyntheticEvent<T> {
         altKey: boolean;
         changedTouches: TouchList;
         ctrlKey: boolean;
@@ -666,13 +666,13 @@ declare namespace React {
         touches: TouchList;
     }
 
-    interface UIEvent<T> extends SyntheticEvent<T> {
+    interface UIEvent<T = Element> extends SyntheticEvent<T> {
         detail: number;
         nativeEvent: NativeUIEvent;
         view: AbstractView;
     }
 
-    interface WheelEvent<T> extends MouseEvent<T> {
+    interface WheelEvent<T = Element> extends MouseEvent<T> {
         deltaMode: number;
         deltaX: number;
         deltaY: number;
@@ -680,14 +680,14 @@ declare namespace React {
         nativeEvent: NativeWheelEvent;
     }
 
-    interface AnimationEvent<T> extends SyntheticEvent<T> {
+    interface AnimationEvent<T = Element> extends SyntheticEvent<T> {
         animationName: string;
         elapsedTime: number;
         nativeEvent: NativeAnimationEvent;
         pseudoElement: string;
     }
 
-    interface TransitionEvent<T> extends SyntheticEvent<T> {
+    interface TransitionEvent<T = Element> extends SyntheticEvent<T> {
         elapsedTime: number;
         nativeEvent: NativeTransitionEvent;
         propertyName: string;
@@ -700,21 +700,21 @@ declare namespace React {
 
     type EventHandler<E extends SyntheticEvent<any>> = { bivarianceHack(event: E): void }["bivarianceHack"];
 
-    type ReactEventHandler<T> = EventHandler<SyntheticEvent<T>>;
+    type ReactEventHandler<T = Element> = EventHandler<SyntheticEvent<T>>;
 
-    type ClipboardEventHandler<T> = EventHandler<ClipboardEvent<T>>;
-    type CompositionEventHandler<T> = EventHandler<CompositionEvent<T>>;
-    type DragEventHandler<T> = EventHandler<DragEvent<T>>;
-    type FocusEventHandler<T> = EventHandler<FocusEvent<T>>;
-    type FormEventHandler<T> = EventHandler<FormEvent<T>>;
-    type ChangeEventHandler<T> = EventHandler<ChangeEvent<T>>;
-    type KeyboardEventHandler<T> = EventHandler<KeyboardEvent<T>>;
-    type MouseEventHandler<T> = EventHandler<MouseEvent<T>>;
-    type TouchEventHandler<T> = EventHandler<TouchEvent<T>>;
-    type UIEventHandler<T> = EventHandler<UIEvent<T>>;
-    type WheelEventHandler<T> = EventHandler<WheelEvent<T>>;
-    type AnimationEventHandler<T> = EventHandler<AnimationEvent<T>>;
-    type TransitionEventHandler<T> = EventHandler<TransitionEvent<T>>;
+    type ClipboardEventHandler<T = Element> = EventHandler<ClipboardEvent<T>>;
+    type CompositionEventHandler<T = Element> = EventHandler<CompositionEvent<T>>;
+    type DragEventHandler<T = Element> = EventHandler<DragEvent<T>>;
+    type FocusEventHandler<T = Element> = EventHandler<FocusEvent<T>>;
+    type FormEventHandler<T = Element> = EventHandler<FormEvent<T>>;
+    type ChangeEventHandler<T = Element> = EventHandler<ChangeEvent<T>>;
+    type KeyboardEventHandler<T = Element> = EventHandler<KeyboardEvent<T>>;
+    type MouseEventHandler<T = Element> = EventHandler<MouseEvent<T>>;
+    type TouchEventHandler<T = Element> = EventHandler<TouchEvent<T>>;
+    type UIEventHandler<T = Element> = EventHandler<UIEvent<T>>;
+    type WheelEventHandler<T = Element> = EventHandler<WheelEvent<T>>;
+    type AnimationEventHandler<T = Element> = EventHandler<AnimationEvent<T>>;
+    type TransitionEventHandler<T = Element> = EventHandler<TransitionEvent<T>>;
 
     //
     // Props / DOM Attributes


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: Changing because a default type parameter would make these types (`SyntheticEvent` and `EventHandler`) easier to use, and `Element` seems like a reasonable default.
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
