### PR TITLE
Adds support in inquirer for selection of different input and output streams

### DIFF
--- a/types/inquirer/index.d.ts
+++ b/types/inquirer/index.d.ts
@@ -22,8 +22,12 @@ declare namespace inquirer {
         | Question<T>
         | ReadonlyArray<Question<T>>
         | Rx.Observable<Question<T>>;
-    type OutputStreamOption = {output: NodeJS.WritableStream};
-    type InputStreamOption = {input: NodeJS.ReadableStream};
+    interface OutputStreamOption {
+        output: NodeJS.WriteStream
+    }
+    interface InputStreamOption {
+        input: NodeJS.ReadStream
+    }
     type StreamOptions = InputStreamOption | OutputStreamOption | (InputStreamOption & OutputStreamOption);
 
     interface Inquirer {
@@ -38,7 +42,7 @@ declare namespace inquirer {
          * Create a new self-contained prompt module.
          * @param opt Object specifying input and output streams for the prompt
          */
-        createPromptModule(opt?: StreamOptions): PromptModule;
+        createPromptModule(opt?: OutputStreamOption): PromptModule;
         /**
          * Public CLI helper interface
          * @param questions Questions settings array

--- a/types/inquirer/index.d.ts
+++ b/types/inquirer/index.d.ts
@@ -21,6 +21,9 @@ declare namespace inquirer {
         | Question<T>
         | ReadonlyArray<Question<T>>
         | Rx.Observable<Question<T>>;
+    type OutputStreamOption = {output: NodeJS.WritableStream};
+    type InputStreamOption = {input: NodeJS.ReadableStream};
+    type StreamOptions = InputStreamOption | OutputStreamOption | (InputStreamOption & OutputStreamOption);
 
     interface Inquirer {
         restoreDefaultPrompts(): void;
@@ -32,8 +35,9 @@ declare namespace inquirer {
         registerPrompt(name: string, prompt: PromptModule): void;
         /**
          * Create a new self-contained prompt module.
+         * @param opt Object specifying input and output streams for the prompt
          */
-        createPromptModule(): PromptModule;
+        createPromptModule(opt?: StreamOptions): PromptModule;
         /**
          * Public CLI helper interface
          * @param questions Questions settings array

--- a/types/inquirer/index.d.ts
+++ b/types/inquirer/index.d.ts
@@ -42,7 +42,7 @@ declare namespace inquirer {
          * Create a new self-contained prompt module.
          * @param opt Object specifying input and output streams for the prompt
          */
-        createPromptModule(opt?: OutputStreamOption): PromptModule;
+        createPromptModule(opt?: StreamOptions): PromptModule;
         /**
          * Public CLI helper interface
          * @param questions Questions settings array

--- a/types/inquirer/index.d.ts
+++ b/types/inquirer/index.d.ts
@@ -7,6 +7,7 @@
 //                 Jason Dreyzehner <https://github.com/bitjson>
 //                 Synarque <https://github.com/synarque>
 //                 Justin Rockwood <https://github.com/jrockwood>
+//                 Keith Kelly <https://github.com/kwkelly>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 // TypeScript Version: 2.3

--- a/types/inquirer/inquirer-tests.ts
+++ b/types/inquirer/inquirer-tests.ts
@@ -626,3 +626,47 @@ async function testAsyncPrompt(): Promise<void> {
 }
 
 testAsyncPrompt();
+
+/**
+ * Different prompt output example
+ */
+
+"use strict";
+//var inquirer = require("../lib/inquirer");
+
+var questions = [
+    {
+        type: "input",
+        name: "first_name",
+        message: "What's your first name",
+        prefix: "1 - "
+    },
+    {
+        type: "input",
+        name: "last_name",
+        message: "What's your last name",
+        default: function() {
+            return "Doe";
+        },
+        suffix: "!!"
+    },
+    {
+        type: "input",
+        name: "phone",
+        message: "What's your phone number",
+        validate: function(value: string): string | boolean {
+            var pass = value.match(
+                /^([01]{1})?[\-\.\s]?\(?(\d{3})\)?[\-\.\s]?(\d{3})[\-\.\s]?(\d{4})\s?((?:#|ext\.?\s?|x\.?\s?){1}(?:\d+)?)?$/i
+            );
+            if (pass) {
+                return true;
+            } else {
+                return "Please enter a valid phone number";
+            }
+        }
+    }
+];
+
+inquirer.createPromptModule({ output: process.stderr })(questions, function(answers) {
+    console.log(JSON.stringify(answers, null, "  "));
+});


### PR DESCRIPTION
As can be seen in the link below, inquirer.js allows the user to specify the input and output streams, but the typings do not allow any input. This pull request adds an optional input to the createPromptModule function and associated types.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/SBoudrias/Inquirer.js/blob/4d21bb539d0773a356821e73a4ddf4ecfd7de954/packages/inquirer/lib/inquirer.js#L25
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.