### PR TITLE
Knockout: Remove hardcoded nulls for observables

### DIFF
--- a/types/knockout/index.d.ts
+++ b/types/knockout/index.d.ts
@@ -106,12 +106,14 @@ interface KnockoutObservableArray<T> extends KnockoutObservable<T[]>, KnockoutOb
 interface KnockoutObservableStatic {
     fn: KnockoutObservableFunctions<any>;
 
-    <T>(value?: T | null): KnockoutObservable<T>;
+    <T = any>(): KnockoutObservable<T | undefined>
+    <T = any>(value: null): KnockoutObservable<T | null>
+    <T>(value: T): KnockoutObservable<T>;
 }
 
 interface KnockoutObservable<T> extends KnockoutSubscribable<T>, KnockoutObservableFunctions<T> {
     (): T;
-    (value: T | null): void;
+    (value: T): void;
 
     peek(): T;
     valueHasMutated?:{(): void;};

--- a/types/knockout/test/templatingBehaviors.ts
+++ b/types/knockout/test/templatingBehaviors.ts
@@ -575,7 +575,7 @@ describe('Templating', function() {
 
         // Now set the observable to null and check it's treated like an empty array
         // (because how else should null be interpreted?)
-        myArray(null);
+        myArray(null as any); // DefinitelyTyped note: while KO accepts this, I wouldn't consider it a well-typed usage of the API
         expect(testNode.childNodes[0].childNodes.length).toEqual(0);
     });
 
@@ -640,7 +640,7 @@ describe('Templating', function() {
         ko.setTemplateEngine(new dummyTemplateEngine({ myTemplate: "Value: [js: myProp().childProp]" }));
         testNode.innerHTML = "<div data-bind='template: { name: \"myTemplate\", \"if\": myProp }'></div>";
 
-        var viewModel = { myProp: ko.observable({ childProp: 'abc' }) };
+        var viewModel = { myProp: ko.observable<{childProp: string} | null>({ childProp: 'abc' }) };
         ko.applyBindings(viewModel, testNode);
 
         // Initially there is a value
@@ -678,7 +678,7 @@ describe('Templating', function() {
         ko.setTemplateEngine(new dummyTemplateEngine({ myTemplate: "Value: [js: myProp().childProp]" }));
         testNode.innerHTML = "<div data-bind='template: { name: \"myTemplate\", \"if\": myProp, foreach: [$data, $data, $data] }'></div>";
 
-        var viewModel = { myProp: ko.observable({ childProp: 'abc' }) };
+        var viewModel = { myProp: ko.observable<{childProp: string} | null>({ childProp: 'abc' }) };
         ko.applyBindings(viewModel, testNode);
         expect(testNode.childNodes[0].childNodes[0].nodeValue).toEqual("Value: abc");
         expect(testNode.childNodes[0].childNodes[1].nodeValue).toEqual("Value: abc");

--- a/types/knockout/test/templatingBehaviors.ts
+++ b/types/knockout/test/templatingBehaviors.ts
@@ -575,7 +575,8 @@ describe('Templating', function() {
 
         // Now set the observable to null and check it's treated like an empty array
         // (because how else should null be interpreted?)
-        myArray(null as any); // DefinitelyTyped note: while KO accepts this, I wouldn't consider it a well-typed usage of the API
+        // DefinitelyTyped note: while KO accepts this, I wouldn't consider it a well-typed usage of the API
+        myArray(null); // $ExpectError
         expect(testNode.childNodes[0].childNodes.length).toEqual(0);
     });
 

--- a/types/valerie/valerie-tests.ts
+++ b/types/valerie/valerie-tests.ts
@@ -9,7 +9,7 @@ enum enumTest { male, female }
  */
 function ObservableValidationTypes() {
     // any
-    var t0 = ko.observable<any>()
+    var t0 = ko.observable()
         .validate()
         .end();
 


### PR DESCRIPTION
The current typings for observable allow null to be written to the observable, regardless of whether the observable is actually typed to allow nulls.  This allows for type unfriendly code like:

```
const o = ko.observable("someString");
o(null); // Legal due to the `|| null`
const value = o();  // According to TS, value is string, but it's really null
```

This PR changes it so that the observable needs to be typed to accept `null`:

```
const o = ko.observable<string | null>("someString");
o(null);
o(); // Correctly typed as string | null
```

---

There's a similar issue with the variant of the observable "constructor":

```
// Both these are typed as `KnockoutObservable<string>` but actually hold `undefined` and `null`
// leading to the same sort of type issues as above
const o = ko.observable<string>(null);
const o2 = ko.observable<string>();
```

With the new version, these are inferred as `KnockoutObservable<string | null>` and `KnockoutObservable<string | undefined>` respectively. 

---

The behavior of `ko.observable()` (with no type params) is actually slightly widened to `KnockoutObservable<any>`, compared to the existing: `KnockoutObservable<{} | null>`, with the main difference being that it accepts `undefined`.