### PR TITLE
[cosmiconfig] fix wrong "export default"

### DIFF
--- a/types/cosmiconfig/cosmiconfig-tests.ts
+++ b/types/cosmiconfig/cosmiconfig-tests.ts
@@ -1,4 +1,5 @@
-import cosmiconfig, { CosmiconfigResult } from "cosmiconfig";
+import cosmiconfig = require("cosmiconfig");
+import { CosmiconfigResult } from "cosmiconfig";
 import * as path from "path";
 
 const explorer = cosmiconfig("yourModuleName", {

--- a/types/cosmiconfig/index.d.ts
+++ b/types/cosmiconfig/index.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: ozum <https://github.com/ozum>
 //                 szeck87 <https://github.com/szeck87>
 //                 saadq <https://github.com/saadq>
+//                 jinwoo <https://github.com/jinwoo>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 

--- a/types/cosmiconfig/index.d.ts
+++ b/types/cosmiconfig/index.d.ts
@@ -8,52 +8,56 @@
 
 /// <reference types="node" />
 
-export interface Config {
-  [key: string]: any;
+declare function cosmiconfig(moduleName: string, options?: cosmiconfig.ExplorerOptions): cosmiconfig.Explorer;
+
+declare namespace cosmiconfig {
+  interface Config {
+    [key: string]: any;
+  }
+
+  type CosmiconfigResult = {
+    config: Config;
+    filepath: string;
+    isEmpty?: boolean;
+  } | null;
+
+  interface LoaderResult {
+    config: Config | null;
+    filepath: string;
+  }
+
+  type SyncLoader = (filepath: string, content: string) => Config | null;
+  type AsyncLoader = (filepath: string, content: string) => Config | null | Promise<object | null>;
+
+  interface LoaderEntry {
+    sync?: SyncLoader;
+    async?: AsyncLoader;
+  }
+
+  interface Loaders {
+    [key: string]: LoaderEntry;
+  }
+
+  interface Explorer {
+    search(searchFrom?: string): Promise<null | CosmiconfigResult>;
+    searchSync(searchFrom?: string): null | CosmiconfigResult;
+    load(loadPath: string): Promise<CosmiconfigResult>;
+    loadSync(loadPath: string): CosmiconfigResult;
+    clearLoadCache(): void;
+    clearSearchCache(): void;
+    clearCaches(): void;
+  }
+
+  // These are the user options with defaults applied.
+  interface ExplorerOptions {
+    stopDir?: string;
+    cache?: boolean;
+    transform?: (result: CosmiconfigResult) => Promise<CosmiconfigResult> | CosmiconfigResult;
+    packageProp?: string;
+    loaders?: Loaders;
+    searchPlaces?: string[];
+    ignoreEmptySearchPlaces?: boolean;
+  }
 }
 
-export type CosmiconfigResult = {
-  config: Config;
-  filepath: string;
-  isEmpty?: boolean;
-} | null;
-
-export interface LoaderResult {
-  config: Config | null;
-  filepath: string;
-}
-
-export type SyncLoader = (filepath: string, content: string) => Config | null;
-export type AsyncLoader = (filepath: string, content: string) => Config | null | Promise<object | null>;
-
-export interface LoaderEntry {
-  sync?: SyncLoader;
-  async?: AsyncLoader;
-}
-
-export interface Loaders {
-  [key: string]: LoaderEntry;
-}
-
-export interface Explorer {
-  search(searchFrom?: string): Promise<null | CosmiconfigResult>;
-  searchSync(searchFrom?: string): null | CosmiconfigResult;
-  load(loadPath: string): Promise<CosmiconfigResult>;
-  loadSync(loadPath: string): CosmiconfigResult;
-  clearLoadCache(): void;
-  clearSearchCache(): void;
-  clearCaches(): void;
-}
-
-// These are the user options with defaults applied.
-export interface ExplorerOptions {
-  stopDir?: string;
-  cache?: boolean;
-  transform?: (result: CosmiconfigResult) => Promise<CosmiconfigResult> | CosmiconfigResult;
-  packageProp?: string;
-  loaders?: Loaders;
-  searchPlaces?: string[];
-  ignoreEmptySearchPlaces?: boolean;
-}
-
-export default function cosmiconfig(moduleName: string, options?: ExplorerOptions): Explorer;
+export = cosmiconfig;


### PR DESCRIPTION
cosmiconfig is not a ES6 module and doesn't have an "export
default". Having "export default" in the type definition breaks when a
client project doesn't use --esModuleInterop.

See https://github.com/davidtheclark/cosmiconfig/blob/master/src/index.js#L8

Client code must use "import cosmiconfig = require('cosmiconfig')" form.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/davidtheclark/cosmiconfig/blob/master/src/index.js#L8
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
