### PR TITLE
[fork-ts-checker-webpack-plugin]: add missing tslint dependency

### DIFF
--- a/types/fork-ts-checker-webpack-plugin/package.json
+++ b/types/fork-ts-checker-webpack-plugin/package.json
@@ -1,4 +1,5 @@
 {
+    "private": true,
     "dependencies": {
         "tslint": "*"
     }

--- a/types/fork-ts-checker-webpack-plugin/package.json
+++ b/types/fork-ts-checker-webpack-plugin/package.json
@@ -1,0 +1,5 @@
+{
+    "dependencies": {
+        "tslint": "*"
+    }
+}


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).


When installing `@types/fork-ts-checker-webpack-plugin` in a project, its `package.json` is missing `tslint` as a dependency:

```json
{
    "dependencies": {
        "@types/webpack": "*",
        "@types/node": "*"
    },
}
```

I'm not sure why `tslint` is not included in here, but from reading the documentation, I can manually add dependencies by creating a `package.json` file here, so I did that. Let me know if there's a better way to go about this!