### PR TITLE
[node] Added missing COPYFILE_* constants

### DIFF
--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -4471,6 +4471,17 @@ declare module "fs" {
         /** Constant for fs.access(). File can be executed by the calling process. */
         export const X_OK: number;
 
+        // File Copy Constants
+
+        /** Constant for fs.copyFile. Flag indicating the destination file should not be overwritten if it already exists. */
+        export const COPYFILE_EXCL: number;
+
+        /** Constant for fs.copyFile. copy operation will attempt to create a copy-on-write reflink. If the underlying platform does not support copy-on-write, then a fallback copy mechanism is used. */
+        export const COPYFILE_FICLONE: number;
+
+        /** Constant for fs.copyFile. Copy operation will attempt to create a copy-on-write reflink. If the underlying platform does not support copy-on-write, then the operation will fail with an error. */
+        export const COPYFILE_FICLONE_FORCE: number;
+
         // File Open Constants
 
         /** Constant for fs.open(). Flag indicating to open a file for read-only access. */
@@ -4584,9 +4595,6 @@ declare module "fs" {
 
         /** Constant for fs.Stats mode property for determining access permissions for a file. File mode indicating executable by others. */
         export const S_IXOTH: number;
-
-        /** Constant for fs.copyFile. Flag indicating the destination file should not be overwritten if it already exists. */
-        export const COPYFILE_EXCL: number;
     }
 
     /**
@@ -6700,6 +6708,9 @@ declare module "constants" {
     export var R_OK: number;
     export var W_OK: number;
     export var X_OK: number;
+    export var COPYFILE_EXCL: number;
+    export var COPYFILE_FICLONE: number;
+    export var COPYFILE_FICLONE_FORCE: number;
     export var UV_UDP_REUSEADDR: number;
     export var SIGQUIT: number;
     export var SIGTRAP: number;

--- a/types/node/node-tests.ts
+++ b/types/node/node-tests.ts
@@ -390,8 +390,12 @@ namespace fs_tests {
     {
         fs.copyFile('/path/to/src', '/path/to/dest', (err) => console.error(err));
         fs.copyFile('/path/to/src', '/path/to/dest', fs.constants.COPYFILE_EXCL, (err) => console.error(err));
+        fs.copyFile('/path/to/src', '/path/to/dest', fs.constants.COPYFILE_FICLONE, (err) => console.error(err));
+        fs.copyFile('/path/to/src', '/path/to/dest', fs.constants.COPYFILE_FICLONE_FORCE, (err) => console.error(err));
 
         fs.copyFileSync('/path/to/src', '/path/to/dest', fs.constants.COPYFILE_EXCL);
+        fs.copyFileSync('/path/to/src', '/path/to/dest', fs.constants.COPYFILE_FICLONE);
+        fs.copyFileSync('/path/to/src', '/path/to/dest', fs.constants.COPYFILE_FICLONE_FORCE);
 
         const cf = util.promisify(fs.copyFile);
         cf('/path/to/src', '/path/to/dest', fs.constants.COPYFILE_EXCL).then(console.log);


### PR DESCRIPTION
fixes #26534

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://nodejs.org/dist/latest-v10.x/docs/api/fs.html#fs_file_copy_constants>>
- [x] Increase the version number in the header if appropriate. **is not appropriate**
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. **changes are not substantial**
