### PR TITLE
fix able to use promise for onAfterOpen in react modal

### DIFF
--- a/types/react-modal/index.d.ts
+++ b/types/react-modal/index.d.ts
@@ -58,7 +58,7 @@ declare namespace ReactModal {
         appElement?: HTMLElement | {};
 
         /* Function that will be run after the modal has opened. */
-        onAfterOpen?(): void;
+        onAfterOpen?(): void | Promise<void>;
 
         /* Function that will be run when the modal is requested to be closed, prior to actually closing. */
         onRequestClose?(event: (MouseEvent | KeyboardEvent)): void;


### PR DESCRIPTION
I wanna use async function for `onAfterOpen` function in react-modal package.
I thought these codes can fix this.
Please review or comments 🙏 

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
