### PR TITLE
[@types/d3-transition] Add a new type to d3-transition that represents either a selection or transition

### DIFF
--- a/types/d3-transition/index.d.ts
+++ b/types/d3-transition/index.d.ts
@@ -565,7 +565,7 @@ export interface Transition<GElement extends BaseType, Datum, PElement extends B
  * Represents the union of the Selection and Transition types for any usages that operate on both.
  * Typically used for functions which take in either a selection or transition and set or update attributes.
  */
-type SelectionOrTransition<GElement extends d3.BaseType, Datum, PElement extends d3.BaseType, PDatum> = d3.Selection<GElement, Datum, PElement, PDatum> | d3.Transition<GElement, Datum, PElement, PDatum>
+export type SelectionOrTransition<GElement extends BaseType, Datum, PElement extends BaseType, PDatum> = Selection<GElement, Datum, PElement, PDatum> | Transition<GElement, Datum, PElement, PDatum>;
 
 /**
  * Returns a new transition with the specified name. If a name is not specified, null is used.

--- a/types/d3-transition/index.d.ts
+++ b/types/d3-transition/index.d.ts
@@ -562,6 +562,12 @@ export interface Transition<GElement extends BaseType, Datum, PElement extends B
 }
 
 /**
+ * Represents the union of the Selection and Transition types for any usages that operate on both.
+ * Typically used for functions which take in either a selection or transition and set or update attributes.
+ */
+type SelectionOrTransition<GElement extends d3.BaseType, Datum, PElement extends d3.BaseType, PDatum> = d3.Selection<GElement, Datum, PElement, PDatum> | d3.Transition<GElement, Datum, PElement, PDatum>
+
+/**
  * Returns a new transition with the specified name. If a name is not specified, null is used.
  * The new transition is only exclusive with other transitions of the same name.
  *

--- a/types/d3-zoom/d3-zoom-tests.ts
+++ b/types/d3-zoom/d3-zoom-tests.ts
@@ -166,7 +166,7 @@ svgZoom = svgZoom.touchable(true);
 svgZoom = svgZoom.touchable(function(d, i, group) {
     const that: SVGRectElement = this;
     const datum: SVGDatum = d;
-    const g: SVGRectElement[] | NodeListOf<SVGRectElement> = group;
+    const g: SVGRectElement[] | ArrayLike<SVGRectElement> = group;
     return "ontouchstart" in this && datum.height > 0;
 });
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
`.

This change doesn't change any existing definitions, but provides a convenience type for what I think is a common use case.  We often need to update every part of a selection or transition, and we don't care which, since the only function we'll be using is `attr()`.  I was going to include this type in a local common definitions file, but thought it might usefully be added here.
