### PR TITLE
Upgrade archiver types: Add ArchiverError, some explicit event handlers

### DIFF
--- a/types/archiver/archiver-tests.ts
+++ b/types/archiver/archiver-tests.ts
@@ -67,3 +67,15 @@ archiver.use(() => {});
 archiver.finalize();
 
 archiver.symlink('./path', './target');
+
+function fakeHandler(err: Archiver.ArchiverError) {
+    console.log(err.code);
+    console.log(err.message);
+    console.log(err.stack);
+    console.log(err.data);
+}
+
+const fakeError = new Archiver.ArchiverError('code', 'foo');
+
+archiver.on('error', fakeHandler);
+archiver.on('warning', fakeHandler);

--- a/types/archiver/index.d.ts
+++ b/types/archiver/index.d.ts
@@ -24,8 +24,25 @@ declare namespace archiver {
         mode?: number;
     }
 
+    interface ProgressData {
+        entries: {
+            total: number;
+            processed: number;
+        };
+        fs: {
+            totalBytes: number;
+            processedBytes: number;
+        };
+    }
+
     /** A function that lets you either opt out of including an entry (by returning false), or modify the contents of an entry as it is added (by returning an EntryData) */
     type EntryDataFunction = (entry: EntryData) => false | EntryData;
+
+    class ArchiverError extends Error {
+        code: string;       // Since archiver format support is modular, we cannot enumerate all possible error codes, as the modules can throw arbitrary ones.
+        data: any;
+        constructor(code: string, data: any);
+    }
 
     interface Archiver extends stream.Transform {
         abort(): this;
@@ -44,6 +61,13 @@ declare namespace archiver {
         use(plugin: Function): this;
 
         symlink(filepath: string, target: string): this;
+
+        on(event: 'error' | 'warning', listener: (error: ArchiverError) => void): this;
+        on(event: 'data', listener: (data: EntryData) => void): this;
+        on(event: 'progress', listener: (progress: ProgressData) => void): this;
+        on(event: 'close' | 'drain' | 'finish', listener: () => void): this;
+        on(event: 'pipe' | 'unpipe', listener: (src: stream.Readable) => void): this;
+        on(event: string, listener: (...args: any[]) => void): this;
     }
 
     type ArchiverOptions = CoreOptions & TransformOptions & ZipOptions & TarOptions;


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/archiverjs/node-archiver
https://github.com/archiverjs/node-archiver/blob/master/lib/error.js
- [X] Increase the version number in the header if appropriate. - I do not believe that it is appropriate.
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. - Already exists