### PR TITLE
p-defer: Promise.resolve does not require an argument

### DIFF
--- a/types/p-defer/index.d.ts
+++ b/types/p-defer/index.d.ts
@@ -5,7 +5,7 @@
 
 declare namespace pDefer {
 	interface DeferredPromise<T> {
-		resolve<U>(value: U | PromiseLike<U>): Promise<U>;
+		resolve<U>(value?: U | PromiseLike<U>): Promise<U>;
 		reject(reason: any): Promise<never>;
 		promise: Promise<T>;
 	}

--- a/types/p-defer/p-defer-tests.ts
+++ b/types/p-defer/p-defer-tests.ts
@@ -7,3 +7,7 @@ function delay(deferred: pDefer.DeferredPromise<string>,  ms: number) {
 
 let s: string;
 async function f() { s = await delay(pDefer<string>(), 100); }
+
+async function u() {
+	const u: Promise<any> = pDefer().resolve();
+}


### PR DESCRIPTION
The p-defer library is just exposing the Promise `resolve` function, which does not require an argument.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/sindresorhus/p-defer/blob/f3a74a0da062c6cdff278a170d38cb87eff2b823/index.js#L5-L6
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
