### PR TITLE
Add .container to ChartSpecs for google.visualization

### DIFF
--- a/types/google.visualization/index.d.ts
+++ b/types/google.visualization/index.d.ts
@@ -20,6 +20,7 @@ declare namespace google {
 
         export interface ChartSpecs {
             chartType: string;
+            container?: HTMLElement;
             containerId?: string;
             options?: Object;
             dataTable?: Object;


### PR DESCRIPTION
Can be given element in .container instead of passing an ID in .containerID