### PR TITLE
(@featherjs/authentication-client) fix return type of verifyJWT

### DIFF
--- a/types/feathersjs__authentication-client/index.d.ts
+++ b/types/feathersjs__authentication-client/index.d.ts
@@ -53,7 +53,7 @@ export interface Passport {
 
     getJWT(): Promise<any>;
 
-    verifyJWT(token: string): Promise<string>;
+    verifyJWT(token: string): Promise<any>;
 
     payloadIsValid(payload: string): boolean;
 


### PR DESCRIPTION
It returns the JWT payload, so not a string.