### PR TITLE
[redux-first-router] Update types for compatibility with redux@^4.0.0

### DIFF
--- a/types/redux-first-router/index.d.ts
+++ b/types/redux-first-router/index.d.ts
@@ -4,6 +4,7 @@
 //                 viggyfresh <https://github.com/viggyfresh>
 //                 janb87 <https://github.com/janb87>
 //                 corydeppen <https://github.com/corydeppen>
+//                 jscinoz <https://github.com/jscinoz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.4
 
@@ -12,7 +13,7 @@ import {
     Store,
     Reducer,
     Middleware,
-    GenericStoreEnhancer
+    StoreEnhancer
 } from 'redux';
 import { History } from 'history';
 
@@ -233,7 +234,7 @@ export function connectRoutes<TKeys = {}, TState = any>(
         reducer: Reducer<LocationState<TKeys, TState>>;
         middleware: Middleware;
         thunk(store: Store<TState>): Promise<Nullable<RouteThunk<TState>>>;
-        enhancer: GenericStoreEnhancer;
+        enhancer: StoreEnhancer;
         initialDispatch?(): void;
     };
 

--- a/types/redux-first-router/package.json
+++ b/types/redux-first-router/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "redux": "^3.7.0"
+        "redux": "^4.0.0"
     }
 }

--- a/types/redux-first-router/redux-first-router-tests.ts
+++ b/types/redux-first-router/redux-first-router-tests.ts
@@ -10,6 +10,7 @@ import {
     pathToAction
 } from 'redux-first-router';
 import {
+    AnyAction,
     createStore,
     applyMiddleware,
     Middleware,
@@ -18,7 +19,7 @@ import {
     Dispatch,
     compose,
     Action,
-    GenericStoreEnhancer,
+    StoreEnhancer,
     StoreEnhancerStoreCreator,
     combineReducers
 } from 'redux';
@@ -32,7 +33,6 @@ interface Keys {
 }
 interface State {
     location: LocationState<Keys, State>;
-    stale: boolean;
 }
 type StoreCreator = StoreEnhancerStoreCreator<State>;
 
@@ -78,7 +78,7 @@ const dumbMiddleware: Middleware = store => next => action => next(action);
 
 const composedMiddleware = applyMiddleware(middleware, dumbMiddleware);
 
-const storeEnhancer = compose<StoreCreator, StoreCreator, StoreCreator>(
+const storeEnhancer = compose(
     enhancer,
     composedMiddleware
 );
@@ -112,7 +112,7 @@ const action: ReduxFirstRouterAction = {
 };
 redirect(action); // $ExpectType Action
 
-// $ExpectType Store<State>
+// $ExpectType Store<State, AnyAction>
 store;
 
 store.getState().location.routesMap; // $ExpectType RoutesMap<Keys, State>


### PR DESCRIPTION
Redux 4 fixes the Reducer type definition which was originally incorrect with regards to runtime behaviour. In Redux 3, the typedef was:

[Redux 3](https://github.com/reduxjs/redux/blob/v3.7.2/index.d.ts#L57)
```typescript
export type Reducer<S> = (state: S, action: AnyAction) => S;
```
This was incorrect, as `state` can be undefined, as is the case on initial dispatch when state is initialised. This is fixed in the typedefs for Redux 4:

[Redux 4](https://github.com/reduxjs/redux/blob/v4.0.0/index.d.ts#L59)
```typescript
export type Reducer<S = any, A extends Action = AnyAction> = (state: S | undefined, action: A) => S;
```

redux-first-router is compatible with Redux 4 at runtime, but presently requires type assertions to compile due to the incompatible definitions for `Reducer`. This commit updates the dependency to `^4.0.0` and also replaces `GenericStoreEnhancer` with `StoreEnhancer`, as the former type has since been removed from Redux.