### PR TITLE
Allow any comparison type for rejectBy

### DIFF
--- a/types/ember/index.d.ts
+++ b/types/ember/index.d.ts
@@ -1173,7 +1173,7 @@ declare module 'ember' {
              * key.  You can pass an optional second argument with the target value.  Otherwise
              * this will match any property that evaluates to false.
              */
-            rejectBy(key: string, value?: string): NativeArray<T>;
+            rejectBy(key: string, value?: any): NativeArray<T>;
             /**
              * Returns the first item in the array for which the callback returns true.
              * This method works similar to the `filter()` method defined in JavaScript 1.6


### PR DESCRIPTION
Currently `rejectBy` only allow a string as the comparison value, but the ember implementation allows `any` type as the comparison

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: https://emberjs.com/api/ember/2.6/classes/Ember.Enumerable/methods/rejectBy?anchor=rejectBy
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
