### PR TITLE
[expo] Expose FontMap from Expo

### DIFF
--- a/types/expo/index.d.ts
+++ b/types/expo/index.d.ts
@@ -1379,11 +1379,11 @@ export namespace Fingerprint {
 /**
  * Font
  */
-export namespace Font {
-    interface FontMap {
-        [name: string]: RequireSource;
-    }
+export interface FontMap {
+    [name: string]: RequireSource;
+}
 
+export namespace Font {
     function loadAsync(name: string, url: string): Promise<void>;
     function loadAsync(map: FontMap): Promise<void>;
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes

```typescript
import { Font, FontMap } from "expo";

// I need access to FontMap type
const cacheFonts = (fonts: FontMap[]) => {
  return fonts.map(font => Font.loadAsync(font));
};
```
