### PR TITLE
[jest] Add equals method to MatcherUtils

### DIFF
--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -266,6 +266,10 @@ declare namespace jest {
             printWithType(name: string, received: any, print: (value: any) => string): string;
             stringify(object: {}, maxDepth?: number): string;
         };
+        /**
+         *  This is a deep-equality function that will return true if two objects have the same values (recursively).
+         */
+        equals(a: any, b: any): boolean;
     }
 
     interface ExpectExtendMap {


### PR DESCRIPTION
See http://jestjs.io/docs/en/expect.html#thisequalsa-b

> this.equals(a, b)
> This is a deep-equality function that will return true if two objects have the same values (recursively).

@NoHomey @jwbay @asvetliakov @alexjoverm @alexjoverm @epicallan @ikatyang @ikatyang @wsmd @JamieMason @douglasduteil @ahnpnl @joshuakgoldberg @UselessPickles @r3nya @hotell
