### PR TITLE
fix webpack-serve args definition by using WebpackServe.Options

### DIFF
--- a/types/webpack-serve/index.d.ts
+++ b/types/webpack-serve/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for webpack-serve 1.0
 // Project: https://github.com/webpack-contrib/webpack-serve
 // Definitions by: Ryan Clark <https://github.com/rynclark>
+//                 Jokcy <https://github.com/Jokcy>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -21,7 +22,7 @@ declare module 'webpack' {
 }
 
 declare function WebpackServe(
-  { config }: { config: webpack.Configuration }
+  options: WebpackServe.Options
 ): Promise<WebpackServe.Instance>;
 
 declare namespace WebpackServe {

--- a/types/webpack-serve/webpack-serve-tests.ts
+++ b/types/webpack-serve/webpack-serve-tests.ts
@@ -1,22 +1,50 @@
 import webpack = require('webpack');
 import serve = require('webpack-serve');
 
-const compiler = webpack();
+const config: webpack.Configuration = {
+  mode: 'development',
+  entry: ['index.js'], // when use compiler entry must be array or object
+};
+
+const serveConfig = {
+  http2: true,
+  dev: {
+    publicPath: '/',
+    logLevel: 'info'
+  },
+  host: 'localhost'
+};
+
+const compiler = webpack(config);
 
 const server = serve({
-  config: {
-    serve: {
-      http2: true,
-      dev: {
-        publicPath: '/',
-        logLevel: 'info'
-      },
-      host: 'localhost'
-    },
-  },
+  compiler,
+  ...serveConfig
 });
 
 server
+  .then((server) => {
+    server.on('listening', () => {
+      server.close();
+    });
+  });
+
+const config2: webpack.Configuration = {
+  ...config,
+  serve: {
+    ...serveConfig,
+    port: 8888,
+    hot: {
+      port: 8889
+    }
+  },
+};
+
+const server2 = serve({
+  config: config2
+});
+
+server2
   .then((server) => {
     server.on('listening', () => {
       server.close();


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/webpack-contrib/webpack-serve#serveoptions>>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

