### PR TITLE
angular-translate: Update typings for version 2.16

### DIFF
--- a/types/angular-translate/index.d.ts
+++ b/types/angular-translate/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Angular Translate (pascalprecht.translate module) 2.15
+// Type definitions for Angular Translate (pascalprecht.translate module) 2.16
 // Project: https://github.com/PascalPrecht/angular-translate
 // Definitions by: Michel Salib <https://github.com/michelsalib>, Gabriel Gil <https://github.com/GabrielGil>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -47,8 +47,8 @@ declare module 'angular' {
         }
 
         interface ITranslateService {
-            (translationId: string, interpolateParams?: any, interpolationId?: string, defaultTranslationText?: string, forceLanguage?: string): angular.IPromise<string>;
-            (translationId: string[], interpolateParams?: any, interpolationId?: string, defaultTranslationText?: string, forceLanguage?: string): angular.IPromise<{ [key: string]: string }>;
+            (translationId: string, interpolateParams?: any, interpolationId?: string, defaultTranslationText?: string, forceLanguage?: string, sanitizeStrategy?: string): angular.IPromise<string>;
+            (translationId: string[], interpolateParams?: any, interpolationId?: string, defaultTranslationText?: string, forceLanguage?: string, sanitizeStrategy?: string): angular.IPromise<{ [key: string]: string }>;
             cloakClassName(): string;
             cloakClassName(name: string): ITranslateProvider;
             fallbackLanguage(langKey?: string): string;


### PR DESCRIPTION
Hey,

in version 2.16 of angular-translate a new parameter was added to its $translate service, `sanitizeStrategy`: https://github.com/angular-translate/angular-translate/commit/4a2c3ab

This PR updates the typings accordingly. :)

Cheers,
Benjamin