### PR TITLE
Update dependancy for 'connect-mongo'

### DIFF
--- a/types/connect-mongo/tsconfig.json
+++ b/types/connect-mongo/tsconfig.json
@@ -7,7 +7,10 @@
         "paths": {
             "mongodb": [
                 "mongodb/v2"
-            ]
+            ],
+            "mongoose": [
+                "mongoose/v4" 
+             ]
         },
         "noImplicitAny": true,
         "noImplicitThis": true,


### PR DESCRIPTION
Without this change the types of 'mongoose' of v5 will be used. 
These are not compatible with v2 of the 'mongdb' typings.

For example they caused problems for other users:
https://github.com/DefinitelyTyped/DefinitelyTyped/issues/23518#issuecomment-385171522

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/jdesboeufs/connect-mongo/blob/master/package.json
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
