### PR TITLE
(angular.js) Introduce type aliases LinkFnControllerType and RequireT…

### DIFF
--- a/types/angular/index.d.ts
+++ b/types/angular/index.d.ts
@@ -2075,10 +2075,14 @@ declare namespace angular {
             scope: TScope,
             instanceElement: JQLite,
             instanceAttributes: IAttributes,
-            controller?: IController | IController[] | {[key: string]: IController},
+            controller?: LinkFnControllerType,
             transclude?: ITranscludeFunction
         ): void;
     }
+
+    type RequireType = string | string[] | {[key: string]: string};
+
+    type LinkFnControllerType = IController | IController[] | {[key: string]: IController};
 
     interface IDirectivePrePost<TScope extends IScope = IScope> {
         pre?: IDirectiveLinkFn<TScope>;
@@ -2116,7 +2120,7 @@ declare namespace angular {
          * @deprecated
          */
         replace?: boolean;
-        require?: string | string[] | {[controller: string]: string};
+        require?: RequireType;
         restrict?: string;
         scope?: boolean | {[boundProperty: string]: string};
         template?: string | ((tElement: JQLite, tAttrs: IAttributes) => string);


### PR DESCRIPTION
…ype.

This allows users to write callbacks using those aliases instead of the
full type.

Having convinient aliases is required for having AngularJS in TS work
better with strictFunctionTypes flag on.
see: https://github.com/angular/angular.js/issues/16617

Also having them next to each other shows the symmetry between the
require and controller param better.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/angular/angular.js/issues/16617
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.