### PR TITLE
(react-navigation) Allow setParams to be partial

### DIFF
--- a/types/react-navigation/index.d.ts
+++ b/types/react-navigation/index.d.ts
@@ -576,7 +576,7 @@ export interface NavigationScreenProp<S, P = NavigationParams> {
   closeDrawer: () => any;
   toggleDrawer: () => any;
   getParam: <T extends keyof P>(param: T, fallback?: P[T]) => P[T];
-  setParams: (newParams: P) => boolean;
+  setParams: (newParams: Partial<P>) => boolean;
   addListener: (
     eventName: string,
     callback: NavigationEventCallback

--- a/types/react-navigation/react-navigation-tests.tsx
+++ b/types/react-navigation/react-navigation-tests.tsx
@@ -489,3 +489,28 @@ const CustomHeaderStack = createStackNavigator({
         }
     }
 });
+
+interface ScreenProps {
+    name: string;
+    onPlay(): void;
+}
+
+class SetParamsTest extends React.Component<NavigationScreenProps<ScreenProps>> {
+    componentDidMount() {
+        this.props.navigation.setParams({
+            onPlay: this.onPlay
+        });
+    }
+
+    onPlay = () => {
+        //
+    }
+
+    render() {
+        const name = this.props.navigation.getParam('name');
+
+        return (
+            <Text>My name is {name}</Text>
+        );
+    }
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://reactnavigation.org/docs/en/navigation-prop.html#setparams-make-changes-to-route-params>>

Currently to call `setParams` for attaching an event to a button in the header requires setting all of the screenProps, even those that were sent in via `this.props.navigate('route', { myprop: 'foo'})`. Instead, it should be a Partial.