### PR TITLE
[@types/mongoose] add query-helpers to Schema

### DIFF
--- a/types/mongoose/index.d.ts
+++ b/types/mongoose/index.d.ts
@@ -791,6 +791,8 @@ declare module "mongoose" {
     methods: any;
     /** Object of currently defined statics on this schema. */
     statics: any;
+    /** Object of currently defined query helpers on this schema. */
+    query: any;
     /** The original object passed to the schema constructor */
     obj: any;
   }

--- a/types/mongoose/v4/index.d.ts
+++ b/types/mongoose/v4/index.d.ts
@@ -754,6 +754,8 @@ declare module "mongoose" {
     methods: any;
     /** Object of currently defined statics on this schema. */
     statics: any;
+    /** Object of currently defined query helpers on this schema. */
+    query: any;
     /** The original object passed to the schema constructor */
     obj: any;
   }


### PR DESCRIPTION
Add property for the not-so-well documented Schema.prototype.query "query-helper" property.

References:
https://github.com/Automattic/mongoose/blob/master/lib/schema.js#L81
http://mongoosejs.com/docs/guide.html#query-helpers