### PR TITLE
chore: bumped redux version to 4.x & correct (Generic)StoreEnhancer import

### DIFF
--- a/types/remote-redux-devtools/index.d.ts
+++ b/types/remote-redux-devtools/index.d.ts
@@ -7,7 +7,7 @@ import {
   Action,
   ActionCreator,
   ActionCreatorsMapObject,
-  GenericStoreEnhancer
+  StoreEnhancer
 } from "redux";
 
 export interface RemoteReduxDevToolsOptions {
@@ -108,5 +108,5 @@ export interface RemoteReduxDevToolsOptions {
   id?: string;
 }
 
-export function composeWithDevTools(options?: RemoteReduxDevToolsOptions): (...funcs: GenericStoreEnhancer[]) => GenericStoreEnhancer;
-export function composeWithDevTools(...funcs: GenericStoreEnhancer[]): GenericStoreEnhancer;
+export function composeWithDevTools(options?: RemoteReduxDevToolsOptions): (...funcs: StoreEnhancer[]) => StoreEnhancer;
+export function composeWithDevTools(...funcs: StoreEnhancer[]): StoreEnhancer;

--- a/types/remote-redux-devtools/package.json
+++ b/types/remote-redux-devtools/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "redux": "^3.6.0"
+        "redux": "^4.0.0"
     }
 }


### PR DESCRIPTION
The underlying packages of remote-redux-devtools, redux-devtools-instrument has received an update to support redux 4.x so currently when using redux 4.x , Typescript compilation breaks because this type definition uses Redux 3.x's `GenericStoreEnhancer` instead of the Redux 4.x `StoreEnhancer` tyoe.