### PR TITLE
[webpack-serve] optional serve property and correct node api types

### DIFF
--- a/types/webpack-serve/index.d.ts
+++ b/types/webpack-serve/index.d.ts
@@ -16,7 +16,7 @@ export = WebpackServe;
 
 declare module 'webpack' {
   interface Configuration {
-    serve: WebpackServe.Options;
+    serve?: WebpackServe.Options;
   }
 }
 

--- a/types/webpack-serve/index.d.ts
+++ b/types/webpack-serve/index.d.ts
@@ -21,7 +21,7 @@ declare module 'webpack' {
 }
 
 declare function WebpackServe(
-  { config }: { config: WebpackServe.Options }
+  { config }: { config: webpack.Configuration }
 ): Promise<WebpackServe.Instance>;
 
 declare namespace WebpackServe {

--- a/types/webpack-serve/webpack-serve-tests.ts
+++ b/types/webpack-serve/webpack-serve-tests.ts
@@ -5,13 +5,15 @@ const compiler = webpack();
 
 const server = serve({
   config: {
-    http2: true,
-    dev: {
-      publicPath: '/',
-      logLevel: 'info'
+    serve: {
+      http2: true,
+      dev: {
+        publicPath: '/',
+        logLevel: 'info'
+      },
+      host: 'localhost'
     },
-    host: 'localhost'
-  }
+  }.
 });
 
 server

--- a/types/webpack-serve/webpack-serve-tests.ts
+++ b/types/webpack-serve/webpack-serve-tests.ts
@@ -13,7 +13,7 @@ const server = serve({
       },
       host: 'localhost'
     },
-  }.
+  },
 });
 
 server


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

This was an oversight when first creating the typings, as `serve` is optional on the `webpack.Configuration` interface.