### PR TITLE
@feathersjs/authentication-jwt - make individual options optional, fix export name

### DIFF
--- a/types/feathersjs__authentication-jwt/index.d.ts
+++ b/types/feathersjs__authentication-jwt/index.d.ts
@@ -43,7 +43,7 @@ export interface FeathersAuthenticationJWTOptions {
     /**
      * A Verifier class. Defaults to the built-in one but can be a custom one. See below for details.
      */
-    Verifier: Verifier;
+    Verifier: typeof Verifier;
 }
 
 export class Verifier {

--- a/types/feathersjs__authentication-jwt/index.d.ts
+++ b/types/feathersjs__authentication-jwt/index.d.ts
@@ -8,7 +8,7 @@ import { Application } from '@feathersjs/feathers';
 import { Request } from 'express';
 import * as self from '@feathersjs/authentication-jwt';
 
-declare const feathersAuthenticationJwt: ((options?: FeathersAuthenticationJWTOptions) => () => void) & typeof self;
+declare const feathersAuthenticationJwt: ((options?: Partial<FeathersAuthenticationJWTOptions>) => () => void) & typeof self;
 export default feathersAuthenticationJwt;
 
 export interface FeathersAuthenticationJWTOptions {
@@ -43,10 +43,10 @@ export interface FeathersAuthenticationJWTOptions {
     /**
      * A Verifier class. Defaults to the built-in one but can be a custom one. See below for details.
      */
-    Verifier: JWTVerifier;
+    Verifier: Verifier;
 }
 
-export class JWTVerifier {
+export class Verifier {
     constructor(app: Application, options: any); // the class constructor
 
     verify(req: Request, payload: any, done: (error: any, user?: any, info?: any) => void): void;


### PR DESCRIPTION
- Individual options can be optional (https://github.com/feathersjs/authentication-jwt/blob/master/lib/index.js)
- Verifier class is exported as `Verifier` https://github.com/feathersjs/authentication-jwt/blob/master/lib/index.js#L102