### PR TITLE
new-relic-browser: Correct doc URLs

### DIFF
--- a/types/new-relic-browser/index.d.ts
+++ b/types/new-relic-browser/index.d.ts
@@ -13,7 +13,7 @@ declare namespace NewRelic {
          * @param releaseId The ID or version of this release; for example, a version number, build number
          *   from your CI environment, GitHub SHA, GUID, or a hash of the contents. Since New Relic converts this
          *   value into a string, you can also use null or undefined if necessary
-         * @see https://docs.newrelic.com/docs/browser/new-relic-browser/browser-agent-spa-api/addRelease
+         * @see https://docs.newrelic.com/docs/browser/new-relic-browser/browser-agent-spa-api/add-release
          */
         addRelease(releaseName: string, releaseId: string): void;
 
@@ -23,7 +23,7 @@ declare namespace NewRelic {
          * @param name Name or category of the action. Reports to Insights as the actionName attribute.
          * @param attributes JSON object with one or more key/value pairs.
          *   The key will report to Insights as its own PageAction attribute with the specified values.
-         * @see https://docs.newrelic.com/docs/browser/new-relic-browser/browser-agent-spa-api/addPageAction
+         * @see https://docs.newrelic.com/docs/browser/new-relic-browser/browser-agent-spa-api/add-page-action
          */
         addPageAction(name: string, attributes: { [key: string]: string }): void;
 
@@ -51,7 +51,7 @@ declare namespace NewRelic {
          *
          * @param Provide a meaningful error message that you can use when analyzing data on
          *   New Relic Browser's JavaScript errors page.
-         * @see https://docs.newrelic.com/docs/browser/new-relic-browser/browser-agent-spa-api/noticeError
+         * @see https://docs.newrelic.com/docs/browser/new-relic-browser/browser-agent-spa-api/notice-error
          */
         noticeError(error: any): void;
 
@@ -63,7 +63,7 @@ declare namespace NewRelic {
          * @param value Value of the attribute. Appears as the value in the named attribute column in the
          *   PageView event. It will appear as a column in the PageAction event if you are using it. Custom attribute
          *   values cannot be complex objects, only simple types such as strings and numbers.
-         * @see https://docs.newrelic.com/docs/browser/new-relic-browser/browser-agent-spa-api/setCustomAttribute
+         * @see https://docs.newrelic.com/docs/browser/new-relic-browser/browser-agent-spa-api/set-custom-attribute
          */
         setCustomAttribute(name: string, value: string): void;
 
@@ -72,7 +72,7 @@ declare namespace NewRelic {
          *
          * @param filterCallback The callback will be called with each error, so it is not
          *   specific to one error. `err` will usually be an error object, but it can be other data types.
-         * @see https://docs.newrelic.com/docs/browser/new-relic-browser/browser-agent-spa-api/setErrorHandler
+         * @see https://docs.newrelic.com/docs/browser/new-relic-browser/browser-agent-spa-api/set-error-handler
          */
         setErrorHandler(filterCallback: (err: any) => boolean): void;
 
@@ -84,7 +84,7 @@ declare namespace NewRelic {
          *   To further group these custom transactions, provide a custom host. Otherwise, the page views will be
          *   assigned the default domain custom.transaction. Segments within the name must be explicitly added to
          *   the Whitelist segments in your URL whitelist settings if they do not already appear.
-         * @see https://docs.newrelic.com/docs/browser/new-relic-browser/browser-agent-spa-api/setPageViewName
+         * @see https://docs.newrelic.com/docs/browser/new-relic-browser/browser-agent-spa-api/set-pageview-name
          */
         setPageViewName(name: string, host?: string): void;
 


### PR DESCRIPTION
This PR is merely correcting the JSDoc-documentation.
