### PR TITLE
[jquery] Remove type parameter from `JQueryStatic`

### DIFF
--- a/types/jquery/index.d.ts
+++ b/types/jquery/index.d.ts
@@ -38,7 +38,7 @@ declare const $: JQueryStatic;
 // Used by JQuery.Event
 type _Event = Event;
 
-interface JQueryStatic<TElement = HTMLElement> {
+interface JQueryStatic {
     /**
      * @see \`{@link http://api.jquery.com/jquery.ajax/#jQuery-ajax1 }\`
      * @deprecated Use jQuery.ajaxSetup(options)
@@ -54,7 +54,7 @@ interface JQueryStatic<TElement = HTMLElement> {
      * @since 1.5
      */
     Deferred: JQuery.DeferredStatic;
-    Event: JQuery.EventStatic<TElement>;
+    Event: JQuery.EventStatic;
     /**
      * Hook directly into jQuery to override how particular CSS properties are retrieved or set, normalize
      * CSS property naming, or create custom properties.
@@ -62,7 +62,8 @@ interface JQueryStatic<TElement = HTMLElement> {
      * @see \`{@link https://api.jquery.com/jQuery.cssHooks/ }\`
      * @since 1.4.3
      */
-    cssHooks: JQuery.PlainObject<JQuery.CSSHook<TElement>>;
+    // Set to HTMLElement to minimize breaks but should probably be Element.
+    cssHooks: JQuery.PlainObject<JQuery.CSSHook<HTMLElement>>;
     /**
      * An object containing all CSS properties that may be used without a unit. The .css() method uses this
      * object to see if it may append px to unitless values.
@@ -71,7 +72,8 @@ interface JQueryStatic<TElement = HTMLElement> {
      * @since 1.4.3
      */
     cssNumber: JQuery.PlainObject<boolean>;
-    readonly fn: JQuery<TElement>;
+    // Set to HTMLElement to minimize breaks but should probably be Element.
+    readonly fn: JQuery<HTMLElement>;
     fx: {
         /**
          * The rate (in milliseconds) at which animations fire.
@@ -96,7 +98,7 @@ interface JQueryStatic<TElement = HTMLElement> {
      * @see \`{@link https://api.jquery.com/jQuery.ready/ }\`
      * @since 1.8
      */
-    ready: JQuery.Thenable<JQueryStatic<TElement>>;
+    ready: JQuery.Thenable<JQueryStatic>;
     /**
      * A collection of properties that represent the presence of different browser features or bugs.
      * Intended for jQuery's internal use; specific properties may be removed when they are no longer
@@ -109,7 +111,11 @@ interface JQueryStatic<TElement = HTMLElement> {
      * @deprecated 1.9
      */
     support: JQuery.PlainObject;
-    valHooks: JQuery.PlainObject<JQuery.ValHook<TElement>>;
+    // Set to HTMLElement to minimize breaks but should probably be Element.
+    valHooks: JQuery.PlainObject<JQuery.ValHook<HTMLElement>>;
+    // HACK: This is the factory function returned when importing jQuery without a DOM. Declaring it separately breaks using the type parameter on JQueryStatic.
+    // HACK: The discriminator parameter handles the edge case of passing a Window object to JQueryStatic. It doesn't actually exist on the factory function.
+    (window: Window, discriminator: boolean): JQueryStatic;
     /**
      * Creates DOM elements on the fly from the provided string of raw HTML.
      *
@@ -121,7 +127,7 @@ interface JQueryStatic<TElement = HTMLElement> {
      * @since 1.0
      * @since 1.4
      */
-    (html: JQuery.htmlString, ownerDocument_attributes: Document | JQuery.PlainObject): JQuery<TElement>;
+    <TElement extends HTMLElement = HTMLElement>(html: JQuery.htmlString, ownerDocument_attributes?: Document | JQuery.PlainObject): JQuery<TElement>;
     /**
      * Accepts a string containing a CSS selector which is then used to match a set of elements.
      *
@@ -130,10 +136,7 @@ interface JQueryStatic<TElement = HTMLElement> {
      * @see \`{@link https://api.jquery.com/jQuery/ }\`
      * @since 1.0
      */
-    (selector: JQuery.Selector, context: Element | Document | JQuery | undefined): JQuery<TElement>;
-    // HACK: This is the factory function returned when importing jQuery without a DOM. Declaring it separately breaks using the type parameter on JQueryStatic.
-    // HACK: The discriminator parameter handles the edge case of passing a Window object to JQueryStatic. It doesn't actually exist on the factory function.
-    <FElement extends Node = HTMLElement>(window: Window, discriminator: boolean): JQueryStatic<FElement>;
+    <TElement extends Element = HTMLElement>(selector: JQuery.Selector, context?: Element | Document | JQuery): JQuery<TElement>;
     /**
      * Return a collection of matched elements either found in the DOM based on passed argument(s) or created
      * by passing an HTML string.
@@ -154,19 +157,13 @@ interface JQueryStatic<TElement = HTMLElement> {
      */
     <T>(selection: JQuery<T>): JQuery<T>;
     /**
-     * Accepts a string containing a CSS selector which is then used to match a set of elements.
-     *
-     * Creates DOM elements on the fly from the provided string of raw HTML.
-     *
      * Binds a function to be executed when the DOM has finished loading.
      *
-     * @param selector_object_callback A string containing a selector expression
-     *                                 A string of HTML to create on the fly. Note that this parses HTML, not XML.
-     *                                 The function to execute when the DOM is ready.
+     * @param callback The function to execute when the DOM is ready.
      * @see \`{@link https://api.jquery.com/jQuery/ }\`
      * @since 1.0
      */
-    (selector_object_callback: JQuery.Selector | JQuery.htmlString | ((this: Document, $: JQueryStatic<TElement>) => void)): JQuery<TElement>; // tslint:disable-line:unified-signatures
+    <TElement = HTMLElement>(callback: ((this: Document, $: JQueryStatic) => void)): JQuery<TElement>; // tslint:disable-line:unified-signatures
     /**
      * Return a collection of matched elements either found in the DOM based on passed argument(s) or created by passing an HTML string.
      *
@@ -181,7 +178,7 @@ interface JQueryStatic<TElement = HTMLElement> {
      * @see {@link https://api.jquery.com/jQuery/}
      * @since 1.4
      */
-    (): JQuery<TElement>;
+    <TElement = HTMLElement>(): JQuery<TElement>;
     /**
      * A multi-purpose callbacks list object that provides a powerful way to manage callback lists.
      *
@@ -3000,7 +2997,7 @@ interface JQueryStatic<TElement = HTMLElement> {
      * @see \`{@link https://api.jquery.com/jQuery.speed/ }\`
      * @since 1.1
      */
-    speed(duration: JQuery.Duration, easing: string, complete: (this: TElement) => void): JQuery.EffectsOptions<TElement>;
+    speed<TElement extends Element = HTMLElement>(duration: JQuery.Duration, easing: string, complete: (this: TElement) => void): JQuery.EffectsOptions<TElement>;
     /**
      * Creates an object containing a set of properties ready to be used in the definition of custom animations.
      *
@@ -3011,8 +3008,8 @@ interface JQueryStatic<TElement = HTMLElement> {
      * @since 1.0
      * @since 1.1
      */
-    speed(duration: JQuery.Duration,
-          easing_complete: string | ((this: TElement) => void)): JQuery.EffectsOptions<TElement>;
+    speed<TElement extends Element = HTMLElement>(duration: JQuery.Duration,
+                                                  easing_complete: string | ((this: TElement) => void)): JQuery.EffectsOptions<TElement>;
     /**
      * Creates an object containing a set of properties ready to be used in the definition of custom animations.
      *
@@ -3022,7 +3019,7 @@ interface JQueryStatic<TElement = HTMLElement> {
      * @since 1.0
      * @since 1.1
      */
-    speed(duration_complete_settings?: JQuery.Duration | ((this: TElement) => void) | JQuery.SpeedSettings<TElement>): JQuery.EffectsOptions<TElement>;
+    speed<TElement extends Element = HTMLElement>(duration_complete_settings?: JQuery.Duration | ((this: TElement) => void) | JQuery.SpeedSettings<TElement>): JQuery.EffectsOptions<TElement>;
     /**
      * Remove the whitespace from the beginning and end of a string.
      *
@@ -5023,7 +5020,7 @@ interface JQuery<TElement = HTMLElement> extends Iterable<TElement> {
      * @since 1.0
      * @deprecated 3.0
      */
-    ready(handler: ($: JQueryStatic<TElement>) => void): this;
+    ready(handler: ($: JQueryStatic) => void): this;
     /**
      * Remove the set of matched elements from the DOM.
      *
@@ -7815,11 +7812,11 @@ declare namespace JQuery {
     // This should be a class but doesn't work correctly under the JQuery namespace. Event should be an inner class of jQuery.
 
     // Static members
-    interface EventStatic<TTarget = EventTarget> {
-        <T extends object>(event: string, properties?: T): JQuery.Event<TTarget> & T;
-        <T extends EventLike>(properties: T): JQuery.Event<TTarget> & T;
-        new <T extends object>(event: string, properties?: T): JQuery.Event<TTarget> & T;
-        new <T extends EventLike>(properties: T): JQuery.Event<TTarget> & T;
+    interface EventStatic {
+        <T extends object, TTarget extends EventTarget = HTMLElement>(event: string, properties?: T): JQuery.Event<TTarget> & T;
+        <T extends EventLike, TTarget extends EventTarget = HTMLElement>(properties: T): JQuery.Event<TTarget> & T;
+        new <T extends object, TTarget extends EventTarget = HTMLElement>(event: string, properties?: T): JQuery.Event<TTarget> & T;
+        new <T extends EventLike, TTarget extends EventTarget = HTMLElement>(properties: T): JQuery.Event<TTarget> & T;
     }
 
     // Instance members

--- a/types/jquery/index.d.ts
+++ b/types/jquery/index.d.ts
@@ -73,7 +73,7 @@ interface JQueryStatic {
      */
     cssNumber: JQuery.PlainObject<boolean>;
     // Set to HTMLElement to minimize breaks but should probably be Element.
-    readonly fn: JQuery<HTMLElement>;
+    readonly fn: JQuery;
     fx: {
         /**
          * The rate (in milliseconds) at which animations fire.
@@ -127,6 +127,7 @@ interface JQueryStatic {
      * @since 1.0
      * @since 1.4
      */
+    // tslint:disable-next-line:no-unnecessary-generics
     <TElement extends HTMLElement = HTMLElement>(html: JQuery.htmlString, ownerDocument_attributes?: Document | JQuery.PlainObject): JQuery<TElement>;
     /**
      * Accepts a string containing a CSS selector which is then used to match a set of elements.
@@ -136,6 +137,7 @@ interface JQueryStatic {
      * @see \`{@link https://api.jquery.com/jQuery/ }\`
      * @since 1.0
      */
+    // tslint:disable-next-line:no-unnecessary-generics
     <TElement extends Element = HTMLElement>(selector: JQuery.Selector, context?: Element | Document | JQuery): JQuery<TElement>;
     /**
      * Return a collection of matched elements either found in the DOM based on passed argument(s) or created
@@ -143,7 +145,7 @@ interface JQueryStatic {
      *
      * @param element_elementArray A DOM element to wrap in a jQuery object.
      *                             An array containing a set of DOM elements to wrap in a jQuery object.
-     * @see {@link https://api.jquery.com/jQuery/}
+     * @see \`{@link https://api.jquery.com/jQuery/ }\`
      * @since 1.0
      */
     <T extends Element>(element_elementArray: T | ArrayLike<T>): JQuery<T>;
@@ -152,7 +154,7 @@ interface JQueryStatic {
      * by passing an HTML string.
      *
      * @param selection An existing jQuery object to clone.
-     * @see {@link https://api.jquery.com/jQuery/}
+     * @see \`{@link https://api.jquery.com/jQuery/ }\`
      * @since 1.0
      */
     <T>(selection: JQuery<T>): JQuery<T>;
@@ -163,21 +165,23 @@ interface JQueryStatic {
      * @see \`{@link https://api.jquery.com/jQuery/ }\`
      * @since 1.0
      */
-    <TElement = HTMLElement>(callback: ((this: Document, $: JQueryStatic) => void)): JQuery<TElement>; // tslint:disable-line:unified-signatures
+    // tslint:disable-next-line:no-unnecessary-generics unified-signatures
+    <TElement = HTMLElement>(callback: ((this: Document, $: JQueryStatic) => void)): JQuery<TElement>;
     /**
      * Return a collection of matched elements either found in the DOM based on passed argument(s) or created by passing an HTML string.
      *
      * @param object A plain object to wrap in a jQuery object.
-     * @see {@link https://api.jquery.com/jQuery/}
+     * @see \`{@link https://api.jquery.com/jQuery/ }\`
      * @since 1.0
      */
     <T extends JQuery.PlainObject>(object: T): JQuery<T>;
     /**
      * Returns an empty jQuery set.
      *
-     * @see {@link https://api.jquery.com/jQuery/}
+     * @see \`{@link https://api.jquery.com/jQuery/ }\`
      * @since 1.4
      */
+    // tslint:disable-next-line:no-unnecessary-generics
     <TElement = HTMLElement>(): JQuery<TElement>;
     /**
      * A multi-purpose callbacks list object that provides a powerful way to manage callback lists.
@@ -186,6 +190,7 @@ interface JQueryStatic {
      * @see \`{@link https://api.jquery.com/jQuery.Callbacks/ }\`
      * @since 1.7
      */
+    // tslint:disable-next-line:ban-types no-unnecessary-generics
     Callbacks<T extends Function>(flags?: string): JQuery.Callbacks<T>;
     /**
      * Perform an asynchronous HTTP (Ajax) request.
@@ -631,6 +636,7 @@ interface JQueryStatic {
      * @since 1.2
      * @deprecated 3.3
      */
+    // tslint:disable-next-line:ban-types
     isFunction(obj: any): obj is Function;
     /**
      * Determines whether its argument represents a JavaScript number.
@@ -3065,10 +3071,10 @@ interface JQueryStatic {
      * @since 1.5
      */
     when<TR1, UR1, VR1,
-        TJ1 = any, UJ1 = any, VJ1 = any>
-        (deferredT: JQuery.Promise<TR1, TJ1, any> | JQuery.Thenable<TR1> | TR1,
-         deferredU: JQuery.Promise<UR1, UJ1, any> | JQuery.Thenable<UR1> | UR1,
-         deferredV: JQuery.Promise<VR1, VJ1, any> | JQuery.Thenable<VR1> | VR1): JQuery.Promise3<TR1, TJ1, never,
+        TJ1 = any, UJ1 = any, VJ1 = any>(
+            deferredT: JQuery.Promise<TR1, TJ1, any> | JQuery.Thenable<TR1> | TR1, // tslint:disable-line:use-default-type-parameter
+            deferredU: JQuery.Promise<UR1, UJ1, any> | JQuery.Thenable<UR1> | UR1, // tslint:disable-line:use-default-type-parameter
+            deferredV: JQuery.Promise<VR1, VJ1, any> | JQuery.Thenable<VR1> | VR1): JQuery.Promise3<TR1, TJ1, never,  // tslint:disable-line:use-default-type-parameter
         UR1, UJ1, never,
         VR1, VJ1, never>;
     /**
@@ -3079,9 +3085,9 @@ interface JQueryStatic {
      * @since 1.5
      */
     when<TR1, UR1,
-        TJ1 = any, UJ1 = any>
-        (deferredT: JQuery.Promise<TR1, TJ1, any> | JQuery.Thenable<TR1> | TR1,
-         deferredU: JQuery.Promise<UR1, UJ1, any> | JQuery.Thenable<UR1> | UR1): JQuery.Promise2<TR1, TJ1, never,
+        TJ1 = any, UJ1 = any>(
+            deferredT: JQuery.Promise<TR1, TJ1, any> | JQuery.Thenable<TR1> | TR1, // tslint:disable-line:use-default-type-parameter
+            deferredU: JQuery.Promise<UR1, UJ1, any> | JQuery.Thenable<UR1> | UR1): JQuery.Promise2<TR1, TJ1, never, // tslint:disable-line:use-default-type-parameter
         UR1, UJ1, never>;
     /**
      * Provides a way to execute callback functions based on zero or more Thenable objects, usually
@@ -3092,9 +3098,9 @@ interface JQueryStatic {
      */
     when<TR1, TJ1,
         TR2, TJ2,
-        TR3 = never, TJ3 = never>
-        (deferredT: JQuery.Promise3<TR1, TJ1, any, TR2, TJ2, any, TR3, TJ3, any> |
-            JQuery.Promise2<TR1, TJ1, any, TR2, TJ2, any>): JQuery.Promise3<TR1, TJ1, never, TR2, TJ2, never, TR3, TJ3, never>;
+        TR3 = never, TJ3 = never>(
+            deferredT: JQuery.Promise3<TR1, TJ1, any, TR2, TJ2, any, TR3, TJ3, any> |
+                       JQuery.Promise2<TR1, TJ1, any, TR2, TJ2, any>): JQuery.Promise3<TR1, TJ1, never, TR2, TJ2, never, TR3, TJ3, never>;
     /**
      * Provides a way to execute callback functions based on zero or more Thenable objects, usually
      * Deferred objects that represent asynchronous events.
@@ -3102,7 +3108,7 @@ interface JQueryStatic {
      * @see \`{@link https://api.jquery.com/jQuery.when/ }\`
      * @since 1.5
      */
-    when<TR1, TJ1 = any>(deferred: JQuery.Promise<TR1, TJ1, any> | JQuery.Thenable<TR1> | TR1): JQuery.Promise<TR1, TJ1, never>;
+    when<TR1, TJ1 = any>(deferred: JQuery.Promise<TR1, TJ1, any> | JQuery.Thenable<TR1> | TR1): JQuery.Promise<TR1, TJ1, never>; // tslint:disable-line:use-default-type-parameter
     /**
      * Provides a way to execute callback functions based on zero or more Thenable objects, usually
      * Deferred objects that represent asynchronous events.
@@ -3111,7 +3117,7 @@ interface JQueryStatic {
      * @see \`{@link https://api.jquery.com/jQuery.when/ }\`
      * @since 1.5
      */
-    when<TR1 = never, TJ1 = never>(...deferreds: Array<JQuery.Promise<TR1, TJ1, any> | JQuery.Thenable<TR1> | TR1>): JQuery.Promise<TR1, TJ1, never>;
+    when<TR1 = never, TJ1 = never>(...deferreds: Array<JQuery.Promise<TR1, TJ1, any> | JQuery.Thenable<TR1> | TR1>): JQuery.Promise<TR1, TJ1, never>; // tslint:disable-line:use-default-type-parameter
     /**
      * Provides a way to execute callback functions based on zero or more Thenable objects, usually
      * Deferred objects that represent asynchronous events.
@@ -4076,6 +4082,7 @@ interface JQuery<TElement = HTMLElement> extends Iterable<TElement> {
      * @since 1.4
      */
     // HACK: The type parameter T is not used but ensures the 'event' callback parameter is typed correctly.
+    // tslint:disable-next-line:no-unnecessary-generics
     hover<T>(handlerInOut: JQuery.EventHandler<TElement> | JQuery.EventHandlerBase<any, JQuery.Event<TElement>> | false,
              handlerOut?: JQuery.EventHandler<TElement> | JQuery.EventHandlerBase<any, JQuery.Event<TElement>> | false): this;
     /**
@@ -4553,10 +4560,10 @@ interface JQuery<TElement = HTMLElement> extends Iterable<TElement> {
      * @see \`{@link https://api.jquery.com/on/ }\`
      * @since 1.7
      */
-    on<TData>(events: string,
-        selector: JQuery.Selector | null,
-        data: TData,
-        handler: ((event: JQueryEventObject) => void)): this; // tslint:disable-line:unified-signatures
+    on(events: string,
+       selector: JQuery.Selector | null,
+       data: any,
+       handler: ((event: JQueryEventObject) => void)): this; // tslint:disable-line:unified-signatures
     /**
      * Attach an event handler function for one or more events to the selected elements.
      *
@@ -4582,8 +4589,8 @@ interface JQuery<TElement = HTMLElement> extends Iterable<TElement> {
      * @since 1.7
      */
     on(events: string,
-        selector: JQuery.Selector,
-        handler: ((event: JQueryEventObject) => void)): this; // tslint:disable-line:unified-signatures
+       selector: JQuery.Selector,
+       handler: ((event: JQueryEventObject) => void)): this; // tslint:disable-line:unified-signatures
     /**
      * Attach an event handler function for one or more events to the selected elements.
      *
@@ -4605,9 +4612,9 @@ interface JQuery<TElement = HTMLElement> extends Iterable<TElement> {
      * @see \`{@link https://api.jquery.com/on/ }\`
      * @since 1.7
      */
-    on<TData>(events: string,
-        data: TData,
-        handler: ((event: JQueryEventObject) => void)): this; // tslint:disable-line:unified-signatures
+    on(events: string,
+       data: any, // tslint:disable-line:unified-signatures
+       handler: ((event: JQueryEventObject) => void)): this;
     /**
      * Attach an event handler function for one or more events to the selected elements.
      *
@@ -4628,7 +4635,7 @@ interface JQuery<TElement = HTMLElement> extends Iterable<TElement> {
      * @since 1.7
      */
     on(events: string,
-        handler: ((event: JQueryEventObject) => void)): this; // tslint:disable-line:unified-signatures
+       handler: ((event: JQueryEventObject) => void)): this; // tslint:disable-line:unified-signatures
     /**
      * Attach an event handler function for one or more events to the selected elements.
      *
@@ -5636,6 +5643,7 @@ interface JQuery<TElement = HTMLElement> extends Iterable<TElement> {
 }
 
 // ES5 compatibility
+// tslint:disable-next-line:no-empty-interface
 interface Iterable<T> { }
 
 declare namespace JQuery {
@@ -5704,7 +5712,7 @@ declare namespace JQuery {
         type TextStatus = SuccessTextStatus | ErrorTextStatus;
 
         interface SuccessCallback<TContext> {
-            (this: TContext, data: any, textStatus: SuccessTextStatus, jqXHR: JQuery.jqXHR): void;
+            (this: TContext, data: any, textStatus: SuccessTextStatus, jqXHR: jqXHR): void;
         }
 
         interface ErrorCallback<TContext> {
@@ -5755,7 +5763,7 @@ declare namespace JQuery {
              * "timeout", "abort", or "parsererror"). As of jQuery 1.5, the complete setting can accept an array of
              * functions. Each function will be called in turn. This is an Ajax Event.
              */
-            complete?: TypeOrArray<Ajax.CompleteCallback<TContext>>;
+            complete?: TypeOrArray<CompleteCallback<TContext>>;
             /**
              * An object of string/regular-expression pairs that determine how jQuery will parse the response,
              * given its content type.
@@ -5844,7 +5852,7 @@ declare namespace JQuery {
              * 1.5, the error setting can accept an array of functions. Each function will be called in turn. Note:
              * This handler is not called for cross-domain script and cross-domain JSONP requests. This is an Ajax Event.
              */
-            error?: TypeOrArray<Ajax.ErrorCallback<TContext>>;
+            error?: TypeOrArray<ErrorCallback<TContext>>;
             /**
              * Whether to trigger global Ajax event handlers for this request. The default is true. Set to false to
              * prevent the global handlers like ajaxStart or ajaxStop from being triggered. This can be used to
@@ -5930,7 +5938,7 @@ declare namespace JQuery {
              * XMLHttpRequest) object. As of jQuery 1.5, the success setting can accept an array of functions. Each
              * function will be called in turn. This is an Ajax Event.
              */
-            success?: TypeOrArray<Ajax.SuccessCallback<TContext>>;
+            success?: TypeOrArray<SuccessCallback<TContext>>;
             /**
              * Set a timeout (in milliseconds) for the request. A value of 0 means there will be no timeout. This
              * will override any global timeout set with $.ajaxSetup(). The timeout period starts at the point the
@@ -6446,6 +6454,7 @@ declare namespace JQuery {
 
     // region Callbacks
 
+    // tslint:disable-next-line:ban-types
     interface Callbacks<T extends Function = Function> {
         /**
          * Add a callback or a collection of callbacks to a callback list.
@@ -6565,13 +6574,13 @@ declare namespace JQuery {
          * @returns A Promise for the completion of which ever callback is executed.
          */
         then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | null,
-                                             onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | null): JQuery._Promise<TResult1 | TResult2>;
+                                             onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | null): _Promise<TResult1 | TResult2>;
         /**
          * Attaches a callback for only the rejection of the Promise.
          * @param onrejected The callback to execute when the Promise is rejected.
          * @returns A Promise for the completion of the callback.
          */
-        catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | null): JQuery._Promise<T | TResult>;
+        catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | null): _Promise<T | TResult>;
     }
 
     // Type parameter guide
@@ -6599,7 +6608,7 @@ declare namespace JQuery {
     interface PromiseBase<TR, TJ, TN,
         UR, UJ, UN,
         VR, VJ, VN,
-        SR, SJ, SN> extends JQuery._Promise<TR>, PromiseLike<TR> {
+        SR, SJ, SN> extends _Promise<TR>, PromiseLike<TR> {
         /**
          * Add handlers to be called when the Deferred object is either resolved or rejected.
          *
@@ -6688,19 +6697,19 @@ declare namespace JQuery {
             ARP = never, AJP = never, ANP = never,
             BRP = never, BJP = never, BNP = never,
             CRP = never, CJP = never, CNP = never,
-            RRP = never, RJP = never, RNP = never>
-            (doneFilter: (t: TR, u: UR, v: VR, ...s: SR[]) => PromiseBase<ARD, AJD, AND,
-                 BRD, BJD, BND,
-                 CRD, CJD, CND,
-                 RRD, RJD, RND> | Thenable<ARD> | ARD,
-             failFilter: (t: TJ, u: UJ, v: VJ, ...s: SJ[]) => PromiseBase<ARF, AJF, ANF,
-                 BRF, BJF, BNF,
-                 CRF, CJF, CNF,
-                 RRF, RJF, RNF> | Thenable<AJF> | AJF,
-             progressFilter: (t: TN, u: UN, v: VN, ...s: SN[]) => PromiseBase<ARP, AJP, ANP,
-                 BRP, BJP, BNP,
-                 CRP, CJP, CNP,
-                 RRP, RJP, RNP> | Thenable<ANP> | ANP): PromiseBase<ARD | ARF | ARP, AJD | AJF | AJP, AND | ANF | ANP,
+            RRP = never, RJP = never, RNP = never>(
+                doneFilter: (t: TR, u: UR, v: VR, ...s: SR[]) => PromiseBase<ARD, AJD, AND,
+                    BRD, BJD, BND,
+                    CRD, CJD, CND,
+                    RRD, RJD, RND> | Thenable<ARD> | ARD,
+                failFilter: (t: TJ, u: UJ, v: VJ, ...s: SJ[]) => PromiseBase<ARF, AJF, ANF,
+                    BRF, BJF, BNF,
+                    CRF, CJF, CNF,
+                    RRF, RJF, RNF> | Thenable<AJF> | AJF,
+                progressFilter: (t: TN, u: UN, v: VN, ...s: SN[]) => PromiseBase<ARP, AJP, ANP,
+                    BRP, BJP, BNP,
+                    CRP, CJP, CNP,
+                    RRP, RJP, RNP> | Thenable<ANP> | ANP): PromiseBase<ARD | ARF | ARP, AJD | AJF | AJP, AND | ANF | ANP,
             BRD | BRF | BRP, BJD | BJF | BJP, BND | BNF | BNP,
             CRD | CRF | CRP, CJD | CJF | CJP, CND | CNF | CNP,
             RRD | RRF | RRP, RJD | RJF | RJP, RND | RNF | RNP>;
@@ -6722,16 +6731,16 @@ declare namespace JQuery {
             ARP = never, AJP = never, ANP = never,
             BRP = never, BJP = never, BNP = never,
             CRP = never, CJP = never, CNP = never,
-            RRP = never, RJP = never, RNP = never>
-            (doneFilter: null,
-             failFilter: (t: TJ, u: UJ, v: VJ, ...s: SJ[]) => PromiseBase<ARF, AJF, ANF,
-                 BRF, BJF, BNF,
-                 CRF, CJF, CNF,
-                 RRF, RJF, RNF> | Thenable<AJF> | AJF,
-             progressFilter: (t: TN, u: UN, v: VN, ...s: SN[]) => PromiseBase<ARP, AJP, ANP,
-                 BRP, BJP, BNP,
-                 CRP, CJP, CNP,
-                 RRP, RJP, RNP> | Thenable<ANP> | ANP): PromiseBase<ARF | ARP, AJF | AJP, ANF | ANP,
+            RRP = never, RJP = never, RNP = never>(
+                doneFilter: null,
+                failFilter: (t: TJ, u: UJ, v: VJ, ...s: SJ[]) => PromiseBase<ARF, AJF, ANF,
+                    BRF, BJF, BNF,
+                    CRF, CJF, CNF,
+                    RRF, RJF, RNF> | Thenable<AJF> | AJF,
+                progressFilter: (t: TN, u: UN, v: VN, ...s: SN[]) => PromiseBase<ARP, AJP, ANP,
+                    BRP, BJP, BNP,
+                    CRP, CJP, CNP,
+                    RRP, RJP, RNP> | Thenable<ANP> | ANP): PromiseBase<ARF | ARP, AJF | AJP, ANF | ANP,
             BRF | BRP, BJF | BJP, BNF | BNP,
             CRF | CRP, CJF | CJP, CNF | CNP,
             RRF | RRP, RJF | RJP, RNF | RNP>;
@@ -6753,16 +6762,16 @@ declare namespace JQuery {
             ARP = never, AJP = never, ANP = never,
             BRP = never, BJP = never, BNP = never,
             CRP = never, CJP = never, CNP = never,
-            RRP = never, RJP = never, RNP = never>
-            (doneFilter: (t: TR, u: UR, v: VR, ...s: SR[]) => PromiseBase<ARD, AJD, AND,
-                 BRD, BJD, BND,
-                 CRD, CJD, CND,
-                 RRD, RJD, RND> | Thenable<ARD> | ARD,
-             failFilter: null,
-             progressFilter: (t: TN, u: UN, v: VN, ...s: SN[]) => PromiseBase<ARP, AJP, ANP,
-                 BRP, BJP, BNP,
-                 CRP, CJP, CNP,
-                 RRP, RJP, RNP> | Thenable<ANP> | ANP): PromiseBase<ARD | ARP, AJD | AJP, AND | ANP,
+            RRP = never, RJP = never, RNP = never>(
+                doneFilter: (t: TR, u: UR, v: VR, ...s: SR[]) => PromiseBase<ARD, AJD, AND,
+                    BRD, BJD, BND,
+                    CRD, CJD, CND,
+                    RRD, RJD, RND> | Thenable<ARD> | ARD,
+                failFilter: null,
+                progressFilter: (t: TN, u: UN, v: VN, ...s: SN[]) => PromiseBase<ARP, AJP, ANP,
+                    BRP, BJP, BNP,
+                    CRP, CJP, CNP,
+                    RRP, RJP, RNP> | Thenable<ANP> | ANP): PromiseBase<ARD | ARP, AJD | AJP, AND | ANP,
             BRD | BRP, BJD | BJP, BND | BNP,
             CRD | CRP, CJD | CJP, CND | CNP,
             RRD | RRP, RJD | RJP, RND | RNP>;
@@ -6780,13 +6789,13 @@ declare namespace JQuery {
         pipe<ARP = never, AJP = never, ANP = never,
             BRP = never, BJP = never, BNP = never,
             CRP = never, CJP = never, CNP = never,
-            RRP = never, RJP = never, RNP = never>
-            (doneFilter: null,
-             failFilter: null,
-             progressFilter?: (t: TN, u: UN, v: VN, ...s: SN[]) => PromiseBase<ARP, AJP, ANP,
-                 BRP, BJP, BNP,
-                 CRP, CJP, CNP,
-                 RRP, RJP, RNP> | Thenable<ANP> | ANP): PromiseBase<ARP, AJP, ANP,
+            RRP = never, RJP = never, RNP = never>(
+                doneFilter: null,
+                failFilter: null,
+                progressFilter?: (t: TN, u: UN, v: VN, ...s: SN[]) => PromiseBase<ARP, AJP, ANP,
+                    BRP, BJP, BNP,
+                    CRP, CJP, CNP,
+                    RRP, RJP, RNP> | Thenable<ANP> | ANP): PromiseBase<ARP, AJP, ANP,
             BRP, BJP, BNP,
             CRP, CJP, CNP,
             RRP, RJP, RNP>;
@@ -6808,16 +6817,16 @@ declare namespace JQuery {
             ARF = never, AJF = never, ANF = never,
             BRF = never, BJF = never, BNF = never,
             CRF = never, CJF = never, CNF = never,
-            RRF = never, RJF = never, RNF = never>
-            (doneFilter: (t: TR, u: UR, v: VR, ...s: SR[]) => PromiseBase<ARD, AJD, AND,
-                 BRD, BJD, BND,
-                 CRD, CJD, CND,
-                 RRD, RJD, RND> | Thenable<ARD> | ARD,
-             failFilter: (t: TJ, u: UJ, v: VJ, ...s: SJ[]) => PromiseBase<ARF, AJF, ANF,
-                 BRF, BJF, BNF,
-                 CRF, CJF, CNF,
-                 RRF, RJF, RNF> | Thenable<AJF> | AJF,
-             progressFilter?: null): PromiseBase<ARD | ARF, AJD | AJF, AND | ANF,
+            RRF = never, RJF = never, RNF = never>(
+                doneFilter: (t: TR, u: UR, v: VR, ...s: SR[]) => PromiseBase<ARD, AJD, AND,
+                    BRD, BJD, BND,
+                    CRD, CJD, CND,
+                    RRD, RJD, RND> | Thenable<ARD> | ARD,
+                failFilter: (t: TJ, u: UJ, v: VJ, ...s: SJ[]) => PromiseBase<ARF, AJF, ANF,
+                    BRF, BJF, BNF,
+                    CRF, CJF, CNF,
+                    RRF, RJF, RNF> | Thenable<AJF> | AJF,
+                progressFilter?: null): PromiseBase<ARD | ARF, AJD | AJF, AND | ANF,
             BRD | BRF, BJD | BJF, BND | BNF,
             CRD | CRF, CJD | CJF, CND | CNF,
             RRD | RRF, RJD | RJF, RND | RNF>;
@@ -6835,13 +6844,13 @@ declare namespace JQuery {
         pipe<ARF = never, AJF = never, ANF = never,
             BRF = never, BJF = never, BNF = never,
             CRF = never, CJF = never, CNF = never,
-            RRF = never, RJF = never, RNF = never>
-            (doneFilter: null,
-             failFilter: (t: TJ, u: UJ, v: VJ, ...s: SJ[]) => PromiseBase<ARF, AJF, ANF,
-                 BRF, BJF, BNF,
-                 CRF, CJF, CNF,
-                 RRF, RJF, RNF> | Thenable<AJF> | AJF,
-             progressFilter?: null): PromiseBase<ARF, AJF, ANF,
+            RRF = never, RJF = never, RNF = never>(
+                doneFilter: null,
+                failFilter: (t: TJ, u: UJ, v: VJ, ...s: SJ[]) => PromiseBase<ARF, AJF, ANF,
+                    BRF, BJF, BNF,
+                    CRF, CJF, CNF,
+                    RRF, RJF, RNF> | Thenable<AJF> | AJF,
+                progressFilter?: null): PromiseBase<ARF, AJF, ANF,
             BRF, BJF, BNF,
             CRF, CJF, CNF,
             RRF, RJF, RNF>;
@@ -6859,13 +6868,13 @@ declare namespace JQuery {
         pipe<ARD = never, AJD = never, AND = never,
             BRD = never, BJD = never, BND = never,
             CRD = never, CJD = never, CND = never,
-            RRD = never, RJD = never, RND = never>
-            (doneFilter: (t: TR, u: UR, v: VR, ...s: SR[]) => PromiseBase<ARD, AJD, AND,
-                 BRD, BJD, BND,
-                 CRD, CJD, CND,
-                 RRD, RJD, RND> | Thenable<ARD> | ARD,
-             failFilter?: null,
-             progressFilter?: null): PromiseBase<ARD, AJD, AND,
+            RRD = never, RJD = never, RND = never>(
+                doneFilter: (t: TR, u: UR, v: VR, ...s: SR[]) => PromiseBase<ARD, AJD, AND,
+                    BRD, BJD, BND,
+                    CRD, CJD, CND,
+                    RRD, RJD, RND> | Thenable<ARD> | ARD,
+                failFilter?: null,
+                progressFilter?: null): PromiseBase<ARD, AJD, AND,
             BRD, BJD, BND,
             CRD, CJD, CND,
             RRD, RJD, RND>;
@@ -6894,19 +6903,19 @@ declare namespace JQuery {
             ARP = never, AJP = never, ANP = never,
             BRP = never, BJP = never, BNP = never,
             CRP = never, CJP = never, CNP = never,
-            RRP = never, RJP = never, RNP = never>
-            (doneFilter: (t: TR, u: UR, v: VR, ...s: SR[]) => PromiseBase<ARD, AJD, AND,
-                 BRD, BJD, BND,
-                 CRD, CJD, CND,
-                 RRD, RJD, RND> | Thenable<ARD> | ARD,
-             failFilter: (t: TJ, u: UJ, v: VJ, ...s: SJ[]) => PromiseBase<ARF, AJF, ANF,
-                 BRF, BJF, BNF,
-                 CRF, CJF, CNF,
-                 RRF, RJF, RNF> | Thenable<ARF> | ARF,
-             progressFilter: (t: TN, u: UN, v: VN, ...s: SN[]) => PromiseBase<ARP, AJP, ANP,
-                 BRP, BJP, BNP,
-                 CRP, CJP, CNP,
-                 RRP, RJP, RNP> | Thenable<ANP> | ANP): PromiseBase<ARD | ARF | ARP, AJD | AJF | AJP, AND | ANF | ANP,
+            RRP = never, RJP = never, RNP = never>(
+                doneFilter: (t: TR, u: UR, v: VR, ...s: SR[]) => PromiseBase<ARD, AJD, AND,
+                    BRD, BJD, BND,
+                    CRD, CJD, CND,
+                    RRD, RJD, RND> | Thenable<ARD> | ARD,
+                failFilter: (t: TJ, u: UJ, v: VJ, ...s: SJ[]) => PromiseBase<ARF, AJF, ANF,
+                    BRF, BJF, BNF,
+                    CRF, CJF, CNF,
+                    RRF, RJF, RNF> | Thenable<ARF> | ARF,
+                progressFilter: (t: TN, u: UN, v: VN, ...s: SN[]) => PromiseBase<ARP, AJP, ANP,
+                    BRP, BJP, BNP,
+                    CRP, CJP, CNP,
+                    RRP, RJP, RNP> | Thenable<ANP> | ANP): PromiseBase<ARD | ARF | ARP, AJD | AJF | AJP, AND | ANF | ANP,
             BRD | BRF | BRP, BJD | BJF | BJP, BND | BNF | BNP,
             CRD | CRF | CRP, CJD | CJF | CJP, CND | CNF | CNP,
             RRD | RRF | RRP, RJD | RJF | RJP, RND | RNF | RNP>;
@@ -6926,16 +6935,16 @@ declare namespace JQuery {
             ARP = never, AJP = never, ANP = never,
             BRP = never, BJP = never, BNP = never,
             CRP = never, CJP = never, CNP = never,
-            RRP = never, RJP = never, RNP = never>
-            (doneFilter: null,
-             failFilter: (t: TJ, u: UJ, v: VJ, ...s: SJ[]) => PromiseBase<ARF, AJF, ANF,
-                 BRF, BJF, BNF,
-                 CRF, CJF, CNF,
-                 RRF, RJF, RNF> | Thenable<ARF> | ARF,
-             progressFilter: (t: TN, u: UN, v: VN, ...s: SN[]) => PromiseBase<ARP, AJP, ANP,
-                 BRP, BJP, BNP,
-                 CRP, CJP, CNP,
-                 RRP, RJP, RNP> | Thenable<ANP> | ANP): PromiseBase<ARF | ARP, AJF | AJP, ANF | ANP,
+            RRP = never, RJP = never, RNP = never>(
+                doneFilter: null,
+                failFilter: (t: TJ, u: UJ, v: VJ, ...s: SJ[]) => PromiseBase<ARF, AJF, ANF,
+                    BRF, BJF, BNF,
+                    CRF, CJF, CNF,
+                    RRF, RJF, RNF> | Thenable<ARF> | ARF,
+                progressFilter: (t: TN, u: UN, v: VN, ...s: SN[]) => PromiseBase<ARP, AJP, ANP,
+                    BRP, BJP, BNP,
+                    CRP, CJP, CNP,
+                    RRP, RJP, RNP> | Thenable<ANP> | ANP): PromiseBase<ARF | ARP, AJF | AJP, ANF | ANP,
             BRF | BRP, BJF | BJP, BNF | BNP,
             CRF | CRP, CJF | CJP, CNF | CNP,
             RRF | RRP, RJF | RJP, RNF | RNP>;
@@ -6955,16 +6964,16 @@ declare namespace JQuery {
             ARP = never, AJP = never, ANP = never,
             BRP = never, BJP = never, BNP = never,
             CRP = never, CJP = never, CNP = never,
-            RRP = never, RJP = never, RNP = never>
-            (doneFilter: (t: TR, u: UR, v: VR, ...s: SR[]) => PromiseBase<ARD, AJD, AND,
-                 BRD, BJD, BND,
-                 CRD, CJD, CND,
-                 RRD, RJD, RND> | Thenable<ARD> | ARD,
-             failFilter: null,
-             progressFilter: (t: TN, u: UN, v: VN, ...s: SN[]) => PromiseBase<ARP, AJP, ANP,
-                 BRP, BJP, BNP,
-                 CRP, CJP, CNP,
-                 RRP, RJP, RNP> | Thenable<ANP> | ANP): PromiseBase<ARD | ARP, AJD | AJP, AND | ANP,
+            RRP = never, RJP = never, RNP = never>(
+                doneFilter: (t: TR, u: UR, v: VR, ...s: SR[]) => PromiseBase<ARD, AJD, AND,
+                    BRD, BJD, BND,
+                    CRD, CJD, CND,
+                    RRD, RJD, RND> | Thenable<ARD> | ARD,
+                failFilter: null,
+                progressFilter: (t: TN, u: UN, v: VN, ...s: SN[]) => PromiseBase<ARP, AJP, ANP,
+                    BRP, BJP, BNP,
+                    CRP, CJP, CNP,
+                    RRP, RJP, RNP> | Thenable<ANP> | ANP): PromiseBase<ARD | ARP, AJD | AJP, AND | ANP,
             BRD | BRP, BJD | BJP, BND | BNP,
             CRD | CRP, CJD | CJP, CND | CNP,
             RRD | RRP, RJD | RJP, RND | RNP>;
@@ -6980,13 +6989,13 @@ declare namespace JQuery {
         then<ARP = never, AJP = never, ANP = never,
             BRP = never, BJP = never, BNP = never,
             CRP = never, CJP = never, CNP = never,
-            RRP = never, RJP = never, RNP = never>
-            (doneFilter: null,
-             failFilter: null,
-             progressFilter?: (t: TN, u: UN, v: VN, ...s: SN[]) => PromiseBase<ARP, AJP, ANP,
-                 BRP, BJP, BNP,
-                 CRP, CJP, CNP,
-                 RRP, RJP, RNP> | Thenable<ANP> | ANP): PromiseBase<ARP, AJP, ANP,
+            RRP = never, RJP = never, RNP = never>(
+                doneFilter: null,
+                failFilter: null,
+                progressFilter?: (t: TN, u: UN, v: VN, ...s: SN[]) => PromiseBase<ARP, AJP, ANP,
+                    BRP, BJP, BNP,
+                    CRP, CJP, CNP,
+                    RRP, RJP, RNP> | Thenable<ANP> | ANP): PromiseBase<ARP, AJP, ANP,
             BRP, BJP, BNP,
             CRP, CJP, CNP,
             RRP, RJP, RNP>;
@@ -7006,16 +7015,16 @@ declare namespace JQuery {
             ARF = never, AJF = never, ANF = never,
             BRF = never, BJF = never, BNF = never,
             CRF = never, CJF = never, CNF = never,
-            RRF = never, RJF = never, RNF = never>
-            (doneFilter: (t: TR, u: UR, v: VR, ...s: SR[]) => PromiseBase<ARD, AJD, AND,
-                 BRD, BJD, BND,
-                 CRD, CJD, CND,
-                 RRD, RJD, RND> | Thenable<ARD> | ARD,
-             failFilter: (t: TJ, u: UJ, v: VJ, ...s: SJ[]) => PromiseBase<ARF, AJF, ANF,
-                 BRF, BJF, BNF,
-                 CRF, CJF, CNF,
-                 RRF, RJF, RNF> | Thenable<ARF> | ARF,
-             progressFilter?: null): PromiseBase<ARD | ARF, AJD | AJF, AND | ANF,
+            RRF = never, RJF = never, RNF = never>(
+                doneFilter: (t: TR, u: UR, v: VR, ...s: SR[]) => PromiseBase<ARD, AJD, AND,
+                    BRD, BJD, BND,
+                    CRD, CJD, CND,
+                    RRD, RJD, RND> | Thenable<ARD> | ARD,
+                failFilter: (t: TJ, u: UJ, v: VJ, ...s: SJ[]) => PromiseBase<ARF, AJF, ANF,
+                    BRF, BJF, BNF,
+                    CRF, CJF, CNF,
+                    RRF, RJF, RNF> | Thenable<ARF> | ARF,
+                progressFilter?: null): PromiseBase<ARD | ARF, AJD | AJF, AND | ANF,
             BRD | BRF, BJD | BJF, BND | BNF,
             CRD | CRF, CJD | CJF, CND | CNF,
             RRD | RRF, RJD | RJF, RND | RNF>;
@@ -7031,13 +7040,13 @@ declare namespace JQuery {
         then<ARF = never, AJF = never, ANF = never,
             BRF = never, BJF = never, BNF = never,
             CRF = never, CJF = never, CNF = never,
-            RRF = never, RJF = never, RNF = never>
-            (doneFilter: null,
-             failFilter: (t: TJ, u: UJ, v: VJ, ...s: SJ[]) => PromiseBase<ARF, AJF, ANF,
-                 BRF, BJF, BNF,
-                 CRF, CJF, CNF,
-                 RRF, RJF, RNF> | Thenable<ARF> | ARF,
-             progressFilter?: null): PromiseBase<ARF, AJF, ANF,
+            RRF = never, RJF = never, RNF = never>(
+                doneFilter: null,
+                failFilter: (t: TJ, u: UJ, v: VJ, ...s: SJ[]) => PromiseBase<ARF, AJF, ANF,
+                    BRF, BJF, BNF,
+                    CRF, CJF, CNF,
+                    RRF, RJF, RNF> | Thenable<ARF> | ARF,
+                progressFilter?: null): PromiseBase<ARF, AJF, ANF,
             BRF, BJF, BNF,
             CRF, CJF, CNF,
             RRF, RJF, RNF>;
@@ -7053,13 +7062,13 @@ declare namespace JQuery {
         then<ARD = never, AJD = never, AND = never,
             BRD = never, BJD = never, BND = never,
             CRD = never, CJD = never, CND = never,
-            RRD = never, RJD = never, RND = never>
-            (doneFilter: (t: TR, u: UR, v: VR, ...s: SR[]) => PromiseBase<ARD, AJD, AND,
-                 BRD, BJD, BND,
-                 CRD, CJD, CND,
-                 RRD, RJD, RND> | Thenable<ARD> | ARD,
-             failFilter?: null,
-             progressFilter?: null): PromiseBase<ARD, AJD, AND,
+            RRD = never, RJD = never, RND = never>(
+                doneFilter: (t: TR, u: UR, v: VR, ...s: SR[]) => PromiseBase<ARD, AJD, AND,
+                    BRD, BJD, BND,
+                    CRD, CJD, CND,
+                    RRD, RJD, RND> | Thenable<ARD> | ARD,
+                failFilter?: null,
+                progressFilter?: null): PromiseBase<ARD, AJD, AND,
             BRD, BJD, BND,
             CRD, CJD, CND,
             RRD, RJD, RND>;
@@ -7076,11 +7085,11 @@ declare namespace JQuery {
         catch<ARF = never, AJF = never, ANF = never,
             BRF = never, BJF = never, BNF = never,
             CRF = never, CJF = never, CNF = never,
-            RRF = never, RJF = never, RNF = never>
-            (failFilter?: ((t: TJ, u: UJ, v: VJ, ...s: SJ[]) => PromiseBase<ARF, AJF, ANF,
-                BRF, BJF, BNF,
-                CRF, CJF, CNF,
-                RRF, RJF, RNF> | Thenable<ARF> | ARF) | null): PromiseBase<ARF, AJF, ANF,
+            RRF = never, RJF = never, RNF = never>(
+                failFilter?: ((t: TJ, u: UJ, v: VJ, ...s: SJ[]) => PromiseBase<ARF, AJF, ANF,
+                    BRF, BJF, BNF,
+                    CRF, CJF, CNF,
+                    RRF, RJF, RNF> | Thenable<ARF> | ARF) | null): PromiseBase<ARF, AJF, ANF,
             BRF, BJF, BNF,
             CRF, CJF, CNF,
             RRF, RJF, RNF>;
@@ -7125,7 +7134,7 @@ declare namespace JQuery {
     interface DeferredStatic {
         // https://jquery.com/upgrade-guide/3.0/#callback-exit
         exceptionHook: any;
-        <TR = any, TJ = any, TN = any>(beforeStart?: (this: JQuery.Deferred<TR, TJ, TN>, deferred: JQuery.Deferred<TR, TJ, TN>) => void): JQuery.Deferred<TR, TJ, TN>;
+        <TR = any, TJ = any, TN = any>(beforeStart?: (this: Deferred<TR, TJ, TN>, deferred: Deferred<TR, TJ, TN>) => void): Deferred<TR, TJ, TN>;
     }
 
     interface Deferred<TR, TJ = any, TN = any> {
@@ -7229,14 +7238,14 @@ declare namespace JQuery {
          * @see \`{@link https://api.jquery.com/deferred.promise/ }\`
          * @since 1.5
          */
-        promise<TTarget extends object>(target: TTarget): JQuery.Promise<TR, TJ, TN> & TTarget;
+        promise<TTarget extends object>(target: TTarget): Promise<TR, TJ, TN> & TTarget;
         /**
          * Return a Deferred's Promise object.
          *
          * @see \`{@link https://api.jquery.com/deferred.promise/ }\`
          * @since 1.5
          */
-        promise(): JQuery.Promise<TR, TJ, TN>;
+        promise(): Promise<TR, TJ, TN>;
         /**
          * Determine the current state of a Deferred object.
          *
@@ -7269,19 +7278,19 @@ declare namespace JQuery {
             ARP = never, AJP = never, ANP = never,
             BRP = never, BJP = never, BNP = never,
             CRP = never, CJP = never, CNP = never,
-            RRP = never, RJP = never, RNP = never>
-            (doneFilter: (...t: TR[]) => PromiseBase<ARD, AJD, AND,
-                 BRD, BJD, BND,
-                 CRD, CJD, CND,
-                 RRD, RJD, RND> | Thenable<ARD> | ARD,
-             failFilter: (...t: TJ[]) => PromiseBase<ARF, AJF, ANF,
-                 BRF, BJF, BNF,
-                 CRF, CJF, CNF,
-                 RRF, RJF, RNF> | Thenable<AJF> | AJF,
-             progressFilter: (...t: TN[]) => PromiseBase<ARP, AJP, ANP,
-                 BRP, BJP, BNP,
-                 CRP, CJP, CNP,
-                 RRP, RJP, RNP> | Thenable<ANP> | ANP): PromiseBase<ARD | ARF | ARP, AJD | AJF | AJP, AND | ANF | ANP,
+            RRP = never, RJP = never, RNP = never>(
+                doneFilter: (...t: TR[]) => PromiseBase<ARD, AJD, AND,
+                    BRD, BJD, BND,
+                    CRD, CJD, CND,
+                    RRD, RJD, RND> | Thenable<ARD> | ARD,
+                failFilter: (...t: TJ[]) => PromiseBase<ARF, AJF, ANF,
+                    BRF, BJF, BNF,
+                    CRF, CJF, CNF,
+                    RRF, RJF, RNF> | Thenable<AJF> | AJF,
+                progressFilter: (...t: TN[]) => PromiseBase<ARP, AJP, ANP,
+                    BRP, BJP, BNP,
+                    CRP, CJP, CNP,
+                    RRP, RJP, RNP> | Thenable<ANP> | ANP): PromiseBase<ARD | ARF | ARP, AJD | AJF | AJP, AND | ANF | ANP,
             BRD | BRF | BRP, BJD | BJF | BJP, BND | BNF | BNP,
             CRD | CRF | CRP, CJD | CJF | CJP, CND | CNF | CNP,
             RRD | RRF | RRP, RJD | RJF | RJP, RND | RNF | RNP>;
@@ -7303,16 +7312,16 @@ declare namespace JQuery {
             ARP = never, AJP = never, ANP = never,
             BRP = never, BJP = never, BNP = never,
             CRP = never, CJP = never, CNP = never,
-            RRP = never, RJP = never, RNP = never>
-            (doneFilter: null,
-             failFilter: (...t: TJ[]) => PromiseBase<ARF, AJF, ANF,
-                 BRF, BJF, BNF,
-                 CRF, CJF, CNF,
-                 RRF, RJF, RNF> | Thenable<AJF> | AJF,
-             progressFilter: (...t: TN[]) => PromiseBase<ARP, AJP, ANP,
-                 BRP, BJP, BNP,
-                 CRP, CJP, CNP,
-                 RRP, RJP, RNP> | Thenable<ANP> | ANP): PromiseBase<ARF | ARP, AJF | AJP, ANF | ANP,
+            RRP = never, RJP = never, RNP = never>(
+                doneFilter: null,
+                failFilter: (...t: TJ[]) => PromiseBase<ARF, AJF, ANF,
+                    BRF, BJF, BNF,
+                    CRF, CJF, CNF,
+                    RRF, RJF, RNF> | Thenable<AJF> | AJF,
+                progressFilter: (...t: TN[]) => PromiseBase<ARP, AJP, ANP,
+                    BRP, BJP, BNP,
+                    CRP, CJP, CNP,
+                    RRP, RJP, RNP> | Thenable<ANP> | ANP): PromiseBase<ARF | ARP, AJF | AJP, ANF | ANP,
             BRF | BRP, BJF | BJP, BNF | BNP,
             CRF | CRP, CJF | CJP, CNF | CNP,
             RRF | RRP, RJF | RJP, RNF | RNP>;
@@ -7334,16 +7343,16 @@ declare namespace JQuery {
             ARP = never, AJP = never, ANP = never,
             BRP = never, BJP = never, BNP = never,
             CRP = never, CJP = never, CNP = never,
-            RRP = never, RJP = never, RNP = never>
-            (doneFilter: (...t: TR[]) => PromiseBase<ARD, AJD, AND,
-                 BRD, BJD, BND,
-                 CRD, CJD, CND,
-                 RRD, RJD, RND> | Thenable<ARD> | ARD,
-             failFilter: null,
-             progressFilter: (...t: TN[]) => PromiseBase<ARP, AJP, ANP,
-                 BRP, BJP, BNP,
-                 CRP, CJP, CNP,
-                 RRP, RJP, RNP> | Thenable<ANP> | ANP): PromiseBase<ARD | ARP, AJD | AJP, AND | ANP,
+            RRP = never, RJP = never, RNP = never>(
+                doneFilter: (...t: TR[]) => PromiseBase<ARD, AJD, AND,
+                    BRD, BJD, BND,
+                    CRD, CJD, CND,
+                    RRD, RJD, RND> | Thenable<ARD> | ARD,
+                failFilter: null,
+                progressFilter: (...t: TN[]) => PromiseBase<ARP, AJP, ANP,
+                    BRP, BJP, BNP,
+                    CRP, CJP, CNP,
+                    RRP, RJP, RNP> | Thenable<ANP> | ANP): PromiseBase<ARD | ARP, AJD | AJP, AND | ANP,
             BRD | BRP, BJD | BJP, BND | BNP,
             CRD | CRP, CJD | CJP, CND | CNP,
             RRD | RRP, RJD | RJP, RND | RNP>;
@@ -7361,13 +7370,13 @@ declare namespace JQuery {
         pipe<ARP = never, AJP = never, ANP = never,
             BRP = never, BJP = never, BNP = never,
             CRP = never, CJP = never, CNP = never,
-            RRP = never, RJP = never, RNP = never>
-            (doneFilter: null,
-             failFilter: null,
-             progressFilter?: (...t: TN[]) => PromiseBase<ARP, AJP, ANP,
-                 BRP, BJP, BNP,
-                 CRP, CJP, CNP,
-                 RRP, RJP, RNP> | Thenable<ANP> | ANP): PromiseBase<ARP, AJP, ANP,
+            RRP = never, RJP = never, RNP = never>(
+                doneFilter: null,
+                failFilter: null,
+                progressFilter?: (...t: TN[]) => PromiseBase<ARP, AJP, ANP,
+                    BRP, BJP, BNP,
+                    CRP, CJP, CNP,
+                    RRP, RJP, RNP> | Thenable<ANP> | ANP): PromiseBase<ARP, AJP, ANP,
             BRP, BJP, BNP,
             CRP, CJP, CNP,
             RRP, RJP, RNP>;
@@ -7389,16 +7398,16 @@ declare namespace JQuery {
             ARF = never, AJF = never, ANF = never,
             BRF = never, BJF = never, BNF = never,
             CRF = never, CJF = never, CNF = never,
-            RRF = never, RJF = never, RNF = never>
-            (doneFilter: (...t: TR[]) => PromiseBase<ARD, AJD, AND,
-                 BRD, BJD, BND,
-                 CRD, CJD, CND,
-                 RRD, RJD, RND> | Thenable<ARD> | ARD,
-             failFilter: (...t: TJ[]) => PromiseBase<ARF, AJF, ANF,
-                 BRF, BJF, BNF,
-                 CRF, CJF, CNF,
-                 RRF, RJF, RNF> | Thenable<AJF> | AJF,
-             progressFilter?: null): PromiseBase<ARD | ARF, AJD | AJF, AND | ANF,
+            RRF = never, RJF = never, RNF = never>(
+                doneFilter: (...t: TR[]) => PromiseBase<ARD, AJD, AND,
+                    BRD, BJD, BND,
+                    CRD, CJD, CND,
+                    RRD, RJD, RND> | Thenable<ARD> | ARD,
+                failFilter: (...t: TJ[]) => PromiseBase<ARF, AJF, ANF,
+                    BRF, BJF, BNF,
+                    CRF, CJF, CNF,
+                    RRF, RJF, RNF> | Thenable<AJF> | AJF,
+                progressFilter?: null): PromiseBase<ARD | ARF, AJD | AJF, AND | ANF,
             BRD | BRF, BJD | BJF, BND | BNF,
             CRD | CRF, CJD | CJF, CND | CNF,
             RRD | RRF, RJD | RJF, RND | RNF>;
@@ -7416,13 +7425,13 @@ declare namespace JQuery {
         pipe<ARF = never, AJF = never, ANF = never,
             BRF = never, BJF = never, BNF = never,
             CRF = never, CJF = never, CNF = never,
-            RRF = never, RJF = never, RNF = never>
-            (doneFilter: null,
-             failFilter: (...t: TJ[]) => PromiseBase<ARF, AJF, ANF,
-                 BRF, BJF, BNF,
-                 CRF, CJF, CNF,
-                 RRF, RJF, RNF> | Thenable<AJF> | AJF,
-             progressFilter?: null): PromiseBase<ARF, AJF, ANF,
+            RRF = never, RJF = never, RNF = never>(
+                doneFilter: null,
+                failFilter: (...t: TJ[]) => PromiseBase<ARF, AJF, ANF,
+                    BRF, BJF, BNF,
+                    CRF, CJF, CNF,
+                    RRF, RJF, RNF> | Thenable<AJF> | AJF,
+                progressFilter?: null): PromiseBase<ARF, AJF, ANF,
             BRF, BJF, BNF,
             CRF, CJF, CNF,
             RRF, RJF, RNF>;
@@ -7440,13 +7449,13 @@ declare namespace JQuery {
         pipe<ARD = never, AJD = never, AND = never,
             BRD = never, BJD = never, BND = never,
             CRD = never, CJD = never, CND = never,
-            RRD = never, RJD = never, RND = never>
-            (doneFilter: (...t: TR[]) => PromiseBase<ARD, AJD, AND,
-                 BRD, BJD, BND,
-                 CRD, CJD, CND,
-                 RRD, RJD, RND> | Thenable<ARD> | ARD,
-             failFilter?: null,
-             progressFilter?: null): PromiseBase<ARD, AJD, AND,
+            RRD = never, RJD = never, RND = never>(
+                doneFilter: (...t: TR[]) => PromiseBase<ARD, AJD, AND,
+                    BRD, BJD, BND,
+                    CRD, CJD, CND,
+                    RRD, RJD, RND> | Thenable<ARD> | ARD,
+                failFilter?: null,
+                progressFilter?: null): PromiseBase<ARD, AJD, AND,
             BRD, BJD, BND,
             CRD, CJD, CND,
             RRD, RJD, RND>;
@@ -7475,19 +7484,19 @@ declare namespace JQuery {
             ARP = never, AJP = never, ANP = never,
             BRP = never, BJP = never, BNP = never,
             CRP = never, CJP = never, CNP = never,
-            RRP = never, RJP = never, RNP = never>
-            (doneFilter: (...t: TR[]) => PromiseBase<ARD, AJD, AND,
-                 BRD, BJD, BND,
-                 CRD, CJD, CND,
-                 RRD, RJD, RND> | Thenable<ARD> | ARD,
-             failFilter: (...t: TJ[]) => PromiseBase<ARF, AJF, ANF,
-                 BRF, BJF, BNF,
-                 CRF, CJF, CNF,
-                 RRF, RJF, RNF> | Thenable<ARF> | ARF,
-             progressFilter: (...t: TN[]) => PromiseBase<ARP, AJP, ANP,
-                 BRP, BJP, BNP,
-                 CRP, CJP, CNP,
-                 RRP, RJP, RNP> | Thenable<ANP> | ANP): PromiseBase<ARD | ARF | ARP, AJD | AJF | AJP, AND | ANF | ANP,
+            RRP = never, RJP = never, RNP = never>(
+                doneFilter: (...t: TR[]) => PromiseBase<ARD, AJD, AND,
+                    BRD, BJD, BND,
+                    CRD, CJD, CND,
+                    RRD, RJD, RND> | Thenable<ARD> | ARD,
+                failFilter: (...t: TJ[]) => PromiseBase<ARF, AJF, ANF,
+                    BRF, BJF, BNF,
+                    CRF, CJF, CNF,
+                    RRF, RJF, RNF> | Thenable<ARF> | ARF,
+                progressFilter: (...t: TN[]) => PromiseBase<ARP, AJP, ANP,
+                    BRP, BJP, BNP,
+                    CRP, CJP, CNP,
+                    RRP, RJP, RNP> | Thenable<ANP> | ANP): PromiseBase<ARD | ARF | ARP, AJD | AJF | AJP, AND | ANF | ANP,
             BRD | BRF | BRP, BJD | BJF | BJP, BND | BNF | BNP,
             CRD | CRF | CRP, CJD | CJF | CJP, CND | CNF | CNP,
             RRD | RRF | RRP, RJD | RJF | RJP, RND | RNF | RNP>;
@@ -7507,16 +7516,16 @@ declare namespace JQuery {
             ARP = never, AJP = never, ANP = never,
             BRP = never, BJP = never, BNP = never,
             CRP = never, CJP = never, CNP = never,
-            RRP = never, RJP = never, RNP = never>
-            (doneFilter: null,
-             failFilter: (...t: TJ[]) => PromiseBase<ARF, AJF, ANF,
-                 BRF, BJF, BNF,
-                 CRF, CJF, CNF,
-                 RRF, RJF, RNF> | Thenable<ARF> | ARF,
-             progressFilter: (...t: TN[]) => PromiseBase<ARP, AJP, ANP,
-                 BRP, BJP, BNP,
-                 CRP, CJP, CNP,
-                 RRP, RJP, RNP> | Thenable<ANP> | ANP): PromiseBase<ARF | ARP, AJF | AJP, ANF | ANP,
+            RRP = never, RJP = never, RNP = never>(
+                doneFilter: null,
+                failFilter: (...t: TJ[]) => PromiseBase<ARF, AJF, ANF,
+                    BRF, BJF, BNF,
+                    CRF, CJF, CNF,
+                    RRF, RJF, RNF> | Thenable<ARF> | ARF,
+                progressFilter: (...t: TN[]) => PromiseBase<ARP, AJP, ANP,
+                    BRP, BJP, BNP,
+                    CRP, CJP, CNP,
+                    RRP, RJP, RNP> | Thenable<ANP> | ANP): PromiseBase<ARF | ARP, AJF | AJP, ANF | ANP,
             BRF | BRP, BJF | BJP, BNF | BNP,
             CRF | CRP, CJF | CJP, CNF | CNP,
             RRF | RRP, RJF | RJP, RNF | RNP>;
@@ -7536,16 +7545,16 @@ declare namespace JQuery {
             ARP = never, AJP = never, ANP = never,
             BRP = never, BJP = never, BNP = never,
             CRP = never, CJP = never, CNP = never,
-            RRP = never, RJP = never, RNP = never>
-            (doneFilter: (...t: TR[]) => PromiseBase<ARD, AJD, AND,
-                 BRD, BJD, BND,
-                 CRD, CJD, CND,
-                 RRD, RJD, RND> | Thenable<ARD> | ARD,
-             failFilter: null,
-             progressFilter: (...t: TN[]) => PromiseBase<ARP, AJP, ANP,
-                 BRP, BJP, BNP,
-                 CRP, CJP, CNP,
-                 RRP, RJP, RNP> | Thenable<ANP> | ANP): PromiseBase<ARD | ARP, AJD | AJP, AND | ANP,
+            RRP = never, RJP = never, RNP = never>(
+                doneFilter: (...t: TR[]) => PromiseBase<ARD, AJD, AND,
+                    BRD, BJD, BND,
+                    CRD, CJD, CND,
+                    RRD, RJD, RND> | Thenable<ARD> | ARD,
+                failFilter: null,
+                progressFilter: (...t: TN[]) => PromiseBase<ARP, AJP, ANP,
+                    BRP, BJP, BNP,
+                    CRP, CJP, CNP,
+                    RRP, RJP, RNP> | Thenable<ANP> | ANP): PromiseBase<ARD | ARP, AJD | AJP, AND | ANP,
             BRD | BRP, BJD | BJP, BND | BNP,
             CRD | CRP, CJD | CJP, CND | CNP,
             RRD | RRP, RJD | RJP, RND | RNP>;
@@ -7561,13 +7570,13 @@ declare namespace JQuery {
         then<ARP = never, AJP = never, ANP = never,
             BRP = never, BJP = never, BNP = never,
             CRP = never, CJP = never, CNP = never,
-            RRP = never, RJP = never, RNP = never>
-            (doneFilter: null,
-             failFilter: null,
-             progressFilter?: (...t: TN[]) => PromiseBase<ARP, AJP, ANP,
-                 BRP, BJP, BNP,
-                 CRP, CJP, CNP,
-                 RRP, RJP, RNP> | Thenable<ANP> | ANP): PromiseBase<ARP, AJP, ANP,
+            RRP = never, RJP = never, RNP = never>(
+                doneFilter: null,
+                failFilter: null,
+                progressFilter?: (...t: TN[]) => PromiseBase<ARP, AJP, ANP,
+                    BRP, BJP, BNP,
+                    CRP, CJP, CNP,
+                    RRP, RJP, RNP> | Thenable<ANP> | ANP): PromiseBase<ARP, AJP, ANP,
             BRP, BJP, BNP,
             CRP, CJP, CNP,
             RRP, RJP, RNP>;
@@ -7587,16 +7596,16 @@ declare namespace JQuery {
             ARF = never, AJF = never, ANF = never,
             BRF = never, BJF = never, BNF = never,
             CRF = never, CJF = never, CNF = never,
-            RRF = never, RJF = never, RNF = never>
-            (doneFilter: (...t: TR[]) => PromiseBase<ARD, AJD, AND,
-                 BRD, BJD, BND,
-                 CRD, CJD, CND,
-                 RRD, RJD, RND> | Thenable<ARD> | ARD,
-             failFilter: (...t: TJ[]) => PromiseBase<ARF, AJF, ANF,
-                 BRF, BJF, BNF,
-                 CRF, CJF, CNF,
-                 RRF, RJF, RNF> | Thenable<ARF> | ARF,
-             progressFilter?: null): PromiseBase<ARD | ARF, AJD | AJF, AND | ANF,
+            RRF = never, RJF = never, RNF = never>(
+                doneFilter: (...t: TR[]) => PromiseBase<ARD, AJD, AND,
+                    BRD, BJD, BND,
+                    CRD, CJD, CND,
+                    RRD, RJD, RND> | Thenable<ARD> | ARD,
+                failFilter: (...t: TJ[]) => PromiseBase<ARF, AJF, ANF,
+                    BRF, BJF, BNF,
+                    CRF, CJF, CNF,
+                    RRF, RJF, RNF> | Thenable<ARF> | ARF,
+                progressFilter?: null): PromiseBase<ARD | ARF, AJD | AJF, AND | ANF,
             BRD | BRF, BJD | BJF, BND | BNF,
             CRD | CRF, CJD | CJF, CND | CNF,
             RRD | RRF, RJD | RJF, RND | RNF>;
@@ -7612,13 +7621,13 @@ declare namespace JQuery {
         then<ARF = never, AJF = never, ANF = never,
             BRF = never, BJF = never, BNF = never,
             CRF = never, CJF = never, CNF = never,
-            RRF = never, RJF = never, RNF = never>
-            (doneFilter: null,
-             failFilter: (...t: TJ[]) => PromiseBase<ARF, AJF, ANF,
-                 BRF, BJF, BNF,
-                 CRF, CJF, CNF,
-                 RRF, RJF, RNF> | Thenable<ARF> | ARF,
-             progressFilter?: null): PromiseBase<ARF, AJF, ANF,
+            RRF = never, RJF = never, RNF = never>(
+                doneFilter: null,
+                failFilter: (...t: TJ[]) => PromiseBase<ARF, AJF, ANF,
+                    BRF, BJF, BNF,
+                    CRF, CJF, CNF,
+                    RRF, RJF, RNF> | Thenable<ARF> | ARF,
+                progressFilter?: null): PromiseBase<ARF, AJF, ANF,
             BRF, BJF, BNF,
             CRF, CJF, CNF,
             RRF, RJF, RNF>;
@@ -7634,13 +7643,13 @@ declare namespace JQuery {
         then<ARD = never, AJD = never, AND = never,
             BRD = never, BJD = never, BND = never,
             CRD = never, CJD = never, CND = never,
-            RRD = never, RJD = never, RND = never>
-            (doneFilter: (...t: TR[]) => PromiseBase<ARD, AJD, AND,
-                 BRD, BJD, BND,
-                 CRD, CJD, CND,
-                 RRD, RJD, RND> | Thenable<ARD> | ARD,
-             failFilter?: null,
-             progressFilter?: null): PromiseBase<ARD, AJD, AND,
+            RRD = never, RJD = never, RND = never>(
+                doneFilter: (...t: TR[]) => PromiseBase<ARD, AJD, AND,
+                    BRD, BJD, BND,
+                    CRD, CJD, CND,
+                    RRD, RJD, RND> | Thenable<ARD> | ARD,
+                failFilter?: null,
+                progressFilter?: null): PromiseBase<ARD, AJD, AND,
             BRD, BJD, BND,
             CRD, CJD, CND,
             RRD, RJD, RND>;
@@ -7657,11 +7666,11 @@ declare namespace JQuery {
         catch<ARF = never, AJF = never, ANF = never,
             BRF = never, BJF = never, BNF = never,
             CRF = never, CJF = never, CNF = never,
-            RRF = never, RJF = never, RNF = never>
-            (failFilter?: ((...t: TJ[]) => PromiseBase<ARF, AJF, ANF,
-                BRF, BJF, BNF,
-                CRF, CJF, CNF,
-                RRF, RJF, RNF> | Thenable<ARF> | ARF) | null): PromiseBase<ARF, AJF, ANF,
+            RRF = never, RJF = never, RNF = never>(
+                failFilter?: ((...t: TJ[]) => PromiseBase<ARF, AJF, ANF,
+                    BRF, BJF, BNF,
+                    CRF, CJF, CNF,
+                    RRF, RJF, RNF> | Thenable<ARF> | ARF) | null): PromiseBase<ARF, AJF, ANF,
             BRF, BJF, BNF,
             CRF, CJF, CNF,
             RRF, RJF, RNF>;
@@ -7719,7 +7728,7 @@ declare namespace JQuery {
          * A function to be called when the animation on an element completes or stops without completing (its
          * Promise object is either resolved or rejected).
          */
-        always?(this: TElement, animation: JQuery.Promise<any>, jumpedToEnd: boolean): void;
+        always?(this: TElement, animation: Promise<any>, jumpedToEnd: boolean): void;
         /**
          * A function that is called once the animation on an element is complete.
          */
@@ -7727,7 +7736,7 @@ declare namespace JQuery {
         /**
          * A function to be called when the animation on an element completes (its Promise object is resolved).
          */
-        done?(this: TElement, animation: JQuery.Promise<any>, jumpedToEnd: boolean): void;
+        done?(this: TElement, animation: Promise<any>, jumpedToEnd: boolean): void;
         /**
          * A string or number determining how long the animation will run.
          */
@@ -7739,12 +7748,12 @@ declare namespace JQuery {
         /**
          * A function to be called when the animation on an element fails to complete (its Promise object is rejected).
          */
-        fail?(this: TElement, animation: JQuery.Promise<any>, jumpedToEnd: boolean): void;
+        fail?(this: TElement, animation: Promise<any>, jumpedToEnd: boolean): void;
         /**
          * A function to be called after each step of the animation, only once per animated element regardless
          * of the number of animated properties.
          */
-        progress?(this: TElement, animation: JQuery.Promise<any>, progress: number, remainingMs: number): void;
+        progress?(this: TElement, animation: Promise<any>, progress: number, remainingMs: number): void;
         /**
          * A Boolean indicating whether to place the animation in the effects queue. If false, the animation
          * will begin immediately. As of jQuery 1.7, the queue option can also accept a string, in which case
@@ -7760,7 +7769,7 @@ declare namespace JQuery {
         /**
          * A function to call when the animation on an element begins.
          */
-        start?(this: TElement, animation: JQuery.Promise<any>): void;
+        start?(this: TElement, animation: Promise<any>): void;
         /**
          * A function to be called for each animated property of each animated element. This function provides
          * an opportunity to modify the Tween object to change the value of the property before it is set.
@@ -7800,7 +7809,7 @@ declare namespace JQuery {
     }
 
     interface AnimationHook<TElement> {
-        (fx: JQuery.Tween<TElement>): void;
+        (fx: Tween<TElement>): void;
     }
 
     // endregion
@@ -7813,10 +7822,14 @@ declare namespace JQuery {
 
     // Static members
     interface EventStatic {
-        <T extends object, TTarget extends EventTarget = HTMLElement>(event: string, properties?: T): JQuery.Event<TTarget> & T;
-        <T extends EventLike, TTarget extends EventTarget = HTMLElement>(properties: T): JQuery.Event<TTarget> & T;
-        new <T extends object, TTarget extends EventTarget = HTMLElement>(event: string, properties?: T): JQuery.Event<TTarget> & T;
-        new <T extends EventLike, TTarget extends EventTarget = HTMLElement>(properties: T): JQuery.Event<TTarget> & T;
+        // tslint:disable-next-line:no-unnecessary-generics
+        <T extends object, TTarget extends EventTarget = HTMLElement>(event: string, properties?: T): Event<TTarget> & T;
+        // tslint:disable-next-line:no-unnecessary-generics
+        <T extends EventLike, TTarget extends EventTarget = HTMLElement>(properties: T): Event<TTarget> & T;
+        // tslint:disable-next-line:no-unnecessary-generics
+        new <T extends object, TTarget extends EventTarget = HTMLElement>(event: string, properties?: T): Event<TTarget> & T;
+        // tslint:disable-next-line:no-unnecessary-generics
+        new <T extends EventLike, TTarget extends EventTarget = HTMLElement>(properties: T): Event<TTarget> & T;
     }
 
     // Instance members
@@ -7971,7 +7984,7 @@ declare namespace JQuery {
 
     // endregion
 
-    interface EventHandler<TCurrentTarget, TData = null> extends EventHandlerBase<TCurrentTarget, JQuery.Event<TCurrentTarget, TData>> { }
+    interface EventHandler<TCurrentTarget, TData = null> extends EventHandlerBase<TCurrentTarget, Event<TCurrentTarget, TData>> { }
 
     interface EventHandlerBase<TContext, T> {
         // Extra parameters can be passed from trigger()
@@ -7979,6 +7992,7 @@ declare namespace JQuery {
     }
 
     // Provided for convenience for use with jQuery.Event.which
+    // tslint:disable-next-line:no-const-enum
     const enum Mouse {
         None = 0,
         Left = 1,
@@ -7987,6 +8001,7 @@ declare namespace JQuery {
     }
 
     // Provided for convenience for use with jQuery.Event.which
+    // tslint:disable-next-line:no-const-enum
     const enum Key {
         Backspace = 8,
         Tab = 9,
@@ -8123,21 +8138,28 @@ declare namespace JQuery {
 
 // region Legacy types
 
-interface JQueryCallback extends JQuery.Callbacks<Function> { }
+// tslint:disable-next-line:no-empty-interface
+interface JQueryCallback extends JQuery.Callbacks { }
 interface JQueryDeferred<T> extends JQuery.Deferred<T> { }
-interface JQueryEventConstructor extends JQuery.Event<EventTarget> { }
+// tslint:disable-next-line:no-empty-interface
+interface JQueryEventConstructor extends JQuery.EventStatic { }
 interface JQueryDeferred<T> extends JQuery.Deferred<T> { }
+// tslint:disable-next-line:no-empty-interface
 interface JQueryAjaxSettings extends JQuery.AjaxSettings { }
 interface JQueryAnimationOptions extends JQuery.EffectsOptions<Element> { }
+// tslint:disable-next-line:no-empty-interface
 interface JQueryCoordinates extends JQuery.Coordinates { }
 interface JQueryGenericPromise<T> extends JQuery.Thenable<T> { }
+// tslint:disable-next-line:no-empty-interface
 interface JQueryXHR extends JQuery.jqXHR { }
 interface JQueryPromise<T> extends JQuery.Promise<T> { }
+// tslint:disable-next-line:no-empty-interface
 interface JQuerySerializeArrayElement extends JQuery.NameValuePair { }
 
 /**
  * @deprecated 1.9
  */
+// tslint:disable-next-line:no-empty-interface
 interface JQuerySupport extends JQuery.PlainObject { }
 
 // Legacy types that are not represented in the current type definitions are marked deprecated.

--- a/types/jquery/jquery-tests.ts
+++ b/types/jquery/jquery-tests.ts
@@ -1,8 +1,4 @@
 function JQueryStatic() {
-    function type_assertion() {
-        const $Canvas = $ as JQueryStatic<HTMLCanvasElement>;
-    }
-
     function type_annotation() {
         const jq: JQueryStatic = $;
     }
@@ -52,7 +48,7 @@ function JQueryStatic() {
         $(function($) {
             // $ExpectType Document
             this;
-            // $ExpectType JQueryStatic<HTMLElement>
+            // $ExpectType JQueryStatic
             $;
         });
 
@@ -101,7 +97,7 @@ function JQueryStatic() {
     }
 
     function Event() {
-        // $ExpectType EventStatic<HTMLElement>
+        // $ExpectType EventStatic
         $.Event;
     }
 
@@ -138,7 +134,7 @@ function JQueryStatic() {
     }
 
     function ready() {
-        // $ExpectType Thenable<JQueryStatic<HTMLElement>>
+        // $ExpectType Thenable<JQueryStatic>
         $.ready;
     }
 
@@ -869,10 +865,10 @@ function JQueryStatic() {
     }
 
     function noConflict() {
-        // $ExpectType JQueryStatic<HTMLElement>
+        // $ExpectType JQueryStatic
         $.noConflict(true);
 
-        // $ExpectType JQueryStatic<HTMLElement>
+        // $ExpectType JQueryStatic
         $.noConflict();
     }
 
@@ -5344,7 +5340,7 @@ function JQuery() {
         function ready() {
             // $ExpectType JQuery<HTMLElement>
             $('p').ready(($) => {
-                // $ExpectType JQueryStatic<HTMLElement>
+                // $ExpectType JQueryStatic
                 $;
             });
         }
@@ -7188,7 +7184,7 @@ function JQuery_Promise3() {
             p.then(() => {
                 return $.ready;
             }).then((a) => {
-                a; // $ExpectType JQueryStatic<HTMLElement>
+                a; // $ExpectType JQueryStatic
             });
 
             p.then(() => {
@@ -7218,7 +7214,7 @@ function JQuery_Promise3() {
             p.then(null, () => {
                 return $.ready;
             }).then((a) => {
-                a; // $ExpectType JQueryStatic<HTMLElement>
+                a; // $ExpectType JQueryStatic
             });
 
             p.then(null, () => {
@@ -7574,7 +7570,7 @@ function JQuery_Promise2(p: JQuery.Promise2<string, Error, number, JQuery, strin
             p.then(() => {
                 return $.ready;
             }).then((a) => {
-                a; // $ExpectType JQueryStatic<HTMLElement>
+                a; // $ExpectType JQueryStatic
             });
 
             p.then(() => {
@@ -7601,7 +7597,7 @@ function JQuery_Promise2(p: JQuery.Promise2<string, Error, number, JQuery, strin
             p.then(null, () => {
                 return $.ready;
             }).then((a) => {
-                a; // $ExpectType JQueryStatic<HTMLElement>
+                a; // $ExpectType JQueryStatic
             });
 
             p.then(null, () => {
@@ -7701,7 +7697,7 @@ function JQuery_Promise(p: JQuery.Promise<string, Error, number>) {
             p.then(() => {
                 return $.ready;
             }).then((a) => {
-                a; // $ExpectType JQueryStatic<HTMLElement>
+                a; // $ExpectType JQueryStatic
             });
 
             p.then(() => {
@@ -7725,7 +7721,7 @@ function JQuery_Promise(p: JQuery.Promise<string, Error, number>) {
             p.then(null, () => {
                 return $.ready;
             }).then((a) => {
-                a; // $ExpectType JQueryStatic<HTMLElement>
+                a; // $ExpectType JQueryStatic
             });
 
             p.then(null, () => {

--- a/types/jquery/jquery-tests.ts
+++ b/types/jquery/jquery-tests.ts
@@ -57,35 +57,35 @@ function JQueryStatic() {
 
         // https://github.com/DefinitelyTyped/DefinitelyTyped/issues/19597#issuecomment-378218432
         function issue_19597_378218432() {
-            let myDiv = $(document.createElement('div'));
+            const myDiv = $(document.createElement('div'));
             // $ExpectType JQuery<HTMLDivElement>
             myDiv;
             myDiv.on('click', (evt) => {
-                let target = evt.target;
+                const target = evt.target;
                 // $ExpectType HTMLDivElement
                 target;
             });
-            let myDiv1 = $<HTMLDivElement>(document.createElement('div'));
+            const myDiv1 = $<HTMLDivElement>(document.createElement('div'));
 
-            let myForcedDiv: JQuery<HTMLDivElement> = $(document.createElement('div')) as any;
+            const myForcedDiv: JQuery<HTMLDivElement> = $(document.createElement('div')) as any;
             myForcedDiv.on('click', (evt) => {
-                let target = evt.target; // HTMLDivElement
+                const target = evt.target; // HTMLDivElement
                 // $ExpectType HTMLDivElement
                 target;
             });
-            let myDoc = $(document);
+            const myDoc = $(document);
             // $ExpectType JQuery<Document>
             myDoc;
             myDoc.on('click', (evt) => {
-                let target = evt.target;
+                const target = evt.target;
                 // $ExpectType Document
                 target;
             });
-            let myDocForced: JQuery<Document> = $(document);
-            let myWindow = $(window);
+            const myDocForced: JQuery<Document> = $(document);
+            const myWindow = $(window);
             // $ExpectType JQuery<Window>
             myWindow;
-            let myWindowForced: JQuery<Window> = $(window);
+            const myWindowForced: JQuery<Window> = $(window);
             // $ExpectType JQuery<Window>
             myWindowForced;
         }
@@ -730,7 +730,7 @@ function JQueryStatic() {
 
     function map() {
         // $ExpectType number[]
-        $.map([1, 2, 3], function (elementOfArray, indexInArray) {
+        $.map([1, 2, 3], function(elementOfArray, indexInArray) {
             // $ExpectType Window
             this;
             // $ExpectType number
@@ -742,7 +742,7 @@ function JQueryStatic() {
         });
 
         // $ExpectType number[]
-        $.map([1, 2, 3], function (elementOfArray, indexInArray) {
+        $.map([1, 2, 3], function(elementOfArray, indexInArray) {
             // $ExpectType Window
             this;
             // $ExpectType number
@@ -754,7 +754,7 @@ function JQueryStatic() {
         });
 
         // $ExpectType (number | null)[]
-        $.map([1, 2, 3], function (elementOfArray, indexInArray) {
+        $.map([1, 2, 3], function(elementOfArray, indexInArray) {
             // $ExpectType Window
             this;
             // $ExpectType number
@@ -766,7 +766,7 @@ function JQueryStatic() {
         });
 
         // $ExpectType (number | undefined)[]
-        $.map([1, 2, 3], function (elementOfArray, indexInArray) {
+        $.map([1, 2, 3], function(elementOfArray, indexInArray) {
             // $ExpectType Window
             this;
             // $ExpectType number
@@ -781,7 +781,7 @@ function JQueryStatic() {
         $.map({
             myProp: true,
             name: 'Rogers',
-        }, function (propertyOfObject, key) {
+        }, function(propertyOfObject, key) {
             // $ExpectType Window
             this;
             // $ExpectType string | boolean
@@ -801,7 +801,7 @@ function JQueryStatic() {
         $.map({
             myProp: true,
             name: 'Rogers',
-        }, function (propertyOfObject, key) {
+        }, function(propertyOfObject, key) {
             // $ExpectType Window
             this;
             // $ExpectType string | boolean
@@ -817,7 +817,7 @@ function JQueryStatic() {
             myProp: true,
             name: 'Rogers',
             anotherProp: 70,
-        }, function (propertyOfObject, key) {
+        }, function(propertyOfObject, key) {
             // $ExpectType Window
             this;
             // $ExpectType string | number | boolean
@@ -840,7 +840,7 @@ function JQueryStatic() {
             myProp: true,
             name: 'Rogers',
             anotherProp: 70,
-        }, function (propertyOfObject, key) {
+        }, function(propertyOfObject, key) {
             // $ExpectType Window
             this;
             // $ExpectType string | number | boolean
@@ -2153,9 +2153,8 @@ function JQueryStatic() {
 }
 
 function JQuery() {
-    function type_assertion() {
-        const $el = $(document.createElement('canvas'));
-        const $canvas = $el as JQuery<HTMLCanvasElement>;
+    function type_annotation() {
+        const $canvas: JQuery<Element> = $(document.createElement('canvas'));
     }
 
     function iterable() {
@@ -7074,6 +7073,7 @@ function JQuery_Promise3() {
     interface I8 { kind: 'I8'; }
     interface I9 { kind: 'I9'; }
 
+    // tslint:disable-next-line:ban-types
     const p: JQuery.Promise3<string, Error, number, JQuery, string, boolean, any, Function, never> = {} as any;
     const p1: JQuery.Promise3<I1, I2, I3, I4, I5, I6, I7, I8, I9> = {} as any;
     const p2: JQuery.Promise3<I2, I3, I4, I5, I6, I7, I8, I9, I1> = {} as any;
@@ -7451,7 +7451,7 @@ function JQuery_Promise3() {
             });
             // $ExpectType PromiseBase<any, jqXHR<any>, never, SuccessTextStatus, ErrorTextStatus, never, jqXHR<any>, string, never, never, never, never>
             a;
-            const b: JQuery.Promise3<any, JQuery.jqXHR<any>, never, JQuery.Ajax.SuccessTextStatus, JQuery.Ajax.ErrorTextStatus, never, JQuery.jqXHR<any>, string, never> = a;
+            const b: JQuery.Promise3<any, JQuery.jqXHR, never, JQuery.Ajax.SuccessTextStatus, JQuery.Ajax.ErrorTextStatus, never, JQuery.jqXHR, string, never> = a;
         }
 
         // $ExpectType PromiseBase<never, never, never, never, never, never, never, never, never, never, never, never>
@@ -7472,6 +7472,7 @@ function JQuery_Promise3() {
     }
 
     async function testAsync(p: JQuery.Promise3<string, {}, {}, {}, {}, {}, {}, {}, {}>): Promise<string> {
+        // tslint:disable-next-line:await-promise
         const s: string = await p;
         return s;
     }
@@ -7616,6 +7617,7 @@ function JQuery_Promise2(p: JQuery.Promise2<string, Error, number, JQuery, strin
     }
 
     async function testAsync(p: JQuery.Promise2<string, {}, {}, {}, {}, {}>): Promise<string> {
+        // tslint:disable-next-line:await-promise
         const s: string = await p;
         return s;
     }

--- a/types/jquery/jquery-tests.ts
+++ b/types/jquery/jquery-tests.ts
@@ -17,6 +17,9 @@ function JQueryStatic() {
             }
         });
 
+        // $ExpectType JQuery<HTMLParagraphElement>
+        $<HTMLParagraphElement>('<p></p>');
+
         // $ExpectType JQuery<HTMLElement>
         $('span', new HTMLElement());
 
@@ -29,20 +32,20 @@ function JQueryStatic() {
         // $ExpectType JQuery<HTMLElement>
         $('span');
 
-        // $ExpectType JQuery<HTMLElement>
-        $('<p></p>');
+        // $ExpectType JQuery<SVGLineElement>
+        $<SVGLineElement>('.mysvgline');
 
-        // $ExpectType JQuery<HTMLElement>
-        $(new HTMLElement());
+        // $ExpectType JQuery<HTMLParagraphElement>
+        $(new HTMLParagraphElement());
 
-        // $ExpectType JQuery<HTMLElement>
-        $([new HTMLElement()]);
+        // $ExpectType JQuery<HTMLParagraphElement>
+        $([new HTMLParagraphElement()]);
 
         // $ExpectType JQuery<{ foo: string; hello: string; }>
         $({ foo: 'bar', hello: 'world' });
 
-        // $ExpectType JQuery<HTMLElement>
-        $($('p'));
+        // $ExpectType JQuery<SVGSVGElement>
+        $($(document.createElementNS("http://www.w3.org/2000/svg", "svg")));
 
         // $ExpectType JQuery<HTMLElement>
         $(function($) {
@@ -52,8 +55,19 @@ function JQueryStatic() {
             $;
         });
 
+        // $ExpectType JQuery<Element>
+        $<Element>(function($) {
+            // $ExpectType Document
+            this;
+            // $ExpectType JQueryStatic
+            $;
+        });
+
         // $ExpectType JQuery<HTMLElement>
         $();
+
+        // $ExpectType JQuery<Element>
+        $<Element>();
 
         // https://github.com/DefinitelyTyped/DefinitelyTyped/issues/19597#issuecomment-378218432
         function issue_19597_378218432() {

--- a/types/jquery/test/jquery-no-window-module-tests.ts
+++ b/types/jquery/test/jquery-no-window-module-tests.ts
@@ -1,5 +1,5 @@
 import jQueryFactory = require('jquery');
 
 const jq = jQueryFactory(window, true);
-// $ExpectType JQueryStatic<HTMLElement>
+// $ExpectType JQueryStatic
 jq;

--- a/types/jquery/test/jquery-slim-no-window-module-tests.ts
+++ b/types/jquery/test/jquery-slim-no-window-module-tests.ts
@@ -1,5 +1,5 @@
 import jQueryFactory = require('jquery/dist/jquery.slim');
 
 const jq = jQueryFactory(window, true);
-// $ExpectType JQueryStatic<HTMLElement>
+// $ExpectType JQueryStatic
 jq;

--- a/types/jquery/test/jquery-window-module-tests.ts
+++ b/types/jquery/test/jquery-window-module-tests.ts
@@ -3,16 +3,3 @@ import jq = require('jquery');
 const $window = jq(window);
 // $ExpectType JQuery<Window>
 $window;
-
-class CanvasLayersDirective {
-    private readonly $renderingCanvas: JQuery<HTMLCanvasElement>;
-    private readonly $offscreenCanvas: JQuery<HTMLCanvasElement>;
-
-    constructor(elementRef: { nativeElement: any; }) {
-        // This type assertion results in an error when exporting 'typeof factory & JQueryStatic' where
-        // 'factory' is jQuery's factory function.
-        const $Canvas = $ as JQueryStatic<HTMLCanvasElement>;
-        this.$renderingCanvas = $Canvas(elementRef.nativeElement);
-        this.$offscreenCanvas = $Canvas(document.createElement('canvas'));
-    }
-}

--- a/types/jquery/tslint.json
+++ b/types/jquery/tslint.json
@@ -1,24 +1,16 @@
 {
     "extends": "dtslint/dt.json",
     "rules": {
-        // All are TODOs
-        "await-promise": false,
-        "ban-types": false,
         "callable-types": false,
         "interface-name": false,
         "no-any-union": false,
+        "no-declare-current-package": false,
+
+        "ban-types": false,
         "no-arg": false,
         "no-boolean-literal-compare": false,
-        "no-const-enum": false,
-        "no-declare-current-package": false,
-        "no-empty-interface": false,
-        "no-misused-new": false,
         "no-object-literal-type-assertion": false,
-        "no-redundant-jsdoc-2": false,
-        "no-unnecessary-generics": false,
-        "no-unnecessary-qualifier": false,
         "no-unnecessary-type-assertion": false,
-        "no-var": false,
         "no-var-keyword": false,
         "object-literal-key-quotes": false,
         "object-literal-shorthand": false,
@@ -29,9 +21,7 @@
         "prefer-for-of": false,
         "prefer-switch": false,
         "prefer-template": false,
-        "space-before-function-paren": false,
         "space-within-parens": false,
-        "triple-equals": false,
-        "use-default-type-parameter": false
+        "triple-equals": false
     }
 }


### PR DESCRIPTION
The type parameter on `JQueryStatic` does not improve type safety and actually reduces type safety in certain scenarios. This PR removes the type parameter on `JQueryStatic` and replaces it with member-level type parameters where appropriate.

Previously, the following code was not possible.

```typescript
let jSvgLineElement2: JQuery<SVGLineElement> = $('.mysvgline');
```

`$('.mysvgline')` would use the default type parameter `HTMLElement` and would not be assignable to `jSvgLineElement2` without a double assertion even though the return `JQuery` object could contain `SVGLineElement` objects at runtime. This change now makes it possible with the following syntax.

```typescript
let jSvgLineElement2: JQuery<SVGLineElement> = $<SVGLineElement>('.mysvgline');
```

@HolgerJeromin 

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- ~~Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>~~
- ~~Increase the version number in the header if appropriate.~~
- ~~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.~~
