### PR TITLE
[react-router] Change staticContext to optional prop

### DIFF
--- a/types/react-router/index.d.ts
+++ b/types/react-router/index.d.ts
@@ -67,7 +67,7 @@ export interface RouteComponentProps<P, C extends StaticContext = StaticContext>
   history: H.History;
   location: H.Location;
   match: match<P>;
-  staticContext: C | undefined;
+  staticContext?: C;
 }
 
 export interface RouteProps {


### PR DESCRIPTION
Change staticContext to optional prop, instead of a required (but possibly `undefined`) prop. This fixes an issue brought up [here](https://github.com/DefinitelyTyped/DefinitelyTyped/commit/1b920ca75b2a33f3d7ac3892edcac46992f0a081#r29408509). 