### PR TITLE
react-stripe-elements: fix StripeProvider stripe prop

### DIFF
--- a/types/react-stripe-elements/index.d.ts
+++ b/types/react-stripe-elements/index.d.ts
@@ -30,7 +30,7 @@ export namespace ReactStripeElements {
 	interface StripeProviderOptions {
 		stripeAccount?: string;
 	}
-	type StripeProviderProps = { apiKey: string; stripe?: never; } & StripeProviderOptions | { apiKey?: never; stripe: stripe.Stripe | null | null; } & StripeProviderOptions;
+	type StripeProviderProps = { apiKey: string; stripe?: never; } & StripeProviderOptions | { apiKey?: never; stripe: stripe.Stripe | null; } & StripeProviderOptions;
 
 	interface StripeProps {
 		createSource(sourceData?: SourceOptions): Promise<SourceResponse>;

--- a/types/react-stripe-elements/index.d.ts
+++ b/types/react-stripe-elements/index.d.ts
@@ -30,7 +30,7 @@ export namespace ReactStripeElements {
 	interface StripeProviderOptions {
 		stripeAccount?: string;
 	}
-	type StripeProviderProps = { apiKey: string; stripe?: never; } & StripeProviderOptions | { apiKey?: never; stripe: StripeProps | null; } & StripeProviderOptions;
+	type StripeProviderProps = { apiKey: string; stripe?: never; } & StripeProviderOptions | { apiKey?: never; stripe: stripe.Stripe | null | null; } & StripeProviderOptions;
 
 	interface StripeProps {
 		createSource(sourceData?: SourceOptions): Promise<SourceResponse>;

--- a/types/react-stripe-elements/react-stripe-elements-tests.tsx
+++ b/types/react-stripe-elements/react-stripe-elements-tests.tsx
@@ -16,7 +16,6 @@ import ElementChangeResponse = stripe.elements.ElementChangeResponse;
 import ElementsOptions = stripe.elements.ElementsOptions;
 import ElementsCreateOptions = stripe.elements.ElementsCreateOptions;
 import PatchedTokenResponse = ReactStripeElements.PatchedTokenResponse;
-import StripeProps = ReactStripeElements.StripeProps;
 
 const cardElementProps: ElementsOptions = {
     iconStyle: 'solid',
@@ -185,7 +184,7 @@ const ElementsDefaultPropsTest: React.SFC = () => (
 const TestStripeProviderProps1: React.SFC = () => <StripeProvider apiKey="" />;
 
 const TestStripeProviderProps2: React.SFC<{
-    stripe: StripeProps;
+    stripe: stripe.Stripe;
 }> = props => <StripeProvider stripe={props.stripe} />;
 
 /**
@@ -193,8 +192,21 @@ const TestStripeProviderProps2: React.SFC<{
  * See: https://github.com/stripe/react-stripe-elements#props-shape
  */
 const TestStripeProviderProps3: React.SFC<{
-    stripe: StripeProps;
+    stripe: stripe.Stripe;
 }> = props => <StripeProvider stripe={null} />;
+
+/**
+ * End-to-end usage of loading stripe.js asynchronously.
+ * See: https://github.com/stripe/react-stripe-elements#loading-stripejs-asynchronously
+ */
+const TestStripeProviderProps4: React.SFC<{
+    stripe: null | stripe.Stripe
+}> = props =>
+    <StripeProvider stripe={props.stripe}>
+        <Elements>
+            <div />
+        </Elements>
+    </StripeProvider>;
 
 /**
  * StripeProvider should be able to accept options.


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/stripe/react-stripe-elements#loading-stripejs-asynchronously and https://github.com/DefinitelyTyped/DefinitelyTyped/pull/23890#issuecomment-389638679

As mentioned by @LinusU in the comment above, `StripeProvider` should get the full stripe instance. I believe this was previously only ever passing because the tests were not written correctly and causing false positives.

I've included a fourth test `TestStripeProviderProps4` which uses almost an exact example from https://github.com/stripe/react-stripe-elements#loading-stripejs-asynchronously. It's also the same code that I used in my own project (not open source) which fails to compile with the current definitions.