### PR TITLE
Adding additional bodyPadding to IFrameOptions to iframe-resizer

### DIFF
--- a/types/iframe-resizer/index.d.ts
+++ b/types/iframe-resizer/index.d.ts
@@ -33,6 +33,11 @@ export interface IFrameOptions {
    */
   bodyMargin?: number | string;
   /**
+   * Override the default body padding style in the iFrame. A string can be any valid value for the
+   * CSS margin attribute, for example '8px 3em'. A number value is converted into px.
+   */
+  bodyPadding?: number | string;
+  /**
    * When set to true, only allow incoming messages from the domain listed in the src property of the iFrame tag.
    * If your iFrame navigates between different domains, ports or protocols; then you will need to
    * provide an array of URLs or disable this option.


### PR DESCRIPTION
This change add the missing bodyPadding to the IFrameOptions definition.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/davidjbradshaw/iframe-resizer/blob/master/src/iframeResizer.js#L37 (I also submitted a PR of that repo to make part of the README.md)
- [X] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
