### PR TITLE
Fix/chai assert missing method

### DIFF
--- a/types/chai/chai-tests.ts
+++ b/types/chai/chai-tests.ts
@@ -1361,6 +1361,39 @@ suite('assert', () => {
         assert.notDeepEqual(circularObject, secondCircularObject);
     });
 
+    test('deepStrictEqual', () => {
+        assert.deepStrictEqual({tea: 'chai'}, {tea: 'chai'});
+        assert.throws(() => assert.deepStrictEqual({tea: 'chai'}, {tea: 'black'}));
+
+        const obja = Object.create({tea: 'chai'});
+        const objb = Object.create({tea: 'chai'});
+
+        assert.deepStrictEqual(obja, objb);
+
+        const obj1 = Object.create({tea: 'chai'});
+        const obj2 = Object.create({tea: 'black'});
+
+        assert.throws(() => assert.deepStrictEqual(obj1, obj2));
+    });
+
+    test('deepStrictEqual (ordering)', () => {
+        const a = {a: 'b', c: 'd'};
+        const b = {c: 'd', a: 'b'};
+        assert.deepStrictEqual(a, b);
+    });
+
+    test('deepStrictEqual (circular)', () => {
+        const circularObject: any = {};
+        const secondCircularObject: any = {};
+        circularObject.field = circularObject;
+        secondCircularObject.field = secondCircularObject;
+
+        assert.deepStrictEqual(circularObject, secondCircularObject);
+
+        secondCircularObject.field2 = secondCircularObject;
+        assert.deepStrictEqual(circularObject, secondCircularObject);
+    });
+
     test('isNull', () => {
         assert.isNull(null);
         assert.isNull(undefined);

--- a/types/chai/index.d.ts
+++ b/types/chai/index.d.ts
@@ -353,7 +353,7 @@ declare namespace Chai {
         notStrictEqual<T>(actual: T, expected: T, message?: string): void;
 
         /**
-         * Asserts that actual is deeply equal to expected.
+         * Asserts that actual is deeply equal (==) to expected.
          *
          * @type T   Type of the objects.
          * @param actual   Actual value.
@@ -363,7 +363,7 @@ declare namespace Chai {
         deepEqual<T>(actual: T, expected: T, message?: string): void;
 
         /**
-         * Asserts that actual is not deeply equal to expected.
+         * Asserts that actual is not deeply equal (==) to expected.
          *
          * @type T   Type of the objects.
          * @param actual   Actual value.
@@ -371,6 +371,16 @@ declare namespace Chai {
          * @param message   Message to display on error.
          */
         notDeepEqual<T>(actual: T, expected: T, message?: string): void;
+
+        /**
+         * Asserts that actual is deeply strict equal (===) to expected.
+         *
+         * @type T   Type of the objects.
+         * @param actual   Actual value.
+         * @param expected   Potential expected value.
+         * @param message   Message to display on error.
+         */
+        deepStrictEqual<T>(actual: T, expected: T, message?: string): void;
 
         /**
          * Asserts valueToCheck is strictly greater than (>) valueToBeAbove.


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: 

Strangely this method isn't documented in [the chai documentation](http://www.chaijs.com/api/assert/). But I tested it an the method exists and works:

![image](https://user-images.githubusercontent.com/7669818/41103310-1fff1784-6a69-11e8-9030-869a6701f804.png)

You can refer to the tests in this PR or get the code in this [Gist](https://gist.github.com/FabianTe/a0bbe4e13350d222a8da0a09daf922b2)

- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
