### PR TITLE
fix(prettier): add missing getFileInfo APIs

### DIFF
--- a/types/prettier/index.d.ts
+++ b/types/prettier/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for prettier 1.12
+// Type definitions for prettier 1.13
 // Project: https://github.com/prettier/prettier
 // Definitions by: Ika <https://github.com/ikatyang>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -288,6 +288,23 @@ export type SupportOptionValue = number | boolean | string;
 export interface SupportInfo {
     languages: SupportLanguage[];
     options: SupportOption[];
+}
+
+export interface FileInfoOptions {
+    ignorePath?: string;
+    withNodeModules?: boolean;
+    plugins?: string[];
+}
+
+export interface FileInfoResult {
+    ignored: boolean;
+    inferredParser: string | null;
+}
+
+export function getFileInfo(filePath: string, options?: FileInfoOptions): Promise<FileInfoResult>;
+
+export namespace getFileInfo {
+    function sync(filePath: string, options?: FileInfoOptions): FileInfoResult;
 }
 
 /**

--- a/types/prettier/prettier-tests.ts
+++ b/types/prettier/prettier-tests.ts
@@ -24,6 +24,16 @@ prettier.resolveConfig('path/to/somewhere').then(options => {
     }
 });
 
+if (prettier.getFileInfo.sync('./tsconfig.json').inferredParser !== 'json') {
+    throw new Error('Bad parser');
+}
+
+prettier.getFileInfo('./tsconfig.json').then((result) => {
+  if (result.inferredParser !== 'json') {
+      throw new Error('Bad parser');
+  }
+});
+
 // $ExpectError
 prettier.resolveConfig();
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://prettier.io/docs/en/api.html#prettiergetfileinfofilepath-options
