### PR TITLE
[serialport] added readonly properties

### DIFF
--- a/types/serialport/index.d.ts
+++ b/types/serialport/index.d.ts
@@ -12,6 +12,11 @@ declare class SerialPort extends Stream.Duplex {
 	constructor(path: string, callback?: SerialPort.ErrorCallback);
 	constructor(path: string, options?: SerialPort.OpenOptions, callback?: SerialPort.ErrorCallback);
 
+	readonly baudRate: number;
+	readonly binding: SerialPort.BaseBinding;
+	readonly isOpen: boolean;
+	readonly path: string;
+
 	open(callback?: SerialPort.ErrorCallback): void;
 	update(options: SerialPort.UpdateOptions, callback?: SerialPort.ErrorCallback): void;
 

--- a/types/serialport/serialport-tests.ts
+++ b/types/serialport/serialport-tests.ts
@@ -117,3 +117,12 @@ function test_parsers() {
     port.pipe(ReadyParser);
     port.pipe(RegexParser);
 }
+
+function test_properties() {
+    const port = new SerialPort('');
+
+    const baudRate: number = port.baudRate;
+    const binding: SerialPort.BaseBinding = port.binding;
+    const isOpen: boolean = port.isOpen;
+    const path: string = port.path;
+}


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://node-serialport.github.io/node-serialport/SerialPort.html
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
