### PR TITLE
[ember] - Add missing Ember.Route#intermediateTransitionTo method

### DIFF
--- a/types/ember/index.d.ts
+++ b/types/ember/index.d.ts
@@ -7,6 +7,7 @@
 //                 Theron Cross <https://github.com/theroncross>
 //                 Martin Feckie <https://github.com/mfeckie>
 //                 Alex LaFroscia <https://github.com/alexlafroscia>
+//                 Mike North <https://github.com/mike-north>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.4
 

--- a/types/ember/index.d.ts
+++ b/types/ember/index.d.ts
@@ -1990,6 +1990,19 @@ declare module 'ember' {
              */
             transitionTo(name: string, ...object: any[]): Transition;
 
+            // https://emberjs.com/api/ember/3.2/classes/Route/methods/intermediateTransitionTo?anchor=intermediateTransitionTo
+            /**
+             * Perform a synchronous transition into another route without attempting to resolve promises,
+             * update the URL, or abort any currently active asynchronous transitions
+             * (i.e. regular transitions caused by transitionTo or URL changes).
+             *
+             * @param name           the name of the route or a URL
+             * @param object         the model(s) or identifier(s) to be used while
+             *                       transitioning to the route.
+             * @returns              the Transition object associated with this attempted transition
+             */
+            intermediateTransitionTo(name: string, ...object: any[]): Transition;
+
             // properties
             /**
              * The controller associated with this route.

--- a/types/ember/test/route.ts
+++ b/types/ember/test/route.ts
@@ -92,4 +92,13 @@ class RouteUsingClass extends Route.extend({
     beforeModel(this: RouteUsingClass) {
         return 'beforeModel can return anything, not just promises';
     }
+    intermediateTransitionWithoutModel() {
+        this.intermediateTransitionTo('some-route');
+    }
+    intermediateTransitionWithModel() {
+        this.intermediateTransitionTo('some.other.route', { });
+    }
+    intermediateTransitionWithMultiModel() {
+        this.intermediateTransitionTo('some.other.route', 1, 2, { });
+    }
 }

--- a/types/ember/test/router.ts
+++ b/types/ember/test/router.ts
@@ -34,6 +34,11 @@ const RouterServiceConsumer = Ember.Service.extend({
         Ember.get(this, 'router')
         .transitionTo('some.other.route', model);
     },
+    transitionWithMultiModel() {
+        const model = Ember.Object.create();
+        Ember.get(this, 'router')
+        .transitionTo('some.other.route', model, model);
+    },
     transitionWithModelAndOptions() {
         const model = Ember.Object.create();
         Ember.get(this, 'router')


### PR DESCRIPTION
This is a public method from the Ember.Route type.

eg: https://www.emberjs.com/api/ember/3.2/classes/Ember.Route/methods/intermediateTransitionTo?anchor=intermediateTransitionTo

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.emberjs.com/api/ember/3.2/classes/Route/methods/intermediateTransitionTo?anchor=intermediateTransitionTo
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
