### PR TITLE
mssql: fix definitions for PreparedStatements class

### DIFF
--- a/types/mssql/index.d.ts
+++ b/types/mssql/index.d.ts
@@ -1,6 +1,12 @@
 // Type definitions for mssql 4.0.5
 // Project: https://www.npmjs.com/package/mssql
-// Definitions by: COLSA Corporation <http://www.colsa.com/>, Ben Farr <https://github.com/jaminfarr>, Vitor Buzinaro <https://github.com/buzinas>, Matt Richardson <https://github.com/mrrichar>, Jørgen Elgaard Larsen <https://github.com/elhaard>, Peter Keuter <https://github.com/pkeuter>
+// Definitions by: COLSA Corporation <http://www.colsa.com/>
+//                 Ben Farr <https://github.com/jaminfarr>
+//                 Vitor Buzinaro <https://github.com/buzinas>
+//                 Matt Richardson <https://github.com/mrrichar>
+//                 Jørgen Elgaard Larsen <https://github.com/elhaard>
+//                 Peter Keuter <https://github.com/pkeuter>
+//                 David Gasperoni <https://github.com/mcdado>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />

--- a/types/mssql/index.d.ts
+++ b/types/mssql/index.d.ts
@@ -311,8 +311,10 @@ export declare class PreparedStatement extends events.EventEmitter {
     public output(name: string, type: (() => ISqlType) | ISqlType): PreparedStatement;
     public prepare(statement?: string): Promise<void>;
     public prepare(statement?: string, callback?: (err?: Error) => void): PreparedStatement;
-    public execute(values: Object): Promise<void>;
-    public execute(values: Object, callback: (err?: Error) => void): Request;
+    public execute(values: Object): Promise<IProcedureResult<any>>;
+    public execute<Entity>(values: Object): Promise<IProcedureResult<Entity>>;
+    public execute(values: Object, callback: (err?: Error, result?: IProcedureResult<any>) => void): Request;
+    public execute<Entity>(values: Object, callback: (err?: Error, result?: IProcedureResult<Entity>) => void): Request;
     public unprepare(): Promise<void>;
     public unprepare(callback: (err?: Error) => void): PreparedStatement;
 }


### PR DESCRIPTION
The execute methods of PreparedStatement object lacked the specific return types.
Before they simply returned void, now the adhere to the IProcedureResult interface.

Since I'm not well versed in file definitions, I looked up some information on [typescriptlang.org](https://www.typescriptlang.org) and copied from `Request` class. Still, I'm not sure what the `<Entity>` lines are for. If they're unnecessary they could be removed I guess.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [method in code](https://github.com/tediousjs/node-mssql/blob/fd49c617b12c8bd42a1315530196a449134130cc/lib/base.js#L628), [docs](https://tediousjs.github.io/node-mssql/#prepared-statement)
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
