### PR TITLE
[react-stripe-elements] - Options should be spread into StripeProvider props

### DIFF
--- a/types/react-stripe-elements/index.d.ts
+++ b/types/react-stripe-elements/index.d.ts
@@ -30,7 +30,7 @@ export namespace ReactStripeElements {
 	interface StripeProviderOptions {
 		stripeAccount?: string;
 	}
-	type StripeProviderProps = { apiKey: string; stripe?: never; options?: StripeProviderOptions } | { apiKey?: never; stripe: StripeProps | null; options?: StripeProviderOptions; };
+	type StripeProviderProps = { apiKey: string; stripe?: never; } & StripeProviderOptions | { apiKey?: never; stripe: StripeProps | null; } & StripeProviderOptions;
 
 	interface StripeProps {
 		createSource(sourceData?: SourceOptions): Promise<SourceResponse>;

--- a/types/react-stripe-elements/react-stripe-elements-tests.tsx
+++ b/types/react-stripe-elements/react-stripe-elements-tests.tsx
@@ -197,6 +197,7 @@ const TestStripeProviderProps3: React.SFC<{
 }> = props => <StripeProvider stripe={null} />;
 
 /**
- * StripeProvider should be able to accept an `options` prop
+ * StripeProvider should be able to accept options.
+ * See: https://stripe.com/docs/stripe-js/reference#stripe-function for options.
  */
-const TestStripeProviderOptions: React.SFC = () => <StripeProvider apiKey="" options={{stripeAccount: ""}} />;
+const TestStripeProviderOptions: React.SFC = () => <StripeProvider apiKey="" stripeAccount="" />;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://stripe.com/docs/stripe-js/reference#stripe-function

## Summary
In #26071 I **erroneously** typed the StripeProvider options as a distinct `options` prop. The options are actually spread into the component, so this fixes that.

### Before
```javascript
<StripeProvider apiKey='xxx' options={{ stripeAccount: 'abc' }} />
```
### After (this fix)
```javascript
<StripeProvider apiKey='xxx' stripeAccount='abc' />
```

Apologies for the inconvenience. 😅 