### PR TITLE
[jsdom] Depend on correct version of parse5.

### DIFF
--- a/types/jsdom/index.d.ts
+++ b/types/jsdom/index.d.ts
@@ -7,7 +7,7 @@
 /// <reference types="node" />
 
 import { EventEmitter } from 'events';
-import { ElementLocation } from 'parse5';
+import { MarkupData } from './node_modules/parse5';
 import * as tough from 'tough-cookie';
 import { Script } from 'vm';
 
@@ -32,7 +32,7 @@ export class JSDOM {
     /**
      * The nodeLocation() method will find where a DOM node is within the source document, returning the parse5 location info for the node.
      */
-    nodeLocation(node: Node): ElementLocation | null;
+    nodeLocation(node: Node): MarkupData.ElementLocation | null;
 
     /**
      * The built-in vm module of Node.js allows you to create Script instances,


### PR DESCRIPTION
The introduction of type declarations for `parse5` (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/25943) causes `@types/jsdom` to use the newer, incorrect version which is incompatible. I changed the import to a relative path. I'm not sure if it's the proper fix but the linter seems to be happy.

Fixes https://github.com/DefinitelyTyped/DefinitelyTyped/issues/26338.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
https://github.com/jsdom/jsdom/blob/0f4128dabbf155160eceae50a2217572439a631e/package.json#L30
- ~~Increase the version number in the header if appropriate.~~
- ~~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.~~
