### PR TITLE
[react] InputHTMLAttributes - capture attribute can be a string or a boolean

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -16,6 +16,7 @@
 //                 Guilherme Hübner <https://github.com/guilhermehubner>
 //                 Ferdy Budhidharma <https://github.com/ferdaber>
 //                 Johann Rakotoharisoa <https://github.com/jrakotoharisoa>
+//                 Olivier Pascal <https://github.com/pascaloliv>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.6
 
@@ -1224,7 +1225,7 @@ declare namespace React {
         autoComplete?: string;
         autoFocus?: boolean;
         autoPlay?: boolean;
-        capture?: boolean;
+        capture?: boolean | string;
         cellPadding?: number | string;
         cellSpacing?: number | string;
         charSet?: string;
@@ -1461,7 +1462,7 @@ declare namespace React {
         alt?: string;
         autoComplete?: string;
         autoFocus?: boolean;
-        capture?: boolean; // https://www.w3.org/TR/html-media-capture/#the-capture-attribute
+        capture?: boolean | string; // https://www.w3.org/TR/html-media-capture/#the-capture-attribute
         checked?: boolean;
         crossOrigin?: string;
         disabled?: boolean;


### PR DESCRIPTION
Hello everyone,

according to [`react-dom` source](https://github.com/facebook/react/blob/6a530e3baa9c44a509979c5d7013d4e1617cbc76/packages/react-dom/src/shared/DOMProperty.js#L327) - the `capture`  attribute on a input type file should accept a string or a boolean value (they call it "overloaded" boolean).

At the moment in `@types/react`, `capture` only accepts a boolean value.
The purpose of this PR is to accept a boolean OR a string value. 

More informations : HTML Media Capture : [w3c spec](https://www.w3.org/TR/html-media-capture/#the-capture-attribute).

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.