### PR TITLE
recharts X/YAxis label prop can be of type LabelProps

### DIFF
--- a/types/recharts/index.d.ts
+++ b/types/recharts/index.d.ts
@@ -910,7 +910,7 @@ export interface XAxisProps extends EventAttributes {
     interval?: AxisInterval;
     reversed?: boolean;
     // see label section at http://recharts.org/#/en-US/api/XAxis
-    label?: string | number | Label;
+    label?: string | number | Label | LabelProps;
 }
 
 export class XAxis extends React.Component<XAxisProps> { }
@@ -961,7 +961,7 @@ export interface YAxisProps extends EventAttributes {
     interval?: AxisInterval;
     reversed?: boolean;
     // see label section at http://recharts.org/#/en-US/api/YAxis
-    label?: string | number | Label;
+    label?: string | number | Label | LabelProps;
 }
 
 export class YAxis extends React.Component<YAxisProps> { }

--- a/types/recharts/recharts-tests.tsx
+++ b/types/recharts/recharts-tests.tsx
@@ -136,12 +136,8 @@ class Component extends React.Component<{}, ComponentState> {
                 </ResponsiveContainer>
                 <ResponsiveContainer>
                     <LineChart width={500} height={300} data={data}>
-                        <XAxis dataKey="name">
-                            <Label>X axis - name</Label>
-                        </XAxis>
-                        <YAxis>
-                            <Label>Y axis</Label>
-                        </YAxis>
+                        <XAxis dataKey="name" label={{ value: "X axis - name" }} />
+                        <YAxis label={{ value: "Y axis" }} />
                         <CartesianGrid stroke="#eee" strokeDasharray="5 5"  />
                         <Line type="monotone" dataKey="uv" stroke="#8884d8" onClick={ this.clickHandler } />
                         <Line type="monotone" dataKey="pv" stroke="#82ca9d" />


### PR DESCRIPTION
Reopening https://github.com/DefinitelyTyped/DefinitelyTyped/pull/25928 with updated PR.

recharts `label` prop can be an object of type [`LabelProps`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/recharts/index.d.ts#L834) in addition to existing types.

[Source code reference](https://github.com/recharts/recharts/blob/03e554401a1b97e116746710247df0dd544b10dc/src/component/Label.js#L373), and [issue mention](https://github.com/recharts/recharts/issues/184).

Test case is amended from using `<Label />` as a child component. Using `<Label />` as a child component is still tested in the suite elsewhere.

---------------

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/recharts/recharts/blob/03e554401a1b97e116746710247df0dd544b10dc/src/component/Label.js#L373
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
