### PR TITLE
mongodb: improved overloads for Collection.aggregate()

### DIFF
--- a/types/mongodb/index.d.ts
+++ b/types/mongodb/index.d.ts
@@ -482,8 +482,9 @@ export interface Collection<TSchema = Default> {
     // Get current index hint for collection.
     hint: any;
     /** http://mongodb.github.io/node-mongodb-native/3.0/api/Collection.html#aggregate */
+    aggregate<T = TSchema>(callback: MongoCallback<AggregationCursor<T>>): AggregationCursor<T>;
     aggregate<T = TSchema>(pipeline: Object[], callback: MongoCallback<AggregationCursor<T>>): AggregationCursor<T>;
-    aggregate<T = TSchema>(pipeline: Object[], options?: CollectionAggregationOptions, callback?: MongoCallback<AggregationCursor<T>>): AggregationCursor<T>;
+    aggregate<T = TSchema>(pipeline?: Object[], options?: CollectionAggregationOptions, callback?: MongoCallback<AggregationCursor<T>>): AggregationCursor<T>;
     /** http://mongodb.github.io/node-mongodb-native/3.0/api/Collection.html#bulkWrite */
     bulkWrite(operations: Object[], callback: MongoCallback<BulkWriteOpResultObject>): void;
     bulkWrite(operations: Object[], options?: CollectionBluckWriteOptions): Promise<BulkWriteOpResultObject>;

--- a/types/mongodb/mongodb-tests.ts
+++ b/types/mongodb/mongodb-tests.ts
@@ -121,6 +121,31 @@ MongoClient.connect('mongodb://127.0.0.1:27017/test', options, function (err: mo
         let payment: { total: number };
         type payment = typeof payment;
         let cursor: mongodb.AggregationCursor<payment> = collection.aggregate<payment>([{}])
+
+        collection.aggregate([{ $match: { bar: 1 } }, { $limit: 10 }])
+        collection.aggregate([{ $match: { bar: 1 } }]).limit(10)
+        collection.aggregate([]).match({ bar: 1 }).limit(10)
+        collection.aggregate().match({ bar: 1 }).limit(10)
+
+        collection.aggregate<payment>(
+            [{ $match: { bar: 1 } }],
+            function (err: mongodb.MongoError, cursor: mongodb.AggregationCursor<payment>) {
+                cursor.limit(10)
+            }
+        )
+
+        collection.aggregate<payment>(
+            [],
+            function (err: mongodb.MongoError, cursor: mongodb.AggregationCursor<payment>) {
+                cursor.match({ bar: 1 }).limit(10)
+            }
+        )
+
+        collection.aggregate<payment>(
+            function (err: mongodb.MongoError, cursor: mongodb.AggregationCursor<payment>) {
+                cursor.match({ bar: 1 }).limit(10)
+            }
+        )
     }
 
     // test for new typings


### PR DESCRIPTION
The `pipeline` parameter is currently still documented as required, but a PR that fixes this has already 
been merged: https://github.com/mongodb/node-mongodb-native/pull/1763

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/mongodb/node-mongodb-native/pull/1763
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.