### PR TITLE
pngjs: Fix PNG.ColorType values

### DIFF
--- a/types/pngjs/index.d.ts
+++ b/types/pngjs/index.d.ts
@@ -85,7 +85,7 @@ export interface PackerOptions {
 
 export type PNGOptions = BaseOptions & ParserOptions & PackerOptions;
 
-export type ColorType = 0 | 1 | 2 | 4;
+export type ColorType = 0 | 2 | 4 | 6;
 
 export interface Metadata {
 	width: number;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.npmjs.com/package/pngjs

The currently supported colorType options are listed in the documentation as:
> `colorType` - the output colorType - see constants. 0 = grayscale, no alpha, 2 = color, no alpha, 4 = grayscale & alpha, 6 = color & alpha. Default currently 6, but in the future may calculate best mode.
