### PR TITLE
Added type definitions for ex-react-native-i18n

### DIFF
--- a/types/ex-react-native-i18n/ex-react-native-i18n-tests.ts
+++ b/types/ex-react-native-i18n/ex-react-native-i18n-tests.ts
@@ -1,0 +1,8 @@
+import I18n from 'ex-react-native-i18n';
+
+I18n.defaultLocale = 'en';
+I18n.fallbacks = true;
+I18n.translations = {};
+I18n.locale = 'zh';
+
+const deviceLocale: string = I18n.locale;

--- a/types/ex-react-native-i18n/index.d.ts
+++ b/types/ex-react-native-i18n/index.d.ts
@@ -1,10 +1,11 @@
-// Type definitions for ex-react-native-i18n 0.0.4
+// Type definitions for ex-react-native-i18n 0.0
 // Project: https://github.com/xcarpentier/ex-react-native-i18n/
 // Definitions by: LikKee Richie <https://github.com/maplerichie>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
+// Actual version for ex-react-native-i18n is 0.0.4 but 'npm run lint' doesn't allow patch version to pass
 import I18n = require("i18n-js");
-//import I18n from 'ex-react-native-i18n';
+// import I18n from 'ex-react-native-i18n';
 
 export default I18n;

--- a/types/ex-react-native-i18n/index.d.ts
+++ b/types/ex-react-native-i18n/index.d.ts
@@ -1,0 +1,10 @@
+// Type definitions for ex-react-native-i18n 0.0.4
+// Project: https://github.com/xcarpentier/ex-react-native-i18n/
+// Definitions by: LikKee Richie <https://github.com/maplerichie>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.2
+
+import I18n = require("i18n-js");
+//import I18n from 'ex-react-native-i18n';
+
+export default I18n;

--- a/types/ex-react-native-i18n/tsconfig.json
+++ b/types/ex-react-native-i18n/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "ex-react-native-i18n-tests.ts"
+    ]
+}

--- a/types/ex-react-native-i18n/tslint.json
+++ b/types/ex-react-native-i18n/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
**Error**: https://github.com/xcarpentier/ex-react-native-i18n update to 0.0.4 only which

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.