### PR TITLE
Types for JQuery Mouse Exit

### DIFF
--- a/types/jquery-mouse-exit/index.d.ts
+++ b/types/jquery-mouse-exit/index.d.ts
@@ -1,0 +1,23 @@
+// Type definitions for jquery-mouse-exit 1.0
+// Project: https://github.com/makeup-jquery/jquery-mouse-exit
+// Definitions by: Anderson Friaça <https://github.com/AndersonFriaca>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
+
+/// <reference types="jquery" />
+
+export type Options = Partial<{
+    delay: number;
+}>;
+
+export type FocusElements = Partial<{
+    lostFocus: HTMLElement;
+    gainedFocus: HTMLElement;
+}>;
+
+declare global {
+    interface JQuery {
+        mouseExit(options?: Options): JQuery;
+        on(event: 'mouseExit', handler: ((event: JQuery.Event<HTMLElement>, data: FocusElements) => void)): JQuery;
+    }
+}

--- a/types/jquery-mouse-exit/jquery-mouse-exit-tests.ts
+++ b/types/jquery-mouse-exit/jquery-mouse-exit-tests.ts
@@ -1,0 +1,9 @@
+// init plugin
+$('#container').mouseExit({
+  delay: 500
+});
+
+// handle event
+$('#container').on('mouseExit', (e, data) => {
+  console.log(data.lostFocus, data.gainedFocus);
+});

--- a/types/jquery-mouse-exit/tsconfig.json
+++ b/types/jquery-mouse-exit/tsconfig.json
@@ -1,0 +1,25 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "esModuleInterop": true
+    },
+    "files": [
+        "index.d.ts",
+        "jquery-mouse-exit-tests.ts"
+    ]
+}

--- a/types/jquery-mouse-exit/tslint.json
+++ b/types/jquery-mouse-exit/tslint.json
@@ -1,0 +1,1 @@
+{"extends": "dtslint/dt.json"}


### PR DESCRIPTION
Types creation of [https://github.com/makeup-jquery/jquery-mouse-exit](https://github.com/makeup-jquery/jquery-mouse-exit)
NPM: [https://www.npmjs.com/package/jquery-mouse-exit](https://www.npmjs.com/package/jquery-mouse-exit)

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- [X] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [X] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [X] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.