### PR TITLE
Expand argument types to match documentation.

### DIFF
--- a/types/datatables.net/datatables.net-tests.ts
+++ b/types/datatables.net/datatables.net-tests.ts
@@ -1002,6 +1002,9 @@ const static_6 = new $.fn.dataTable.Api("selector");
 
 const version: boolean = $.fn.dataTable.versionCheck("1.10.0");
 const isDataTable: boolean = $.fn.dataTable.isDataTable("selector");
+const isDataTable_3: boolean = $.fn.dataTable.isDataTable(dt.row("selector").node());
+const isDataTable_2: boolean = $.fn.dataTable.isDataTable($("selector"));
+const isDataTable_4: boolean = $.fn.dataTable.isDataTable($("selector").dataTable().api());
 const escapeRegex: string = $.fn.dataTable.util.escapeRegex("");
 
 const throttle_1 = $.fn.dataTable.util.throttle((data) => {

--- a/types/datatables.net/index.d.ts
+++ b/types/datatables.net/index.d.ts
@@ -1094,13 +1094,13 @@ declare namespace DataTables {
         (): JQueryDataTables;
 
         /**
-         * Check is a table node is a DataTable or not
+         * Check if a table node is a DataTable already or not.
          *
          * Usage:
          * $.fn.dataTable.isDataTable("selector");
-         * @param table Selector string for table
+         * @param table The table to check.
          */
-        isDataTable(table: string): boolean;
+        isDataTable(table: string | Node | JQuery | Api): boolean;
 
         /**
          * Helpers for `columns.render`.


### PR DESCRIPTION
$.fn.dataTables.isDataTable: Expand argument types to match documentation.

https://datatables.net/reference/api/%24.fn.dataTable.isDataTable()

Please fill in this template.

- [ x ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ x ] Test the change in your own code. (Compile and run.)
- [ x ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ x ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ x ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ x ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [ x ] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://datatables.net/reference/api/%24.fn.dataTable.isDataTable()>>
- [ x ] Increase the version number in the header if appropriate.
- [ x ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
