### PR TITLE
showdown: 'Global' setOption type should match 'local' setOption

### DIFF
--- a/types/showdown/index.d.ts
+++ b/types/showdown/index.d.ts
@@ -380,8 +380,11 @@ declare namespace Showdown {
 
     /**
      * Setting a "global" option affects all instances of showdown
+     * 
+     * @param optionKey
+     * @param value
      */
-    function setOption(optionKey: string, value: string): void;
+    function setOption(optionKey: string, value: any): void;
 
     /**
      * Retrieve previous set global option.


### PR DESCRIPTION
This makes the same change as in #21397 but for the 'global' setOption rather than the 'local' setOption that was updated in that PR.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: See #21397

