### PR TITLE
[knockout] Reorder overrides of ko.observable to handle an edge-case better.

### DIFF
--- a/types/knockout/index.d.ts
+++ b/types/knockout/index.d.ts
@@ -106,9 +106,9 @@ interface KnockoutObservableArray<T> extends KnockoutObservable<T[]>, KnockoutOb
 interface KnockoutObservableStatic {
     fn: KnockoutObservableFunctions<any>;
 
-    <T = any>(): KnockoutObservable<T | undefined>
-    <T = any>(value: null): KnockoutObservable<T | null>
     <T>(value: T): KnockoutObservable<T>;
+    <T = any>(value: null): KnockoutObservable<T | null>
+    <T = any>(): KnockoutObservable<T | undefined>
 }
 
 interface KnockoutObservable<T> extends KnockoutSubscribable<T>, KnockoutObservableFunctions<T> {

--- a/types/knockout/test/index.ts
+++ b/types/knockout/test/index.ts
@@ -757,3 +757,7 @@ interface MyObservableArray extends KnockoutObservableArray<any> {
 interface MyComputed extends KnockoutComputed<any> {
     isBeautiful?: boolean;
 }
+
+function observableAny() {
+    ko.observable<number>(5 as any); // $ExpectType KnockoutObservable<number>
+}


### PR DESCRIPTION
A slight tweak to #26627:  I discovered an edge case where the ordering of `ko.observable` overrides was unfortunate:

    ko.observable<number>(5 as any);

The expected result of this line is `KnockoutObservable<number>`, but with the old ordering of overrides it was matching `<T = any>(value: null): KnockoutObservable<T | null>` and the result was `KnockoutObservable<number | null>`.  Swapping the order of the overrides around fixes this case.