### PR TITLE
[@types/decompress] decompress function should have four overloads

### DIFF
--- a/types/decompress/decompress-tests.ts
+++ b/types/decompress/decompress-tests.ts
@@ -19,3 +19,24 @@ decompress('unicorn.zip', 'dist', {
 }).then((files: decompress.File[]) => {
 	console.log('done!');
 });
+
+// Test decompress with no output to filesystem
+decompress('unicorn.zip')
+	.then(
+		(files: decompress.File[]) => {
+			console.log('Decompressed ' + files.length + " files with no write to filesystem");
+		}
+	);
+
+// Test decompress with DecompressOptions as second argument
+decompress(
+	'unicorn.zip',
+	{
+		filter: file => path.extname(file.path) !== '.exe'
+	}
+)
+	.then(
+		(files: decompress.File[]) => {
+			console.log('Decompressed ' + files.length + " files with filter options");
+		}
+	);

--- a/types/decompress/decompress-tests.ts
+++ b/types/decompress/decompress-tests.ts
@@ -24,7 +24,7 @@ decompress('unicorn.zip', 'dist', {
 decompress('unicorn.zip')
 	.then(
 		(files: decompress.File[]) => {
-			console.log('Decompressed ' + files.length + " files with no write to filesystem");
+			console.log(`Decompressed ${files.length} files with no write to filesystem`);
 		}
 	);
 
@@ -37,6 +37,6 @@ decompress(
 )
 	.then(
 		(files: decompress.File[]) => {
-			console.log('Decompressed ' + files.length + " files with filter options");
+			console.log(`Decompressed ${files.length} files with filter options`);
 		}
 	);

--- a/types/decompress/index.d.ts
+++ b/types/decompress/index.d.ts
@@ -7,7 +7,7 @@
 
 export = decompress;
 
-declare function decompress(input: string | Buffer, output: string, opts?: decompress.DecompressOptions): Promise<decompress.File[]>;
+declare function decompress(input: string | Buffer, output?: string | decompress.DecompressOptions, opts?: decompress.DecompressOptions): Promise<decompress.File[]>;
 
 declare namespace decompress {
     interface File {

--- a/types/decompress/index.d.ts
+++ b/types/decompress/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for decompress 4.2
 // Project: https://github.com/kevva/decompress#readme
 // Definitions by: York Yao <https://github.com/plantain-00>
+//                 Jesse Bethke <https://github.com/jbethke>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />


### PR DESCRIPTION
kevaa/decompress exports a function with 4 overloads:

1. decompress (input, output, opts)
2. decompress (input, output)
3. decompress (input, opts)
4. decompress (input)

Prior definition did not support third and fourth overload patterns. This pull request corrects that.

- [ x ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ x ] Test the change in your own code. (Compile and run.)
- [ x ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ x ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ x ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ x ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [ x ] Provide a URL to documentation or source code which provides context for the suggested changes: 

Line 41 provides for undefined options
_function extractFile is invoked from decompress on line 95_
https://github.com/kevva/decompress/blob/master/index.js#L40

Line 81 allows for DecompressOptions sent as second argument instead of third
https://github.com/kevva/decompress/blob/master/index.js#L81