### PR TITLE
[ember-qunit] Add definition for `start()`

### DIFF
--- a/types/ember-qunit/ember-qunit-tests.ts
+++ b/types/ember-qunit/ember-qunit-tests.ts
@@ -2,6 +2,7 @@ import Ember from 'ember';
 import hbs from 'htmlbars-inline-precompile';
 import { module } from 'qunit';
 import {
+    start,
     test,
     skip,
     moduleFor,
@@ -137,3 +138,5 @@ module('x-foo', function(hooks) {
 module('foo service', function(hooks) {
     setupTest(hooks);
 });
+
+start();

--- a/types/ember-qunit/index.d.ts
+++ b/types/ember-qunit/index.d.ts
@@ -97,6 +97,48 @@ declare module 'ember-qunit' {
     export class QUnitAdapter extends Ember.Test.Adapter { }
 
     export { module, test, skip, only, todo } from 'qunit';
+
+    interface QUnitStartOptions {
+        /**
+         * If `false` tests will not be loaded automatically.
+         */
+        loadTests?: boolean;
+
+        /**
+         * If `false` the test container will not be setup based on `devmode`,
+         * `dockcontainer`, or `nocontainer` URL params.
+         */
+        setupTestContainer?: boolean;
+
+        /**
+         * If `false` tests will not be automatically started (you must run
+         * `QUnit.start()` to kick them off).
+         */
+        startTests?: boolean;
+
+        /**
+         * If `false` the default Ember.Test adapter will not be updated.
+         */
+        setupTestAdapter?: boolean;
+
+        /**
+         * `false` opts out of the default behavior of setting `Ember.testing`
+         * to `true` before all tests and back to `false` after each test will.
+         */
+        setupEmberTesting?: boolean;
+
+        /**
+         * If `false` validation of `Ember.onerror` will be disabled.
+         */
+        setupEmberOnerrorValidation?: boolean;
+
+        /**
+         * If `false` test isolation validation will be disabled.
+         */
+        setupTestIsolationValidatoin?: boolean;
+    }
+
+    export function start(options?: QUnitStartOptions): void;
 }
 
 declare module 'qunit' {


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/emberjs/ember-qunit/blob/27e1b64a29df61442f9dc0d1dc6c87cbfb811893/addon-test-support/ember-qunit/index.js#L261-L280
- [x] Increase the version number in the header if appropriate.

This function is [used by the default Ember app blueprint](https://github.com/ember-cli/ember-new-output/blob/d71a22728e8e31e068c1336de99e20bbfa3a60c6/tests/test-helper.js#L4-L8), but hadn't made it into the declarations for `ember-qunit` yet.