### PR TITLE
Correctly named Interface.interfaceNumber on usb package

### DIFF
--- a/types/usb/index.d.ts
+++ b/types/usb/index.d.ts
@@ -62,7 +62,7 @@ export class ConfigDescriptor {
 }
 
 export class Interface {
-  interface: number;
+  interfaceNumber: number;
   altSetting: number;
   descriptor: InterfaceDescriptor;
   endpoints: Endpoint[];

--- a/types/usb/usb-tests.ts
+++ b/types/usb/usb-tests.ts
@@ -57,7 +57,7 @@ device.allConfigDescriptors = [configDesc];
 
 const iface = new usb.Interface(device, 1);
 
-iface.interface = 1;
+iface.interfaceNumber = 1;
 iface.altSetting = 0;
 iface.claim();
 iface.release((error: string) => null);


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/tessel/node-usb/blob/master/usb.js#L171
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

Annoyingly the `usb package` types for `Interface` correctly reflect [the documentation](https://github.com/tessel/node-usb#interface-1) which doesn't match the [actual source](https://github.com/tessel/node-usb/blob/master/usb.js#L171).

Changed `Interface.interface` -> `Interface.interfaceNumber`.
