### PR TITLE
Add a type for PrismicDOM.RichText text function

### DIFF
--- a/types/prismic-dom/index.d.ts
+++ b/types/prismic-dom/index.d.ts
@@ -1,10 +1,12 @@
 // Type definitions for prismic-dom 2.0
 // Project: https://github.com/prismicio/prismic-dom#readme
 // Definitions by: Nick Whyte <https://github.com/nickw444>
+//                 Siggy Bilstein <https://github.com/sbilstein>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 interface RichText {
     asHtml(richText: any, linkResolver?: (doc: any) => string): string;
+    asText(richText: any, linkResolver?: (doc: any) => string): string;
 }
 
 export const RichText: RichText;

--- a/types/prismic-dom/index.d.ts
+++ b/types/prismic-dom/index.d.ts
@@ -6,7 +6,7 @@
 
 interface RichText {
     asHtml(richText: any, linkResolver?: (doc: any) => string): string;
-    asText(richText: any, linkResolver?: (doc: any) => string): string;
+    asText(richText: any,  joinString?: string): string;
 }
 
 export const RichText: RichText;


### PR DESCRIPTION

- [x ] Use a meaningful title for the pull request. Include the name of the package modified.
- [x ] Test the change in your own code. (Compile and run.)
- [ x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x ] Provide a URL to documentation or source code which provides context for the suggested changes: 
https://github.com/prismicio/prismic-dom 
About halfway down the page you will see there is also a 
`DOM.RichText.asText(mydoc.data.myrichtext)` function available. I've added a type for it.
- [ ] Increase the version number in the header if appropriate.
No version in header at the moment
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
