### PR TITLE
babel-traverse: Improve safety on NodePath

### DIFF
--- a/types/babel-core/index.d.ts
+++ b/types/babel-core/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Troy Gerwien <https://github.com/yortus>
 //                 Marvin Hagemeister <https://github.com/marvinhagemeister>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 import * as t from 'babel-types';
 export { t as types };

--- a/types/babel-generator/index.d.ts
+++ b/types/babel-generator/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Troy Gerwien <https://github.com/yortus>
 //                 Johnny Estilles <https://github.com/johnnyestilles>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 import * as t from 'babel-types';
 

--- a/types/babel-template/index.d.ts
+++ b/types/babel-template/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Troy Gerwien <https://github.com/yortus>
 //                 Marvin Hagemeister <https://github.com/marvinhagemeister>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 import { BabylonOptions } from 'babylon';
 import * as t from 'babel-types';

--- a/types/babel-traverse/index.d.ts
+++ b/types/babel-traverse/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/babel/babel/tree/master/packages/babel-traverse
 // Definitions by: Troy Gerwien <https://github.com/yortus>
 //                 Marvin Hagemeister <https://github.com/marvinhagemeister>
+//                 Ryan Petrich <https://github.com/rpetrich>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.9
 

--- a/types/babel-traverse/index.d.ts
+++ b/types/babel-traverse/index.d.ts
@@ -8,9 +8,10 @@
 import * as t from 'babel-types';
 export type Node = t.Node;
 
-export default function traverse(parent: Node | Node[], opts?: TraverseOptions, scope?: Scope, state?: any, parentPath?: NodePath): void;
+export default function traverse<S>(parent: Node | Node[], opts: TraverseOptions<S>, scope: Scope, state: S, parentPath?: NodePath): void;
+export default function traverse(parent: Node | Node[], opts: TraverseOptions, scope?: Scope, state?: any, parentPath?: NodePath): void;
 
