### PR TITLE
[@types/graphql] Add generic type on ExecutionResult

### DIFF
--- a/types/graphql/execution/execute.d.ts
+++ b/types/graphql/execution/execute.d.ts
@@ -42,9 +42,9 @@ export interface ExecutionContext {
  *   - `errors` is included when any errors occurred as a non-empty array.
  *   - `data` is the result of a successful execution of the query.
  */
-export interface ExecutionResult {
+export interface ExecutionResult<TData> {
     errors?: ReadonlyArray<GraphQLError>;
-    data?: { [key: string]: any };
+    data?: Readonly<TData>;
 }
 
 export type ExecutionArgs = {
@@ -69,8 +69,8 @@ export type ExecutionArgs = {
  *
  * Accepts either an object with named arguments, or individual arguments.
  */
-export function execute(args: ExecutionArgs): MaybePromise<ExecutionResult>;
-export function execute(
+export function execute<TData>(args: ExecutionArgs): MaybePromise<ExecutionResult<TData>>;
+export function execute<TData>(
     schema: GraphQLSchema,
     document: DocumentNode,
     rootValue?: any,
@@ -78,7 +78,7 @@ export function execute(
     variableValues?: Maybe<{ [key: string]: any }>,
     operationName?: Maybe<string>,
     fieldResolver?: Maybe<GraphQLFieldResolver<any, any>>
-): MaybePromise<ExecutionResult>;
+): MaybePromise<ExecutionResult<TData>>;
 
 /**
  * Given a ResponsePath (found in the `path` entry in the information provided

--- a/types/graphql/execution/execute.d.ts
+++ b/types/graphql/execution/execute.d.ts
@@ -48,7 +48,7 @@ export interface ExecutionResultDataDefault {
  */
 export interface ExecutionResult<TData = ExecutionResultDataDefault> {
     errors?: ReadonlyArray<GraphQLError>;
-    data?: Readonly<TData>;
+    data?: TData;
 }
 
 export type ExecutionArgs = {

--- a/types/graphql/execution/execute.d.ts
+++ b/types/graphql/execution/execute.d.ts
@@ -36,13 +36,17 @@ export interface ExecutionContext {
     errors: GraphQLError[];
 }
 
+export interface ExecutionResultDataDefault {
+    [key: string]: any
+}
+
 /**
  * The result of GraphQL execution.
  *
  *   - `errors` is included when any errors occurred as a non-empty array.
  *   - `data` is the result of a successful execution of the query.
  */
-export interface ExecutionResult<TData> {
+export interface ExecutionResult<TData = ExecutionResultDataDefault> {
     errors?: ReadonlyArray<GraphQLError>;
     data?: Readonly<TData>;
 }
@@ -69,8 +73,8 @@ export type ExecutionArgs = {
  *
  * Accepts either an object with named arguments, or individual arguments.
  */
-export function execute<TData>(args: ExecutionArgs): MaybePromise<ExecutionResult<TData>>;
-export function execute<TData>(
+export function execute<TData = ExecutionResultDataDefault>(args: ExecutionArgs): MaybePromise<ExecutionResult<TData>>;
+export function execute<TData = ExecutionResultDataDefault>(
     schema: GraphQLSchema,
     document: DocumentNode,
     rootValue?: any,
@@ -89,6 +93,7 @@ export function responsePathAsArray(path: ResponsePath): ReadonlyArray<string | 
 /**
  * Given a ResponsePath and a key, return a new ResponsePath containing the
  * new key.
+
  */
 export function addPath(
     prev: ResponsePath | undefined,

--- a/types/graphql/graphql.d.ts
+++ b/types/graphql/graphql.d.ts
@@ -2,7 +2,7 @@ import Maybe from "./tsutils/Maybe";
 import { Source } from "./language/source";
 import { GraphQLFieldResolver } from "./type/definition";
 import { GraphQLSchema } from "./type/schema";
-import { ExecutionResult } from "./execution/execute";
+import { ExecutionResult, ExecutionResultDataDefault } from "./execution/execute";
 
 /**
  * This is the primary entry point function for fulfilling GraphQL operations
@@ -44,8 +44,8 @@ export interface GraphQLArgs {
     fieldResolver?: Maybe<GraphQLFieldResolver<any, any>>;
 }
 
-export function graphql<TData>(args: GraphQLArgs): Promise<ExecutionResult<TData>>;
-export function graphql<TData>(
+export function graphql<TData = ExecutionResultDataDefault>(args: GraphQLArgs): Promise<ExecutionResult<TData>>;
+export function graphql<TData = ExecutionResultDataDefault>(
     schema: GraphQLSchema,
     source: Source | string,
     rootValue?: any,
@@ -61,8 +61,8 @@ export function graphql<TData>(
  * However, it guarantees to complete synchronously (or throw an error) assuming
  * that all field resolvers are also synchronous.
  */
-export function graphqlSync<TData>(args: GraphQLArgs): ExecutionResult<TData>;
-export function graphqlSync<TData>(
+export function graphqlSync<TData = ExecutionResultDataDefault>(args: GraphQLArgs): ExecutionResult<TData>;
+export function graphqlSync<TData = ExecutionResultDataDefault>(
     schema: GraphQLSchema,
     source: Source | string,
     rootValue?: any,

--- a/types/graphql/graphql.d.ts
+++ b/types/graphql/graphql.d.ts
@@ -44,8 +44,8 @@ export interface GraphQLArgs {
     fieldResolver?: Maybe<GraphQLFieldResolver<any, any>>;
 }
 
-export function graphql(args: GraphQLArgs): Promise<ExecutionResult>;
-export function graphql(
+export function graphql<TData>(args: GraphQLArgs): Promise<ExecutionResult<TData>>;
+export function graphql<TData>(
     schema: GraphQLSchema,
     source: Source | string,
     rootValue?: any,
@@ -53,7 +53,7 @@ export function graphql(
     variableValues?: Maybe<{ [key: string]: any }>,
     operationName?: Maybe<string>,
     fieldResolver?: Maybe<GraphQLFieldResolver<any, any>>
-): Promise<ExecutionResult>;
+): Promise<ExecutionResult<TData>>;
 
 /**
  * The graphqlSync function also fulfills GraphQL operations by parsing,
@@ -61,8 +61,8 @@ export function graphql(
  * However, it guarantees to complete synchronously (or throw an error) assuming
  * that all field resolvers are also synchronous.
  */
-export function graphqlSync(args: GraphQLArgs): ExecutionResult;
-export function graphqlSync(
+export function graphqlSync<TData>(args: GraphQLArgs): ExecutionResult<TData>;
+export function graphqlSync<TData>(
     schema: GraphQLSchema,
     source: Source | string,
     rootValue?: any,
@@ -70,4 +70,4 @@ export function graphqlSync(
     variableValues?: Maybe<{ [key: string]: any }>,
     operationName?: Maybe<string>,
     fieldResolver?: Maybe<GraphQLFieldResolver<any, any>>
-): ExecutionResult;
+): ExecutionResult<TData>;

--- a/types/graphql/index.d.ts
+++ b/types/graphql/index.d.ts
@@ -14,6 +14,7 @@
 //                 Alessio Dionisi <https://github.com/adnsio>
 //                 Divyendu Singh <https://github.com/divyenduz>
 //                 Brad Zacher <https://github.com/bradzacher>
+//                 Curtis Layne <https://github.com/clayne11>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 

--- a/types/graphql/subscription/subscribe.d.ts
+++ b/types/graphql/subscription/subscribe.d.ts
@@ -24,7 +24,7 @@ import { ExecutionResult } from "../execution/execute";
  *
  * Accepts either an object with named arguments, or individual arguments.
  */
-export function subscribe(args: {
+export function subscribe<TData>(args: {
     schema: GraphQLSchema;
     document: DocumentNode;
     rootValue?: any;
@@ -33,9 +33,9 @@ export function subscribe(args: {
     operationName?: Maybe<string>;
     fieldResolver?: Maybe<GraphQLFieldResolver<any, any>>;
     subscribeFieldResolver?: Maybe<GraphQLFieldResolver<any, any>>;
-}): Promise<AsyncIterator<ExecutionResult> | ExecutionResult>;
+}): Promise<AsyncIterator<ExecutionResult<TData>> | ExecutionResult<TData>>;
 
-export function subscribe(
+export function subscribe<TData>(
     schema: GraphQLSchema,
     document: DocumentNode,
     rootValue?: any,
@@ -44,7 +44,7 @@ export function subscribe(
     operationName?: Maybe<string>,
     fieldResolver?: Maybe<GraphQLFieldResolver<any, any>>,
     subscribeFieldResolver?: Maybe<GraphQLFieldResolver<any, any>>
-): Promise<AsyncIterator<ExecutionResult> | ExecutionResult>;
+): Promise<AsyncIterator<ExecutionResult<TData>> | ExecutionResult<TData>>;
 
 /**
  * Implements the "CreateSourceEventStream" algorithm described in the
@@ -64,7 +64,7 @@ export function subscribe(
  * or otherwise separating these two steps. For more on this, see the
  * "Supporting Subscriptions at Scale" information in the GraphQL specification.
  */
-export function createSourceEventStream(
+export function createSourceEventStream<TData>(
     schema: GraphQLSchema,
     document: DocumentNode,
     rootValue?: any,
@@ -72,4 +72,4 @@ export function createSourceEventStream(
     variableValues?: { [key: string]: any },
     operationName?: Maybe<string>,
     fieldResolver?: Maybe<GraphQLFieldResolver<any, any>>
-): Promise<AsyncIterable<any> | ExecutionResult>;
+): Promise<AsyncIterable<any> | ExecutionResult<TData>>;

--- a/types/graphql/subscription/subscribe.d.ts
+++ b/types/graphql/subscription/subscribe.d.ts
@@ -2,7 +2,7 @@ import Maybe from "../tsutils/Maybe";
 import { GraphQLSchema } from "../type/schema";
 import { DocumentNode } from "../language/ast";
 import { GraphQLFieldResolver } from "../type/definition";
-import { ExecutionResult } from "../execution/execute";
+import { ExecutionResult, ExecutionResultDataDefault } from "../execution/execute";
 
 /**
  * Implements the "Subscribe" algorithm described in the GraphQL specification.
@@ -24,7 +24,7 @@ import { ExecutionResult } from "../execution/execute";
  *
  * Accepts either an object with named arguments, or individual arguments.
  */
-export function subscribe<TData>(args: {
+export function subscribe<TData = ExecutionResultDataDefault>(args: {
     schema: GraphQLSchema;
     document: DocumentNode;
     rootValue?: any;
@@ -35,7 +35,7 @@ export function subscribe<TData>(args: {
     subscribeFieldResolver?: Maybe<GraphQLFieldResolver<any, any>>;
 }): Promise<AsyncIterator<ExecutionResult<TData>> | ExecutionResult<TData>>;
 
-export function subscribe<TData>(
+export function subscribe<TData = ExecutionResultDataDefault>(
     schema: GraphQLSchema,
     document: DocumentNode,
     rootValue?: any,
@@ -64,7 +64,7 @@ export function subscribe<TData>(
  * or otherwise separating these two steps. For more on this, see the
  * "Supporting Subscriptions at Scale" information in the GraphQL specification.
  */
-export function createSourceEventStream<TData>(
+export function createSourceEventStream<TData = ExecutionResultDataDefault>(
     schema: GraphQLSchema,
     document: DocumentNode,
     rootValue?: any,


### PR DESCRIPTION
Without a generic type on ExecutionResult we can't have typesafe
operations.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.