### PR TITLE
Added startOpen prop

### DIFF
--- a/types/react-datepicker/index.d.ts
+++ b/types/react-datepicker/index.d.ts
@@ -76,6 +76,7 @@ export interface ReactDatePickerProps {
 	showWeekNumbers?: boolean;
 	showYearDropdown?: boolean;
 	startDate?: moment.Moment;
+	startOpen?: boolean;
 	tabIndex?: number;
 	title?: string;
 	todayButton?: string;


### PR DESCRIPTION
This PR adds the _startOpen_ prop on the DatePicker. This prop was missing, but exists as documented here: https://github.com/Hacker0x01/react-datepicker/blob/master/docs/datepicker.md


