### PR TITLE
Fix types for Expo Camera Constants and typo

### DIFF
--- a/types/expo/index.d.ts
+++ b/types/expo/index.d.ts
@@ -8,6 +8,7 @@
 //                 Umidbek Karimov <https://github.com/umidbekkarimov>
 //                 Moshe Feuchtwanger <https://github.com/moshfeu>
 //                 Michael Prokopchuk <https://github.com/prokopcm>
+//                 Tina Roh <https://github.com/tinaroh>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.6
 
@@ -789,11 +790,31 @@ export interface CameraProps extends ViewProps {
 }
 
 export interface CameraConstants {
-    readonly Type: string;
-    readonly FlashMode: string;
-    readonly AutoFocus: string;
-    readonly WhiteBalance: string;
-    readonly VideoQuality: string;
+    readonly Type: {
+        back: string;
+        front: string;
+    };
+    readonly FlashMode: {
+        on: string;
+        off: string;
+        auto: string;
+        torch: string;
+    };
+    readonly AutoFocus: {
+        on: string;
+        off: string;
+    };
+    readonly WhiteBalance: {
+        auto: string;
+        sunny: string;
+        cloudy: string;
+        shadow: string;
+        fluorescent: string;
+        incandescent: string;
+    };
+    readonly VideoQuality: {
+        [videoQuality: string]: number;
+    };
     readonly BarCodeType: {
         aztec: string;
         codabar: string;

--- a/types/expo/index.d.ts
+++ b/types/expo/index.d.ts
@@ -900,7 +900,7 @@ export namespace Constants {
         };
         appKey?: string;
         androidStatusBar?: {
-            barStyle?: 'lignt-content' | 'dark-content',
+            barStyle?: 'light-content' | 'dark-content',
             backgroundColor?: string
         };
         androidShowExponentNotificationInShellApp?: boolean;

--- a/types/expo/v26/index.d.ts
+++ b/types/expo/v26/index.d.ts
@@ -898,7 +898,7 @@ export namespace Constants {
         };
         appKey?: string;
         androidStatusBar?: {
-            barStyle?: 'lignt-content' | 'dark-content',
+            barStyle?: 'light-content' | 'dark-content',
             backgroundColor?: string
         };
         androidShowExponentNotificationInShellApp?: boolean;

--- a/types/expo/v26/index.d.ts
+++ b/types/expo/v26/index.d.ts
@@ -6,6 +6,7 @@
 //                 Sergio Sánchez <https://github.com/ssanchezmarc>
 //                 Fernando Helwanger <https://github.com/fhelwanger>
 //                 Umidbek Karimov <https://github.com/umidbekkarimov>
+//                 Tina Roh <https://github.com/tinaroh>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.6
 
@@ -787,11 +788,31 @@ export interface CameraProps extends ViewProps {
 }
 
 export interface CameraConstants {
-    readonly Type: string;
-    readonly FlashMode: string;
-    readonly AutoFocus: string;
-    readonly WhiteBalance: string;
-    readonly VideoQuality: string;
+    readonly Type: {
+        back: string;
+        front: string;
+    };
+    readonly FlashMode: {
+        on: string;
+        off: string;
+        auto: string;
+        torch: string;
+    };
+    readonly AutoFocus: {
+        on: string;
+        off: string;
+    };
+    readonly WhiteBalance: {
+        auto: string;
+        sunny: string;
+        cloudy: string;
+        shadow: string;
+        fluorescent: string;
+        incandescent: string;
+    };
+    readonly VideoQuality: {
+        [videoQuality: string]: number;
+    };
     readonly BarCodeType: {
         aztec: string;
         codabar: string;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
v26: https://docs.expo.io/versions/v26.0.0/sdk/camera
v27: https://docs.expo.io/versions/v27.0.0/sdk/camera
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

**Context**
Previously, the CameraConstants declared only that the types were `string`, but looking at [the usage](https://docs.expo.io/versions/v27.0.0/sdk/camera#type), they should have constants defined within e.g. (`Type.back` and `Type.front`).

I added the constants according to Expo's code ([Android](https://github.com/expo/expo/blob/d386a57534fd67f385b881d689ec26a58fe58645/modules/expo-camera/android/src/main/java/expo/modules/camera/CameraModule.java#L76), [iOS](https://github.com/expo/expo/blob/d386a57534fd67f385b881d689ec26a58fe58645/modules/expo-camera/ios/EXCamera/EXCameraManager.m#L38)), checked them against the API, and tested them in my own code.

There is a slight discrepancy between Expo's code and the [doc for `flashMode`](https://docs.expo.io/versions/v27.0.0/sdk/camera#flashmode). The docs are wrong. I verified with manual testing that `Constants.Type.torch`/`Constants.FlashMode.Type.torch` did not work but `Constants.FlashMode.torch` did.

**Notes for Reviewers**
- I'm only updating the latest two SDKs. Please let me know if I should also change the older versions.
- The [`VideoQuality` usage](https://docs.expo.io/versions/v27.0.0/sdk/camera#quality-videoquality----specify-the-quality-of) is: `Camera.Constants.VideoQuality['<value>']`. I'm not sure if I declared it correctly. It returns an integer according to the code ([Android](https://github.com/expo/expo/blob/d386a57534fd67f385b881d689ec26a58fe58645/modules/expo-camera/android/src/main/java/expo/modules/camera/CameraModule.java#L36), [iOS](https://github.com/expo/expo/blob/9b3495c02ffcd17541d6b889acba3c189d436124/modules/expo-camera/ios/EXCamera/EXCameraManager.h#L42)).