### PR TITLE
Bigi: Return type of bigi.compareTo is wrong

### DIFF
--- a/types/bigi/bigi-tests.ts
+++ b/types/bigi/bigi-tests.ts
@@ -14,3 +14,6 @@ const b6 = b4.multiply(b5);
 
 console.log(b6);
 // => BigInteger { '0': 420, '1': 0, t: 1, s: 0 }
+
+console.log(b1.compareTo(b2));
+// => 70

--- a/types/bigi/index.d.ts
+++ b/types/bigi/index.d.ts
@@ -23,7 +23,7 @@ declare class bigi {
     clamp(): void;
     clearBit(n: number): bigi;
     clone(): bigi;
-    compareTo(a: bigi): bigi;
+    compareTo(a: bigi): number;
     copyTo(r: any): void;
     dAddOffset(n: any, w: any): void;
     dMultiply(n: number): void;


### PR DESCRIPTION
The return type is actually number and not bigi

Please fill in this template.

- [V] Use a meaningful title for the pull request. Include the name of the package modified.
- [V] Test the change in your own code. (Compile and run.)
- [V] Add or edit tests to reflect the change. (Run with `npm test`.)
- [V] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [V] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [V] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [V] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/cryptocoinjs/bigi/blob/master/lib/bigi.js#L240
