### PR TITLE
[@types/three.core.BufferGeometry] Fix  BufferGeometry 'attributes' field type

### DIFF
--- a/types/three/three-core.d.ts
+++ b/types/three/three-core.d.ts
@@ -840,7 +840,9 @@ export class BufferGeometry extends EventDispatcher {
     name: string;
     type: string;
     index: BufferAttribute;
-    attributes: BufferAttribute|InterleavedBufferAttribute[];
+    attributes: {
+      [name: string]: BufferAttribute|InterleavedBufferAttribute;
+    };
     morphAttributes: any;
     groups: {start: number, count: number, materialIndex?: number}[];
     boundingBox: Box3;


### PR DESCRIPTION

- [*] Use a meaningful title for the pull request. Include the name of the package modified.
- [*] Test the change in your own code. (Compile and run.)
- [-] Add or edit tests to reflect the change. (Run with `npm test`.)
- [*] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [*] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [*] Run `npm run lint three` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:


If changing an existing definition:
- [*] Provide a URL to documentation or source code which provides context for the suggested changes: https://threejs.org/docs/index.html#api/core/BufferGeometry.attributes
- [-] Increase the version number in the header if appropriate. (small fix - does not affect functionality, but helps extending BufferGeometry)
- [-] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.


