### PR TITLE
Introduce types for @ember/test-helpers

### DIFF
--- a/types/ember__test-helpers/ember__test-helpers-tests.ts
+++ b/types/ember__test-helpers/ember__test-helpers-tests.ts
@@ -1,0 +1,95 @@
+/// <reference types="ember-qunit" />
+
+import { test } from 'qunit';
+import Application from '@ember/application';
+import hbs from 'htmlbars-inline-precompile';
+import {
+    click,
+    doubleClick,
+    tap,
+    focus,
+    blur,
+    triggerEvent,
+    triggerKeyEvent,
+    fillIn,
+    render,
+    find,
+    findAll,
+    getRootElement,
+    pauseTest,
+    resumeTest,
+    waitFor,
+    waitUntil,
+    settled,
+    isSettled,
+    getSettledState,
+    visit,
+    currentURL,
+    currentRouteName,
+    setApplication
+} from '@ember/test-helpers';
+
+const MyApp = Application.extend({ modulePrefix: 'my-app' });
+
+setApplication(MyApp.create());
+
+test('DOM interactions', async () => {
+    await render(hbs`<div class="message">Hello, world</div>`);
+
+    await click('.message');
+    await doubleClick('.message');
+    await tap('.message');
+    await focus('.message');
+    await blur('.message');
+    await triggerEvent('.message', 'custom-event');
+    await triggerKeyEvent('.message', 'keydown', 'Enter', { ctrlKey: true });
+    await fillIn('.message', 'content');
+
+    const messageElement = find('.message')!;
+    await click(messageElement);
+    await doubleClick(messageElement);
+    await tap(messageElement);
+    await focus(messageElement);
+    await blur(messageElement);
+    await triggerEvent(messageElement, 'custom-event');
+    await triggerKeyEvent(messageElement, 'keydown', 'Enter', { ctrlKey: true });
+    await fillIn(messageElement, 'content');
+
+    const allMessages = findAll('.message');
+    for (const element of allMessages) {
+        await click(element);
+    }
+
+    const root = getRootElement();
+    await click(root);
+});
+
+test('routing helpers', async (assert) => {
+    await visit('/foo');
+
+    assert.equal(currentURL(), '/foo');
+    assert.equal(currentRouteName(), 'foo');
+});
+
+test('pause and resume', async () => {
+    await pauseTest();
+    setTimeout(resumeTest, 1000);
+});
+
+test('wait helpers', async (assert) => {
+    await render(hbs`<div class="message">Hello</div>`);
+
+    await waitFor('.message', { count: 1, timeout: 10, timeoutMessage: 'uh oh' });
+    await waitUntil(() => 'hello', { timeout: 1000, timeoutMessage: 'boom' });
+
+    await settled();
+    assert.ok(isSettled());
+
+    const {
+        hasPendingRequests,
+        hasPendingTimers,
+        hasPendingWaiters,
+        hasRunLoop,
+        pendingRequestCount
+    } = getSettledState();
+});

