### PR TITLE
[@types/passport]: Add callbackURL to the list of options

### DIFF
--- a/types/passport/index.d.ts
+++ b/types/passport/index.d.ts
@@ -52,7 +52,7 @@ declare namespace passport {
         userProperty?: string;
         passReqToCallback?: boolean;
         prompt?: string;
-		callbackURL?: string;
+        callbackURL?: string;
     }
 
     interface Authenticator<InitializeRet = express.Handler, AuthenticateRet = any, AuthorizeRet = AuthenticateRet> {

--- a/types/passport/index.d.ts
+++ b/types/passport/index.d.ts
@@ -52,6 +52,7 @@ declare namespace passport {
         userProperty?: string;
         passReqToCallback?: boolean;
         prompt?: string;
+		callbackURL?: string;
     }
 
     interface Authenticator<InitializeRet = express.Handler, AuthenticateRet = any, AuthorizeRet = AuthenticateRet> {


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/jaredhanson/passport-oauth2/blob/master/lib/strategy.js#L135

Method `.authenticate` is the method that custom passport strategies implement theirselves. `options` object is being passed to them as a second argument. Since we don't know which of the `.authenticate` methods will get called at type-checking stage and it's `options` object's properties can vary between implementations, `[key: any]: any` should probably be added to it. However I'm not sure if this is a correct way to do it, so at least I added a `callbackURL` option from oauth2 package. It already has got options that are from external strategies such as `passReqToCallback` (from oauth2 too), so I think it's fine to add another one.