### PR TITLE
[mustache] Add constructor-definitions and documentation-comments

### DIFF
--- a/types/mustache/index.d.ts
+++ b/types/mustache/index.d.ts
@@ -64,7 +64,7 @@ interface MustacheStatic {
      *
      * A function that is used to load partial template on the fly that takes a single argument: the name of the partial.
      */
-    render(template: string, view: any | Mustache.Context, partials?: any): string;
+    render(template: string, view: any | MustacheContext, partials?: any): string;
 
     /**
      * Renders the `template` with the given `view` and `partials` using the default writer.
@@ -82,146 +82,144 @@ interface MustacheStatic {
      *
      * A function that is used to load partial template on the fly that takes a single argument: the name of the partial.
      */
-    to_html(template: string, view: any | Mustache.Context, partials?: any, send?: any): any;
+    to_html(template: string, view: any | MustacheContext, partials?: any, send?: any): any;
 }
 
-declare namespace Mustache {
+/**
+ * A simple string scanner that is used by the template parser to find tokens in template strings.
+ */
+declare class MustacheScanner {
+    string: string;
+    tail: string;
+    pos: number;
+
     /**
-     * A simple string scanner that is used by the template parser to find tokens in template strings.
+     * Initializes a new instance of the `MustacheScanner` class.
      */
-    class Scanner {
-        string: string;
-        tail: string;
-        pos: number;
-
-        /**
-         * Initializes a new instance of the `MustacheScanner` class.
-         */
-        constructor(string: string);
-
-        /**
-         * Returns `true` if the tail is empty (end of string).
-         */
-        eos(): boolean;
-
-        /**
-         * Tries to match the given regular expression at the current position.
-         *
-         * @param re
-         * The regex-pattern to match.
-         *
-         * @returns
-         * The matched text if it can match, the empty string otherwise.
-         */
-        scan(re: RegExp): string;
-
-        /**
-         * Skips all text until the given regular expression can be matched.
-         *
-         * @param re
-         * The regex-pattern to match.
-         *
-         * @returns
-         * Returns the skipped string, which is the entire tail if no match can be made.
-         */
-        scanUntil(re: RegExp): string;
-    }
+    constructor(string: string);
 
     /**
-     * Represents a rendering context by wrapping a view object and maintaining a reference to the parent context.
+     * Returns `true` if the tail is empty (end of string).
      */
-    class Context {
-        view: any;
-        parentContext: Context;
-
-        /**
-         * Initializes a new instance of the `MustacheContenxt` class.
-         */
-        constructor(view: any, parentContext: Context);
-
-        /**
-         * Initializes a new instance of the `MustacheContenxt` class.
-         */
-        constructor(view: any);
-
-        /**
-         * Creates a new context using the given view with this context as the parent.
-         *
-         * @param view
-         * The view to create the new context with.
-         */
-        push(view: any): Context;
-
-        /**
-         * Returns the value of the given name in this context, traversing up the context hierarchy if the value is absent in this context's view.
-         *
-         * @param name
-         * The name to look up.
-         */
-        lookup(name: string): any;
-    }
+    eos(): boolean;
 
     /**
-     * A Writer knows how to take a stream of tokens and render them to a `string`, given a context.
+     * Tries to match the given regular expression at the current position.
      *
-     * It also maintains a cache of templates to avoid the need to parse the same template twice.
+     * @param re
+     * The regex-pattern to match.
+     *
+     * @returns
+     * The matched text if it can match, the empty string otherwise.
      */
-    class Writer {
-        /**
-         * Initializes a new instance of the `MustacheWriter` class.
-         */
-        constructor();
-    
-        /**
-         * Clears all cached templates in this writer.
-         */
-        clearCache(): void;
-    
-        /**
-         * Parses and caches the given `template` and returns the array of tokens that is generated from the parse.
-         *
-         * @param template
-         * The template to parse.
-         */
-        parse(template: string, tags?: any): any;
-    
-        /**
-         * High-level method that is used to render the given `template` with the given `view`.
-         *
-         * @param template
-         * The template to render.
-         *
-         * @param view
-         * The view to render the template with.
-         *
-         * @param partials
-         * Either an object that contains the names and templates of partials that are used in a template
-         *
-         * -- or --
-         *
-         * A function that is used to load partial template on the fly that takes a single argument: the name of the partial.
-         */
-        render(template: string, view: any | Context, partials: any): string;
-    
-        /**
-         * Low-level method that renders the given array of `tokens` using the given `context` and `partials`.
-         *
-         * @param tokens
-         * The tokens to render.
-         *
-         * @param context
-         * The context to use for rendering the tokens.
-         *
-         * @param partials
-         * The partials to use for rendering the tokens.
-         *
-         * @param originalTemplate
-         * An object used to extract the portion of the original template that was contained in a higher-order section.
-         *
-         * If the template doesn't use higher-order sections, this argument may be omitted.
-         */
-        renderTokens(tokens: string[], context: Context, partials: any, originalTemplate: any): string;
-    }
+    scan(re: RegExp): string;
+
+    /**
+     * Skips all text until the given regular expression can be matched.
+     *
+     * @param re
+     * The regex-pattern to match.
+     *
+     * @returns
+     * Returns the skipped string, which is the entire tail if no match can be made.
+     */
+    scanUntil(re: RegExp): string;
+}
+
+/**
+ * Represents a rendering context by wrapping a view object and maintaining a reference to the parent context.
+ */
+declare class MustacheContext {
+    view: any;
+    parentContext: MustacheContext;
+
+    /**
+     * Initializes a new instance of the `MustacheContenxt` class.
+     */
+    constructor(view: any, parentContext: MustacheContext);
+
+    /**
+     * Initializes a new instance of the `MustacheContenxt` class.
+     */
+    constructor(view: any);
+
+    /**
+     * Creates a new context using the given view with this context as the parent.
+     *
+     * @param view
+     * The view to create the new context with.
+     */
+    push(view: any): MustacheContext;
+
+    /**
+     * Returns the value of the given name in this context, traversing up the context hierarchy if the value is absent in this context's view.
+     *
+     * @param name
+     * The name to look up.
+     */
+    lookup(name: string): any;
+}
+
+/**
+ * A Writer knows how to take a stream of tokens and render them to a `string`, given a context.
+ *
+ * It also maintains a cache of templates to avoid the need to parse the same template twice.
+ */
+declare class MustacheWriter {
+    /**
+     * Initializes a new instance of the `MustacheWriter` class.
+     */
+    constructor();
+
+    /**
+     * Clears all cached templates in this writer.
+     */
+    clearCache(): void;
+
+    /**
+     * Parses and caches the given `template` and returns the array of tokens that is generated from the parse.
+     *
+     * @param template
+     * The template to parse.
+     */
+    parse(template: string, tags?: any): any;
+
+    /**
+     * High-level method that is used to render the given `template` with the given `view`.
+     *
+     * @param template
+     * The template to render.
+     *
+     * @param view
+     * The view to render the template with.
+     *
+     * @param partials
+     * Either an object that contains the names and templates of partials that are used in a template
+     *
+     * -- or --
+     *
+     * A function that is used to load partial template on the fly that takes a single argument: the name of the partial.
+     */
+    render(template: string, view: any | MustacheContext, partials: any): string;
+
+    /**
+     * Low-level method that renders the given array of `tokens` using the given `context` and `partials`.
+     *
+     * @param tokens
+     * The tokens to render.
+     *
+     * @param context
+     * The context to use for rendering the tokens.
+     *
+     * @param partials
+     * The partials to use for rendering the tokens.
+     *
+     * @param originalTemplate
+     * An object used to extract the portion of the original template that was contained in a higher-order section.
+     *
+     * If the template doesn't use higher-order sections, this argument may be omitted.
+     */
+    renderTokens(tokens: string[], context: MustacheContext, partials: any, originalTemplate: any): string;
 }
 
 declare var Mustache: MustacheStatic;

--- a/types/mustache/index.d.ts
+++ b/types/mustache/index.d.ts
@@ -183,7 +183,7 @@ interface MustacheStatic {
      * @param value
      * The string to escape.
      */
-    escape(value: string): string;
+    escape: (value: string) => string;
 
     /**
      * Clears all cached templates in this writer.

--- a/types/mustache/index.d.ts
+++ b/types/mustache/index.d.ts
@@ -89,7 +89,7 @@ declare namespace Mustache {
     /**
      * A simple string scanner that is used by the template parser to find tokens in template strings.
      */
-    export class Scanner {
+    class Scanner {
         string: string;
         tail: string;
         pos: number;
@@ -130,7 +130,7 @@ declare namespace Mustache {
     /**
      * Represents a rendering context by wrapping a view object and maintaining a reference to the parent context.
      */
-    export class Context {
+    class Context {
         view: any;
         parentContext: Context;
 
@@ -166,7 +166,7 @@ declare namespace Mustache {
      *
      * It also maintains a cache of templates to avoid the need to parse the same template twice.
      */
-    export class Writer {
+    class Writer {
         /**
          * Initializes a new instance of the `MustacheWriter` class.
          */

--- a/types/mustache/index.d.ts
+++ b/types/mustache/index.d.ts
@@ -4,144 +4,6 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /**
- * A simple string scanner that is used by the template parser to find tokens in template strings.
- */
-interface MustacheScanner {
-    string: string;
-    tail: string;
-    pos: number;
-
-    /**
-     * Initializes a new instance of the `MustacheScanner` class.
-     */
-    new(string: string): MustacheScanner;
-
-    /**
-     * Returns `true` if the tail is empty (end of string).
-     */
-    eos(): boolean;
-
-    /**
-     * Tries to match the given regular expression at the current position.
-     *
-     * @param re
-     * The regex-pattern to match.
-     *
-     * @returns
-     * The matched text if it can match, the empty string otherwise.
-     */
-    scan(re: RegExp): string;
-
-    /**
-     * Skips all text until the given regular expression can be matched.
-     *
-     * @param re
-     * The regex-pattern to match.
-     *
-     * @returns
-     * Returns the skipped string, which is the entire tail if no match can be made.
-     */
-    scanUntil(re: RegExp): string;
-}
-
-/**
- * Represents a rendering context by wrapping a view object and maintaining a reference to the parent context.
- */
-interface MustacheContext {
-    view: any;
-    parentContext: MustacheContext;
-
-    /**
-     * Initializes a new instance of the `MustacheContenxt` class.
-     */
-    new(view: any, parentContext: MustacheContext): MustacheContext;
-
-    /**
-     * Initializes a new instance of the `MustacheContenxt` class.
-     */
-    new(view: any): MustacheContext;
-
-    /**
-     * Creates a new context using the given view with this context as the parent.
-     *
-     * @param view
-     * The view to create the new context with.
-     */
-    push(view: any): MustacheContext;
-
-    /**
-     * Returns the value of the given name in this context, traversing up the context hierarchy if the value is absent in this context's view.
-     *
-     * @param name
-     * The name to look up.
-     */
-    lookup(name: string): any;
-}
-
-/**
- * A Writer knows how to take a stream of tokens and render them to a `string`, given a context.
- *
- * It also maintains a cache of templates to avoid the need to parse the same template twice.
- */
-interface MustacheWriter {
-
-    /**
-     * Initializes a new instance of the `MustacheWriter` class.
-     */
-    new(): MustacheWriter;
-
-    /**
-     * Clears all cached templates in this writer.
-     */
-    clearCache(): void;
-
-    /**
-     * Parses and caches the given `template` and returns the array of tokens that is generated from the parse.
-     *
-     * @param template
-     * The template to parse.
-     */
-    parse(template: string, tags?: any): any;
-
-    /**
-     * High-level method that is used to render the given `template` with the given `view`.
-     *
-     * @param template
-     * The template to render.
-     *
-     * @param view
-     * The view to render the template with.
-     *
-     * @param partials
-     * Either an object that contains the names and templates of partials that are used in a template
-     *
-     * -- or --
-     *
-     * A function that is used to load partial template on the fly that takes a single argument: the name of the partial.
-     */
-    render(template: string, view: any | MustacheContext, partials: any): string;
-
-    /**
-     * Low-level method that renders the given array of `tokens` using the given `context` and `partials`.
-     *
-     * @param tokens
-     * The tokens to render.
-     *
-     * @param context
-     * The context to use for rendering the tokens.
-     *
-     * @param partials
-     * The partials to use for rendering the tokens.
-     *
-     * @param originalTemplate
-     * An object used to extract the portion of the original template that was contained in a higher-order section.
-     *
-     * If the template doesn't use higher-order sections, this argument may be omitted.
-     */
-    renderTokens(tokens: string[], context: MustacheContext, partials: any, originalTemplate: any): string;
-}
-
-/**
  * Provides the functionality to render templates with `{{mustaches}}`.
  */
 interface MustacheStatic {
@@ -161,23 +23,6 @@ interface MustacheStatic {
     tags: string;
 
     /**
-     * A simple string scanner that is used by the template parser to find tokens in template strings.
-     */
-    Scanner: MustacheScanner;
-
-    /**
-     * Represents a rendering context by wrapping a view object and maintaining a reference to the parent context.
-     */
-    Context: MustacheContext;
-
-    /**
-     * A Writer knows how to take a stream of tokens and render them to a `string`, given a context.
-     *
-     * It also maintains a cache of templates to avoid the need to parse the same template twice.
-     */
-    Writer: MustacheWriter;
-
-    /**
      * Escapes HTML-characters.
      *
      * @param value
@@ -188,7 +33,7 @@ interface MustacheStatic {
     /**
      * Clears all cached templates in this writer.
      */
-    clearCache(): MustacheWriter;
+    clearCache(): void;
 
     /**
      * Parses and caches the given template in the default writer and returns the array of tokens it contains.
@@ -219,7 +64,7 @@ interface MustacheStatic {
      *
      * A function that is used to load partial template on the fly that takes a single argument: the name of the partial.
      */
-    render(template: string, view: any | MustacheContext, partials?: any): string;
+    render(template: string, view: any | Mustache.Context, partials?: any): string;
 
     /**
      * Renders the `template` with the given `view` and `partials` using the default writer.
@@ -237,14 +82,148 @@ interface MustacheStatic {
      *
      * A function that is used to load partial template on the fly that takes a single argument: the name of the partial.
      */
-    to_html(template: string, view: any | MustacheContext, partials?: any, send?: any): any;
+    to_html(template: string, view: any | Mustache.Context, partials?: any, send?: any): any;
 }
 
-/**
- * Provides the functionality to render templates with `{{mustaches}}`.
- */
+declare namespace Mustache {
+    /**
+     * A simple string scanner that is used by the template parser to find tokens in template strings.
+     */
+    export class Scanner {
+        string: string;
+        tail: string;
+        pos: number;
+
+        /**
+         * Initializes a new instance of the `MustacheScanner` class.
+         */
+        constructor(string: string);
+
+        /**
+         * Returns `true` if the tail is empty (end of string).
+         */
+        eos(): boolean;
+
+        /**
+         * Tries to match the given regular expression at the current position.
+         *
+         * @param re
+         * The regex-pattern to match.
+         *
+         * @returns
+         * The matched text if it can match, the empty string otherwise.
+         */
+        scan(re: RegExp): string;
+
+        /**
+         * Skips all text until the given regular expression can be matched.
+         *
+         * @param re
+         * The regex-pattern to match.
+         *
+         * @returns
+         * Returns the skipped string, which is the entire tail if no match can be made.
+         */
+        scanUntil(re: RegExp): string;
+    }
+
+    /**
+     * Represents a rendering context by wrapping a view object and maintaining a reference to the parent context.
+     */
+    export class Context {
+        view: any;
+        parentContext: Context;
+
+        /**
+         * Initializes a new instance of the `MustacheContenxt` class.
+         */
+        constructor(view: any, parentContext: Context);
+
+        /**
+         * Initializes a new instance of the `MustacheContenxt` class.
+         */
+        constructor(view: any);
+
+        /**
+         * Creates a new context using the given view with this context as the parent.
+         *
+         * @param view
+         * The view to create the new context with.
+         */
+        push(view: any): Context;
+
+        /**
+         * Returns the value of the given name in this context, traversing up the context hierarchy if the value is absent in this context's view.
+         *
+         * @param name
+         * The name to look up.
+         */
+        lookup(name: string): any;
+    }
+
+    /**
+     * A Writer knows how to take a stream of tokens and render them to a `string`, given a context.
+     *
+     * It also maintains a cache of templates to avoid the need to parse the same template twice.
+     */
+    export class Writer {
+        /**
+         * Initializes a new instance of the `MustacheWriter` class.
+         */
+        constructor();
+    
+        /**
+         * Clears all cached templates in this writer.
+         */
+        clearCache(): void;
+    
+        /**
+         * Parses and caches the given `template` and returns the array of tokens that is generated from the parse.
+         *
+         * @param template
+         * The template to parse.
+         */
+        parse(template: string, tags?: any): any;
+    
+        /**
+         * High-level method that is used to render the given `template` with the given `view`.
+         *
+         * @param template
+         * The template to render.
+         *
+         * @param view
+         * The view to render the template with.
+         *
+         * @param partials
+         * Either an object that contains the names and templates of partials that are used in a template
+         *
+         * -- or --
+         *
+         * A function that is used to load partial template on the fly that takes a single argument: the name of the partial.
+         */
+        render(template: string, view: any | Context, partials: any): string;
+    
+        /**
+         * Low-level method that renders the given array of `tokens` using the given `context` and `partials`.
+         *
+         * @param tokens
+         * The tokens to render.
+         *
+         * @param context
+         * The context to use for rendering the tokens.
+         *
+         * @param partials
+         * The partials to use for rendering the tokens.
+         *
+         * @param originalTemplate
+         * An object used to extract the portion of the original template that was contained in a higher-order section.
+         *
+         * If the template doesn't use higher-order sections, this argument may be omitted.
+         */
+        renderTokens(tokens: string[], context: Context, partials: any, originalTemplate: any): string;
+    }
+}
+
 declare var Mustache: MustacheStatic;
-
-declare module 'mustache' {
-    export = Mustache;
-}
+export = Mustache;
+export as namespace Mustache;

--- a/types/mustache/index.d.ts
+++ b/types/mustache/index.d.ts
@@ -23,10 +23,10 @@ interface MustacheScanner {
 
     /**
      * Tries to match the given regular expression at the current position.
-     * 
+     *
      * @param re
      * The regex-pattern to match.
-     * 
+     *
      * @returns
      * The matched text if it can match, the empty string otherwise.
      */
@@ -34,10 +34,10 @@ interface MustacheScanner {
 
     /**
      * Skips all text until the given regular expression can be matched.
-     * 
+     *
      * @param re
      * The regex-pattern to match.
-     * 
+     *
      * @returns
      * Returns the skipped string, which is the entire tail if no match can be made.
      */
@@ -63,7 +63,7 @@ interface MustacheContext {
 
     /**
      * Creates a new context using the given view with this context as the parent.
-     * 
+     *
      * @param view
      * The view to create the new context with.
      */
@@ -71,7 +71,7 @@ interface MustacheContext {
 
     /**
      * Returns the value of the given name in this context, traversing up the context hierarchy if the value is absent in this context's view.
-     * 
+     *
      * @param name
      * The name to look up.
      */
@@ -80,7 +80,7 @@ interface MustacheContext {
 
 /**
  * A Writer knows how to take a stream of tokens and render them to a `string`, given a context.
- * 
+ *
  * It also maintains a cache of templates to avoid the need to parse the same template twice.
  */
 interface MustacheWriter {
@@ -97,7 +97,7 @@ interface MustacheWriter {
 
     /**
      * Parses and caches the given `template` and returns the array of tokens that is generated from the parse.
-     * 
+     *
      * @param template
      * The template to parse.
      */
@@ -105,37 +105,37 @@ interface MustacheWriter {
 
     /**
      * High-level method that is used to render the given `template` with the given `view`.
-     * 
+     *
      * @param template
      * The template to render.
-     * 
+     *
      * @param view
      * The view to render the template with.
-     * 
+     *
      * @param partials
      * Either an object that contains the names and templates of partials that are used in a template
-     * 
+     *
      * -- or --
-     * 
-     * A functino that is used to load partial template on the fly that takes a single argument: the n ame of the partial.
+     *
+     * A function that is used to load partial template on the fly that takes a single argument: the name of the partial.
      */
     render(template: string, view: any | MustacheContext, partials: any): string;
 
     /**
      * Low-level method that renders the given array of `tokens` using the given `context` and `partials`.
-     * 
+     *
      * @param tokens
      * The tokens to render.
-     * 
+     *
      * @param context
      * The context to use for rendering the tokens.
-     * 
+     *
      * @param partials
      * The partials to use for rendering the tokens.
-     * 
+     *
      * @param originalTemplate
      * An object used to extract the portion of the original template that was contained in a higher-order section.
-     * 
+     *
      * If the template doesn't use higher-order sections, this argument may be omitted.
      */
     renderTokens(tokens: string[], context: MustacheContext, partials: any, originalTemplate: any): string;
@@ -172,14 +172,14 @@ interface MustacheStatic {
 
     /**
      * A Writer knows how to take a stream of tokens and render them to a `string`, given a context.
-     * 
+     *
      * It also maintains a cache of templates to avoid the need to parse the same template twice.
      */
     Writer: MustacheWriter;
 
     /**
      * Escapes HTML-characters.
-     * 
+     *
      * @param value
      * The string to escape.
      */
@@ -192,12 +192,12 @@ interface MustacheStatic {
 
     /**
      * Parses and caches the given template in the default writer and returns the array of tokens it contains.
-     * 
+     *
      * Doing this ahead of time avoids the need to parse templates on the fly as they are rendered.
-     * 
+     *
      * @param template
      * The template to parse.
-     * 
+     *
      * @param tags
      * The tags to use.
      */
@@ -205,37 +205,37 @@ interface MustacheStatic {
 
     /**
      * Renders the `template` with the given `view` and `partials` using the default writer.
-     * 
+     *
      * @param template
      * The template to render.
-     * 
+     *
      * @param view
      * The view to render the template with.
-     * 
+     *
      * @param partials
      * Either an object that contains the names and templates of partials that are used in a template
-     * 
+     *
      * -- or --
-     * 
-     * A functino that is used to load partial template on the fly that takes a single argument: the n ame of the partial.
+     *
+     * A function that is used to load partial template on the fly that takes a single argument: the name of the partial.
      */
     render(template: string, view: any | MustacheContext, partials?: any): string;
 
     /**
      * Renders the `template` with the given `view` and `partials` using the default writer.
-     * 
+     *
      * @param template
      * The template to render.
-     * 
+     *
      * @param view
      * The view to render the template with.
-     * 
+     *
      * @param partials
      * Either an object that contains the names and templates of partials that are used in a template
-     * 
+     *
      * -- or --
-     * 
-     * A functino that is used to load partial template on the fly that takes a single argument: the n ame of the partial.
+     *
+     * A function that is used to load partial template on the fly that takes a single argument: the name of the partial.
      */
     to_html(template: string, view: any | MustacheContext, partials?: any, send?: any): any;
 }

--- a/types/mustache/index.d.ts
+++ b/types/mustache/index.d.ts
@@ -23,6 +23,23 @@ interface MustacheStatic {
     tags: string;
 
     /**
+     * A simple string scanner that is used by the template parser to find tokens in template strings.
+     */
+    Scanner: typeof MustacheScanner
+
+    /**
+     * Represents a rendering context by wrapping a view object and maintaining a reference to the parent context.
+     */
+    Context: typeof MustacheContext;
+
+    /**
+     * A Writer knows how to take a stream of tokens and render them to a `string`, given a context.
+     *
+     * It also maintains a cache of templates to avoid the need to parse the same template twice.
+     */
+    Writer: typeof MustacheWriter;
+
+    /**
      * Escapes HTML-characters.
      *
      * @param value
@@ -222,6 +239,9 @@ declare class MustacheWriter {
     renderTokens(tokens: string[], context: MustacheContext, partials: any, originalTemplate: any): string;
 }
 
+/**
+ * Provides the functionality to render templates with `{{mustaches}}`.
+ */
 declare var Mustache: MustacheStatic;
 export = Mustache;
 export as namespace Mustache;

--- a/types/mustache/index.d.ts
+++ b/types/mustache/index.d.ts
@@ -14,7 +14,7 @@ interface MustacheScanner {
     /**
      * Initializes a new instance of the `MustacheScanner` class.
      */
-    new (string: string): MustacheScanner;
+    new(string: string): MustacheScanner;
 
     /**
      * Returns `true` if the tail is empty (end of string).
@@ -54,12 +54,12 @@ interface MustacheContext {
     /**
      * Initializes a new instance of the `MustacheContenxt` class.
      */
-    new(view: any): MustacheContext;
-    
+    new(view: any, parentContext: MustacheContext): MustacheContext;
+
     /**
      * Initializes a new instance of the `MustacheContenxt` class.
      */
-    new(view: any, parentContext: MustacheContext): MustacheContext;
+    new(view: any): MustacheContext;
 
     /**
      * Creates a new context using the given view with this context as the parent.
@@ -119,7 +119,7 @@ interface MustacheWriter {
      * 
      * A functino that is used to load partial template on the fly that takes a single argument: the n ame of the partial.
      */
-    render(template: string, view: any|MustacheContext, partials: any): string;
+    render(template: string, view: any | MustacheContext, partials: any): string;
 
     /**
      * Low-level method that renders the given array of `tokens` using the given `context` and `partials`.
@@ -159,12 +159,12 @@ interface MustacheStatic {
      * The opening and closing tags to parse.
      */
     tags: string;
-    
+
     /**
      * A simple string scanner that is used by the template parser to find tokens in template strings.
      */
     Scanner: MustacheScanner;
-    
+
     /**
      * Represents a rendering context by wrapping a view object and maintaining a reference to the parent context.
      */
@@ -176,7 +176,7 @@ interface MustacheStatic {
      * It also maintains a cache of templates to avoid the need to parse the same template twice.
      */
     Writer: MustacheWriter;
-    
+
     /**
      * Escapes HTML-characters.
      * 
@@ -219,8 +219,8 @@ interface MustacheStatic {
      * 
      * A functino that is used to load partial template on the fly that takes a single argument: the n ame of the partial.
      */
-    render(template: string, view: any|MustacheContext, partials?: any): string;
-    
+    render(template: string, view: any | MustacheContext, partials?: any): string;
+
     /**
      * Renders the `template` with the given `view` and `partials` using the default writer.
      * 
@@ -237,7 +237,7 @@ interface MustacheStatic {
      * 
      * A functino that is used to load partial template on the fly that takes a single argument: the n ame of the partial.
      */
-    to_html(template: string, view: any|MustacheContext, partials?: any, send?: any): any;
+    to_html(template: string, view: any | MustacheContext, partials?: any, send?: any): any;
 }
 
 /**
@@ -246,5 +246,5 @@ interface MustacheStatic {
 declare var Mustache: MustacheStatic;
 
 declare module 'mustache' {
-	export = Mustache;
+    export = Mustache;
 }

--- a/types/mustache/index.d.ts
+++ b/types/mustache/index.d.ts
@@ -243,5 +243,7 @@ declare class MustacheWriter {
  * Provides the functionality to render templates with `{{mustaches}}`.
  */
 declare var Mustache: MustacheStatic;
-export = Mustache;
-export as namespace Mustache;
+
+declare module "mustache" {
+    export = Mustache;
+}

--- a/types/mustache/index.d.ts
+++ b/types/mustache/index.d.ts
@@ -1,51 +1,248 @@
 // Type definitions for Mustache 0.8.2
 // Project: https://github.com/janl/mustache.js
-// Definitions by: Mark Ashley Bell <https://github.com/markashleybell>
+// Definitions by: Mark Ashley Bell <https://github.com/markashleybell>, Manuel Thalmann <https://github.com/manuth>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-
+/**
+ * A simple string scanner that is used by the template parser to find tokens in template strings.
+ */
 interface MustacheScanner {
     string: string;
     tail: string;
     pos: number;
 
+    /**
+     * Initializes a new instance of the `MustacheScanner` class.
+     */
+    new (string: string): MustacheScanner;
+
+    /**
+     * Returns `true` if the tail is empty (end of string).
+     */
     eos(): boolean;
+
+    /**
+     * Tries to match the given regular expression at the current position.
+     * 
+     * @param re
+     * The regex-pattern to match.
+     * 
+     * @returns
+     * The matched text if it can match, the empty string otherwise.
+     */
     scan(re: RegExp): string;
+
+    /**
+     * Skips all text until the given regular expression can be matched.
+     * 
+     * @param re
+     * The regex-pattern to match.
+     * 
+     * @returns
+     * Returns the skipped string, which is the entire tail if no match can be made.
+     */
     scanUntil(re: RegExp): string;
 }
 
+/**
+ * Represents a rendering context by wrapping a view object and maintaining a reference to the parent context.
+ */
 interface MustacheContext {
     view: any;
     parentContext: MustacheContext;
 
+    /**
+     * Initializes a new instance of the `MustacheContenxt` class.
+     */
+    new(view: object): MustacheContext;
+    
+    /**
+     * Initializes a new instance of the `MustacheContenxt` class.
+     */
+    new(view: object, parentContext: MustacheContext): MustacheContext;
+
+    /**
+     * Creates a new context using the given view with this context as the parent.
+     * 
+     * @param view
+     * The view to create the new context with.
+     */
     push(view: any): MustacheContext;
+
+    /**
+     * Returns the value of the given name in this context, traversing up the context hierarchy if the value is absent in this context's view.
+     * 
+     * @param name
+     * The name to look up.
+     */
     lookup(name: string): any;
 }
 
+/**
+ * A Writer knows how to take a stream of tokens and render them to a `string`, given a context.
+ * 
+ * It also maintains a cache of templates to avoid the need to parse the same template twice.
+ */
 interface MustacheWriter {
-    (view: any): string;
 
+    /**
+     * Initializes a new instance of the `MustacheWriter` class.
+     */
+    new(): MustacheWriter;
+
+    /**
+     * Clears all cached templates in this writer.
+     */
     clearCache(): void;
+
+    /**
+     * Parses and caches the given `template` and returns the array of tokens that is generated from the parse.
+     * 
+     * @param template
+     * The template to parse.
+     */
     parse(template: string, tags?: any): any;
-    render(template: string, view: any, partials: any): string;
+
+    /**
+     * High-level method that is used to render the given `template` with the given `view`.
+     * 
+     * @param template
+     * The template to render.
+     * 
+     * @param view
+     * The view to render the template with.
+     * 
+     * @param partials
+     * Either an object that contains the names and templates of partials that are used in a template
+     * 
+     * -- or --
+     * 
+     * A functino that is used to load partial template on the fly that takes a single argument: the n ame of the partial.
+     */
+    render(template: string, view: any|MustacheContext, partials: any): string;
+
+    /**
+     * Low-level method that renders the given array of `tokens` using the given `context` and `partials`.
+     * 
+     * @param tokens
+     * The tokens to render.
+     * 
+     * @param context
+     * The context to use for rendering the tokens.
+     * 
+     * @param partials
+     * The partials to use for rendering the tokens.
+     * 
+     * @param originalTemplate
+     * An object used to extract the portion of the original template that was contained in a higher-order section.
+     * 
+     * If the template doesn't use higher-order sections, this argument may be omitted.
+     */
     renderTokens(tokens: string[], context: MustacheContext, partials: any, originalTemplate: any): string;
 }
 
+/**
+ * Provides the functionality to render templates with `{{mustaches}}`.
+ */
 interface MustacheStatic {
+    /**
+     * The name of the module.
+     */
     name: string;
-    version: string;
-    tags: string;
-    Scanner: MustacheScanner;
-    Context: MustacheContext;
-    Writer: MustacheWriter;
-    escape: any;
 
+    /**
+     * The version of the module.
+     */
+    version: string;
+
+    /**
+     * The opening and closing tags to parse.
+     */
+    tags: string;
+    
+    /**
+     * A simple string scanner that is used by the template parser to find tokens in template strings.
+     */
+    Scanner: MustacheScanner;
+    
+    /**
+     * Represents a rendering context by wrapping a view object and maintaining a reference to the parent context.
+     */
+    Context: MustacheContext;
+
+    /**
+     * A Writer knows how to take a stream of tokens and render them to a `string`, given a context.
+     * 
+     * It also maintains a cache of templates to avoid the need to parse the same template twice.
+     */
+    Writer: MustacheWriter;
+    
+    /**
+     * Escapes HTML-characters.
+     * 
+     * @param value
+     * The string to escape.
+     */
+    escape(value: string): string;
+
+    /**
+     * Clears all cached templates in this writer.
+     */
     clearCache(): MustacheWriter;
-    parse(template: string, tags?: any): any;
-    render(template: string, view: any, partials?: any): string;
-    to_html(template: string, view: any, partials?: any, send?: any): any;
+
+    /**
+     * Parses and caches the given template in the default writer and returns the array of tokens it contains.
+     * 
+     * Doing this ahead of time avoids the need to parse templates on the fly as they are rendered.
+     * 
+     * @param template
+     * The template to parse.
+     * 
+     * @param tags
+     * The tags to use.
+     */
+    parse(template: string, tags?: string[]): any;
+
+    /**
+     * Renders the `template` with the given `view` and `partials` using the default writer.
+     * 
+     * @param template
+     * The template to render.
+     * 
+     * @param view
+     * The view to render the template with.
+     * 
+     * @param partials
+     * Either an object that contains the names and templates of partials that are used in a template
+     * 
+     * -- or --
+     * 
+     * A functino that is used to load partial template on the fly that takes a single argument: the n ame of the partial.
+     */
+    render(template: string, view: any|MustacheContext, partials?: any): string;
+    
+    /**
+     * Renders the `template` with the given `view` and `partials` using the default writer.
+     * 
+     * @param template
+     * The template to render.
+     * 
+     * @param view
+     * The view to render the template with.
+     * 
+     * @param partials
+     * Either an object that contains the names and templates of partials that are used in a template
+     * 
+     * -- or --
+     * 
+     * A functino that is used to load partial template on the fly that takes a single argument: the n ame of the partial.
+     */
+    to_html(template: string, view: any|MustacheContext, partials?: any, send?: any): any;
 }
 
+/**
+ * Provides the functionality to render templates with `{{mustaches}}`.
+ */
 declare var Mustache: MustacheStatic;
 
 declare module 'mustache' {

--- a/types/mustache/index.d.ts
+++ b/types/mustache/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Mustache 0.8.2
+// Type definitions for Mustache 0.8.3
 // Project: https://github.com/janl/mustache.js
 // Definitions by: Mark Ashley Bell <https://github.com/markashleybell>, Manuel Thalmann <https://github.com/manuth>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/mustache/index.d.ts
+++ b/types/mustache/index.d.ts
@@ -243,7 +243,5 @@ declare class MustacheWriter {
  * Provides the functionality to render templates with `{{mustaches}}`.
  */
 declare var Mustache: MustacheStatic;
-
-declare module "mustache" {
-    export = Mustache;
-}
+export = Mustache;
+export as namespace Mustache;

--- a/types/mustache/index.d.ts
+++ b/types/mustache/index.d.ts
@@ -54,12 +54,12 @@ interface MustacheContext {
     /**
      * Initializes a new instance of the `MustacheContenxt` class.
      */
-    new(view: object): MustacheContext;
+    new(view: any): MustacheContext;
     
     /**
      * Initializes a new instance of the `MustacheContenxt` class.
      */
-    new(view: object, parentContext: MustacheContext): MustacheContext;
+    new(view: any, parentContext: MustacheContext): MustacheContext;
 
     /**
      * Creates a new context using the given view with this context as the parent.

--- a/types/mustache/mustache-tests.ts
+++ b/types/mustache/mustache-tests.ts
@@ -12,3 +12,18 @@ var output2 = Mustache.render(template2, view2);
 var view3 = { firstName: "John", lastName: "Smith", blogURL: "http://testblog.com" };
 var template3 = "<h1>{{firstName}} {{lastName}}</h1>Blog: {{blogURL}}";
 var html = Mustache.to_html(template3, view3);
+
+var view4 = new class extends Mustache.Context
+{
+    constructor()
+    {
+        super({});
+    }
+
+    public lookup(name: string)
+    {
+        return name.toUpperCase();
+    }
+};
+var template4 = "Hello, {{firstName}} {{lastName}}";
+var html4 = Mustache.render(template4, view4);

--- a/types/node-vault/index.d.ts
+++ b/types/node-vault/index.d.ts
@@ -111,7 +111,7 @@ declare namespace NodeVault {
         debug?(...args: any[]): any;
         tv4?(...args: any[]): any;
         commands?: Array<{ method: string, path: string, scheme: any }>;
-        mustache?: MustacheStatic;
+        mustache?: typeof mustache;
         "request-promise"?: any;
         Promise?: PromiseConstructor;
 


### PR DESCRIPTION
When I was working with `@types/mustache` I noticed that there's no way to inherit from `mustache.Context`, `mustache.Writer` etc.  
Neither is it possible to create new instances from said classes.

This PR fixes said issue by adding propper constructors to all interfaces.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/janl/mustache.js/blob/master/mustache.js>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
