### PR TITLE
@types/serialport: Make the callback of the "on" method non-optional

### DIFF
--- a/types/serialport/index.d.ts
+++ b/types/serialport/index.d.ts
@@ -36,7 +36,7 @@ declare class SerialPort extends Stream.Duplex {
 	pause(): this;
 	resume(): this;
 
-	on(event: string, callback?: (data?: any) => void): this;
+	on(event: string, callback: (data?: any) => void): this;
 
 	static Binding: SerialPort.BaseBinding;
 


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 

https://github.com/DefinitelyTyped/DefinitelyTyped/blob/290798c432e34b5a957fab8d0fd01729209c7d27/types/node/v6/index.d.ts#L3746

- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

This resolves a type mismatch between `SerialPort` and its inherited
`Readable` class.

This fixes an error detected by typescript@2.9.2 in strict mode.
