### PR TITLE
Node-Auth0: add paged 'getUsers' query

### DIFF
--- a/types/auth0/auth0-tests.ts
+++ b/types/auth0/auth0-tests.ts
@@ -29,6 +29,40 @@ management
     // Handle the error.
   });
 
+// Search users without paging - callback style
+management.getUsers({search_engine: 'v3', q: 'name:"jane"', per_page: 25}, (err: Error, users: auth0.User[]) => {
+    if (err) {
+        // Handle error
+    }
+    console.log(users);
+});
+
+// Search users without paging - promise style
+management.getUsers({search_engine: 'v3', q: 'name:"jane"', per_page: 25})
+    .then((users) => {
+        console.log(users);
+    })
+    .catch((err) => {
+        // Handle the error
+    });
+
+// Search users with paging - callback style
+management.getUsers({search_engine: 'v3', q: 'name:"jane"', per_page: 25, include_totals: true}, (err: Error, userPage: auth0.UserPage) => {
+    if (err) {
+        // Handle error
+    }
+    console.log(userPage.total);
+});
+
+// Search users with paging - promise style
+management.getUsers({search_engine: 'v3', q: 'name:"jane"', per_page: 25, include_totals: true})
+    .then((users: auth0.UserPage) => {
+        console.log(users.total);
+    })
+    .catch((err) => {
+        // Handle the error
+    });
+
 // Using a callback.
 management.getUser({id: 'user_id'},(err: Error, user: auth0.User) => {
   if (err) {

--- a/types/auth0/index.d.ts
+++ b/types/auth0/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for auth0 2.9.1
+// Type definitions for auth0 2.9.2
 // Project: https://github.com/auth0/node-auth0
 // Definitions by: Wilson Hobbs <https://github.com/wbhob>, Seth Westphal <https://github.com/westy92>, Amiram Korach <https://github.com/amiram>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/auth0/index.d.ts
+++ b/types/auth0/index.d.ts
@@ -68,13 +68,16 @@ export interface UpdateUserData extends UserData {
 export interface GetUsersData {
   per_page?: number;
   page?: number;
-  include_totals?: boolean;
   sort?: string;
   connection?: string;
   fields?: string;
   include_fields?: boolean;
   q?: string;
   search_engine?: string;
+}
+
+export interface GetUsersDataPaged extends GetUsersData {
+  include_totals: boolean;
 }
 
 export interface Rule {
@@ -345,6 +348,17 @@ export interface User {
   family_name?: string;
 }
 
+export interface Page {
+  start: number;
+  limit: number;
+  length: number;
+  total: number;
+}
+
+export interface UserPage extends Page {
+  users: User[]
+}
+
 export interface Identity {
   connection: string;
   user_id: string;
@@ -353,7 +367,7 @@ export interface Identity {
   access_token?: string;
   profileData?: {
     email?: string;
-    email_verified?: boolean;   
+    email_verified?: boolean;
     name?: string;
     phone_number?: string;
     phone_verified?: boolean;
@@ -662,7 +676,7 @@ export class ManagementClient {
   deleteClient(params: ClientParams): Promise<void>;
   deleteClient(params: ClientParams, cb: (err: Error) => void): void;
 
-                                              
+
   // Client Grants
   getClientGrants(): Promise<ClientGrant[]>;
   getClientGrants(cb: (err: Error, data: ClientGrant[]) => void): void;
@@ -706,6 +720,8 @@ export class ManagementClient {
 
 
   // Users
+  getUsers(params: GetUsersDataPaged): Promise<UserPage>;
+  getUsers(params: GetUsersDataPaged, cb: (err: Error, userPage: UserPage) => void): void;
   getUsers(params?: GetUsersData): Promise<User[]>;
   getUsers(cb: (err: Error, users: User[]) => void): void;
   getUsers(params?: GetUsersData, cb?: (err: Error, users: User[]) => void): void;

--- a/types/auth0/index.d.ts
+++ b/types/auth0/index.d.ts
@@ -356,7 +356,7 @@ export interface Page {
 }
 
 export interface UserPage extends Page {
-  users: User[]
+  users: User[];
 }
 
 export interface Identity {


### PR DESCRIPTION
This PR addresses a [bug](https://github.com/auth0/node-auth0/issues/276#issuecomment-398515690) in the Auth0 project.

According to the d.ts, calling the `getUsers` method always returns an array of users (either passed to a callback or wrapped in a promise). However, adding a special `include_totals` flag to the query actually makes it return a special paged search object (with the results array as a member). This PR adds type documentation for that behaviour.

PR guidelines

√ code is tested
√ code can be built with
√ tests are updated
√ formatting is consistent
√ code is linted
√ incremented version number in header

RFC
@wbhob 
@westy92 
@amiram
