### PR TITLE
Add string to Tether.ITetherOptions.classes

### DIFF
--- a/types/tether/index.d.ts
+++ b/types/tether/index.d.ts
@@ -24,7 +24,7 @@ declare namespace Tether {
     interface ITetherOptions {
         attachment: string;
         bodyElement?: HTMLElement;
-        classes?: {[className: string]: boolean};
+        classes?: {[className: string]: boolean | string};
         classPrefix?: string;
         constraints?: ITetherConstraint[];
         element?: HTMLElement | string | any /* JQuery */;

--- a/types/tether/tether-tests.ts
+++ b/types/tether/tether-tests.ts
@@ -9,7 +9,11 @@ new Tether({
     targetAttachment: "top middle",
     targetModifier: "visible",
     offset: "-15px 0",
-    targetOffset: "0 0"
+    targetOffset: "0 0",
+    classes: {
+      'element': false,
+      'target': 'someClassName'
+    }
 });
 
 new Tether({
@@ -50,4 +54,3 @@ new Tether({
         }
     ]
 });
-


### PR DESCRIPTION
Boolean is used for disabling classes while strings is used for overriding. See docs screenshot from http://tether.io/ 

<img width="607" alt="screen shot 2018-06-26 at 11 47 18 pm" src="https://user-images.githubusercontent.com/7935599/41958467-fab0494a-799e-11e8-9f05-63cda51efa0a.png">

@adidahiya @TrevorBurnham