### PR TITLE
stripe: add missing properties to IPlan

### DIFF
--- a/types/stripe/index.d.ts
+++ b/types/stripe/index.d.ts
@@ -2880,6 +2880,30 @@ declare namespace Stripe {
     }
 
     namespace plans {
+        interface ITier {
+            /**
+             * Per unit price for units relevant to the tier.
+             */
+            amount: number;
+
+            /**
+             * Up to and including to this quantity will be contained in the tier.
+             */
+            up_to: number;
+        }
+
+        interface ITransformUsage {
+            /**
+             * Divide usage by this number.
+             */
+            divide_by: number;
+
+            /**
+             * After division, either round the result `up` or `down`.
+             */
+            round: "up" | "down";
+        }
+
         /**
          * A subscription plan contains the pricing information for different products and feature levels on your site.
          * For example, you might have a $10/month plan for basic features and a different $20/month plan for premium features.
@@ -2891,40 +2915,89 @@ declare namespace Stripe {
             object: "plan";
 
             /**
+             * Whether the plan is currently available for new subscriptions.
+             */
+            active: boolean;
+
+            /**
+             * Specifies a usage aggregation strategy for plans of `usage_type=metered`. Allowed values are `sum` for summing up all usage during a period, `last_during_period` for picking the last usage record reported within a period, `last_ever` for picking the last usage record ever (across period bounds) or `max` which picks the usage record with the maximum reported usage during a period. Defaults to `sum`.
+             */
+            aggregate_usage: "sum" | "last_during_period" | "last_ever" | "max" | null;
+
+            /**
              * The amount in cents to be charged on the interval specified
              */
             amount: number;
 
+            /**
+             * Describes how to compute the price per period. Either `per_unit` or `tiered`. `per_unit` indicates that the fixed amount (specified in `amount`) will be charged per unit in `quantity` (for plans with `usage_type=licensed`), or per unit of total usage (for plans with `usage_type=metered`). `tiered` indicates that the unit pricing will be computed using a tiering strategy as defined using the `tiers` and `tiers_mode` attributes.
+             */
+            billing_scheme: "per_unit" | "tiered";
+
+            /**
+             * Time at which the object was created. Measured in seconds since the Unix epoch.
+             */
             created: number;
 
             /**
-             * Currency in which subscription will be charged
+             * Three-letter ISO currency code, in lowercase. Must be a supported currency.
              */
             currency: string;
 
             /**
-             * One of "day", "week", "month" or "year". The frequency with which a subscription should be billed.
+             * One of `day`, `week`, `month` or `year`. The frequency with which a subscription should be billed.
              */
             interval: IntervalUnit;
 
             /**
-             * The number of intervals (specified in the interval property) between each subscription billing. For example,
-             * interval=month and interval_count=3 bills every 3 months.
+             * The number of intervals (specified in the `interval` property) between subscription billings. For example, `interval=month` and `interval_count=3` bills every 3 months.
              */
             interval_count: number;
 
+            /**
+             * Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode.
+             */
             livemode: boolean;
+
+            /**
+             * Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format.
+             */
             metadata: IMetadata;
 
             /**
              * A brief description of the plan, hidden from customers.
              */
-            nickname?: string;
+            nickname: string | null;
 
             /**
              * The product whose pricing this plan determines. [Expandable]
              */
             product?: string | products.IProduct;
+
+            /**
+             * Each element represents a pricing tier. This parameter requires `billing_scheme` to be set to `tiered`. See also the documentation for `billing_scheme`.
+             */
+            tiers: plans.ITier[] | null;
+
+            /**
+             * Defines if the tiering price should be `graduated` or `volume` based. In `volume`-based tiering, the maximum quantity within a period determines the per unit price, in `graduated` tiering pricing can successively change as the quantity grows.
+             */
+            tiers_mode: "graduated" | "volume" | null;
+
+            /**
+             * Apply a transformation to the reported usage or set quantity before computing the billed price. Cannot be combined with `tiers`.
+             */
+            transform_usage: plans.ITransformUsage | null;
+
+            /**
+             * Default number of trial days when subscribing a customer to this plan using `trial_from_plan=true`.
+             */
+            trial_period_days: number;
+
+            /**
+             * Configures how the quantity per period should be determined, can be either `metered` or `licensed`. `licensed` will automatically bill the `quantity` set for a plan when adding it to a subscription, `metered` will aggregate the total usage based on usage records. Defaults to `licensed`.
+             */
+            usage_type: "metered" | "licensed";
         }
 
         interface IPlanCreationOptions extends IDataOptionsWithMetadata {


### PR DESCRIPTION
When fixing this https://github.com/DefinitelyTyped/DefinitelyTyped/commit/0525e27d3c298b82c5cdd24820913d5ffa253e57#r29414120 I also realized that there was a lot of other fields missing.

I've gone thru the entire Plan object and added all attributes, and also made sure that the descriptions are copied straight off from the documentation.

-----

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://stripe.com/docs/api#plan_object
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.