### PR TITLE
[expect-puppeteer] toDisplayDialog() should return a Dialog

### DIFF
--- a/types/expect-puppeteer/expect-puppeteer-tests.ts
+++ b/types/expect-puppeteer/expect-puppeteer-tests.ts
@@ -5,7 +5,8 @@ const testGlobal = async (instance: ElementHandle | Page) => {
     await expect(instance).toClick("selector", { polling: "mutation", text: "text" });
     await expect(instance).toClick("selector", { polling: "raf", timeout: 777 });
 
-    await expect(instance).toDisplayDialog(async () => {});
+    const dialog = await expect(instance).toDisplayDialog(async () => {});
+    console.log(dialog.message());
 
     await expect(instance).toFill("selector", "value");
     await expect(instance).toFill("selector", "value", { polling: 777 });

--- a/types/expect-puppeteer/index.d.ts
+++ b/types/expect-puppeteer/index.d.ts
@@ -1,12 +1,13 @@
 // Type definitions for expect-puppeteer 2.2
 // Project: https://github.com/smooth-code/jest-puppeteer/tree/master/packages/expect-puppeteer
 // Definitions by: Josh Goldberg <https://github.com/JoshuaKGoldberg>
+//                 Tanguy Krotoff <https://github.com/tkrotoff>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
 /// <reference types="jest" />
 
-import { ElementHandle, Page } from "puppeteer";
+import { ElementHandle, Page, Dialog } from "puppeteer";
 
 /**
  * Interval at which pageFunctions may be executed.
@@ -39,7 +40,7 @@ interface ExpectPuppeteer {
     // These must all match the ExpectPuppeteer interface above.
     // We can't extend from it directly because some method names conflict in type-incompatible ways.
     toClick(selector: string, options?: ExpectToClickOptions): Promise<void>;
-    toDisplayDialog(block: () => Promise<void>): Promise<void>;
+    toDisplayDialog(block: () => Promise<void>): Promise<Dialog>;
     toFill(selector: string, value: string, options?: ExpectTimingActions): Promise<void>;
     toMatch(selector: string, options?: ExpectTimingActions): Promise<void>;
     toMatchElement(selector: string, options?: ExpectToClickOptions): Promise<void>;
@@ -54,7 +55,7 @@ declare global {
             // These must all match the ExpectPuppeteer interface above.
             // We can't extend from it directly because some method names conflict in type-incompatible ways.
             toClick(selector: string, options?: ExpectToClickOptions): Promise<void>;
-            toDisplayDialog(block: () => Promise<void>): Promise<void>;
+            toDisplayDialog(block: () => Promise<void>): Promise<Dialog>;
             toFill(selector: string, value: string, options?: ExpectTimingActions): Promise<void>;
             toMatch(selector: string, options?: ExpectTimingActions): Promise<void>;
             toMatchElement(selector: string, options?: ExpectToClickOptions): Promise<void>;


### PR DESCRIPTION
See documentation https://github.com/smooth-code/jest-puppeteer/blob/v3.2.1/packages/expect-puppeteer/README.md#toDisplayDialog

```JS
const dialog = await expect(page).toDisplayDialog(async () => {
  await expect(page).toClick('button', { text: 'Show dialog' });
});
console.log(dialog.message());
```