### PR TITLE
[yup] fix return types of validate and validateSync

### DIFF
--- a/types/yup/index.d.ts
+++ b/types/yup/index.d.ts
@@ -37,8 +37,8 @@ export interface Schema<T> {
     meta(): any;
     describe(): SchemaDescription;
     concat(schema: this): this;
-    validate(value: T, options?: ValidateOptions): Promise<ValidationError | T>;
-    validateSync(value: T, options?: ValidateOptions): ValidationError | T;
+    validate(value: T, options?: ValidateOptions): Promise<T>;
+    validateSync(value: T, options?: ValidateOptions): T;
     isValid(value: T, options?: any): Promise<boolean>;
     isValidSync(value: T, options?: any): boolean;
     cast(value: any, options?: any): T;

--- a/types/yup/yup-tests.ts
+++ b/types/yup/yup-tests.ts
@@ -307,7 +307,7 @@ const testObject: MyInterface = {
     arrayField: ["hi"],
 };
 
-typedSchema.validateSync(testObject); // $ExpectType ValidationError | MyInterface
+typedSchema.validateSync(testObject); // $ExpectType MyInterface
 
 // $ExpectError
 yup.object<MyInterface>({


### PR DESCRIPTION
I fixed return types of `validate` and `validateSync` according actual behavior and [documentation](https://github.com/jquense/yup#mixedvalidatevalue-any-options-object-promiseany-validationerror).