### PR TITLE
Remove RequestInfo conflict

### DIFF
--- a/types/react-native/globals.d.ts
+++ b/types/react-native/globals.d.ts
@@ -26,10 +26,10 @@ declare function fetchBundle(bundleId: number, callback: (error?: Error | null) 
 //
 
 declare interface GlobalFetch {
-  fetch(input: RequestInfo, init?: RequestInit): Promise<Response>;
+  fetch(input: RequestInfo_, init?: RequestInit): Promise<Response>;
 }
 
-declare function fetch(input: RequestInfo, init?: RequestInit): Promise<Response>;
+declare function fetch(input: RequestInfo_, init?: RequestInit): Promise<Response>;
 
 interface Blob {}
 
@@ -89,7 +89,7 @@ declare var Request: {
   new(input: Request | string, init?: RequestInit): Request;
 };
 
-declare type RequestInfo = Request | string;
+type RequestInfo_ = Request | string;
 
 declare interface ResponseInit {
   headers?: HeadersInit_;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

I'm trying to allow the use of react native type and dom library. It could be usefull for react-native-web project.

The conflict are : 

- The requestInfo definition
- The console var definition (Cannot redeclare block-scoped variable 'console'.)
- The geolocation var type(Subsequent property declarations must have the same type. Property 'geolocation' must be of type 'Geolocation', but here has type 'GeolocationStatic'.)
- The navigator var definition (Cannot redeclare block-scoped variable 'navigator'.)

This PR fix the first one I introduced in the last commit of this file.
I actually didn't find how to fix others.

NB : This PR has some impacts because RequestInfo is not defined and imported by RN anymore. You'll have some error message for librairie like apollo-link-http-common without "dom" library.

```
node_modules/apollo-link-http-common/lib/index.d.ts:76:54 - error TS2304: Cannot find name 'RequestInfo'.
export declare const checkFetcher: (fetcher: (input: RequestInfo, init?: RequestInit) => Promise<Response>) => void;
```

But I'm not sure it's RN job to have the RequestInfo definition.