### PR TITLE
Add type definition for config-yaml

### DIFF
--- a/types/config-yaml/config-yaml-tests.ts
+++ b/types/config-yaml/config-yaml-tests.ts
@@ -1,0 +1,5 @@
+import yaml = require('config-yaml');
+
+yaml('./simple.yaml');
+yaml('./simple.yaml', { encoding: 'gbk' });
+yaml('./simple.yaml', { encoding: 'utf-8' });

--- a/types/config-yaml/index.d.ts
+++ b/types/config-yaml/index.d.ts
@@ -1,0 +1,19 @@
+// Type definitions for config-yaml 1.1
+// Project: https://github.com/neolao/config-yaml#readme
+// Definitions by: My Self <https://github.com/me>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+// TypeScript Version: 2.1
+
+/// <reference types="node" />
+import * as fs from 'fs';
+
+export = Yaml;
+
+declare namespace Yaml {
+    interface Options {
+        encoding: string;
+    }
+}
+
+declare function Yaml(path: fs.PathLike, options?: Partial<Yaml.Options>): any;

--- a/types/config-yaml/tsconfig.json
+++ b/types/config-yaml/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "allowSyntheticDefaultImports": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "config-yaml-tests.ts"
+    ]
+}

--- a/types/config-yaml/tslint.json
+++ b/types/config-yaml/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.