### PR TITLE
[react-native] - Move onKeyPress from TextInputIOSProps to TextInputProps

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -1000,13 +1000,6 @@ export interface TextInputIOSProps {
     keyboardAppearance?: "default" | "light" | "dark";
 
     /**
-     * Callback that is called when a key is pressed.
-     * Pressed key value is passed as an argument to the callback handler.
-     * Fires before onChange callbacks.
-     */
-    onKeyPress?: (event: {nativeEvent: {key: string}}) => void;
-
-    /**
      * See DocumentSelectionState.js, some state that is responsible for maintaining selection information for a document
      */
     selectionState?: DocumentSelectionState;
@@ -1082,6 +1075,9 @@ export type ReturnKeyTypeAndroid = "none" | "previous";
 export type ReturnKeyTypeIOS = "default" | "google" | "join" | "route" | "yahoo" | "emergency-call";
 export type ReturnKeyTypeOptions = ReturnKeyType | ReturnKeyTypeAndroid | ReturnKeyTypeIOS;
 
+/**
+ * @see TextInputProps.onFocus
+ */
 export interface TextInputFocusEventData {
     target: number;
     text: string;
@@ -1104,6 +1100,13 @@ export interface TextInputSelectionChangeEventData {
         end: number;
     };
     target: number;
+}
+
+/**
+ * @see TextInputProps.onKeyPress
+ */
+export interface TextInputKeyPressEventData {
+    key: string;
 }
 
 /**
@@ -1245,6 +1248,17 @@ export interface TextInputProps
      * May also contain other properties from ScrollEvent but on Android contentSize is not provided for performance reasons.
      */
     onScroll?: (e: NativeSyntheticEvent<TextInputScrollEventData>) => void;
+
+    /**
+     * Callback that is called when a key is pressed.
+     * This will be called with
+     *  `{ nativeEvent: { key: keyValue } }`
+     * where keyValue is 'Enter' or 'Backspace' for respective keys and the typed-in character otherwise including ' ' for space.
+     *
+     * Fires before onChange callbacks.
+     * Note: on Android only the inputs from soft keyboard are handled, not the hardware keyboard inputs.
+     */
+    onKeyPress?: (e: NativeSyntheticEvent<TextInputKeyPressEventData>) => void;
 
     /**
      * The string that will be rendered before text input has been entered

--- a/types/react-native/test/index.tsx
+++ b/types/react-native/test/index.tsx
@@ -58,6 +58,7 @@ import {
     GestureResponderEvent,
     TextInputScrollEventData,
     TextInputSelectionChangeEventData,
+    TextInputKeyPressEventData,
 } from "react-native";
 
 declare module "react-native" {
@@ -501,6 +502,11 @@ class TextInputTest extends React.Component<{}, {username: string}> {
         console.log(`end: ${ e.nativeEvent.selection.end }`);
     }
 
+    handleOnKeyPress = (e: NativeSyntheticEvent<TextInputKeyPressEventData>) => {
+        testNativeSyntheticEvent(e);
+        console.log(`key: ${ e.nativeEvent.key }`);
+    }
+
     render() {
         return (
             <View>
@@ -524,6 +530,10 @@ class TextInputTest extends React.Component<{}, {username: string}> {
 
                 <TextInput
                     onSelectionChange={this.handleOnSelectionChange}
+                />
+
+                <TextInput
+                    onKeyPress={this.handleOnKeyPress}
                 />
             </View>
         );


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://facebook.github.io/react-native/docs/textinput.html#onkeypress>>, <<https://github.com/facebook/react-native/blob/398f1d8dddaa5f5c12909ab479e99c3e83c3b884/RNTester/js/TextInputExample.ios.js#L77>>, <<https://github.com/facebook/react-native/blob/0e5c2633ee261d27c57e180494a2662a9f00dbc8/RNTester/js/TextInputExample.android.js#L60>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
