### PR TITLE
parse5: fix exports of CJS modules

### DIFF
--- a/types/parse5-htmlparser2-tree-adapter/index.d.ts
+++ b/types/parse5-htmlparser2-tree-adapter/index.d.ts
@@ -6,205 +6,207 @@
 
 import * as parse5 from "parse5";
 
-/**
- * htmlparser2 tree adapter Node interface.
- */
-export interface Node {
+declare namespace treeAdapter {
     /**
-     * The type of the node. E.g. {@link Document} will have `type` equal to 'root'`.
+     * htmlparser2 tree adapter Node interface.
      */
-    type: string;
-    /**
-     * [DOM spec](https://dom.spec.whatwg.org/#dom-node-nodetype)-compatible node {@link type}.
-     */
-    nodeType: number;
-    /**
-     * Parent node.
-     */
-    parent: ParentNode;
-    /**
-     * Same as {@link parent}. [DOM spec](https://dom.spec.whatwg.org)-compatible alias.
-     */
-    parentNode: ParentNode;
-    /**
-     * Previous sibling.
-     */
-    prev: Node;
-    /**
-     * Same as {@link prev}. [DOM spec](https://dom.spec.whatwg.org)-compatible alias.
-     */
-    previousSibling: Node;
-    /**
-     * Next sibling.
-     */
-    next: Node;
-    /**
-     * Same as {@link next}. [DOM spec](https://dom.spec.whatwg.org)-compatible alias.
-     */
-    nextSibling: Node;
-}
+    interface Node {
+        /**
+         * The type of the node. E.g. {@link Document} will have `type` equal to 'root'`.
+         */
+        type: string;
+        /**
+         * [DOM spec](https://dom.spec.whatwg.org/#dom-node-nodetype)-compatible node {@link type}.
+         */
+        nodeType: number;
+        /**
+         * Parent node.
+         */
+        parent: ParentNode;
+        /**
+         * Same as {@link parent}. [DOM spec](https://dom.spec.whatwg.org)-compatible alias.
+         */
+        parentNode: ParentNode;
+        /**
+         * Previous sibling.
+         */
+        prev: Node;
+        /**
+         * Same as {@link prev}. [DOM spec](https://dom.spec.whatwg.org)-compatible alias.
+         */
+        previousSibling: Node;
+        /**
+         * Next sibling.
+         */
+        next: Node;
+        /**
+         * Same as {@link next}. [DOM spec](https://dom.spec.whatwg.org)-compatible alias.
+         */
+        nextSibling: Node;
+    }
 
-/**
- * htmlparser2 tree adapter ParentNode interface.
- */
-export interface ParentNode extends Node {
     /**
-     * Child nodes.
+     * htmlparser2 tree adapter ParentNode interface.
      */
-    children: Node[];
-    /**
-     * Same as {@link children}. [DOM spec](https://dom.spec.whatwg.org)-compatible alias.
-     */
-    childNodes: Node[];
-    /**
-     * First child of the node.
-     */
-    firstChild: Node;
-    /**
-     * Last child of the node.
-     */
-    lastChild: Node;
-}
+    interface ParentNode extends Node {
+        /**
+         * Child nodes.
+         */
+        children: Node[];
+        /**
+         * Same as {@link children}. [DOM spec](https://dom.spec.whatwg.org)-compatible alias.
+         */
+        childNodes: Node[];
+        /**
+         * First child of the node.
+         */
+        firstChild: Node;
+        /**
+         * Last child of the node.
+         */
+        lastChild: Node;
+    }
 
-/**
- * htmlparser2 tree adapter DocumentType interface.
- */
-export interface DocumentType extends Node {
     /**
-     * The type of the node.
+     * htmlparser2 tree adapter DocumentType interface.
      */
-    type: "directive";
-    /**
-     * Node name.
-     */
-    name: "!doctype";
-    /**
-     * Serialized doctype {@link name}, {@link publicId} and {@link systemId}.
-     */
-    data: string;
-    /**
-     * Document type name.
-     */
-    "x-name": string;
-    /**
-     * Document type public identifier.
-     */
-    "x-publicId": string;
-    /**
-     * Document type system identifier.
-     */
-    "x-systemId": string;
-}
+    interface DocumentType extends Node {
+        /**
+         * The type of the node.
+         */
+        type: "directive";
+        /**
+         * Node name.
+         */
+        name: "!doctype";
+        /**
+         * Serialized doctype {@link name}, {@link publicId} and {@link systemId}.
+         */
+        data: string;
+        /**
+         * Document type name.
+         */
+        "x-name": string;
+        /**
+         * Document type public identifier.
+         */
+        "x-publicId": string;
+        /**
+         * Document type system identifier.
+         */
+        "x-systemId": string;
+    }
 
-/**
- * htmlparser2 tree adapter Document interface.
- */
-export interface Document extends ParentNode {
     /**
-     * The type of the node.
+     * htmlparser2 tree adapter Document interface.
      */
-    type: "root";
-    /**
-     * The name of the node.
-     */
-    name: "root";
-    /**
-     * [Document mode](https://dom.spec.whatwg.org/#concept-document-limited-quirks).
-     */
-    "x-mode": parse5.DocumentMode;
-}
+    interface Document extends ParentNode {
+        /**
+         * The type of the node.
+         */
+        type: "root";
+        /**
+         * The name of the node.
+         */
+        name: "root";
+        /**
+         * [Document mode](https://dom.spec.whatwg.org/#concept-document-limited-quirks).
+         */
+        "x-mode": parse5.DocumentMode;
+    }
 
-/**
- * htmlparser2 tree adapter DocumentFragment interface.
- */
-export interface DocumentFragment extends ParentNode {
     /**
-     * The type of the node.
+     * htmlparser2 tree adapter DocumentFragment interface.
      */
-    type: "root";
-    /**
-     * The name of the node.
-     */
-    name: "root";
-}
+    interface DocumentFragment extends ParentNode {
+        /**
+         * The type of the node.
+         */
+        type: "root";
+        /**
+         * The name of the node.
+         */
+        name: "root";
+    }
 
-/**
- * htmlparser2 tree adapter Element interface.
- */
-export interface Element extends ParentNode {
     /**
-     * The name of the node. Equals to element {@link tagName}.
+     * htmlparser2 tree adapter Element interface.
      */
-    name: string;
-    /**
-     * Element tag name.
-     */
-    tagName: string;
-    /**
-     * Element namespace.
-     */
-    namespace: string;
-    /**
-     * Element attributes.
-     */
-    attribs: { [name: string]: string };
-    /**
-     * Element attribute namespaces.
-     */
-    "x-attribsNamespace": { [name: string]: string };
-    /**
-     * Element attribute namespace-related prefixes.
-     */
-    "x-attribsPrefix": { [name: string]: string };
-    /**
-     * Element source code location info. Available if location info is enabled via ParserOptions.
-     */
-    sourceCodeLocation?: parse5.ElementLocation;
-}
+    interface Element extends ParentNode {
+        /**
+         * The name of the node. Equals to element {@link tagName}.
+         */
+        name: string;
+        /**
+         * Element tag name.
+         */
+        tagName: string;
+        /**
+         * Element namespace.
+         */
+        namespace: string;
+        /**
+         * Element attributes.
+         */
+        attribs: { [name: string]: string };
+        /**
+         * Element attribute namespaces.
+         */
+        "x-attribsNamespace": { [name: string]: string };
+        /**
+         * Element attribute namespace-related prefixes.
+         */
+        "x-attribsPrefix": { [name: string]: string };
+        /**
+         * Element source code location info. Available if location info is enabled via ParserOptions.
+         */
+        sourceCodeLocation?: parse5.ElementLocation;
+    }
 
-/**
- * htmlparser2 tree adapter CommentNode interface.
- */
-export interface CommentNode extends Node {
     /**
-     * The name of the node.
+     * htmlparser2 tree adapter CommentNode interface.
      */
-    name: "comment";
-    /**
-     * Comment text.
-     */
-    data: string;
-    /**
-     * Same as {@link data}. [DOM spec](https://dom.spec.whatwg.org)-compatible alias.
-     */
-    nodeValue: string;
-    /**
-     * Comment source code location info. Available if location info is enabled via ParserOptions.
-     */
-    sourceCodeLocation?: parse5.Location;
-}
+    interface CommentNode extends Node {
+        /**
+         * The name of the node.
+         */
+        name: "comment";
+        /**
+         * Comment text.
+         */
+        data: string;
+        /**
+         * Same as {@link data}. [DOM spec](https://dom.spec.whatwg.org)-compatible alias.
+         */
+        nodeValue: string;
+        /**
+         * Comment source code location info. Available if location info is enabled via ParserOptions.
+         */
+        sourceCodeLocation?: parse5.Location;
+    }
 
-/**
- * htmlparser2 tree adapter TextNode interface.
- */
-export interface TextNode extends Node {
     /**
-     * The name of the node.
+     * htmlparser2 tree adapter TextNode interface.
      */
-    name: "text";
-    /**
-     * Text content.
-     */
-    data: string;
-    /**
-     * Same as {@link data}. [DOM spec](https://dom.spec.whatwg.org)-compatible alias.
-     */
-    nodeValue: string;
-    /**
-     * Comment source code location info. Available if location info is enabled via ParserOptions.
-     */
-    sourceCodeLocation?: parse5.Location;
+    interface TextNode extends Node {
+        /**
+         * The name of the node.
+         */
+        name: "text";
+        /**
+         * Text content.
+         */
+        data: string;
+        /**
+         * Same as {@link data}. [DOM spec](https://dom.spec.whatwg.org)-compatible alias.
+         */
+        nodeValue: string;
+        /**
+         * Comment source code location info. Available if location info is enabled via ParserOptions.
+         */
+        sourceCodeLocation?: parse5.Location;
+    }
 }
 
 declare const treeAdapter: parse5.TreeAdapter;
-export default treeAdapter;
+export = treeAdapter;

--- a/types/parse5-htmlparser2-tree-adapter/parse5-htmlparser2-tree-adapter-tests.ts
+++ b/types/parse5-htmlparser2-tree-adapter/parse5-htmlparser2-tree-adapter-tests.ts
@@ -1,5 +1,5 @@
 import { parse } from "parse5";
-import treeAdapter, {
+import {
     Node,
     ParentNode,
     Document,
@@ -8,6 +8,7 @@ import treeAdapter, {
     TextNode,
     CommentNode
 } from "parse5-htmlparser2-tree-adapter";
+import treeAdapter = require('parse5-htmlparser2-tree-adapter');
 
 // htmlparser2 AST
 const htmlparser2Document = parse("<html>", {

--- a/types/parse5-parser-stream/index.d.ts
+++ b/types/parse5-parser-stream/index.d.ts
@@ -33,7 +33,7 @@ import * as parse5 from "parse5";
  * });
  * ```
  */
-export default class ParserStream<TDocument> extends stream.Writable {
+declare class ParserStream<TDocument> extends stream.Writable {
     /**
      * @param options - Parsing options.
      */
@@ -90,3 +90,7 @@ export default class ParserStream<TDocument> extends stream.Writable {
      */
     on(event: string, listener: (...params: any[]) => any): this;
 }
+
+declare namespace ParserStream {}
+
+export = ParserStream;

--- a/types/parse5-parser-stream/parse5-parser-stream-tests.ts
+++ b/types/parse5-parser-stream/parse5-parser-stream-tests.ts
@@ -1,5 +1,5 @@
 import * as parse5 from "parse5";
-import ParserStream from "parse5-parser-stream";
+import * as ParserStream from "parse5-parser-stream";
 import { createReadStream } from "fs";
 
 const defaultAdapter = new Object() as parse5.TreeAdapter;

--- a/types/parse5-plain-text-conversion-stream/index.d.ts
+++ b/types/parse5-plain-text-conversion-stream/index.d.ts
@@ -4,7 +4,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
-import ParserStream from "parse5-parser-stream";
+import * as ParserStream from "parse5-parser-stream";
 
 /**
  * Converts plain text files into HTML document as required by [HTML specification](https://html.spec.whatwg.org/#read-text).
@@ -28,6 +28,10 @@ import ParserStream from "parse5-parser-stream";
  * file.pipe(converter);
  * ```
  */
-export default class PlainTextConversionStream<TDocument> extends ParserStream<
+declare class PlainTextConversionStream<TDocument> extends ParserStream<
     TDocument
 > {}
+
+declare namespace PlainTextConversionStream {}
+
+export = PlainTextConversionStream;

--- a/types/parse5-plain-text-conversion-stream/parse5-plain-text-conversion-stream-tests.ts
+++ b/types/parse5-plain-text-conversion-stream/parse5-plain-text-conversion-stream-tests.ts
@@ -1,5 +1,5 @@
 import * as parse5 from "parse5";
-import PlainTextConversionStream from "parse5-plain-text-conversion-stream";
+import * as PlainTextConversionStream from "parse5-plain-text-conversion-stream";
 import { createReadStream } from "fs";
 
 const defaultAdapter = new Object() as parse5.TreeAdapter;

--- a/types/parse5-sax-parser/index.d.ts
+++ b/types/parse5-sax-parser/index.d.ts
@@ -9,84 +9,86 @@
 import * as stream from "stream";
 import * as parse5 from "parse5";
 
-export interface StartTagToken {
-    /**
-     * Tag name.
-     */
-    tagName: string;
-    /**
-     * List of attributes.
-     */
-    attrs: parse5.Attribute[];
-    /**
-     * Indicates if the tag is self-closing.
-     */
-    selfClosing: boolean;
-    /**
-     * Start tag source code location info. Available if location info is enabled via {@link SAXParserOptions}.
-     */
-    sourceCodeLocation?: parse5.StartTagLocation;
-}
+declare namespace SAXParser {
+    interface StartTagToken {
+        /**
+         * Tag name.
+         */
+        tagName: string;
+        /**
+         * List of attributes.
+         */
+        attrs: parse5.Attribute[];
+        /**
+         * Indicates if the tag is self-closing.
+         */
+        selfClosing: boolean;
+        /**
+         * Start tag source code location info. Available if location info is enabled via {@link SAXParserOptions}.
+         */
+        sourceCodeLocation?: parse5.StartTagLocation;
+    }
 
-export interface EndTagToken {
-    /**
-     * Tag name.
-     */
-    tagName: string;
-    /**
-     * End tag source code location info. Available if location info is enabled via {@link SAXParserOptions}.
-     */
-    sourceCodeLocation?: parse5.Location;
-}
+    interface EndTagToken {
+        /**
+         * Tag name.
+         */
+        tagName: string;
+        /**
+         * End tag source code location info. Available if location info is enabled via {@link SAXParserOptions}.
+         */
+        sourceCodeLocation?: parse5.Location;
+    }
 
-export interface CommentToken {
-    /**
-     * Comment text.
-     */
-    text: string;
-    /**
-     * Comment source code location info. Available if location info is enabled via {@link SAXParserOptions}.
-     */
-    sourceCodeLocation?: parse5.Location;
-}
+    interface CommentToken {
+        /**
+         * Comment text.
+         */
+        text: string;
+        /**
+         * Comment source code location info. Available if location info is enabled via {@link SAXParserOptions}.
+         */
+        sourceCodeLocation?: parse5.Location;
+    }
 
-export interface TextToken {
-    /**
-     * Text content.
-     */
-    text: string;
-    /**
-     * Text content source code location info. Available if location info is enabled via {@link SAXParserOptions}.
-     */
-    sourceCodeLocation?: parse5.Location;
-}
+    interface TextToken {
+        /**
+         * Text content.
+         */
+        text: string;
+        /**
+         * Text content source code location info. Available if location info is enabled via {@link SAXParserOptions}.
+         */
+        sourceCodeLocation?: parse5.Location;
+    }
 
-export interface DoctypeToken {
-    /**
-     * Document type name.
-     */
-    name: string;
-    /**
-     * Document type public identifier.
-     */
-    publicId: string;
-    /**
-     * Document type system identifier.
-     */
-    systemId: string;
-    /**
-     * Document type declaration source code location info. Available if location info is enabled via {@link SAXParserOptions}.
-     */
-    sourceCodeLocation?: parse5.Location;
-}
+    interface DoctypeToken {
+        /**
+         * Document type name.
+         */
+        name: string;
+        /**
+         * Document type public identifier.
+         */
+        publicId: string;
+        /**
+         * Document type system identifier.
+         */
+        systemId: string;
+        /**
+         * Document type declaration source code location info. Available if location info is enabled via {@link SAXParserOptions}.
+         */
+        sourceCodeLocation?: parse5.Location;
+    }
 
-export interface SAXParserOptions {
-    /**
-     * Enables source code location information for the tokens.
-     * When enabled, each token event handler will receive {@link Location} (or {@link StartTagLocation})
-     * object as its last argument.
-     */
-    sourceCodeLocationInfo?: boolean;
+    interface SAXParserOptions {
+        /**
+         * Enables source code location information for the tokens.
+         * When enabled, each token event handler will receive {@link Location} (or {@link StartTagLocation})
+         * object as its last argument.
+         */
+        sourceCodeLocationInfo?: boolean;
+    }
 }
 
 /**
@@ -119,43 +121,43 @@ export interface SAXParserOptions {
  * });
  * ```
  */
-export default class SAXParser extends stream.Transform {
+declare class SAXParser extends stream.Transform {
     /**
      * @param options - Parsing options.
      */
-    constructor(options?: SAXParserOptions);
+    constructor(options?: SAXParser.SAXParserOptions);
 
     /**
      * Raised when the parser encounters a start tag.
      *
      * @param listener.startTag - Start tag token.
      */
-    on(event: "startTag", listener: (startTag: StartTagToken) => void): this;
+    on(event: "startTag", listener: (startTag: SAXParser.StartTagToken) => void): this;
 
     /**
      * Raised when parser encounters an end tag.
      *
      * @param listener.endTag - End tag token.
      */
-    on(event: "endTag", listener: (endTag: EndTagToken) => void): this;
+    on(event: "endTag", listener: (endTag: SAXParser.EndTagToken) => void): this;
     /**
      * Raised when parser encounters text content.
      *
      * @param listener.text - Text token.
      */
-    on(event: "text", listener: (text: TextToken) => void): this;
+    on(event: "text", listener: (text: SAXParser.TextToken) => void): this;
     /**
      * Raised when parser encounters a comment.
      *
      * @param listener.comment - Comment content.
      */
-    on(event: "comment", listener: (comment: CommentToken) => void): this;
+    on(event: "comment", listener: (comment: SAXParser.CommentToken) => void): this;
     /**
      * Raised when parser encounters a [document type declaration](https://en.wikipedia.org/wiki/Document_type_declaration).
      *
      * @param listener.doctype - Document type token.
      */
-    on(event: "doctype", listener: (doctype: DoctypeToken) => void): this;
+    on(event: "doctype", listener: (doctype: SAXParser.DoctypeToken) => void): this;
     /**
      * TransformStream events
      */
@@ -190,3 +192,5 @@ export default class SAXParser extends stream.Transform {
      */
     stop(): void;
 }
+
+export = SAXParser;

--- a/types/parse5-sax-parser/parse5-sax-parser-tests.ts
+++ b/types/parse5-sax-parser/parse5-sax-parser-tests.ts
@@ -1,10 +1,11 @@
-import SAXParser, {
+import {
     StartTagToken,
     EndTagToken,
     CommentToken,
     TextToken,
     DoctypeToken
 } from "parse5-sax-parser";
+import SAXParser = require("parse5-sax-parser");
 import { createReadStream, createWriteStream } from "fs";
 
 let sax = new SAXParser();

--- a/types/parse5-serializer-stream/index.d.ts
+++ b/types/parse5-serializer-stream/index.d.ts
@@ -30,7 +30,7 @@ import * as parse5 from "parse5";
  * serializer.pipe(file);
  * ```
  */
-export default class SerializerStream extends stream.Readable {
+declare class SerializerStream extends stream.Readable {
     /**
      * Streaming AST node to an HTML serializer. A readable stream.
      *
@@ -39,3 +39,7 @@ export default class SerializerStream extends stream.Readable {
      */
     constructor(node: parse5.Node, options?: parse5.SerializerOptions);
 }
+
+declare namespace SerializerStream {}
+
+export = SerializerStream;

--- a/types/parse5-serializer-stream/parse5-serializer-stream-tests.ts
+++ b/types/parse5-serializer-stream/parse5-serializer-stream-tests.ts
@@ -1,5 +1,5 @@
 import { parse, TreeAdapter } from "parse5";
-import SerializerStream from "parse5-serializer-stream";
+import * as SerializerStream from "parse5-serializer-stream";
 import { createReadStream, createWriteStream } from "fs";
 
 const document = parse("<html>");


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/inikulin/parse5/blob/4350f6a03dcd57dd9b3d8ba3c962ebf31a5f7f54/packages/parse5-sax-parser/lib/index.js#L157
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

There are no `default` exports in those packages, because all of them use `module.exports = `.

Note that I added a `declare namespace` declaration to all of the packages, even if they are currently empty. This allows them to be imported with `import * as XXX from''` and makes adding exported interfaces easier in the future.

On a related note: there are no typings for `parse5-html-rewriting-stream`.

/cc @inikulin 