### PR TITLE
[js-yaml] Revert return type of loader functions to any

### DIFF
--- a/types/js-yaml/index.d.ts
+++ b/types/js-yaml/index.d.ts
@@ -6,10 +6,8 @@
 
 export as namespace jsyaml;
 
-export type DocumentLoadResult = object | undefined;
-
-export function safeLoad(str: string, opts?: LoadOptions): DocumentLoadResult;
-export function load(str: string, opts?: LoadOptions): DocumentLoadResult;
+export function safeLoad(str: string, opts?: LoadOptions): any;
+export function load(str: string, opts?: LoadOptions): any;
 
 export class Type {
 	constructor(tag: string, opts?: TypeConstructorOptions);
@@ -30,10 +28,10 @@ export class Schema implements SchemaDefinition {
 	static create(schemas: Schema[] | Schema, types: Type[] | Type): Schema;
 }
 
-export function safeLoadAll(str: string, iterator?: undefined, opts?: LoadOptions): DocumentLoadResult[];
+export function safeLoadAll(str: string, iterator?: undefined, opts?: LoadOptions): any[];
 export function safeLoadAll(str: string, iterator: (doc: any) => void, opts?: LoadOptions): undefined;
 
-export function loadAll(str: string, iterator?: undefined, opts?: LoadOptions): DocumentLoadResult[];
+export function loadAll(str: string, iterator?: undefined, opts?: LoadOptions): any[];
 
 export function loadAll(str: string, iterator: (doc: any) => void, opts?: LoadOptions): undefined;
 

--- a/types/js-yaml/js-yaml-tests.ts
+++ b/types/js-yaml/js-yaml-tests.ts
@@ -109,19 +109,19 @@ type.styleAliases;
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
 
-// $ExpectType DocumentLoadResult
+// $ExpectType any
 yaml.safeLoad(str);
-// $ExpectType DocumentLoadResult
+// $ExpectType any
 yaml.safeLoad(str, loadOpts);
 
-// $ExpectType DocumentLoadResult
+// $ExpectType any
 yaml.load(str);
-// $ExpectType DocumentLoadResult
+// $ExpectType any
 yaml.load(str, loadOpts);
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
 
-// $ExpectType DocumentLoadResult[]
+// $ExpectType any[]
 yaml.safeLoadAll(str);
 
 // $ExpectType undefined
@@ -132,10 +132,10 @@ yaml.safeLoadAll(str, (doc) => {
 yaml.safeLoadAll(str, (doc) => {
 	value = doc;
 }, loadOpts);
-// $ExpectType DocumentLoadResult[]
+// $ExpectType any[]
 value = yaml.safeLoadAll(str, undefined, loadOpts);
 
-// $ExpectType DocumentLoadResult[]
+// $ExpectType any[]
 value = yaml.loadAll(str);
 
 // $ExpectType undefined
@@ -146,7 +146,7 @@ yaml.loadAll(str, (doc) => {
 yaml.loadAll(str, (doc) => {
 	value = doc;
 }, loadOpts);
-// $ExpectType DocumentLoadResult[]
+// $ExpectType any[]
 value = yaml.loadAll(str, undefined, loadOpts);
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --


### PR DESCRIPTION
Reverts https://github.com/DefinitelyTyped/DefinitelyTyped/pull/24385

This pull request reverts changes from  https://github.com/DefinitelyTyped/DefinitelyTyped/pull/24385, because `object | undefined` type is not assignable to any primitive type (e.g. `string`, `number`), which is incorrect behavior:

```ts
const str: string = yaml.safeLoad('str')!; // Error: object is not assignable to string
```

In future for safety new [`unknown` type](https://github.com/Microsoft/TypeScript/pull/24439) can be used here.

***

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/nodeca/js-yaml/blob/2d1fbed8f3a76ff93cccb9a8a418b4c4a482d3d9/lib/js-yaml/loader.js#L1568
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
