### PR TITLE
Add definition for node-memwatch

### DIFF
--- a/types/node-memwatch/index.d.ts
+++ b/types/node-memwatch/index.d.ts
@@ -1,0 +1,87 @@
+// Type definitions for node-memwatch 1.0
+// Project: https://github.com/eduardbcom/node-memwatch#readme
+// Definitions by: Eunchong Yu <https://github.com/Kroisse>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import { EventEmitter } from 'events';
+
+export = memwatch;
+
+declare const memwatch: MemWatch;
+
+interface MemWatch extends EventEmitter {
+    on(eventName: "leak", callback: (event: LeakInformation) => void): this;
+    on(eventName: "stats", callback: (event: StatsInformation) => void): this;
+
+    /**
+     * Force V8 to do a full GC and heap compaction.
+     *
+     * It's intended to be used for debugging. Calling it in production is highly discouraged.
+     */
+    gc(): void;
+
+    HeapDiff: typeof HeapDiff;
+}
+
+interface StatsInformation {
+    current_base: number;
+    estimated_base: number;
+    heap_compactions: number;
+    max: number;
+    min: number;
+    num_full_gc: number;
+    num_inc_gc: number;
+    usage_trend: number;
+}
+
+interface LeakInformation {
+    /**
+     * Amount of heap growth in bytes.
+     */
+    growth: number;
+
+    /**
+     * Human-readable description.
+     */
+    reason: string;
+}
+
+/**
+ * Compare the state of your heap between two points in time, telling you what has been allocated, and what has been released.
+ */
+declare class HeapDiff {
+    constructor();
+
+    /**
+     * Compute the diff.
+     */
+    end: () => HeapDiffInformation;
+}
+
+interface HeapDiffInformation {
+    before: HeapDiffSnapshot;
+    after: HeapDiffSnapshot;
+    change: HeapDiffChange;
+}
+
+interface HeapDiffSnapshot {
+    nodes: number;
+    size_bytes: number;
+    size: string;
+}
+
+interface HeapDiffChange {
+    size_bytes: number;
+    size: string;
+    freed_nodes: number;
+    allocated_nodes: number;
+    details: HeapDiffDetail[];
+}
+
+interface HeapDiffDetail {
+    what: string;
+    size_bytes: number;
+    size: string;
+    "+": number;
+    "-": number;
+}

--- a/types/node-memwatch/node-memwatch-tests.ts
+++ b/types/node-memwatch/node-memwatch-tests.ts
@@ -1,0 +1,14 @@
+import memwatch = require("node-memwatch");
+
+memwatch.on("stats", info => {
+    info.estimated_base;
+});
+
+memwatch.on("leak", info => {
+    info.growth;
+});
+
+const hd = new memwatch.HeapDiff();
+const diff = hd.end();
+diff.change.allocated_nodes;
+diff.change.details[0].what;

--- a/types/node-memwatch/tsconfig.json
+++ b/types/node-memwatch/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "node-memwatch-tests.ts"
+    ]
+}

--- a/types/node-memwatch/tslint.json
+++ b/types/node-memwatch/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Some of types were brought from @cyrilschumacher's memwatch-next definition.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
