### PR TITLE
[koa-router] Change type of returned middleware to match type that Koa expects

### DIFF
--- a/types/koa-router/index.d.ts
+++ b/types/koa-router/index.d.ts
@@ -225,19 +225,19 @@ declare class Router {
     /**
      * Returns router middleware which dispatches a route matching the request.
      */
-    routes(): Router.IMiddleware;
+    routes(): Koa.Middleware;
 
     /**
      * Returns router middleware which dispatches a route matching the request.
      */
-    middleware(): Router.IMiddleware;
+    middleware(): Koa.Middleware;
 
     /**
      * Returns separate middleware for responding to `OPTIONS` requests with
      * an `Allow` header containing the allowed methods, as well as responding
      * with `405 Method Not Allowed` and `501 Not Implemented` as appropriate.
      */
-    allowedMethods(options?: Router.IRouterAllowedMethodsOptions): Router.IMiddleware;
+    allowedMethods(options?: Router.IRouterAllowedMethodsOptions): Koa.Middleware;
 
     /**
      * Redirect `source` to `destination` URL with optional 30x status `code`.


### PR DESCRIPTION
Koa router has two types of middleware: the middleware it accepts for routes like `router.get(path, middleware)` and the middleware it creates, like `router.routes()`, that is passed to `koa.use(...)`. The former takes context objects with a `params` field while the latter doesn't. These are two different types of middleware and this commit changes the TypeScript declaration to reflect those two different types. This fixes a type error where `koa.use(router.routes())` fails to type check because the `Context` that Koa will pass in doesn't satisfy `IRouterContext` that `router.routes()` wanted.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/alexmingoia/koa-router/blob/master/lib/router.js#L344 (the context object doesn't have `params` until `koarouter.routes()` adds it)
- [x] Increase the version number in the header if appropriate.
