### PR TITLE
ThreeJS : Add null types to scene #fog and #overrideMaterial.

### DIFF
--- a/types/three/three-core.d.ts
+++ b/types/three/three-core.d.ts
@@ -6287,12 +6287,12 @@ export class Scene extends Object3D {
     /**
      * A fog instance defining the type of fog that affects everything rendered in the scene. Default is null.
      */
-    fog: IFog;
+    fog: IFog | null;
 
     /**
      * If not null, it will force everything in the scene to be rendered with that material. Default is null.
      */
-    overrideMaterial: Material;
+    overrideMaterial: Material | null;
     autoUpdate: boolean;
     background: any;
 


### PR DESCRIPTION
Adds the `null` type for `scene.fog` and also `scene.overrideMaterial`. As stated in the existing comments in the code they can both be `null` but this type seemed to have remained forgotten.

<hr/>

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://threejs.org/docs/#api/scenes/Scene>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.