### PR TITLE
Added href to SVGAttributes<T> for React

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -3103,6 +3103,7 @@ declare namespace React {
         hanging?: number | string;
         horizAdvX?: number | string;
         horizOriginX?: number | string;
+        href?: string;
         ideographic?: number | string;
         imageRendering?: number | string;
         in2?: number | string;

--- a/types/react/v15/index.d.ts
+++ b/types/react/v15/index.d.ts
@@ -3028,6 +3028,7 @@ declare namespace React {
         hanging?: number | string;
         horizAdvX?: number | string;
         horizOriginX?: number | string;
+        href?: string;
         ideographic?: number | string;
         imageRendering?: number | string;
         in2?: number | string;


### PR DESCRIPTION
I added an optional `href` property to `SVGAttributes<T>` in the index.d.ts file for React.

**Rationale**

According to [MDN](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/xlink:href), `xlink:href` has been deprecated. The recommendation is to use `href` (without the namespace prefix) instead. 

This is a simple, non-breaking change. I've tested the fix in my application, and it worked. I'm not clear on how I would write a test for a simple string property. Also, I was unable to find a test for `xlinkHref` (the legacy version of `href`) to work from.

**Discussion**

It appears that, if you attempt to open a "naked" SVG file in a browser (I tested with Chrome), it will choke if the SVG contains `xlink:href`, even if the SVG file has a version number of 1.1 (which is an older version that _should_ require `xlink:href` and not support `href`). It will also choke in Microsoft PowerPoint (and presumably other Office apps).

For some reason, if the SVG is inline (i.e., embedded in an HTML file), rather than naked, the browser will allow `xlink:href`. Nonetheless, it's important to be able to use `href` to support the case where you want to export an SVG generated with a React app (e.g., an image editor) to a file.

**Example usage**

`<use href="#canvas" />`