### PR TITLE
[react] Allow to initialize state in constructor 

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -306,7 +306,7 @@ declare namespace React {
         // In the future, if we can define its call signature conditionally
         // on the existence of `children` in `P`, then we should remove this.
         readonly props: Readonly<{ children?: ReactNode }> & Readonly<P>;
-        readonly state: null | Readonly<S>;
+        state: null | Readonly<S>;
         /**
          * @deprecated
          * https://reactjs.org/docs/legacy-context.html


### PR DESCRIPTION
Partial rollback of the https://github.com/DefinitelyTyped/DefinitelyTyped/pull/26813 that allow developers to follow react recommended way of initializing state in constructor
