### PR TITLE
Fix stellar-sdk memo type strings

### DIFF
--- a/types/stellar-sdk/index.d.ts
+++ b/types/stellar-sdk/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/stellar/js-stellar-sdk
 // Definitions by: Carl Foster <https://github.com/carl-foster>
 //                 Triston Jones <https://github.com/tristonj>
+//                 Paul Selden <https://github.com/pselden>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.4
 
@@ -505,15 +506,21 @@ export class Memo {
     static return(hash: string): Memo;
     static text(text: string): Memo;
 
-    constructor(type: 'MemoNone')
-    constructor(type: 'MemoID' | 'MemoText', value: string)
-    constructor(type: 'MemoHash' | 'MemoReturn', value: Buffer)
+    constructor(type: 'none');
+    constructor(type: 'id' | 'text' | 'hash' | 'return', value: string)
+    constructor(type: 'hash' | 'return', value: Buffer)
 
-    type: 'MemoNone' | 'MemoID' | 'MemoText' | 'MemoHash' | 'MemoReturn';
+    type: string;
     value: null | string | Buffer;
 
     toXDRObject(): xdr.Memo;
 }
+
+export const MemoNone = 'none';
+export const MemoID = 'id';
+export const MemoText = 'text';
+export const MemoHash = 'hash';
+export const MemoReturn = 'return';
 
 export enum Networks {
     PUBLIC = 'Public Global Stellar Network ; September 2015',

--- a/types/stellar-sdk/stellar-sdk-tests.ts
+++ b/types/stellar-sdk/stellar-sdk-tests.ts
@@ -5,5 +5,6 @@ const destKey = StellarSdk.Keypair.random();
 const account = new StellarSdk.Account(sourceKey.publicKey(), 1);
 const transaction = new StellarSdk.TransactionBuilder(account)
     .addOperation(StellarSdk.Operation.accountMerge({destination: destKey.publicKey()}))
+    .addMemo(new StellarSdk.Memo(StellarSdk.MemoText, "memo"))
     .build(); // $ExpectType () => Transaction
 transaction; // $ExpectType Transaction


### PR DESCRIPTION
The documentation sort of implies that the strings are actually 'MemoID', 'MemoHash', etc..., however they are shorter common names that are also exported as constants.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://stellar.github.io/js-stellar-sdk/node_modules_stellar-base_src_memo.js.html
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
