### PR TITLE
[@types/three]: Fix `type` property compatibility.

### DIFF
--- a/types/three/three-core.d.ts
+++ b/types/three/three-core.d.ts
@@ -5246,7 +5246,7 @@ export class Mesh extends Object3D {
     morphTargetInfluences?: number[];
     morphTargetDictionary?: { [key: string]: number; };
     isMesh: true;
-    type: "Mesh";
+    type: string;
 
     setDrawMode(drawMode: TrianglesDrawModes): void;
     updateMorphTargets(): void;


### PR DESCRIPTION
Fix for https://github.com/DefinitelyTyped/DefinitelyTyped/pull/26772
