### PR TITLE
Chartist - Make ns optional for svg

### DIFF
--- a/types/chartist/chartist-tests.ts
+++ b/types/chartist/chartist-tests.ts
@@ -343,6 +343,7 @@ chart2.on('draw', (data: any) => {
             style: 'fill-opacity: 1'
         }, 'ct-area');
 
+        triangle.attr({ style: 'fill-opacity: .5' });
         // With data.element we get the Chartist SVG wrapper and we can replace the original point drawn by Chartist with our newly created triangle
         data.element.replace(triangle);
     }

--- a/types/chartist/index.d.ts
+++ b/types/chartist/index.d.ts
@@ -534,7 +534,7 @@ declare namespace Chartist {
         /**
          * Set attributes on the current SVG element of the wrapper you're currently working on.
          */
-        attr(attributes: Object | string, ns: string): Object | string;
+        attr(attributes: Object | string, ns?: string): Object | string;
 
         /**
          * Create a new SVG element whose wrapper object will be selected for further operations. This way you can also create nested groups easily.


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/gionkunz/chartist-js/blob/8ae511b85956d6f93f38619d85bc045aa51bcf2e/src/scripts/svg.js#L60

Hello! According to the jsdoc, the ns parameter (and code) is optional. Just updating the type definition. Copied below for reviewer.

```js
  /**
   * Set attributes on the current SVG element of the wrapper you're currently working on.
   *
   * @memberof Chartist.Svg
   * @param {Object|String} attributes An object with properties that will be added as attributes to the SVG element that is created. Attributes with undefined values will not be added. If this parameter is a String then the function is used as a getter and will return the attribute value.
   * @param {String} [ns] If specified, the attribute will be obtained using getAttributeNs. In order to write namepsaced attributes you can use the namespace:attribute notation within the attributes object.
   * @return {Object|String} The current wrapper object will be returned so it can be used for chaining or the attribute value if used as getter function.
   */
```
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.