### PR TITLE
Add new type declarations for the swagger-ui-express package

### DIFF
--- a/types/swagger-ui-express/index.d.ts
+++ b/types/swagger-ui-express/index.d.ts
@@ -1,0 +1,86 @@
+// Type definitions for swagger-ui-express 3.0
+// Project: https://github.com/scottie1984/swagger-ui-express
+// Definitions by: Dmitry Rogozhny <https://github.com/dmitryrogozhny>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.8
+
+import { RequestHandler } from "express";
+import { ServeStaticOptions } from "serve-static";
+
+declare namespace SwaggerUiExpress {
+    type JsonObject = { [key: string]: any; };
+    type SwaggerUiOptions = { [key: string]: any; };
+    type SwaggerOptions = { [key: string]: any; };
+
+    /**
+     * Creates a middleware function that returns the pre-generated html file for the Swagger UI page.
+     *
+     * @param {(JsonObject | null)} [swaggerDoc] json object with the API schema.
+     * @param {(SwaggerUiOptions | false | null)} [opts] swagger-ui-express options.
+     * @param {SwaggerOptions} [options] custom swagger options.
+     * @param {(string | false | null)} [customCss] string with a custom css to embed into the page.
+     * @param {(string | false | null)} [customfavIcon] link to a custom favicon.
+     * @param {(string | false | null)} [swaggerUrl] Url of the swagger API schema, can be specified instead of the swaggerDoc.
+     * @param {(string | false | null)} [customeSiteTitle] custom title for a page
+     * @returns {RequestHandler} an express middleware function that returns the generated html page.
+     */
+    function setup(swaggerDoc?: JsonObject | null,
+        opts?: SwaggerUiOptions | false | null,
+        options?: SwaggerOptions,
+        customCss?: string | false | null,
+        customfavIcon?: string | false | null,
+        swaggerUrl?: string | false | null,
+        customeSiteTitle?: string | false | null): RequestHandler;
+
+    /**
+     * Returns handlers for serving Swagger UI files.
+     * This includes custom initialization js file and static files of Swagger UI.
+     *
+     * @returns {Array<RequestHandler>} Express handlers that process requests and return files for Swagger UI.
+     */
+    function serve(): Array<RequestHandler>;
+
+    /**
+     * Returns handlers for serving Swagger UI files.
+     * This includes custom initialization js file and static files of Swagger UI.
+     * Additional options are passed to the express.static middleware.
+     *
+     * @param {ServeStaticOptions} options options object that is passed to the express.static middleware.
+     * @returns {Array<RequestHandler>} Express handlers that process requests and return files for Swagger UI.
+     */
+    function serveWithOptions(options: ServeStaticOptions): Array<RequestHandler>;
+
+    /**
+     * Generates the custom html page for the UI API.
+     *
+     * @param {(JsonObject | null)} [swaggerDoc] json object with the API schema.
+     * @param {(SwaggerUiOptions | false | null)} [opts] swagger-ui-express options.
+     * @param {SwaggerOptions} [options] custom swagger options.
+     * @param {(string | false | null)} [customCss] string with a custom css to embed into the page.
+     * @param {(string | false | null)} [customfavIcon] link to a custom favicon.
+     * @param {(string | false | null)} [swaggerUrl] Url of the swagger API schema, can be specified instead of the swaggerDoc.
+     * @param {(string | false | null)} [customeSiteTitle] custom title for a page
+     * @returns {string} the generated html page.
+     */
+    function generateHTML(swaggerDoc?: JsonObject | null,
+        opts?: SwaggerUiOptions | false | null,
+        options?: SwaggerOptions,
+        customCss?: string | false | null,
+        customfavIcon?: string | false | null,
+        swaggerUrl?: string | false | null,
+        customeSiteTitle?: string | false | null): string;
+
+
+    /**
+     * Returns handlers for serving Swagger UI files.
+     * This includes custom initialization js file and static files of Swagger UI.
+     * Additional options object is passed to Swagger UI.
+     *
+     * @param {JsonObject} [swaggerDoc] json object with the Swagger API schema.
+     * @param {SwaggerUiOptions} [opts] options to pass to Swagger UI.
+     * @returns {Array<RequestHandler>} Express handlers that process requests and return files for Swagger UI.
+     */
+    function serveFiles(swaggerDoc?: JsonObject, opts?: SwaggerUiOptions): Array<RequestHandler>;
+}
+
+export default SwaggerUiExpress;

--- a/types/swagger-ui-express/index.d.ts
+++ b/types/swagger-ui-express/index.d.ts
@@ -7,11 +7,11 @@
 import { RequestHandler } from "express";
 import { ServeStaticOptions } from "serve-static";
 
