### PR TITLE
[@feathersjs/feathers] add feathers.SKIP and ability to return it from hooks

### DIFF
--- a/types/feathersjs__feathers/index.d.ts
+++ b/types/feathersjs__feathers/index.d.ts
@@ -48,7 +48,7 @@ export interface Paginated<T> {
 // tslint:disable-next-line void-return
 export type Hook = (hook: HookContext) => (Promise<HookContext | SkipSymbol | void> | HookContext | SkipSymbol | void);
 
-export type SkipSymbol = Symbol | '__feathersSkipHooks';
+export type SkipSymbol = symbol | '__feathersSkipHooks';
 
 export interface HookContext<T = any> {
     app?: Application;

--- a/types/feathersjs__feathers/index.d.ts
+++ b/types/feathersjs__feathers/index.d.ts
@@ -14,6 +14,7 @@ declare const feathers: (() => Application<object>) & typeof self;
 export default feathers;
 
 export const version: string;
+export const SKIP: SkipSymbol;
 
 export type Id = number | string;
 export type NullableId = Id | null;
@@ -45,7 +46,9 @@ export interface Paginated<T> {
 }
 
 // tslint:disable-next-line void-return
-export type Hook = (hook: HookContext) => (Promise<HookContext> | void);
+export type Hook = (hook: HookContext) => (Promise<HookContext | SkipSymbol | void> | HookContext | SkipSymbol | void);
+
+export type SkipSymbol = Symbol | '__feathersSkipHooks';
 
 export interface HookContext<T = any> {
     app?: Application;


### PR DESCRIPTION
from the docs:

```
A hook function can be a normal or async function or arrow function that takes the hook context as the parameter and can

  return a context object
  return nothing (undefined)
  return feathers.SKIP to skip all further hooks
  throw an error

for asynchronous operations return a Promise that
  resolves with a context object
  resolves with undefined
  rejects with an error
```
