### PR TITLE
remote-redux-devtools: bumped redux version to 4.x & correct (Generic)StoreEnhancer import & TypeScript 2.3

### DIFF
--- a/types/remote-redux-devtools/index.d.ts
+++ b/types/remote-redux-devtools/index.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: Colin Eberhardt <https://github.com/ColinEberhardt>
 //                 Daniel Perez Alvarez <https://github.com/unindented>
 //                 Maximo Dominguez <https://github.com/mamodom>
+//                 Colin Dekker <https://github.com/colindekker>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 

--- a/types/remote-redux-devtools/index.d.ts
+++ b/types/remote-redux-devtools/index.d.ts
@@ -7,7 +7,7 @@ import {
   Action,
   ActionCreator,
   ActionCreatorsMapObject,
-  GenericStoreEnhancer
+  StoreEnhancer
 } from "redux";
 
 export interface RemoteReduxDevToolsOptions {
@@ -108,5 +108,5 @@ export interface RemoteReduxDevToolsOptions {
   id?: string;
 }
 
-export function composeWithDevTools(options?: RemoteReduxDevToolsOptions): (...funcs: GenericStoreEnhancer[]) => GenericStoreEnhancer;
-export function composeWithDevTools(...funcs: GenericStoreEnhancer[]): GenericStoreEnhancer;
+export function composeWithDevTools(options?: RemoteReduxDevToolsOptions): (...funcs: StoreEnhancer[]) => StoreEnhancer;
+export function composeWithDevTools(...funcs: StoreEnhancer[]): StoreEnhancer;

--- a/types/remote-redux-devtools/index.d.ts
+++ b/types/remote-redux-devtools/index.d.ts
@@ -1,7 +1,10 @@
 // Type definitions for remote-redux-devtools 0.5
 // Project: https://github.com/zalmoxisus/remote-redux-devtools
-// Definitions by: Colin Eberhardt <https://github.com/ColinEberhardt>, Daniel Perez Alvarez <https://github.com/unindented>
+// Definitions by: Colin Eberhardt <https://github.com/ColinEberhardt>
+//                 Daniel Perez Alvarez <https://github.com/unindented>
+//                 Maximo Dominguez <https://github.com/mamodom>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
 
 import {
   Action,

--- a/types/remote-redux-devtools/package.json
+++ b/types/remote-redux-devtools/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "redux": "^3.6.0"
+        "redux": "^4.0.0"
     }
 }


### PR DESCRIPTION
Quoting @colindekker on #26822: 
> The underlying packages of remote-redux-devtools, redux-devtools-instrument has received an update to support redux 4.x so currently when using redux 4.x , Typescript compilation breaks because this type definition uses Redux 3.x's GenericStoreEnhancer instead of the Redux 4.x StoreEnhancer tyoe.  

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-3.html#generic-parameter-defaults
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

