### PR TITLE
react-dom: optional `key` param for `createPortal`

### DIFF
--- a/types/react-dom/index.d.ts
+++ b/types/react-dom/index.d.ts
@@ -19,7 +19,7 @@ import {
 export function findDOMNode(instance: ReactInstance): Element | null | Text;
 export function unmountComponentAtNode(container: Element): boolean;
 
-export function createPortal(children: ReactNode, container: Element): ReactPortal;
+export function createPortal(children: ReactNode, container: Element, key?: null | string): ReactPortal;
 
 export const version: string;
 export const render: Renderer;

--- a/types/react-dom/react-dom-tests.tsx
+++ b/types/react-dom/react-dom-tests.tsx
@@ -42,7 +42,14 @@ describe('ReactDOM', () => {
             }
         }
 
-        ReactDOM.createPortal(React.createElement('div'), portalTarget);
+        ReactDOM.createPortal(<div />, document.createElement('div'));
+        ReactDOM.createPortal(<div />, document.createElement('div'), null);
+        ReactDOM.createPortal(<div />, document.createElement('div'), 'key');
+
+        ReactDOM.createPortal(React.createElement('div'), document.createElement('div'));
+        ReactDOM.createPortal(React.createElement('div'), document.createElement('div'), null);
+        ReactDOM.createPortal(React.createElement('div'), document.createElement('div'), 'key');
+
         ReactDOM.render(<ClassComponent />, rootElement);
     });
 });


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/facebook/react/blob/master/packages/shared/ReactPortal.js#L19>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

That `key` params is not well documented. But the fact is that it exists and changes behaviour of `ReactPortal` in some cases.