### PR TITLE
Fix test argument type for jest-each

### DIFF
--- a/types/jest-each/index.d.ts
+++ b/types/jest-each/index.d.ts
@@ -9,7 +9,7 @@ export = JestEach;
 declare function JestEach(parameters: any[][]): JestEach.ReturnType;
 
 declare namespace JestEach {
-	type SyncCallback = (...args: string[]) => void;
+	type SyncCallback = (...args: any[]) => void;
 	type AsyncCallback = () => void;
 
 	type TestCallback = SyncCallback | AsyncCallback;

--- a/types/jest-each/index.d.ts
+++ b/types/jest-each/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for jest-each 0.3
 // Project: https://github.com/mattphillips/jest-each
-// Definitions by: Michael Utz <https://github.com/theutz>
+// Definitions by: Michael Utz <https://github.com/theutz>, Nick McCurdy <https://github.com/nickmccurdy>
 // Definitions: <https://github.com/DefinitelyTyped/DefinitelyTyped>
 // TypeScript Version: 2.1
 


### PR DESCRIPTION
In `jest-each`, the each callback args are forced to be strings, but they should be any. This is a bug fix to prevent the types from being too restrictive, so I didn't change the version (assuming it will still republish with the fix).

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: See parameters of the JestEach function declaration, and note that `any[][]` and `string[]` are not consistent, it should be `any[]`.
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.