### PR TITLE
[ci] remove workaround to fix number of child processes

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "scripts": {
         "compile-scripts": "tsc -p scripts",
         "not-needed": "node scripts/not-needed.js",
-        "test": "node node_modules/types-publisher/bin/tester/test.js --run-from-definitely-typed --nProcesses 2",
+        "test": "node node_modules/types-publisher/bin/tester/test.js --run-from-definitely-typed",
         "lint": "dtslint types"
     },
     "devDependencies": {


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)

Remove workaround added in #26848 to force 2 child processes for `npm test` because types-publisher got updated to do this automatically (see https://github.com/Microsoft/types-publisher/pull/470).