### PR TITLE
Added the IANAZone class for luxon

### DIFF
--- a/types/luxon/index.d.ts
+++ b/types/luxon/index.d.ts
@@ -209,8 +209,8 @@ declare module 'luxon' {
             toLocaleParts(options?: DateTimeFormatOptions): any[];
             toLocaleString(options?: DateTimeFormatOptions): string;
             toMillis(): number;
-            toObject(options?: { includeConfig?: boolean }): DateObject;
             toMillis(): number;
+            toObject(options?: { includeConfig?: boolean }): DateObject;
             toRFC2822(): string;
             toSQL(options?: Object): string;
             toSQLDate(): string;
@@ -401,6 +401,10 @@ declare module 'luxon' {
             static universal: boolean;
             equals(other: Zone): boolean;
             offset(ts: number): number;
+        }
+
+        class IANAZone extends Zone {
+            constructor(ianaString: string);
         }
     }
 

--- a/types/luxon/luxon-tests.ts
+++ b/types/luxon/luxon-tests.ts
@@ -1,4 +1,4 @@
-import { DateTime, Duration, Interval, Info, Settings } from 'luxon';
+import { DateTime, Duration, Interval, Info, Settings, IANAZone } from 'luxon';
 
 /* DateTime */
 const dt = DateTime.local(2017, 5, 15, 8, 30);
@@ -11,6 +11,11 @@ const fromObject = DateTime.fromObject({
     hour: 12,
     zone: 'America/Los_Angeles',
     numberingSystem: 'beng'
+});
+
+const ianaZone = new IANAZone('America/Los_Angeles');
+const ianaZoneTest = DateTime.fromObject({
+    zone: ianaZone
 });
 
 const fromIso = DateTime.fromISO('2017-05-15'); // => May 15, 2017 at midnight


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: 
[https://github.com/moment/luxon/issues/89#issuecomment-378826414](Improve the performance of luxon using the IANAZone class.)

BTW, i also had to move the toMillis signature because it was breaking the linter:
`adjacent-overload-signatures  All 'toMillis' signatures should be adjacent`.