### PR TITLE
[nuka-carousel] Add support for null in RenderControl type

### DIFF
--- a/types/nuka-carousel/index.d.ts
+++ b/types/nuka-carousel/index.d.ts
@@ -64,7 +64,7 @@ export interface SlideRenderControlProps {
   goToSlide: (index: number) => void;
 }
 
-export type RenderControl = (props: SlideRenderControlProps) => JSX.Element;
+export type RenderControl = (props: SlideRenderControlProps) => JSX.Element | null;
 
 export interface CarouselProps {
   /**

--- a/types/nuka-carousel/nuka-carousel-tests.tsx
+++ b/types/nuka-carousel/nuka-carousel-tests.tsx
@@ -25,7 +25,7 @@ const props: CarouselProps = {
 	renderCenterCenterControls: () => <button />,
 	renderCenterRightControls: () => <button />,
 	renderBottomLeftControls: () => <button />,
-	renderBottomCenterControls: () => <button />,
+	renderBottomCenterControls: () => null,
 	renderBottomRightControls: () => <button />,
 	slideIndex: 2,
 	slidesToScroll: 'auto',


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/FormidableLabs/nuka-carousel/blob/master/src/index.js#L1152
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

Allow null to easily disable default controls.

Before, in order to hide default controls we needed to provide an empty `Fragment`
```javascript
      renderCenterLeftControls: () => <Fragment />,
      renderCenterRightControls: () => <Fragment />,
      renderBottomCenterControls: () => <Fragment />,
```

Now we can simply return null
```javascript
      renderCenterLeftControls: () => null,
      renderCenterRightControls: () => null,
      renderBottomCenterControls: () => null,
```
