### PR TITLE
WIP: [react] more strict typings with breaking changes

### DIFF
--- a/types/react-addons-test-utils/index.d.ts
+++ b/types/react-addons-test-utils/index.d.ts
@@ -120,8 +120,8 @@ declare namespace TestUtils {
         element: DOMElement<any, T>): T;
     export function renderIntoDocument(
         element: SFCElement<any>): void;
-    export function renderIntoDocument<T extends Component<any>>(
-        element: CElement<any, T>): T;
+    export function renderIntoDocument<T extends Component>(
+        element: CElement<T>): T;
     export function renderIntoDocument<P>(
         element: ReactElement<P>): Component<P> | Element | void;
 
@@ -132,10 +132,10 @@ declare namespace TestUtils {
         element: ReactElement<any>, type: string): element is ReactHTMLElement<T>;
     export function isElementOfType<P extends DOMAttributes<{}>, T extends Element>(
         element: ReactElement<any>, type: string): element is DOMElement<P, T>;
-    export function isElementOfType<P>(
+    export function isElementOfType<P extends object>(
         element: ReactElement<any>, type: SFC<P>): element is SFCElement<P>;
-    export function isElementOfType<P, T extends Component<P>, C extends ComponentClass<P>>(
-        element: ReactElement<any>, type: ClassType<P, T, C>): element is CElement<P, T>;
+    export function isElementOfType<P extends object, T extends Component<P>, C extends ComponentClass<P>>(
+        element: ReactElement<any>, type: ClassType<P, T, C>): element is CElement<T, P>;
 
     export function isDOMComponent(instance: ReactInstance): instance is Element;
     export function isCompositeComponent(instance: ReactInstance): instance is Component<any>;
@@ -160,13 +160,13 @@ declare namespace TestUtils {
         root: Component<any>,
         tagName: string): Element;
 
-    export function scryRenderedComponentsWithType<T extends Component<{}>, C extends ComponentClass<{}>>(
-        root: Component<any>,
-        type: ClassType<any, T, C>): T[];
+    export function scryRenderedComponentsWithType<T extends Component<object>, C extends ComponentClass<object>, P = T['props']>(
+        root: T,
+        type: ComponentClass<P>): T[];
 
-    export function findRenderedComponentWithType<T extends Component<{}>, C extends ComponentClass<{}>>(
-        root: Component<any>,
-        type: ClassType<any, T, C>): T;
+    export function findRenderedComponentWithType<T extends Component, C extends ComponentClass, P = T['props']>(
+        root: T,
+        type: ComponentClass<P>): T;
 
     export function createRenderer(): ShallowRenderer;
 }

--- a/types/react-dom/index.d.ts
+++ b/types/react-dom/index.d.ts
@@ -34,9 +34,9 @@ export function unstable_renderSubtreeIntoContainer<T extends Element>(
     element: DOMElement<DOMAttributes<T>, T>,
     container: Element,
     callback?: (element: T) => any): T;