-declare namespace SwaggerUiExpress {
-    interface JsonObject { [key: string]: any; }
-    interface SwaggerUiOptions { [key: string]: any; }
-    interface SwaggerOptions { [key: string]: any; }
+interface JsonObject { [key: string]: any; }
+interface SwaggerUiOptions { [key: string]: any; }
+interface SwaggerOptions { [key: string]: any; }
 
+interface SwaggerUiExpress {
     /**
      * Creates a middleware function that returns the pre-generated html file for the Swagger UI page.
      *
@@ -24,7 +24,7 @@ declare namespace SwaggerUiExpress {
      * @param customeSiteTitle custom title for a page
      * @returns an express middleware function that returns the generated html page.
      */
-    function setup(swaggerDoc?: JsonObject | null,
+    setup(swaggerDoc?: JsonObject | null,
         opts?: SwaggerUiOptions | false | null,
         options?: SwaggerOptions,
         customCss?: string | false | null,
@@ -38,7 +38,7 @@ declare namespace SwaggerUiExpress {
      *
      * @returns Express handlers that process requests and return files for Swagger UI.
      */
-    function serve(): RequestHandler[];
+    serve(): RequestHandler[];
 
     /**
      * Returns handlers for serving Swagger UI files.
@@ -48,7 +48,7 @@ declare namespace SwaggerUiExpress {
      * @param options options object that is passed to the express.static middleware.
      * @returns Express handlers that process requests and return files for Swagger UI.
      */
-    function serveWithOptions(options: ServeStaticOptions): RequestHandler[];
+    serveWithOptions(options: ServeStaticOptions): RequestHandler[];
 
     /**
      * Generates the custom html page for the UI API.
@@ -62,7 +62,7 @@ declare namespace SwaggerUiExpress {
      * @param customeSiteTitle custom title for a page
      * @returns the generated html page.
      */
-    function generateHTML(swaggerDoc?: JsonObject | null,
+    generateHTML(swaggerDoc?: JsonObject | null,
         opts?: SwaggerUiOptions | false | null,
         options?: SwaggerOptions,
         customCss?: string | false | null,
@@ -79,7 +79,9 @@ declare namespace SwaggerUiExpress {
      * @param opts options to pass to Swagger UI.
      * @returns Express handlers that process requests and return files for Swagger UI.
      */
-    function serveFiles(swaggerDoc?: JsonObject, opts?: SwaggerUiOptions): RequestHandler[];
+    serveFiles(swaggerDoc?: JsonObject, opts?: SwaggerUiOptions): RequestHandler[];
 }
 
-export default SwaggerUiExpress;
+declare const swaggerUiExpress: SwaggerUiExpress;
+
+export = swaggerUiExpress;

--- a/types/swagger-ui-express/index.d.ts
+++ b/types/swagger-ui-express/index.d.ts
@@ -8,21 +8,21 @@ import { RequestHandler } from "express";
 import { ServeStaticOptions } from "serve-static";
 
 declare namespace SwaggerUiExpress {
-    type JsonObject = { [key: string]: any; };
-    type SwaggerUiOptions = { [key: string]: any; };
-    type SwaggerOptions = { [key: string]: any; };
+    interface JsonObject { [key: string]: any; }
+    interface SwaggerUiOptions { [key: string]: any; }
+    interface SwaggerOptions { [key: string]: any; }
 
     /**
      * Creates a middleware function that returns the pre-generated html file for the Swagger UI page.
      *
-     * @param {(JsonObject | null)} [swaggerDoc] json object with the API schema.
-     * @param {(SwaggerUiOptions | false | null)} [opts] swagger-ui-express options.
-     * @param {SwaggerOptions} [options] custom swagger options.
-     * @param {(string | false | null)} [customCss] string with a custom css to embed into the page.
-     * @param {(string | false | null)} [customfavIcon] link to a custom favicon.
-     * @param {(string | false | null)} [swaggerUrl] Url of the swagger API schema, can be specified instead of the swaggerDoc.
-     * @param {(string | false | null)} [customeSiteTitle] custom title for a page
-     * @returns {RequestHandler} an express middleware function that returns the generated html page.
+     * @param swaggerDoc json object with the API schema.
+     * @param opts swagger-ui-express options.
+     * @param options custom swagger options.
+     * @param customCss string with a custom css to embed into the page.
+     * @param customfavIcon link to a custom favicon.
+     * @param swaggerUrl Url of the swagger API schema, can be specified instead of the swaggerDoc.
+     * @param customeSiteTitle custom title for a page
+     * @returns an express middleware function that returns the generated html page.
      */
     function setup(swaggerDoc?: JsonObject | null,
         opts?: SwaggerUiOptions | false | null,
@@ -36,31 +36,31 @@ declare namespace SwaggerUiExpress {
      * Returns handlers for serving Swagger UI files.
      * This includes custom initialization js file and static files of Swagger UI.
      *
-     * @returns {Array<RequestHandler>} Express handlers that process requests and return files for Swagger UI.
+     * @returns Express handlers that process requests and return files for Swagger UI.
      */
-    function serve(): Array<RequestHandler>;
+    function serve(): RequestHandler[];
 
     /**
      * Returns handlers for serving Swagger UI files.
      * This includes custom initialization js file and static files of Swagger UI.
      * Additional options are passed to the express.static middleware.
      *
-     * @param {ServeStaticOptions} options options object that is passed to the express.static middleware.
-     * @returns {Array<RequestHandler>} Express handlers that process requests and return files for Swagger UI.
+     * @param options options object that is passed to the express.static middleware.
+     * @returns Express handlers that process requests and return files for Swagger UI.
      */
-    function serveWithOptions(options: ServeStaticOptions): Array<RequestHandler>;
+    function serveWithOptions(options: ServeStaticOptions): RequestHandler[];
 
     /**
      * Generates the custom html page for the UI API.
      *
-     * @param {(JsonObject | null)} [swaggerDoc] json object with the API schema.
-     * @param {(SwaggerUiOptions | false | null)} [opts] swagger-ui-express options.
-     * @param {SwaggerOptions} [options] custom swagger options.
-     * @param {(string | false | null)} [customCss] string with a custom css to embed into the page.
-     * @param {(string | false | null)} [customfavIcon] link to a custom favicon.
-     * @param {(string | false | null)} [swaggerUrl] Url of the swagger API schema, can be specified instead of the swaggerDoc.
-     * @param {(string | false | null)} [customeSiteTitle] custom title for a page
-     * @returns {string} the generated html page.
+     * @param swaggerDoc json object with the API schema.
+     * @param opts swagger-ui-express options.
+     * @param options custom swagger options.
+     * @param customCss string with a custom css to embed into the page.
+     * @param customfavIcon link to a custom favicon.
+     * @param swaggerUrl Url of the swagger API schema, can be specified instead of the swaggerDoc.
+     * @param customeSiteTitle custom title for a page
+     * @returns the generated html page.
      */
     function generateHTML(swaggerDoc?: JsonObject | null,
         opts?: SwaggerUiOptions | false | null,
@@ -70,17 +70,16 @@ declare namespace SwaggerUiExpress {
         swaggerUrl?: string | false | null,
         customeSiteTitle?: string | false | null): string;
 
-
     /**
      * Returns handlers for serving Swagger UI files.
      * This includes custom initialization js file and static files of Swagger UI.
      * Additional options object is passed to Swagger UI.
      *
-     * @param {JsonObject} [swaggerDoc] json object with the Swagger API schema.
-     * @param {SwaggerUiOptions} [opts] options to pass to Swagger UI.
-     * @returns {Array<RequestHandler>} Express handlers that process requests and return files for Swagger UI.
+     * @param swaggerDoc json object with the Swagger API schema.
+     * @param opts options to pass to Swagger UI.
+     * @returns Express handlers that process requests and return files for Swagger UI.
      */
-    function serveFiles(swaggerDoc?: JsonObject, opts?: SwaggerUiOptions): Array<RequestHandler>;
+    function serveFiles(swaggerDoc?: JsonObject, opts?: SwaggerUiOptions): RequestHandler[];
 }
 
 export default SwaggerUiExpress;

--- a/types/swagger-ui-express/swagger-ui-express-tests.ts
+++ b/types/swagger-ui-express/swagger-ui-express-tests.ts
@@ -2,21 +2,25 @@
  * Tests are taken from the module's repository at https://github.com/scottie1984/swagger-ui-express/blob/master/test/testapp/app.js
  */
 
-import swaggerUi from "swagger-ui-express";
+import swaggerUi = require('swagger-ui-express');
+import express = require('express');
 
-const express = require('express');
 const app = express();
-const swaggerDocument = require('./swagger.json');
-const swaggerDocumentSplit = require('./swagger-split.json');
+const swaggerDocument = {
+	swagger: '2.0',
+	info: { version: '1.0.0', title: 'Example API' },
+	paths: { '/user': { get: { responses: { 200: { description: 'all users' } } } } }
+};
+const swaggerDocumentSplit = swaggerDocument;
 
 const options = {
 	validatorUrl: null,
 	oauth: {
-		clientId: "your-client-id1",
-		clientSecret: "your-client-secret-if-required1",
-		realm: "your-realms1",
-		appName: "your-app-name1",
-		scopeSeparator: ",",
+		clientId: 'your-client-id1',
+		clientSecret: 'your-client-secret-if-required1',
+		realm: 'your-realms1',
+		appName: 'your-app-name1',
+		scopeSeparator: ',',
 		additionalQueryStringParams: {}
 	},
 	docExpansion: 'full',

--- a/types/swagger-ui-express/swagger-ui-express-tests.ts
+++ b/types/swagger-ui-express/swagger-ui-express-tests.ts
@@ -1,0 +1,63 @@
+/**
+ * Tests are taken from the module's repository at https://github.com/scottie1984/swagger-ui-express/blob/master/test/testapp/app.js
+ */
+
+import swaggerUi from "swagger-ui-express";
+
+const express = require('express');
+const app = express();
+const swaggerDocument = require('./swagger.json');
+const swaggerDocumentSplit = require('./swagger-split.json');
+
+const options = {
+	validatorUrl: null,
+	oauth: {
+		clientId: "your-client-id1",
+		clientSecret: "your-client-secret-if-required1",
+		realm: "your-realms1",
+		appName: "your-app-name1",
+		scopeSeparator: ",",
+		additionalQueryStringParams: {}
+	},
+	docExpansion: 'full',
+};
+
+app.use('/api-docs', swaggerUi.serve);
+app.get('/api-docs', swaggerUi.setup(swaggerDocument, false, options, '.swagger-ui .topbar { background-color: red }'));
+
+app.use('/api-docs-from-url', swaggerUi.serve);
+app.get('/api-docs-from-url', swaggerUi.setup(null, false, options, '.swagger-ui .topbar { background-color: red }', null, '/swagger.json'));
+
+const swaggerUiOpts = {
+	explorer: false,
+	swaggerOptions: options,
+	customCss: '.swagger-ui .topbar { background-color: blue }'
+};
+
+app.use('/api-docs-using-object', swaggerUi.serve);
+app.get('/api-docs-using-object', swaggerUi.setup(swaggerDocument, swaggerUiOpts));
+
+const swaggerUiOpts2 = {
+	explorer: false,
+	swaggerOptions: options,
+	customCss: '.swagger-ui .topbar { background-color: pink }',
+	swaggerUrl: '/swagger.json',
+	customJs: '/my-custom.js',
+	operationsSorter: 'alpha'
+};
+
+app.use('/api-docs-from-url-using-object', swaggerUi.serve);
+app.get('/api-docs-from-url-using-object', swaggerUi.setup(null, swaggerUiOpts2));
+
+app.use('/api-docs-with-null', swaggerUi.serve);
+app.get('/api-docs-with-null', swaggerUi.setup(swaggerDocument, null, options, '.swagger-ui .topbar { background-color: orange }'));
+
+app.use('/api-docs-split', swaggerUi.serve);
+app.get('/api-docs-split', swaggerUi.setup(swaggerDocumentSplit, null, options, '.swagger-ui .topbar { background-color: orange }'));
+
+app.use('/api-docs-with-opts/', swaggerUi.serveWithOptions({ redirect: false }));
+app.get('/api-docs-with-opts/', swaggerUi.setup(swaggerDocumentSplit, null, options, '.swagger-ui .topbar { background-color: orange }'));
+
+const swaggerHtml = swaggerUi.generateHTML(swaggerDocument, swaggerUiOpts);
+
+app.use('/api-docs-html1', swaggerUi.serveFiles(swaggerDocument, swaggerUiOpts));

--- a/types/swagger-ui-express/tsconfig.json
+++ b/types/swagger-ui-express/tsconfig.json
@@ -7,7 +7,7 @@
         "noImplicitAny": true,
         "noImplicitThis": true,
         "strictNullChecks": true,
-        "strictFunctionTypes": false,
+        "strictFunctionTypes": true,
         "baseUrl": "../",
         "typeRoots": [
             "../"

--- a/types/swagger-ui-express/tsconfig.json
+++ b/types/swagger-ui-express/tsconfig.json
@@ -7,6 +7,7 @@
         "noImplicitAny": true,
         "noImplicitThis": true,
         "strictNullChecks": true,
+        "strictFunctionTypes": false,
         "baseUrl": "../",
         "typeRoots": [
             "../"

--- a/types/swagger-ui-express/tsconfig.json
+++ b/types/swagger-ui-express/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "swagger-ui-express-tests.ts"
+    ]
+}

--- a/types/swagger-ui-express/tslint.json
+++ b/types/swagger-ui-express/tslint.json
@@ -1,0 +1,6 @@
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "no-var-requires": false
+    }
+}

--- a/types/swagger-ui-express/tslint.json
+++ b/types/swagger-ui-express/tslint.json
@@ -1,6 +1,3 @@
 {
-    "extends": "dtslint/dt.json",
-    "rules": {
-        "no-var-requires": false
-    }
+    "extends": "dtslint/dt.json"
 }


### PR DESCRIPTION
Types for the [swagger-ui-express](https://www.npmjs.com/package/swagger-ui-express) npm package.

This package automates the generation of a Swagger UI page for Express-based applications. The Swagger UI page shows the information about the API schema.

Tests for types are taken from the package's tests: https://github.com/scottie1984/swagger-ui-express/tree/master/test/testapp

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).


If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.