### PR TITLE
Allow the return type for Chart.js Callback to return null or undefined

### DIFF
--- a/types/chart.js/chart.js-tests.ts
+++ b/types/chart.js/chart.js-tests.ts
@@ -41,7 +41,7 @@ const chart: Chart = new Chart(new CanvasRenderingContext2D(), {
             xAxes: [
                 {
                     ticks: {
-                        callback: Math.floor
+                        callback: Math.floor | undefined | null
                     },
                     gridLines: {
                         display: false,

--- a/types/chart.js/index.d.ts
+++ b/types/chart.js/index.d.ts
@@ -459,7 +459,7 @@ declare namespace Chart {
         backdropPaddingX?: number;
         backdropPaddingY?: number;
         beginAtZero?: boolean;
-        callback?(value: any, index: any, values: any): string | number;
+        callback?(value: any, index: any, values: any): string | number | undefined | null;;
         display?: boolean;
         fontColor?: ChartColor;
         fontFamily?: string;

--- a/types/chart.js/index.d.ts
+++ b/types/chart.js/index.d.ts
@@ -459,7 +459,7 @@ declare namespace Chart {
         backdropPaddingX?: number;
         backdropPaddingY?: number;
         beginAtZero?: boolean;
-        callback?(value: any, index: any, values: any): string | number | undefined | null;;
+        callback?(value: any, index: any, values: any): string | number | undefined | null;
         display?: boolean;
         fontColor?: ChartColor;
         fontFamily?: string;

--- a/types/chart.js/index.d.ts
+++ b/types/chart.js/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Chart.js 2.7
+// Type definitions for Chart.js 2.8
 // Project: https://github.com/nnnick/Chart.js
 // Definitions by: Alberto Nuti <https://github.com/anuti>
 //                 Fabien Lavocat <https://github.com/FabienLavocat>
@@ -14,6 +14,7 @@
 //                 Slavik Nychkalo <https://github.com/gebeto>
 //                 Francesco Benedetto <https://github.com/frabnt>
 //                 Alexandros Dorodoulis <https://github.com/alexdor>
+//                 Amir Mousavi <https://github.com/amirhmk>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 


### PR DESCRIPTION
Please fill in this template.

The Callback function in ticks for Chart.js now expects a number or a string, but according to the documentoiatoin linkied above, it should also allow undefined and null, in which case it would just have an empty tick with no values. 

I changed the test for the callback only, but could not figure out how to change the parent test, because it seems undefined can not be returned at all. Hence the test failures. 

There is a tslint.json file, but running `npm run lint chart.js` failed, tried lots of combinations, did not work. Running on other packages worked though.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present). 

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <<http://www.chartjs.org/docs/latest/axes/labelling.html?h=ticks%20callbac>>
- [X] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
