### PR TITLE
[jest] Allow async extension functions

### DIFF
--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -269,7 +269,7 @@ declare namespace jest {
     }
 
     interface ExpectExtendMap {
-        [key: string]: (this: MatcherUtils, received: any, ...actual: any[]) => { message(): string, pass: boolean };
+        [key: string]: (this: MatcherUtils, received: any, ...actual: any[]) => { message(): string, pass: boolean } | Promise<{ message(): string, pass: boolean }>;
     }
 
     interface SnapshotSerializerOptions {


### PR DESCRIPTION
According to http://jestjs.io/docs/en/expect.html#expectextendmatchers 

> `expect.extends` also supports async matchers. Async matchers return a `Promise` so you will need to `await` the returned value.

This updates the typings of `ExpectExtendMap` to allow a `Promise` to be returned.

@NoHomey @jwbay @asvetliakov @alexjoverm @alexjoverm @epicallan @ikatyang @ikatyang @wsmd @JamieMason @douglasduteil @ahnpnl @joshuakgoldberg @UselessPickles @r3nya @hotell
