### PR TITLE
[rsvp] Add label argument to Promise constructor

### DIFF
--- a/types/rsvp/index.d.ts
+++ b/types/rsvp/index.d.ts
@@ -99,7 +99,8 @@ declare module 'rsvp' {
                 executor: (
                     resolve: (value?: RSVP.Arg<T>) => void,
                     reject: (reason?: any) => void
-                ) => void
+                ) => void,
+                label?: string
             );
 
             new<T>(

--- a/types/rsvp/rsvp-tests.ts
+++ b/types/rsvp/rsvp-tests.ts
@@ -55,6 +55,10 @@ function testPromise() {
     assertType<RSVP.Promise<number>>(promiseOfString.then((s: string) => s.length));
 }
 
+function testPromiseWithLabel() {
+    new RSVP.Promise((resolve: any, reject: any) => resolve('foo'), 'my promise');
+}
+
 function testAll() {
     const imported = all([]);
     const empty = RSVP.Promise.all([]);


### PR DESCRIPTION
Looking at the actual `RSVP.Promise` implementation, I noticed that the constructor should be able to take a `label` as a second argument, but this is missing from the type definition.

https://github.com/tildeio/rsvp.js/blob/238f66bbb475acfce4c37989dc420e244ccee1b8/lib/rsvp/promise.js#L132

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/tildeio/rsvp.js/blob/238f66bbb475acfce4c37989dc420e244ccee1b8/lib/rsvp/promise.js#L132
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.