### PR TITLE
dockerode - Allow passing in array of streams to run command.

### DIFF
--- a/types/dockerode/index.d.ts
+++ b/types/dockerode/index.d.ts
@@ -11,6 +11,7 @@
 
 /// <reference types="node" />
 
+import * as stream from 'stream';
 import * as events from 'events';
 
 declare namespace Dockerode {

--- a/types/dockerode/index.d.ts
+++ b/types/dockerode/index.d.ts
@@ -11,7 +11,6 @@
 
 /// <reference types="node" />
 
-import * as stream from 'stream';
 import * as events from 'events';
 
 declare namespace Dockerode {
@@ -962,11 +961,11 @@ declare class Dockerode {
   pull(repoTag: string, options: {}, callback: Callback<any>, auth?: {}): Dockerode.Image;
   pull(repoTag: string, options: {}, auth?: {}): Promise<any>;
 
-  run(image: string, cmd: string[], outputStream: NodeJS.WritableStream, createOptions: {}, startOptions: {}, callback: Callback<any>): events.EventEmitter;
-  run(image: string, cmd: string[], outputStream: NodeJS.WritableStream, startOptions: {}, callback: Callback<any>): events.EventEmitter;
-  run(image: string, cmd: string[], outputStream: NodeJS.WritableStream, callback: Callback<any>): events.EventEmitter;
-  run(image: string, cmd: string[], outputStream: NodeJS.WritableStream, createOptions: {}, callback: Callback<any>): events.EventEmitter;
-  run(image: string, cmd: string[], outputStream: NodeJS.WritableStream, createOptions?: {}, startOptions?: {}): Promise<any>;
+  run(image: string, cmd: string[], outputStream: NodeJS.WritableStream | NodeJS.WritableStream[], createOptions: {}, startOptions: {}, callback: Callback<any>): events.EventEmitter;
+  run(image: string, cmd: string[], outputStream: NodeJS.WritableStream | NodeJS.WritableStream[], startOptions: {}, callback: Callback<any>): events.EventEmitter;
+  run(image: string, cmd: string[], outputStream: NodeJS.WritableStream | NodeJS.WritableStream[], callback: Callback<any>): events.EventEmitter;
+  run(image: string, cmd: string[], outputStream: NodeJS.WritableStream | NodeJS.WritableStream[], createOptions: {}, callback: Callback<any>): events.EventEmitter;
+  run(image: string, cmd: string[], outputStream: NodeJS.WritableStream | NodeJS.WritableStream[], createOptions?: {}, startOptions?: {}): Promise<any>;
 
   swarmInit(options: {}, callback: Callback<any>): void;
   swarmInit(options: {}): Promise<any>;


### PR DESCRIPTION
Issue raised in dockerode repo: https://github.com/apocas/dockerode/issues/464

When using the run command, to split the stdout and stderr, an array of streams should be passed in as the 3rd parameter of the run command. Optionally you can pass in a single stream as well.