### PR TITLE
Add `renderAs` prop to `qrcode.react` QRCode definition

### DIFF
--- a/types/qrcode.react/index.d.ts
+++ b/types/qrcode.react/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for qrcode.react 0.6
+// Type definitions for qrcode.react 0.8
 // Project: https://github.com/zpao/qrcode.react
 // Definitions by: Mleko <https://github.com/mleko>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -13,6 +13,7 @@ declare namespace qrcode {
 		bgColor?: string;
 		fgColor?: string;
 		level?: "L"|"M"|"Q"|"H";
+		renderAs?: "svg" | "canvas";
 	}
 
 	type QRCode = React.ComponentClass<QRCodeProps>;

--- a/types/qrcode.react/qrcode.react-tests.tsx
+++ b/types/qrcode.react/qrcode.react-tests.tsx
@@ -9,4 +9,5 @@ const qrcodes = [
 	<QRCode value="https://github.com/DefinitelyTyped/DefinitelyTyped" level="L"/>,
 	<QRCode value="https://github.com/DefinitelyTyped/DefinitelyTyped" level="H"/>,
 	<QRCode value="https://github.com/DefinitelyTyped/DefinitelyTyped" size={256} bgColor="pink" fgColor="red" level="Q"/>,
+	<QRCode value="https://github.com/DefinitelyTyped/DefinitelyTyped" renderAs="svg"/>,
 ];


### PR DESCRIPTION
Adds the `renderAs` prop to the definition of https://github.com/zpao/qrcode.react

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/zpao/qrcode.react/commit/ad6182b6b5366e2c72cf0fd93ef057626473633d>>
