### PR TITLE
[react-native-tab-view] Remove `void` State generic

### DIFF
--- a/types/react-native-tab-view/index.d.ts
+++ b/types/react-native-tab-view/index.d.ts
@@ -4,7 +4,7 @@
 //                 Kyle Roach <https://github.com/iRoachie>
 //                 Tim Wang <https://github.com/timwangdev>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.9
+// TypeScript Version: 2.6
 import { PureComponent, ReactNode, ComponentType } from 'react'
 import {
   Animated,

--- a/types/react-native-tab-view/index.d.ts
+++ b/types/react-native-tab-view/index.d.ts
@@ -2,8 +2,9 @@
 // Project: https://github.com/react-native-community/react-native-tab-view
 // Definitions by: Kalle Ott <https://github.com/kaoDev>
 //                 Kyle Roach <https://github.com/iRoachie>
+//                 Tim Wang <https://github.com/timwangdev>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.9
 import { PureComponent, ReactNode, ComponentType } from 'react'
 import {
   Animated,
@@ -91,10 +92,7 @@ export type TabViewProps<
   style?: StyleProp<ViewStyle>
 }
 
-export class TabView<T extends Route = Route> extends PureComponent<
-  TabViewProps<T>,
-  any
-> {}
+export class TabView<T extends Route = Route> extends PureComponent<TabViewProps<T>> {}
 
 export type GestureEvent = {
   nativeEvent: {
@@ -144,10 +142,7 @@ export type DefaultTransitionSpec = {
   friction: 35
 }
 
-export class PagerPan<T extends Route = Route> extends PureComponent<
-  PagerPanProps<T>,
-  void
-> {
+export class PagerPan<T extends Route = Route> extends PureComponent<PagerPanProps<T>> {
   static defaultProps: {
     configureTransition: () => DefaultTransitionSpec
     initialLayout: {
@@ -176,10 +171,7 @@ export type PagerScrollProps<
   children?: ReactNode
 }
 
-export class PagerScroll<T extends Route = Route> extends PureComponent<
-PagerScrollProps<T>,
-  any
-> {}
+export class PagerScroll<T extends Route = Route> extends PureComponent<PagerScrollProps<T>> {}
 
 export type PageScrollEvent = {
   nativeEvent: {
@@ -198,10 +190,7 @@ export type PagerAndroidProps<
   children?: ReactNode
 }
 
-export class PagerAndroid<T extends Route = Route> extends PureComponent<
-  PagerAndroidProps<T>,
-  void
-> {}
+export class PagerAndroid<T extends Route = Route> extends PureComponent<PagerAndroidProps<T>> {}
 
 export type IndicatorProps<
   T extends RouteBase = RouteBase
@@ -227,10 +216,7 @@ export type TabBarProps<T extends RouteBase = RouteBase> = SceneRendererProps<
   style?: StyleProp<ViewStyle>
 }
 
-export class TabBar<T extends Route = Route> extends PureComponent<
-  TabBarProps<T>,
-  any
-> {}
+export class TabBar<T extends Route = Route> extends PureComponent<TabBarProps<T>> {}
 
 export function SceneMap(scenes: {
   [key: string]: ComponentType<any>


### PR DESCRIPTION
Second generic template for `React.PureComponent` is optional (`{}`), and `void` is not valid. Also the State here don't really matter in a type definition file.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.