### PR TITLE
Add type declarations for mongodb-memory-server

### DIFF
--- a/types/mongodb-memory-server/index.d.ts
+++ b/types/mongodb-memory-server/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for mongodb-memory-server 1.8
 // Project: https://github.com/nodkz/mongodb-memory-server
-// Definitions by: My Self <https://github.com/me>
+// Definitions by: Dmitry Rogozhny <https://github.com/dmitryrogozhny>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 

--- a/types/mongodb-memory-server/index.d.ts
+++ b/types/mongodb-memory-server/index.d.ts
@@ -1,0 +1,153 @@
+// Type definitions for mongodb-memory-server 1.8
+// Project: https://github.com/nodkz/mongodb-memory-server
+// Definitions by: My Self <https://github.com/me>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.8
+
+/// <reference types="node" />
+
+import { ChildProcess } from "child_process";
+
+import MongoMemoryServer = _MongoMemoryServer.MongoMemoryServer;
+import MongoInstance = _MongoInstance.MongodbInstance;
+import MongoBinary = _MongoBinary.MongoBinary;
+
+export default MongoMemoryServer;
+export { MongoMemoryServer, MongoInstance, MongoBinary };
+
+// exports from the ./util/MongoBinary.js.flow file
+declare namespace _MongoBinary {
+    interface MongoBinaryCache {
+        [version: string]: string;
+    }
+
+    interface MongoBinaryOpts {
+        version?: string;
+        downloadDir?: string;
+        platform?: string;
+        arch?: string;
+        debug?: boolean | ((...args: any[]) => any);
+    }
+
+    // disable error for a class with all static functions,
+    // so the TypeScript declaration would map the implementation with flow types for easier support.
+    // tslint:disable-next-line:no-unnecessary-class
+    class MongoBinary {
+        static cache: MongoBinaryCache;
+
+        static getPath(opts?: MongoBinaryOpts): Promise<string>;
+        static hasValidBinPath(files: string[]): boolean;
+    }
+}
+
+// exports from the ./util/MongoInstance.js.flow file
+declare namespace _MongoInstance {
+    interface MongodOps {
+        // instance options
+        instance: {
+            port: number,
+            storageEngine?: string,
+            dbPath: string,
+            debug?: boolean | ((...args: any[]) => any),
+        };
+
+        // mongo binary options
+        binary?: _MongoBinary.MongoBinaryOpts;
+
+        // child process spawn options
+        spawn?: {
+            cwd?: string,
+            env?: object,
+            argv0?: string,
+            stdio?: string | any[],
+            detached?: boolean,
+            uid?: number,
+            gid?: number,
+            shell?: boolean | string,
+        };
+
+        debug?: boolean | ((...args: any[]) => any);
+    }
+
+    class MongodbInstance {
+        static childProcessList: ChildProcess[];
+
+        opts: MongodOps;
+        debug: ((...args: any[]) => any);
+        childProcess: ChildProcess;
+        killerProcess: ChildProcess;
+        instanceReady: ((...args: any[]) => any);
+        instanceFailed: ((...args: any[]) => any);
+
+        static run(opts: MongodOps): Promise<MongodbInstance>;
+
+        constructor(opts: MongodOps);
+
+        prepareCommandArgs(): string[];
+        run(): Promise<MongodbInstance>;
+        kill(): Promise<MongodbInstance>;
+        getPid(): number | undefined;
+        _launchMongod(mongoBin: string): ChildProcess;
+        _launchKiller(parentPid: number, childPid: number): ChildProcess;
+        errorHandler(err: string): void;
+        closeHandler(code: number): void;
+        stderrHandler(message: string | Buffer): void;
+        stdoutHandler(message: string | Buffer): void;
+    }
+}
+
+// exports from the MongoMemoryServer.js.flow file
+declare namespace _MongoMemoryServer {
+    interface MongoMemoryServerOptsT {
+        instance: {
+            port?: number,
+            dbPath?: string,
+            dbName?: string,
+            storageEngine?: string,
+            debug?: boolean | ((...args: any[]) => any),
+        };
+        binary: {
+            version?: string,
+            downloadDir?: string,
+            platform?: string,
+            arch?: string,
+            debug?: boolean | ((...args: any[]) => any),
+        };
+        debug?: boolean;
+        spawn: any;
+        autoStart?: boolean;
+    }
+
+    interface MongoInstanceDataT {
+        port: number;
+        dbPath: string;
+        dbName: string;
+        uri: string;
+        storageEngine: string;
+        instance: _MongoInstance.MongodbInstance;
+        childProcess: ChildProcess;
+        tmpDir?: {
+            name: string,
+            removeCallback: ((...args: any[]) => any),
+        };
+    }
+
+    class MongoMemoryServer {
+        isRunning: boolean;
+        runningInstance: Promise<MongoInstanceDataT> | undefined;
+        opts: MongoMemoryServerOptsT;
+        debug: ((...args: any[]) => any);
+
+        constructor(opts?: Partial<MongoMemoryServerOptsT>);
+
+        start(): Promise<boolean>;
+        _startUpInstance(): Promise<MongoInstanceDataT>;
+        stop(): Promise<boolean>;
+        getInstanceData(): Promise<MongoInstanceDataT>;
+        getUri(otherDbName?: string | boolean): Promise<string>;
+        getConnectionString(otherDbName?: string | boolean): Promise<string>;
+        getPort(): Promise<number>;
+        getDbPath(): Promise<string>;
+        getDbName(): Promise<string>;
+    }
+}

--- a/types/mongodb-memory-server/mongodb-memory-server-tests.ts
+++ b/types/mongodb-memory-server/mongodb-memory-server-tests.ts
@@ -1,0 +1,15 @@
+import MongodbMemoryServer from 'mongodb-memory-server';
+
+// Simple server start example from https://www.npmjs.com/package/mongodb-memory-server
+async function simpleServerStart() {
+    const mongod = new MongodbMemoryServer();
+
+    const uri = await mongod.getConnectionString();
+    const port = await mongod.getPort();
+    const dbPath = await mongod.getDbPath();
+    const dbName = await mongod.getDbName();
+
+    // you may stop mongod manually
+    mongod.stop();
+    // or it will be stopped automatically when you exit from script
+}

--- a/types/mongodb-memory-server/mongodb-memory-server-tests.ts
+++ b/types/mongodb-memory-server/mongodb-memory-server-tests.ts
@@ -11,5 +11,5 @@ async function simpleServerStart() {
 
     // you may stop mongod manually
     mongod.stop();
-    // or it will be stopped automatically when you exit from script.
+    // or it will be stopped automatically when you exit from script
 }

--- a/types/mongodb-memory-server/mongodb-memory-server-tests.ts
+++ b/types/mongodb-memory-server/mongodb-memory-server-tests.ts
@@ -11,5 +11,5 @@ async function simpleServerStart() {
 
     // you may stop mongod manually
     mongod.stop();
-    // or it will be stopped automatically when you exit from script
+    // or it will be stopped automatically when you exit from script.
 }

--- a/types/mongodb-memory-server/tsconfig.json
+++ b/types/mongodb-memory-server/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "mongodb-memory-server-tests.ts"
+    ]
+}

--- a/types/mongodb-memory-server/tslint.json
+++ b/types/mongodb-memory-server/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Type declarations for the [mongodb-memory-server](https://www.npmjs.com/package/mongodb-memory-server) package.

This package spins up an actual MongoDB Server programmatically from node for testing or mocking during development.

Declarations have been copied from flow types defined in the [source code](https://github.com/nodkz/mongodb-memory-server).

The example for a test is taken from the npm package description.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
