### PR TITLE
[@types/angular-mocks] fix: put back ability for data param to be undefined

### DIFF
--- a/types/angular-mocks/angular-mocks-tests.ts
+++ b/types/angular-mocks/angular-mocks-tests.ts
@@ -1509,6 +1509,7 @@ requestHandler.respond(expectedData);
 requestHandler.respond({ key: 'value' });
 requestHandler.respond({ key: 'value' }, { header: 'value' });
 requestHandler.respond({ key: 'value' }, { header: 'value' }, 'responseText');
+requestHandler.respond(404);
 requestHandler.respond(404, 'data');
 requestHandler.respond(404, 'data').respond({});
 requestHandler.respond(404, { key: 'value' });

--- a/types/angular-mocks/index.d.ts
+++ b/types/angular-mocks/index.d.ts
@@ -464,7 +464,7 @@ declare module 'angular' {
        */
       respond(
         status: number,
-        data: string | object,
+        data?: string | object,
         headers?: IHttpHeaders,
         responseText?: string
       ): IRequestHandler;


### PR DESCRIPTION
This fixes an issue where changing from using Object to object broke some usages of the respond method. These usages only cared about the status number and as such were passing undefined as the value for the data param.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/DefinitelyTyped/DefinitelyTyped/issues/26641>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
