### PR TITLE
(re-opened) Type definitions for slate-react

### DIFF
--- a/types/slate-react/index.d.ts
+++ b/types/slate-react/index.d.ts
@@ -6,7 +6,7 @@
 //                 Patrick Sachs <https://github.com/PatrickSachs>
 //                 Brandon Shelton <https://github.com/YangusKhan>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 import { Slate } from 'slate';
 import * as Immutable from 'immutable';
 import * as React from 'react';

--- a/types/slate-react/index.d.ts
+++ b/types/slate-react/index.d.ts
@@ -1,0 +1,108 @@
+// Type definitions for slate-react 0.12
+// Project: https://github.com/ianstormtaylor/slate
+// Definitions by: Andy Kent <https://github.com/andykent>
+//                 Jamie Talbot <https://github.com/majelbstoat>
+//                 Jan Löbel <https://github.com/JanLoebel>
+//                 Patrick Sachs <https://github.com/PatrickSachs>
+//                 Brandon Shelton <https://github.com/YangusKhan>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
+import { Slate } from 'slate';
+import * as Immutable from 'immutable';
+import * as React from 'react';
+
+// Values prefixed with "data-..." (Used for spellchecking according to docs)
+export interface RenderAttributes {
+  [key: string]: any;
+}
+
+export interface RenderMarkProps {
+  attributes: RenderAttributes;
+  children: React.ReactNode;
+  editor: Editor;
+  mark: Slate.Mark;
+  marks: Immutable.Set<Slate.Mark>;
+  node: Slate.Node;
+  offset: number;
+  text: string;
+}
+
+export interface RenderNodeProps {
+  attributes: RenderAttributes;
+  children: React.ReactNode;
+  editor: Editor;
+  isSelected: boolean;
+  key: string;
+  node: Slate.Block;
+  parent: Slate.Node;
+}
+
+export interface Plugin {
+  onBeforeInput?: (event: Event, change: Slate.Change, editor: Editor) => Slate.Change | void;
+  onBlur?: (event: Event, change: Slate.Change, editor: Editor) => Slate.Change | void;
+  onFocus?: (event: Event, change: Slate.Change, editor: Editor) => Slate.Change | void;
+  onClick?: (event: Event, change: Slate.Change, editor: Editor) => Slate.Change | void;
+  onCopy?: (event: Event, change: Slate.Change, editor: Editor) => Slate.Change | void;
+  onCut?: (event: Event, change: Slate.Change, editor: Editor) => Slate.Change | void;
+  onDrop?: (event: Event, change: Slate.Change, editor: Editor) => Slate.Change | void;
+  onKeyDown?: (event: Event, change: Slate.Change, editor: Editor) => Slate.Change | void;
+  onKeyUp?: (event: Event, change: Slate.Change, editor: Editor) => Slate.Change | void;
+  onPaste?: (event: Event, change: Slate.Change, editor: Editor) => Slate.Change | void;
+  onSelect?: (event: Event, change: Slate.Change, editor: Editor) => Slate.Change | void;
+  onChange?: (change: Slate.Change) => any;
+  renderEditor?: (props: RenderAttributes, editor: Editor) => object | void;
+  schema?: Slate.Schema;
+  decorateNode?: (node: Slate.Node) => Slate.Range[] | void;
+  renderMark?: (props: RenderMarkProps) => any;
+  renderNode?: (props: RenderNodeProps) => any;
+  renderPlaceholder?: (props: RenderAttributes) => any;
+  renderPortal?: (props: RenderAttributes) => any;
+  validateNode?: (node: Node) => any;
+}
+
+export interface BasicEditorProps {
+  value: Slate.Value;
+  autoCorrect?: boolean;
+  autoFocus?: boolean;
+  className?: string;
+  onChange?: (change: Slate.Change) => any;
+  placeholder?: any;
+  plugins?: Plugin[];
+  readOnly?: boolean;
+  role?: string;
+  schema?: Slate.Schema;
+  spellCheck?: boolean;
+  style?: { [key: string]: string };
+  tabIndex?: number;
+}
+
+// tsling:disable interface-over-type-literal
+export type EditorProps = BasicEditorProps & Plugin;
+
+export interface EditorState {
+  schema: Slate.Schema;
+  value: Slate.Value;
+  stack: Slate.Stack; // [TODO] define stack
+}
+
+export class Editor extends React.Component<EditorProps, EditorState> {
+  schema: Slate.Schema;
+  value: Slate.Value;
+  stack: Slate.Stack;
+
+  // Instance Methods
+  blur(): void;
+  change(fn: (change: Slate.Change) => any): void;
+  change(...args: any[]): void;
+  focus(): void;
+}
+
+export type SlateType = 'fragment' | 'html' | 'node' | 'rich' | 'text' | 'files';
+
+export function findDOMNode(node: Slate.Node): Element;
+export function findDOMRange(range: Slate.Range): Range;
+export function findNode(element: Element, value: Slate.Value): Slate.Node;
+export function findRange(selection: Selection, value: Slate.Value): Slate.Range;
+export function getEventRange(event: Event, value: Slate.Value): Slate.Range;
+export function getEventTransfer(event: Event): { type: SlateType; node: Slate.Node };
+export function setEventTransfer(event: Event, type: SlateType, data: any): void;

--- a/types/slate-react/package.json
+++ b/types/slate-react/package.json
@@ -1,0 +1,6 @@
+{
+  "private": true,
+  "dependencies": {
+    "immutable": "^3.8.2"
+  }
+}

--- a/types/slate-react/slate-react-tests.tsx
+++ b/types/slate-react/slate-react-tests.tsx
@@ -1,0 +1,28 @@
+import { Editor, Plugin, EditorProps } from "slate-react";
+import { Slate } from "slate";
+import * as React from "react";
+
+class MyPlugin implements Plugin {
+    onChange(change: Slate.Change): void {
+        change.blur();
+    }
+}
+
+const myPlugin = new MyPlugin();
+
+interface MyEditorState {
+    value: Slate.Value;
+}
+
+class MyEditor extends React.Component<EditorProps, MyEditorState> {
+    constructor(props: EditorProps) {
+        super(props);
+        this.state = {
+            value: Slate.Value.create()
+        };
+    }
+
+    render() {
+        return <Editor value={this.state.value} onChange={myPlugin.onChange} />;
+    }
+}

--- a/types/slate-react/tsconfig.json
+++ b/types/slate-react/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "types": [],
+        "noEmit": true,
+        "jsx": "preserve",
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "slate-react-tests.tsx"
+    ]
+}

--- a/types/slate-react/tslint.json
+++ b/types/slate-react/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "dtslint/dt.json"
+}


### PR DESCRIPTION
I made some git errors in my previous pull request for this, so I closed that PR and opened a new one after fixing my git repository.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.