### PR TITLE
Add generic for push to add more type safety (react-native-navigation)

### DIFF
--- a/types/react-native-navigation/index.d.ts
+++ b/types/react-native-navigation/index.d.ts
@@ -85,13 +85,13 @@ export interface ModalScreen extends Screen {
     animationType?: 'slide-up' | 'none';
 }
 
-export interface ResetScreen extends Screen {
-    passProps?: object;
+export interface ResetScreen<P> extends Screen {
+    passProps?: P;
     animated?: boolean;
     animationType?: 'fade' | 'slide-horizontal';
 }
 
-export interface PushedScreen extends ResetScreen {
+export interface PushedScreen<P> extends ResetScreen<P> {
     titleImage?: any;
     backButtonTitle?: string;
     backButtonHidden?: boolean;
@@ -123,10 +123,10 @@ export interface NavigatorEvent {
 }
 
 export class Navigator {
-    push(params: PushedScreen): void;
+    push<P>(params: PushedScreen<P>): void;
     pop(params?: { animated?: boolean; animationType?: 'fade' | 'slide-horizontal'; }): void;
     popToRoot(params?: { animated?: boolean; animationType?: 'fade' | 'slide-horizontal'; }): void;
-    resetTo(params: PushedScreen): void;
+    resetTo<P>(params: PushedScreen<P>): void;
     showModal(params: ModalScreen): void;
     dismissModal(params?: { animationType?: 'none' | 'slide-down' }): void;
     dismissAllModals(params?: { animationType?: 'none' | 'slide-down' }): void;

--- a/types/react-native-navigation/react-native-navigation-tests.tsx
+++ b/types/react-native-navigation/react-native-navigation-tests.tsx
@@ -30,7 +30,11 @@ class Screen1 extends React.Component<Props> {
     };
 
     componentDidMount() {
-        this.props.navigator.push({ screen: 'example.Screen2', overrideBackPress: false });
+        this.props.navigator.push<Screen2OwnProps>({
+            screen: 'example.Screen2',
+            overrideBackPress: false,
+            passProps: { name: 'Henrik' },
+        });
         this.props.navigator.setTabBadge({ badge: null });
     }
 
@@ -43,7 +47,13 @@ class Screen1 extends React.Component<Props> {
     }
 }
 
-class Screen2 extends React.Component<NavigationComponentProps> {
+interface Screen2OwnProps {
+    name: string;
+}
+
+type Screen2Props = Screen2OwnProps & NavigationComponentProps;
+
+class Screen2 extends React.Component<Screen2Props> {
     static navigatorStyle: NavigatorStyle = {
         drawUnderNavBar: true,
         navBarTranslucent: true
@@ -57,6 +67,7 @@ class Screen2 extends React.Component<NavigationComponentProps> {
         return (
             <View>
                 <Text>Screen 2</Text>
+                <Text>Hello {this.props.name}</Text>
             </View>
         );
     }

--- a/types/react-native-navigation/tslint.json
+++ b/types/react-native-navigation/tslint.json
@@ -1,1 +1,1 @@
-{ "extends": "dtslint/dt.json" }
+{ "extends": "dtslint/dt.json", "rules": {"no-unnecessary-generics": false} }


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Think about this:
You have C screen where you can go from two different screens: A and B. You also have to pass some props for screen C when you push that screen. So you do pass props from A and B as you should. Later you add some other prop that is required. Before this PR you can easily forget to add the new prop for all places where you are pushing screen C. Now with the generic you can!

Tell me what your guys think. I think this would increase type safety a lot!