### PR TITLE
Update koa-bodyparser with stricter body and rawBody

### DIFF
--- a/types/koa-bodyparser/index.d.ts
+++ b/types/koa-bodyparser/index.d.ts
@@ -1,6 +1,6 @@
-// Type definitions for koa-bodyparser 4.2
+// Type definitions for koa-bodyparser 5.0
 // Project: https://github.com/koajs/bodyparser
-// Definitions by: Jerry Chin <https://github.com/hellopao>
+// Definitions by: Jerry Chin <https://github.com/hellopao>, Anup Kishore <https://github.com/anup-2s>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -18,8 +18,8 @@ import * as Koa from "koa";
 
 declare module "koa" {
     interface Request {
-        body: any;
-        rawBody: any;
+        body: {} | null | undefined;
+        rawBody: {} | null | undefined;
     }
 }
 


### PR DESCRIPTION
Parsed body should be `unknown` type (simulated until release in
Typescript 3.0). Any manipulations on `body` should come with type
assertions and/or verification. Note, this is a major change, and a
significant tightening of type safety.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/Microsoft/TypeScript/pull/24439
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.