### PR TITLE
[sequelize/v3] Deferrable option mistakenly refers to the interface and not it's contents

### DIFF
--- a/types/sequelize/v3/index.d.ts
+++ b/types/sequelize/v3/index.d.ts
@@ -4339,7 +4339,7 @@ declare namespace sequelize {
          *
          * PostgreSQL only
          */
-        deferrable?: Deferrable;
+        deferrable?: DeferrableInitiallyDeferred | DeferrableInitiallyImmediate | DeferrableNot | DeferrableSetDeferred | DeferrableSetImmediate;
 
     }
 


### PR DESCRIPTION
When defining a model, the type misdefinition doesn't allow you to use the Sequelize builtins for Deferrable FK references.

This ports the fix for sequelize v4 types from [PR 18677](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/18677) to sequelize v3 types.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://sequelize.readthedocs.io/en/v3/docs/models-definition/>
