### PR TITLE
[react-redux-i18n] Correct Translate and Localize props typings

### DIFF
--- a/types/react-redux-i18n/index.d.ts
+++ b/types/react-redux-i18n/index.d.ts
@@ -31,14 +31,22 @@ declare module 'react-redux-i18n' {
   }
 
   type TranslateProps = {
+    className?: string;
+    dangerousHTML?: boolean;
+    style?: React.CSSProperties;
+    tag?: React.ReactType;
     value: string;
-    [prop: string]: string;
-
+    [prop: string]: any;
   }
+
   type LocalizeProps = {
-    value: string | number;
+    className?: string;
+    dangerousHTML?: boolean;
     dateFormat?: string;
     options?: Object;
+    style?: React.CSSProperties;
+    tag?: React.ReactType;
+    value: string | number | object;
   }
 
   /**


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:

https://github.com/JSxMachina/react-i18nify/blob/master/src/lib/Translate.jsx
https://github.com/JSxMachina/react-i18nify/blob/master/src/lib/Localize.jsx

Important : documentation points to another repository (`react-i18nify`) because `react-redux-i18n` uses this one as a dependency.
And `react-i18nify` does not provide typings.

This PR update props typings to sync them with `react-i18nify` definitions.