### PR TITLE
Added range case for formatText method and Keyboard module in QuillJs types 

### DIFF
--- a/types/quill/index.d.ts
+++ b/types/quill/index.d.ts
@@ -176,6 +176,7 @@ export class Quill implements EventEmitter {
     formatText(index: number, length: number, format: string, value: any, source?: Sources): DeltaStatic;
     formatText(index: number, length: number, formats: StringMap, source?: Sources): DeltaStatic;
     formatText(range: RangeStatic, format: string, value: any, source?: Sources): DeltaStatic;
+    formatText(range: RangeStatic, formats: StringMap, source?: Sources): DeltaStatic;
     getFormat(range?: RangeStatic): StringMap;
     getFormat(index: number, length?: number): StringMap;
     removeFormat(index: number, length: number, source?: Sources): DeltaStatic;

--- a/types/quill/index.d.ts
+++ b/types/quill/index.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: Sumit <https://github.com/sumitkm>
 //                 Guillaume <https://github.com/guillaume-ro-fr>
 //                 James Garbutt <https://github.com/43081j>
+//                 Aniello Falcone <https://github.com/AnielloFalcone>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 import { Blot } from 'parchment/dist/src/blot/abstract/blot';
@@ -142,6 +143,7 @@ export class Quill implements EventEmitter {
     root: HTMLDivElement;
     clipboard: ClipboardStatic;
     scroll: Blot;
+    keyboard: KeyboardStatic;
     constructor(container: string | Element, options?: QuillOptionsStatic);
     deleteText(index: number, length: number, source?: Sources): DeltaStatic;
     disable(): void;
@@ -173,6 +175,7 @@ export class Quill implements EventEmitter {
     formatText(index: number, length: number, source?: Sources): DeltaStatic;
     formatText(index: number, length: number, format: string, value: any, source?: Sources): DeltaStatic;
     formatText(index: number, length: number, formats: StringMap, source?: Sources): DeltaStatic;
+    formatText(range: RangeStatic, format: string, value: any, source?: Sources): DeltaStatic;
     getFormat(range?: RangeStatic): StringMap;
     getFormat(index: number, length?: number): StringMap;
     removeFormat(index: number, length: number, source?: Sources): DeltaStatic;

--- a/types/quill/quill-tests.ts
+++ b/types/quill/quill-tests.ts
@@ -79,6 +79,15 @@ function test_formatText2() {
     });
 }
 
+function test_formatText3() {
+    const quillEditor = new Quill('#editor');
+    const range = {index: 0, length: 5};
+    quillEditor.formatText(range, {
+        bold: false,
+        color: 'rgb(0, 0, 255)'
+    });
+}
+
 function test_formatLine1() {
     const quillEditor = new Quill('#editor');
     quillEditor.formatLine(1, 3, 'api');

--- a/types/quill/quill-tests.ts
+++ b/types/quill/quill-tests.ts
@@ -82,10 +82,7 @@ function test_formatText2() {
 function test_formatText3() {
     const quillEditor = new Quill('#editor');
     const range = {index: 0, length: 5};
-    quillEditor.formatText(range, {
-        bold: false,
-        color: 'rgb(0, 0, 255)'
-    });
+    quillEditor.formatText(range, 'bold', true);
 }
 
 function test_formatLine1() {

--- a/types/quill/quill-tests.ts
+++ b/types/quill/quill-tests.ts
@@ -85,6 +85,15 @@ function test_formatText3() {
     quillEditor.formatText(range, 'bold', true);
 }
 
+function test_formatText4() {
+    const quillEditor = new Quill('#editor');
+    const range = {index: 0, length: 5};
+    quillEditor.formatText(range, {
+        bold: false,
+        color: 'rgb(0, 0, 255)'
+    });
+}
+
 function test_formatLine1() {
     const quillEditor = new Quill('#editor');
     quillEditor.formatLine(1, 3, 'api');


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://quilljs.com/docs/modules/keyboard/>> It's the in first example shown in the page.
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.