### PR TITLE
[jest] Added Jest 23 matchers, with tests

### DIFF
--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -10,9 +10,11 @@
 //                 Waseem Dahman <https://github.com/wsmd>
 //                 Jamie Mason <https://github.com/JamieMason>
 //                 Douglas Duteil <https://github.com/douglasduteil>
-//                 Ahn <https://github.com/AhnpGit>
+//                 Ahn <https://github.com/ahnpnl>
 //                 Josh Goldberg <https://github.com/joshuakgoldberg>
 //                 Bradley Ayers <https://github.com/bradleyayers>
+//                 Jeff Lau <https://github.com/UselessPickles>
+//                 Andrew Makarov <https://github.com/r3nya>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -358,9 +360,21 @@ declare namespace jest {
 
     interface Matchers<R> {
         /**
+         * Ensures the last call to a mock function was provided specific args.
+         */
+        lastCalledWith(...args: any[]): R;
+        /**
+         * Ensure that the last call to a mock function has returned a specified value.
+         */
+        lastReturnedWith(value: any): R;
+        /**
          * If you know how to test something, `.not` lets you test its opposite.
          */
         not: Matchers<R>;
+        /**
+         * Ensure that the nth call to a mock function has returned a specified value.
+         */
+        nthReturnedWith(n: number, value: any): R;
         /**
          * Use resolves to unwrap the value of a fulfilled promise so any other
          * matcher can be chained. If the promise is rejected the assertion fails.
@@ -371,7 +385,6 @@ declare namespace jest {
          * If the promise is fulfilled the assertion fails.
          */
         rejects: Matchers<Promise<R>>;
-        lastCalledWith(...args: any[]): R;
         /**
          * Checks that a value is what you expect. It uses `===` to check strict equality.
          * Don't use `toBe` with floating-point numbers.
@@ -469,16 +482,45 @@ declare namespace jest {
          */
         toHaveBeenCalledWith(...params: any[]): R;
         /**
+         * Ensure that a mock function is called with specific arguments on an Nth call.
+         */
+        toHaveBeenNthCalledWith(nthCall: number, ...params: any[]): R;
+        /**
          * If you have a mock function, you can use `.toHaveBeenLastCalledWith`
          * to test what arguments it was last called with.
          */
         toHaveBeenLastCalledWith(...params: any[]): R;
         /**
+         * Use to test the specific value that a mock function last returned.
+         * If the last call to the mock function threw an error, then this matcher will fail
+         * no matter what value you provided as the expected return value.
+         */
+        toHaveLastReturnedWith(expected: any): R;
+        /**
          * Used to check that an object has a `.length` property
          * and it is set to a certain numeric value.
          */
         toHaveLength(expected: number): R;
+        /**
+         * Use to test the specific value that a mock function returned for the nth call.
+         * If the nth call to the mock function threw an error, then this matcher will fail
+         * no matter what value you provided as the expected return value.
+         */
+        toHaveNthReturnedWith(nthCall: number, expected: any): R;
         toHaveProperty(propertyPath: string | any[], value?: any): R;
+        /**
+         * Use to test that the mock function successfully returned (i.e., did not throw an error) at least one time
+         */
+        toHaveReturned(): R;
+        /**
+         * Use to ensure that a mock function returned successfully (i.e., did not throw an error) an exact number of times.
+         * Any calls to the mock function that throw an error are not counted toward the number of times the function returned.
+         */
+        toHaveReturnedTimes(expected: number): R;
+        /**
+         * Use to ensure that a mock function returned a specific value.
+         */
+        toHaveReturnedWith(expected: any): R;
         /**
          * Check that a string matches a regular expression.
          */
@@ -492,6 +534,22 @@ declare namespace jest {
          * Check out [the Snapshot Testing guide](http://facebook.github.io/jest/docs/snapshot-testing.html) for more information.
          */
         toMatchSnapshot(snapshotName?: string): R;
+        /**
+         * Ensure that a mock function has returned (as opposed to thrown) at least once.
+         */
+        toReturn(): R;
+        /**
+         * Ensure that a mock function has returned (as opposed to thrown) a specified number of times.
+         */
+        toReturnTimes(count: number): R;
+        /**
+         * Ensure that a mock function has returned a specified value at least once.
+         */
+        toReturnWith(value: any): R;
+        /**
+         * Use to test that objects have the same types as well as structure.
+         */
+        toStrictEqual(expected: {}): R;
         /**
          * Used to test that a function throws when it is called.
          */
@@ -550,9 +608,29 @@ declare namespace jest {
         mockRejectedValueOnce(value: any): Mock<T>;
     }
 
+    /**
+     * Represents the result of a single call to a mock function.
+     */
+    interface MockResult {
+        /**
+         * True if the function threw.
+         * False if the function returned.
+         */
+        isThrow: boolean;
+        /**
+         * The value that was either thrown or returned by the function.
+         */
+        value: any;
+    }
+
     interface MockContext<T> {
         calls: any[][];
         instances: T[];
+        invocationCallOrder: number[];
+        /**
+         * List of results of calls to the mock function.
+         */
+        results: MockResult[];
     }
 }
 

--- a/types/jest/jest-tests.ts
+++ b/types/jest/jest-tests.ts
@@ -213,6 +213,9 @@ describe('Assymetric matchers', () => {
             greeting: expect.stringContaining('hello'),
         });
 
+        expect("foo").toStrictEqual("foo");
+        expect({ a: "foo" }).toStrictEqual({ a: "foo" });
+
         const callback = jest.fn();
         expect(callback).toEqual(expect.any(Function));
         callback(5, "test");
@@ -252,6 +255,26 @@ describe('setTimeout', () => {
             done();
         }, 900);
     });
+});
+
+describe("spy call matchers", () => {
+    const spy = jest.fn();
+
+    expect(spy).lastReturnedWith("foo");
+    expect(spy).nthReturnedWith(3, "foo");
+    expect(spy).toHaveBeenCalled();
+    expect(spy).toHaveBeenCalledTimes(7);
+    expect(spy).toHaveBeenCalledWith("foo");
+    expect(spy).toHaveBeenLastCalledWith("foo");
+    expect(spy).toHaveBeenNthCalledWith(3, "foo");
+    expect(spy).toHaveReturned();
+    expect(spy).toHaveReturnedTimes(7);
+    expect(spy).toHaveReturnedWith("foo");
+    expect(spy).toHaveLastReturnedWith("foo");
+    expect(spy).toHaveNthReturnedWith(3, "foo");
+    expect(spy).toReturn();
+    expect(spy).toReturnTimes(3);
+    expect(spy).toReturnWith("foo");
 });
 
 describe('Extending extend', () => {


### PR DESCRIPTION
Superset of the following PRs, with author attributions:
* https://github.com/DefinitelyTyped/DefinitelyTyped/pull/26230
* https://github.com/DefinitelyTyped/DefinitelyTyped/pull/26236
* https://github.com/DefinitelyTyped/DefinitelyTyped/pull/26399

I tried to keep things in alphabetical order. Filed https://github.com/DefinitelyTyped/DefinitelyTyped/issues/26424 to clean up the tests file after this.

Does not add `jest-each`per https://github.com/DefinitelyTyped/DefinitelyTyped/issues/26368. Will do separately.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://facebook.github.io/jest/blog/2018/05/29/jest-23-blazing-fast-delightful-testing.html
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
