### PR TITLE
Update Helmet class definition for 'react-helmet'

### DIFF
--- a/types/react-helmet/index.d.ts
+++ b/types/react-helmet/index.d.ts
@@ -25,7 +25,7 @@ export interface HelmetProps {
     titleTemplate?: string;
 }
 
-export class Helmet extends React.Component<HelmetProps> {
+export class Helmet extends React.Component<HelmetProps, {}> {
     static peek(): HelmetData;
     static rewind(): HelmetData;
     static renderStatic(): HelmetData;


### PR DESCRIPTION
Comply with the React.Component generic class which takes 2 types, not one.