### PR TITLE
[mongodb] current URL string parser is deprecated.

### DIFF
--- a/types/mongodb/index.d.ts
+++ b/types/mongodb/index.d.ts
@@ -11,6 +11,7 @@
 //                 Julien Chaumond <https://github.com/julien-c>
 //                 Dan Aprahamian <https://github.com/daprahamian>
 //                 Denys Bushulyak <https://github.com/denys-bushulyak>
+//                 Geraldine Lemeur <https://github.com/geraldinelemeur>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -102,7 +103,8 @@ export interface MongoClientOptions extends
     auth?: {
         user: string;
         password: string;
-    }
+    };
+    useNewUrlParser?: boolean;
 }
 
 export interface SSLOptions {


### PR DESCRIPTION
Starting with driver v3.1 you'll get a deprecation notice if not using this flag.
See https://github.com/mongodb/node-mongodb-native/commit/c1c5d8dad6c98d103bf9e198c51f2374713668ac

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
