### PR TITLE
@lingui/core: Add Typescript definitions

### DIFF
--- a/types/lingui__core/formats.d.ts
+++ b/types/lingui__core/formats.d.ts
@@ -1,0 +1,2 @@
+export function date(language: string, format?: Intl.DateTimeFormatOptions): (value: Date) => string;
+export function number(language: string, format?: Intl.NumberFormatOptions): (value: number) => string;

--- a/types/lingui__core/i18n.d.ts
+++ b/types/lingui__core/i18n.d.ts
@@ -1,0 +1,69 @@
+import { SelectProps, PluralProps } from "./select";
+
+// In flowtype, MessageOptions is declared as exact type
+export interface MessageOptions {
+    defaults?: string;
+    formats?: object;
+}
+
+export interface LanguageData {
+    plurals?: (n: number, pluralType?: "cardinal" | "ordinal") => string;
+}
+
+export interface Messages {
+    [key: string]: string | ((context: (name: string, type?: string, format?: any) => string) => (string | string[]));
+}
+
+export interface Catalog {
+    messages: Messages;
+    languageData?: LanguageData;
+}
+
+export interface Catalogs {
+    [key: string]: Catalog;
+}
+
+export interface setupI18nProps {
+    language?: string;
+    catalogs?: Catalogs;
+    development?: object;
+}
+
+export class I18n {
+    t(strings: TemplateStringsArray, ...values: any[]): string;
+
+    t(id: string): (strings: TemplateStringsArray, ...values: any[]) => string;
+
+    select(config: SelectProps): string;
+
+    select(id: string, config: SelectProps): string;
+
+    plural(config: PluralProps): string;
+
+    plural(id: string, config: PluralProps): string;
+
+    selectOrdinal(config: PluralProps): string;
+
+    selectOrdinal(id: string, config: PluralProps): string;
+
+    constructor();
+
+    availableLanguages: string[];
+    language: string;
+    messages: Messages;
+    languageData: LanguageData;
+
+    load(catalogs: Catalogs): void;
+
+    activate(language: string): void;
+
+    use(language: string): I18n;
+
+    _(id: string, values?: object, messageOptions?: MessageOptions): string;
+
+    pluralForm(n: number, pluralType?: "cardinal" | "ordinal"): string;
+}
+
+export function setupI18n(params?: setupI18nProps): I18n;
+
+export const i18n: I18n;

--- a/types/lingui__core/index.d.ts
+++ b/types/lingui__core/index.d.ts
@@ -1,0 +1,21 @@
+// Type definitions for @lingui/core 2.1
+// Project: https://lingui.github.io/js-lingui/
+// Definitions by: Jeow Li Huan <https://github.com/huan086>
+// Definitions: https://github.com/huan086/lingui-typings
+
+export {
+    i18n,
+    setupI18n,
+    Catalog,
+    Catalogs,
+    MessageOptions,
+    LanguageData,
+    I18n
+} from './i18n';
+
+export {
+    date,
+    number
+} from './formats';
+
+export function i18nMark(id: string): string;

--- a/types/lingui__core/lingui__core-tests.ts
+++ b/types/lingui__core/lingui__core-tests.ts
@@ -1,0 +1,89 @@
+import {
+    i18n,
+    setupI18n,
+    Catalog,
+    Catalogs,
+    MessageOptions,
+    LanguageData,
+    I18n,
+    date,
+    number,
+    i18nMark
+} from '@lingui/core';
+
+const age = 12;
+const templateResult: string = i18n.t`${age} years old`;
+const templateIdResult: string = i18n.t('templateId')`${age} years old`;
+const translateResult: string = i18n._('age', { age }, { defaults: '{age} years old' });
+
+const count = 42;
+
+const pluralResult: string = i18n.plural({
+    value: count,
+    0: 'no books',
+    one: '# book',
+    other: '# books'
+});
+const pluralIdResult: string = i18n.plural('pluralId', {
+    value: count,
+    0: 'no books',
+    one: '# book',
+    other: '# books'
+});
+
+const selectOrdinalResult: string = i18n.selectOrdinal({
+    value: count,
+    0: 'Zeroth book',
+    one: '#st book',
+    two: '#nd book',
+    few: '#rd book',
+    other: '#th book'
+});
+const selectOrdinalIdResult: string = i18n.selectOrdinal('selectOrdinalId', {
+    value: count,
+    0: 'Zeroth book',
+    one: '#st book',
+    two: '#nd book',
+    few: '#rd book',
+    other: '#th book'
+});
+
+const gender = 'female';
+const numOfGuests = 2;
+const host = 'Amy';
+const guest = 'Bob';
+const selectResult = i18n.select({
+    value: gender,
+    female: i18n.plural({
+        value: numOfGuests,
+        offset: 1,
+        0: i18n.t`${host} does not give a party.`,
+        1: i18n.t`${host} invites ${guest} to her party.`,
+        2: i18n.t`${host} invites ${guest} and one other person to her party.`,
+        other: i18n.t`${host} invites ${guest} and # other people to her party.`
+    }),
+    male: 'male',
+    other: 'other'
+});
+
+const selectIdResult = i18n.select('selectId', {
+    value: gender,
+    female: 'female',
+    male: 'male',
+    other: 'other'
+});
+
+const catalog: Catalog = {
+    messages: {
+        age(a) {
+            return [a('age'), 'años de edad'];
+        }
+    }
+};
+const catalogs: Catalogs = { es: catalog };
+const setupResult: I18n = setupI18n({ catalogs, language: 'es' });
+
+const formattedDate: string = date('en', { timeZone: 'UTC' })(new Date());
+const formattedNumber: string = number('en', { style: 'currency', currency: 'EUR' })(1234.56);
+
+const mark: string = i18nMark('mark');

--- a/types/lingui__core/select.d.ts
+++ b/types/lingui__core/select.d.ts
@@ -1,0 +1,20 @@
+export interface PluralForms {
+    zero?: string;
+    one?: string;
+    two?: string;
+    few?: string;
+    many?: string;
+    other: string;
+    [exact: number]: string;
+}
+
+export interface PluralProps extends PluralForms {
+    value: number;
+    offset?: number;
+}
+
+export interface SelectProps {
+    value: string;
+    other: string;
+    [selectForm: string]: string;
+}

--- a/types/lingui__core/tsconfig.json
+++ b/types/lingui__core/tsconfig.json
@@ -1,0 +1,28 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "paths": {
+            "@lingui/core": [
+                "lingui__core"
+            ]
+        }
+    },
+    "files": [
+        "index.d.ts",
+        "lingui__core-tests.ts"
+    ]
+}

--- a/types/lingui__core/tslint.json
+++ b/types/lingui__core/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
https://github.com/lingui/js-lingui/issues/213.

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
