### PR TITLE
Change traverse.paths type from string[] to string[][], since the fun…

### DIFF
--- a/types/traverse/index.d.ts
+++ b/types/traverse/index.d.ts
@@ -42,7 +42,7 @@ declare namespace traverse {
    * Return an `Array` of every possible non-cyclic path in the object. 
    * Paths are `Array`s of string keys.
    */
-  function paths(obj: any): string[];
+  function paths(obj: any): string[][];
 
   /**
    * Return an `Array` of every node in the object.
@@ -91,7 +91,7 @@ declare namespace traverse {
      * Return an `Array` of every possible non-cyclic path in the object. 
      * Paths are `Array`s of string keys.
      */
-    paths(): string[];
+    paths(): string[][];
 
     /**
      * Return an `Array` of every node in the object.

--- a/types/traverse/traverse-tests.ts
+++ b/types/traverse/traverse-tests.ts
@@ -37,3 +37,28 @@ function testMap(){
     });
     console.dir(scrubbed);
 }
+
+function testPaths(){
+    let obj = {a: {b: {c: 42}}, d: {e: 44}};
+    let paths : string[][] = traverse(obj).paths();
+
+    const expected = [
+        [],
+        ['a'],
+        ['a', 'b'],
+        ['a', 'b', 'c'],
+        ['d'],
+        ['d', 'e']
+    ];
+
+    expected.forEach((path, ix) => {
+        const actual = paths[ix];
+
+        path.forEach((expectedItem, jx) => {
+            const actualItem = actual[jx];
+            if(expectedItem !== actualItem){
+                throw new Error(`The path ${path} and ${actual} do not macth`);
+            }
+        })
+    })
+}


### PR DESCRIPTION
Update traverse.path function to return string[][] instead of string[].

The example test verifies that the behavior is indeed as described.