### PR TITLE
[@types/react-select] Fix OnInputChangeHandler type.

### DIFF
--- a/types/react-select/index.d.ts
+++ b/types/react-select/index.d.ts
@@ -40,7 +40,7 @@ export type FilterOptionsHandler<TValue = OptionValues> = (options: Options<TVal
 export type InputRendererHandler = (props: { [key: string]: any }) => HandlerRendererResult;
 export type MenuRendererHandler<TValue = OptionValues> = (props: MenuRendererProps<TValue>) => HandlerRendererResult;
 export type OnCloseHandler = () => void;
-export type OnInputChangeHandler = (inputValue: string) => void;
+export type OnInputChangeHandler = (inputValue: string) => string;
 export type OnInputKeyDownHandler = React.KeyboardEventHandler<HTMLDivElement | HTMLInputElement>;
 export type OnMenuScrollToBottomHandler = () => void;
 export type OnOpenHandler = () => void;


### PR DESCRIPTION
`OnInputChangeHandler` should return `string` instead of `void`
See:
https://github.com/JedWatson/react-select/tree/v1.2.1#updating-input-values-with-oninputchange