### PR TITLE
[jquery] Fix documentation links for Visual Studio Code.

### DIFF
--- a/types/jquery/index.d.ts
+++ b/types/jquery/index.d.ts
@@ -42,7 +42,7 @@ type _Promise<T> = Promise<T>;
 
 interface JQueryStatic<TElement extends Node = HTMLElement> {
     /**
-     * @see {@link http://api.jquery.com/jquery.ajax/#jQuery-ajax1}
+     * @see \`{@link http://api.jquery.com/jquery.ajax/#jQuery-ajax1 }\`
      * @deprecated Use jQuery.ajaxSetup(options)
      */
     ajaxSettings: JQuery.AjaxSettings;
@@ -52,7 +52,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * any synchronous or asynchronous function.
      *
      * @param beforeStart A function that is called just before the constructor returns.
-     * @see {@link https://api.jquery.com/jQuery.Deferred/}
+     * @see \`{@link https://api.jquery.com/jQuery.Deferred/ }\`
      * @since 1.5
      */
     Deferred: JQuery.DeferredStatic;
@@ -61,7 +61,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * Hook directly into jQuery to override how particular CSS properties are retrieved or set, normalize
      * CSS property naming, or create custom properties.
      *
-     * @see {@link https://api.jquery.com/jQuery.cssHooks/}
+     * @see \`{@link https://api.jquery.com/jQuery.cssHooks/ }\`
      * @since 1.4.3
      */
     cssHooks: JQuery.PlainObject<JQuery.CSSHook<TElement>>;
@@ -69,7 +69,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * An object containing all CSS properties that may be used without a unit. The .css() method uses this
      * object to see if it may append px to unitless values.
      *
-     * @see {@link https://api.jquery.com/jQuery.cssNumber/}
+     * @see \`{@link https://api.jquery.com/jQuery.cssNumber/ }\`
      * @since 1.4.3
      */
     cssNumber: JQuery.PlainObject<boolean>;
@@ -78,7 +78,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
         /**
          * The rate (in milliseconds) at which animations fire.
          *
-         * @see {@link https://api.jquery.com/jQuery.fx.interval/}
+         * @see \`{@link https://api.jquery.com/jQuery.fx.interval/ }\`
          * @since 1.4.3
          * @deprecated 3.0
          */
@@ -86,7 +86,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
         /**
          * Globally disable all animations.
          *
-         * @see {@link https://api.jquery.com/jQuery.fx.off/}
+         * @see \`{@link https://api.jquery.com/jQuery.fx.off/ }\`
          * @since 1.3
          */
         off: boolean;
@@ -95,7 +95,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
     /**
      * A Promise-like object (or "thenable") that resolves when the document is ready.
      *
-     * @see {@link https://api.jquery.com/jQuery.ready/}
+     * @see \`{@link https://api.jquery.com/jQuery.ready/ }\`
      * @since 1.8
      */
     ready: JQuery.Thenable<JQueryStatic<TElement>>;
@@ -106,7 +106,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * needs, we strongly recommend the use of an external library such as Modernizr instead of dependency
      * on properties in jQuery.support.
      *
-     * @see {@link https://api.jquery.com/jQuery.support/}
+     * @see \`{@link https://api.jquery.com/jQuery.support/ }\`
      * @since 1.3
      * @deprecated 1.9
      */
@@ -119,7 +119,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *             A string defining a single, standalone, HTML element (e.g. <div/> or <div></div>).
      * @param ownerDocument_attributes A document in which the new elements will be created.
      *                                 An object of attributes, events, and methods to call on the newly-created element.
-     * @see {@link https://api.jquery.com/jQuery/}
+     * @see \`{@link https://api.jquery.com/jQuery/ }\`
      * @since 1.0
      * @since 1.4
      */
@@ -129,7 +129,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param selector A string containing a selector expression
      * @param context A DOM Element, Document, or jQuery to use as context
-     * @see {@link https://api.jquery.com/jQuery/}
+     * @see \`{@link https://api.jquery.com/jQuery/ }\`
      * @since 1.0
      */
     (selector: JQuery.Selector, context: Element | Document | JQuery | undefined): JQuery<TElement>;
@@ -147,7 +147,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *                                 A plain object to wrap in a jQuery object.
      *                                 An existing jQuery object to clone.
      *                                 The function to execute when the DOM is ready.
-     * @see {@link https://api.jquery.com/jQuery/}
+     * @see \`{@link https://api.jquery.com/jQuery/ }\`
      * @since 1.0
      * @since 1.4
      */
@@ -158,7 +158,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * A multi-purpose callbacks list object that provides a powerful way to manage callback lists.
      *
      * @param flags An optional list of space-separated flags that change how the callback list behaves.
-     * @see {@link https://api.jquery.com/jQuery.Callbacks/}
+     * @see \`{@link https://api.jquery.com/jQuery.Callbacks/ }\`
      * @since 1.7
      */
     Callbacks<T extends Function>(flags?: string): JQuery.Callbacks<T>;
@@ -168,7 +168,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * @param url A string containing the URL to which the request is sent.
      * @param settings A set of key/value pairs that configure the Ajax request. All settings are optional. A default can
      *                 be set for any option with $.ajaxSetup(). See jQuery.ajax( settings ) below for a complete list of all settings.
-     * @see {@link https://api.jquery.com/jQuery.ajax/}
+     * @see \`{@link https://api.jquery.com/jQuery.ajax/ }\`
      * @since 1.5
      */
     ajax(url: string, settings?: JQuery.AjaxSettings): JQuery.jqXHR;
@@ -177,7 +177,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param settings A set of key/value pairs that configure the Ajax request. All settings are optional. A default can
      *                 be set for any option with $.ajaxSetup().
-     * @see {@link https://api.jquery.com/jQuery.ajax/}
+     * @see \`{@link https://api.jquery.com/jQuery.ajax/ }\`
      * @since 1.0
      */
     ajax(settings?: JQuery.AjaxSettings): JQuery.jqXHR;
@@ -187,7 +187,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param dataTypes An optional string containing one or more space-separated dataTypes
      * @param handler A handler to set default values for future Ajax requests.
-     * @see {@link https://api.jquery.com/jQuery.ajaxPrefilter/}
+     * @see \`{@link https://api.jquery.com/jQuery.ajaxPrefilter/ }\`
      * @since 1.5
      */
     ajaxPrefilter(dataTypes: string,
@@ -197,7 +197,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * are processed by $.ajax().
      *
      * @param handler A handler to set default values for future Ajax requests.
-     * @see {@link https://api.jquery.com/jQuery.ajaxPrefilter/}
+     * @see \`{@link https://api.jquery.com/jQuery.ajaxPrefilter/ }\`
      * @since 1.5
      */
     ajaxPrefilter(handler: (options: JQuery.AjaxSettings, originalOptions: JQuery.AjaxSettings, jqXHR: JQuery.jqXHR) => string | void): void;
@@ -205,7 +205,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * Set default values for future Ajax requests. Its use is not recommended.
      *
      * @param options A set of key/value pairs that configure the default Ajax request. All options are optional.
-     * @see {@link https://api.jquery.com/jQuery.ajaxSetup/}
+     * @see \`{@link https://api.jquery.com/jQuery.ajaxSetup/ }\`
      * @since 1.1
      */
     ajaxSetup(options: JQuery.AjaxSettings): JQuery.AjaxSettings;
@@ -214,7 +214,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param dataType A string identifying the data type to use
      * @param handler A handler to return the new transport object to use with the data type provided in the first argument.
-     * @see {@link https://api.jquery.com/jQuery.ajaxTransport/}
+     * @see \`{@link https://api.jquery.com/jQuery.ajaxTransport/ }\`
      * @since 1.5
      */
     ajaxTransport(dataType: string,
@@ -228,7 +228,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param container The DOM element that may contain the other element.
      * @param contained The DOM element that may be contained by (a descendant of) the other element.
-     * @see {@link https://api.jquery.com/jQuery.contains/}
+     * @see \`{@link https://api.jquery.com/jQuery.contains/ }\`
      * @since 1.4
      */
     contains(container: Element, contained: Element): boolean;
@@ -239,7 +239,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param element The DOM element to query for the data.
      * @param key Name of the data stored.
-     * @see {@link https://api.jquery.com/jQuery.data/}
+     * @see \`{@link https://api.jquery.com/jQuery.data/ }\`
      * @since 1.2.3
      */
     data(element: Element, key: string, undefined: undefined): any; // tslint:disable-line:unified-signatures
@@ -249,7 +249,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * @param element The DOM element to associate with the data.
      * @param key A string naming the piece of data to set.
      * @param value The new data value; this can be any Javascript type except undefined.
-     * @see {@link https://api.jquery.com/jQuery.data/}
+     * @see \`{@link https://api.jquery.com/jQuery.data/ }\`
      * @since 1.2.3
      */
     data<T>(element: Element, key: string, value: T): T;
@@ -259,7 +259,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param element The DOM element to query for the data.
      * @param key Name of the data stored.
-     * @see {@link https://api.jquery.com/jQuery.data/}
+     * @see \`{@link https://api.jquery.com/jQuery.data/ }\`
      * @since 1.2.3
      * @since 1.4
      */
@@ -269,7 +269,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param element A DOM element from which to remove and execute a queued function.
      * @param queueName A string containing the name of the queue. Defaults to fx, the standard effects queue.
-     * @see {@link https://api.jquery.com/jQuery.dequeue/}
+     * @see \`{@link https://api.jquery.com/jQuery.dequeue/ }\`
      * @since 1.3
      */
     dequeue(element: Element, queueName?: string): void;
@@ -280,7 +280,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param array The array to iterate over.
      * @param callback The function that will be executed on every object.
-     * @see {@link https://api.jquery.com/jQuery.each/}
+     * @see \`{@link https://api.jquery.com/jQuery.each/ }\`
      * @since 1.0
      */
     each<T>(array: ArrayLike<T>, callback: (this: T, indexInArray: number, value: T) => false | any): ArrayLike<T>;
@@ -291,7 +291,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param obj The object to iterate over.
      * @param callback The function that will be executed on every object.
-     * @see {@link https://api.jquery.com/jQuery.each/}
+     * @see \`{@link https://api.jquery.com/jQuery.each/ }\`
      * @since 1.0
      */
     each<T, K extends keyof T>(obj: T, callback: (this: T[K], propertyName: K, valueOfProperty: T[K]) => false | any): T;
@@ -299,7 +299,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * Takes a string and throws an exception containing it.
      *
      * @param message The message to send out.
-     * @see {@link https://api.jquery.com/jQuery.error/}
+     * @see \`{@link https://api.jquery.com/jQuery.error/ }\`
      * @since 1.4.1
      */
     error(message: string): any;
@@ -307,7 +307,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * Escapes any character that has a special meaning in a CSS selector.
      *
      * @param selector A string containing a selector expression to escape.
-     * @see {@link https://api.jquery.com/jQuery.escapeSelector/}
+     * @see \`{@link https://api.jquery.com/jQuery.escapeSelector/ }\`
      * @since 3.0
      */
     escapeSelector(selector: JQuery.Selector): JQuery.Selector;
@@ -316,7 +316,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param deep If true, the merge becomes recursive (aka. deep copy). Passing false for this argument is not supported.
      * @param target The object to extend. It will receive the new properties.
-     * @see {@link https://api.jquery.com/jQuery.extend/}
+     * @see \`{@link https://api.jquery.com/jQuery.extend/ }\`
      * @since 1.1.4
      */
     extend<T, U, V, W, X, Y, Z>(deep: true, target: T, object1: U, object2: V, object3: W, object4: X, object5: Y, object6: Z): T & U & V & W & X & Y & Z;
@@ -325,7 +325,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param deep If true, the merge becomes recursive (aka. deep copy). Passing false for this argument is not supported.
      * @param target The object to extend. It will receive the new properties.
-     * @see {@link https://api.jquery.com/jQuery.extend/}
+     * @see \`{@link https://api.jquery.com/jQuery.extend/ }\`
      * @since 1.1.4
      */
     extend<T, U, V, W, X, Y>(deep: true, target: T, object1: U, object2: V, object3: W, object4: X, object5: Y): T & U & V & W & X & Y;
@@ -334,7 +334,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param deep If true, the merge becomes recursive (aka. deep copy). Passing false for this argument is not supported.
      * @param target The object to extend. It will receive the new properties.
-     * @see {@link https://api.jquery.com/jQuery.extend/}
+     * @see \`{@link https://api.jquery.com/jQuery.extend/ }\`
      * @since 1.1.4
      */
     extend<T, U, V, W, X>(deep: true, target: T, object1: U, object2: V, object3: W, object4: X): T & U & V & W & X;
@@ -343,7 +343,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param deep If true, the merge becomes recursive (aka. deep copy). Passing false for this argument is not supported.
      * @param target The object to extend. It will receive the new properties.
-     * @see {@link https://api.jquery.com/jQuery.extend/}
+     * @see \`{@link https://api.jquery.com/jQuery.extend/ }\`
      * @since 1.1.4
      */
     extend<T, U, V, W>(deep: true, target: T, object1: U, object2: V, object3: W): T & U & V & W;
@@ -352,7 +352,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param deep If true, the merge becomes recursive (aka. deep copy). Passing false for this argument is not supported.
      * @param target The object to extend. It will receive the new properties.
-     * @see {@link https://api.jquery.com/jQuery.extend/}
+     * @see \`{@link https://api.jquery.com/jQuery.extend/ }\`
      * @since 1.1.4
      */
     extend<T, U, V>(deep: true, target: T, object1: U, object2: V): T & U & V;
@@ -361,7 +361,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param deep If true, the merge becomes recursive (aka. deep copy). Passing false for this argument is not supported.
      * @param target The object to extend. It will receive the new properties.
-     * @see {@link https://api.jquery.com/jQuery.extend/}
+     * @see \`{@link https://api.jquery.com/jQuery.extend/ }\`
      * @since 1.1.4
      */
     extend<T, U>(deep: true, target: T, object1: U): T & U;
@@ -370,7 +370,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param deep If true, the merge becomes recursive (aka. deep copy). Passing false for this argument is not supported.
      * @param target The object to extend. It will receive the new properties.
-     * @see {@link https://api.jquery.com/jQuery.extend/}
+     * @see \`{@link https://api.jquery.com/jQuery.extend/ }\`
      * @since 1.1.4
      */
     extend(deep: true, target: any, object1: any, ...objects: any[]): any;
@@ -379,7 +379,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param target An object that will receive the new properties if additional objects are passed in or that will
      *               extend the jQuery namespace if it is the sole argument.
-     * @see {@link https://api.jquery.com/jQuery.extend/}
+     * @see \`{@link https://api.jquery.com/jQuery.extend/ }\`
      * @since 1.0
      */
     extend<T, U, V, W, X, Y, Z>(target: T, object1: U, object2: V, object3: W, object4: X, object5: Y, object6: Z): T & U & V & W & X & Y & Z;
@@ -388,7 +388,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param target An object that will receive the new properties if additional objects are passed in or that will
      *               extend the jQuery namespace if it is the sole argument.
-     * @see {@link https://api.jquery.com/jQuery.extend/}
+     * @see \`{@link https://api.jquery.com/jQuery.extend/ }\`
      * @since 1.0
      */
     extend<T, U, V, W, X, Y>(target: T, object1: U, object2: V, object3: W, object4: X, object5: Y): T & U & V & W & X & Y;
@@ -397,7 +397,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param target An object that will receive the new properties if additional objects are passed in or that will
      *               extend the jQuery namespace if it is the sole argument.
-     * @see {@link https://api.jquery.com/jQuery.extend/}
+     * @see \`{@link https://api.jquery.com/jQuery.extend/ }\`
      * @since 1.0
      */
     extend<T, U, V, W, X>(target: T, object1: U, object2: V, object3: W, object4: X): T & U & V & W & X;
@@ -406,7 +406,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param target An object that will receive the new properties if additional objects are passed in or that will
      *               extend the jQuery namespace if it is the sole argument.
-     * @see {@link https://api.jquery.com/jQuery.extend/}
+     * @see \`{@link https://api.jquery.com/jQuery.extend/ }\`
      * @since 1.0
      */
     extend<T, U, V, W>(target: T, object1: U, object2: V, object3: W): T & U & V & W;
@@ -415,7 +415,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param target An object that will receive the new properties if additional objects are passed in or that will
      *               extend the jQuery namespace if it is the sole argument.
-     * @see {@link https://api.jquery.com/jQuery.extend/}
+     * @see \`{@link https://api.jquery.com/jQuery.extend/ }\`
      * @since 1.0
      */
     extend<T, U, V>(target: T, object1: U, object2: V): T & U & V;
@@ -424,7 +424,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param target An object that will receive the new properties if additional objects are passed in or that will
      *               extend the jQuery namespace if it is the sole argument.
-     * @see {@link https://api.jquery.com/jQuery.extend/}
+     * @see \`{@link https://api.jquery.com/jQuery.extend/ }\`
      * @since 1.0
      */
     extend<T, U>(target: T, object1: U): T & U;
@@ -433,7 +433,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param target An object that will receive the new properties if additional objects are passed in or that will
      *               extend the jQuery namespace if it is the sole argument.
-     * @see {@link https://api.jquery.com/jQuery.extend/}
+     * @see \`{@link https://api.jquery.com/jQuery.extend/ }\`
      * @since 1.0
      */
     extend(target: any, object1: any, ...objects: any[]): any;
@@ -445,7 +445,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * @param success A callback function that is executed if the request succeeds. Required if dataType is provided, but
      *                you can use null or jQuery.noop as a placeholder.
      * @param dataType The type of data expected from the server. Default: Intelligent Guess (xml, json, script, text, html).
-     * @see {@link https://api.jquery.com/jQuery.get/}
+     * @see \`{@link https://api.jquery.com/jQuery.get/ }\`
      * @since 1.0
      */
     get(url: string,
@@ -459,7 +459,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * @param success A callback function that is executed if the request succeeds. Required if dataType is provided, but
      *                you can use null or jQuery.noop as a placeholder.
      * @param dataType The type of data expected from the server. Default: Intelligent Guess (xml, json, script, text, html).
-     * @see {@link https://api.jquery.com/jQuery.get/}
+     * @see \`{@link https://api.jquery.com/jQuery.get/ }\`
      * @since 1.0
      */
     get(url: string,
@@ -472,7 +472,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * @param success_data A callback function that is executed if the request succeeds. Required if dataType is provided, but
      *                     you can use null or jQuery.noop as a placeholder.
      *                     A plain object or string that is sent to the server with the request.
-     * @see {@link https://api.jquery.com/jQuery.get/}
+     * @see \`{@link https://api.jquery.com/jQuery.get/ }\`
      * @since 1.0
      */
     get(url: string,
@@ -484,7 +484,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *                     A set of key/value pairs that configure the Ajax request. All properties except for url are
      *                     optional. A default can be set for any option with $.ajaxSetup(). See jQuery.ajax( settings ) for a
      *                     complete list of all settings. The type option will automatically be set to GET.
-     * @see {@link https://api.jquery.com/jQuery.get/}
+     * @see \`{@link https://api.jquery.com/jQuery.get/ }\`
      * @since 1.0
      * @since 1.12
      * @since 2.2
@@ -496,7 +496,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * @param url A string containing the URL to which the request is sent.
      * @param data A plain object or string that is sent to the server with the request.
      * @param success A callback function that is executed if the request succeeds.
-     * @see {@link https://api.jquery.com/jQuery.getJSON/}
+     * @see \`{@link https://api.jquery.com/jQuery.getJSON/ }\`
      * @since 1.0
      */
     getJSON(url: string,
@@ -508,7 +508,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * @param url A string containing the URL to which the request is sent.
      * @param success_data A callback function that is executed if the request succeeds.
      *                     A plain object or string that is sent to the server with the request.
-     * @see {@link https://api.jquery.com/jQuery.getJSON/}
+     * @see \`{@link https://api.jquery.com/jQuery.getJSON/ }\`
      * @since 1.0
      */
     getJSON(url: string,
@@ -518,7 +518,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param url A string containing the URL to which the request is sent.
      * @param success A callback function that is executed if the request succeeds.
-     * @see {@link https://api.jquery.com/jQuery.getScript/}
+     * @see \`{@link https://api.jquery.com/jQuery.getScript/ }\`
      * @since 1.0
      */
     getScript(url: string,
@@ -527,7 +527,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * Execute some JavaScript code globally.
      *
      * @param code The JavaScript code to execute.
-     * @see {@link https://api.jquery.com/jQuery.globalEval/}
+     * @see \`{@link https://api.jquery.com/jQuery.globalEval/ }\`
      * @since 1.0.4
      */
     globalEval(code: string): void;
@@ -540,7 +540,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * @param invert If "invert" is false, or not provided, then the function returns an array consisting of all elements
      *               for which "callback" returns true. If "invert" is true, then the function returns an array
      *               consisting of all elements for which "callback" returns false.
-     * @see {@link https://api.jquery.com/jQuery.grep/}
+     * @see \`{@link https://api.jquery.com/jQuery.grep/ }\`
      * @since 1.0
      */
     grep<T>(array: ArrayLike<T>,
@@ -550,7 +550,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * Determine whether an element has any jQuery data associated with it.
      *
      * @param element A DOM element to be checked for data.
-     * @see {@link https://api.jquery.com/jQuery.hasData/}
+     * @see \`{@link https://api.jquery.com/jQuery.hasData/ }\`
      * @since 1.5
      */
     hasData(element: Element): boolean;
@@ -558,7 +558,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * Holds or releases the execution of jQuery's ready event.
      *
      * @param hold Indicates whether the ready hold is being requested or released
-     * @see {@link https://api.jquery.com/jQuery.holdReady/}
+     * @see \`{@link https://api.jquery.com/jQuery.holdReady/ }\`
      * @since 1.6
      * @deprecated 3.2
      */
@@ -567,7 +567,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * Modify and filter HTML strings passed through jQuery manipulation methods.
      *
      * @param html The HTML string on which to operate.
-     * @see {@link https://api.jquery.com/jQuery.htmlPrefilter/}
+     * @see \`{@link https://api.jquery.com/jQuery.htmlPrefilter/ }\`
      * @since 1.12/2.2
      */
     htmlPrefilter(html: JQuery.htmlString): JQuery.htmlString;
@@ -577,7 +577,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * @param value The value to search for.
      * @param array An array through which to search.
      * @param fromIndex The index of the array at which to begin the search. The default is 0, which will search the whole array.
-     * @see {@link https://api.jquery.com/jQuery.inArray/}
+     * @see \`{@link https://api.jquery.com/jQuery.inArray/ }\`
      * @since 1.2
      */
     inArray<T>(value: T, array: T[], fromIndex?: number): number;
@@ -585,7 +585,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * Determine whether the argument is an array.
      *
      * @param obj Object to test whether or not it is an array.
-     * @see {@link https://api.jquery.com/jQuery.isArray/}
+     * @see \`{@link https://api.jquery.com/jQuery.isArray/ }\`
      * @since 1.3
      * @deprecated 3.2
      */
@@ -594,7 +594,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * Check to see if an object is empty (contains no enumerable properties).
      *
      * @param obj The object that will be checked to see if it's empty.
-     * @see {@link https://api.jquery.com/jQuery.isEmptyObject/}
+     * @see \`{@link https://api.jquery.com/jQuery.isEmptyObject/ }\`
      * @since 1.4
      */
     isEmptyObject(obj: any): boolean;
@@ -602,7 +602,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * Determine if the argument passed is a JavaScript function object.
      *
      * @param obj Object to test whether or not it is a function.
-     * @see {@link https://api.jquery.com/jQuery.isFunction/}
+     * @see \`{@link https://api.jquery.com/jQuery.isFunction/ }\`
      * @since 1.2
      * @deprecated 3.3
      */
@@ -611,7 +611,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * Determines whether its argument represents a JavaScript number.
      *
      * @param value The value to be tested.
-     * @see {@link https://api.jquery.com/jQuery.isNumeric/}
+     * @see \`{@link https://api.jquery.com/jQuery.isNumeric/ }\`
      * @since 1.7
      * @deprecated 3.3
      */
@@ -620,7 +620,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * Check to see if an object is a plain object (created using "{}" or "new Object").
      *
      * @param obj The object that will be checked to see if it's a plain object.
-     * @see {@link https://api.jquery.com/jQuery.isPlainObject/}
+     * @see \`{@link https://api.jquery.com/jQuery.isPlainObject/ }\`
      * @since 1.4
      */
     isPlainObject(obj: any): obj is JQuery.PlainObject;
@@ -628,7 +628,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * Determine whether the argument is a window.
      *
      * @param obj Object to test whether or not it is a window.
-     * @see {@link https://api.jquery.com/jQuery.isWindow/}
+     * @see \`{@link https://api.jquery.com/jQuery.isWindow/ }\`
      * @since 1.4.3
      * @deprecated 3.3
      */
@@ -637,7 +637,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * Check to see if a DOM node is within an XML document (or is an XML document).
      *
      * @param node The DOM node that will be checked to see if it's in an XML document.
-     * @see {@link https://api.jquery.com/jQuery.isXMLDoc/}
+     * @see \`{@link https://api.jquery.com/jQuery.isXMLDoc/ }\`
      * @since 1.1.4
      */
     isXMLDoc(node: Node): boolean;
@@ -645,7 +645,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * Convert an array-like object into a true JavaScript array.
      *
      * @param obj Any object to turn into a native Array.
-     * @see {@link https://api.jquery.com/jQuery.makeArray/}
+     * @see \`{@link https://api.jquery.com/jQuery.makeArray/ }\`
      * @since 1.2
      */
     makeArray<T>(obj: ArrayLike<T>): T[];
@@ -656,7 +656,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * @param callback The function to process each item against. The first argument to the function is the array item, the
      *                 second argument is the index in array The function can return any value. A returned array will be
      *                 flattened into the resulting array. Within the function, this refers to the global (window) object.
-     * @see {@link https://api.jquery.com/jQuery.map/}
+     * @see \`{@link https://api.jquery.com/jQuery.map/ }\`
      * @since 1.0
      */
     map<T, R>(array: T[], callback: (elementOfArray: T, indexInArray: number) => R): R[];
@@ -668,7 +668,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *                 second argument is the key of the object property. The function can return any value to add to the
      *                 array. A returned array will be flattened into the resulting array. Within the function, this refers
      *                 to the global (window) object.
-     * @see {@link https://api.jquery.com/jQuery.map/}
+     * @see \`{@link https://api.jquery.com/jQuery.map/ }\`
      * @since 1.6
      */
     map<T, K extends keyof T, R>(obj: T, callback: (propertyOfObject: T[K], key: K) => R): R[];
@@ -677,7 +677,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param first The first array-like object to merge, the elements of second added.
      * @param second The second array-like object to merge into the first, unaltered.
-     * @see {@link https://api.jquery.com/jQuery.merge/}
+     * @see \`{@link https://api.jquery.com/jQuery.merge/ }\`
      * @since 1.0
      */
     merge<T, U>(first: ArrayLike<T>, second: ArrayLike<U>): Array<T | U>;
@@ -685,21 +685,21 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * Relinquish jQuery's control of the $ variable.
      *
      * @param removeAll A Boolean indicating whether to remove all jQuery variables from the global scope (including jQuery itself).
-     * @see {@link https://api.jquery.com/jQuery.noConflict/}
+     * @see \`{@link https://api.jquery.com/jQuery.noConflict/ }\`
      * @since 1.0
      */
     noConflict(removeAll?: boolean): this;
     /**
      * An empty function.
      *
-     * @see {@link https://api.jquery.com/jQuery.noop/}
+     * @see \`{@link https://api.jquery.com/jQuery.noop/ }\`
      * @since 1.4
      */
     noop(): undefined;
     /**
      * Return a number representing the current time.
      *
-     * @see {@link https://api.jquery.com/jQuery.now/}
+     * @see \`{@link https://api.jquery.com/jQuery.now/ }\`
      * @since 1.4.3
      * @deprecated 3.3 Use Date.now().
      */
@@ -711,7 +711,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param obj An array, a plain object, or a jQuery object to serialize.
      * @param traditional A Boolean indicating whether to perform a traditional "shallow" serialization.
-     * @see {@link https://api.jquery.com/jQuery.param/}
+     * @see \`{@link https://api.jquery.com/jQuery.param/ }\`
      * @since 1.2
      * @since 1.4
      */
@@ -722,7 +722,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * @param data HTML string to be parsed
      * @param context Document element to serve as the context in which the HTML fragment will be created
      * @param keepScripts A Boolean indicating whether to include scripts passed in the HTML string
-     * @see {@link https://api.jquery.com/jQuery.parseHTML/}
+     * @see \`{@link https://api.jquery.com/jQuery.parseHTML/ }\`
      * @since 1.8
      */
     parseHTML(data: string, context: Document | null | undefined, keepScripts: boolean): JQuery.Node[];
@@ -732,7 +732,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * @param data HTML string to be parsed
      * @param context_keepScripts Document element to serve as the context in which the HTML fragment will be created
      *                            A Boolean indicating whether to include scripts passed in the HTML string
-     * @see {@link https://api.jquery.com/jQuery.parseHTML/}
+     * @see \`{@link https://api.jquery.com/jQuery.parseHTML/ }\`
      * @since 1.8
      */
     parseHTML(data: string, context_keepScripts?: Document | null | boolean): JQuery.Node[];
@@ -740,7 +740,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * Takes a well-formed JSON string and returns the resulting JavaScript value.
      *
      * @param json The JSON string to parse.
-     * @see {@link https://api.jquery.com/jQuery.parseJSON/}
+     * @see \`{@link https://api.jquery.com/jQuery.parseJSON/ }\`
      * @since 1.4.1
      * @deprecated 3.0
      */
@@ -749,7 +749,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * Parses a string into an XML document.
      *
      * @param data a well-formed XML string to be parsed
-     * @see {@link https://api.jquery.com/jQuery.parseXML/}
+     * @see \`{@link https://api.jquery.com/jQuery.parseXML/ }\`
      * @since 1.5
      */
     parseXML(data: string): XMLDocument;
@@ -761,7 +761,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * @param success A callback function that is executed if the request succeeds. Required if dataType is provided, but
      *                can be null in that case.
      * @param dataType The type of data expected from the server. Default: Intelligent Guess (xml, json, script, text, html).
-     * @see {@link https://api.jquery.com/jQuery.post/}
+     * @see \`{@link https://api.jquery.com/jQuery.post/ }\`
      * @since 1.0
      */
     post(url: string,
@@ -775,7 +775,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * @param success A callback function that is executed if the request succeeds. Required if dataType is provided, but
      *                can be null in that case.
      * @param dataType The type of data expected from the server. Default: Intelligent Guess (xml, json, script, text, html).
-     * @see {@link https://api.jquery.com/jQuery.post/}
+     * @see \`{@link https://api.jquery.com/jQuery.post/ }\`
      * @since 1.0
      */
     post(url: string,
@@ -788,7 +788,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * @param success_data A callback function that is executed if the request succeeds. Required if dataType is provided, but
      *                     can be null in that case.
      *                     A plain object or string that is sent to the server with the request.
-     * @see {@link https://api.jquery.com/jQuery.post/}
+     * @see \`{@link https://api.jquery.com/jQuery.post/ }\`
      * @since 1.0
      */
     post(url: string,
@@ -800,7 +800,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *                     A set of key/value pairs that configure the Ajax request. All properties except for url are
      *                     optional. A default can be set for any option with $.ajaxSetup(). See jQuery.ajax( settings ) for a
      *                     complete list of all settings. Type will automatically be set to POST.
-     * @see {@link https://api.jquery.com/jQuery.post/}
+     * @see \`{@link https://api.jquery.com/jQuery.post/ }\`
      * @since 1.0
      * @since 1.12
      * @since 2.2
@@ -820,7 +820,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -833,7 +833,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -846,7 +846,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -859,7 +859,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -872,7 +872,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -885,7 +885,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -898,7 +898,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4`
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -912,7 +912,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -928,7 +928,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -943,7 +943,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -958,7 +958,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -973,7 +973,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -988,7 +988,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1003,7 +1003,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1018,7 +1018,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1033,7 +1033,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1050,7 +1050,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1065,7 +1065,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1080,7 +1080,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1095,7 +1095,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1110,7 +1110,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1125,7 +1125,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1140,7 +1140,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1155,7 +1155,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1172,7 +1172,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1187,7 +1187,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1202,7 +1202,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1217,7 +1217,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1232,7 +1232,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1247,7 +1247,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1262,7 +1262,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1277,7 +1277,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1294,7 +1294,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1309,7 +1309,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1324,7 +1324,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1339,7 +1339,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1354,7 +1354,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1369,7 +1369,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1384,7 +1384,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1399,7 +1399,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1416,7 +1416,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1431,7 +1431,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1446,7 +1446,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1461,7 +1461,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1476,7 +1476,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1491,7 +1491,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1506,7 +1506,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1521,7 +1521,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1538,7 +1538,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1553,7 +1553,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1568,7 +1568,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1583,7 +1583,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1598,7 +1598,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1613,7 +1613,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1628,7 +1628,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1643,7 +1643,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1660,7 +1660,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1675,7 +1675,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1690,7 +1690,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1705,7 +1705,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1720,7 +1720,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1735,7 +1735,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1750,7 +1750,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1765,7 +1765,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1785,7 +1785,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
      * @param additionalArguments Any number of arguments to be passed to the function referenced in the function argument.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated 3.3 Use Function#bind.
      */
@@ -1808,7 +1808,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -1823,7 +1823,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -1838,7 +1838,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -1853,7 +1853,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -1868,7 +1868,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -1883,7 +1883,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -1898,7 +1898,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4`
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -1913,7 +1913,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -1931,7 +1931,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -1948,7 +1948,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -1965,7 +1965,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -1982,7 +1982,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -1999,7 +1999,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2016,7 +2016,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2033,7 +2033,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2050,7 +2050,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2069,7 +2069,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2086,7 +2086,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2103,7 +2103,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2120,7 +2120,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2137,7 +2137,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2154,7 +2154,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2171,7 +2171,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2188,7 +2188,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2207,7 +2207,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2224,7 +2224,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2241,7 +2241,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2258,7 +2258,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2275,7 +2275,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2292,7 +2292,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2309,7 +2309,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2326,7 +2326,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2345,7 +2345,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2362,7 +2362,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2379,7 +2379,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2396,7 +2396,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2413,7 +2413,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2430,7 +2430,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2447,7 +2447,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2464,7 +2464,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2483,7 +2483,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2500,7 +2500,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2517,7 +2517,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2534,7 +2534,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2551,7 +2551,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2568,7 +2568,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2585,7 +2585,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2602,7 +2602,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2621,7 +2621,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2638,7 +2638,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2655,7 +2655,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2672,7 +2672,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2689,7 +2689,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2706,7 +2706,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2723,7 +2723,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2740,7 +2740,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2759,7 +2759,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2776,7 +2776,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2793,7 +2793,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2810,7 +2810,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2827,7 +2827,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2844,7 +2844,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2861,7 +2861,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2878,7 +2878,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2900,7 +2900,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
      * @param additionalArguments Any number of arguments to be passed to the function referenced in the function argument.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2922,7 +2922,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * @param context The object to which the context of the function should be set.
      * @param name The name of the function whose context will be changed (should be a property of the context object).
      * @param additionalArguments Any number of arguments to be passed to the function named in the name argument.
-     * @see {@link https://api.jquery.com/jQuery.proxy/}
+     * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
      * @deprecated 3.3 Use Function#bind.
@@ -2942,7 +2942,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * @param queueName A string containing the name of the queue. Defaults to fx, the standard effects queue.
      * @param newQueue The new function to add to the queue.
      *                 An array of functions to replace the current queue contents.
-     * @see {@link https://api.jquery.com/jQuery.queue/}
+     * @see \`{@link https://api.jquery.com/jQuery.queue/ }\`
      * @since 1.3
      */
     queue<T extends Element>(element: T, queueName?: string, newQueue?: JQuery.TypeOrArray<JQuery.QueueFunction<T>>): JQuery.Queue<T>;
@@ -2950,7 +2950,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * Handles errors thrown synchronously in functions wrapped in jQuery().
      *
      * @param error An error thrown in the function wrapped in jQuery().
-     * @see {@link https://api.jquery.com/jQuery.readyException/}
+     * @see \`{@link https://api.jquery.com/jQuery.readyException/ }\`
      * @since 3.1
      */
     readyException(error: Error): any;
@@ -2959,7 +2959,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param element A DOM element from which to remove data.
      * @param name A string naming the piece of data to remove.
-     * @see {@link https://api.jquery.com/jQuery.removeData/}
+     * @see \`{@link https://api.jquery.com/jQuery.removeData/ }\`
      * @since 1.2.3
      */
     removeData(element: Element, name?: string): void;
@@ -2969,7 +2969,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * @param duration A string or number determining how long the animation will run.
      * @param easing A string indicating which easing function to use for the transition.
      * @param complete A function to call once the animation is complete, called once per matched element.
-     * @see {@link https://api.jquery.com/jQuery.speed/}
+     * @see \`{@link https://api.jquery.com/jQuery.speed/ }\`
      * @since 1.1
      */
     speed(duration: JQuery.Duration, easing: string, complete: (this: TElement) => void): JQuery.EffectsOptions<TElement>;
@@ -2979,7 +2979,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * @param duration A string or number determining how long the animation will run.
      * @param easing_complete A string indicating which easing function to use for the transition.
      *                        A function to call once the animation is complete, called once per matched element.
-     * @see {@link https://api.jquery.com/jQuery.speed/}
+     * @see \`{@link https://api.jquery.com/jQuery.speed/ }\`
      * @since 1.0
      * @since 1.1
      */
@@ -2990,7 +2990,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      *
      * @param duration_complete_settings A string or number determining how long the animation will run.
      *                                   A function to call once the animation is complete, called once per matched element.
-     * @see {@link https://api.jquery.com/jQuery.speed/}
+     * @see \`{@link https://api.jquery.com/jQuery.speed/ }\`
      * @since 1.0
      * @since 1.1
      */
@@ -2999,7 +2999,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * Remove the whitespace from the beginning and end of a string.
      *
      * @param str The string to trim.
-     * @see {@link https://api.jquery.com/jQuery.trim/}
+     * @see \`{@link https://api.jquery.com/jQuery.trim/ }\`
      * @since 1.0
      */
     trim(str: string): string;
@@ -3007,7 +3007,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * Determine the internal JavaScript [[Class]] of an object.
      *
      * @param obj Object to get the internal JavaScript [[Class]] of.
-     * @see {@link https://api.jquery.com/jQuery.type/}
+     * @see \`{@link https://api.jquery.com/jQuery.type/ }\`
      * @since 1.4.3
      * @deprecated 3.3
      */
@@ -3017,7 +3017,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * arrays of DOM elements, not strings or numbers.
      *
      * @param array The Array of DOM elements.
-     * @see {@link https://api.jquery.com/jQuery.unique/}
+     * @see \`{@link https://api.jquery.com/jQuery.unique/ }\`
      * @since 1.1.3
      * @deprecated 3.0
      */
@@ -3027,7 +3027,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * arrays of DOM elements, not strings or numbers.
      *
      * @param array The Array of DOM elements.
-     * @see {@link https://api.jquery.com/jQuery.uniqueSort/}
+     * @see \`{@link https://api.jquery.com/jQuery.uniqueSort/ }\`
      * @since 1.12
      * @since 2.2
      */
@@ -3036,7 +3036,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * Provides a way to execute callback functions based on zero or more Thenable objects, usually
      * Deferred objects that represent asynchronous events.
      *
-     * @see {@link https://api.jquery.com/jQuery.when/}
+     * @see \`{@link https://api.jquery.com/jQuery.when/ }\`
      * @since 1.5
      */
     when<TR1, UR1, VR1,
@@ -3050,7 +3050,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * Provides a way to execute callback functions based on zero or more Thenable objects, usually
      * Deferred objects that represent asynchronous events.
      *
-     * @see {@link https://api.jquery.com/jQuery.when/}
+     * @see \`{@link https://api.jquery.com/jQuery.when/ }\`
      * @since 1.5
      */
     when<TR1, UR1,
@@ -3062,7 +3062,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * Provides a way to execute callback functions based on zero or more Thenable objects, usually
      * Deferred objects that represent asynchronous events.
      *
-     * @see {@link https://api.jquery.com/jQuery.when/}
+     * @see \`{@link https://api.jquery.com/jQuery.when/ }\`
      * @since 1.5
      */
     when<TR1, TJ1,
@@ -3074,7 +3074,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * Provides a way to execute callback functions based on zero or more Thenable objects, usually
      * Deferred objects that represent asynchronous events.
      *
-     * @see {@link https://api.jquery.com/jQuery.when/}
+     * @see \`{@link https://api.jquery.com/jQuery.when/ }\`
      * @since 1.5
      */
     when<TR1, TJ1 = any>(deferred: JQuery.Promise<TR1, TJ1, any> | JQuery.Thenable<TR1> | TR1): JQuery.Promise<TR1, TJ1, never>;
@@ -3083,7 +3083,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * Deferred objects that represent asynchronous events.
      *
      * @param deferreds Zero or more Thenable objects.
-     * @see {@link https://api.jquery.com/jQuery.when/}
+     * @see \`{@link https://api.jquery.com/jQuery.when/ }\`
      * @since 1.5
      */
     when<TR1 = never, TJ1 = never>(...deferreds: Array<JQuery.Promise<TR1, TJ1, any> | JQuery.Thenable<TR1> | TR1>): JQuery.Promise<TR1, TJ1, never>;
@@ -3092,7 +3092,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * Deferred objects that represent asynchronous events.
      *
      * @param deferreds Zero or more Thenable objects.
-     * @see {@link https://api.jquery.com/jQuery.when/}
+     * @see \`{@link https://api.jquery.com/jQuery.when/ }\`
      * @since 1.5
      */
     when(...deferreds: any[]): JQuery.Promise<any, any, never>;
@@ -3102,14 +3102,14 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
     /**
      * A string containing the jQuery version number.
      *
-     * @see {@link https://api.jquery.com/jquery/}
+     * @see \`{@link https://api.jquery.com/jquery/ }\`
      * @since 1.0
      */
     jquery: string;
     /**
      * The number of elements in the jQuery object.
      *
-     * @see {@link https://api.jquery.com/length/}
+     * @see \`{@link https://api.jquery.com/length/ }\`
      * @since 1.0
      */
     length: number;
@@ -3119,7 +3119,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param selector A string representing a selector expression to find additional elements to add to the set of matched elements.
      * @param context The point in the document at which the selector should begin matching; similar to the context
      *                argument of the $(selector, context) method.
-     * @see {@link https://api.jquery.com/add/}
+     * @see \`{@link https://api.jquery.com/add/ }\`
      * @since 1.4
      */
     add(selector: JQuery.Selector, context: Element): this;
@@ -3130,7 +3130,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *                 One or more elements to add to the set of matched elements.
      *                 An HTML fragment to add to the set of matched elements.
      *                 An existing jQuery object to add to the set of matched elements.
-     * @see {@link https://api.jquery.com/add/}
+     * @see \`{@link https://api.jquery.com/add/ }\`
      * @since 1.0
      * @since 1.3.2
      */
@@ -3139,7 +3139,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Add the previous set of elements on the stack to the current set, optionally filtered by a selector.
      *
      * @param selector A string containing a selector expression to match the current set of elements against.
-     * @see {@link https://api.jquery.com/addBack/}
+     * @see \`{@link https://api.jquery.com/addBack/ }\`
      * @since 1.8
      */
     addBack(selector?: JQuery.Selector): this;
@@ -3151,7 +3151,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *                  A function returning one or more space-separated class names to be added to the existing class
      *                  name(s). Receives the index position of the element in the set and the existing class name(s) as
      *                  arguments. Within the function, this refers to the current element in the set.
-     * @see {@link https://api.jquery.com/addClass/}
+     * @see \`{@link https://api.jquery.com/addClass/ }\`
      * @since 1.0
      * @since 1.4
      * @since 3.3
@@ -3162,7 +3162,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param contents One or more additional DOM elements, text nodes, arrays of elements and text nodes, HTML strings, or
      *                 jQuery objects to insert after each element in the set of matched elements.
-     * @see {@link https://api.jquery.com/after/}
+     * @see \`{@link https://api.jquery.com/after/ }\`
      * @since 1.0
      */
     after(...contents: Array<JQuery.htmlString | JQuery.TypeOrArray<JQuery.Node | JQuery<JQuery.Node>>>): this;
@@ -3173,7 +3173,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *           after each element in the set of matched elements. Receives the index position of the element in the
      *           set and the old HTML value of the element as arguments. Within the function, this refers to the
      *           current element in the set.
-     * @see {@link https://api.jquery.com/after/}
+     * @see \`{@link https://api.jquery.com/after/ }\`
      * @since 1.4
      * @since 1.10
      */
@@ -3182,7 +3182,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Register a handler to be called when Ajax requests complete. This is an AjaxEvent.
      *
      * @param handler The function to be invoked.
-     * @see {@link https://api.jquery.com/ajaxComplete/}
+     * @see \`{@link https://api.jquery.com/ajaxComplete/ }\`
      * @since 1.0
      */
     ajaxComplete(handler: (this: Document, event: JQuery.Event<Document>, jqXHR: JQuery.jqXHR, ajaxOptions: JQuery.AjaxSettings) => void | false): this;
@@ -3190,7 +3190,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Register a handler to be called when Ajax requests complete with an error. This is an Ajax Event.
      *
      * @param handler The function to be invoked.
-     * @see {@link https://api.jquery.com/ajaxError/}
+     * @see \`{@link https://api.jquery.com/ajaxError/ }\`
      * @since 1.0
      */
     ajaxError(handler: (this: Document, event: JQuery.Event<Document>, jqXHR: JQuery.jqXHR, ajaxSettings: JQuery.AjaxSettings, thrownError: string) => void | false): this;
@@ -3198,7 +3198,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Attach a function to be executed before an Ajax request is sent. This is an Ajax Event.
      *
      * @param handler The function to be invoked.
-     * @see {@link https://api.jquery.com/ajaxSend/}
+     * @see \`{@link https://api.jquery.com/ajaxSend/ }\`
      * @since 1.0
      */
     ajaxSend(handler: (this: Document, event: JQuery.Event<Document>, jqXHR: JQuery.jqXHR, ajaxOptions: JQuery.AjaxSettings) => void | false): this;
@@ -3206,7 +3206,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Register a handler to be called when the first Ajax request begins. This is an Ajax Event.
      *
      * @param handler The function to be invoked.
-     * @see {@link https://api.jquery.com/ajaxStart/}
+     * @see \`{@link https://api.jquery.com/ajaxStart/ }\`
      * @since 1.0
      */
     ajaxStart(handler: (this: Document) => void | false): this;
@@ -3214,7 +3214,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Register a handler to be called when all Ajax requests have completed. This is an Ajax Event.
      *
      * @param handler The function to be invoked.
-     * @see {@link https://api.jquery.com/ajaxStop/}
+     * @see \`{@link https://api.jquery.com/ajaxStop/ }\`
      * @since 1.0
      */
     ajaxStop(handler: (this: Document) => void | false): this;
@@ -3222,7 +3222,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Attach a function to be executed whenever an Ajax request completes successfully. This is an Ajax Event.
      *
      * @param handler The function to be invoked.
-     * @see {@link https://api.jquery.com/ajaxSuccess/}
+     * @see \`{@link https://api.jquery.com/ajaxSuccess/ }\`
      * @since 1.0
      */
     ajaxSuccess(handler: (this: Document, event: JQuery.Event<Document>, jqXHR: JQuery.jqXHR, ajaxOptions: JQuery.AjaxSettings, data: JQuery.PlainObject) => void | false): this;
@@ -3233,7 +3233,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param duration A string or number determining how long the animation will run.
      * @param easing A string indicating which easing function to use for the transition.
      * @param complete A function to call once the animation is complete, called once per matched element.
-     * @see {@link https://api.jquery.com/animate/}
+     * @see \`{@link https://api.jquery.com/animate/ }\`
      * @since 1.0
      */
     animate(properties: JQuery.PlainObject,
@@ -3247,7 +3247,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param duration_easing A string or number determining how long the animation will run.
      *                        A string indicating which easing function to use for the transition.
      * @param complete A function to call once the animation is complete, called once per matched element.
-     * @see {@link https://api.jquery.com/animate/}
+     * @see \`{@link https://api.jquery.com/animate/ }\`
      * @since 1.0
      */
     animate(properties: JQuery.PlainObject,
@@ -3258,7 +3258,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param properties An object of CSS properties and values that the animation will move toward.
      * @param options A map of additional options to pass to the method.
-     * @see {@link https://api.jquery.com/animate/}
+     * @see \`{@link https://api.jquery.com/animate/ }\`
      * @since 1.0
      */
     animate(properties: JQuery.PlainObject,
@@ -3268,7 +3268,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param properties An object of CSS properties and values that the animation will move toward.
      * @param complete A function to call once the animation is complete, called once per matched element.
-     * @see {@link https://api.jquery.com/animate/}
+     * @see \`{@link https://api.jquery.com/animate/ }\`
      * @since 1.0
      */
     animate(properties: JQuery.PlainObject,
@@ -3278,7 +3278,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param contents One or more additional DOM elements, text nodes, arrays of elements and text nodes, HTML strings, or
      *                 jQuery objects to insert at the end of each element in the set of matched elements.
-     * @see {@link https://api.jquery.com/append/}
+     * @see \`{@link https://api.jquery.com/append/ }\`
      * @since 1.0
      */
     append(...contents: Array<JQuery.htmlString | JQuery.TypeOrArray<JQuery.Node | JQuery<JQuery.Node>>>): this;
@@ -3289,7 +3289,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *           the end of each element in the set of matched elements. Receives the index position of the element
      *           in the set and the old HTML value of the element as arguments. Within the function, this refers to
      *           the current element in the set.
-     * @see {@link https://api.jquery.com/append/}
+     * @see \`{@link https://api.jquery.com/append/ }\`
      * @since 1.4
      */
     append(fn: (this: TElement, index: number, html: string) => JQuery.htmlString | JQuery.TypeOrArray<JQuery.Node | JQuery<JQuery.Node>>): this;
@@ -3298,7 +3298,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param target A selector, element, HTML string, array of elements, or jQuery object; the matched set of elements
      *               will be inserted at the end of the element(s) specified by this parameter.
-     * @see {@link https://api.jquery.com/appendTo/}
+     * @see \`{@link https://api.jquery.com/appendTo/ }\`
      * @since 1.0
      */
     appendTo(target: JQuery.Selector | JQuery.htmlString | JQuery.TypeOrArray<Element> | JQuery): this;
@@ -3309,7 +3309,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param value A value to set for the attribute. If null, the specified attribute will be removed (as in .removeAttr()).
      *              A function returning the value to set. this is the current element. Receives the index position of
      *              the element in the set and the old attribute value as arguments.
-     * @see {@link https://api.jquery.com/attr/}
+     * @see \`{@link https://api.jquery.com/attr/ }\`
      * @since 1.0
      * @since 1.1
      */
@@ -3319,7 +3319,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Set one or more attributes for the set of matched elements.
      *
      * @param attributes An object of attribute-value pairs to set.
-     * @see {@link https://api.jquery.com/attr/}
+     * @see \`{@link https://api.jquery.com/attr/ }\`
      * @since 1.0
      */
     attr(attributes: JQuery.PlainObject): this;
@@ -3327,7 +3327,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Get the value of an attribute for the first element in the set of matched elements.
      *
      * @param attributeName The name of the attribute to get.
-     * @see {@link https://api.jquery.com/attr/}
+     * @see \`{@link https://api.jquery.com/attr/ }\`
      * @since 1.0
      */
     attr(attributeName: string): string | undefined;
@@ -3336,7 +3336,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param contents One or more additional DOM elements, text nodes, arrays of elements and text nodes, HTML strings, or
      *                 jQuery objects to insert before each element in the set of matched elements.
-     * @see {@link https://api.jquery.com/before/}
+     * @see \`{@link https://api.jquery.com/before/ }\`
      * @since 1.0
      */
     before(...contents: Array<JQuery.htmlString | JQuery.TypeOrArray<JQuery.Node | JQuery<JQuery.Node>>>): this;
@@ -3347,7 +3347,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *           before each element in the set of matched elements. Receives the index position of the element in
      *           the set and the old HTML value of the element as arguments. Within the function, this refers to the
      *           current element in the set.
-     * @see {@link https://api.jquery.com/before/}
+     * @see \`{@link https://api.jquery.com/before/ }\`
      * @since 1.4
      * @since 1.10
      */
@@ -3359,7 +3359,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param eventType A string containing one or more DOM event types, such as "click" or "submit," or custom event names.
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute each time the event is triggered.
-     * @see {@link https://api.jquery.com/bind/}
+     * @see \`{@link https://api.jquery.com/bind/ }\`
      * @since 1.0
      * @since 1.4.3
      * @deprecated 3.0
@@ -3374,7 +3374,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param handler A function to execute each time the event is triggered.
      *                Setting the second argument to false will attach a function that prevents the default action from
      *                occurring and stops the event from bubbling.
-     * @see {@link https://api.jquery.com/bind/}
+     * @see \`{@link https://api.jquery.com/bind/ }\`
      * @since 1.0
      * @since 1.4.3
      * @deprecated 3.0
@@ -3385,7 +3385,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Attach a handler to an event for the elements.
      *
      * @param events An object containing one or more DOM event types and functions to execute for them.
-     * @see {@link https://api.jquery.com/bind/}
+     * @see \`{@link https://api.jquery.com/bind/ }\`
      * @since 1.4
      * @deprecated 3.0
      */
@@ -3395,7 +3395,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute each time the event is triggered.
-     * @see {@link https://api.jquery.com/blur/}
+     * @see \`{@link https://api.jquery.com/blur/ }\`
      * @since 1.4.3
      * @deprecated 3.3
      */
@@ -3405,7 +3405,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Bind an event handler to the "blur" JavaScript event, or trigger that event on an element.
      *
      * @param handler A function to execute each time the event is triggered.
-     * @see {@link https://api.jquery.com/blur/}
+     * @see \`{@link https://api.jquery.com/blur/ }\`
      * @since 1.0
      * @deprecated 3.3
      */
@@ -3415,7 +3415,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute each time the event is triggered.
-     * @see {@link https://api.jquery.com/change/}
+     * @see \`{@link https://api.jquery.com/change/ }\`
      * @since 1.4.3
      * @deprecated 3.3
      */
@@ -3425,7 +3425,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Bind an event handler to the "change" JavaScript event, or trigger that event on an element.
      *
      * @param handler A function to execute each time the event is triggered.
-     * @see {@link https://api.jquery.com/change/}
+     * @see \`{@link https://api.jquery.com/change/ }\`
      * @since 1.0
      * @deprecated 3.3
      */
@@ -3434,7 +3434,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Get the children of each element in the set of matched elements, optionally filtered by a selector.
      *
      * @param selector A string containing a selector expression to match elements against.
-     * @see {@link https://api.jquery.com/children/}
+     * @see \`{@link https://api.jquery.com/children/ }\`
      * @since 1.0
      */
     children(selector?: JQuery.Selector): this;
@@ -3442,7 +3442,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Remove from the queue all items that have not yet been run.
      *
      * @param queueName A string containing the name of the queue. Defaults to fx, the standard effects queue.
-     * @see {@link https://api.jquery.com/clearQueue/}
+     * @see \`{@link https://api.jquery.com/clearQueue/ }\`
      * @since 1.4
      */
     clearQueue(queueName?: string): this;
@@ -3451,7 +3451,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute each time the event is triggered.
-     * @see {@link https://api.jquery.com/click/}
+     * @see \`{@link https://api.jquery.com/click/ }\`
      * @since 1.4.3
      * @deprecated 3.3
      */
@@ -3461,7 +3461,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Bind an event handler to the "click" JavaScript event, or trigger that event on an element.
      *
      * @param handler A function to execute each time the event is triggered.
-     * @see {@link https://api.jquery.com/click/}
+     * @see \`{@link https://api.jquery.com/click/ }\`
      * @since 1.0
      * @deprecated 3.3
      */
@@ -3474,7 +3474,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *                          to false in 1.5.1 and up.
      * @param deepWithDataAndEvents A Boolean indicating whether event handlers and data for all children of the cloned element should
      *                              be copied. By default its value matches the first argument's value (which defaults to false).
-     * @see {@link https://api.jquery.com/clone/}
+     * @see \`{@link https://api.jquery.com/clone/ }\`
      * @since 1.0
      * @since 1.5
      */
@@ -3485,7 +3485,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param selector A string containing a selector expression to match elements against.
      * @param context A DOM element within which a matching element may be found.
-     * @see {@link https://api.jquery.com/closest/}
+     * @see \`{@link https://api.jquery.com/closest/ }\`
      * @since 1.4
      */
     closest(selector: JQuery.Selector, context: Element): this;
@@ -3496,7 +3496,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param selector A string containing a selector expression to match elements against.
      *                 A jQuery object to match elements against.
      *                 An element to match elements against.
-     * @see {@link https://api.jquery.com/closest/}
+     * @see \`{@link https://api.jquery.com/closest/ }\`
      * @since 1.3
      * @since 1.6
      */
@@ -3504,7 +3504,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
     /**
      * Get the children of each element in the set of matched elements, including text and comment nodes.
      *
-     * @see {@link https://api.jquery.com/contents/}
+     * @see \`{@link https://api.jquery.com/contents/ }\`
      * @since 1.2
      */
     contents(): JQuery<TElement | Text | Comment>;
@@ -3513,7 +3513,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute each time the event is triggered.
-     * @see {@link https://api.jquery.com/contextmenu/}
+     * @see \`{@link https://api.jquery.com/contextmenu/ }\`
      * @since 1.4.3
      * @deprecated 3.3
      */
@@ -3523,7 +3523,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Bind an event handler to the "contextmenu" JavaScript event, or trigger that event on an element.
      *
      * @param handler A function to execute each time the event is triggered.
-     * @see {@link https://api.jquery.com/contextmenu/}
+     * @see \`{@link https://api.jquery.com/contextmenu/ }\`
      * @since 1.0
      * @deprecated 3.3
      */
@@ -3535,7 +3535,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param value A value to set for the property.
      *              A function returning the value to set. this is the current element. Receives the index position of
      *              the element in the set and the old value as arguments.
-     * @see {@link https://api.jquery.com/css/}
+     * @see \`{@link https://api.jquery.com/css/ }\`
      * @since 1.0
      * @since 1.4
      */
@@ -3545,7 +3545,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Set one or more CSS properties for the set of matched elements.
      *
      * @param properties An object of property-value pairs to set.
-     * @see {@link https://api.jquery.com/css/}
+     * @see \`{@link https://api.jquery.com/css/ }\`
      * @since 1.0
      */
     css(properties: JQuery.PlainObject<string | number | ((this: TElement, index: number, value: string) => string | number | void | undefined)>): this;
@@ -3554,7 +3554,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param propertyName A CSS property.
      *                     An array of one or more CSS properties.
-     * @see {@link https://api.jquery.com/css/}
+     * @see \`{@link https://api.jquery.com/css/ }\`
      * @since 1.0
      */
     css(propertyName: string): string;
@@ -3562,7 +3562,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Get the computed style properties for the first element in the set of matched elements.
      *
      * @param propertyNames An array of one or more CSS properties.
-     * @see {@link https://api.jquery.com/css/}
+     * @see \`{@link https://api.jquery.com/css/ }\`
      * @since 1.9
      */
     css(propertyNames: string[]): JQuery.PlainObject<string>;
@@ -3571,7 +3571,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * data(name, value) or by an HTML5 data-* attribute.
      *
      * @param key Name of the data stored.
-     * @see {@link https://api.jquery.com/data/}
+     * @see \`{@link https://api.jquery.com/data/ }\`
      * @since 1.2.3
      */
     data(key: string, undefined: undefined): any; // tslint:disable-line:unified-signatures
@@ -3580,7 +3580,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param key A string naming the piece of data to set.
      * @param value The new data value; this can be any Javascript type except undefined.
-     * @see {@link https://api.jquery.com/data/}
+     * @see \`{@link https://api.jquery.com/data/ }\`
      * @since 1.2.3
      */
     data(key: string, value: any): this;
@@ -3588,7 +3588,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Store arbitrary data associated with the matched elements.
      *
      * @param obj An object of key-value pairs of data to update.
-     * @see {@link https://api.jquery.com/data/}
+     * @see \`{@link https://api.jquery.com/data/ }\`
      * @since 1.4.3
      */
     data(obj: JQuery.PlainObject): this;
@@ -3597,7 +3597,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * data(name, value) or by an HTML5 data-* attribute.
      *
      * @param key Name of the data stored.
-     * @see {@link https://api.jquery.com/data/}
+     * @see \`{@link https://api.jquery.com/data/ }\`
      * @since 1.2.3
      */
     data(key: string): any;
@@ -3605,7 +3605,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Return the value at the named data store for the first element in the jQuery collection, as set by
      * data(name, value) or by an HTML5 data-* attribute.
      *
-     * @see {@link https://api.jquery.com/data/}
+     * @see \`{@link https://api.jquery.com/data/ }\`
      * @since 1.4
      */
     data(): JQuery.PlainObject;
@@ -3614,7 +3614,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute each time the event is triggered.
-     * @see {@link https://api.jquery.com/dblclick/}
+     * @see \`{@link https://api.jquery.com/dblclick/ }\`
      * @since 1.4.3
      * @deprecated 3.3
      */
@@ -3624,7 +3624,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Bind an event handler to the "dblclick" JavaScript event, or trigger that event on an element.
      *
      * @param handler A function to execute each time the event is triggered.
-     * @see {@link https://api.jquery.com/dblclick/}
+     * @see \`{@link https://api.jquery.com/dblclick/ }\`
      * @since 1.0
      * @deprecated 3.3
      */
@@ -3634,7 +3634,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param duration An integer indicating the number of milliseconds to delay execution of the next item in the queue.
      * @param queueName A string containing the name of the queue. Defaults to fx, the standard effects queue.
-     * @see {@link https://api.jquery.com/delay/}
+     * @see \`{@link https://api.jquery.com/delay/ }\`
      * @since 1.4
      */
     delay(duration: JQuery.Duration, queueName?: string): this;
@@ -3647,7 +3647,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *                  "keydown," or custom event names.
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute each time the event is triggered.
-     * @see {@link https://api.jquery.com/delegate/}
+     * @see \`{@link https://api.jquery.com/delegate/ }\`
      * @since 1.4.2
      * @deprecated 3.0
      */
@@ -3663,7 +3663,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param eventType A string containing one or more space-separated JavaScript event types, such as "click" or
      *                  "keydown," or custom event names.
      * @param handler A function to execute each time the event is triggered.
-     * @see {@link https://api.jquery.com/delegate/}
+     * @see \`{@link https://api.jquery.com/delegate/ }\`
      * @since 1.4.2
      * @deprecated 3.0
      */
@@ -3676,7 +3676,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param selector A selector to filter the elements that trigger the event.
      * @param events A plain object of one or more event types and functions to execute for them.
-     * @see {@link https://api.jquery.com/delegate/}
+     * @see \`{@link https://api.jquery.com/delegate/ }\`
      * @since 1.4.3
      * @deprecated 3.0
      */
@@ -3686,7 +3686,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Execute the next function on the queue for the matched elements.
      *
      * @param queueName A string containing the name of the queue. Defaults to fx, the standard effects queue.
-     * @see {@link https://api.jquery.com/dequeue/}
+     * @see \`{@link https://api.jquery.com/dequeue/ }\`
      * @since 1.2
      */
     dequeue(queueName?: string): this;
@@ -3694,7 +3694,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Remove the set of matched elements from the DOM.
      *
      * @param selector A selector expression that filters the set of matched elements to be removed.
-     * @see {@link https://api.jquery.com/detach/}
+     * @see \`{@link https://api.jquery.com/detach/ }\`
      * @since 1.4
      */
     detach(selector?: JQuery.Selector): this;
@@ -3702,14 +3702,14 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Iterate over a jQuery object, executing a function for each matched element.
      *
      * @param fn A function to execute for each matched element.
-     * @see {@link https://api.jquery.com/each/}
+     * @see \`{@link https://api.jquery.com/each/ }\`
      * @since 1.0
      */
     each(fn: (this: TElement, index: number, element: TElement) => void | false): this;
     /**
      * Remove all child nodes of the set of matched elements from the DOM.
      *
-     * @see {@link https://api.jquery.com/empty/}
+     * @see \`{@link https://api.jquery.com/empty/ }\`
      * @since 1.0
      */
     empty(): this;
@@ -3717,7 +3717,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * End the most recent filtering operation in the current chain and return the set of matched elements
      * to its previous state.
      *
-     * @see {@link https://api.jquery.com/end/}
+     * @see \`{@link https://api.jquery.com/end/ }\`
      * @since 1.0
      */
     end(): this;
@@ -3726,7 +3726,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param index An integer indicating the 0-based position of the element.
      *              An integer indicating the position of the element, counting backwards from the last element in the set.
-     * @see {@link https://api.jquery.com/eq/}
+     * @see \`{@link https://api.jquery.com/eq/ }\`
      * @since 1.1.2
      * @since 1.4
      */
@@ -3735,7 +3735,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Merge the contents of an object onto the jQuery prototype to provide new jQuery instance methods.
      *
      * @param obj An object to merge onto the jQuery prototype.
-     * @see {@link https://api.jquery.com/jQuery.fn.extend/}
+     * @see \`{@link https://api.jquery.com/jQuery.fn.extend/ }\`
      * @since 1.0
      */
     extend(obj: object): this;
@@ -3745,7 +3745,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param duration A string or number determining how long the animation will run.
      * @param easing A string indicating which easing function to use for the transition.
      * @param complete A function to call once the animation is complete, called once per matched element.
-     * @see {@link https://api.jquery.com/fadeIn/}
+     * @see \`{@link https://api.jquery.com/fadeIn/ }\`
      * @since 1.4.3
      */
     fadeIn(duration: JQuery.Duration, easing: string, complete?: (this: TElement) => void): this;
@@ -3755,7 +3755,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param duration_easing A string or number determining how long the animation will run.
      *                        A string indicating which easing function to use for the transition.
      * @param complete A function to call once the animation is complete, called once per matched element.
-     * @see {@link https://api.jquery.com/fadeIn/}
+     * @see \`{@link https://api.jquery.com/fadeIn/ }\`
      * @since 1.0
      * @since 1.4.3
      */
@@ -3767,7 +3767,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *                                         A string indicating which easing function to use for the transition.
      *                                         A function to call once the animation is complete, called once per matched element.
      *                                         A map of additional options to pass to the method.
-     * @see {@link https://api.jquery.com/fadeIn/}
+     * @see \`{@link https://api.jquery.com/fadeIn/ }\`
      * @since 1.0
      * @since 1.4.3
      */
@@ -3778,7 +3778,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param duration A string or number determining how long the animation will run.
      * @param easing A string indicating which easing function to use for the transition.
      * @param complete A function to call once the animation is complete, called once per matched element.
-     * @see {@link https://api.jquery.com/fadeOut/}
+     * @see \`{@link https://api.jquery.com/fadeOut/ }\`
      * @since 1.4.3
      */
     fadeOut(duration: JQuery.Duration, easing: string, complete?: (this: TElement) => void): this;
@@ -3788,7 +3788,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param duration_easing A string or number determining how long the animation will run.
      *                        A string indicating which easing function to use for the transition.
      * @param complete A function to call once the animation is complete, called once per matched element.
-     * @see {@link https://api.jquery.com/fadeOut/}
+     * @see \`{@link https://api.jquery.com/fadeOut/ }\`
      * @since 1.0
      * @since 1.4.3
      */
@@ -3800,7 +3800,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *                                         A string indicating which easing function to use for the transition.
      *                                         A function to call once the animation is complete, called once per matched element.
      *                                         A map of additional options to pass to the method.
-     * @see {@link https://api.jquery.com/fadeOut/}
+     * @see \`{@link https://api.jquery.com/fadeOut/ }\`
      * @since 1.0
      * @since 1.4.3
      */
@@ -3812,7 +3812,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param opacity A number between 0 and 1 denoting the target opacity.
      * @param easing A string indicating which easing function to use for the transition.
      * @param complete A function to call once the animation is complete, called once per matched element.
-     * @see {@link https://api.jquery.com/fadeTo/}
+     * @see \`{@link https://api.jquery.com/fadeTo/ }\`
      * @since 1.4.3
      */
     fadeTo(duration: JQuery.Duration, opacity: number, easing: string, complete?: (this: TElement) => void): this;
@@ -3822,7 +3822,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param duration A string or number determining how long the animation will run.
      * @param opacity A number between 0 and 1 denoting the target opacity.
      * @param complete A function to call once the animation is complete, called once per matched element.
-     * @see {@link https://api.jquery.com/fadeTo/}
+     * @see \`{@link https://api.jquery.com/fadeTo/ }\`
      * @since 1.0
      */
     fadeTo(duration: JQuery.Duration, opacity: number, complete?: (this: TElement) => void): this;
@@ -3832,7 +3832,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param duration A string or number determining how long the animation will run.
      * @param easing A string indicating which easing function to use for the transition.
      * @param complete A function to call once the animation is complete, called once per matched element.
-     * @see {@link https://api.jquery.com/fadeToggle/}
+     * @see \`{@link https://api.jquery.com/fadeToggle/ }\`
      * @since 1.4.4
      */
     fadeToggle(duration: JQuery.Duration, easing: string, complete?: (this: TElement) => void): this;
@@ -3842,7 +3842,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param duration_easing A string or number determining how long the animation will run.
      *                        A string indicating which easing function to use for the transition.
      * @param complete A function to call once the animation is complete, called once per matched element.
-     * @see {@link https://api.jquery.com/fadeToggle/}
+     * @see \`{@link https://api.jquery.com/fadeToggle/ }\`
      * @since 1.0
      * @since 1.4.3
      */
@@ -3854,7 +3854,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *                                         A string indicating which easing function to use for the transition.
      *                                         A function to call once the animation is complete, called once per matched element.
      *                                         A map of additional options to pass to the method.
-     * @see {@link https://api.jquery.com/fadeToggle/}
+     * @see \`{@link https://api.jquery.com/fadeToggle/ }\`
      * @since 1.0
      * @since 1.4.3
      */
@@ -3866,7 +3866,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *                 One or more DOM elements to match the current set of elements against.
      *                 An existing jQuery object to match the current set of elements against.
      *                 A function used as a test for each element in the set. this is the current DOM element.
-     * @see {@link https://api.jquery.com/filter/}
+     * @see \`{@link https://api.jquery.com/filter/ }\`
      * @since 1.0
      * @since 1.4
      */
@@ -3877,7 +3877,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param selector A string containing a selector expression to match elements against.
      *                 An element or a jQuery object to match elements against.
-     * @see {@link https://api.jquery.com/find/}
+     * @see \`{@link https://api.jquery.com/find/ }\`
      * @since 1.0
      * @since 1.6
      */
@@ -3887,14 +3887,14 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * the matched elements.
      *
      * @param queue The name of the queue in which to stop animations.
-     * @see {@link https://api.jquery.com/finish/}
+     * @see \`{@link https://api.jquery.com/finish/ }\`
      * @since 1.9
      */
     finish(queue?: string): this;
     /**
      * Reduce the set of matched elements to the first in the set.
      *
-     * @see {@link https://api.jquery.com/first/}
+     * @see \`{@link https://api.jquery.com/first/ }\`
      * @since 1.4
      */
     first(): this;
@@ -3903,7 +3903,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute each time the event is triggered.
-     * @see {@link https://api.jquery.com/focus/}
+     * @see \`{@link https://api.jquery.com/focus/ }\`
      * @since 1.4.3
      * @deprecated 3.3
      */
@@ -3913,7 +3913,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Bind an event handler to the "focus" JavaScript event, or trigger that event on an element.
      *
      * @param handler A function to execute each time the event is triggered.
-     * @see {@link https://api.jquery.com/focus/}
+     * @see \`{@link https://api.jquery.com/focus/ }\`
      * @since 1.0
      * @deprecated 3.3
      */
@@ -3923,7 +3923,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute each time the event is triggered.
-     * @see {@link https://api.jquery.com/focusin/}
+     * @see \`{@link https://api.jquery.com/focusin/ }\`
      * @since 1.4.3
      * @deprecated 3.3
      */
@@ -3933,7 +3933,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Bind an event handler to the "focusin" event.
      *
      * @param handler A function to execute each time the event is triggered.
-     * @see {@link https://api.jquery.com/focusin/}
+     * @see \`{@link https://api.jquery.com/focusin/ }\`
      * @since 1.4
      * @deprecated 3.3
      */
@@ -3943,7 +3943,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute each time the event is triggered.
-     * @see {@link https://api.jquery.com/focusout/}
+     * @see \`{@link https://api.jquery.com/focusout/ }\`
      * @since 1.4.3
      * @deprecated 3.3
      */
@@ -3953,7 +3953,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Bind an event handler to the "focusout" JavaScript event.
      *
      * @param handler A function to execute each time the event is triggered.
-     * @see {@link https://api.jquery.com/focusout/}
+     * @see \`{@link https://api.jquery.com/focusout/ }\`
      * @since 1.4
      * @deprecated 3.3
      */
@@ -3962,14 +3962,14 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Retrieve one of the elements matched by the jQuery object.
      *
      * @param index A zero-based integer indicating which element to retrieve.
-     * @see {@link https://api.jquery.com/get/}
+     * @see \`{@link https://api.jquery.com/get/ }\`
      * @since 1.0
      */
     get(index: number): TElement;
     /**
      * Retrieve the elements matched by the jQuery object.
      *
-     * @see {@link https://api.jquery.com/get/}
+     * @see \`{@link https://api.jquery.com/get/ }\`
      * @since 1.0
      */
     get(): TElement[];
@@ -3978,7 +3978,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param selector A string containing a selector expression to match elements against.
      *                 A DOM element to match elements against.
-     * @see {@link https://api.jquery.com/has/}
+     * @see \`{@link https://api.jquery.com/has/ }\`
      * @since 1.4
      */
     has(selector: string | Element): this;
@@ -3986,7 +3986,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Determine whether any of the matched elements are assigned the given class.
      *
      * @param className The class name to search for.
-     * @see {@link https://api.jquery.com/hasClass/}
+     * @see \`{@link https://api.jquery.com/hasClass/ }\`
      * @since 1.2
      */
     hasClass(className: string): boolean;
@@ -3997,7 +3997,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *              appended (as a string).
      *              A function returning the height to set. Receives the index position of the element in the set and
      *              the old height as arguments. Within the function, this refers to the current element in the set.
-     * @see {@link https://api.jquery.com/height/}
+     * @see \`{@link https://api.jquery.com/height/ }\`
      * @since 1.0
      * @since 1.4.1
      */
@@ -4005,7 +4005,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
     /**
      * Get the current computed height for the first element in the set of matched elements.
      *
-     * @see {@link https://api.jquery.com/height/}
+     * @see \`{@link https://api.jquery.com/height/ }\`
      * @since 1.0
      */
     height(): number | undefined;
@@ -4015,7 +4015,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param duration A string or number determining how long the animation will run.
      * @param easing A string indicating which easing function to use for the transition.
      * @param complete A function to call once the animation is complete, called once per matched element.
-     * @see {@link https://api.jquery.com/hide/}
+     * @see \`{@link https://api.jquery.com/hide/ }\`
      * @since 1.4.3
      */
     hide(duration: JQuery.Duration, easing: string, complete: (this: TElement) => void): this;
@@ -4025,7 +4025,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param duration A string or number determining how long the animation will run.
      * @param easing_complete A string indicating which easing function to use for the transition.
      *                        A function to call once the animation is complete, called once per matched element.
-     * @see {@link https://api.jquery.com/hide/}
+     * @see \`{@link https://api.jquery.com/hide/ }\`
      * @since 1.0
      * @since 1.4.3
      */
@@ -4036,7 +4036,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param duration_complete_options A string or number determining how long the animation will run.
      *                                  A function to call once the animation is complete, called once per matched element.
      *                                  A map of additional options to pass to the method.
-     * @see {@link https://api.jquery.com/hide/}
+     * @see \`{@link https://api.jquery.com/hide/ }\`
      * @since 1.0
      */
     hide(duration_complete_options?: JQuery.Duration | ((this: TElement) => void) | JQuery.EffectsOptions<TElement>): this;
@@ -4046,7 +4046,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param handlerInOut A function to execute when the mouse pointer enters or leaves the element.
      * @param handlerOut A function to execute when the mouse pointer leaves the element.
-     * @see {@link https://api.jquery.com/hover/}
+     * @see \`{@link https://api.jquery.com/hover/ }\`
      * @since 1.0
      * @since 1.4
      */
@@ -4060,7 +4060,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *                   A function returning the HTML content to set. Receives the index position of the element in the set
      *                   and the old HTML value as arguments. jQuery empties the element before calling the function; use the
      *                   oldhtml argument to reference the previous content. Within the function, this refers to the current element in the set.
-     * @see {@link https://api.jquery.com/html/}
+     * @see \`{@link https://api.jquery.com/html/ }\`
      * @since 1.0
      * @since 1.4
      */
@@ -4068,7 +4068,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
     /**
      * Get the HTML contents of the first element in the set of matched elements.
      *
-     * @see {@link https://api.jquery.com/html/}
+     * @see \`{@link https://api.jquery.com/html/ }\`
      * @since 1.0
      */
     html(): string;
@@ -4077,7 +4077,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param element The DOM element or first element within the jQuery object to look for.
      *                A selector representing a jQuery collection in which to look for an element.
-     * @see {@link https://api.jquery.com/index/}
+     * @see \`{@link https://api.jquery.com/index/ }\`
      * @since 1.0
      * @since 1.4
      */
@@ -4090,7 +4090,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *              A function returning the inner height (including padding but not border) to set. Receives the index
      *              position of the element in the set and the old inner height as arguments. Within the function, this
      *              refers to the current element in the set.
-     * @see {@link https://api.jquery.com/innerHeight/}
+     * @see \`{@link https://api.jquery.com/innerHeight/ }\`
      * @since 1.8.0
      */
     innerHeight(value: string | number | ((this: TElement, index: number, height: number) => string | number)): this;
@@ -4098,7 +4098,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Get the current computed height for the first element in the set of matched elements, including
      * padding but not border.
      *
-     * @see {@link https://api.jquery.com/innerHeight/}
+     * @see \`{@link https://api.jquery.com/innerHeight/ }\`
      * @since 1.2.6
      */
     innerHeight(): number | undefined;
@@ -4110,7 +4110,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *              A function returning the inner width (including padding but not border) to set. Receives the index
      *              position of the element in the set and the old inner width as arguments. Within the function, this
      *              refers to the current element in the set.
-     * @see {@link https://api.jquery.com/innerWidth/}
+     * @see \`{@link https://api.jquery.com/innerWidth/ }\`
      * @since 1.8.0
      */
     innerWidth(value: string | number | ((this: TElement, index: number, width: number) => string | number)): this;
@@ -4118,7 +4118,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Get the current computed inner width for the first element in the set of matched elements, including
      * padding but not border.
      *
-     * @see {@link https://api.jquery.com/innerWidth/}
+     * @see \`{@link https://api.jquery.com/innerWidth/ }\`
      * @since 1.2.6
      */
     innerWidth(): number | undefined;
@@ -4127,7 +4127,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param target A selector, element, array of elements, HTML string, or jQuery object; the matched set of elements
      *               will be inserted after the element(s) specified by this parameter.
-     * @see {@link https://api.jquery.com/insertAfter/}
+     * @see \`{@link https://api.jquery.com/insertAfter/ }\`
      * @since 1.0
      */
     insertAfter(target: JQuery.Selector | JQuery.htmlString | JQuery.TypeOrArray<Element> | JQuery): this;
@@ -4136,7 +4136,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param target A selector, element, array of elements, HTML string, or jQuery object; the matched set of elements
      *               will be inserted before the element(s) specified by this parameter.
-     * @see {@link https://api.jquery.com/insertBefore/}
+     * @see \`{@link https://api.jquery.com/insertBefore/ }\`
      * @since 1.0
      */
     insertBefore(target: JQuery.Selector | JQuery.htmlString | JQuery.TypeOrArray<Element> | JQuery): this;
@@ -4150,7 +4150,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *                 function, this refers to the current DOM element.
      *                 An existing jQuery object to match the current set of elements against.
      *                 One or more elements to match the current set of elements against.
-     * @see {@link https://api.jquery.com/is/}
+     * @see \`{@link https://api.jquery.com/is/ }\`
      * @since 1.0
      * @since 1.6
      */
@@ -4160,7 +4160,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute each time the event is triggered.
-     * @see {@link https://api.jquery.com/keydown/}
+     * @see \`{@link https://api.jquery.com/keydown/ }\`
      * @since 1.4.3
      * @deprecated 3.3
      */
@@ -4170,7 +4170,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Bind an event handler to the "keydown" JavaScript event, or trigger that event on an element.
      *
      * @param handler A function to execute each time the event is triggered.
-     * @see {@link https://api.jquery.com/keydown/}
+     * @see \`{@link https://api.jquery.com/keydown/ }\`
      * @since 1.0
      * @deprecated 3.3
      */
@@ -4180,7 +4180,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute each time the event is triggered.
-     * @see {@link https://api.jquery.com/keypress/}
+     * @see \`{@link https://api.jquery.com/keypress/ }\`
      * @since 1.4.3
      * @deprecated 3.3
      */
@@ -4190,7 +4190,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Bind an event handler to the "keypress" JavaScript event, or trigger that event on an element.
      *
      * @param handler A function to execute each time the event is triggered.
-     * @see {@link https://api.jquery.com/keypress/}
+     * @see \`{@link https://api.jquery.com/keypress/ }\`
      * @since 1.0
      * @deprecated 3.3
      */
@@ -4200,7 +4200,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute each time the event is triggered.
-     * @see {@link https://api.jquery.com/keyup/}
+     * @see \`{@link https://api.jquery.com/keyup/ }\`
      * @since 1.4.3
      * @deprecated 3.3
      */
@@ -4210,7 +4210,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Bind an event handler to the "keyup" JavaScript event, or trigger that event on an element.
      *
      * @param handler A function to execute each time the event is triggered.
-     * @see {@link https://api.jquery.com/keyup/}
+     * @see \`{@link https://api.jquery.com/keyup/ }\`
      * @since 1.0
      * @deprecated 3.3
      */
@@ -4218,7 +4218,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
     /**
      * Reduce the set of matched elements to the final one in the set.
      *
-     * @see {@link https://api.jquery.com/last/}
+     * @see \`{@link https://api.jquery.com/last/ }\`
      * @since 1.4
      */
     last(): this;
@@ -4228,7 +4228,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param url A string containing the URL to which the request is sent.
      * @param data A plain object or string that is sent to the server with the request.
      * @param complete A callback function that is executed when the request completes.
-     * @see {@link https://api.jquery.com/load/}
+     * @see \`{@link https://api.jquery.com/load/ }\`
      * @since 1.0
      */
     load(url: string,
@@ -4240,7 +4240,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param url A string containing the URL to which the request is sent.
      * @param complete_data A callback function that is executed when the request completes.
      *                      A plain object or string that is sent to the server with the request.
-     * @see {@link https://api.jquery.com/load/}
+     * @see \`{@link https://api.jquery.com/load/ }\`
      * @since 1.0
      */
     load(url: string,
@@ -4250,7 +4250,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * containing the return values.
      *
      * @param callback A function object that will be invoked for each element in the current set.
-     * @see {@link https://api.jquery.com/map/}
+     * @see \`{@link https://api.jquery.com/map/ }\`
      * @since 1.2
      */
     map(callback: (this: TElement, index: number, domElement: TElement) => any | any[] | null | undefined): this;
@@ -4259,7 +4259,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute each time the event is triggered.
-     * @see {@link https://api.jquery.com/mousedown/}
+     * @see \`{@link https://api.jquery.com/mousedown/ }\`
      * @since 1.4.3
      * @deprecated 3.3
      */
@@ -4269,7 +4269,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Bind an event handler to the "mousedown" JavaScript event, or trigger that event on an element.
      *
      * @param handler A function to execute each time the event is triggered.
-     * @see {@link https://api.jquery.com/mousedown/}
+     * @see \`{@link https://api.jquery.com/mousedown/ }\`
      * @since 1.0
      * @deprecated 3.3
      */
@@ -4279,7 +4279,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute each time the event is triggered.
-     * @see {@link https://api.jquery.com/mouseenter/}
+     * @see \`{@link https://api.jquery.com/mouseenter/ }\`
      * @since 1.4.3
      * @deprecated 3.3
      */
@@ -4289,7 +4289,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Bind an event handler to be fired when the mouse enters an element, or trigger that handler on an element.
      *
      * @param handler A function to execute each time the event is triggered.
-     * @see {@link https://api.jquery.com/mouseenter/}
+     * @see \`{@link https://api.jquery.com/mouseenter/ }\`
      * @since 1.0
      * @deprecated 3.3
      */
@@ -4299,7 +4299,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute each time the event is triggered.
-     * @see {@link https://api.jquery.com/mouseleave/}
+     * @see \`{@link https://api.jquery.com/mouseleave/ }\`
      * @since 1.4.3
      * @deprecated 3.3
      */
@@ -4309,7 +4309,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Bind an event handler to be fired when the mouse leaves an element, or trigger that handler on an element.
      *
      * @param handler A function to execute each time the event is triggered.
-     * @see {@link https://api.jquery.com/mouseleave/}
+     * @see \`{@link https://api.jquery.com/mouseleave/ }\`
      * @since 1.0
      * @deprecated 3.3
      */
@@ -4319,7 +4319,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute each time the event is triggered.
-     * @see {@link https://api.jquery.com/mousemove/}
+     * @see \`{@link https://api.jquery.com/mousemove/ }\`
      * @since 1.4.3
      * @deprecated 3.3
      */
@@ -4329,7 +4329,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Bind an event handler to the "mousemove" JavaScript event, or trigger that event on an element.
      *
      * @param handler A function to execute each time the event is triggered.
-     * @see {@link https://api.jquery.com/mousemove/}
+     * @see \`{@link https://api.jquery.com/mousemove/ }\`
      * @since 1.0
      * @deprecated 3.3
      */
@@ -4339,7 +4339,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute each time the event is triggered.
-     * @see {@link https://api.jquery.com/mouseout/}
+     * @see \`{@link https://api.jquery.com/mouseout/ }\`
      * @since 1.4.3
      * @deprecated 3.3
      */
@@ -4349,7 +4349,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Bind an event handler to the "mouseout" JavaScript event, or trigger that event on an element.
      *
      * @param handler A function to execute each time the event is triggered.
-     * @see {@link https://api.jquery.com/mouseout/}
+     * @see \`{@link https://api.jquery.com/mouseout/ }\`
      * @since 1.0
      * @deprecated 3.3
      */
@@ -4359,7 +4359,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute each time the event is triggered.
-     * @see {@link https://api.jquery.com/mouseover/}
+     * @see \`{@link https://api.jquery.com/mouseover/ }\`
      * @since 1.4.3
      * @deprecated 3.3
      */
@@ -4369,7 +4369,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Bind an event handler to the "mouseover" JavaScript event, or trigger that event on an element.
      *
      * @param handler A function to execute each time the event is triggered.
-     * @see {@link https://api.jquery.com/mouseover/}
+     * @see \`{@link https://api.jquery.com/mouseover/ }\`
      * @since 1.0
      * @deprecated 3.3
      */
@@ -4379,7 +4379,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute each time the event is triggered.
-     * @see {@link https://api.jquery.com/mouseup/}
+     * @see \`{@link https://api.jquery.com/mouseup/ }\`
      * @since 1.4.3
      * @deprecated 3.3
      */
@@ -4389,7 +4389,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Bind an event handler to the "mouseup" JavaScript event, or trigger that event on an element.
      *
      * @param handler A function to execute each time the event is triggered.
-     * @see {@link https://api.jquery.com/mouseup/}
+     * @see \`{@link https://api.jquery.com/mouseup/ }\`
      * @since 1.0
      * @deprecated 3.3
      */
@@ -4399,7 +4399,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * is provided, it retrieves the next sibling only if it matches that selector.
      *
      * @param selector A string containing a selector expression to match elements against.
-     * @see {@link https://api.jquery.com/next/}
+     * @see \`{@link https://api.jquery.com/next/ }\`
      * @since 1.0
      */
     next(selector?: JQuery.Selector): this;
@@ -4407,7 +4407,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Get all following siblings of each element in the set of matched elements, optionally filtered by a selector.
      *
      * @param selector A string containing a selector expression to match elements against.
-     * @see {@link https://api.jquery.com/nextAll/}
+     * @see \`{@link https://api.jquery.com/nextAll/ }\`
      * @since 1.2
      */
     nextAll(selector?: string): this;
@@ -4418,7 +4418,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param selector A string containing a selector expression to indicate where to stop matching following sibling elements.
      *                 A DOM node or jQuery object indicating where to stop matching following sibling elements.
      * @param filter A string containing a selector expression to match elements against.
-     * @see {@link https://api.jquery.com/nextUntil/}
+     * @see \`{@link https://api.jquery.com/nextUntil/ }\`
      * @since 1.4
      * @since 1.6
      */
@@ -4431,7 +4431,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *                 element's index in the jQuery collection, and element, which is the DOM element. Within the
      *                 function, this refers to the current DOM element.
      *                 An existing jQuery object to match the current set of elements against.
-     * @see {@link https://api.jquery.com/not/}
+     * @see \`{@link https://api.jquery.com/not/ }\`
      * @since 1.0
      * @since 1.4
      */
@@ -4443,7 +4443,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *               "click", "keydown.myPlugin", or ".myPlugin".
      * @param selector A selector which should match the one originally passed to .on() when attaching event handlers.
      * @param handler A function to execute each time the event is triggered.
-     * @see {@link https://api.jquery.com/off/}
+     * @see \`{@link https://api.jquery.com/off/ }\`
      * @since 1.7
      */
     off(events: string, selector: JQuery.Selector, handler: JQuery.EventHandlerBase<any, JQuery.Event<TElement, any>> | false): this;
@@ -4454,7 +4454,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *               "click", "keydown.myPlugin", or ".myPlugin".
      * @param selector_handler A selector which should match the one originally passed to .on() when attaching event handlers.
      *                         A function to execute each time the event is triggered.
-     * @see {@link https://api.jquery.com/off/}
+     * @see \`{@link https://api.jquery.com/off/ }\`
      * @since 1.7
      */
     off(events: string, selector_handler?: JQuery.Selector | JQuery.EventHandlerBase<any, JQuery.Event<TElement, any>> | false): this;
@@ -4464,7 +4464,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param events An object where the string keys represent one or more space-separated event types and optional
      *               namespaces, and the values represent handler functions previously attached for the event(s).
      * @param selector A selector which should match the one originally passed to .on() when attaching event handlers.
-     * @see {@link https://api.jquery.com/off/}
+     * @see \`{@link https://api.jquery.com/off/ }\`
      * @since 1.7
      */
     off(events: JQuery.PlainObject<JQuery.EventHandlerBase<any, JQuery.Event<TElement, any>> | false>, selector?: JQuery.Selector): this;
@@ -4472,7 +4472,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Remove an event handler.
      *
      * @param event A jQuery.Event object.
-     * @see {@link https://api.jquery.com/off/}
+     * @see \`{@link https://api.jquery.com/off/ }\`
      * @since 1.7
      */
     off(event?: JQuery.Event<TElement>): this;
@@ -4484,21 +4484,21 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *                    A function to return the coordinates to set. Receives the index of the element in the collection as
      *                    the first argument and the current coordinates as the second argument. The function should return an
      *                    object with the new top and left properties.
-     * @see {@link https://api.jquery.com/offset/}
+     * @see \`{@link https://api.jquery.com/offset/ }\`
      * @since 1.4
      */
     offset(coordinates: JQuery.Coordinates | ((this: TElement, index: number, coords: JQuery.Coordinates) => JQuery.Coordinates)): this;
     /**
      * Get the current coordinates of the first element in the set of matched elements, relative to the document.
      *
-     * @see {@link https://api.jquery.com/offset/}
+     * @see \`{@link https://api.jquery.com/offset/ }\`
      * @since 1.2
      */
     offset(): JQuery.Coordinates | undefined;
     /**
      * Get the closest ancestor element that is positioned.
      *
-     * @see {@link https://api.jquery.com/offsetParent/}
+     * @see \`{@link https://api.jquery.com/offsetParent/ }\`
      * @since 1.2.6
      */
     offsetParent(): this;
@@ -4510,7 +4510,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *                 selector is null or omitted, the event is always triggered when it reaches the selected element.
      * @param data Data to be passed to the handler in event.data when an event is triggered.
      * @param handler A function to execute when the event is triggered.
-     * @see {@link https://api.jquery.com/on/}
+     * @see \`{@link https://api.jquery.com/on/ }\`
      * @since 1.7
      */
     on<TData>(events: string,
@@ -4525,7 +4525,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *                 selector is null or omitted, the event is always triggered when it reaches the selected element.
      * @param data Data to be passed to the handler in event.data when an event is triggered.
      * @param handler A function to execute when the event is triggered.
-     * @see {@link https://api.jquery.com/on/}
+     * @see \`{@link https://api.jquery.com/on/ }\`
      * @since 1.7
      */
     on<TData>(events: string,
@@ -4540,7 +4540,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *                 selector is null or omitted, the event is always triggered when it reaches the selected element.
      * @param handler A function to execute when the event is triggered. The value false is also allowed as a shorthand
      *                for a function that simply does return false.
-     * @see {@link https://api.jquery.com/on/}
+     * @see \`{@link https://api.jquery.com/on/ }\`
      * @since 1.7
      */
     on(events: string,
@@ -4553,7 +4553,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param selector A selector string to filter the descendants of the selected elements that trigger the event. If the
      *                 selector is null or omitted, the event is always triggered when it reaches the selected element.
      * @param handler A function to execute when the event is triggered.
-     * @see {@link https://api.jquery.com/on/}
+     * @see \`{@link https://api.jquery.com/on/ }\`
      * @since 1.7
      */
     on(events: string,
@@ -4565,7 +4565,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param events One or more space-separated event types and optional namespaces, such as "click" or "keydown.myPlugin".
      * @param data Data to be passed to the handler in event.data when an event is triggered.
      * @param handler A function to execute when the event is triggered.
-     * @see {@link https://api.jquery.com/on/}
+     * @see \`{@link https://api.jquery.com/on/ }\`
      * @since 1.7
      */
     on<TData>(events: string,
@@ -4577,7 +4577,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param events One or more space-separated event types and optional namespaces, such as "click" or "keydown.myPlugin".
      * @param data Data to be passed to the handler in event.data when an event is triggered.
      * @param handler A function to execute when the event is triggered.
-     * @see {@link https://api.jquery.com/on/}
+     * @see \`{@link https://api.jquery.com/on/ }\`
      * @since 1.7
      */
     on<TData>(events: string,
@@ -4589,7 +4589,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param events One or more space-separated event types and optional namespaces, such as "click" or "keydown.myPlugin".
      * @param handler A function to execute when the event is triggered. The value false is also allowed as a shorthand
      *                for a function that simply does return false.
-     * @see {@link https://api.jquery.com/on/}
+     * @see \`{@link https://api.jquery.com/on/ }\`
      * @since 1.7
      */
     on(events: string,
@@ -4599,7 +4599,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param events One or more space-separated event types and optional namespaces, such as "click" or "keydown.myPlugin".
      * @param handler A function to execute when the event is triggered.
-     * @see {@link https://api.jquery.com/on/}
+     * @see \`{@link https://api.jquery.com/on/ }\`
      * @since 1.7
      */
     on(events: string,
@@ -4612,7 +4612,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param selector A selector string to filter the descendants of the selected elements that will call the handler. If
      *                 the selector is null or omitted, the handler is always called when it reaches the selected element.
      * @param data Data to be passed to the handler in event.data when an event occurs.
-     * @see {@link https://api.jquery.com/on/}
+     * @see \`{@link https://api.jquery.com/on/ }\`
      * @since 1.7
      */
     on<TData>(events: JQuery.PlainObject<JQuery.EventHandler<TElement, TData> | JQuery.EventHandlerBase<any, JQuery.Event<TElement, TData>> | false>,
@@ -4625,7 +4625,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *               namespaces, and the values represent a handler function to be called for the event(s).
      * @param selector A selector string to filter the descendants of the selected elements that will call the handler. If
      *                 the selector is null or omitted, the handler is always called when it reaches the selected element.
-     * @see {@link https://api.jquery.com/on/}
+     * @see \`{@link https://api.jquery.com/on/ }\`
      * @since 1.7
      */
     on(events: JQuery.PlainObject<JQuery.EventHandler<TElement> | JQuery.EventHandlerBase<any, JQuery.Event<TElement>> | false>,
@@ -4636,7 +4636,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param events An object in which the string keys represent one or more space-separated event types and optional
      *               namespaces, and the values represent a handler function to be called for the event(s).
      * @param data Data to be passed to the handler in event.data when an event occurs.
-     * @see {@link https://api.jquery.com/on/}
+     * @see \`{@link https://api.jquery.com/on/ }\`
      * @since 1.7
      */
     on<TData>(events: JQuery.PlainObject<JQuery.EventHandler<TElement, TData> | JQuery.EventHandlerBase<any, JQuery.Event<TElement, TData>> | false>,
@@ -4646,7 +4646,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param events An object in which the string keys represent one or more space-separated event types and optional
      *               namespaces, and the values represent a handler function to be called for the event(s).
-     * @see {@link https://api.jquery.com/on/}
+     * @see \`{@link https://api.jquery.com/on/ }\`
      * @since 1.7
      */
     on(events: JQuery.PlainObject<JQuery.EventHandler<TElement> | JQuery.EventHandlerBase<any, JQuery.Event<TElement>> | false>): this;
@@ -4658,7 +4658,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *                 selector is null or omitted, the event is always triggered when it reaches the selected element.
      * @param data Data to be passed to the handler in event.data when an event is triggered.
      * @param handler A function to execute when the event is triggered.
-     * @see {@link https://api.jquery.com/one/}
+     * @see \`{@link https://api.jquery.com/one/ }\`
      * @since 1.7
      */
     one<TData>(events: string,
@@ -4673,7 +4673,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *                 selector is null or omitted, the event is always triggered when it reaches the selected element.
      * @param handler A function to execute when the event is triggered. The value false is also allowed as a shorthand
      *                for a function that simply does return false.
-     * @see {@link https://api.jquery.com/one/}
+     * @see \`{@link https://api.jquery.com/one/ }\`
      * @since 1.7
      */
     one(events: string,
@@ -4685,7 +4685,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param events One or more space-separated event types and optional namespaces, such as "click" or "keydown.myPlugin".
      * @param data Data to be passed to the handler in event.data when an event is triggered.
      * @param handler A function to execute when the event is triggered.
-     * @see {@link https://api.jquery.com/one/}
+     * @see \`{@link https://api.jquery.com/one/ }\`
      * @since 1.7
      */
     one<TData>(events: string,
@@ -4697,7 +4697,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param events One or more space-separated event types and optional namespaces, such as "click" or "keydown.myPlugin".
      * @param handler A function to execute when the event is triggered. The value false is also allowed as a shorthand
      *                for a function that simply does return false.
-     * @see {@link https://api.jquery.com/one/}
+     * @see \`{@link https://api.jquery.com/one/ }\`
      * @since 1.7
      */
     one(events: string,
@@ -4710,7 +4710,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param selector A selector string to filter the descendants of the selected elements that will call the handler. If
      *                 the selector is null or omitted, the handler is always called when it reaches the selected element.
      * @param data Data to be passed to the handler in event.data when an event occurs.
-     * @see {@link https://api.jquery.com/one/}
+     * @see \`{@link https://api.jquery.com/one/ }\`
      * @since 1.7
      */
     one<TData>(events: JQuery.PlainObject<JQuery.EventHandler<TElement, TData> | JQuery.EventHandlerBase<any, JQuery.Event<TElement, TData>> | false>,
@@ -4723,7 +4723,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *               namespaces, and the values represent a handler function to be called for the event(s).
      * @param selector A selector string to filter the descendants of the selected elements that will call the handler. If
      *                 the selector is null or omitted, the handler is always called when it reaches the selected element.
-     * @see {@link https://api.jquery.com/one/}
+     * @see \`{@link https://api.jquery.com/one/ }\`
      * @since 1.7
      */
     one(events: JQuery.PlainObject<JQuery.EventHandler<TElement> | JQuery.EventHandlerBase<any, JQuery.Event<TElement>> | false>,
@@ -4734,7 +4734,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param events An object in which the string keys represent one or more space-separated event types and optional
      *               namespaces, and the values represent a handler function to be called for the event(s).
      * @param data Data to be passed to the handler in event.data when an event occurs.
-     * @see {@link https://api.jquery.com/one/}
+     * @see \`{@link https://api.jquery.com/one/ }\`
      * @since 1.7
      */
     one<TData>(events: JQuery.PlainObject<JQuery.EventHandler<TElement, TData> | JQuery.EventHandlerBase<any, JQuery.Event<TElement, TData>> | false>,
@@ -4744,7 +4744,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param events An object in which the string keys represent one or more space-separated event types and optional
      *               namespaces, and the values represent a handler function to be called for the event(s).
-     * @see {@link https://api.jquery.com/one/}
+     * @see \`{@link https://api.jquery.com/one/ }\`
      * @since 1.7
      */
     one(events: JQuery.PlainObject<JQuery.EventHandler<TElement> | JQuery.EventHandlerBase<any, JQuery.Event<TElement>> | false>): this;
@@ -4753,7 +4753,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param value A number representing the number of pixels, or a number along with an optional unit of measure
      *              appended (as a string).
-     * @see {@link https://api.jquery.com/outerHeight/}
+     * @see \`{@link https://api.jquery.com/outerHeight/ }\`
      * @since 1.8.0
      */
     outerHeight(value: string | number | ((this: TElement, index: number, height: number) => string | number)): this;
@@ -4762,7 +4762,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * first element in the set of matched elements.
      *
      * @param includeMargin A Boolean indicating whether to include the element's margin in the calculation.
-     * @see {@link https://api.jquery.com/outerHeight/}
+     * @see \`{@link https://api.jquery.com/outerHeight/ }\`
      * @since 1.2.6
      */
     outerHeight(includeMargin?: boolean): number | undefined;
@@ -4773,7 +4773,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *              appended (as a string).
      *              A function returning the outer width to set. Receives the index position of the element in the set
      *              and the old outer width as arguments. Within the function, this refers to the current element in the set.
-     * @see {@link https://api.jquery.com/outerWidth/}
+     * @see \`{@link https://api.jquery.com/outerWidth/ }\`
      * @since 1.8.0
      */
     outerWidth(value: string | number | ((this: TElement, index: number, width: number) => string | number)): this;
@@ -4782,7 +4782,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * first element in the set of matched elements.
      *
      * @param includeMargin A Boolean indicating whether to include the element's margin in the calculation.
-     * @see {@link https://api.jquery.com/outerWidth/}
+     * @see \`{@link https://api.jquery.com/outerWidth/ }\`
      * @since 1.2.6
      */
     outerWidth(includeMargin?: boolean): number | undefined;
@@ -4790,7 +4790,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Get the parent of each element in the current set of matched elements, optionally filtered by a selector.
      *
      * @param selector A string containing a selector expression to match elements against.
-     * @see {@link https://api.jquery.com/parent/}
+     * @see \`{@link https://api.jquery.com/parent/ }\`
      * @since 1.0
      */
     parent(selector?: JQuery.Selector): this;
@@ -4798,7 +4798,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Get the ancestors of each element in the current set of matched elements, optionally filtered by a selector.
      *
      * @param selector A string containing a selector expression to match elements against.
-     * @see {@link https://api.jquery.com/parents/}
+     * @see \`{@link https://api.jquery.com/parents/ }\`
      * @since 1.0
      */
     parents(selector?: JQuery.Selector): this;
@@ -4809,7 +4809,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param selector A string containing a selector expression to indicate where to stop matching ancestor elements.
      *                 A DOM node or jQuery object indicating where to stop matching ancestor elements.
      * @param filter A string containing a selector expression to match elements against.
-     * @see {@link https://api.jquery.com/parentsUntil/}
+     * @see \`{@link https://api.jquery.com/parentsUntil/ }\`
      * @since 1.4
      * @since 1.6
      */
@@ -4817,7 +4817,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
     /**
      * Get the current coordinates of the first element in the set of matched elements, relative to the offset parent.
      *
-     * @see {@link https://api.jquery.com/position/}
+     * @see \`{@link https://api.jquery.com/position/ }\`
      * @since 1.2
      */
     position(): JQuery.Coordinates;
@@ -4826,7 +4826,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param contents One or more additional DOM elements, text nodes, arrays of elements and text nodes, HTML strings, or
      *                 jQuery objects to insert at the beginning of each element in the set of matched elements.
-     * @see {@link https://api.jquery.com/prepend/}
+     * @see \`{@link https://api.jquery.com/prepend/ }\`
      * @since 1.0
      */
     prepend(...contents: Array<JQuery.htmlString | JQuery.TypeOrArray<JQuery.Node | JQuery<JQuery.Node>>>): this;
@@ -4837,7 +4837,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *           the beginning of each element in the set of matched elements. Receives the index position of the
      *           element in the set and the old HTML value of the element as arguments. Within the function, this
      *           refers to the current element in the set.
-     * @see {@link https://api.jquery.com/prepend/}
+     * @see \`{@link https://api.jquery.com/prepend/ }\`
      * @since 1.4
      */
     prepend(fn: (this: TElement, index: number, html: string) => JQuery.htmlString | JQuery.TypeOrArray<JQuery.Node | JQuery<JQuery.Node>>): this;
@@ -4846,7 +4846,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param target A selector, element, HTML string, array of elements, or jQuery object; the matched set of elements
      *               will be inserted at the beginning of the element(s) specified by this parameter.
-     * @see {@link https://api.jquery.com/prependTo/}
+     * @see \`{@link https://api.jquery.com/prependTo/ }\`
      * @since 1.0
      */
     prependTo(target: JQuery.Selector | JQuery.htmlString | JQuery.TypeOrArray<Element> | JQuery): this;
@@ -4855,7 +4855,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * is provided, it retrieves the previous sibling only if it matches that selector.
      *
      * @param selector A string containing a selector expression to match elements against.
-     * @see {@link https://api.jquery.com/prev/}
+     * @see \`{@link https://api.jquery.com/prev/ }\`
      * @since 1.0
      */
     prev(selector?: JQuery.Selector): this;
@@ -4863,7 +4863,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Get all preceding siblings of each element in the set of matched elements, optionally filtered by a selector.
      *
      * @param selector A string containing a selector expression to match elements against.
-     * @see {@link https://api.jquery.com/prevAll/}
+     * @see \`{@link https://api.jquery.com/prevAll/ }\`
      * @since 1.2
      */
     prevAll(selector?: JQuery.Selector): this;
@@ -4874,7 +4874,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param selector A string containing a selector expression to indicate where to stop matching preceding sibling elements.
      *                 A DOM node or jQuery object indicating where to stop matching preceding sibling elements.
      * @param filter A string containing a selector expression to match elements against.
-     * @see {@link https://api.jquery.com/prevUntil/}
+     * @see \`{@link https://api.jquery.com/prevUntil/ }\`
      * @since 1.4
      * @since 1.6
      */
@@ -4885,7 +4885,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param type The type of queue that needs to be observed.
      * @param target Object onto which the promise methods have to be attached
-     * @see {@link https://api.jquery.com/promise/}
+     * @see \`{@link https://api.jquery.com/promise/ }\`
      * @since 1.6
      */
     promise<T extends object>(type: string, target: T): T & JQuery.Promise<this>;
@@ -4894,7 +4894,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * queued or not, have finished.
      *
      * @param target Object onto which the promise methods have to be attached
-     * @see {@link https://api.jquery.com/promise/}
+     * @see \`{@link https://api.jquery.com/promise/ }\`
      * @since 1.6
      */
     promise<T extends object>(target: T): T & JQuery.Promise<this>;
@@ -4903,7 +4903,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * queued or not, have finished.
      *
      * @param type The type of queue that needs to be observed.
-     * @see {@link https://api.jquery.com/promise/}
+     * @see \`{@link https://api.jquery.com/promise/ }\`
      * @since 1.6
      */
     promise(type?: string): JQuery.Promise<this>;
@@ -4913,7 +4913,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param propertyName The name of the property to set.
      * @param value A function returning the value to set. Receives the index position of the element in the set and the
      *              old property value as arguments. Within the function, the keyword this refers to the current element.
-     * @see {@link https://api.jquery.com/prop/}
+     * @see \`{@link https://api.jquery.com/prop/ }\`
      * @since 1.6
      */
     prop(propertyName: string, value: (this: TElement, index: number, oldPropertyValue: any) => any): this;
@@ -4922,7 +4922,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param propertyName The name of the property to set.
      * @param value A value to set for the property.
-     * @see {@link https://api.jquery.com/prop/}
+     * @see \`{@link https://api.jquery.com/prop/ }\`
      * @since 1.6
      */
     prop(propertyName: string, value: any): this; // tslint:disable-line:unified-signatures
@@ -4930,7 +4930,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Set one or more properties for the set of matched elements.
      *
      * @param properties An object of property-value pairs to set.
-     * @see {@link https://api.jquery.com/prop/}
+     * @see \`{@link https://api.jquery.com/prop/ }\`
      * @since 1.6
      */
     prop(properties: JQuery.PlainObject): this;
@@ -4938,7 +4938,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Get the value of a property for the first element in the set of matched elements.
      *
      * @param propertyName The name of the property to get.
-     * @see {@link https://api.jquery.com/prop/}
+     * @see \`{@link https://api.jquery.com/prop/ }\`
      * @since 1.6
      */
     prop(propertyName: string): any | undefined;
@@ -4948,7 +4948,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param elements An array of elements to push onto the stack and make into a new jQuery object.
      * @param name The name of a jQuery method that generated the array of elements.
      * @param args The arguments that were passed in to the jQuery method (for serialization).
-     * @see {@link https://api.jquery.com/pushStack/}
+     * @see \`{@link https://api.jquery.com/pushStack/ }\`
      * @since 1.3
      */
     pushStack(elements: ArrayLike<Element>, name: string, args: any[]): this;
@@ -4956,7 +4956,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Add a collection of DOM elements onto the jQuery stack.
      *
      * @param elements An array of elements to push onto the stack and make into a new jQuery object.
-     * @see {@link https://api.jquery.com/pushStack/}
+     * @see \`{@link https://api.jquery.com/pushStack/ }\`
      * @since 1.0
      */
     pushStack(elements: ArrayLike<Element>): this;
@@ -4966,7 +4966,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param queueName A string containing the name of the queue. Defaults to fx, the standard effects queue.
      * @param newQueue The new function to add to the queue, with a function to call that will dequeue the next item.
      *                 An array of functions to replace the current queue contents.
-     * @see {@link https://api.jquery.com/queue/}
+     * @see \`{@link https://api.jquery.com/queue/ }\`
      * @since 1.2
      */
     queue(queueName: string, newQueue: JQuery.TypeOrArray<JQuery.QueueFunction<TElement>>): this;
@@ -4975,7 +4975,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param newQueue The new function to add to the queue, with a function to call that will dequeue the next item.
      *                 An array of functions to replace the current queue contents.
-     * @see {@link https://api.jquery.com/queue/}
+     * @see \`{@link https://api.jquery.com/queue/ }\`
      * @since 1.2
      */
     queue(newQueue: JQuery.TypeOrArray<JQuery.QueueFunction<TElement>>): this;
@@ -4983,7 +4983,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Show the queue of functions to be executed on the matched elements.
      *
      * @param queueName A string containing the name of the queue. Defaults to fx, the standard effects queue.
-     * @see {@link https://api.jquery.com/queue/}
+     * @see \`{@link https://api.jquery.com/queue/ }\`
      * @since 1.2
      */
     queue(queueName?: string): JQuery.Queue<Node>;
@@ -4991,7 +4991,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Specify a function to execute when the DOM is fully loaded.
      *
      * @param handler A function to execute after the DOM is ready.
-     * @see {@link https://api.jquery.com/ready/}
+     * @see \`{@link https://api.jquery.com/ready/ }\`
      * @since 1.0
      * @deprecated 3.0
      */
@@ -5000,7 +5000,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Remove the set of matched elements from the DOM.
      *
      * @param selector A selector expression that filters the set of matched elements to be removed.
-     * @see {@link https://api.jquery.com/remove/}
+     * @see \`{@link https://api.jquery.com/remove/ }\`
      * @since 1.0
      */
     remove(selector?: string): this;
@@ -5008,7 +5008,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Remove an attribute from each element in the set of matched elements.
      *
      * @param attributeName An attribute to remove; as of version 1.7, it can be a space-separated list of attributes.
-     * @see {@link https://api.jquery.com/removeAttr/}
+     * @see \`{@link https://api.jquery.com/removeAttr/ }\`
      * @since 1.0
      */
     removeAttr(attributeName: string): this;
@@ -5019,7 +5019,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *                  An array of classes to be removed from the class attribute of each matched element.
      *                  A function returning one or more space-separated class names to be removed. Receives the index
      *                  position of the element in the set and the old class value as arguments.
-     * @see {@link https://api.jquery.com/removeClass/}
+     * @see \`{@link https://api.jquery.com/removeClass/ }\`
      * @since 1.0
      * @since 1.4
      * @since 3.3
@@ -5030,7 +5030,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param name A string naming the piece of data to delete.
      *             An array or space-separated string naming the pieces of data to delete.
-     * @see {@link https://api.jquery.com/removeData/}
+     * @see \`{@link https://api.jquery.com/removeData/ }\`
      * @since 1.2.3
      * @since 1.7
      */
@@ -5039,7 +5039,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Remove a property for the set of matched elements.
      *
      * @param propertyName The name of the property to remove.
-     * @see {@link https://api.jquery.com/removeProp/}
+     * @see \`{@link https://api.jquery.com/removeProp/ }\`
      * @since 1.6
      */
     removeProp(propertyName: string): this;
@@ -5047,7 +5047,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Replace each target element with the set of matched elements.
      *
      * @param target A selector string, jQuery object, DOM element, or array of elements indicating which element(s) to replace.
-     * @see {@link https://api.jquery.com/replaceAll/}
+     * @see \`{@link https://api.jquery.com/replaceAll/ }\`
      * @since 1.2
      */
     replaceAll(target: JQuery.Selector | JQuery | JQuery.TypeOrArray<Element>): this;
@@ -5057,7 +5057,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param newContent The content to insert. May be an HTML string, DOM element, array of DOM elements, or jQuery object.
      *                   A function that returns content with which to replace the set of matched elements.
-     * @see {@link https://api.jquery.com/replaceWith/}
+     * @see \`{@link https://api.jquery.com/replaceWith/ }\`
      * @since 1.2
      * @since 1.4
      */
@@ -5067,7 +5067,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute each time the event is triggered.
-     * @see {@link https://api.jquery.com/resize/}
+     * @see \`{@link https://api.jquery.com/resize/ }\`
      * @since 1.4.3
      * @deprecated 3.3
      */
@@ -5077,7 +5077,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Bind an event handler to the "resize" JavaScript event, or trigger that event on an element.
      *
      * @param handler A function to execute each time the event is triggered.
-     * @see {@link https://api.jquery.com/resize/}
+     * @see \`{@link https://api.jquery.com/resize/ }\`
      * @since 1.0
      * @deprecated 3.3
      */
@@ -5087,7 +5087,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute each time the event is triggered.
-     * @see {@link https://api.jquery.com/scroll/}
+     * @see \`{@link https://api.jquery.com/scroll/ }\`
      * @since 1.4.3
      * @deprecated 3.3
      */
@@ -5097,7 +5097,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Bind an event handler to the "scroll" JavaScript event, or trigger that event on an element.
      *
      * @param handler A function to execute each time the event is triggered.
-     * @see {@link https://api.jquery.com/scroll/}
+     * @see \`{@link https://api.jquery.com/scroll/ }\`
      * @since 1.0
      * @deprecated 3.3
      */
@@ -5106,14 +5106,14 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Set the current horizontal position of the scroll bar for each of the set of matched elements.
      *
      * @param value An integer indicating the new position to set the scroll bar to.
-     * @see {@link https://api.jquery.com/scrollLeft/}
+     * @see \`{@link https://api.jquery.com/scrollLeft/ }\`
      * @since 1.2.6
      */
     scrollLeft(value: number): this;
     /**
      * Get the current horizontal position of the scroll bar for the first element in the set of matched elements.
      *
-     * @see {@link https://api.jquery.com/scrollLeft/}
+     * @see \`{@link https://api.jquery.com/scrollLeft/ }\`
      * @since 1.2.6
      */
     scrollLeft(): number | undefined;
@@ -5121,7 +5121,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Set the current vertical position of the scroll bar for each of the set of matched elements.
      *
      * @param value A number indicating the new position to set the scroll bar to.
-     * @see {@link https://api.jquery.com/scrollTop/}
+     * @see \`{@link https://api.jquery.com/scrollTop/ }\`
      * @since 1.2.6
      */
     scrollTop(value: number): this;
@@ -5129,7 +5129,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Get the current vertical position of the scroll bar for the first element in the set of matched
      * elements or set the vertical position of the scroll bar for every matched element.
      *
-     * @see {@link https://api.jquery.com/scrollTop/}
+     * @see \`{@link https://api.jquery.com/scrollTop/ }\`
      * @since 1.2.6
      */
     scrollTop(): number | undefined;
@@ -5138,7 +5138,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute each time the event is triggered.
-     * @see {@link https://api.jquery.com/select/}
+     * @see \`{@link https://api.jquery.com/select/ }\`
      * @since 1.4.3
      * @deprecated 3.3
      */
@@ -5148,7 +5148,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Bind an event handler to the "select" JavaScript event, or trigger that event on an element.
      *
      * @param handler A function to execute each time the event is triggered.
-     * @see {@link https://api.jquery.com/select/}
+     * @see \`{@link https://api.jquery.com/select/ }\`
      * @since 1.0
      * @deprecated 3.3
      */
@@ -5156,14 +5156,14 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
     /**
      * Encode a set of form elements as a string for submission.
      *
-     * @see {@link https://api.jquery.com/serialize/}
+     * @see \`{@link https://api.jquery.com/serialize/ }\`
      * @since 1.0
      */
     serialize(): string;
     /**
      * Encode a set of form elements as an array of names and values.
      *
-     * @see {@link https://api.jquery.com/serializeArray/}
+     * @see \`{@link https://api.jquery.com/serializeArray/ }\`
      * @since 1.2
      */
     serializeArray(): JQuery.NameValuePair[];
@@ -5173,7 +5173,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param duration A string or number determining how long the animation will run.
      * @param easing A string indicating which easing function to use for the transition.
      * @param complete A function to call once the animation is complete, called once per matched element.
-     * @see {@link https://api.jquery.com/show/}
+     * @see \`{@link https://api.jquery.com/show/ }\`
      * @since 1.4.3
      */
     show(duration: JQuery.Duration, easing: string, complete: (this: TElement) => void): this;
@@ -5183,7 +5183,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param duration A string or number determining how long the animation will run.
      * @param easing_complete A string indicating which easing function to use for the transition.
      *                        A function to call once the animation is complete, called once per matched element.
-     * @see {@link https://api.jquery.com/show/}
+     * @see \`{@link https://api.jquery.com/show/ }\`
      * @since 1.0
      * @since 1.4.3
      */
@@ -5194,7 +5194,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param duration_complete_options A string or number determining how long the animation will run.
      *                                  A function to call once the animation is complete, called once per matched element.
      *                                  A map of additional options to pass to the method.
-     * @see {@link https://api.jquery.com/show/}
+     * @see \`{@link https://api.jquery.com/show/ }\`
      * @since 1.0
      */
     show(duration_complete_options?: JQuery.Duration | ((this: TElement) => void) | JQuery.EffectsOptions<TElement>): this;
@@ -5202,7 +5202,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Get the siblings of each element in the set of matched elements, optionally filtered by a selector.
      *
      * @param selector A string containing a selector expression to match elements against.
-     * @see {@link https://api.jquery.com/siblings/}
+     * @see \`{@link https://api.jquery.com/siblings/ }\`
      * @since 1.0
      */
     siblings(selector?: JQuery.Selector): this;
@@ -5213,7 +5213,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *              it indicates an offset from the end of the set.
      * @param end An integer indicating the 0-based position at which the elements stop being selected. If negative,
      *            it indicates an offset from the end of the set. If omitted, the range continues until the end of the set.
-     * @see {@link https://api.jquery.com/slice/}
+     * @see \`{@link https://api.jquery.com/slice/ }\`
      * @since 1.1.4
      */
     slice(start: number, end?: number): this;
@@ -5223,7 +5223,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param duration A string or number determining how long the animation will run.
      * @param easing A string indicating which easing function to use for the transition.
      * @param complete A function to call once the animation is complete, called once per matched element.
-     * @see {@link https://api.jquery.com/slideDown/}
+     * @see \`{@link https://api.jquery.com/slideDown/ }\`
      * @since 1.4.3
      */
     slideDown(duration: JQuery.Duration, easing: string, complete?: (this: TElement) => void): this;
@@ -5233,7 +5233,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param duration_easing A string or number determining how long the animation will run.
      *                        A string indicating which easing function to use for the transition.
      * @param complete A function to call once the animation is complete, called once per matched element.
-     * @see {@link https://api.jquery.com/slideDown/}
+     * @see \`{@link https://api.jquery.com/slideDown/ }\`
      * @since 1.0
      * @since 1.4.3
      */
@@ -5245,7 +5245,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *                                         A string indicating which easing function to use for the transition.
      *                                         A function to call once the animation is complete, called once per matched element.
      *                                         A map of additional options to pass to the method.
-     * @see {@link https://api.jquery.com/slideDown/}
+     * @see \`{@link https://api.jquery.com/slideDown/ }\`
      * @since 1.0
      * @since 1.4.3
      */
@@ -5256,7 +5256,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param duration A string or number determining how long the animation will run.
      * @param easing A string indicating which easing function to use for the transition.
      * @param complete A function to call once the animation is complete, called once per matched element.
-     * @see {@link https://api.jquery.com/slideToggle/}
+     * @see \`{@link https://api.jquery.com/slideToggle/ }\`
      * @since 1.4.3
      */
     slideToggle(duration: JQuery.Duration, easing: string, complete?: (this: TElement) => void): this;
@@ -5266,7 +5266,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param duration_easing A string or number determining how long the animation will run.
      *                        A string indicating which easing function to use for the transition.
      * @param complete A function to call once the animation is complete, called once per matched element.
-     * @see {@link https://api.jquery.com/slideToggle/}
+     * @see \`{@link https://api.jquery.com/slideToggle/ }\`
      * @since 1.0
      * @since 1.4.3
      */
@@ -5278,7 +5278,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *                                         A string indicating which easing function to use for the transition.
      *                                         A function to call once the animation is complete, called once per matched element.
      *                                         A map of additional options to pass to the method.
-     * @see {@link https://api.jquery.com/slideToggle/}
+     * @see \`{@link https://api.jquery.com/slideToggle/ }\`
      * @since 1.0
      * @since 1.4.3
      */
@@ -5289,7 +5289,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param duration A string or number determining how long the animation will run.
      * @param easing A string indicating which easing function to use for the transition.
      * @param complete A function to call once the animation is complete, called once per matched element.
-     * @see {@link https://api.jquery.com/slideUp/}
+     * @see \`{@link https://api.jquery.com/slideUp/ }\`
      * @since 1.4.3
      */
     slideUp(duration: JQuery.Duration, easing: string, complete?: (this: TElement) => void): this;
@@ -5299,7 +5299,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param duration_easing A string or number determining how long the animation will run.
      *                        A string indicating which easing function to use for the transition.
      * @param complete A function to call once the animation is complete, called once per matched element.
-     * @see {@link https://api.jquery.com/slideUp/}
+     * @see \`{@link https://api.jquery.com/slideUp/ }\`
      * @since 1.0
      * @since 1.4.3
      */
@@ -5311,7 +5311,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *                                         A string indicating which easing function to use for the transition.
      *                                         A function to call once the animation is complete, called once per matched element.
      *                                         A map of additional options to pass to the method.
-     * @see {@link https://api.jquery.com/slideUp/}
+     * @see \`{@link https://api.jquery.com/slideUp/ }\`
      * @since 1.0
      * @since 1.4.3
      */
@@ -5322,7 +5322,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param queue The name of the queue in which to stop animations.
      * @param clearQueue A Boolean indicating whether to remove queued animation as well. Defaults to false.
      * @param jumpToEnd A Boolean indicating whether to complete the current animation immediately. Defaults to false.
-     * @see {@link https://api.jquery.com/stop/}
+     * @see \`{@link https://api.jquery.com/stop/ }\`
      * @since 1.7
      */
     stop(queue: string, clearQueue?: boolean, jumpToEnd?: boolean): this;
@@ -5331,7 +5331,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param clearQueue A Boolean indicating whether to remove queued animation as well. Defaults to false.
      * @param jumpToEnd A Boolean indicating whether to complete the current animation immediately. Defaults to false.
-     * @see {@link https://api.jquery.com/stop/}
+     * @see \`{@link https://api.jquery.com/stop/ }\`
      * @since 1.2
      */
     stop(clearQueue?: boolean, jumpToEnd?: boolean): this;
@@ -5340,7 +5340,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute each time the event is triggered.
-     * @see {@link https://api.jquery.com/submit/}
+     * @see \`{@link https://api.jquery.com/submit/ }\`
      * @since 1.4.3
      * @deprecated 3.3
      */
@@ -5350,7 +5350,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * Bind an event handler to the "submit" JavaScript event, or trigger that event on an element.
      *
      * @param handler A function to execute each time the event is triggered.
-     * @see {@link https://api.jquery.com/submit/}
+     * @see \`{@link https://api.jquery.com/submit/ }\`
      * @since 1.0
      * @deprecated 3.3
      */
@@ -5362,7 +5362,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *             be converted to a String representation.
      *             A function returning the text content to set. Receives the index position of the element in the set
      *             and the old text value as arguments.
-     * @see {@link https://api.jquery.com/text/}
+     * @see \`{@link https://api.jquery.com/text/ }\`
      * @since 1.0
      * @since 1.4
      */
@@ -5370,14 +5370,14 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
     /**
      * Get the combined text contents of each element in the set of matched elements, including their descendants.
      *
-     * @see {@link https://api.jquery.com/text/}
+     * @see \`{@link https://api.jquery.com/text/ }\`
      * @since 1.0
      */
     text(): string;
     /**
      * Retrieve all the elements contained in the jQuery set, as an array.
      *
-     * @see {@link https://api.jquery.com/toArray/}
+     * @see \`{@link https://api.jquery.com/toArray/ }\`
      * @since 1.4
      */
     toArray(): TElement[];
@@ -5387,7 +5387,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param duration A string or number determining how long the animation will run.
      * @param easing A string indicating which easing function to use for the transition.
      * @param complete A function to call once the animation is complete, called once per matched element.
-     * @see {@link https://api.jquery.com/toggle/}
+     * @see \`{@link https://api.jquery.com/toggle/ }\`
      * @since 1.4.3
      */
     toggle(duration: JQuery.Duration, easing: string, complete?: (this: TElement) => void): this;
@@ -5396,7 +5396,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param duration A string or number determining how long the animation will run.
      * @param complete A function to call once the animation is complete, called once per matched element.
-     * @see {@link https://api.jquery.com/toggle/}
+     * @see \`{@link https://api.jquery.com/toggle/ }\`
      * @since 1.0
      */
     toggle(duration: JQuery.Duration, complete: (this: TElement) => void): this;
@@ -5407,7 +5407,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *                                          A function to call once the animation is complete, called once per matched element.
      *                                          A map of additional options to pass to the method.
      *                                          Use true to show the element or false to hide it.
-     * @see {@link https://api.jquery.com/toggle/}
+     * @see \`{@link https://api.jquery.com/toggle/ }\`
      * @since 1.0
      * @since 1.3
      */
@@ -5421,7 +5421,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *                  A function that returns class names to be toggled in the class attribute of each element in the
      *                  matched set. Receives the index position of the element in the set, the old class value, and the state as arguments.
      * @param state A Boolean (not just truthy/falsy) value to determine whether the class should be added or removed.
-     * @see {@link https://api.jquery.com/toggleClass/}
+     * @see \`{@link https://api.jquery.com/toggleClass/ }\`
      * @since 1.0
      * @since 1.3
      * @since 1.4
@@ -5434,7 +5434,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * either the class's presence or the value of the state argument.
      *
      * @param state A boolean value to determine whether the class should be added or removed.
-     * @see {@link https://api.jquery.com/toggleClass/}
+     * @see \`{@link https://api.jquery.com/toggleClass/ }\`
      * @since 1.4
      * @deprecated 3.0
      */
@@ -5445,7 +5445,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param eventType A string containing a JavaScript event type, such as click or submit.
      *                  A jQuery.Event object.
      * @param extraParameters Additional parameters to pass along to the event handler.
-     * @see {@link https://api.jquery.com/trigger/}
+     * @see \`{@link https://api.jquery.com/trigger/ }\`
      * @since 1.0
      * @since 1.3
      */
@@ -5456,7 +5456,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param eventType A string containing a JavaScript event type, such as click or submit.
      *                  A jQuery.Event object.
      * @param extraParameters Additional parameters to pass along to the event handler.
-     * @see {@link https://api.jquery.com/triggerHandler/}
+     * @see \`{@link https://api.jquery.com/triggerHandler/ }\`
      * @since 1.2
      * @since 1.3
      */
@@ -5466,7 +5466,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param event A string containing one or more DOM event types, such as "click" or "submit," or custom event names.
      * @param handler A function to execute each time the event is triggered.
-     * @see {@link https://api.jquery.com/unbind/}
+     * @see \`{@link https://api.jquery.com/unbind/ }\`
      * @since 1.0
      * @since 1.4.3
      * @deprecated 3.0
@@ -5477,7 +5477,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param event A string containing one or more DOM event types, such as "click" or "submit," or custom event names.
      *              A jQuery.Event object.
-     * @see {@link https://api.jquery.com/unbind/}
+     * @see \`{@link https://api.jquery.com/unbind/ }\`
      * @since 1.0
      * @deprecated 3.0
      */
@@ -5489,7 +5489,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param selector A selector which will be used to filter the event results.
      * @param eventType A string containing a JavaScript event type, such as "click" or "keydown"
      * @param handler A function to execute each time the event is triggered.
-     * @see {@link https://api.jquery.com/undelegate/}
+     * @see \`{@link https://api.jquery.com/undelegate/ }\`
      * @since 1.4.2
      * @deprecated 3.0
      */
@@ -5501,7 +5501,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * @param selector A selector which will be used to filter the event results.
      * @param eventTypes A string containing a JavaScript event type, such as "click" or "keydown"
      *                   An object of one or more event types and previously bound functions to unbind from them.
-     * @see {@link https://api.jquery.com/undelegate/}
+     * @see \`{@link https://api.jquery.com/undelegate/ }\`
      * @since 1.4.2
      * @since 1.4.3
      * @deprecated 3.0
@@ -5512,7 +5512,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      * specific set of root elements.
      *
      * @param namespace A selector which will be used to filter the event results.
-     * @see {@link https://api.jquery.com/undelegate/}
+     * @see \`{@link https://api.jquery.com/undelegate/ }\`
      * @since 1.4.2
      * @since 1.6
      * @deprecated 3.0
@@ -5523,7 +5523,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *
      * @param selector A selector to check the parent element against. If an element's parent does not match the selector,
      *                 the element won't be unwrapped.
-     * @see {@link https://api.jquery.com/unwrap/}
+     * @see \`{@link https://api.jquery.com/unwrap/ }\`
      * @since 1.4
      * @since 3.0
      */
@@ -5535,7 +5535,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *              element to set as selected/checked.
      *              A function returning the value to set. this is the current element. Receives the index position of
      *              the element in the set and the old value as arguments.
-     * @see {@link https://api.jquery.com/val/}
+     * @see \`{@link https://api.jquery.com/val/ }\`
      * @since 1.0
      * @since 1.4
      */
@@ -5543,7 +5543,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
     /**
      * Get the current value of the first element in the set of matched elements.
      *
-     * @see {@link https://api.jquery.com/val/}
+     * @see \`{@link https://api.jquery.com/val/ }\`
      * @since 1.0
      */
     val(): string | number | string[] | undefined;
@@ -5554,7 +5554,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *              appended (as a string).
      *              A function returning the width to set. Receives the index position of the element in the set and the
      *              old width as arguments. Within the function, this refers to the current element in the set.
-     * @see {@link https://api.jquery.com/width/}
+     * @see \`{@link https://api.jquery.com/width/ }\`
      * @since 1.0
      * @since 1.4.1
      */
@@ -5562,7 +5562,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
     /**
      * Get the current computed width for the first element in the set of matched elements.
      *
-     * @see {@link https://api.jquery.com/width/}
+     * @see \`{@link https://api.jquery.com/width/ }\`
      * @since 1.0
      */
     width(): number | undefined;
@@ -5575,7 +5575,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *                        A callback function returning the HTML content or jQuery object to wrap around the matched elements.
      *                        Receives the index position of the element in the set as an argument. Within the function, this
      *                        refers to the current element in the set.
-     * @see {@link https://api.jquery.com/wrap/}
+     * @see \`{@link https://api.jquery.com/wrap/ }\`
      * @since 1.0
      * @since 1.4
      */
@@ -5588,7 +5588,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *                        elements. Within the function, this refers to the first element in the set. Prior to jQuery 3.0, the
      *                        callback was incorrectly called for every element in the set and received the index position of the
      *                        element in the set as an argument.
-     * @see {@link https://api.jquery.com/wrapAll/}
+     * @see \`{@link https://api.jquery.com/wrapAll/ }\`
      * @since 1.2
      * @since 1.4
      */
@@ -5601,7 +5601,7 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
      *                        A callback function which generates a structure to wrap around the content of the matched elements.
      *                        Receives the index position of the element in the set as an argument. Within the function, this
      *                        refers to the current element in the set.
-     * @see {@link https://api.jquery.com/wrapInner/}
+     * @see \`{@link https://api.jquery.com/wrapInner/ }\`
      * @since 1.2
      * @since 1.4
      */
@@ -5691,7 +5691,7 @@ declare namespace JQuery {
         }
 
         /**
-         * @see {@link http://api.jquery.com/jquery.ajax/#jQuery-ajax-settings}
+         * @see \`{@link http://api.jquery.com/jquery.ajax/#jQuery-ajax-settings }\`
          */
         interface AjaxSettingsBase<TContext> {
             /**
@@ -6378,7 +6378,7 @@ declare namespace JQuery {
     }
 
     /**
-     * @see {@link http://api.jquery.com/jquery.ajax/#jqXHR}
+     * @see \`{@link http://api.jquery.com/jquery.ajax/#jqXHR }\`
      */
     interface jqXHR<TResolve = any> extends Promise3<TResolve, jqXHR<TResolve>, never,
         Ajax.SuccessTextStatus, Ajax.ErrorTextStatus, never,
@@ -6391,7 +6391,7 @@ declare namespace JQuery {
         /**
          * Determine the current state of a Deferred object.
          *
-         * @see {@link https://api.jquery.com/deferred.state/}
+         * @see \`{@link https://api.jquery.com/deferred.state/ }\`
          * @since 1.7
          */
         state(): 'pending' | 'resolved' | 'rejected';
@@ -6425,28 +6425,28 @@ declare namespace JQuery {
          *
          * @param callback A function, or array of functions, that are to be added to the callback list.
          * @param callbacks A function, or array of functions, that are to be added to the callback list.
-         * @see {@link https://api.jquery.com/callbacks.add/}
+         * @see \`{@link https://api.jquery.com/callbacks.add/ }\`
          * @since 1.7
          */
         add(callback: TypeOrArray<T>, ...callbacks: Array<TypeOrArray<T>>): this;
         /**
          * Disable a callback list from doing anything more.
          *
-         * @see {@link https://api.jquery.com/callbacks.disable/}
+         * @see \`{@link https://api.jquery.com/callbacks.disable/ }\`
          * @since 1.7
          */
         disable(): this;
         /**
          * Determine if the callbacks list has been disabled.
          *
-         * @see {@link https://api.jquery.com/callbacks.disabled/}
+         * @see \`{@link https://api.jquery.com/callbacks.disabled/ }\`
          * @since 1.7
          */
         disabled(): boolean;
         /**
          * Remove all of the callbacks from a list.
          *
-         * @see {@link https://api.jquery.com/callbacks.empty/}
+         * @see \`{@link https://api.jquery.com/callbacks.empty/ }\`
          * @since 1.7
          */
         empty(): this;
@@ -6454,7 +6454,7 @@ declare namespace JQuery {
          * Call all of the callbacks with the given arguments.
          *
          * @param args The argument or list of arguments to pass back to the callback list.
-         * @see {@link https://api.jquery.com/callbacks.fire/}
+         * @see \`{@link https://api.jquery.com/callbacks.fire/ }\`
          * @since 1.7
          */
         fire(...args: any[]): this;
@@ -6463,14 +6463,14 @@ declare namespace JQuery {
          *
          * @param context A reference to the context in which the callbacks in the list should be fired.
          * @param args An argument, or array of arguments, to pass to the callbacks in the list.
-         * @see {@link https://api.jquery.com/callbacks.fireWith/}
+         * @see \`{@link https://api.jquery.com/callbacks.fireWith/ }\`
          * @since 1.7
          */
         fireWith(context: object, args?: ArrayLike<any>): this;
         /**
          * Determine if the callbacks have already been called at least once.
          *
-         * @see {@link https://api.jquery.com/callbacks.fired/}
+         * @see \`{@link https://api.jquery.com/callbacks.fired/ }\`
          * @since 1.7
          */
         fired(): boolean;
@@ -6479,21 +6479,21 @@ declare namespace JQuery {
          * argument, determine whether it is in a list.
          *
          * @param callback The callback to search for.
-         * @see {@link https://api.jquery.com/callbacks.has/}
+         * @see \`{@link https://api.jquery.com/callbacks.has/ }\`
          * @since 1.7
          */
         has(callback?: T): boolean;
         /**
          * Lock a callback list in its current state.
          *
-         * @see {@link https://api.jquery.com/callbacks.lock/}
+         * @see \`{@link https://api.jquery.com/callbacks.lock/ }\`
          * @since 1.7
          */
         lock(): this;
         /**
          * Determine if the callbacks list has been locked.
          *
-         * @see {@link https://api.jquery.com/callbacks.locked/}
+         * @see \`{@link https://api.jquery.com/callbacks.locked/ }\`
          * @since 1.7
          */
         locked(): boolean;
@@ -6501,7 +6501,7 @@ declare namespace JQuery {
          * Remove a callback or a collection of callbacks from a callback list.
          *
          * @param callbacks A function, or array of functions, that are to be removed from the callback list.
-         * @see {@link https://api.jquery.com/callbacks.remove/}
+         * @see \`{@link https://api.jquery.com/callbacks.remove/ }\`
          * @since 1.7
          */
         remove(...callbacks: T[]): this;
@@ -6544,7 +6544,7 @@ declare namespace JQuery {
      * This object provides a subset of the methods of the Deferred object (then, done, fail, always,
      * pipe, progress, state and promise) to prevent users from changing the state of the Deferred.
      *
-     * @see {@link http://api.jquery.com/Types/#Promise}
+     * @see \`{@link http://api.jquery.com/Types/#Promise }\`
      * @deprecated Experimental. Avoid referncing this type directly in your code.
      */
     interface PromiseBase<TR, TJ, TN,
@@ -6556,7 +6556,7 @@ declare namespace JQuery {
          *
          * @param alwaysCallback A function, or array of functions, that is called when the Deferred is resolved or rejected.
          * @param alwaysCallbacks Optional additional functions, or arrays of functions, that are called when the Deferred is resolved or rejected.
-         * @see {@link https://api.jquery.com/deferred.always/}
+         * @see \`{@link https://api.jquery.com/deferred.always/ }\`
          * @since 1.6
          */
         always(alwaysCallback: TypeOrArray<Deferred.CallbackBase<TR | TJ, UR | UJ, VR | VJ, SR | SJ>>,
@@ -6566,7 +6566,7 @@ declare namespace JQuery {
          *
          * @param doneCallback A function, or array of functions, that are called when the Deferred is resolved.
          * @param doneCallbacks Optional additional functions, or arrays of functions, that are called when the Deferred is resolved.
-         * @see {@link https://api.jquery.com/deferred.done/}
+         * @see \`{@link https://api.jquery.com/deferred.done/ }\`
          * @since 1.5
          */
         done(doneCallback: TypeOrArray<Deferred.CallbackBase<TR, UR, VR, SR>>,
@@ -6576,7 +6576,7 @@ declare namespace JQuery {
          *
          * @param failCallback A function, or array of functions, that are called when the Deferred is rejected.
          * @param failCallbacks Optional additional functions, or arrays of functions, that are called when the Deferred is rejected.
-         * @see {@link https://api.jquery.com/deferred.fail/}
+         * @see \`{@link https://api.jquery.com/deferred.fail/ }\`
          * @since 1.5
          */
         fail(failCallback: TypeOrArray<Deferred.CallbackBase<TJ, UJ, VJ, SJ>>,
@@ -6587,7 +6587,7 @@ declare namespace JQuery {
          * @param progressCallback A function, or array of functions, to be called when the Deferred generates progress notifications.
          * @param progressCallbacks Optional additional functions, or arrays of functions, to be called when the Deferred generates
          *                          progress notifications.
-         * @see {@link https://api.jquery.com/deferred.progress/}
+         * @see \`{@link https://api.jquery.com/deferred.progress/ }\`
          * @since 1.7
          */
         progress(progressCallback: TypeOrArray<Deferred.CallbackBase<TN, UN, VN, SN>>,
@@ -6596,21 +6596,21 @@ declare namespace JQuery {
          * Return a Deferred's Promise object.
          *
          * @param target Object onto which the promise methods have to be attached
-         * @see {@link https://api.jquery.com/deferred.promise/}
+         * @see \`{@link https://api.jquery.com/deferred.promise/ }\`
          * @since 1.5
          */
         promise<TTarget extends object>(target: TTarget): this & TTarget;
         /**
          * Return a Deferred's Promise object.
          *
-         * @see {@link https://api.jquery.com/deferred.promise/}
+         * @see \`{@link https://api.jquery.com/deferred.promise/ }\`
          * @since 1.5
          */
         promise(): this;
         /**
          * Determine the current state of a Deferred object.
          *
-         * @see {@link https://api.jquery.com/deferred.state/}
+         * @see \`{@link https://api.jquery.com/deferred.state/ }\`
          * @since 1.7
          */
         state(): 'pending' | 'resolved' | 'rejected';
@@ -6623,7 +6623,7 @@ declare namespace JQuery {
          * @param doneFilter An optional function that is called when the Deferred is resolved.
          * @param failFilter An optional function that is called when the Deferred is rejected.
          * @param progressFilter An optional function that is called when progress notifications are sent to the Deferred.
-         * @see {@link https://api.jquery.com/deferred.pipe/}
+         * @see \`{@link https://api.jquery.com/deferred.pipe/ }\`
          * @since 1.6
          * @since 1.7
          * @deprecated 1.8
@@ -6661,7 +6661,7 @@ declare namespace JQuery {
          * @param doneFilter An optional function that is called when the Deferred is resolved.
          * @param failFilter An optional function that is called when the Deferred is rejected.
          * @param progressFilter An optional function that is called when progress notifications are sent to the Deferred.
-         * @see {@link https://api.jquery.com/deferred.pipe/}
+         * @see \`{@link https://api.jquery.com/deferred.pipe/ }\`
          * @since 1.6
          * @since 1.7
          * @deprecated 1.8
@@ -6692,7 +6692,7 @@ declare namespace JQuery {
          * @param doneFilter An optional function that is called when the Deferred is resolved.
          * @param failFilter An optional function that is called when the Deferred is rejected.
          * @param progressFilter An optional function that is called when progress notifications are sent to the Deferred.
-         * @see {@link https://api.jquery.com/deferred.pipe/}
+         * @see \`{@link https://api.jquery.com/deferred.pipe/ }\`
          * @since 1.6
          * @since 1.7
          * @deprecated 1.8
@@ -6723,7 +6723,7 @@ declare namespace JQuery {
          * @param doneFilter An optional function that is called when the Deferred is resolved.
          * @param failFilter An optional function that is called when the Deferred is rejected.
          * @param progressFilter An optional function that is called when progress notifications are sent to the Deferred.
-         * @see {@link https://api.jquery.com/deferred.pipe/}
+         * @see \`{@link https://api.jquery.com/deferred.pipe/ }\`
          * @since 1.6
          * @since 1.7
          * @deprecated 1.8
@@ -6747,7 +6747,7 @@ declare namespace JQuery {
          * @param doneFilter An optional function that is called when the Deferred is resolved.
          * @param failFilter An optional function that is called when the Deferred is rejected.
          * @param progressFilter An optional function that is called when progress notifications are sent to the Deferred.
-         * @see {@link https://api.jquery.com/deferred.pipe/}
+         * @see \`{@link https://api.jquery.com/deferred.pipe/ }\`
          * @since 1.6
          * @since 1.7
          * @deprecated 1.8
@@ -6778,7 +6778,7 @@ declare namespace JQuery {
          * @param doneFilter An optional function that is called when the Deferred is resolved.
          * @param failFilter An optional function that is called when the Deferred is rejected.
          * @param progressFilter An optional function that is called when progress notifications are sent to the Deferred.
-         * @see {@link https://api.jquery.com/deferred.pipe/}
+         * @see \`{@link https://api.jquery.com/deferred.pipe/ }\`
          * @since 1.6
          * @since 1.7
          * @deprecated 1.8
@@ -6802,7 +6802,7 @@ declare namespace JQuery {
          * @param doneFilter An optional function that is called when the Deferred is resolved.
          * @param failFilter An optional function that is called when the Deferred is rejected.
          * @param progressFilter An optional function that is called when progress notifications are sent to the Deferred.
-         * @see {@link https://api.jquery.com/deferred.pipe/}
+         * @see \`{@link https://api.jquery.com/deferred.pipe/ }\`
          * @since 1.6
          * @since 1.7
          * @deprecated 1.8
@@ -6831,7 +6831,7 @@ declare namespace JQuery {
          * @param doneFilter An optional function that is called when the Deferred is resolved.
          * @param failFilter An optional function that is called when the Deferred is rejected.
          * @param progressFilter An optional function that is called when progress notifications are sent to the Deferred.
-         * @see {@link https://api.jquery.com/deferred.then/}
+         * @see \`{@link https://api.jquery.com/deferred.then/ }\`
          * @since 1.8
          */
         then<ARD = never, AJD = never, AND = never,
@@ -6867,7 +6867,7 @@ declare namespace JQuery {
          * @param doneFilter An optional function that is called when the Deferred is resolved.
          * @param failFilter An optional function that is called when the Deferred is rejected.
          * @param progressFilter An optional function that is called when progress notifications are sent to the Deferred.
-         * @see {@link https://api.jquery.com/deferred.then/}
+         * @see \`{@link https://api.jquery.com/deferred.then/ }\`
          * @since 1.8
          */
         then<ARF = never, AJF = never, ANF = never,
@@ -6896,7 +6896,7 @@ declare namespace JQuery {
          * @param doneFilter An optional function that is called when the Deferred is resolved.
          * @param failFilter An optional function that is called when the Deferred is rejected.
          * @param progressFilter An optional function that is called when progress notifications are sent to the Deferred.
-         * @see {@link https://api.jquery.com/deferred.then/}
+         * @see \`{@link https://api.jquery.com/deferred.then/ }\`
          * @since 1.8
          */
         then<ARD = never, AJD = never, AND = never,
@@ -6925,7 +6925,7 @@ declare namespace JQuery {
          * @param doneFilter An optional function that is called when the Deferred is resolved.
          * @param failFilter An optional function that is called when the Deferred is rejected.
          * @param progressFilter An optional function that is called when progress notifications are sent to the Deferred.
-         * @see {@link https://api.jquery.com/deferred.then/}
+         * @see \`{@link https://api.jquery.com/deferred.then/ }\`
          * @since 1.8
          */
         then<ARP = never, AJP = never, ANP = never,
@@ -6947,7 +6947,7 @@ declare namespace JQuery {
          * @param doneFilter An optional function that is called when the Deferred is resolved.
          * @param failFilter An optional function that is called when the Deferred is rejected.
          * @param progressFilter An optional function that is called when progress notifications are sent to the Deferred.
-         * @see {@link https://api.jquery.com/deferred.then/}
+         * @see \`{@link https://api.jquery.com/deferred.then/ }\`
          * @since 1.8
          */
         then<ARD = never, AJD = never, AND = never,
@@ -6976,7 +6976,7 @@ declare namespace JQuery {
          * @param doneFilter An optional function that is called when the Deferred is resolved.
          * @param failFilter An optional function that is called when the Deferred is rejected.
          * @param progressFilter An optional function that is called when progress notifications are sent to the Deferred.
-         * @see {@link https://api.jquery.com/deferred.then/}
+         * @see \`{@link https://api.jquery.com/deferred.then/ }\`
          * @since 1.8
          */
         then<ARF = never, AJF = never, ANF = never,
@@ -6998,7 +6998,7 @@ declare namespace JQuery {
          * @param doneFilter An optional function that is called when the Deferred is resolved.
          * @param failFilter An optional function that is called when the Deferred is rejected.
          * @param progressFilter An optional function that is called when progress notifications are sent to the Deferred.
-         * @see {@link https://api.jquery.com/deferred.then/}
+         * @see \`{@link https://api.jquery.com/deferred.then/ }\`
          * @since 1.8
          */
         then<ARD = never, AJD = never, AND = never,
@@ -7021,7 +7021,7 @@ declare namespace JQuery {
          * Add handlers to be called when the Deferred object is rejected.
          *
          * @param failFilter A function that is called when the Deferred is rejected.
-         * @see {@link https://api.jquery.com/deferred.catch/}
+         * @see \`{@link https://api.jquery.com/deferred.catch/ }\`
          * @since 3.0
          */
         catch<ARF = never, AJF = never, ANF = never,
@@ -7041,7 +7041,7 @@ declare namespace JQuery {
      * This object provides a subset of the methods of the Deferred object (then, done, fail, always,
      * pipe, progress, state and promise) to prevent users from changing the state of the Deferred.
      *
-     * @see {@link http://api.jquery.com/Types/#Promise}
+     * @see \`{@link http://api.jquery.com/Types/#Promise }\`
      */
     interface Promise3<TR, TJ, TN,
         UR, UJ, UN,
@@ -7054,7 +7054,7 @@ declare namespace JQuery {
      * This object provides a subset of the methods of the Deferred object (then, done, fail, always,
      * pipe, progress, state and promise) to prevent users from changing the state of the Deferred.
      *
-     * @see {@link http://api.jquery.com/Types/#Promise}
+     * @see \`{@link http://api.jquery.com/Types/#Promise }\`
      */
     interface Promise2<TR, TJ, TN,
         UR, UJ, UN> extends PromiseBase<TR, TJ, TN,
@@ -7066,7 +7066,7 @@ declare namespace JQuery {
      * This object provides a subset of the methods of the Deferred object (then, done, fail, always,
      * pipe, progress, state and promise) to prevent users from changing the state of the Deferred.
      *
-     * @see {@link http://api.jquery.com/Types/#Promise}
+     * @see \`{@link http://api.jquery.com/Types/#Promise }\`
      */
     interface Promise<TR, TJ = any, TN = any> extends PromiseBase<TR, TJ, TN,
         TR, TJ, TN,
@@ -7084,7 +7084,7 @@ declare namespace JQuery {
          * Call the progressCallbacks on a Deferred object with the given args.
          *
          * @param args Optional arguments that are passed to the progressCallbacks.
-         * @see {@link https://api.jquery.com/deferred.notify/}
+         * @see \`{@link https://api.jquery.com/deferred.notify/ }\`
          * @since 1.7
          */
         notify(...args: TN[]): this;
@@ -7093,7 +7093,7 @@ declare namespace JQuery {
          *
          * @param context Context passed to the progressCallbacks as the this object.
          * @param args An optional array of arguments that are passed to the progressCallbacks.
-         * @see {@link https://api.jquery.com/deferred.notifyWith/}
+         * @see \`{@link https://api.jquery.com/deferred.notifyWith/ }\`
          * @since 1.7
          */
         notifyWith(context: object, args?: ArrayLike<TN>): this;
@@ -7101,7 +7101,7 @@ declare namespace JQuery {
          * Reject a Deferred object and call any failCallbacks with the given args.
          *
          * @param args Optional arguments that are passed to the failCallbacks.
-         * @see {@link https://api.jquery.com/deferred.reject/}
+         * @see \`{@link https://api.jquery.com/deferred.reject/ }\`
          * @since 1.5
          */
         reject(...args: TJ[]): this;
@@ -7110,7 +7110,7 @@ declare namespace JQuery {
          *
          * @param context Context passed to the failCallbacks as the this object.
          * @param args An optional array of arguments that are passed to the failCallbacks.
-         * @see {@link https://api.jquery.com/deferred.rejectWith/}
+         * @see \`{@link https://api.jquery.com/deferred.rejectWith/ }\`
          * @since 1.5
          */
         rejectWith(context: object, args?: ArrayLike<TJ>): this;
@@ -7118,7 +7118,7 @@ declare namespace JQuery {
          * Resolve a Deferred object and call any doneCallbacks with the given args.
          *
          * @param args Optional arguments that are passed to the doneCallbacks.
-         * @see {@link https://api.jquery.com/deferred.resolve/}
+         * @see \`{@link https://api.jquery.com/deferred.resolve/ }\`
          * @since 1.5
          */
         resolve(...args: TR[]): this;
@@ -7127,7 +7127,7 @@ declare namespace JQuery {
          *
          * @param context Context passed to the doneCallbacks as the this object.
          * @param args An optional array of arguments that are passed to the doneCallbacks.
-         * @see {@link https://api.jquery.com/deferred.resolveWith/}
+         * @see \`{@link https://api.jquery.com/deferred.resolveWith/ }\`
          * @since 1.5
          */
         resolveWith(context: object, args?: ArrayLike<TR>): this;
@@ -7137,7 +7137,7 @@ declare namespace JQuery {
          *
          * @param alwaysCallback A function, or array of functions, that is called when the Deferred is resolved or rejected.
          * @param alwaysCallbacks Optional additional functions, or arrays of functions, that are called when the Deferred is resolved or rejected.
-         * @see {@link https://api.jquery.com/deferred.always/}
+         * @see \`{@link https://api.jquery.com/deferred.always/ }\`
          * @since 1.6
          */
         always(alwaysCallback: TypeOrArray<Deferred.Callback<TR | TJ>>,
@@ -7147,7 +7147,7 @@ declare namespace JQuery {
          *
          * @param doneCallback A function, or array of functions, that are called when the Deferred is resolved.
          * @param doneCallbacks Optional additional functions, or arrays of functions, that are called when the Deferred is resolved.
-         * @see {@link https://api.jquery.com/deferred.done/}
+         * @see \`{@link https://api.jquery.com/deferred.done/ }\`
          * @since 1.5
          */
         done(doneCallback: TypeOrArray<Deferred.Callback<TR>>,
@@ -7157,7 +7157,7 @@ declare namespace JQuery {
          *
          * @param failCallback A function, or array of functions, that are called when the Deferred is rejected.
          * @param failCallbacks Optional additional functions, or arrays of functions, that are called when the Deferred is rejected.
-         * @see {@link https://api.jquery.com/deferred.fail/}
+         * @see \`{@link https://api.jquery.com/deferred.fail/ }\`
          * @since 1.5
          */
         fail(failCallback: TypeOrArray<Deferred.Callback<TJ>>,
@@ -7168,7 +7168,7 @@ declare namespace JQuery {
          * @param progressCallback A function, or array of functions, to be called when the Deferred generates progress notifications.
          * @param progressCallbacks Optional additional functions, or arrays of functions, to be called when the Deferred generates
          *                          progress notifications.
-         * @see {@link https://api.jquery.com/deferred.progress/}
+         * @see \`{@link https://api.jquery.com/deferred.progress/ }\`
          * @since 1.7
          */
         progress(progressCallback: TypeOrArray<Deferred.Callback<TN>>,
@@ -7177,21 +7177,21 @@ declare namespace JQuery {
          * Return a Deferred's Promise object.
          *
          * @param target Object onto which the promise methods have to be attached
-         * @see {@link https://api.jquery.com/deferred.promise/}
+         * @see \`{@link https://api.jquery.com/deferred.promise/ }\`
          * @since 1.5
          */
         promise<TTarget extends object>(target: TTarget): JQuery.Promise<TR, TJ, TN> & TTarget;
         /**
          * Return a Deferred's Promise object.
          *
-         * @see {@link https://api.jquery.com/deferred.promise/}
+         * @see \`{@link https://api.jquery.com/deferred.promise/ }\`
          * @since 1.5
          */
         promise(): JQuery.Promise<TR, TJ, TN>;
         /**
          * Determine the current state of a Deferred object.
          *
-         * @see {@link https://api.jquery.com/deferred.state/}
+         * @see \`{@link https://api.jquery.com/deferred.state/ }\`
          * @since 1.7
          */
         state(): 'pending' | 'resolved' | 'rejected';
@@ -7204,7 +7204,7 @@ declare namespace JQuery {
          * @param doneFilter An optional function that is called when the Deferred is resolved.
          * @param failFilter An optional function that is called when the Deferred is rejected.
          * @param progressFilter An optional function that is called when progress notifications are sent to the Deferred.
-         * @see {@link https://api.jquery.com/deferred.pipe/}
+         * @see \`{@link https://api.jquery.com/deferred.pipe/ }\`
          * @since 1.6
          * @since 1.7
          * @deprecated 1.8
@@ -7242,7 +7242,7 @@ declare namespace JQuery {
          * @param doneFilter An optional function that is called when the Deferred is resolved.
          * @param failFilter An optional function that is called when the Deferred is rejected.
          * @param progressFilter An optional function that is called when progress notifications are sent to the Deferred.
-         * @see {@link https://api.jquery.com/deferred.pipe/}
+         * @see \`{@link https://api.jquery.com/deferred.pipe/ }\`
          * @since 1.6
          * @since 1.7
          * @deprecated 1.8
@@ -7273,7 +7273,7 @@ declare namespace JQuery {
          * @param doneFilter An optional function that is called when the Deferred is resolved.
          * @param failFilter An optional function that is called when the Deferred is rejected.
          * @param progressFilter An optional function that is called when progress notifications are sent to the Deferred.
-         * @see {@link https://api.jquery.com/deferred.pipe/}
+         * @see \`{@link https://api.jquery.com/deferred.pipe/ }\`
          * @since 1.6
          * @since 1.7
          * @deprecated 1.8
@@ -7304,7 +7304,7 @@ declare namespace JQuery {
          * @param doneFilter An optional function that is called when the Deferred is resolved.
          * @param failFilter An optional function that is called when the Deferred is rejected.
          * @param progressFilter An optional function that is called when progress notifications are sent to the Deferred.
-         * @see {@link https://api.jquery.com/deferred.pipe/}
+         * @see \`{@link https://api.jquery.com/deferred.pipe/ }\`
          * @since 1.6
          * @since 1.7
          * @deprecated 1.8
@@ -7328,7 +7328,7 @@ declare namespace JQuery {
          * @param doneFilter An optional function that is called when the Deferred is resolved.
          * @param failFilter An optional function that is called when the Deferred is rejected.
          * @param progressFilter An optional function that is called when progress notifications are sent to the Deferred.
-         * @see {@link https://api.jquery.com/deferred.pipe/}
+         * @see \`{@link https://api.jquery.com/deferred.pipe/ }\`
          * @since 1.6
          * @since 1.7
          * @deprecated 1.8
@@ -7359,7 +7359,7 @@ declare namespace JQuery {
          * @param doneFilter An optional function that is called when the Deferred is resolved.
          * @param failFilter An optional function that is called when the Deferred is rejected.
          * @param progressFilter An optional function that is called when progress notifications are sent to the Deferred.
-         * @see {@link https://api.jquery.com/deferred.pipe/}
+         * @see \`{@link https://api.jquery.com/deferred.pipe/ }\`
          * @since 1.6
          * @since 1.7
          * @deprecated 1.8
@@ -7383,7 +7383,7 @@ declare namespace JQuery {
          * @param doneFilter An optional function that is called when the Deferred is resolved.
          * @param failFilter An optional function that is called when the Deferred is rejected.
          * @param progressFilter An optional function that is called when progress notifications are sent to the Deferred.
-         * @see {@link https://api.jquery.com/deferred.pipe/}
+         * @see \`{@link https://api.jquery.com/deferred.pipe/ }\`
          * @since 1.6
          * @since 1.7
          * @deprecated 1.8
@@ -7412,7 +7412,7 @@ declare namespace JQuery {
          * @param doneFilter A function that is called when the Deferred is resolved.
          * @param failFilter An optional function that is called when the Deferred is rejected.
          * @param progressFilter An optional function that is called when progress notifications are sent to the Deferred.
-         * @see {@link https://api.jquery.com/deferred.then/}
+         * @see \`{@link https://api.jquery.com/deferred.then/ }\`
          * @since 1.8
          */
         then<ARD = never, AJD = never, AND = never,
@@ -7448,7 +7448,7 @@ declare namespace JQuery {
          * @param doneFilter A function that is called when the Deferred is resolved.
          * @param failFilter An optional function that is called when the Deferred is rejected.
          * @param progressFilter An optional function that is called when progress notifications are sent to the Deferred.
-         * @see {@link https://api.jquery.com/deferred.then/}
+         * @see \`{@link https://api.jquery.com/deferred.then/ }\`
          * @since 1.8
          */
         then<ARF = never, AJF = never, ANF = never,
@@ -7477,7 +7477,7 @@ declare namespace JQuery {
          * @param doneFilter A function that is called when the Deferred is resolved.
          * @param failFilter An optional function that is called when the Deferred is rejected.
          * @param progressFilter An optional function that is called when progress notifications are sent to the Deferred.
-         * @see {@link https://api.jquery.com/deferred.then/}
+         * @see \`{@link https://api.jquery.com/deferred.then/ }\`
          * @since 1.8
          */
         then<ARD = never, AJD = never, AND = never,
@@ -7506,7 +7506,7 @@ declare namespace JQuery {
          * @param doneFilter A function that is called when the Deferred is resolved.
          * @param failFilter An optional function that is called when the Deferred is rejected.
          * @param progressFilter An optional function that is called when progress notifications are sent to the Deferred.
-         * @see {@link https://api.jquery.com/deferred.then/}
+         * @see \`{@link https://api.jquery.com/deferred.then/ }\`
          * @since 1.8
          */
         then<ARP = never, AJP = never, ANP = never,
@@ -7528,7 +7528,7 @@ declare namespace JQuery {
          * @param doneFilter An optional function that is called when the Deferred is resolved.
          * @param failFilter An optional function that is called when the Deferred is rejected.
          * @param progressFilter An optional function that is called when progress notifications are sent to the Deferred.
-         * @see {@link https://api.jquery.com/deferred.then/}
+         * @see \`{@link https://api.jquery.com/deferred.then/ }\`
          * @since 1.8
          */
         then<ARD = never, AJD = never, AND = never,
@@ -7557,7 +7557,7 @@ declare namespace JQuery {
          * @param doneFilter An optional function that is called when the Deferred is resolved.
          * @param failFilter An optional function that is called when the Deferred is rejected.
          * @param progressFilter An optional function that is called when progress notifications are sent to the Deferred.
-         * @see {@link https://api.jquery.com/deferred.then/}
+         * @see \`{@link https://api.jquery.com/deferred.then/ }\`
          * @since 1.8
          */
         then<ARF = never, AJF = never, ANF = never,
@@ -7579,7 +7579,7 @@ declare namespace JQuery {
          * @param doneFilter An optional function that is called when the Deferred is resolved.
          * @param failFilter An optional function that is called when the Deferred is rejected.
          * @param progressFilter An optional function that is called when progress notifications are sent to the Deferred.
-         * @see {@link https://api.jquery.com/deferred.then/}
+         * @see \`{@link https://api.jquery.com/deferred.then/ }\`
          * @since 1.8
          */
         then<ARD = never, AJD = never, AND = never,
@@ -7602,7 +7602,7 @@ declare namespace JQuery {
          * Add handlers to be called when the Deferred object is rejected.
          *
          * @param failFilter A function that is called when the Deferred is rejected.
-         * @see {@link https://api.jquery.com/deferred.catch/}
+         * @see \`{@link https://api.jquery.com/deferred.catch/ }\`
          * @since 3.0
          */
         catch<ARF = never, AJF = never, ANF = never,
@@ -7663,7 +7663,7 @@ declare namespace JQuery {
     }
 
     /**
-     * @see {@link https://api.jquery.com/animate/#animate-properties-options}
+     * @see \`{@link https://api.jquery.com/animate/#animate-properties-options }\`
      */
     interface EffectsOptions<TElement> {
         /**
@@ -7775,98 +7775,98 @@ declare namespace JQuery {
         /**
          * Indicates whether the META key was pressed when the event fired.
          *
-         * @see {@link https://api.jquery.com/event.metaKey/}
+         * @see \`{@link https://api.jquery.com/event.metaKey/ }\`
          * @since 1.0.4
          */
         metaKey: boolean;
         /**
          * The namespace specified when the event was triggered.
          *
-         * @see {@link https://api.jquery.com/event.namespace/}
+         * @see \`{@link https://api.jquery.com/event.namespace/ }\`
          * @since 1.4.3
          */
         namespace: string;
         /**
          * The mouse position relative to the left edge of the document.
          *
-         * @see {@link https://api.jquery.com/event.pageX/}
+         * @see \`{@link https://api.jquery.com/event.pageX/ }\`
          * @since 1.0.4
          */
         pageX: number;
         /**
          * The mouse position relative to the top edge of the document.
          *
-         * @see {@link https://api.jquery.com/event.pageY/}
+         * @see \`{@link https://api.jquery.com/event.pageY/ }\`
          * @since 1.0.4
          */
         pageY: number;
         /**
          * The last value returned by an event handler that was triggered by this event, unless the value was undefined.
          *
-         * @see {@link https://api.jquery.com/event.result/}
+         * @see \`{@link https://api.jquery.com/event.result/ }\`
          * @since 1.3
          */
         result: any;
         /**
          * The difference in milliseconds between the time the browser created the event and January 1, 1970.
          *
-         * @see {@link https://api.jquery.com/event.timeStamp/}
+         * @see \`{@link https://api.jquery.com/event.timeStamp/ }\`
          * @since 1.2.6
          */
         timeStamp: number;
         /**
          * Describes the nature of the event.
          *
-         * @see {@link https://api.jquery.com/event.type/}
+         * @see \`{@link https://api.jquery.com/event.type/ }\`
          * @since 1.0
          */
         type: string;
         /**
          * For key or mouse events, this property indicates the specific key or button that was pressed.
          *
-         * @see {@link https://api.jquery.com/event.which/}
+         * @see \`{@link https://api.jquery.com/event.which/ }\`
          * @since 1.1.3
          */
         which: number;
         /**
          * Returns whether event.preventDefault() was ever called on this event object.
          *
-         * @see {@link https://api.jquery.com/event.isDefaultPrevented/}
+         * @see \`{@link https://api.jquery.com/event.isDefaultPrevented/ }\`
          * @since 1.3
          */
         isDefaultPrevented(): boolean;
         /**
          * Returns whether event.stopImmediatePropagation() was ever called on this event object.
          *
-         * @see {@link https://api.jquery.com/event.isImmediatePropagationStopped/}
+         * @see \`{@link https://api.jquery.com/event.isImmediatePropagationStopped/ }\`
          * @since 1.3
          */
         isImmediatePropagationStopped(): boolean;
         /**
          * Returns whether event.stopPropagation() was ever called on this event object.
          *
-         * @see {@link https://api.jquery.com/event.isPropagationStopped/}
+         * @see \`{@link https://api.jquery.com/event.isPropagationStopped/ }\`
          * @since 1.3
          */
         isPropagationStopped(): boolean;
         /**
          * If this method is called, the default action of the event will not be triggered.
          *
-         * @see {@link https://api.jquery.com/event.preventDefault/}
+         * @see \`{@link https://api.jquery.com/event.preventDefault/ }\`
          * @since 1.0
          */
         preventDefault(): void;
         /**
          * Keeps the rest of the handlers from being executed and prevents the event from bubbling up the DOM tree.
          *
-         * @see {@link https://api.jquery.com/event.stopImmediatePropagation/}
+         * @see \`{@link https://api.jquery.com/event.stopImmediatePropagation/ }\`
          * @since 1.3
          */
         stopImmediatePropagation(): void;
         /**
          * Prevents the event from bubbling up the DOM tree, preventing any parent handlers from being notified of the event.
          *
-         * @see {@link https://api.jquery.com/event.stopPropagation/}
+         * @see \`{@link https://api.jquery.com/event.stopPropagation/ }\`
          * @since 1.0
          */
         stopPropagation(): void;
@@ -7881,21 +7881,21 @@ declare namespace JQuery {
         /**
          * The current DOM element within the event bubbling phase.
          *
-         * @see {@link https://api.jquery.com/event.currentTarget/}
+         * @see \`{@link https://api.jquery.com/event.currentTarget/ }\`
          * @since 1.3
          */
         currentTarget: TTarget;
         /**
          * An optional object of data passed to an event method when the current executing handler is bound.
          *
-         * @see {@link https://api.jquery.com/event.data/}
+         * @see \`{@link https://api.jquery.com/event.data/ }\`
          * @since 1.1
          */
         data: TData;
         /**
          * The element where the currently-called jQuery event handler was attached.
          *
-         * @see {@link https://api.jquery.com/event.delegateTarget/}
+         * @see \`{@link https://api.jquery.com/event.delegateTarget/ }\`
          * @since 1.7
          */
         delegateTarget: TTarget;
@@ -7903,14 +7903,14 @@ declare namespace JQuery {
         /**
          * The other DOM element involved in the event, if any.
          *
-         * @see {@link https://api.jquery.com/event.relatedTarget/}
+         * @see \`{@link https://api.jquery.com/event.relatedTarget/ }\`
          * @since 1.1.4
          */
         relatedTarget: TTarget | null;
         /**
          * The DOM element that initiated the event.
          *
-         * @see {@link https://api.jquery.com/event.target/}
+         * @see \`{@link https://api.jquery.com/event.target/ }\`
          * @since 1.0
          */
         target: TTarget;
@@ -8117,92 +8117,92 @@ interface JQueryParam {
 interface BaseJQueryEventObject extends Event {
     /**
      * The current DOM element within the event bubbling phase.
-     * @see {@link https://api.jquery.com/event.currentTarget/}
+     * @see \`{@link https://api.jquery.com/event.currentTarget/ }\`
      */
     currentTarget: Element;
     /**
      * An optional object of data passed to an event method when the current executing handler is bound.
-     * @see {@link https://api.jquery.com/event.data/}
+     * @see \`{@link https://api.jquery.com/event.data/ }\`
      */
     data: any;
     /**
      * The element where the currently-called jQuery event handler was attached.
-     * @see {@link https://api.jquery.com/event.delegateTarget/}
+     * @see \`{@link https://api.jquery.com/event.delegateTarget/ }\`
      */
     delegateTarget: Element;
     /**
      * Returns whether event.preventDefault() was ever called on this event object.
-     * @see {@link https://api.jquery.com/event.isDefaultPrevented/}
+     * @see \`{@link https://api.jquery.com/event.isDefaultPrevented/ }\`
      */
     isDefaultPrevented(): boolean;
     /**
      * Returns whether event.stopImmediatePropagation() was ever called on this event object.
-     * @see {@link https://api.jquery.com/event.isImmediatePropagationStopped/}
+     * @see \`{@link https://api.jquery.com/event.isImmediatePropagationStopped/ }\`
      */
     isImmediatePropagationStopped(): boolean;
     /**
      * Returns whether event.stopPropagation() was ever called on this event object.
-     * @see {@link https://api.jquery.com/event.isPropagationStopped/}
+     * @see \`{@link https://api.jquery.com/event.isPropagationStopped/ }\`
      */
     isPropagationStopped(): boolean;
     /**
      * The namespace specified when the event was triggered.
-     * @see {@link https://api.jquery.com/event.namespace/}
+     * @see \`{@link https://api.jquery.com/event.namespace/ }\`
      */
     namespace: string;
     /**
      * The browser's original Event object.
-     * @see {@link https://api.jquery.com/category/events/event-object/}
+     * @see \`{@link https://api.jquery.com/category/events/event-object/ }\`
      */
     originalEvent: Event;
     /**
      * If this method is called, the default action of the event will not be triggered.
-     * @see {@link https://api.jquery.com/event.preventDefault/}
+     * @see \`{@link https://api.jquery.com/event.preventDefault/ }\`
      */
     preventDefault(): any;
     /**
      * The other DOM element involved in the event, if any.
-     * @see {@link https://api.jquery.com/event.relatedTarget/}
+     * @see \`{@link https://api.jquery.com/event.relatedTarget/ }\`
      */
     relatedTarget: Element;
     /**
      * The last value returned by an event handler that was triggered by this event, unless the value was undefined.
-     * @see {@link https://api.jquery.com/event.result/}
+     * @see \`{@link https://api.jquery.com/event.result/ }\`
      */
     result: any;
     /**
      * Keeps the rest of the handlers from being executed and prevents the event from bubbling up the DOM tree.
-     * @see {@link https://api.jquery.com/event.stopImmediatePropagation/}
+     * @see \`{@link https://api.jquery.com/event.stopImmediatePropagation/ }\`
      */
     stopImmediatePropagation(): void;
     /**
      * Prevents the event from bubbling up the DOM tree, preventing any parent handlers from being notified of the event.
-     * @see {@link https://api.jquery.com/event.stopPropagation/}
+     * @see \`{@link https://api.jquery.com/event.stopPropagation/ }\`
      */
     stopPropagation(): void;
     /**
      * The DOM element that initiated the event.
-     * @see {@link https://api.jquery.com/event.target/}
+     * @see \`{@link https://api.jquery.com/event.target/ }\`
      */
     target: Element;
     /**
      * The mouse position relative to the left edge of the document.
-     * @see {@link https://api.jquery.com/event.pageX/}
+     * @see \`{@link https://api.jquery.com/event.pageX/ }\`
      */
     pageX: number;
     /**
      * The mouse position relative to the top edge of the document.
-     * @see {@link https://api.jquery.com/event.pageY/}
+     * @see \`{@link https://api.jquery.com/event.pageY/ }\`
      */
     pageY: number;
     /**
      * For key or mouse events, this property indicates the specific key or button that was pressed.
-     * @see {@link https://api.jquery.com/event.which/}
+     * @see \`{@link https://api.jquery.com/event.which/ }\`
      */
     which: number;
     /**
      * Indicates whether the META key was pressed when the event fired.
-     * @see {@link https://api.jquery.com/event.metaKey/}
+     * @see \`{@link https://api.jquery.com/event.metaKey/ }\`
      */
     metaKey: boolean;
 }

--- a/types/jquery/index.d.ts
+++ b/types/jquery/index.d.ts
@@ -6363,7 +6363,9 @@ declare namespace JQuery {
         };
 
         // Writable properties on XMLHttpRequest
-        interface XHRFields extends Partial<Pick<XMLHttpRequest, 'onreadystatechange' | 'responseType' | 'timeout' | 'withCredentials' | 'msCaching'>> { }
+        interface XHRFields extends Partial<Pick<XMLHttpRequest, 'onreadystatechange' | 'responseType' | 'timeout' | 'withCredentials'>> {
+            msCaching?: string;
+        }
     }
 
     interface Transport {

--- a/types/jquery/tslint.json
+++ b/types/jquery/tslint.json
@@ -14,6 +14,7 @@
         "no-empty-interface": false,
         "no-misused-new": false,
         "no-object-literal-type-assertion": false,
+        "no-redundant-jsdoc-2": false,
         "no-unnecessary-generics": false,
         "no-unnecessary-qualifier": false,
         "no-unnecessary-type-assertion": false,


### PR DESCRIPTION
Visual Studio Code does not handle `@link` tags. It ends up creating a link which includes the closing `}` which does not represent the correct documentation link. This PR inserts a space after the link to prevent the `}` from being appended. It also surrounds `@link` tags with backticks to prevent Visual Studio code from splitting it up into 3 lines.

Fixes #25235

#### WebStorm 2018.1.4

##### Before
![image](https://user-images.githubusercontent.com/5265970/41508324-e8c1a2fa-7210-11e8-819f-9a4b318ba647.png)

##### After
![image](https://user-images.githubusercontent.com/5265970/41249004-bf1d4c72-6d80-11e8-94ce-8d4a0eb49dee.png)

#### Visual Studio Code 1.24.0

##### Before
![image](https://user-images.githubusercontent.com/5265970/41508335-1e618d76-7211-11e8-825d-3124bd59dcae.png)

##### After
![image](https://user-images.githubusercontent.com/5265970/41249055-e6e54cc8-6d80-11e8-808c-2b4a1ba08d78.png)

---

Closes #26503

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- ~~Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>~~
- ~~Increase the version number in the header if appropriate.~~
- ~~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.~~
