### PR TITLE
:bug: PouchDB-find: return ExistingDocument instead of Document

### DIFF
--- a/types/pouchdb-find/index.d.ts
+++ b/types/pouchdb-find/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for pouchdb-find 6.3
 // Project: https://pouchdb.com/
 // Definitions by: Jakub Navratil <https://github.com/trubit>
+//                 Sebastian Ramirez <https://github.com/tiangolo>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -100,7 +101,7 @@ declare namespace PouchDB {
         }
 
         interface FindResponse<Content extends {}> {
-            docs: Array<Core.Document<Content>>;
+            docs: Array<Core.ExistingDocument<Content>>;
         }
 
         interface CreateIndexOptions {


### PR DESCRIPTION
`find` returns `ExistingDocument`s, including the `_rev`, not just `Document`s that don't include it.

Without it, TypeScript complains when trying to update a doc that was got via `find` because it "doesn't have a `_rev` field". While actually it does.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/pouchdb/pouchdb/blob/master/packages/node_modules/pouchdb-find/src/adapters/local/find/index.js
- [] Increase the version number in the header if appropriate.
- [] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
