### PR TITLE
atom: bump to version 1.28

### DIFF
--- a/types/atom/index.d.ts
+++ b/types/atom/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Atom 1.27
+// Type definitions for Atom 1.28
 // Project: https://github.com/atom/atom
 // Definitions by: GlenCFL <https://github.com/GlenCFL>
 //                 smhxx <https://github.com/smhxx>
@@ -7,7 +7,7 @@
 // TypeScript Version: 2.3
 
 // NOTE: only those classes exported within this file should be retain that status below.
-// https://github.com/atom/atom/blob/v1.27.0/exports/atom.js
+// https://github.com/atom/atom/blob/v1.28.0/exports/atom.js
 
 /// <reference types="node" />
 
@@ -5844,7 +5844,7 @@ export interface TextEditorObservedEvent {
 // information under certain contexts.
 
 // NOTE: the config schema with these defaults can be found here:
-//   https://github.com/atom/atom/blob/v1.27.0/src/config-schema.js
+//   https://github.com/atom/atom/blob/v1.28.0/src/config-schema.js
 /**
  *  Allows you to strongly type Atom configuration variables. Additional key:value
  *  pairings merged into this interface will result in configuration values under
@@ -5957,7 +5957,16 @@ export interface ConfigValues {
      *  changes will miss any events caused by applications other than Atom, but may help
      *  prevent crashes or freezes.
      */
-    "core.fileSystemWatcher": "native"|"atom";
+    "core.fileSystemWatcher": "native"|"experimental"|"poll"|"atom";
+
+    /** Experimental: Use the new Tree-sitter parsing system for supported languages. */
+    "core.useTreeSitterParsers": boolean;
+
+    /**
+     * Specify whether Atom should use the operating system's color profile (recommended)
+     * or an alternative color profile.
+     */
+    "core.colorProfile": "default"|"srgb";
 
     "editor.commentStart": string|null;
 


### PR DESCRIPTION
- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: [Atom 1.28 Blog Post](http://blog.atom.io/2018/06/21/atom-1-28.html)
[Atom 1.28 Release Page](https://github.com/atom/atom/releases/tag/v1.28.0)
- [X] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

This is primarily just a bump in the version number so that we have a release available for 1.28, as I couldn't find any changes to the API apart from the configuration variable changes.