### PR TITLE
Change type PendingSuiteFunction with interface

### DIFF
--- a/types/mocha/index.d.ts
+++ b/types/mocha/index.d.ts
@@ -423,7 +423,9 @@ declare namespace Mocha {
      * @returns [bdd] `Suite`
      * @returns [tdd] `void`
      */
-    type PendingSuiteFunction = (title: string, fn: (this: Suite) => void) => Suite | void;
+    interface PendingSuiteFunction {
+        (title: string, fn: (this: Suite) => void): Suite | void;
+    }
 
     interface TestFunction {
         /**

--- a/types/mocha/mocha-tests.ts
+++ b/types/mocha/mocha-tests.ts
@@ -1261,3 +1261,42 @@ function test_interfaces_common(suites: Mocha.Suite[], context: Mocha.MochaGloba
     funcs.test.skip(string);
     funcs.test.retries(number);
 }
+
+// mocha-typescript (https://www.npmjs.com/package/mocha-typescript/) augments
+// the mocha functions and enables them to work as test class decorators.
+declare module "mocha" {
+    interface SuiteFunction {
+        <TFunction extends Function>(target: TFunction): TFunction | void;
+    }
+    interface PendingSuiteFunction {
+        <TFunction extends Function>(target: TFunction): TFunction | void;
+    }
+    interface ExclusiveSuiteFunction {
+        <TFunction extends Function>(target: TFunction): TFunction | void;
+    }
+    interface TestFunction {
+        (target: Object, propertyKey: string | symbol): void;
+    }
+    interface PendingTestFunction {
+        (target: Object, propertyKey: string | symbol): void;
+    }
+    interface ExclusiveTestFunction {
+        (target: Object, propertyKey: string | symbol): void;
+    }
+}
+
+@suite
+class TestClass1 {
+    @test method1() {}
+    @test.only method2() {}
+    @test.skip method3() {}
+}
+
+@suite.skip
+class TestClass2 {
+}
+
+@suite.only
+class TestClass3 {
+}
+// end of augmentations used by mocha-typescript

--- a/types/mocha/tsconfig.json
+++ b/types/mocha/tsconfig.json
@@ -15,7 +15,8 @@
         ],
         "types": [],
         "noEmit": true,
-        "forceConsistentCasingInFileNames": true
+        "forceConsistentCasingInFileNames": true,
+        "experimentalDecorators": true
     },
     "files": [
         "index.d.ts",

--- a/types/mocha/tslint.json
+++ b/types/mocha/tslint.json
@@ -5,6 +5,7 @@
         "interface-name": false,
         "ban-types": false,
         "no-single-declare-module": false,
-        "no-declare-current-package": false
+        "no-declare-current-package": false,
+        "callable-types": false
     }
 }


### PR DESCRIPTION
This allows the PendingSuiteFunction interface to be augmented with additional overloads.
The feature is used in [mocha-typescript](http://github.com/pana-cc/mocha-typescript).

I need to augment the interfaces:
```
declare namespace Mocha {
    interface SuiteFunction {
    }
    interface TestFunction {
    }
    interface PendingSuiteFunction {
    }
    interface PendingTestFunction {
    }
}
```
To be set in stone so their augmentations don't get broken.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).