### PR TITLE
Add scoped-http-client typings

### DIFF
--- a/types/scoped-http-client/index.d.ts
+++ b/types/scoped-http-client/index.d.ts
@@ -1,0 +1,69 @@
+// Type definitions for scoped-http-client 0.11
+// Project: https://github.com/technoweenie/node-scoped-http-client
+// Definitions by: Matt Perry <https://github.com/mattvperry>
+//                 Ryan Adolf <https://github.com/rianadon>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types="node"/>
+
+import { Agent, RequestOptions, IncomingMessage, ClientRequest } from "http";
+
+export type ScopeCallback = (scoped: ScopedClient) => void;
+export type RequestCallback = (err: any, request: ClientRequest) => void;
+export type ResponseCallback = (cb?: (err: any, response: IncomingMessage, body: string) => void) => ScopedClient;
+
+export interface Options extends RequestOptions {
+    encoding?: string;
+    httpAgent?: Agent|boolean;
+    httpsAgent?: Agent|boolean;
+    query?: any;
+    pathname?: string;
+    slashes?: any;
+    hash?: string;
+}
+
+export class ScopedClient {
+    constructor(url: string, options: Options);
+    fullPath(p: string): string;
+    scope(options: Options, callback?: ScopeCallback): ScopedClient;
+    scope(url: string, callback?: ScopeCallback): ScopedClient;
+    scope(url: string, options: Options, callback?: ScopeCallback): ScopedClient;
+    join(suffix: string): string;
+    path(p: string): ScopedClient;
+    query(key: any, value?: any): ScopedClient;
+    host(h: string): ScopedClient;
+    port(p: string|number): ScopedClient;
+    protocol(p: string): ScopedClient;
+    encoding(e?: string): ScopedClient;
+    timeout(time: any): ScopedClient;
+    auth(user?: string, pass?: string): ScopedClient;
+    header(name: string, value: string): ScopedClient;
+    headers(h: any): ScopedClient;
+
+    request(method: string, callback?: RequestCallback): ResponseCallback;
+    request(method: string, reqBody: string, callback?: RequestCallback): ResponseCallback;
+
+    get(callback?: RequestCallback): ResponseCallback;
+    get(reqBody: string, callback?: RequestCallback): ResponseCallback;
+
+    post(callback?: RequestCallback): ResponseCallback;
+    post(reqBody: string, callback?: RequestCallback): ResponseCallback;
+
+    patch(callback?: RequestCallback): ResponseCallback;
+    patch(reqBody: string, callback?: RequestCallback): ResponseCallback;
+
+    put(callback?: RequestCallback): ResponseCallback;
+    put(reqBody: string, callback?: RequestCallback): ResponseCallback;
+
+    delete(callback?: RequestCallback): ResponseCallback;
+    delete(reqBody: string, callback?: RequestCallback): ResponseCallback;
+
+    del(callback?: RequestCallback): ResponseCallback;
+    del(reqBody: string, callback?: RequestCallback): ResponseCallback;
+
+    head(callback?: RequestCallback): ResponseCallback;
+    head(reqBody: string, callback?: RequestCallback): ResponseCallback;
+}
+
+export function create(options: Options): ScopedClient;
+export function create(url?: string, options?: Options): ScopedClient;

--- a/types/scoped-http-client/index.d.ts
+++ b/types/scoped-http-client/index.d.ts
@@ -26,6 +26,7 @@ export class ScopedClient {
     constructor(url: string, options: Options);
     fullPath(p: string): string;
     scope(options: Options, callback?: ScopeCallback): ScopedClient;
+    // tslint:disable-next-line unified-signatures
     scope(url: string, callback?: ScopeCallback): ScopedClient;
     scope(url: string, options: Options, callback?: ScopeCallback): ScopedClient;
     join(suffix: string): string;

--- a/types/scoped-http-client/scoped-http-client-tests.ts
+++ b/types/scoped-http-client/scoped-http-client-tests.ts
@@ -1,0 +1,61 @@
+import * as ScopedClient from "scoped-http-client";
+import { IncomingMessage } from "http";
+
+// Basic client
+let client = ScopedClient.create('https://api.github.com')
+    .header('accept', 'application/json')
+    .path('user/show/technoweenie')
+    .get()((err, resp, body) => {
+        body; // $ExpectType string
+    });
+
+// Setting the url through multiple steps
+client = ScopedClient.create()
+    .protocol('https')
+    .host('api.github.com')
+    .port(443)
+    .path('user/show/technoweenie')
+    .query('key', 'value')
+    .encoding('utf-8')
+    .header('X-Test-Header', 'value')
+    .get()(handler);
+
+// Scoping
+client.path('https://api.github.com');
+client.scope('users/technoweenie', (cli) => {
+    cli.get()((err, resp, body) => {
+        body; // $ExpectType string
+    });
+});
+
+function handler(err: Error, resp: IncomingMessage, body: string) {}
+
+// Other HTTP methods
+client.query({ login: 'technoweenie', token: '...' })
+    .scope('users/technoweenie', (cli) => {
+        cli.post('data')(handler);
+        cli.put('data')(handler);
+        cli.head()(handler);
+        cli.delete()(handler);
+        cli.del()(handler);
+        cli.patch()(handler);
+    });
+
+// Streaming post body
+client.post((err, req) => {
+    req.write("...");
+    req.write("...");
+})(handler);
+
+// HTTP Basic Authentication
+client
+    .auth('technoweenie', '...')
+    .get((err, req) => {});
+
+// Setting a timeout
+client = ScopedClient.create('http://10.255.255.1:9999');
+client.timeout(100);
+
+// Fetching client information
+client.join('suffix'); // $ExpectType string
+client.fullPath('path'); // $ExpectType string

--- a/types/scoped-http-client/tsconfig.json
+++ b/types/scoped-http-client/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "scoped-http-client-tests.ts"
+    ]
+}

--- a/types/scoped-http-client/tslint.json
+++ b/types/scoped-http-client/tslint.json
@@ -1,6 +1,3 @@
 {
-    "extends": "dtslint/dt.json",
-    "rules": {
-        "unified-signatures": false
-    }
+    "extends": "dtslint/dt.json"
 }

--- a/types/scoped-http-client/tslint.json
+++ b/types/scoped-http-client/tslint.json
@@ -1,0 +1,6 @@
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "unified-signatures": false
+    }
+}


### PR DESCRIPTION
This pull request adds typings for the [`scoped-http-client`](https://github.com/technoweenie/node-scoped-http-client) package. The typings come from @mattvperry's [`typed-scoped-http-client`](https://github.com/mattvperry/typed-scoped-http-client) package, which was for when [`typings`](https://github.com/typings/typings) was a thing. Most of the code is the same as the original typings, but it's been slightly modified to pass `tslint`.

----

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.