### PR TITLE
Add type definition for serialize-error

### DIFF
--- a/types/serialize-error/index.d.ts
+++ b/types/serialize-error/index.d.ts
@@ -1,0 +1,17 @@
+// Type definitions for serialize-error 2.1
+// Project: https://github.com/sindresorhus/serialize-error
+// Definitions by: Thomas Thiebaud <https://github.com/thomasthiebaud>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare function SerializeError(error: any): SerializeError.ErrorObject;
+
+declare namespace SerializeError {
+    interface ErrorObject {
+        name: string;
+        stack: string;
+        message: string;
+        [keyof: string]: string;
+    }
+}
+
+export = SerializeError;

--- a/types/serialize-error/serialize-error-tests.ts
+++ b/types/serialize-error/serialize-error-tests.ts
@@ -1,0 +1,5 @@
+import serializeError = require('serialize-error');
+
+const error = new Error('unicorn');
+
+const serializedError = serializeError(error);

--- a/types/serialize-error/tsconfig.json
+++ b/types/serialize-error/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "strictFunctionTypes": true
+    },
+    "files": [
+        "index.d.ts",
+        "serialize-error-tests.ts"
+    ]
+}

--- a/types/serialize-error/tslint.json
+++ b/types/serialize-error/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.