### PR TITLE
[jquery] Fix compatibility issue with `@types/bluebird-global`.

### DIFF
--- a/types/jquery/index.d.ts
+++ b/types/jquery/index.d.ts
@@ -6361,7 +6361,9 @@ declare namespace JQuery {
         };
 
         // Writable properties on XMLHttpRequest
-        interface XHRFields extends Partial<Pick<XMLHttpRequest, 'onreadystatechange' | 'responseType' | 'timeout' | 'withCredentials' | 'msCaching'>> { }
+        interface XHRFields extends Partial<Pick<XMLHttpRequest, 'onreadystatechange' | 'responseType' | 'timeout' | 'withCredentials'>> {
+            msCaching?: string;
+        }
     }
 
     interface Transport {

--- a/types/jquery/index.d.ts
+++ b/types/jquery/index.d.ts
@@ -37,8 +37,6 @@ declare const $: JQueryStatic;
 
 // Used by JQuery.Event
 type _Event = Event;
-// Used by JQuery.Promise3 and JQuery.Promise
-type _Promise<T> = Promise<T>;
 
 interface JQueryStatic<TElement extends Node = HTMLElement> {
     /**
@@ -6525,6 +6523,28 @@ declare namespace JQuery {
      */
     interface Thenable<T> extends PromiseLike<T> { }
 
+    // NOTE: This is a private copy of the global Promise interface. It is used by JQuery.PromiseBase to indicate compatibility with other Promise implementations.
+    //       The global Promise interface cannot be used directly as it may be modified, as in the case of @types/bluebird-global.
+    /**
+     * Represents the completion of an asynchronous operation
+     */
+    interface _Promise<T> {
+        /**
+         * Attaches callbacks for the resolution and/or rejection of the Promise.
+         * @param onfulfilled The callback to execute when the Promise is resolved.
+         * @param onrejected The callback to execute when the Promise is rejected.
+         * @returns A Promise for the completion of which ever callback is executed.
+         */
+        then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | null,
+                                             onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | null): JQuery._Promise<TResult1 | TResult2>;
+        /**
+         * Attaches a callback for only the rejection of the Promise.
+         * @param onrejected The callback to execute when the Promise is rejected.
+         * @returns A Promise for the completion of the callback.
+         */
+        catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | null): JQuery._Promise<T | TResult>;
+    }
+
     // Type parameter guide
     // --------------------
     // Each type parameter represents a parameter in one of the three possible callbacks.
@@ -6550,7 +6570,7 @@ declare namespace JQuery {
     interface PromiseBase<TR, TJ, TN,
         UR, UJ, UN,
         VR, VJ, VN,
-        SR, SJ, SN> extends _Promise<TR>, PromiseLike<TR> {
+        SR, SJ, SN> extends JQuery._Promise<TR>, PromiseLike<TR> {
         /**
          * Add handlers to be called when the Deferred object is either resolved or rejected.
          *

--- a/types/jquery/jquery-tests.ts
+++ b/types/jquery/jquery-tests.ts
@@ -6857,7 +6857,7 @@ function JQuery_jqXHR() {
         }
     }
 
-    function compatibleWithPromise(): Promise<any> {
+    function compatibleWithPromise(): JQuery._Promise<any> {
         return p;
     }
 
@@ -7279,7 +7279,7 @@ function JQuery_Promise3() {
         return s;
     }
 
-    function compatibleWithPromise(): Promise<any> {
+    function compatibleWithPromise(): JQuery._Promise<any> {
         return p;
     }
 
@@ -7423,7 +7423,7 @@ function JQuery_Promise2(p: JQuery.Promise2<string, Error, number, JQuery, strin
         return s;
     }
 
-    function compatibleWithPromise(): Promise<any> {
+    function compatibleWithPromise(): JQuery._Promise<any> {
         return p;
     }
 
@@ -7544,7 +7544,7 @@ function JQuery_Promise(p: JQuery.Promise<string, Error, number>) {
         return s;
     }
 
-    function compatibleWithPromise(): Promise<any> {
+    function compatibleWithPromise(): JQuery._Promise<any> {
         return p;
     }
 }

--- a/types/jquery/test/bluebird-global-tests.ts
+++ b/types/jquery/test/bluebird-global-tests.ts
@@ -1,0 +1,4 @@
+/// <reference types="bluebird-global" />
+
+// Pulls in bluebird-global to test compatibility.
+// Fixes https://github.com/DefinitelyTyped/DefinitelyTyped/issues/26328.

--- a/types/jquery/tsconfig.json
+++ b/types/jquery/tsconfig.json
@@ -21,6 +21,7 @@
     "files": [
         "index.d.ts",
         "jquery-tests.ts",
+        "test/bluebird-global-tests.ts",
         "test/example-tests.ts",
         "test/longdesc-tests.ts",
         "test/learn-tests.ts",

--- a/types/jquery/tslint.json
+++ b/types/jquery/tslint.json
@@ -14,6 +14,7 @@
         "no-empty-interface": false,
         "no-misused-new": false,
         "no-object-literal-type-assertion": false,
+        "no-redundant-jsdoc-2": false,
         "no-unnecessary-generics": false,
         "no-unnecessary-qualifier": false,
         "no-unnecessary-type-assertion": false,


### PR DESCRIPTION
`@types/jquery` used the global Promise interface to indicate compatibility with other Promise implementations. `@types/bluebird-global` modifies the global Promise interface making it unsafe to use.

To remedy this, a private copy of the global Promise interface is introduced.

Fixes #26328

Disabled `no-redundant-jsdoc-2` as I'm not sure what the alternative is supposed to be.

Closes #26503

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- ~~Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>~~
- ~~Increase the version number in the header if appropriate.~~
- ~~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.~~
