### PR TITLE
[react-places-autocomplete] Update typings

### DIFF
--- a/types/react-places-autocomplete/index.d.ts
+++ b/types/react-places-autocomplete/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for react-places-autocomplete 6.1
 // Project: https://github.com/kenny-hibino/react-places-autocomplete/
 // Definitions by: Guilherme Hübner <https://github.com/guilhermehubner>
+//                 Andrew Makarov <https://github.com/r3nya>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.6
 //
@@ -56,6 +57,11 @@ export interface PropTypes {
 }
 
 export function geocodeByAddress(address: string, callback: (results: google.maps.GeocoderResult[], status: google.maps.GeocoderStatus) => void): void;
+export function geocodeByAddress(address: string): Promise<google.maps.GeocoderResult[]>;
+
 export function geocodeByPlaceId(placeId: string, callback: (results: google.maps.GeocoderResult[], status: google.maps.GeocoderStatus) => void): void;
+export function geocodeByPlaceId(placeId: string): Promise<google.maps.GeocoderResult[]>;
+
+export function getLatLng(results: google.maps.GeocoderResult): Promise<google.maps.LatLngLiteral>;
 
 export default class PlacesAutocomplete extends React.Component<PropTypes> {}

--- a/types/react-places-autocomplete/react-places-autocomplete-tests.tsx
+++ b/types/react-places-autocomplete/react-places-autocomplete-tests.tsx
@@ -1,0 +1,52 @@
+import * as React from 'react';
+import PlacesAutocomplete, { geocodeByAddress, geocodeByPlaceId, getLatLng } from 'react-places-autocomplete';
+
+class Test extends React.Component {
+    state = {
+        address: 'San Francisco, CA',
+        placeId: '12345',
+    };
+
+    handleFormSubmit = (event: any) => {
+        event.preventDefault();
+
+        const { address, placeId } = this.state;
+
+        // Old API
+        geocodeByAddress(address, (results, status) => {
+            const latLng = getLatLng(results[0]);
+            console.info(latLng, status);
+        });
+
+        geocodeByPlaceId(placeId, (results, status) => {
+            const latLng = getLatLng(results[0]);
+            console.info(latLng, status);
+        });
+
+        // New API
+        geocodeByAddress(address)
+            .then((results) => getLatLng(results[0]))
+            .then((latLng) => console.log('Success', latLng))
+            .catch((error) => console.error('Error', error));
+
+        geocodeByPlaceId(placeId)
+            .then((results) => getLatLng(results[0]))
+            .then((latLng) => console.log('Success', latLng))
+            .catch((error) => console.error('Error', error));
+    }
+
+    onChange = (address: string) => this.setState({ address });
+
+    render() {
+        const inputProps = {
+            value: this.state.address,
+            onChange: this.onChange,
+        };
+
+        return (
+            <form onSubmit={this.handleFormSubmit}>
+                <PlacesAutocomplete inputProps={inputProps} />
+            </form>
+        );
+    }
+}

--- a/types/react-places-autocomplete/tsconfig.json
+++ b/types/react-places-autocomplete/tsconfig.json
@@ -1,12 +1,19 @@
 {
-  "files": ["index.d.ts"],
+  "files": [
+    "index.d.ts",
+    "react-places-autocomplete-tests.tsx"
+  ],
   "compilerOptions": {
     "module": "commonjs",
-    "lib": ["es6"],
+    "lib": [
+        "es6",
+        "dom"
+    ],
     "noImplicitAny": true,
     "noImplicitThis": true,
     "strictNullChecks": true,
     "strictFunctionTypes": true,
+    "jsx": "react",
     "baseUrl": "../",
     "typeRoots": ["../"],
     "types": [],


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/kenny-hibino/react-places-autocomplete/blob/v6.1.3/src/utils.js
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

## Description

- `react-places-autocomplete@6.1` – `geocodeByAddress`, `geocodeByPlaceId` functions can work with callbacks and can return `Promise` as well.
- Added typings for `getLatLng` function
- I've added test for it.

PS: In `react-places-autocomplete@7` user need to work only with `Promise`. I will create a PR for `react-places-autocomplete@7` after it because we need to update typings for `react-places-autocomplete@6.1`. 😉 