### PR TITLE
[@types/next] Fix wrong router type in app

### DIFF
--- a/types/next/app.d.ts
+++ b/types/next/app.d.ts
@@ -4,6 +4,7 @@ import { RouterProps } from "./router";
 
 export interface AppComponentProps {
     Component: React.ComponentType<any>;
+    router: RouterProps;
     pageProps: any;
 }
 

--- a/types/next/app.d.ts
+++ b/types/next/app.d.ts
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { NextContext } from ".";
-import { SingletonRouter } from "./router";
+import { RouterProps } from "./router";
 
 export interface AppComponentProps {
     Component: React.ComponentType<any>;
@@ -9,7 +9,7 @@ export interface AppComponentProps {
 
 export interface AppComponentContext {
     Component: React.ComponentType<any>;
-    router: SingletonRouter;
+    router: RouterProps;
     ctx: NextContext;
 }
 

--- a/types/next/test/next-app-tests.tsx
+++ b/types/next/test/next-app-tests.tsx
@@ -17,7 +17,7 @@ class TestApp extends App<NextComponentProps> {
     }
 
     render() {
-        const { Component, pageProps } = this.props;
+        const { Component, router, pageProps } = this.props;
         return (
             <Container>
                 <Component {...pageProps} />


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/zeit/next.js/blob/1ebd9967ac79f00ed33f68a02341380d8ce0d609/server/render.js#L8 (not the default export is used (which would be the `SingletonRouter`) but the `Router` class)
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

The `router` passed to `App.getInitialProps` is not the `SingletonRouter` but the `Router` instance itself.
