### PR TITLE
fix 2 typos qMeasureInfo & INxCellRows

### DIFF
--- a/types/qlik-engineapi/index.d.ts
+++ b/types/qlik-engineapi/index.d.ts
@@ -4412,12 +4412,7 @@ declare namespace EngineAPI {
     /**
      * NxCellRows...
      */
-    interface INxCellRows {
-        /**
-         * Array of data.
-         */
-        NxCellRows: INxCell[];
-    }
+    type INxCellRows = INxCell[];
 
     /**
      * INxDataPage...
@@ -8715,7 +8710,7 @@ declare namespace EngineAPI {
         /**
          * Information on the measure.
          */
-        qMeasureInfo: INxMeasureInfo;
+        qMeasureInfo: INxMeasureInfo[];
 
         /**
          * Sort order of the columns in the hypercube.


### PR DESCRIPTION
1. qMeasureInfo has to be an array
2. INxCellRows  has to be a simple array type

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://help.qlik.com/en-US/sense-developer/June2018/APIs/EngineAPI/definitions-HyperCube.html
