### PR TITLE
[cosmiconfig] correct `filePath` to `filepath`

### DIFF
--- a/types/cosmiconfig/cosmiconfig-tests.ts
+++ b/types/cosmiconfig/cosmiconfig-tests.ts
@@ -22,6 +22,13 @@ Promise.all([
   explorer.loadSync(path.join(__dirname, "sample-config.json")),
 ]).then(result => result);
 
+const result = explorer.searchSync();
+if (result) {
+  const config = result.config;
+  const filepath = result.filepath;
+  const isEmpty = result.isEmpty;
+}
+
 explorer.clearLoadCache();
 explorer.clearSearchCache();
 explorer.clearCaches();

--- a/types/cosmiconfig/index.d.ts
+++ b/types/cosmiconfig/index.d.ts
@@ -14,7 +14,7 @@ export interface Config {
 
 export type CosmiconfigResult = {
   config: Config;
-  filePath: string;
+  filepath: string;
   isEmpty?: boolean;
 } | null;
 


### PR DESCRIPTION
It should be `filepath` as can be seen in the code:
https://github.com/davidtheclark/cosmiconfig/blob/3e68a30161fcb65296eed26a31cd7dc42bcbb791/src/createExplorer.js#L237

Also in the document: https://github.com/davidtheclark/cosmiconfig#result

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
