### PR TITLE
[@types/react] Fix React 16.3+ compatibility with Radium

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -1001,7 +1001,7 @@ declare namespace React {
         placeholder?: string;
         slot?: string;
         spellCheck?: boolean;
-        style?: CSSProperties;
+        style?: CSSProperties | CSSProperties[];
         tabIndex?: number;
         title?: string;
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/FormidableLabs/radium#usage
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

Radium is a highly popular library for React component styling (6k+ stars and years of development).  However, with Typescript, Radium is not usable with React 16.3+.  The issue is that Radium supports inline styling of React element using arrays of CSSProperties -- Radium internally manipulates these into a single object that React is then happy with.  However, at the time of type checking, it is currently an error to pass an array of CSSProperties to the style property of an HTMLElement, which prevents React and Radium from interoperating.  This PR makes a one-line change to allow arrays of CSSProperties to be passed to elements' style properties and hence fixes the compatibility issues between React and Radium in Typescript.  While this does very slightly widen the React typings, I hope you consider this PR since currently these popular libraries are incompatible with Typescript.  Thanks!