### PR TITLE
Allow `null` for `width` and `height` on FlexStyle

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -568,7 +568,7 @@ export interface FlexStyle {
     flexGrow?: number;
     flexShrink?: number;
     flexWrap?: "wrap" | "nowrap";
-    height?: number | string;
+    height?: number | string | null;
     justifyContent?: "flex-start" | "flex-end" | "center" | "space-between" | "space-around" | "space-evenly";
     left?: number | string;
     margin?: number | string;
@@ -598,7 +598,7 @@ export interface FlexStyle {
     right?: number | string;
     start?: number | string;
     top?: number | string;
-    width?: number | string;
+    width?: number | string | null;
     zIndex?: number;
 
     /**


### PR DESCRIPTION
This weird feature is not clearly documented (seems to be represented by the "whitespace" between `number` and `string` in the allowed types in  https://facebook.github.io/react-native/docs/layout-props.html#width), but shows up in a lot of example code (e.g. https://kylewbanks.com/blog/fullscreen-background-image-in-react-native) and is required to achieve a lot of effects. It is clearly allowed by the runtime and affects layout.