### PR TITLE
Updates declaration of jquery-mockjax to the v2.3 npm release (and github commit)

### DIFF
--- a/types/jquery-mockjax/index.d.ts
+++ b/types/jquery-mockjax/index.d.ts
@@ -9,6 +9,20 @@
 
 /// <reference types="jquery" />
 
+type MockJaxLoggingFunction = (message?: any, ...additionalParameters: any[]) => void;
+
+interface MockJaxStandardLogger {
+    error?: MockJaxLoggingFunction;
+    warn?: MockJaxLoggingFunction;
+    info?: MockJaxLoggingFunction;
+    log?: MockJaxLoggingFunction;
+    debug?: MockJaxLoggingFunction;
+}
+
+interface MockJaxCustomLogger {
+    [key: string]: MockJaxLoggingFunction;
+}
+
 interface MockJaxSettingsHeaders {
     [key: string]: string;
 }
@@ -36,7 +50,7 @@ interface MockJaxSettings {
     onAfterSuccess?: Function;
     onAfterError?: Function;
     onAfterComplete?: Function;
-    logger?: any;
+    logger?: MockJaxStandardLogger | MockJaxCustomLogger;
     logLevelMethods?: string[];
     namespace?: string;
     throwUnmocked?: boolean;

--- a/types/jquery-mockjax/index.d.ts
+++ b/types/jquery-mockjax/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for jQuery Mockjax 2.3
+// Type definitions for jQuery Mockjax 2.3.0
 // Project: https://github.com/jakerella/jquery-mockjax
 // Definitions by: 
 //                 Laszlo Jakab <https://github.com/laszlojakab>, 

--- a/types/jquery-mockjax/index.d.ts
+++ b/types/jquery-mockjax/index.d.ts
@@ -1,6 +1,9 @@
-// Type definitions for jQuery Mockjax 2.0.1
+// Type definitions for jQuery Mockjax 2.3
 // Project: https://github.com/jakerella/jquery-mockjax
-// Definitions by: Laszlo Jakab <https://github.com/laszlojakab>, Vladimir Đokić <https://github.com/vladeck>
+// Definitions by: 
+//                 Laszlo Jakab <https://github.com/laszlojakab>, 
+//                 Vladimir Đokić <https://github.com/vladeck>,
+//                 James Johnson <https://github.com/hasaki>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -33,15 +36,22 @@ interface MockJaxSettings {
     onAfterSuccess?: Function;
     onAfterError?: Function;
     onAfterComplete?: Function;
+    logger?: any;
+    logLevelMethods?: string[];
+    namespace?: string;
+    throwUnmocked?: boolean;
+    retainAjaxCalls?: boolean;
 }
 
 interface MockJaxStatic {
     (options: MockJaxSettings): number;
+    (options: MockJaxSettings[]): number[];
     handler(id?: number): any;
     clear(id?: number): void;
     mockedAjaxCalls(): any[];
     unfiredHandlers(): any[];
     unmockedAjaxCalls(): any[];
+    clearRetainedAjaxCalls(): void;
 }
 
 interface JQueryStatic {

--- a/types/jquery-mockjax/jquery-mockjax-tests.ts
+++ b/types/jquery-mockjax/jquery-mockjax-tests.ts
@@ -193,7 +193,7 @@ class Tests {
             });
         });
 
-        t('Custom logger gets called', (assert) => {
+        t('Standard logger type gets called', (assert) => {
             let done = assert.async();
             let wasLoggerCalled = false;
 
@@ -209,6 +209,33 @@ class Tests {
                     log: logFunction,
                     debug: logFunction
                 }
+            };
+
+            $.mockjax(settings);
+
+            $.ajax({
+                url: '/custom-logging-function',
+                error: self._noErrorCallbackExpected,
+                complete: (xhr) => {
+                    assert.equal(wasLoggerCalled, true, 'Standard logger was called');
+                    done();
+                }
+            });
+        });
+
+        t('Custom logger object gets called', (assert) => {
+            let done = assert.async();
+            let wasLoggerCalled = false;
+
+            let logFunction = () => wasLoggerCalled = true;
+
+            let settings: MockJaxSettings = {
+                url: '/custom-logging-function',
+                logging: true,
+                logger: {
+                    customName: logFunction
+                },
+                logLevelMethods: ['customName', 'customName', 'customName', 'customName', 'customName']
             };
 
             $.mockjax(settings);

--- a/types/jquery-mockjax/jquery-mockjax-tests.ts
+++ b/types/jquery-mockjax/jquery-mockjax-tests.ts
@@ -192,6 +192,54 @@ class Tests {
                 }
             });
         });
+
+        t('Custom logger gets called', (assert) => {
+            let done = assert.async();
+            let wasLoggerCalled = false;
+
+            let logFunction = () => wasLoggerCalled = true;
+
+            let settings: MockJaxSettings = {
+                url: '/custom-logging-function',
+                logging: true,
+                logger: {
+                    error: logFunction,
+                    warn: logFunction,
+                    info: logFunction,
+                    log: logFunction,
+                    debug: logFunction
+                }
+            };
+
+            $.mockjax(settings);
+
+            $.ajax({
+                url: '/custom-logging-function',
+                error: self._noErrorCallbackExpected,
+                complete: (xhr) => {
+                    assert.equal(wasLoggerCalled, true, 'Custom logger was called');
+                    done();
+                }
+            });
+        });
+
+        t('Throws when ajax call is not mocked', (assert) => {
+            let done = assert.async();
+
+            $.mockjaxSettings.throwUnmocked = true;
+
+            $.ajax({
+                url: '/unmocked-ajax-call',
+                error: (error) => {
+                    assert.ok(error, 'Expected the call to fail because it was not mocked');
+                    done();
+                },
+                complete: (xhr) => {
+                    assert.ok(false, 'Expected a failure');
+                    done();
+                }
+            });
+        });
     }
 }
 


### PR DESCRIPTION
Also adds tests for two features added in the release.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/jakerella/jquery-mockjax
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

Oddly v2.3 isn't available as a github release but it is up on npm and the master branch has a commit saying 2.3 is available.  I went through the documentation and added the missing settings and new `$.mockjax` overload I found.  