### PR TITLE
[jest]: add missing error instance type to toThrow

### DIFF
--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -563,11 +563,11 @@ declare namespace jest {
         /**
          * Used to test that a function throws when it is called.
          */
-        toThrow(error?: string | Constructable | RegExp): R;
+        toThrow(error?: string | Constructable | RegExp | Error): R;
         /**
          * If you want to test that a specific error is thrown inside a function.
          */
-        toThrowError(error?: string | Constructable | RegExp): R;
+        toThrowError(error?: string | Constructable | RegExp | Error): R;
         /**
          * Used to test that a function throws a error matching the most recent snapshot when it is called.
          */

--- a/types/jest/jest-tests.ts
+++ b/types/jest/jest-tests.ts
@@ -556,15 +556,18 @@ describe("", () => {
         expect(true).toStrictEqual(false);
         expect({}).toStrictEqual({});
 
+        const errInstance = new Error();
+        const willThrow = () => { throw new Error(); };
         expect(() => {}).toThrow();
-        expect(() => { throw new Error(); }).toThrow("");
+        expect(willThrow).toThrow("");
+        expect(willThrow).toThrow(errInstance);
         expect(jest.fn()).toThrow(Error);
-        expect(jest.fn(() => { throw new Error(); })).toThrow(/foo/);
+        expect(jest.fn(willThrow)).toThrow(/foo/);
 
         expect(() => {}).toThrowErrorMatchingSnapshot();
-        expect(() => { throw new Error(); }).toThrowErrorMatchingSnapshot();
+        expect(willThrow).toThrowErrorMatchingSnapshot();
         expect(jest.fn()).toThrowErrorMatchingSnapshot();
-        expect(jest.fn(() => { throw new Error(); })).toThrowErrorMatchingSnapshot();
+        expect(jest.fn(willThrow)).toThrowErrorMatchingSnapshot();
 
         /* not */
 


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://facebook.github.io/jest/docs/en/expect#tothrowerror
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

Closes #26756