### PR TITLE
[DyGraphs]: Add plotter to series

### DIFF
--- a/types/dygraphs/index.d.ts
+++ b/types/dygraphs/index.d.ts
@@ -21,6 +21,11 @@ declare namespace dygraphs {
          * A per-series color definition. Used in conjunction with, and overrides, the colors option.
          */
         color?: string;
+                
+        /**
+         * A function which plot data for this series on the chart.         
+         */
+        plotter?: any;
 
         /**
          * Draw a small dot at each point, in addition to a line going through the point. This makes


### PR DESCRIPTION
**Package:** dygraphs
**Info:** Plotter property was absent from series. Adding this to series allows for different plotter functions per series.