-export function unstable_renderSubtreeIntoContainer<P, T extends Component<P, ComponentState>>(
+export function unstable_renderSubtreeIntoContainer<P extends object, T extends Component<P, ComponentState>>(
     parentComponent: Component<any>,
-    element: CElement<P, T>,
+    element: CElement<T, P>,
     container: Element,
     callback?: (component: T) => any): T;
 export function unstable_renderSubtreeIntoContainer<P>(
@@ -67,8 +67,8 @@ export interface Renderer {
         callback?: () => void
     ): void;
 
-    <P, T extends Component<P, ComponentState>>(
-        element: CElement<P, T>,
+    <P extends object, T extends Component<P, ComponentState>>(
+        element: CElement<T, P>,
         container: Element | null,
         callback?: () => void
     ): T;

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -48,7 +48,7 @@ declare namespace React {
     // ----------------------------------------------------------------------
 
     type ReactType<P = any> = string | ComponentType<P>;
-    type ComponentType<P = {}> = ComponentClass<P> | StatelessComponent<P>;
+    type ComponentType<P = object> = ComponentClass<P> | StatelessComponent<P>;
 
     type Key = string | number;
 
@@ -59,7 +59,7 @@ declare namespace React {
     type Ref<T> = string | { bivarianceHack(instance: T | null): any }["bivarianceHack"] | RefObject<T>;
 
     // tslint:disable-next-line:interface-over-type-literal
-    type ComponentState = {};
+    type ComponentState<S = {}> = S;
 
     interface Attributes {
         key?: Key;
@@ -78,13 +78,16 @@ declare namespace React {
         type: SFC<P>;
     }
 
-    type CElement<P, T extends Component<P, ComponentState>> = ComponentElement<P, T>;
-    interface ComponentElement<P, T extends Component<P, ComponentState>> extends ReactElement<P> {
+    type CElement<T extends Component, P = T['props']> = ComponentElement<T, P>;
+    // type CElement<P, T extends Component<P, ComponentState>> = ComponentElement<P, T>;
+    interface ComponentElement<T extends Component, P = T['props']> extends ReactElement<P> {
+    // interface ComponentElement<P, T extends Component<P, ComponentState>> extends ReactElement<P> {
         type: ComponentClass<P>;
         ref?: Ref<T>;
     }
 
-    type ClassicElement<P> = CElement<P, ClassicComponent<P, ComponentState>>;
+    // type ClassicElement<P> = CElement<P, ClassicComponent<P, ComponentState>>;
+    type ClassicElement<P> = CElement<ClassicComponent, P>;
 
     // string fallback for custom web-components
     interface DOMElement<P extends HTMLAttributes<T> | SVGAttributes<T>, T extends Element> extends ReactElement<P> {
@@ -118,11 +121,14 @@ declare namespace React {
 
     type SFCFactory<P> = (props?: Attributes & P, ...children: ReactNode[]) => SFCElement<P>;
 
-    type ComponentFactory<P, T extends Component<P, ComponentState>> =
-        (props?: ClassAttributes<T> & P, ...children: ReactNode[]) => CElement<P, T>;
+    type ComponentFactory<T extends Component, P = T['props']> =
+        (props?: ClassAttributes<T> & P, ...children: ReactNode[]) => CElement<T, P>;
+    // type ComponentFactory<P, T extends Component<P, ComponentState>> =
+    //     (props?: ClassAttributes<T> & P, ...children: ReactNode[]) => CElement<P, T>;
 
-    type CFactory<P, T extends Component<P, ComponentState>> = ComponentFactory<P, T>;
-    type ClassicFactory<P> = CFactory<P, ClassicComponent<P, ComponentState>>;
+    // type CFactory<P, T extends Component<P, ComponentState>> = ComponentFactory<P, T>;
+    type CFactory<T extends Component, P = T['props']> = ComponentFactory<T, P>;
+    type ClassicFactory<P> = CFactory<ClassicComponent<P>, P>;
 
     type DOMFactory<P extends DOMAttributes<T>, T extends Element> =
         (props?: ClassAttributes<T> & P | null, ...children: ReactNode[]) => DOMElement<P, T>;
@@ -163,17 +169,16 @@ declare namespace React {
         type: string): DOMFactory<P, T>;
 
     // Custom components
-    function createFactory<P>(type: SFC<P>): SFCFactory<P>;
-    function createFactory<P>(
-        type: ClassType<P, ClassicComponent<P, ComponentState>, ClassicComponentClass<P>>): CFactory<P, ClassicComponent<P, ComponentState>>;
-    function createFactory<P, T extends Component<P, ComponentState>, C extends ComponentClass<P>>(
-        type: ClassType<P, T, C>): CFactory<P, T>;
-    function createFactory<P>(type: ComponentClass<P>): Factory<P>;
+    function createFactory<P extends object>(type: SFC<P>): SFCFactory<P>;
+    function createFactory<P  extends object>(
+        type: ClassType<P, ClassicComponent<P>, ClassicComponentClass<P>>): CFactory<ClassicComponent<P>, P>;
+    function createFactory<P extends object, T extends Component<P>, C extends ComponentClass<P>>(
+        type: ClassType<P, T, C>): CFactory<T, P>;
+    function createFactory<P extends object>(type: ComponentClass<P>): Factory<P>;
 
     // DOM Elements
-    // TODO: generalize this to everything in `keyof ReactHTML`, not just "input"
     function createElement(
-        type: "input",
+        type: keyof ReactHTML,
         props?: InputHTMLAttributes<HTMLInputElement> & ClassAttributes<HTMLInputElement> | null,
         ...children: ReactNode[]): DetailedReactHTMLElement<InputHTMLAttributes<HTMLInputElement>, HTMLInputElement>;
     function createElement<P extends HTMLAttributes<T>, T extends HTMLElement>(
@@ -190,19 +195,19 @@ declare namespace React {
         ...children: ReactNode[]): DOMElement<P, T>;
 
     // Custom components
-    function createElement<P>(
+    function createElement<P extends object>(
         type: SFC<P>,
         props?: Attributes & P | null,
         ...children: ReactNode[]): SFCElement<P>;
-    function createElement<P>(
-        type: ClassType<P, ClassicComponent<P, ComponentState>, ClassicComponentClass<P>>,
-        props?: ClassAttributes<ClassicComponent<P, ComponentState>> & P | null,
-        ...children: ReactNode[]): CElement<P, ClassicComponent<P, ComponentState>>;
-    function createElement<P, T extends Component<P, ComponentState>, C extends ComponentClass<P>>(
+    function createElement<P extends object>(
+        type: ClassType<P, ClassicComponent<P>, ClassicComponentClass<P>>,
+        props?: ClassAttributes<ClassicComponent<P>> & P | null,
+        ...children: ReactNode[]): CElement<ClassicComponent<P>, P>;
+    function createElement<P extends object, T extends Component<P>, C extends ComponentClass<P>>(
         type: ClassType<P, T, C>,
         props?: ClassAttributes<T> & P | null,
-        ...children: ReactNode[]): CElement<P, T>;
-    function createElement<P>(
+        ...children: ReactNode[]): CElement<T, P>;
+    function createElement<P extends object>(
         type: SFC<P> | ComponentClass<P> | string,
         props?: Attributes & P | null,
         ...children: ReactNode[]): ReactElement<P>;
@@ -230,15 +235,15 @@ declare namespace React {
         ...children: ReactNode[]): DOMElement<P, T>;
 
     // Custom components
-    function cloneElement<P>(
+    function cloneElement<P extends object>(
         element: SFCElement<P>,
         props?: Partial<P> & Attributes,
         ...children: ReactNode[]): SFCElement<P>;
-    function cloneElement<P, T extends Component<P, ComponentState>>(
-        element: CElement<P, T>,
+    function cloneElement<P extends object, T extends Component<P>>(
+        element: CElement<T, P>,
         props?: Partial<P> & ClassAttributes<T>,
-        ...children: ReactNode[]): CElement<P, T>;
-    function cloneElement<P>(
+        ...children: ReactNode[]): CElement<T, P>;
+    function cloneElement<P extends object>(
         element: ReactElement<P>,
         props?: Partial<P> & Attributes,
         ...children: ReactNode[]): ReactElement<P>;
@@ -268,8 +273,8 @@ declare namespace React {
     function isValidElement<P>(object: {} | null | undefined): object is ReactElement<P>;
 
     const Children: ReactChildren;
-    const Fragment: ComponentType;
-    const StrictMode: ComponentType;
+    const Fragment: ComponentType<{children?: ReactNode}>;
+    const StrictMode: ComponentType<{children: ReactNode}>;
     const version: string;
 
     //
@@ -280,14 +285,9 @@ declare namespace React {
 
     // Base component for plain JS classes
     // tslint:disable-next-line:no-empty-interface
-    interface Component<P = {}, S = {}, SS = any> extends ComponentLifecycle<P, S, SS> { }
-    class Component<P, S> {
+    interface Component<P = object, S = {}, SS = any> extends ComponentLifecycle<P, S, SS> { }
+    abstract class Component<P, S> {
         constructor(props: Readonly<P>);
-        /**
-         * @deprecated
-         * https://reactjs.org/docs/legacy-context.html
-         */
-        constructor(props: P, context?: any);
 
         // We MUST keep setState() as a unified signature because it allows proper checking of the method return type.
         // See: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/18365#issuecomment-351013257
@@ -298,64 +298,43 @@ declare namespace React {
         ): void;
 
         forceUpdate(callBack?: () => void): void;
-        render(): ReactNode;
+        abstract render(): ReactNode;
 
-        // React.Props<T> is now deprecated, which means that the `children`
-        // property is not available on `P` by default, even though you can
-        // always pass children as variadic arguments to `createElement`.
-        // In the future, if we can define its call signature conditionally
-        // on the existence of `children` in `P`, then we should remove this.
-        readonly props: Readonly<{ children?: ReactNode }> & Readonly<P>;
-        state: Readonly<S>;
-        /**
-         * @deprecated
-         * https://reactjs.org/docs/legacy-context.html
-         */
-        context: any;
-        /**
-         * @deprecated
-         * https://reactjs.org/docs/refs-and-the-dom.html#legacy-api-string-refs
-         */
-        refs: {
-            [key: string]: ReactInstance
-        };
+        readonly props: Readonly<P>;
+        readonly state: Readonly<S> | null;
     }
 
-    class PureComponent<P = {}, S = {}, SS = any> extends Component<P, S, SS> { }
+    abstract class PureComponent<P = object, S = {}, SS = any> extends Component<P, S, SS> { }
 
-    interface ClassicComponent<P = {}, S = {}> extends Component<P, S> {
+    interface ClassicComponent<P = object, S = {}> extends Component<P, S> {
         replaceState(nextState: S, callback?: () => void): void;
         isMounted(): boolean;
         getInitialState?(): S;
-    }
-
-    interface ChildContextProvider<CC> {
-        getChildContext(): CC;
     }
 
     //
     // Class Interfaces
     // ----------------------------------------------------------------------
 
-    type SFC<P = {}> = StatelessComponent<P>;
-    interface StatelessComponent<P = {}> {
-        (props: P & { children?: ReactNode }, context?: any): ReactElement<any> | null;
+    type SFC<P = object> = StatelessComponent<P>;
+    interface StatelessComponent<P = object> {
+        (props: P): ReactElement<any> | null;
         propTypes?: ValidationMap<P>;
         contextTypes?: ValidationMap<any>;
         defaultProps?: Partial<P>;
         displayName?: string;
     }
 
-    interface RefForwardingComponent<T, P = {}> {
-        (props: P & { children?: ReactNode }, ref?: Ref<T>): ReactElement<any> | null;
+    interface RefForwardingComponent<T, P = object> {
+        (props: P, ref?: Ref<T>): ReactElement<any> | null;
         propTypes?: ValidationMap<P>;
         contextTypes?: ValidationMap<any>;
         defaultProps?: Partial<P>;
         displayName?: string;
     }
 
-    interface ComponentClass<P = {}> extends StaticLifecycle<P, any> {
-        new (props: P, context?: any): Component<P, ComponentState>;
+    interface ComponentClass<P = object, S = {}> extends StaticLifecycle<P, S> {
+        new (props: Readonly<P>): Component<P, S>;
         propTypes?: ValidationMap<P>;
         contextTypes?: ValidationMap<any>;
         childContextTypes?: ValidationMap<any>;
@@ -363,7 +342,10 @@ declare namespace React {
         displayName?: string;
     }
 
-    interface ClassicComponentClass<P = {}> extends ComponentClass<P> {
+    /**
+     * @deprecated
+     */
+    interface ClassicComponentClass<P = object> extends ComponentClass<P> {
         new (props: P, context?: any): ClassicComponent<P, ComponentState>;
         getDefaultProps?(): P;
     }
@@ -373,10 +355,10 @@ declare namespace React {
      * a single argument, which is useful for many top-level API defs.
      * See https://github.com/Microsoft/TypeScript/issues/7234 for more info.
      */
-    type ClassType<P, T extends Component<P, ComponentState>, C extends ComponentClass<P>> =
+    type ClassType<P, T extends Component<P>, C extends ComponentClass<P>> =
         C &
-        (new (props: P, context?: any) => T) &
-        (new (props: P, context?: any) => { props: P });
+        (new (props: P) => T) &
+        (new (props: P) => { props: P });
 
     //
     // Component Specs and Lifecycle
@@ -385,7 +367,7 @@ declare namespace React {
     // This should actually be something like `Lifecycle<P, S> | DeprecatedLifecycle<P, S>`,
     // as React will _not_ call the deprecated lifecycle methods if any of the new lifecycle
     // methods are present.
-    interface ComponentLifecycle<P, S, SS = any> extends NewLifecycle<P, S, SS>, DeprecatedLifecycle<P, S> {
+    interface ComponentLifecycle<P, S = {}, SS = any> extends NewLifecycle<P, S, SS>, DeprecatedLifecycle<P, S> {
         /**
          * Called immediately after a compoment is mounted. Setting state here will trigger re-rendering.
          */
@@ -414,11 +396,11 @@ declare namespace React {
     }
 
     // Unfortunately, we have no way of declaring that the component constructor must implement this
-    interface StaticLifecycle<P, S> {
+    interface StaticLifecycle<P, S = {}> {
         getDerivedStateFromProps?: GetDerivedStateFromProps<P, S>;
     }
 
-    type GetDerivedStateFromProps<P, S> =
+    type GetDerivedStateFromProps<P, S = {}> =
         /**
          * Returns an update to a component's state based on its new props and old state.
          *
@@ -427,7 +409,7 @@ declare namespace React {
         (nextProps: Readonly<P>, prevState: S) => Partial<S> | null;
 
     // This should be "infer SS" but can't use it yet
-    interface NewLifecycle<P, S, SS> {
+    interface NewLifecycle<P, S = {}, SS = S> {
         /**
          * Runs before React applies the result of `render` to the document, and
          * returns an object to be given to componentDidUpdate. Useful for saving
@@ -445,7 +427,7 @@ declare namespace React {
         componentDidUpdate?(prevProps: Readonly<P>, prevState: Readonly<S>, snapshot?: SS): void;
     }
 
-    interface DeprecatedLifecycle<P, S> {
+    interface DeprecatedLifecycle<P, S = {}> {
         /**
          * Called immediately before mounting occurs, and before `Component#render`.
          * Avoid introducing any side-effects or subscriptions in this method.
@@ -534,7 +516,10 @@ declare namespace React {
         UNSAFE_componentWillUpdate?(nextProps: Readonly<P>, nextState: Readonly<S>, nextContext: any): void;
     }
 
-    interface Mixin<P, S> extends ComponentLifecycle<P, S> {
+    /**
+     * @deprecated
+     */
+    interface Mixin<P, S = {}> extends ComponentLifecycle<P, S> {
         mixins?: Array<Mixin<P, S>>;
         statics?: {
             [key: string]: any;
@@ -549,7 +534,7 @@ declare namespace React {
         getInitialState?(): S;
     }
 
-    interface ComponentSpec<P, S> extends Mixin<P, S> {
+    interface ComponentSpec<P, S = {}> extends Mixin<P, S> {
         render(): ReactNode;
 
         [propertyName: string]: any;
@@ -557,7 +542,7 @@ declare namespace React {
 
     function createRef<T>(): RefObject<T>;
 
-    function forwardRef<T, P = {}>(Component: RefForwardingComponent<T, P>): ComponentType<P & ClassAttributes<T>>;
+    function forwardRef<T, P = object>(Component: RefForwardingComponent<T, P>): ComponentType<P & ClassAttributes<T>>;
 
     //
     // Event System

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -47,8 +47,8 @@ declare namespace React {
     // React Elements
     // ----------------------------------------------------------------------
 
-    type ReactType<P = any> = string | ComponentType<P>;
-    type ComponentType<P = object> = ComponentClass<P> | StatelessComponent<P>;
+    type ReactType<P extends object = any> = string | ComponentType<P>;
+    type ComponentType<P extends object = object> = ComponentClass<P> | StatelessComponent<P>;
 
     type Key = string | number;
 
@@ -68,26 +68,26 @@ declare namespace React {
         ref?: Ref<T>;
     }
 
-    interface ReactElement<P> {
+    interface ReactElement<P extends object> {
         type: string | ComponentClass<P> | SFC<P>;
         props: P;
         key: Key | null;
     }
 
-    interface SFCElement<P> extends ReactElement<P> {
+    interface SFCElement<P extends object> extends ReactElement<P> {
         type: SFC<P>;
     }
 
-    type CElement<T extends Component, P = T['props']> = ComponentElement<T, P>;
+    type CElement<T extends Component, P extends object = T['props']> = ComponentElement<T, P>;
     // type CElement<P, T extends Component<P, ComponentState>> = ComponentElement<P, T>;
-    interface ComponentElement<T extends Component, P = T['props']> extends ReactElement<P> {
+    interface ComponentElement<T extends Component, P extends object = T['props']> extends ReactElement<P> {
     // interface ComponentElement<P, T extends Component<P, ComponentState>> extends ReactElement<P> {
         type: ComponentClass<P>;
         ref?: Ref<T>;
     }
 
     // type ClassicElement<P> = CElement<P, ClassicComponent<P, ComponentState>>;
-    type ClassicElement<P> = CElement<ClassicComponent, P>;
+    type ClassicElement<P extends object> = CElement<ClassicComponent, P>;
 
     // string fallback for custom web-components
     interface DOMElement<P extends HTMLAttributes<T> | SVGAttributes<T>, T extends Element> extends ReactElement<P> {
@@ -117,18 +117,18 @@ declare namespace React {
     // Factories
     // ----------------------------------------------------------------------
 
-    type Factory<P> = (props?: Attributes & P, ...children: ReactNode[]) => ReactElement<P>;
+    type Factory<P extends object> = (props?: Attributes & P, ...children: ReactNode[]) => ReactElement<P>;
 
-    type SFCFactory<P> = (props?: Attributes & P, ...children: ReactNode[]) => SFCElement<P>;
+    type SFCFactory<P extends object> = (props?: Attributes & P, ...children: ReactNode[]) => SFCElement<P>;
 
-    type ComponentFactory<T extends Component, P = T['props']> =
+    type ComponentFactory<T extends Component, P extends object = T['props']> =
         (props?: ClassAttributes<T> & P, ...children: ReactNode[]) => CElement<T, P>;
     // type ComponentFactory<P, T extends Component<P, ComponentState>> =
     //     (props?: ClassAttributes<T> & P, ...children: ReactNode[]) => CElement<P, T>;
 
     // type CFactory<P, T extends Component<P, ComponentState>> = ComponentFactory<P, T>;
-    type CFactory<T extends Component, P = T['props']> = ComponentFactory<T, P>;
-    type ClassicFactory<P> = CFactory<ClassicComponent<P>, P>;
+    type CFactory<T extends Component, P extends object = T['props']> = ComponentFactory<T, P>;
+    type ClassicFactory<P extends object> = CFactory<ClassicComponent<P>, P>;
 
     type DOMFactory<P extends DOMAttributes<T>, T extends Element> =
         (props?: ClassAttributes<T> & P | null, ...children: ReactNode[]) => DOMElement<P, T>;
@@ -270,7 +270,7 @@ declare namespace React {
         calculateChangedBits?: (prev: T, next: T) => number
     ): Context<T>;
 
-    function isValidElement<P>(object: {} | null | undefined): object is ReactElement<P>;
+    function isValidElement<P extends object>(object: {} | null | undefined): object is ReactElement<P>;
 
     const Children: ReactChildren;
     const Fragment: ComponentType<{children?: ReactNode}>;
@@ -285,8 +285,8 @@ declare namespace React {
 
     // Base component for plain JS classes
     // tslint:disable-next-line:no-empty-interface
-    interface Component<P = object, S = {}, SS = any> extends ComponentLifecycle<P, S, SS> { }
-    abstract class Component<P, S> {
+    interface Component<P extends object = object, S = {}, SS = any> extends ComponentLifecycle<P, S, SS> { }
+    abstract class Component<P extends object, S> {
         constructor(props: Readonly<P>);
 
         // We MUST keep setState() as a unified signature because it allows proper checking of the method return type.
@@ -304,9 +304,9 @@ declare namespace React {
         readonly state: Readonly<S> | null;
     }
 
-    abstract class PureComponent<P = object, S = {}, SS = any> extends Component<P, S, SS> { }
+    abstract class PureComponent<P extends object = object, S = {}, SS = any> extends Component<P, S, SS> { }
 
-    interface ClassicComponent<P = object, S = {}> extends Component<P, S> {
+    interface ClassicComponent<P extends object = object, S = {}> extends Component<P, S> {
         replaceState(nextState: S, callback?: () => void): void;
         isMounted(): boolean;
         getInitialState?(): S;
@@ -333,7 +333,7 @@ declare namespace React {
         displayName?: string;
     }
 
-    interface ComponentClass<P = object, S = {}> extends StaticLifecycle<P, S> {
+    interface ComponentClass<P extends object = object, S = {}> extends StaticLifecycle<P, S> {
         new (props: Readonly<P>): Component<P, S>;
         propTypes?: ValidationMap<P>;
         contextTypes?: ValidationMap<any>;
@@ -345,7 +345,7 @@ declare namespace React {
     /**
      * @deprecated
      */
-    interface ClassicComponentClass<P = object> extends ComponentClass<P> {
+    interface ClassicComponentClass<P extends object = object> extends ComponentClass<P> {
         new (props: P, context?: any): ClassicComponent<P, ComponentState>;
         getDefaultProps?(): P;
     }
@@ -355,7 +355,7 @@ declare namespace React {
      * a single argument, which is useful for many top-level API defs.
      * See https://github.com/Microsoft/TypeScript/issues/7234 for more info.
      */
-    type ClassType<P, T extends Component<P>, C extends ComponentClass<P>> =
+    type ClassType<P extends object, T extends Component<P>, C extends ComponentClass<P>> =
         C &
         (new (props: P) => T) &
         (new (props: P) => { props: P });

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -301,7 +301,7 @@ declare namespace React {
         abstract render(): ReactNode;
 
         readonly props: Readonly<P>;
-        readonly state: Readonly<S> | null;
+        state: Readonly<S> | null;
     }
 
     abstract class PureComponent<P extends object = object, S = {}, SS = any> extends Component<P, S, SS> { }

--- a/types/react/test/index.ts
+++ b/types/react/test/index.ts
@@ -104,11 +104,6 @@ declare const container: Element;
         }
         mutateState() {
             // $ExpectError
-            this.state = {
-                inputValue: 'hello',
-                seconds: 0
-            };
-            // $ExpectError
             this.state.inputValue = 'hello';
 
             // Even if state is not set, this is allowed by React

--- a/types/react/test/index.ts
+++ b/types/react/test/index.ts
@@ -56,6 +56,10 @@ declare const container: Element;
 // Top-Level API
 // --------------------------------------------------------------------------
 {
+    // $ExpectError
+    class Foo extends React.Component<number> {
+        render() { return this.props.toFixed; }
+    }
     interface State {
         inputValue: string;
         seconds: number;

--- a/types/react/test/index.ts
+++ b/types/react/test/index.ts
@@ -17,6 +17,7 @@ import * as DOM from "react-dom-factories";
 interface Props extends React.Attributes {
     hello: string;
     world?: string;
+    someValue?: string;
     foo: number;
 }
 
@@ -37,7 +38,7 @@ interface ChildContext {
     someOtherValue: string;
 }
 
-interface MyComponent extends React.Component<Props, State> {
+interface MyComponent {
     reset(): void;
 }
 
@@ -60,35 +61,51 @@ declare const container: Element;
         seconds: number;
     }
     class SettingStateFromCtorComponent extends React.Component<Props, State, Snapshot> {
+        readonly state: State;
         constructor(props: Props) {
             super(props);
-            // $ExpectError
             this.state = {
-                inputValue: 'hello'
+                inputValue: 'hello',
+                seconds: 123
             };
         }
         render() { return null; }
+        doSomething() {
+            console.log(this.state.seconds);
+            // $ExpectError
+            this.state = {
+                inputValue: 'hello',
+                seconds: 0
+            };
+        }
     }
 
     class BadlyInitializedState extends React.Component<Props, State, Snapshot> {
-        // $ExpectError -> this throws error on TS 2.6 uncomment once TS requirement is TS >= 2.7
+        // $ExpectError -> // this throws error on TS 2.6 uncomment once TS requirement is TS >= 2.7
         // state = {
         //     secondz: 0,
         //     inputValuez: 'hello'
         // };
         render() { return null; }
+        doSomething() {
+            // $ExpectError
+            console.log(this.state.seconds);
+        }
     }
     class BetterPropsAndStateChecksComponent extends React.Component<Props, State, Snapshot> {
         render() { return null; }
         componentDidMount() {
-            // $ExpectError -> this will be true in next BC release where state is gonna be `null | Readonly<S>`
+            // $ExpectError
             console.log(this.state.inputValue);
         }
         mutateState() {
             // $ExpectError
             this.state = {
-                inputValue: 'hello'
+                inputValue: 'hello',
+                seconds: 0
             };
+            // $ExpectError
+            this.state.inputValue = 'hello';
 
             // Even if state is not set, this is allowed by React
             this.setState({inputValue: 'hello'});
@@ -116,36 +133,20 @@ declare const container: Element;
 }
 
 class ModernComponent extends React.Component<Props, State, Snapshot>
-    implements MyComponent, React.ChildContextProvider<ChildContext> {
+    implements MyComponent {
     static propTypes: React.ValidationMap<Props> = {
         foo: PropTypes.number
     };
 
-    static contextTypes: React.ValidationMap<Context> = {
-        someValue: PropTypes.string
-    };
-
-    static childContextTypes: React.ValidationMap<ChildContext> = {
-        someOtherValue: PropTypes.string
-    };
-
-    context: Context;
-
-    getChildContext() {
-        return {
-            someOtherValue: "foo"
-        };
-    }
-
     state = {
-        inputValue: this.context.someValue,
+        inputValue: this.props.someValue,
         seconds: this.props.foo
     };
 
     reset() {
         this._myComponent.reset();
         this.setState({
-            inputValue: this.context.someValue,
+            inputValue: this.props.someValue,
             seconds: this.props.foo
         });
     }
@@ -184,11 +185,12 @@ class ModernComponentArrayRender extends React.Component<Props> {
     }
 }
 
-class ModernComponentNoState extends React.Component<Props> { }
-class ModernComponentNoPropsAndState extends React.Component { }
+class ModernComponentNoState extends React.Component<Props> { render() { return null; } }
+class ModernComponentNoPropsAndState extends React.Component { render() { return null; } }
 
 interface SCProps {
     foo?: number;
+    children?: React.ReactNode;
 }
 
 function StatelessComponent(props: SCProps) {
@@ -217,10 +219,9 @@ const StatelessComponent3: React.SFC<SCProps> =
 // allows null as props
 const StatelessComponent4: React.SFC = props => null;
 
-// React.createFactory
-const factory: React.CFactory<Props, ModernComponent> =
+const factory: React.CFactory<ModernComponent> =
     React.createFactory(ModernComponent);
-const factoryElement: React.CElement<Props, ModernComponent> =
+const factoryElement: React.CElement<ModernComponent> =
     factory(props);
 
 const statelessFactory: React.SFCFactory<SCProps> =
@@ -234,9 +235,9 @@ const domFactoryElement: React.DOMElement<React.DOMAttributes<{}>, Element> =
     domFactory();
 
 // React.createElement
-const element: React.CElement<Props, ModernComponent> = React.createElement(ModernComponent, props);
-const elementNoState: React.CElement<Props, ModernComponentNoState> = React.createElement(ModernComponentNoState, props);
-const elementNullProps: React.CElement<{}, ModernComponentNoPropsAndState> = React.createElement(ModernComponentNoPropsAndState, null);
+const element: React.CElement<ModernComponent> = React.createElement(ModernComponent, props);
+const elementNoState: React.CElement<ModernComponentNoState> = React.createElement(ModernComponentNoState, props);
+const elementNullProps: React.CElement<ModernComponentNoPropsAndState> = React.createElement(ModernComponentNoPropsAndState, null);
 const statelessElement: React.SFCElement<SCProps> = React.createElement(StatelessComponent, props);
 const statelessElementNullProps: React.SFCElement<SCProps> = React.createElement(StatelessComponent4, null);
 const domElement: React.DOMElement<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement> = React.createElement("div");
@@ -260,16 +261,16 @@ function foo3(child: React.ComponentClass<{ name: string }> | React.StatelessCom
 }
 
 // React.cloneElement
-const clonedElement: React.CElement<Props, ModernComponent> = React.cloneElement(element, { foo: 43 });
+const clonedElement: React.CElement<ModernComponent> = React.cloneElement(element, { foo: 43 });
 
 React.cloneElement(element, {});
 React.cloneElement(element, {}, null);
 
-const clonedElement2: React.CElement<Props, ModernComponent> =
+const clonedElement2: React.CElement<ModernComponent> =
     React.cloneElement(element, {
         ref: c => c && c.reset()
     });
-const clonedElement3: React.CElement<Props, ModernComponent> =
+const clonedElement3: React.CElement<ModernComponent> =
     React.cloneElement(element, {
         key: "8eac7",
         foo: 55
@@ -340,6 +341,7 @@ interface RCProps { }
 
 class RefComponent extends React.Component<RCProps> {
     static create = React.createFactory(RefComponent);
+    render() { return null; }
     refMethod() {
     }
 }
@@ -358,7 +360,7 @@ DOM.div({ ref: node => domNodeRef = node });
 let inputNodeRef: HTMLInputElement | null;
 DOM.input({ ref: node => inputNodeRef = node as HTMLInputElement });
 
-const ForwardingRefComponent = React.forwardRef((props: {}, ref: React.Ref<RefComponent>) => {
+const ForwardingRefComponent = React.forwardRef<RefComponent>((props, ref) => {
     return React.createElement(RefComponent, { ref });
 });
 
@@ -693,7 +695,7 @@ const foundComponents: ModernComponent[] = TestUtils.scryRenderedComponentsWithT
 
 // ReactTestUtils custom type guards
 
-const emptyElement1: React.ReactElement<{}> = React.createElement(ModernComponent);
+const emptyElement1: React.ReactElement<Props> = React.createElement(ModernComponent);
 if (TestUtils.isElementOfType(emptyElement1, StatelessComponent)) {
     emptyElement1.props.foo;
 }
@@ -783,6 +785,7 @@ const formEvent: InputFormEvent = changeEvent;
         static defaultProps = {
             prop3: "default value",
         };
+        render() { return null; }
     }
     const VariableWithAClass: React.ComponentClass<ComponentProps> = ComponentWithDefaultProps;
 }
@@ -798,7 +801,7 @@ declare var x: React.DOMElement<{
 }, Element>;
 
 // React 16 should be able to render its children directly
-class RenderChildren extends React.Component {
+class RenderChildren extends React.Component<{children?: React.ReactNode}> {
     render() {
         const { children } = this.props;
         return children !== undefined ? children : null;

--- a/types/react/test/tsx.tsx
+++ b/types/react/test/tsx.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 
 interface SCProps {
     foo?: number;
+    children?: React.ReactNode;
 }
 const StatelessComponent: React.SFC<SCProps> = ({ foo }: SCProps) => {
     return <div>{foo}</div>;
@@ -59,14 +60,17 @@ interface State {
     foobar: string;
 }
 class ComponentWithPropsAndState extends React.Component<Props, State> {
+    render() { return null; }
 }
 <ComponentWithPropsAndState hello="TypeScript" />;
 
 class ComponentWithoutState extends React.Component<Props> {
+    render() { return null; }
 }
 <ComponentWithoutState hello="TypeScript" />;
 
 class ComponentWithoutPropsAndState extends React.Component {
+    render() { return null; }
 }
 <ComponentWithoutPropsAndState />;
 
@@ -117,6 +121,7 @@ class SetStateTest extends React.Component<{}, { foo: boolean, bar: boolean }> {
       this.setState({ foo: true, bar: undefined}); // $ExpectError
       this.setState(prevState => (prevState.bar ? { bar: false } : null));
     }
+    render() { return null; }
 }
 
 // Below tests that extended types for state work
@@ -182,17 +187,52 @@ class PureComponentWithNewLifecycles extends React.PureComponent<NewProps, NewSt
 }
 <PureComponentWithNewLifecycles foo="bar" />;
 
-class ComponentWithLargeState extends React.Component<{}, Record<'a'|'b'|'c', string>> {
+class ComponentWithLargeState extends React.Component<object, Record<'a'|'b'|'c', string>> {
     static getDerivedStateFromProps: React.GetDerivedStateFromProps<{}, Record<'a'|'b'|'c', string>> = () => {
         return { a: 'a' };
     }
+    render() { return null; }
 }
-const AssignedComponentWithLargeState: React.ComponentClass = ComponentWithLargeState;
+const AssignedComponentWithLargeState: React.ComponentClass<object, Record<'a'|'b'|'c', string>> = ComponentWithLargeState;
 
-const componentWithBadLifecycle = new (class extends React.Component<{}, {}, number> {})({});
+const componentWithBadLifecycle = new (class extends React.Component<{}, {}, number> { render() { return null; } })({ });
 componentWithBadLifecycle.getSnapshotBeforeUpdate = () => { // $ExpectError
     return 'number';
 };
 componentWithBadLifecycle.componentDidUpdate = (prevProps: {}, prevState: {}, snapshot?: string) => { // $ExpectError
     return;
 };
+
+// children API
+// you need to explicitly provide children, to make clear API statement to consumer that he needs to provide children
+{
+    class TestNoChildrenClass extends React.Component {
+        // $ExpectError
+        render() { return this.props.children; }
+    }
+    // $ExpectError
+    const TestNoChildrenSFC: React.SFC = (props) => props.children;
+
+    class TestChildrenClass extends React.Component<{children: React.ReactNode}> {
+        render() { return this.props.children; }
+    }
+    class TestChildrenOptionalClass extends React.Component<{children?: React.ReactNode}> {
+        render() { return this.props.children ? this.props.children : null; }
+    }
+
+    const TestChildrenSFC: React.SFC<{ children: React.ReactNode }> = (props) => <div>
+            {props.children}
+        </div>;
+
+    // $ExpectError
+    (<TestChildrenClass></TestChildrenClass>);
+    // $ExpectError
+    (<TestChildrenSFC></TestChildrenSFC>);
+
+    const App = () => <>
+            <TestChildrenClass>Hello World</TestChildrenClass>
+            <TestChildrenOptionalClass/>
+            <TestChildrenOptionalClass>Hello World</TestChildrenOptionalClass>
+            <TestChildrenSFC>Hello World</TestChildrenSFC>
+        </>;
+}

--- a/types/react/test/tsx.tsx
+++ b/types/react/test/tsx.tsx
@@ -125,14 +125,14 @@ class SetStateTest extends React.Component<{}, { foo: boolean, bar: boolean }> {
 }
 
 // Below tests that extended types for state work
-export abstract class SetStateTestForExtendsState<P, S extends { baseProp: string }> extends React.Component<P, S> {
+export abstract class SetStateTestForExtendsState<P extends object, S extends { baseProp: string }> extends React.Component<P, S> {
 	foo() {
 		this.setState({ baseProp: 'foobar' });
 	}
 }
 
 // Below tests that & generic still works
-export abstract class SetStateTestForAndedState<P, S> extends React.Component<P, S & { baseProp: string }> {
+export abstract class SetStateTestForAndedState<P extends object, S> extends React.Component<P, S & { baseProp: string }> {
 	foo() {
 		this.setState({ baseProp: 'foobar' });
 	}

--- a/types/react/tsconfig.json
+++ b/types/react/tsconfig.json
@@ -11,9 +11,9 @@
             "es6"
         ],
         "noImplicitAny": true,
-        "noImplicitThis": false,
+        "noImplicitThis": true,
         "strictNullChecks": true,
-        "strictFunctionTypes": false,
+        "strictFunctionTypes": true,
         "baseUrl": "../",
         "typeRoots": [
             "../"


### PR DESCRIPTION
#### This reintroduces changes from https://github.com/DefinitelyTyped/DefinitelyTyped/pull/26813 and adds other type safety improvements

> **NOTE:**
>
> - Build will fail as https://github.com/DefinitelyTyped/DefinitelyTyped/pull/26545 needs to be merged first
> - This PR is here for discussion and hopefully/potentially it will end up being merged with breaking change version bump of course

#### Breaking Changes:

1.  if your component supports children prop you need to explicitly define it in your component props definition

**Before:**

```tsx
class TestChildrenClass extends React.Component {
  render() {
    return this.props.children;
  }
}
const App = () => (
  <div>
    <TestChildrenClass />
  </div>
);
```

**After:**

```tsx
class TestChildrenClass extends React.Component<{ children: React.ReactNode }> {
  render() {
    return this.props.children;
  }
}

// Error, children is required
const App = () => (
  <div>
    <TestChildrenClass />
  </div>
);

// no errors
const App = () => (
  <div>
    <TestChildrenClass> Im allowed and type child! </TestChildrenClass>
  </div>
);
```

2.  state is defined as `Readonly<S> | null` union type. In runtime if state is not set it's `null` by default. You need to set state via class property or if you're initializing it from constructor explicitly provide typescript property definition, to tell the compiler that you're gonna use state which will be defined within constructor instead of property.

**Update:**
I reverted marking state as readonly -> [based on this discussion](https://github.com/Microsoft/TypeScript/issues/25134#issuecomment-401120150)

**Before:**

```tsx
type Props = {};
type State = { who: string };
class MyCmp extends Component<Props, State> {
  constructor(props: Props) {
    super(props);
    this.state = { who: 'Morpheus' };
  }
  render() {
    return null;
  }
}

// following runtime errors ( forgetting to set state ) were not exposed during compile time

class MyCmp extends Component<Props, State> {
  constructor(props: Props) {
    super(props);
  }
  render() {
    return this.state.who
  }
}
```

**After:**

```tsx
type Props = {};
type State = { who: string };
class MyCmp extends Component<Props, State> {
  // you need to explicitly define state, to tell TS that it will be defined within constructor - idiomatic TS
  readonly state: State;
  constructor(props: Props) {
    super(props);
    this.state = { who: 'Morpheus' };
  }
}

// OR set state via class property and completely skip constructor

type Props = {};
type State = { who: string };
class MyCmp extends Component<Props, State> {
  readonly state = { who: 'Morpheus' };
}

// following will produce compile error now, as state is `null` if not set, which is correct behaviour reflecting runtime in compile time

class MyCmp extends Component<Props, State> {
  render() {
    // $ExpectError -> this.state is null or S -> strictNullCheck errors
    return this.state.who
  }
}
```

3.  all TS strict flags are now enabled 🖖

4.  Component,PureComponent are now abstract so you have to implement always render which will mitigate any previous runtime errors on compile time

**Before:**

```tsx
// this compiles without errors
class Test extends Component {}
```

**After:**

```tsx
// this throws compile error as Component is abstract and you need to implement render
class Test extends Component {}
```

5. change generics order to get better type inference 

- `type CElement<T extends Component, P = T['props']> = ComponentElement<T, P>;`
- `interface ComponentElement<T extends Component, P = T['props']> extends ReactElement<P> {`
- others, pls see diff

6. Props generic has now default value `object` which describes runtime ( if you won't provide props, it will be empty object by default ) `{}` is like `mixed` in Flow ( which allows to set primitives and non-primitive values as well

**Before:**

```tsx
// this compiles without errors
class Test extends Component<number> {}
```

**After:**

```tsx
// this throws compile error as Component props need to be `object`
class Test extends Component<number> {}
```

---

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:

- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
