### PR TITLE
nodegit: fix the arguments list of Repository.createRevWalk()

### DIFF
--- a/types/nodegit/repository.d.ts
+++ b/types/nodegit/repository.d.ts
@@ -136,7 +136,7 @@ export class Repository {
     /**
      * Instantiate a new revision walker for browsing the Repository"s history. See also Commit.prototype.history()
      */
-    createRevWalk(string: string | Oid): Revwalk;
+    createRevWalk(): Revwalk;
     /**
      * Retrieve the master branch commit.
      */


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: the [source code of `Repository.createRevWalk()`](https://github.com/nodegit/nodegit/blob/master/lib/repository.js#L704); unfortunately, the docblock in the source code and the [documentation](http://www.nodegit.org/api/repository/#createBranch) are incorrect.
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
