### PR TITLE
Chartist: Relax constraints on meta.

### DIFF
--- a/types/chartist/chartist-tests.ts
+++ b/types/chartist/chartist-tests.ts
@@ -247,7 +247,7 @@ new Chartist.Pie('.ct-chart', {
         value: 70,
         name: 'Series 3',
         className: 'my-custom-class-three',
-        meta: 'Meta Three'
+        meta: {  description: 'Meta Three' }
     }]
 });
 

--- a/types/chartist/index.d.ts
+++ b/types/chartist/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for Chartist v0.9.81
 // Project: https://github.com/gionkunz/chartist-js
-// Definitions by: Matt Gibbs <https://github.com/mtgibbs>, Simon Pfeifer <https://github.com/psimonski>, Cassey Lottman <https://github.com/clottman>, Anastasiia Antonova <https://github.com/affilnost>
+// Definitions by: Matt Gibbs <https://github.com/mtgibbs>, Simon Pfeifer <https://github.com/psimonski>, Cassey Lottman <https://github.com/clottman>, Anastasiia Antonova <https://github.com/affilnost>, Sunny Juneja <https://github.com/sunnyrjuneja>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare namespace Chartist {
@@ -101,7 +101,7 @@ declare namespace Chartist {
         value?: number;
         data?: Array<number>;
         className?: string;
-        meta?: string; // I assume this could probably be a number as well?
+        meta?: any;
     }
 
     interface IChartistBase<T extends IChartOptions> {


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:

The purpose of this PR is to relax the constraint on meta. Meta is commonly to provide additional context  to further customize Chartist (by plugins or library users). It simply serializes what's in meta to the DOM and is useful checking attributes during an event handler (example: context.meta.needsExtraColors). Below is a link to a test which stores JavaScript object in meta.
 https://github.com/gionkunz/chartist-js/blob/6076b7df0ae30268f40eb720e0ed0bf529b8cc43/test/spec/spec-pie-chart.js#L16

Copied for benefit of reviewer.
```javascript
      var meta = {
        test: 'Serialized Test'
      };

      var data = {
        labels: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu'],
        series: [
          [5, 2, 4, {
            value: 2,
            meta: meta
          }, 0]
        ]
      };
```

- [x] Increase the version number in the header if appropriate
Not appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
Not necessary.