### PR TITLE
Resolve "parse5/lib/index has no exported member ElementLocation" in types/jsdom/index.d.ts

### DIFF
--- a/types/jsdom/index.d.ts
+++ b/types/jsdom/index.d.ts
@@ -7,7 +7,7 @@
 /// <reference types="node" />
 
 import { EventEmitter } from 'events';
-import { ElementLocation } from 'parse5';
+import { MarkupData } from 'parse5';
 import * as tough from 'tough-cookie';
 import { Script } from 'vm';
 
@@ -32,7 +32,7 @@ export class JSDOM {
     /**
      * The nodeLocation() method will find where a DOM node is within the source document, returning the parse5 location info for the node.
      */
-    nodeLocation(node: Node): ElementLocation | null;
+    nodeLocation(node: Node): MarkupData.ElementLocation | null;
 
     /**
      * The built-in vm module of Node.js allows you to create Script instances,


### PR DESCRIPTION
We're receiving the following error in all our builds:

ERROR in [at-loader] ./node_modules/@types/jsdom/index.d.ts:10:10
    TS2305: Module '"..../node_modules/parse5/lib/index"' has no exported member 'ElementLocation'.


- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).


I'm not hugely familiar with TS - but this appears to resolve the problem we have with our use of jsdom. 

@inikulin could you verify?
