### PR TITLE
vuex-i18n - Nested Translations interface and support for translateIn with two parameters

### DIFF
--- a/types/vuex-i18n/index.d.ts
+++ b/types/vuex-i18n/index.d.ts
@@ -64,7 +64,7 @@ export interface Ii18n {
   /**
    * get localized string from store in a given language if available.
    */
-  translateIn(locale: string, key: string, options: any, pluralization?: number): string | undefined;
+  translateIn(locale: string, key: string, options?: any, pluralization?: number): string | undefined;
 
   /**
    * get localized string from store in a given language if available.

--- a/types/vuex-i18n/index.d.ts
+++ b/types/vuex-i18n/index.d.ts
@@ -17,7 +17,7 @@ declare module "vue/types/vue" {
 }
 
 export interface Translations {
-  [key: string]: string;
+  [key: string]: string | Translations;
 }
 
 export interface Ii18n {

--- a/types/vuex-i18n/index.d.ts
+++ b/types/vuex-i18n/index.d.ts
@@ -25,6 +25,9 @@ export interface Ii18n {
   /** get the current locale */
   locale(): string;
 
+  /** get all the registered locales */
+  locales(): string[];
+
   /** set the current locale (i.e. 'de', 'en') */
   set(locale: string): void;
 

--- a/types/vuex-i18n/index.d.ts
+++ b/types/vuex-i18n/index.d.ts
@@ -73,7 +73,7 @@ export interface Ii18n {
   /**
    * get localized string from store in a given language if available.
    */
-  translateIn(locale: string, key: string, defaultValue: string, options: any, pluralization?: number): string | undefined;
+  translateIn(locale: string, key: string, defaultValue: string, options?: any, pluralization?: number): string | undefined;
 
   /**
    * check if the given locale translations are present in the store

--- a/types/vuex-i18n/index.d.ts
+++ b/types/vuex-i18n/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for vuex-i18n 1.7
 // Project: https://github.com/dkfbasel/vuex-i18n
 // Definitions by: Cedric Kemp <https://github.com/jaeggerr>
+//                 Noam Kfir <https://github.com/noamkfir>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 

--- a/types/vuex-i18n/vuex-i18n-tests.ts
+++ b/types/vuex-i18n/vuex-i18n-tests.ts
@@ -23,7 +23,10 @@ Vue.use(vuexI18n.plugin, store);
 // structured as object trees and will automatically be flattened by the the
 // plugin
 const translationsEn = {
-  content: "This is some {type} content"
+  content: "This is some {type} content",
+  tree: {
+    nested: "This is nested content"
+  }
 };
 
 // translations can be kept in separate files for each language

--- a/types/vuex-i18n/vuex-i18n-tests.ts
+++ b/types/vuex-i18n/vuex-i18n-tests.ts
@@ -42,3 +42,5 @@ Vue.i18n.add("de", translationsDe);
 
 // set the start locale to use
 Vue.i18n.set("en");
+
+Vue.i18n.translateIn("en", "tree.nested");


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: [flattened translations](https://github.com/dkfbasel/vuex-i18n/blob/6f3043670dd220437451277dd60e3b48b1771730/src/vuex-i18n-store.js#L143) and [translateIn signature](https://github.com/dkfbasel/vuex-i18n/blob/6f3043670dd220437451277dd60e3b48b1771730/src/vuex-i18n-plugin.js#L117)
- [X] Increase the version number in the header if appropriate.
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
