### PR TITLE
YouTube - Make width and height strings, so they can accept 100%

### DIFF
--- a/types/youtube/index.d.ts
+++ b/types/youtube/index.d.ts
@@ -373,12 +373,12 @@ declare namespace YT
 		/**
 		 * Player width.
 		 */
-		width?: number;
+		width?: string | number;
 
 		/**
 		 * Player height
 		 */
-		height?: number;
+		height?: string | number;
 
 		/**
 		 * ID of the video to load.


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developers.google.com/youtube/iframe_api_reference#Loading_a_Video_Player
   - **Note** - the docs say number, but the example shows it as a string
