### PR TITLE
node: Added missing method of terminal output stream

### DIFF
--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -6424,6 +6424,7 @@ declare module "tty" {
         columns: number;
         rows: number;
         isTTY: boolean;
+        getColorDepth(env?: NodeJS.ProcessEnv): number;
     }
 }
 


### PR DESCRIPTION
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://nodejs.org/api/tty.html#tty_writestream_getcolordepth_env>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
