### PR TITLE
[webpack-sources] Make constructor argument optional

### DIFF
--- a/types/webpack-sources/index.d.ts
+++ b/types/webpack-sources/index.d.ts
@@ -154,7 +154,7 @@ export class ReplaceSource extends Source implements SourceAndMapMixin {
     _name: string;
     replacements: any[][];
 
-    constructor(source: Source, name: string);
+    constructor(source: Source, name?: string);
 
     replace(start: number, end: number, newValue: string): void;
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: There is no documentation, but here is the source: https://github.com/webpack/webpack-sources/blob/master/lib/ReplaceSource.js `this._name` isn't used at all.
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
