### PR TITLE
[zen-observable] Add 'concat' method

### DIFF
--- a/types/zen-observable/index.d.ts
+++ b/types/zen-observable/index.d.ts
@@ -1,7 +1,8 @@
-// Type definitions for zen-observable 0.5
+// Type definitions for zen-observable 0.8
 // Project: https://github.com/zenparsing/zen-observable
 // Definitions by: Kombu <https://github.com/aicest>
 //                 JounQin <https://github.com/JounQin>
+//                 Thomas <https://github.com/itomtom>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare global {
@@ -52,6 +53,7 @@ declare class Observable<T> {
     reduce(callback: (previousValue: T, currentValue: T) => T, initialValue?: T): Observable<T>;
     reduce<R>(callback: (previousValue: R, currentValue: T) => R, initialValue?: R): Observable<R>;
     flatMap<R>(callback: (value: T) => ZenObservable.ObservableLike<R>): Observable<R>;
+    concat<R>(...observable: Array<Observable<R>>): Observable<R>;
 
     static from<R>(observable: Observable<R> | ZenObservable.ObservableLike<R> | ArrayLike<R>): Observable<R>;
     static of<R>(...items: R[]): Observable<R>;

--- a/types/zen-observable/zen-observable-tests.ts
+++ b/types/zen-observable/zen-observable-tests.ts
@@ -95,6 +95,14 @@ Observable.of(1, 2, 3)
     .subscribe(val => assert(typeof val === 'string'));
 
 /**
+ * observable.concat
+ */
+
+Observable.of(1, 2, 3)
+.concat(Observable.of(4, 5, 6), Observable.of(7, 8, 9))
+.subscribe(val => assert(typeof val === 'number'));
+
+/**
  * ZenObservable
  */
 


### PR DESCRIPTION
Adding missing method concat as shown here https://github.com/zenparsing/zen-observable.
Concat merges the current observable with additional observables.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
