### PR TITLE
[@types/facebook-js-sdk] fix getAuthResponse type

### DIFF
--- a/types/facebook-js-sdk/facebook-js-sdk-tests.ts
+++ b/types/facebook-js-sdk/facebook-js-sdk-tests.ts
@@ -8,25 +8,22 @@ FB.init({
    xfbml: true
 });
 
-FB.getLoginStatus(function(response: fb.AuthResponse) {
+FB.getLoginStatus(function(response: fb.StatusResponse) {
     console.log(response);
     console.log(response.status);
     console.log(response.authResponse.accessToken);
 });
 
-FB.getLoginStatus(function(response: fb.AuthResponse) {
+FB.getLoginStatus(function(response: fb.StatusResponse) {
     console.log(response);
     console.log(response.status);
     console.log(response.authResponse.accessToken);
 }, true);
 
-FB.getAuthResponse(function(response: fb.AuthResponse) {
-    console.log(response);
-    console.log(response.status);
-    console.log(response.authResponse.accessToken);
-});
+const authResponse: fb.AuthResponse = FB.getAuthResponse();
+console.log(authResponse.accessToken);
 
-FB.login(function(response: fb.AuthResponse) {
+FB.login(function(response: fb.StatusResponse) {
     console.log(response);
     console.log(response.status);
     console.log(response.authResponse.accessToken);
@@ -34,7 +31,7 @@ FB.login(function(response: fb.AuthResponse) {
     scope: 'public_profile'
 });
 
-FB.logout(function(response: fb.AuthResponse) {
+FB.logout(function(response: fb.StatusResponse) {
     console.log(response);
     console.log(response.status);
     console.log(response.authResponse.accessToken);

--- a/types/facebook-js-sdk/index.d.ts
+++ b/types/facebook-js-sdk/index.d.ts
@@ -1,12 +1,14 @@
 // Type definitions for the Facebook Javascript SDK 2.8
 // Project: https://developers.facebook.com/docs/javascript
-// Definitions by: Amrit Kahlon <https://github.com/amritk>
+// Definitions by:  Amrit Kahlon    <https://github.com/amritk>
+//                  Mahmoud Zohdi   <https://github.com/mahmoudzohdi>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 import fb = facebook;
 declare var FB: fb.FacebookStatic;
 declare namespace facebook {
-
+    
+    
     interface FacebookStatic {
         api: any;
         AppEvents: any;
@@ -18,15 +20,17 @@ declare namespace facebook {
          * The synchronous nature of this method is what sets it apart from the other login methods.
          *
          * @param callback function to handle the response.
+         * 
+         * This method is similar in nature to FB.getLoginStatus(), but it returns just the authResponse object.
          */
-        getAuthResponse(callback: (response: AuthResponse) => void): void;
+        getAuthResponse(): AuthResponse;
         /**
          * FB.getLoginStatus() allows you to determine if a user is
          * logged in to Facebook and has authenticated your app.
          *
          * @param callback function to handle the response.
          */
-        getLoginStatus(callback: (response: AuthResponse) => void, roundtrip?: boolean ): void;
+        getLoginStatus(callback: (response: StatusResponse) => void, roundtrip?: boolean ): void;
         /**
          * The method FB.init() is used to initialize and setup the SDK.
          *
@@ -43,13 +47,13 @@ declare namespace facebook {
          * @param callback function to handle the response.
          * @param options optional ILoginOption to add params such as scope.
          */
-        login(callback: (response: AuthResponse) => void, options?: LoginOptions): void;
+        login(callback: (response: StatusResponse) => void, options?: LoginOptions): void;
         /**
          * The method FB.logout() logs the user out of your site and, in some cases, Facebook.
          *
          * @param callback function to handle the response
          */
-        logout(callback: (response: AuthResponse) => void): void;
+        logout(callback: (response: StatusResponse) => void): void;
 
         /**
          * @see https://developers.facebook.com/docs/sharing/reference/share-dialog
@@ -180,16 +184,16 @@ declare namespace facebook {
     //  RESPONSES
     //
     ////////////////////////
-
     interface AuthResponse {
+        accessToken: string;
+        expiresIn: number;
+        signedRequest: string;
+        userID: string;
+    }
+    
+    interface StatusResponse {
         status: string;
-        authResponse: {
-            accessToken: string;
-            expiresIn: number;
-	        grantedScopes: string;
-            signedRequest: string;
-            userID: string;
-        };
+        authResponse: AuthResponse;
     }
 
     interface ShareDialogResponse {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
 - FB.getAuthResponse: https://developers.facebook.com/docs/reference/javascript/FB.getAuthResponse/
 - authResponse Object type: https://developers.facebook.com/docs/reference/javascript/FB.getLoginStatus
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
