### PR TITLE
[mongodb] Added countDocuments() and estimatedDocumentCount() 

### DIFF
--- a/types/mongodb/index.d.ts
+++ b/types/mongodb/index.d.ts
@@ -2,7 +2,6 @@
 // Project: https://github.com/mongodb/node-mongodb-native/tree/3.0.0
 // Definitions by: Federico Caselli <https://github.com/CaselIT>
 //                 Alan Marcell <https://github.com/alanmarcell>
-//                 Gady Piazza <https://github.com/kikar>
 //                 Jason Dreyzehner <https://github.com/bitjson>
 //                 Gaurav Lahoti <https://github.com/dante-101>
 //                 Mariano Cortesi <https://github.com/mcortesi>
@@ -493,8 +492,10 @@ export interface Collection<TSchema = Default> {
     bulkWrite(operations: Object[], callback: MongoCallback<BulkWriteOpResultObject>): void;
     bulkWrite(operations: Object[], options?: CollectionBulkWriteOptions): Promise<BulkWriteOpResultObject>;
     bulkWrite(operations: Object[], options: CollectionBulkWriteOptions, callback: MongoCallback<BulkWriteOpResultObject>): void;
-    /** http://mongodb.github.io/node-mongodb-native/3.1/api/Collection.html#count */
-    /** @deprecated Use countDocuments or estimatedDocumentCount */
+    /**
+     * http://mongodb.github.io/node-mongodb-native/3.1/api/Collection.html#count
+     * @deprecated Use countDocuments or estimatedDocumentCount
+     */
     count(callback: MongoCallback<number>): void;
     count(query: Object, callback: MongoCallback<number>): void;
     count(query?: Object, options?: MongoCountPreferences): Promise<number>;

--- a/types/mongodb/index.d.ts
+++ b/types/mongodb/index.d.ts
@@ -494,6 +494,7 @@ export interface Collection<TSchema = Default> {
     bulkWrite(operations: Object[], options?: CollectionBulkWriteOptions): Promise<BulkWriteOpResultObject>;
     bulkWrite(operations: Object[], options: CollectionBulkWriteOptions, callback: MongoCallback<BulkWriteOpResultObject>): void;
     /** http://mongodb.github.io/node-mongodb-native/3.1/api/Collection.html#count */
+    /** @deprecated Use countDocuments or estimatedDocumentCount */
     count(callback: MongoCallback<number>): void;
     count(query: Object, callback: MongoCallback<number>): void;
     count(query?: Object, options?: MongoCountPreferences): Promise<number>;

--- a/types/mongodb/index.d.ts
+++ b/types/mongodb/index.d.ts
@@ -12,6 +12,7 @@
 //                 Dan Aprahamian <https://github.com/daprahamian>
 //                 Denys Bushulyak <https://github.com/denys-bushulyak>
 //                 Bastien Arata <https://github.com/BastienAr>
+//                 Wan Bachtiar <https://github.com/sindbach>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -497,6 +498,11 @@ export interface Collection<TSchema = Default> {
     count(query: Object, callback: MongoCallback<number>): void;
     count(query?: Object, options?: MongoCountPreferences): Promise<number>;
     count(query: Object, options: MongoCountPreferences, callback: MongoCallback<number>): void;
+    /** http://mongodb.github.io/node-mongodb-native/3.1/api/Collection.html#countDocuments */
+    countDocuments(callback: MongoCallback<number>): void;
+    countDocuments(query: Object, callback: MongoCallback<number>): void;
+    countDocuments(query?: Object, options?: MongoCountPreferences): Promise<number>;
+    countDocuments(query: Object, options: MongoCountPreferences, callback: MongoCallback<number>): void;
     /** http://mongodb.github.io/node-mongodb-native/3.1/api/Collection.html#createIndex */
     createIndex(fieldOrSpec: string | any, callback: MongoCallback<string>): void;
     createIndex(fieldOrSpec: string | any, options?: IndexOptions): Promise<string>;
@@ -529,6 +535,11 @@ export interface Collection<TSchema = Default> {
     dropIndexes(options?: {session?: ClientSession, maxTimeMS?: number}): Promise<any>;
     dropIndexes(callback?: MongoCallback<any>): void;
     dropIndexes(options: {session?: ClientSession, maxTimeMS?: number}, callback: MongoCallback<any>): void;
+    /** http://mongodb.github.io/node-mongodb-native/3.1/api/Collection.html#estimatedDocumentCount */
+    estimatedDocumentCount(callback: MongoCallback<number>): void;
+    estimatedDocumentCount(query: Object, callback: MongoCallback<number>): void;
+    estimatedDocumentCount(query?: Object, options?: MongoCountPreferences): Promise<number>;
+    estimatedDocumentCount(query: Object, options: MongoCountPreferences, callback: MongoCallback<number>): void;
     /** http://mongodb.github.io/node-mongodb-native/3.1/api/Collection.html#find */
     find<T = TSchema>(query?: FilterQuery<TSchema>): Cursor<T>;
     /** @deprecated */

--- a/types/mongodb/mongodb-tests.ts
+++ b/types/mongodb/mongodb-tests.ts
@@ -38,27 +38,27 @@ MongoClient.connect('mongodb://127.0.0.1:27017/test', options, function (err: mo
 
         // Intentionally omitted type annotation from 'count'.
         // This way it requires a more accurate typedef which allows inferring that it's a number.
-        collection.count(function (err: mongodb.MongoError, count) {
+        collection.countDocuments(function (err: mongodb.MongoError, count) {
             console.log(format("count = %s", count));
         });
 
-        collection.count().then(function (count: number) {
+        collection.countDocuments().then(function (count: number) {
             console.log(format("count = %s", count));
         });
 
-        collection.count({ foo: 1 }, function (err: mongodb.MongoError, count: number) {
+        collection.countDocuments({ foo: 1 }, function (err: mongodb.MongoError, count: number) {
             console.log(format("count = %s", count));
         });
 
-        collection.count({ foo: 1 }).then(function (count: number) {
+        collection.countDocuments({ foo: 1 }).then(function (count: number) {
             console.log(format("count = %s", count));
         });
 
-        collection.count({ foo: 1 }, { limit: 10 }, function (err: mongodb.MongoError, count: number) {
+        collection.countDocuments({ foo: 1 }, { limit: 10 }, function (err: mongodb.MongoError, count: number) {
             console.log(format("count = %s", count));
         });
 
-        collection.count({ foo: 1 }, { limit: 10 }).then(function (count: number) {
+        collection.countDocuments({ foo: 1 }, { limit: 10 }).then(function (count: number) {
             console.log(format("count = %s", count));
         });
 


### PR DESCRIPTION
The method `count()` has been deprecated in v3.1, added new methods `countDocuments()` and estimatedDocumentCount()`. See also : [NODE-1501](https://jira.mongodb.org/browse/NODE-1501)

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://mongodb.github.io/node-mongodb-native/3.1/api/Collection.html#countDocuments
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

