### PR TITLE
[react] Add `type` property for `<ol>`

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -1545,6 +1545,7 @@ declare namespace React {
     interface OlHTMLAttributes<T> extends HTMLAttributes<T> {
         reversed?: boolean;
         start?: number;
+        type?: '1' | 'a' | 'A' | 'i' | 'I';
     }
 
     interface OptgroupHTMLAttributes<T> extends HTMLAttributes<T> {


### PR DESCRIPTION
Maybe there was a reason `type` was excluded?
https://developer.mozilla.org/en-US/docs/Web/API/HTMLOListElement

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
