### PR TITLE
Remove breaking change (react)

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -306,7 +306,7 @@ declare namespace React {
         // In the future, if we can define its call signature conditionally
         // on the existence of `children` in `P`, then we should remove this.
         readonly props: Readonly<{ children?: ReactNode }> & Readonly<P>;
-        state: null | Readonly<S>;
+        state: Readonly<S>;
         /**
          * @deprecated
          * https://reactjs.org/docs/legacy-context.html


### PR DESCRIPTION
Someone added a single line breaking change to React's Typedefs causing a worldwide problem for people using `@types/react`. If this change ever goes in it needs to be at a SemVer version change, not as a patch change...

Note that without this reversion all the React examples (including the one linked below) would actually be wrong as they would need to check for the existence of `this.state` before using it.

The version number shouldn't be changed as this should be a correction for the previous PR...

Referencing #26813

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://reactjs.org/docs/state-and-lifecycle.html
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
