### PR TITLE
[@types/bluebird] bluebird.method can take 0-arg function

### DIFF
--- a/types/bluebird/bluebird-tests.ts
+++ b/types/bluebird/bluebird-tests.ts
@@ -784,6 +784,11 @@ fooProm = Promise.attempt(() => {
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
 asyncfunc = Promise.method(() => {});
+{
+	const noArg: () => Promise<void> = Promise.method(() => {});
+	const oneArg: (x1: number) => Promise<void> = Promise.method((x1: number) => {});
+	const twoArg: (x1: number, x2: string) => Promise<void> = Promise.method((x1: number, x2: string) => {});
+}
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 

--- a/types/bluebird/index.d.ts
+++ b/types/bluebird/index.d.ts
@@ -542,6 +542,7 @@ declare class Bluebird<R> implements PromiseLike<R>, Bluebird.Inspection<R> {
    * The new function will always return a promise that is fulfilled with the original functions return values or rejected with thrown exceptions from the original function.
    * This method is convenient when a function can sometimes return synchronously or throw synchronously.
    */
+  static method<R>(fn: () => R | PromiseLike<R>): () => Bluebird<R>;
   static method<R, A1>(fn: (arg1: A1) => R | PromiseLike<R>): (arg1: A1) => Bluebird<R>;
   static method<R, A1, A2>(fn: (arg1: A1, arg2: A2) => R | PromiseLike<R>): (arg1: A1, arg2: A2) => Bluebird<R>;
   static method<R, A1, A2, A3>(fn: (arg1: A1, arg2: A2, arg3: A3) => R | PromiseLike<R>): (arg1: A1, arg2: A2, arg3: A3) => Bluebird<R>;


### PR DESCRIPTION
`Bluebird.method` takes a function with any number of args, and returns a function with the same number of args. At the moment, the types do not support a 0-arg version.
```typescript
const doThing = () => 22;

const asyncDoThing = Bluebird.method(doThing); // type => (arg0: {}) => Bluebird<number>;
```

[Here are relevant docs](http://bluebirdjs.com/docs/api/promise.method.html)
