### PR TITLE
Lodash: `mapValues`: fix usage with type aliases

### DIFF
--- a/types/lodash/common/object.d.ts
+++ b/types/lodash/common/object.d.ts
@@ -2251,13 +2251,6 @@ declare module "../index" {
          * TODO: This would be better if we had a separate overload for obj: NumericDictionary that returned a NumericDictionary,
          *       but TypeScript cannot select overload signatures based on number vs string index key type.
          */
-        mapValues<T, TResult>(obj: Dictionary<T> | NumericDictionary<T> | null | undefined, callback: DictionaryIterator<T, TResult>): Dictionary<TResult>;
-
-        /**
-         * @see _.mapValues
-         * TODO: This would be better if we had a separate overload for obj: NumericDictionary that returned a NumericDictionary,
-         *       but TypeScript cannot select overload signatures based on number vs string index key type.
-         */
         mapValues<T>(obj: Dictionary<T> | NumericDictionary<T> | null | undefined, iteratee: object): Dictionary<boolean>;
 
         /**

--- a/types/lodash/common/object.d.ts
+++ b/types/lodash/common/object.d.ts
@@ -2243,15 +2243,15 @@ declare module "../index" {
 
         /**
          * @see _.mapValues
+         */
+        mapValues<T extends object, TResult>(obj: T | null | undefined, callback: ObjectIterator<T, TResult>): { [P in keyof T]: TResult };
+
+        /**
+         * @see _.mapValues
          * TODO: This would be better if we had a separate overload for obj: NumericDictionary that returned a NumericDictionary,
          *       but TypeScript cannot select overload signatures based on number vs string index key type.
          */
         mapValues<T, TResult>(obj: Dictionary<T> | NumericDictionary<T> | null | undefined, callback: DictionaryIterator<T, TResult>): Dictionary<TResult>;
-
-        /**
-         * @see _.mapValues
-         */
-        mapValues<T extends object, TResult>(obj: T | null | undefined, callback: ObjectIterator<T, TResult>): { [P in keyof T]: TResult };
 
         /**
          * @see _.mapValues

--- a/types/lodash/index.d.ts
+++ b/types/lodash/index.d.ts
@@ -10,7 +10,7 @@
 //                 Jack Moore <https://github.com/jtmthf>,
 //                 Dominique Rau <https://github.com/DomiR>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.9
 
 /// <reference path="./common/common.d.ts" />
 /// <reference path="./common/array.d.ts" />

--- a/types/lodash/lodash-tests.ts
+++ b/types/lodash/lodash-tests.ts
@@ -5370,7 +5370,7 @@ fp.now(); // $ExpectType number
         return abcObject;
     });
 
-    // $ExpectType Dictionary<string>
+    // $ExpectType { [x: string]: string; }
     _.mapValues(dictionary, (value, key, collection) => {
         value;  // $ExpectType AbcObject
         key; // $ExpectType string
@@ -5378,12 +5378,11 @@ fp.now(); // $ExpectType number
         return "";
     });
 
-    // Can"t really support NumericDictionary fully, but it at least gets treated like a Dictionary
-    // $ExpectType Dictionary<string>
+    // $ExpectType { [x: number]: string; }
     _.mapValues(numericDictionary, (value, key, collection) => {
         value;  // $ExpectType AbcObject
         key; // $ExpectType string
-        collection; // $ExpectType Dictionary<AbcObject>
+        collection; // $ExpectType NumericDictionary<AbcObject>
         return "";
     });
 

--- a/types/lodash/lodash-tests.ts
+++ b/types/lodash/lodash-tests.ts
@@ -5395,6 +5395,15 @@ fp.now(); // $ExpectType number
         return "";
     });
 
+    const abcObjectRecord: Record<'a' | 'b' | 'c', string> = anything;
+    // $ExpectType { a: string; b: string; c: string; }
+    _.mapValues(abcObjectRecord, (value, key, collection) => {
+        value;  // $ExpectType string
+        key; // $ExpectType string
+        collection; // $ExpectType Record<"a" | "b" | "c", string>
+        return "";
+    });
+
     _.mapValues(dictionary, {}); // $ExpectType Dictionary<boolean>
     // Can"t really support NumericDictionary fully, but it at least gets treated like a Dictionary
     _.mapValues(numericDictionary, {}); // $ExpectType Dictionary<boolean>


### PR DESCRIPTION
Currenty, if `mapValues` is given a ~mapped type~ value whose type is a type alias (instead of an interface), it returns a `Dictionary`, i.e. it loses all information about the object keys. I expect it to return a mapped type, i.e. retain all information about object keys.

This can be fixed by switching the order of the overloads, so the more specific overload is used first.

However, this breaks other tests. I tried fixing them, but then I got errors for older TypeScript versions. Can anyone help?

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.