### PR TITLE
 Expo: Add support for missing height and width Svg.Use props

### DIFF
--- a/types/expo/expo-tests.tsx
+++ b/types/expo/expo-tests.tsx
@@ -478,6 +478,7 @@ async () => {
             />
         </Svg.G>
         <Svg.Use href="#shape" x="20" y="0" />
+        <Svg.Use href="#shape" x="20" y="0" width="20" height="20"/>
         <Svg.Symbol id="symbol" viewBox="0 0 150 110" width="100" height="50">
             <Svg.Circle cx="50" cy="50" r="40" strokeWidth="8" stroke="red" fill="red"/>
             <Svg.Circle cx="90" cy="60" r="40" strokeWidth="8" stroke="green" fill="white"/>

--- a/types/expo/index.d.ts
+++ b/types/expo/index.d.ts
@@ -2076,6 +2076,8 @@ export interface SvgUseProps extends SvgCommonProps {
     href: string;
     x: number | string;
     y: number | string;
+    width?: number | string;
+    height?: number | string;
 }
 
 export interface SvgSymbolProps extends SvgCommonProps {


### PR DESCRIPTION
I updated an existing definition to add support for the optional height and width properties on the Svg.Use component. I also updated the relevant tests to check for these attributes.

Expo wraps react-native-svg [(expo docs)](https://docs.expo.io/versions/latest/sdk/svg), so the functionality of the Expo.Svg components should mirror that of the React Native SVG project's components.
In the RN SVG's [documentation examples](https://github.com/react-native-community/react-native-svg#use), the `height` and `width` properties are demonstrated as valid props. Adding the props to the `<Use>` component also works in Expo's wrapped version and exhibits the expected behavior at runtime.