### PR TITLE
Fix d3 version 3 d3.layout.treemap.sticky return type as per official documentation and actual API

### DIFF
--- a/types/d3/v3/index.d.ts
+++ b/types/d3/v3/index.d.ts
@@ -3277,7 +3277,7 @@ declare namespace d3 {
             round(round: boolean): Treemap<T>;
 
             sticky(): boolean;
-            sticky(sticky: boolean): boolean;
+            sticky(sticky: boolean): Treemap<T>;
 
             mode(): string;
             mode(mode: "squarify"): Treemap<T>;


### PR DESCRIPTION
According to the official documentation

> Like other classes in D3, layouts follow the method chaining pattern where setter methods return the layout itself, allowing multiple setters to be invoked in a concise statement.

And d3.layout.treemap.sticky specifically https://github.com/d3/d3-3.x-api-reference/blob/master/Treemap-Layout.md#sticky  should return Treemap<T>.

This file should comply with the actual API, why it is not?

Submitting this PR for your consideration

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
