### PR TITLE
removed http2 types to ensure compatibility with node < v8

### DIFF
--- a/types/restify/index.d.ts
+++ b/types/restify/index.d.ts
@@ -8,16 +8,13 @@
 // TypeScript Version: 2.2
 
 /// <reference types="node" />
-
 import http = require('http');
 import https = require('https');
-import http2 = require('http2');
 import Logger = require('bunyan');
 import url = require('url');
 import spdy = require('spdy');
 import stream = require('stream');
-import { Certificate } from 'crypto';
-import { ZlibOptions } from 'zlib';
+import zlib = require('zlib');
 
 export interface ServerOptions {
     ca?: string | Buffer | ReadonlyArray<string | Buffer>;
@@ -62,7 +59,7 @@ export interface ServerOptions {
 
     secureOptions?: number;
 
-    http2?: http2.SecureServerOptions;
+    http2?: any;
 
     dtrace?: boolean;
 
@@ -247,7 +244,7 @@ export interface Server extends http.Server {
     url: string;
 
     /** Node server instance */
-    server: http.Server | https.Server | spdy.Server | http2.Http2SecureServer;
+    server: http.Server | https.Server | spdy.Server;
 
     /** Router instance */
     router: Router;
@@ -1373,7 +1370,7 @@ export namespace plugins {
      * gzips the response if client send `accept-encoding: gzip`
      * @param options options to pass to gzlib
      */
-    function gzipResponse(options?: ZlibOptions): RequestHandler;
+    function gzipResponse(options?: zlib.ZlibOptions): RequestHandler;
 
     interface InflightRequestThrottleOptions {
         limit: number;


### PR DESCRIPTION
As described in https://github.com/DefinitelyTyped/DefinitelyTyped/issues/26260 requiring `http2` causes issues with node v6, where there are no definitions for `http2`.

Any advice on upgrading type definitions based on node version is greatly appreciated.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).


If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/26260
- [X] Increase the version number in the header if appropriate.
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
