### PR TITLE
new-relic-browser: Export api and fix doc

### DIFF
--- a/types/new-relic-browser/index.d.ts
+++ b/types/new-relic-browser/index.d.ts
@@ -3,8 +3,6 @@
 // Definitions by: Rene Hamburger <https://github.com/renehamburger>, Piotr Kubisa <https://github.com/piotrkubisa>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare const newrelic: NewRelic.Browser;
-
 declare namespace NewRelic {
     interface Browser {
         /**
@@ -186,7 +184,7 @@ declare namespace NewRelic {
          * Adds a custom SPA attribute only to the current interaction in New Relic Browser.
          *
          * @param key Used as the attribute name on the BrowserInteraction event.
-         * @param Used as the attribute value on the BrowserInteraction event. This can be a
+         * @param value Used as the attribute value on the BrowserInteraction event. This can be a
          *   string, number, boolean, or object. If it is an object, New Relic serializes it to a JSON string.
          * @returns This method returns the same API object created by interaction().
          * @see https://docs.newrelic.com/docs/browser/new-relic-browser/browser-agent-spa-api/spa-set-attribute
@@ -205,3 +203,6 @@ declare namespace NewRelic {
         setName(name: string, trigger?: string): BrowserInteraction;
     }
 }
+
+declare const api: NewRelic.Browser;
+export = api;

--- a/types/new-relic-browser/new-relic-browser-tests.ts
+++ b/types/new-relic-browser/new-relic-browser-tests.ts
@@ -1,4 +1,4 @@
-import * as newrelic from "new-relic-browser";
+import newrelic = require("new-relic-browser");
 
 // The following tests are largely taken straight from the examples at https://docs.newrelic.com/docs/browser/new-relic-browser/browser-agent-spa-api
 

--- a/types/new-relic-browser/new-relic-browser-tests.ts
+++ b/types/new-relic-browser/new-relic-browser-tests.ts
@@ -1,3 +1,5 @@
+import * as newrelic from "new-relic-browser";
+
 // The following tests are largely taken straight from the examples at https://docs.newrelic.com/docs/browser/new-relic-browser/browser-agent-spa-api
 
 // --- NewRelic.Browser methods ----------------------------------------------


### PR DESCRIPTION
api was not exporting anything. changed to be consistent with newrelic types

https://github.com/DefinitelyTyped/DefinitelyTyped/blob/2039466749e8dc995251df2624cfa4a38f6c0168/types/newrelic/index.d.ts#L350

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