--- a/types/ember__test-helpers/index.d.ts
+++ b/types/ember__test-helpers/index.d.ts
@@ -1,0 +1,220 @@
+// Type definitions for @ember/test-helpers 0.7
+// Project: https://github.com/emberjs/ember-test-helpers
+// Definitions by: Dan Freeman <https://github.com/dfreeman>
+//                 James C. Davis <https://github.com/jamescdavis>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.6
+
+/// <reference types="ember" />
+
+declare module '@ember/test-helpers' {
+    // DOM Interaction Helpers
+
+    export type Target = string | Element;
+
+    export { default as click } from '@ember/test-helpers/dom/click';
+    export { default as doubleClick } from '@ember/test-helpers/dom/double-click';
+    export { default as tap } from '@ember/test-helpers/dom/tap';
+    export { default as focus } from '@ember/test-helpers/dom/focus';
+    export { default as blur } from '@ember/test-helpers/dom/blur';
+    export { default as triggerEvent } from '@ember/test-helpers/dom/trigger-event';
+    export { default as triggerKeyEvent } from '@ember/test-helpers/dom/trigger-key-event';
+    export { default as fillIn } from '@ember/test-helpers/dom/fill-in';
+
+    // DOM Query Helpers
+
+    export { default as find } from '@ember/test-helpers/dom/find';
+    export { default as findAll } from '@ember/test-helpers/dom/find-all';
+    export { default as getRootElement } from '@ember/test-helpers/dom/get-root-element';
+
+    // Routing Helpers
+
+    export { visit, currentRouteName, currentURL } from '@ember/test-helpers/setup-application-context';
+
+    // Rendering Helpers
+
+    export { render, clearRender } from '@ember/test-helpers/setup-rendering-context';
+
+    // Wait Helpers
+
+    export { default as waitFor } from '@ember/test-helpers/dom/wait-for';
+    export { default as waitUntil } from '@ember/test-helpers/wait-until';
+    export { default as settled, isSettled, getSettledState } from '@ember/test-helpers/settled';
+
+    // Pause Helpers
+
+    export { pauseTest, resumeTest } from '@ember/test-helpers/setup-context';
+
+    // Test Framework APIs
+
+    export { setResolver, getResolver } from '@ember/test-helpers/resolver';
+    export { default as setupContext, getContext, setContext, unsetContext } from '@ember/test-helpers/setup-context';
+    export { default as teardownContext } from '@ember/test-helpers/teardown-context';
+    export { default as setupRenderingContext } from '@ember/test-helpers/setup-rendering-context';
+    export { default as teardownRenderingContext } from '@ember/test-helpers/teardown-rendering-context';
+    export { getApplication, setApplication } from '@ember/test-helpers/application';
+    export { default as setupApplicationContext } from '@ember/test-helpers/setup-application-context';
+    export { default as teardownApplicationContext } from '@ember/test-helpers/teardown-application-context';
+    export { default as validateErrorHandler } from '@ember/test-helpers/validate-error-handler';
+}
+
+declare module '@ember/test-helpers/dom/click' {
+    import { Target } from '@ember/test-helpers';
+
+    export default function(target: Target): Promise<void>;
+}
+
+declare module '@ember/test-helpers/dom/double-click' {
+    import { Target } from '@ember/test-helpers';
+
+    export default function(target: Target): Promise<void>;
+}
+
+declare module '@ember/test-helpers/dom/tap' {
+    import { Target } from '@ember/test-helpers';
+
+    export default function(target: Target): Promise<void>;
+}
+
+declare module '@ember/test-helpers/dom/focus' {
+    import { Target } from '@ember/test-helpers';
+
+    export default function(target: Target): Promise<void>;
+}
+
+declare module '@ember/test-helpers/dom/blur' {
+    import { Target } from '@ember/test-helpers';
+
+    export default function(target: Target): Promise<void>;
+}
+
+declare module '@ember/test-helpers/dom/trigger-event' {
+    import { Target } from '@ember/test-helpers';
+
+    export default function(target: Target, eventType: string, options?: object): Promise<void>;
+}
+
+declare module '@ember/test-helpers/dom/trigger-key-event' {
+    import { Target } from '@ember/test-helpers';
+
+    export type KeyEvent = 'keydown' | 'keyup' | 'keypress';
+
+    export interface KeyModifiers {
+        ctrlKey?: boolean;
+        altKey?: boolean;
+        shiftKey?: boolean;
+        metaKey?: boolean;
+    }
+
+    export default function(target: Target, eventType: KeyEvent, key: number | string, modifiers?: KeyModifiers): Promise<void>;
+}
+
+declare module '@ember/test-helpers/dom/fill-in' {
+    import { Target } from '@ember/test-helpers';
+
+    export default function(target: Target, text: string): Promise<void>;
+}
+
+declare module '@ember/test-helpers/dom/find' {
+    export default function(selector: string): Element | null;
+}
+
+declare module '@ember/test-helpers/dom/find-all' {
+    export default function(selector: string): Element[];
+}
+
+declare module '@ember/test-helpers/dom/get-root-element' {
+    export default function(): Element;
+}
+
+declare module '@ember/test-helpers/setup-application-context' {
+    export default function<Context extends object>(context: Context): Promise<Context>;
+    export function visit(url: string): Promise<void>;
+    export function currentRouteName(): string;
+    export function currentURL(): string;
+}
+
+declare module '@ember/test-helpers/setup-rendering-context' {
+    import { TemplateFactory } from 'htmlbars-inline-precompile';
+
+    export default function<Context extends object>(context: Context): Promise<Context>;
+    export function render(template: TemplateFactory): Promise<void>;
+    export function clearRender(): Promise<void>;
+}
+
+declare module '@ember/test-helpers/dom/wait-for' {
+    export interface Options {
+        timeout?: number;
+        count?: number;
+        timeoutMessage?: string;
+    }
+
+    export default function(selector: string, options?: Options): Promise<Element | Element[]>;
+}
+
+declare module '@ember/test-helpers/wait-until' {
+    export interface Options {
+        timeout?: number;
+        timeoutMessage?: string;
+    }
+
+    export default function<T>(callback: () => T, options?: Options): Promise<T>;
+}
+
+declare module '@ember/test-helpers/settled' {
+    export interface SettledState {
+        hasRunLoop: boolean;
+        hasPendingTimers: boolean;
+        hasPendingWaiters: boolean;
+        hasPendingRequests: boolean;
+        pendingRequestCount: number;
+    }
+
+    export default function(): Promise<void>;
+    export function isSettled(): boolean;
+    export function getSettledState(): SettledState;
+}
+
+declare module '@ember/test-helpers/setup-context' {
+    import Resolver from '@ember/application/resolver';
+
+    export default function<C extends object>(context: C, options?: { resolver?: Resolver }): Promise<C>;
+    export function getContext(): object;
+    export function setContext(context: object): void;
+    export function unsetContext(): void;
+
+    export function pauseTest(): Promise<void>;
+    export function resumeTest(): void;
+}
+
+declare module '@ember/test-helpers/resolver' {
+    import Resolver from '@ember/application/resolver';
+
+    export function setResolver(resolver: Resolver): void;
+    export function getResolver(): Resolver;
+}
+
+declare module '@ember/test-helpers/teardown-context' {
+    export default function(context: object): Promise<void>;
+}
+
+declare module '@ember/test-helpers/teardown-rendering-context' {
+    export default function(context: object): Promise<void>;
+}
+
+declare module '@ember/test-helpers/teardown-application-context' {
+    export default function(context: object): Promise<void>;
+}
+
+declare module '@ember/test-helpers/validate-error-handler' {
+    import Error from '@ember/error';
+
+    export default function(callback?: (error: Error) => void): { isValid: boolean, message: string };
+}
+
+declare module '@ember/test-helpers/application' {
+    import Application from '@ember/application';
+
+    export function getApplication(): Application;
+    export function setApplication(application: Application): void;
+}

--- a/types/ember__test-helpers/tsconfig.json
+++ b/types/ember__test-helpers/tsconfig.json
@@ -1,0 +1,27 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": false,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "paths": {
+            "@ember/test-helpers": ["ember__test-helpers"]
+        }
+    },
+    "files": [
+        "index.d.ts",
+        "ember__test-helpers-tests.ts"
+    ]
+}

--- a/types/ember__test-helpers/tslint.json
+++ b/types/ember__test-helpers/tslint.json
@@ -1,0 +1,6 @@
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "strict-export-declare-modifiers": false
+    }
+}


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true` (except `strictFunctionTypes`, which is currently incompatible with Ember's typings).

Documentation is available [here](https://github.com/emberjs/ember-test-helpers/blob/master/API.md), and the types themselves are mostly extracted from the declarations in [ember-osf-web](https://github.com/CenterForOpenScience/ember-osf-web/blob/043107fe7dfe9979a1f47a97fd2d31a1a4ea8205/types/ember-test-helpers/index.d.ts) by @jamescdavis, with a few additions and tweaks.