### PR TITLE
[ESLint] fix baseConfig type in CLIEngine.Options

### DIFF
--- a/types/eslint/eslint-tests.ts
+++ b/types/eslint/eslint-tests.ts
@@ -446,6 +446,7 @@ let cli: CLIEngine;
 
 cli = new CLIEngine({ allowInlineConfig: false });
 cli = new CLIEngine({ baseConfig: false });
+cli = new CLIEngine({ baseConfig: { extends: ['lynt'] }});
 cli = new CLIEngine({ cache: true });
 cli = new CLIEngine({ cacheFile: 'foo' });
 cli = new CLIEngine({ configFile: 'foo' });

--- a/types/eslint/index.d.ts
+++ b/types/eslint/index.d.ts
@@ -483,7 +483,7 @@ export class CLIEngine {
 export namespace CLIEngine {
     class Options {
         allowInlineConfig?: boolean;
-        baseConfig?: boolean;
+        baseConfig?: false | { [name: string]: any };
         cache?: boolean;
         cacheFile?: string;
         cacheLocation?: string;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://eslint.org/docs/developer-guide/nodejs-api#cliengine>

The description of the `baseConfig` property:

> Set to false to disable use of base config. Could be set to an object to override default base config as well
