### PR TITLE
redux-form: loosen redux dependency to also allow v4

### DIFF
--- a/types/redux-form/lib/reducer.d.ts
+++ b/types/redux-form/lib/reducer.d.ts
@@ -8,7 +8,8 @@ export interface FormReducer extends Reducer<FormStateMap> {
 export const reducer: FormReducer;
 
 export interface FormReducerMapObject {
-    [formName: string]: Reducer<any>;
+    // tslint:disable-next-line use-default-type-parameter
+    [formName: string]: Reducer<any>; // <any> is default type in redux v4
 }
 
 export interface FormStateMap {

--- a/types/redux-form/package.json
+++ b/types/redux-form/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "redux": "^3.6.0"
+        "redux": "^3.6.0 || ^4.0.0"
     }
 }


### PR DESCRIPTION
Redux-form has added support for Redux 4 in version 7.4.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).