### PR TITLE
@types/three Update missing property

### DIFF
--- a/types/three/three-core.d.ts
+++ b/types/three/three-core.d.ts
@@ -5329,6 +5329,11 @@ export interface WebGLRendererParameters {
      * default is false.
      */
     logarithmicDepthBuffer?: boolean;
+
+	/**
+     * default is null.
+     */
+    context?: CanvasRenderingContext2D | WebGLRenderingContext;
 }
 
 


### PR DESCRIPTION
There is missing property in 'WebGLRendererParameters' interface. According to sources of Three.js in constructor there is possibility to pass also 'context' as one of parameter.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://threejs.org/docs/index.html#api/renderers/WebGLRenderer

