### PR TITLE
improve http-graceful-shutdown - library should also support https servers

### DIFF
--- a/types/http-graceful-shutdown/http-graceful-shutdown-tests.ts
+++ b/types/http-graceful-shutdown/http-graceful-shutdown-tests.ts
@@ -19,7 +19,10 @@ const httpServer = http.createServer((req, res) => {
     res.end();
 });
 
-const httpsServer = https.createServer({}, (req, res) => {
+const httpsServer = https.createServer({
+    key: new Buffer('foo'),
+    cert: new Buffer('bar')
+}, (req, res) => {
     res.end();
 });
 

--- a/types/http-graceful-shutdown/http-graceful-shutdown-tests.ts
+++ b/types/http-graceful-shutdown/http-graceful-shutdown-tests.ts
@@ -19,7 +19,7 @@ const httpServer = http.createServer((req, res) => {
     res.end();
 });
 
-const httpsServer = https.createServer((req, res) => {
+const httpsServer = https.createServer({}, (req, res) => {
     res.end();
 });
 

--- a/types/http-graceful-shutdown/http-graceful-shutdown-tests.ts
+++ b/types/http-graceful-shutdown/http-graceful-shutdown-tests.ts
@@ -1,5 +1,6 @@
 import GracefulShutdown = require('http-graceful-shutdown');
 import * as http from "http";
+import * as https from "https";
 
 const opts: GracefulShutdown.Options = {
     signals: "SIGINT SIGTERM",
@@ -14,8 +15,13 @@ const opts: GracefulShutdown.Options = {
     }
 };
 
-const server = http.createServer((req, res) => {
+const httpServer = http.createServer((req, res) => {
     res.end();
 });
 
-GracefulShutdown(server, opts);
+const httpsServer = https.createServer((req, res) => {
+    res.end();
+});
+
+GracefulShutdown(httpServer, opts);
+GracefulShutdown(httpsServer, opts);

--- a/types/http-graceful-shutdown/index.d.ts
+++ b/types/http-graceful-shutdown/index.d.ts
@@ -5,9 +5,10 @@
 
 /// <reference types="node" />
 
-import { Server } from "http";
+import { Server as HttpServer } from "http";
+import { Server as HttpsServer } from "https";
 
-declare function GracefulShutdown(server: Server, options?: GracefulShutdown.Options): void;
+declare function GracefulShutdown(server: HttpServer | HttpsServer, options?: GracefulShutdown.Options): void;
 
 declare namespace GracefulShutdown {
     interface Options {


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: 

https://github.com/sebhildebrandt/http-graceful-shutdown/blob/master/lib/index.js
This shows the `server` parameter has a `close` method called on it, and it registers some event handlers.
According to the documentation found at https://nodejs.org/api/https.html#https_class_https_server, the https.Server class also features a close method and it "emits events same as http.Server".

- [X] Increase the version number in the header if appropriate. - N/A
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. - N/A