### PR TITLE
@types/documentdb: Use specified return type in queryDocuments

### DIFF
--- a/types/documentdb/index.d.ts
+++ b/types/documentdb/index.d.ts
@@ -802,7 +802,7 @@ export class DocumentClient {
      * @param [options]      - Represents the feed options.
      * @returns              - An instance of queryIterator to handle reading feed.
      */
-    queryDocuments<TDocument>(collectionLink: string, query: DocumentQuery, options?: FeedOptions): QueryIterator<RetrievedDocument>;
+    queryDocuments<TDocument>(collectionLink: string, query: DocumentQuery, options?: FeedOptions): QueryIterator<RetrievedDocument & TDocument>;
 
     /**
      * Query the triggers for the collection.


### PR DESCRIPTION
`queryDocuments` already has a type variable but it is not being used in the return type.
This PR simply merges the RetrievedDocument type with the input type.