-export interface TraverseOptions extends Visitor {
+export interface TraverseOptions<S = Node> extends Visitor<S> {
     scope?: Scope;
     noScope?: boolean;
 }
@@ -353,7 +354,8 @@ export class NodePath<T = Node> {
 
     buildCodeFrameError<TError extends Error>(msg: string, Error?: new (msg: string) => TError): TError;
 
-    traverse(visitor: Visitor, state?: any): void;
+    traverse<T>(visitor: Visitor<T>, state: T): void;
+    traverse(visitor: Visitor): void;
 
     set(key: string, node: Node): void;
 

--- a/types/babel-traverse/index.d.ts
+++ b/types/babel-traverse/index.d.ts
@@ -540,6 +540,9 @@ export class NodePath<T = Node> {
     /** Get the source code associated with this node. */
     getSource(): string;
 
+    /** Check if the current path will maybe execute before another path */
+    willIMaybeExecuteBefore(path: NodePath): boolean;
+
     // ------------------------- context -------------------------
     call(key: string): boolean;
 

--- a/types/babel-traverse/index.d.ts
+++ b/types/babel-traverse/index.d.ts
@@ -344,7 +344,7 @@ export class NodePath<T = Node> {
     key: string | number;
     node: T;
     scope: Scope;
-    type: string;
+    type: T extends undefined | null ? string | null : string;
     typeAnnotation: object;
 
     getScope(scope: Scope): Scope;

--- a/types/babel-traverse/index.d.ts
+++ b/types/babel-traverse/index.d.ts
@@ -374,10 +374,10 @@ export class NodePath<T = Node> {
     find(callback: (path: NodePath) => boolean): NodePath;
 
     /** Get the parent function of the current path. */
-    getFunctionParent(): NodePath;
+    getFunctionParent(): NodePath<t.Function>;
 
     /** Walk up the tree until we hit a parent node path in a list. */
-    getStatementParent(): NodePath;
+    getStatementParent(): NodePath<t.Statement>;
 
     /**
      * Get the deepest common ancestor and then from it, get the earliest relationship path
@@ -584,7 +584,9 @@ export class NodePath<T = Node> {
 
     getCompletionRecords(): NodePath[];
 
-    getSibling(key: string): NodePath;
+    getSibling(key: string | number): NodePath;
+    getAllPrevSiblings(): NodePath[];
+    getAllNextSiblings(): NodePath[];
 
     get(key: string, context?: boolean | TraversalContext): NodePath;
 

--- a/types/babel-traverse/index.d.ts
+++ b/types/babel-traverse/index.d.ts
@@ -340,7 +340,7 @@ export class NodePath<T = Node> {
     listKey: string;
     inList: boolean;
     parentKey: string;
-    key: string;
+    key: string | number;
     node: T;
     scope: Scope;
     type: string;

--- a/types/babel-traverse/index.d.ts
+++ b/types/babel-traverse/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Troy Gerwien <https://github.com/yortus>
 //                 Marvin Hagemeister <https://github.com/marvinhagemeister>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.9
 
 import * as t from 'babel-types';
 export type Node = t.Node;
@@ -588,7 +588,8 @@ export class NodePath<T = Node> {
     getAllPrevSiblings(): NodePath[];
     getAllNextSiblings(): NodePath[];
 
-    get(key: string, context?: boolean | TraversalContext): NodePath;
+    get<K extends keyof T>(key: K, context?: boolean | TraversalContext): T[K] extends (Node | null | undefined)[] ? NodePath<T[K][number]>[] : T[K] extends Node | null | undefined ? NodePath<T[K]> : never;
+    get(key: string, context?: boolean | TraversalContext): NodePath | NodePath[];
 
     getBindingIdentifiers(duplicates?: boolean): Node[];
 

--- a/types/babel-traverse/index.d.ts
+++ b/types/babel-traverse/index.d.ts
@@ -593,7 +593,10 @@ export class NodePath<T = Node> {
     getAllPrevSiblings(): NodePath[];
     getAllNextSiblings(): NodePath[];
 
-    get<K extends keyof T>(key: K, context?: boolean | TraversalContext): T[K] extends (Node | null | undefined)[] ? NodePath<T[K][number]>[] : T[K] extends Node | null | undefined ? NodePath<T[K]> : never;
+    get<K extends keyof T>(key: K, context?: boolean | TraversalContext):
+        T[K] extends Array<Node | null | undefined> ? Array<NodePath<T[K][number]>> :
+        T[K] extends Node | null | undefined ? NodePath<T[K]> :
+        never;
     get(key: string, context?: boolean | TraversalContext): NodePath | NodePath[];
 
     getBindingIdentifiers(duplicates?: boolean): Node[];

--- a/types/babel-traverse/index.d.ts
+++ b/types/babel-traverse/index.d.ts
@@ -4,7 +4,7 @@
 //                 Marvin Hagemeister <https://github.com/marvinhagemeister>
 //                 Ryan Petrich <https://github.com/rpetrich>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.9
+// TypeScript Version: 2.8
 
 import * as t from 'babel-types';
 export type Node = t.Node;

--- a/types/babel-traverse/index.d.ts
+++ b/types/babel-traverse/index.d.ts
@@ -26,6 +26,7 @@ export class Scope {
     bindings: { [name: string]: Binding; };
 
     /** Traverse node with current scope and path. */
+    traverse<S>(node: Node | Node[], opts: TraverseOptions<S>, state: S): void;
     traverse(node: Node | Node[], opts?: TraverseOptions, state?: any): void;
 
     /** Generate a unique identifier and add it to the current scope. */

--- a/types/babel-types/index.d.ts
+++ b/types/babel-types/index.d.ts
@@ -5,7 +5,7 @@
 //                 Marvin Hagemeister <https://github.com/marvinhagemeister>
 //                 Boris Cherny <https://github.com/bcherny>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 export interface Comment {
     value: string;

--- a/types/babel-webpack-plugin/index.d.ts
+++ b/types/babel-webpack-plugin/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/simlrh/babel-webpack-plugin
 // Definitions by: Jed Fox <https://github.com/j-f1>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 import { Plugin } from 'webpack';
 import { TransformOptions } from 'babel-core';

--- a/types/babelify/index.d.ts
+++ b/types/babelify/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: TeamworkGuy2 <https://github.com/TeamworkGuy2>
 //                 Marvin Hagemeister <https://github.com/marvinhagemeister>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 /// <reference types="node" />
 

--- a/types/babylon-walk/index.d.ts
+++ b/types/babylon-walk/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/pugjs/babylon-walk
 // Definitions by: Marek Buchar <https://github.com/czbuchi>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 import * as babelTypes from 'babel-types';
 

--- a/types/babylon/index.d.ts
+++ b/types/babylon/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Troy Gerwien <https://github.com/yortus>
 //                 Marvin Hagemeister <https://github.com/marvinhagemeister>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 import { File, Expression } from 'babel-types';
 

--- a/types/istanbul-lib-instrument/index.d.ts
+++ b/types/istanbul-lib-instrument/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/istanbuljs/istanbuljs
 // Definitions by: Jason Cheatham <https://github.com/jason0x43>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.4
+// TypeScript Version: 2.8
 
 import { FileCoverage, FileCoverageData, Range } from 'istanbul-lib-coverage';
 import { RawSourceMap } from 'source-map';

--- a/types/prettier/index.d.ts
+++ b/types/prettier/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/prettier/prettier
 // Definitions by: Ika <https://github.com/ikatyang>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 export type AST = any;
 export type Doc = doc.builders.Doc;


### PR DESCRIPTION
- Return more specific types from `getFunctionParent` and `getStatementParent` methods
- Allow traversing against `Visitor`s that require custom state
- Infer return type for `get` based on the node's type
- Make the types of `type` and `key` properties more accurate
- Add missing methods

_(built alongside updated types for babel-traverse in #26433)_
