### PR TITLE
[react-native] Fix `TextInput.State` and SectionList prop `onScrollToIndexFailed`

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -3891,6 +3891,13 @@ export interface SectionListProps<ItemT> extends ScrollViewProps {
     initialNumToRender?: number;
 
     /**
+     * Used to extract a unique key for a given item at the specified index. Key is used for caching
+     * and as the react key to track item re-ordering. The default extractor checks `item.key`, then
+     * falls back to using the index, like React does.
+     */
+    keyExtractor?: (item: ItemT, index: number) => string;
+
+    /**
      * Called once when the scroll position gets within onEndReachedThreshold of the rendered content.
      */
     onEndReached?: ((info: { distanceFromEnd: number }) => void) | null;
@@ -3904,17 +3911,21 @@ export interface SectionListProps<ItemT> extends ScrollViewProps {
     onEndReachedThreshold?: number | null;
 
     /**
-     * Used to extract a unique key for a given item at the specified index. Key is used for caching
-     * and as the react key to track item re-ordering. The default extractor checks `item.key`, then
-     * falls back to using the index, like React does.
-     */
-    keyExtractor?: (item: ItemT, index: number) => string;
-
-    /**
      * If provided, a standard RefreshControl will be added for "Pull to Refresh" functionality.
      * Make sure to also set the refreshing prop correctly.
      */
     onRefresh?: (() => void) | null;
+
+    /**
+     * Used to handle failures when scrolling to an index that has not been measured yet.
+     * Recommended action is to either compute your own offset and `scrollTo` it, or scroll as far
+     * as possible and then try again after more items have been rendered.
+     */
+    onScrollToIndexFailed?: (info: {
+        index: number,
+        highestMeasuredFrameIndex: number,
+        averageItemLength: number
+    }) => void;
 
     /**
      * Set this true while waiting for new data from a refresh.

--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -1332,7 +1332,10 @@ interface TextInputState {
 declare class TextInputComponent extends React.Component<TextInputProps> {}
 declare const TextInputBase: Constructor<NativeMethodsMixin> & Constructor<TimerMixin> & typeof TextInputComponent;
 export class TextInput extends TextInputBase {
-    State: TextInputState;
+    /**
+     * Access the current focus state.
+     */
+    static State: TextInputState;
 
     /**
      * Returns if the input is currently focused.


### PR DESCRIPTION
Fix two minor issues:
1. `TextInput.State` is a static member of `TextInput`
2. `SectionList` supports the props of `VirtualizedList` including `onScrollToIndexFailed`

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
https://github.com/facebook/react-native/blob/86d8c7a9b37c93955ac0a444093fbd4b1b0c31c0/Libraries/Components/TextInput/TextInput.js#L327
https://github.com/facebook/react-native/blob/86d8c7a9b37c93955ac0a444093fbd4b1b0c31c0/Libraries/Lists/VirtualizedSectionList.js#L119
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.