### PR TITLE
WIP [socket.io] Fixing missing types for Server.bind parameter and Server.engine member

### DIFF
--- a/types/socket.io/index.d.ts
+++ b/types/socket.io/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for socket.io 1.4.5
+// Type definitions for socket.io 2.1.1
 // Project: http://socket.io/
 // Definitions by: PROGRE <https://github.com/progre>
 //                 Damian Connolly <https://github.com/divillysausages>

--- a/types/socket.io/index.d.ts
+++ b/types/socket.io/index.d.ts
@@ -6,9 +6,12 @@
 //                 KentarouTakeda <https://github.com/KentarouTakeda>
 //                 Alexey Snigirev <https://github.com/gigi>
 //                 Ezinwa Okpoechi <https://github.com/BrainMaestro>
+//                 Matthieu Vion   <https://github.com/MattMattV>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 ///<reference types="node" />
+
+import * as engineIO from "engine.io";
 
 declare const SocketIO: SocketIOStatic;
 export = SocketIO;
@@ -50,7 +53,7 @@ interface SocketIOStatic {
 
 declare namespace SocketIO {
 	interface Server {
-		engine: { ws: any };
+		engine: engineIO.Server;
 
 		/**
 		 * A dictionary of all the namespaces currently on this Server
@@ -170,10 +173,10 @@ declare namespace SocketIO {
 
 		/**
 		 * Binds socket.io to an engine.io intsance
-		 * @param src The Engine.io (or compatible) server to bind to
+		 * @param {engineIO.Server} srv engine.io (or compatible) server
 		 * @return This Server
 		 */
-		bind( srv: any ): Server;
+		bind(srv: engineIO.Server ): Server;
 
 		/**
 		 * Called with each incoming connection

--- a/types/socket.io/socket.io-tests.ts
+++ b/types/socket.io/socket.io-tests.ts
@@ -1,5 +1,7 @@
 import socketIO = require('socket.io');
 
+import { IncomingMessage } from "http";
+
 function testUsingWithNodeHTTPServer() {
     var app = require('http').createServer(handler);
     var io: socketIO.Server = socketIO(app);
@@ -188,4 +190,12 @@ function testSocketUse() {
             console.log(packet);
         });
     });
+}
+
+function customPeerIdGenerationFunction() {
+    var io: socketIO.Server = socketIO();
+
+    io.engine.generateId = (request: IncomingMessage): string => {
+        return (new Date()).toString();
+    }
 }


### PR DESCRIPTION
`bind` method and `engine` member can be improved by attaching the engineIO.Server type to them.

One thing is left to do, now I have linked `socket.io` and `engine.io`, test does not pass anymore...

If you have any clue on how to resolve this, I would be happy to do it !

<details>
<summary>npm test error</summary>
<pre>
Error: socket.io depends on engine.io but has a lower required TypeScript version.
    at checkTypeScriptVersions (/home/matthieu/dev/TSI/GitHub/DefinitelyTyped/node_modules/types-publisher/src/check-parse-results.ts:75:11)
    at Object.<anonymous> (/home/matthieu/dev/TSI/GitHub/DefinitelyTyped/node_modules/types-publisher/src/check-parse-results.ts:19:2)
    at Generator.next (<anonymous>)
    at fulfilled (/home/matthieu/dev/TSI/GitHub/DefinitelyTyped/node_modules/types-publisher/bin/check-parse-results.js:4:58)
npm ERR! Test failed.  See above for more details.
</pre>
</details>
<br>

My changes are based on this [portion of source code](https://github.com/socketio/socket.io/blob/2.1.1/lib/index.js#L417)

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
