### PR TITLE
ClientContext field must be spelt 'custom' so that it is correctly se…

### DIFF
--- a/types/aws-lambda/aws-lambda-tests.ts
+++ b/types/aws-lambda/aws-lambda-tests.ts
@@ -482,7 +482,7 @@ str = cloudwatchLogsDecodedData.logEvents[0].message;
 
 /* ClientContext */
 clientContextClient = clientCtx.client;
-anyObj = clientCtx.Custom;
+anyObj = clientCtx.custom;
 clientContextEnv = clientCtx.env;
 
 /* ClientContextEnv */

--- a/types/aws-lambda/index.d.ts
+++ b/types/aws-lambda/index.d.ts
@@ -404,7 +404,7 @@ export interface CognitoIdentity {
 
 export interface ClientContext {
     client: ClientContextClient;
-    Custom?: any;
+    custom?: any;
     env: ClientContextEnv;
 }
 


### PR DESCRIPTION
The ClientContext is passed between lambdas when they directly invoke each other. The 'custom' field is spelt with a lowercase 'c' in the Java API, and therefore is not correctly serialized and is missing if it is spelt 'Custom'.