### PR TITLE
[@types/ltx] declare xmlns parameter for Element.getChildText optional

### DIFF
--- a/types/ltx/lib/Element.d.ts
+++ b/types/ltx/lib/Element.d.ts
@@ -67,7 +67,7 @@ export declare class Element {
 
     getText(): string;
 
-    getChildText(name: string, xmlns: any): string;
+    getChildText(name: string, xmlns?: any): string;
 
     /**
      * Return all direct descendents that are Elements.

--- a/types/ltx/ltx-tests.ts
+++ b/types/ltx/ltx-tests.ts
@@ -2,6 +2,11 @@ import * as ltx from 'ltx';
 
 ltx.parse('<document/>');
 
+const getChildTextElement = ltx.parse('<test><child>body text</child></test>') as ltx.Element;
+if (getChildTextElement.getChildText('child') !== 'body text') {
+    throw new Error("body does not match");
+}
+
 const p = new ltx.Parser();
 
 p.on('tree', (ignored: any) => {});


### PR DESCRIPTION
## Description

This change declares the second paramter for `Element.getChildText` as optional.
The [implementation of getChildText](https://github.com/xmppjs/ltx/blob/master/lib/Element.js#L207) passes `xmlns` only to `getChild(name: string, xmlns?: any)`. [As you can see](https://github.com/rynclark/DefinitelyTyped/blob/master/types/ltx/lib/Element.d.ts#L50),  `xmlns` in `getChild` is optional. It therefore should be optional in getChildText as well. Thank you for your time.

## Template

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: (see above)
- [X] Increase the version number in the header if appropriate.
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
