### PR TITLE
[pg] Client.query now accepts Submittables

### DIFF
--- a/types/pg-query-stream/index.d.ts
+++ b/types/pg-query-stream/index.d.ts
@@ -6,6 +6,7 @@
 /// <reference types="node" />
 
 import stream = require("stream");
+import pg = require("pg");
 
 declare namespace QueryStream {
     interface Options {
@@ -14,11 +15,12 @@ declare namespace QueryStream {
     }
 }
 
-declare class QueryStream extends stream.Readable {
+declare class QueryStream extends stream.Readable implements pg.Submittable {
     batchSize: number;
     text: string;
     values?: any[];
     constructor(text: string, values?: any[], options?: QueryStream.Options);
+    submit(connection: pg.Connection): void;
 }
 
 export = QueryStream;

--- a/types/pg/index.d.ts
+++ b/types/pg/index.d.ts
@@ -51,6 +51,10 @@ export interface QueryConfig {
     values?: any[];
 }
 
+export interface Submittable {
+    submit: (connection: Connection) => void;
+}
+
 export interface QueryArrayConfig extends QueryConfig {
     rowMode: 'array';
 }
@@ -148,7 +152,7 @@ export class Pool extends events.EventEmitter {
     end(): Promise<void>;
     end(callback: () => void): void;
 
-    query(queryStream: QueryConfig & stream.Readable): stream.Readable;
+    query<T extends Submittable>(queryStream: T): T;
     query(queryConfig: QueryArrayConfig): Promise<QueryArrayResult>;
     query(queryConfig: QueryConfig): Promise<QueryResult>;
     query(queryTextOrConfig: string | QueryConfig, values?: any[]): Promise<QueryResult>;
@@ -166,7 +170,7 @@ export class ClientBase extends events.EventEmitter {
     connect(): Promise<void>;
     connect(callback: (err: Error) => void): void;
 
-    query(queryStream: QueryConfig & stream.Readable): stream.Readable;
+    query<T extends Submittable>(queryStream: T): T;
     query(queryConfig: QueryArrayConfig): Promise<QueryArrayResult>;
     query(queryConfig: QueryConfig): Promise<QueryResult>;
     query(queryTextOrConfig: string | QueryConfig, values?: any[]): Promise<QueryResult>;

--- a/types/pg/index.d.ts
+++ b/types/pg/index.d.ts
@@ -17,6 +17,7 @@ export interface ConnectionConfig {
     host?: string;
     connectionString?: string;
     keepAlive?: boolean;
+    stream?: stream.Duplex;
 }
 
 export interface Defaults extends ConnectionConfig {
@@ -87,6 +88,48 @@ export interface Notification {
 
 export interface ResultBuilder extends QueryResult {
     addRow(row: any): void;
+}
+
+export interface QueryParse {
+    name: string;
+    text: string;
+    types: string[];
+}
+
+export interface BindConfig {
+    portal?: string;
+    statement?: string;
+    binary?: string;
+    values?: Array<(Buffer | null | undefined | string)>;
+}
+
+export interface ExecuteConfig {
+    portal?: string;
+    rows?: string;
+}
+
+export interface MessageConfig {
+    type: string;
+    name?: string;
+}
+
+export class Connection extends events.EventEmitter {
+    readonly stream: stream.Duplex;
+
+    constructor(config?: ConnectionConfig);
+
+    bind(config: BindConfig | null, more: boolean): void;
+    execute(config: ExecuteConfig | null, more: boolean): void;
+    parse(query: QueryParse, more: boolean): void;
+
+    query(text: string): void;
+
+    describe(msg: MessageConfig, more: boolean): void;
+    close(msg: MessageConfig, more: boolean): void;
+
+    flush(): void;
+    sync(): void;
+    end(): void;
 }
 
 export class Pool extends events.EventEmitter {


### PR DESCRIPTION
Mentions: @pspeter3 

This commit creates a new interface on types/pg called Submittable
following the description on node-postgres API doc, which says:

> client.query with a Submittable
>
> If you pass an object to client.query and the object has a .submit
> function on it, the client will pass it's PostgreSQL server connection
> to the object and delegate query dispatching to the supplied object
> [...]

and uses the new interface as argument type to Client.query and
Pool.query. This allows the usage of `pg-copy-streams` package, for example.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://node-postgres.com/api/client#client-query
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.