### PR TITLE
Add missing stripe.iinvoice fields

### DIFF
--- a/types/stripe/index.d.ts
+++ b/types/stripe/index.d.ts
@@ -1896,6 +1896,16 @@ declare namespace Stripe {
             amount_due: number;
 
             /**
+             * The amount, in cents, that was paid.
+             */
+            amount_paid: number;
+
+            /**
+             * The amount remaining, in cents, that is due.
+             */
+            amount_remaining: number;
+
+            /**
              * The fee in cents that will be applied to the invoice and transferred to the application owner's
              * Stripe account when the invoice is paid.
              */
@@ -1916,6 +1926,16 @@ declare namespace Stripe {
             attempted: boolean;
 
             /**
+             * Either charge_automatically, or send_invoice. When charging automatically, Stripe will attempt to pay this invoice using the default source attached to the customer. When sending an invoice, Stripe will email this invoice to the customer with payment instructions.
+             */
+            billing: "charge_automatically" | "send_invoice";
+
+            /**
+             * Indicates the reason why the invoice was created. subscription_cycle indicates an invoice created by a subscription advancing into a new period. subscription_update indicates an invoice created due to creating or updating a subscription. subscription is set for all old invoices to indicate either a change to a subscription or a period advancement. manual is set for all invoices unrelated to a subscription (for example: created via the invoice editor). The upcoming value is reserved for simulated invoices per the upcoming invoice endpoint.
+             */
+            billing_reason: "subscription_cycle" | "subscription_update" | "subscription" | "manual" | "upcoming";
+
+            /**
              * ID of the latest charge generated for this invoice, if any. [Expandable]
              */
             charge: string | charges.ICharge;
@@ -1926,17 +1946,35 @@ declare namespace Stripe {
              */
             closed: boolean;
 
+            /**
+             * Three-letter ISO currency code, in lowercase. Must be a supported currency.
+             */
             currency: string;
+
             customer: string;
+
+            /**
+             * Time at which the object was created. Measured in seconds since the Unix epoch.
+             */
             date: number;
+
+            /**
+             * An arbitrary string attached to the object. Often useful for displaying to users.
+             */
             description: string;
+
             discount: coupons.IDiscount;
+
+            /**
+             * The date on which payment for this invoice is due. This value will be null for invoices where billing=charge_automatically.
+             */
+            due_date: number | null;
 
             /**
              * Ending customer balance after attempting to pay invoice. If the invoice has not been attempted yet,
              * this will be null.
              */
-            ending_balance: number;
+            ending_balance: number | null;
 
             /**
              * Whether or not the invoice has been forgiven. Forgiving an invoice instructs us to update the subscription
@@ -1946,19 +1984,41 @@ declare namespace Stripe {
             forgiven: boolean;
 
             /**
+             * The URL for the hosted invoice page, which allows customers to view and pay an invoice. If the invoice has not been frozen yet, this will be null.
+             */
+            hosted_invoice_url: string | null;
+
+            /**
+             * The link to download the PDF for the invoice. If the invoice has not been frozen yet, this will be null.
+             */
+            invoice_pdf: string | null;
+
+            /**
              * The individual line items that make up the invoice.
              *
              * lines is sorted as follows: invoice items in reverse chronological order, followed by the subscription, if any.
              */
             lines: IList<IInvoiceLineItem>;
 
+            /**
+             * Has the value true if the object exists in live mode or the value false if the object exists in test mode.
+             */
             livemode: boolean;
+
+            /**
+             * Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format.
+             */
             metadata: IMetadata;
 
             /**
              * The time at which payment will next be attempted.
              */
             next_payment_attempt: number;
+
+            /**
+             * A unique, identifying string that appears on emails sent to the customer for this invoice. This starts with the customer’s unique invoice_prefix if it is specified.
+             */
+            number: string;
 
             /**
              * Whether or not payment was successfully collected for this invoice. An invoice can be paid (most commonly)
@@ -1988,7 +2048,7 @@ declare namespace Stripe {
             starting_balance: number;
 
             /**
-             * Extra information about an invoice for the customer�s credit card statement.
+             * Extra information about an invoice for the customer's credit card statement.
              */
             statement_descriptor: string;
 
@@ -2011,14 +2071,14 @@ declare namespace Stripe {
              * The amount of tax included in the total, calculated from tax_percent and the subtotal. If no tax_percent
              * is defined, this value will be null.
              */
-            tax: number;
+            tax: number | null;
 
             /**
              * This percentage of the subtotal has been added to the total amount of the invoice, including invoice line
              * items and discounts. This field is inherited from the subscription's tax_percent field, but can be changed
              * before the invoice is paid. This field defaults to null.
              */
-            tax_percent: number;
+            tax_percent: number | null;
 
             /**
              * Total after discount


### PR DESCRIPTION
- Added: amount_paid, amount_remaining, billing, billing_reason, due_date, hosted_invoice_url, invoice_pdf, number

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://stripe.com/docs/api#invoice_object
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
