### PR TITLE
react-tag-input handleInputBlur signature fixed

### DIFF
--- a/types/react-tag-input/index.d.ts
+++ b/types/react-tag-input/index.d.ts
@@ -19,7 +19,7 @@ export interface ReactTagsProps {
     handleDrag?: ((tag: { id: number; text: string; }, currPos: number, newPos: number) => void);
     handleInputChange?: ((value: string) => void);
     handleFilterSuggestions?: ((textInputValue: string, possibleSuggestionsArray: string[]) => boolean);
-    handleInputBlur?: (() => void);
+    handleInputBlur?: ((textInputValue: string) => void);
 
     autofocus?: boolean;
     allowDeleteFromEmptyInput?: boolean;


### PR DESCRIPTION
Added missing parameter (event target value) to signature.

Reference: https://github.com/prakhar1989/react-tags/blob/master/lib/ReactTags.js#L183