### PR TITLE
[@types/hapi] Add null to Request.params and Request.payload

### DIFF
--- a/types/hapi/index.d.ts
+++ b/types/hapi/index.d.ts
@@ -424,7 +424,7 @@ export interface Request extends Podium {
     /**
      * An object where each key is a path parameter name with matching value as described in [Path parameters](https://github.com/hapijs/hapi/blob/master/API.md#path-parameters).
      */
-    readonly params: Util.Dictionary<string>;
+    readonly params: Util.Dictionary<string> | null;
 
     /**
      * An array containing all the path params values in the order they appeared in the path.
@@ -440,7 +440,7 @@ export interface Request extends Podium {
      * The request payload based on the route payload.output and payload.parse settings.
      * TODO check this typing and add references / links.
      */
-    readonly payload: stream.Readable | Buffer | string | object;
+    readonly payload: stream.Readable | Buffer | string | object | null;
 
     /**
      * Plugin-specific state. Provides a place to store and pass request-level plugin data. The plugins is an object where each key is a plugin name and the value is the state.

--- a/types/hapi/test/request/parameters.ts
+++ b/types/hapi/test/request/parameters.ts
@@ -20,7 +20,7 @@ const serverRoute1: ServerRoute = {
 // Example 2
 // http://localhost:8000/person/rafael/fijalkowski
 const getPerson: Lifecycle.Method = (request, h) => {
-    const nameParts = request.params.name.split('/');
+    const nameParts = request.params ? request.params.name.split('/') : [];
     return { first: nameParts[0], last: nameParts[1] };
 };
 const serverRoute2: ServerRoute = {


### PR DESCRIPTION
based on hapi.js request object on actual module that params and payload are possible to be null when there is no value applied against it.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
https://github.com/hapijs/hapi/blob/master/lib/request.js#L49
https://github.com/hapijs/hapi/blob/master/lib/request.js#L52
