### PR TITLE
[react-navigation] Fixing `withNavigationFocus` definition

### DIFF
--- a/types/react-navigation/index.d.ts
+++ b/types/react-navigation/index.d.ts
@@ -18,6 +18,7 @@
 //                 Edward Sammut Alessi <https://github.com/Slessi>
 //                 Jérémy Magrin <https://github.com/magrinj>
 //                 Luca Campana <https://github.com/TizioFittizio>
+//                 Ullrich Schaefer <https://github.com/stigi>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.6
 
@@ -1165,9 +1166,12 @@ export function withNavigation<T = {}>(
   Component: React.ComponentType<T & NavigationInjectedProps>
 ): React.ComponentType<T & { onRef?: React.Ref<typeof Component> }>;
 
+export interface NavigationFocusInjectedProps extends NavigationInjectedProps {
+  isFocused: boolean;
+}
 export function withNavigationFocus<T = {}>(
-  Component: React.ComponentType<T & NavigationInjectedProps>
-): React.ComponentType<T>;
+  Component: React.ComponentType<T & NavigationFocusInjectedProps>
+): React.ComponentType<T & { onRef?: React.Ref<typeof Component> }>;
 
 /**
  * SafeAreaView Component

--- a/types/react-navigation/react-navigation-tests.tsx
+++ b/types/react-navigation/react-navigation-tests.tsx
@@ -41,8 +41,9 @@ import {
     NavigationScreenComponent,
     NavigationContainerComponent,
     withNavigation,
-    withNavigationFocus,
     NavigationInjectedProps,
+    withNavigationFocus,
+    NavigationFocusInjectedProps
 } from 'react-navigation';
 
 // Constants
@@ -537,7 +538,7 @@ const BackButtonInstance = <BackButtonWithNavigation
 // Test withNavigationFocus
 
 interface MyFocusedComponentProps { expectsFocus: boolean; }
-class MyFocusedComponent extends React.Component<MyFocusedComponentProps & NavigationInjectedProps> {
+class MyFocusedComponent extends React.Component<MyFocusedComponentProps & NavigationFocusInjectedProps> {
     render() {
       return <button title={`${this.props.expectsFocus} vs ${this.props.isFocused}`} onClick={() => { this.props.navigation.goBack(); }} />;
     }

--- a/types/react-navigation/react-navigation-tests.tsx
+++ b/types/react-navigation/react-navigation-tests.tsx
@@ -41,6 +41,7 @@ import {
     NavigationScreenComponent,
     NavigationContainerComponent,
     withNavigation,
+    withNavigationFocus,
     NavigationInjectedProps,
 } from 'react-navigation';
 
@@ -531,4 +532,20 @@ class MyBackButton extends React.Component<BackButtonProps & NavigationInjectedP
 const BackButtonWithNavigation = withNavigation<BackButtonProps>(MyBackButton);
 const BackButtonInstance = <BackButtonWithNavigation
     title="Back" onRef={ref => { const backButtonRef = ref; }}
+/>;
+
+// Test withNavigationFocus
+
+interface MyFocusedComponentProps { expectsFocus: boolean; }
+class MyFocusedComponent extends React.Component<MyFocusedComponentProps & NavigationInjectedProps> {
+    render() {
+      return <button title={`${this.props.expectsFocus} vs ${this.props.isFocused}`} onClick={() => { this.props.navigation.goBack(); }} />;
+    }
+}
+
+// withNavigationFocus returns a component that wraps MyFocusedComponent and passes in the
+// navigation and isFocused prop
+const MyFocusedComponentWithNavigationFocus = withNavigationFocus<MyFocusedComponentProps>(MyFocusedComponent);
+const MyFocusedComponentInstance = <MyFocusedComponentWithNavigationFocus
+    expectsFocus={true} onRef={ref => { const backButtonRef = ref; }}
 />;


### PR DESCRIPTION
The injected props that were used for `withNavigationFocus` were the same as `withNavigation`. The first one explicitly provides the `isFocused` prop though, which the current typings don't support.

Source code reference: https://github.com/react-navigation/react-navigation/blob/master/src/views/withNavigationFocus.js

I updated the tests, and made sure that they [failed](https://travis-ci.org/stigi/DefinitelyTyped/builds/397775359). Then I updated the faulty definition and saw the tests [pass](https://travis-ci.org/stigi/DefinitelyTyped/builds/397778022).

`withNavigationFocus` uses `withNavigation` internally and also provides `NavigationInjectedProps` to the wrapped component, that's why I had `NavigationFocusInjectedProps` extend it. Also the `onRef`/`ref` [hack](https://github.com/react-navigation/react-navigation/pull/3476) was implemented for `withNavigationFocus`, so let's support that, too.

_Side note:  
This is my first contribution to DefinetlyTyped, so please double check. I.E. I'm not sure if I need to bump a version somewhere._