### PR TITLE
Add type definitions for buffer-from

### DIFF
--- a/types/buffer-from/buffer-from-tests.ts
+++ b/types/buffer-from/buffer-from-tests.ts
@@ -1,0 +1,6 @@
+import bufferFrom = require('buffer-from');
+
+bufferFrom([1, 2, 3, 4]); // $ExpectType Buffer
+bufferFrom(new Uint8Array([1, 2, 3, 4]).buffer, 1, 2); // $ExpectType Buffer
+bufferFrom('test', 'utf8'); // $ExpectType Buffer
+bufferFrom(bufferFrom('test')); // $ExpectType Buffer

--- a/types/buffer-from/index.d.ts
+++ b/types/buffer-from/index.d.ts
@@ -1,0 +1,12 @@
+// Type definitions for buffer-from 1.1
+// Project: https://github.com/LinusU/buffer-from#readme
+// Definitions by: Nat Burns <https://github.com/burnnat>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types="node" />
+
+declare function bufferFrom(arrayBuffer: ArrayBuffer, byteOffset?: number, length?: number): Buffer;
+declare function bufferFrom(str: string, encoding?: string): Buffer;
+declare function bufferFrom(data: ReadonlyArray<any> | Buffer): Buffer;
+
+export = bufferFrom;

--- a/types/buffer-from/tsconfig.json
+++ b/types/buffer-from/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "buffer-from-tests.ts"
+    ]
+}

--- a/types/buffer-from/tslint.json
+++ b/types/buffer-from/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
