### PR TITLE
mongodb: improved overloads for Collection.count()

### DIFF
--- a/types/mongodb/index.d.ts
+++ b/types/mongodb/index.d.ts
@@ -487,8 +487,9 @@ export interface Collection<TSchema = Default> {
     bulkWrite(operations: Object[], options?: CollectionBluckWriteOptions): Promise<BulkWriteOpResultObject>;
     bulkWrite(operations: Object[], options: CollectionBluckWriteOptions, callback: MongoCallback<BulkWriteOpResultObject>): void;
     /** http://mongodb.github.io/node-mongodb-native/3.0/api/Collection.html#count */
+    count(callback: MongoCallback<number>): void;
     count(query: Object, callback: MongoCallback<number>): void;
-    count(query: Object, options?: MongoCountPreferences): Promise<number>;
+    count(query?: Object, options?: MongoCountPreferences): Promise<number>;
     count(query: Object, options: MongoCountPreferences, callback: MongoCallback<number>): void;
     /** http://mongodb.github.io/node-mongodb-native/3.0/api/Collection.html#createIndex */
     createIndex(fieldOrSpec: string | any, callback: MongoCallback<string>): void;

--- a/types/mongodb/mongodb-tests.ts
+++ b/types/mongodb/mongodb-tests.ts
@@ -35,7 +35,29 @@ MongoClient.connect('mongodb://127.0.0.1:27017/test', options, function (err: mo
     var collection = db.collection('test_insert');
     collection.insertOne({ a: 2 }, function (err: mongodb.MongoError, docs: any) {
 
-        collection.count(function (err: mongodb.MongoError, count: any) {
+        // Intentionally omitted type annotation from 'count'.
+        // This way it requires a more accurate typedef which allows inferring that it's a number.
+        collection.count(function (err: mongodb.MongoError, count) {
+            console.log(format("count = %s", count));
+        });
+
+        collection.count().then(function (count: number) {
+            console.log(format("count = %s", count));
+        });
+
+        collection.count({ foo: 1 }, function (err: mongodb.MongoError, count: number) {
+            console.log(format("count = %s", count));
+        });
+
+        collection.count({ foo: 1 }).then(function (count: number) {
+            console.log(format("count = %s", count));
+        });
+
+        collection.count({ foo: 1 }, { limit: 10 }, function (err: mongodb.MongoError, count: number) {
+            console.log(format("count = %s", count));
+        });
+
+        collection.count({ foo: 1 }, { limit: 10 }).then(function (count: number) {
             console.log(format("count = %s", count));
         });
 


### PR DESCRIPTION
See https://github.com/mongodb/node-mongodb-native/pull/1756 - the `query` parameter in `Collection.count()` is optional, but was not documented as such.

This is probably the reason it was also non-optional in these typedefs.

I also noticed that the tests already included a case where neither `query` or `options` were passed to `count()`, only `callback`. However, the callback (incorrectly) matched `query: Object`, so it didn't trigger an error.
Removing the `any` annotation from the `count` parameter in the test made it fail with the old typedefs, because it could no longer infer the correct type of the parameter.
I fixed the typedefs so it's now correctly inferred as a number.
I also removed the annotation from the test to increase the likelyhood of catching regressions in the future.

----

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/mongodb/node-mongodb-native/pull/1756
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.