### PR TITLE
[tapable] Make HookInterceptor fields optional

### DIFF
--- a/types/tapable/index.d.ts
+++ b/types/tapable/index.d.ts
@@ -247,7 +247,7 @@ export interface Tap {
 export class Hook<T1 = any, T2 = any, T3 = any> {
     constructor(...args: any[]);
     taps: any[];
-    interceptors: any[];
+    interceptors: HookInterceptor[];
     call: (arg1?: T1, arg2?: T2, arg3?: T3, ...args: any[]) => any;
     promise:(arg1?: T1, arg2?: T2, arg3?: T3, ...args: any[]) => Promise<any>;
     callAsync: (arg1?: T1, arg2?: T2, arg3?: T3, ...args: any[]) => any;
@@ -271,12 +271,11 @@ export class AsyncSeriesBailHook<T1 = any, T2 = any, T3 = any> extends Hook<T1, 
 export class AsyncSeriesWaterfallHook<T1 = any, T2 = any, T3 = any> extends Hook<T1, T2, T3> {}
 
 export class HookInterceptor {
-    call: (...args: any[]) => void;
-    loop: (...args: any[]) => void;
-    tap: (tap: Tap) => void;
-    register: (tap: Tap) => Tap | undefined;
-    context: boolean;
-    name: string;
+    call?: (...args: any[]) => void;
+    loop?: (...args: any[]) => void;
+    tap?: (tap: Tap) => void;
+    register?: (tap: Tap) => Tap | undefined;
+    context?: boolean;
 }
 
 /** A HookMap is a helper class for a Map with Hooks */


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [README.md](https://github.com/webpack/tapable/blob/9b67d42a3594ba57909f4234d49a6deb4eca84b8/README.md#interception) + [Hook](https://github.com/webpack/tapable/blob/9b67d42a3594ba57909f4234d49a6deb4eca84b8/lib/Hook.js) + [HookCodeFactory](https://github.com/webpack/tapable/blob/9b67d42a3594ba57909f4234d49a6deb4eca84b8/lib/HookCodeFactory.js)
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

All HookInterceptor fields are optional, as implied in [tapable's README](https://github.com/webpack/tapable/blob/9b67d42a3594ba57909f4234d49a6deb4eca84b8/README.md#interception), and you can look through tapable's source to find checks like `if(interceptor.register) {` for each of these fields.

Also removed the `name` field, since it does not apply to HookInterceptor.