### PR TITLE
[@types/facebook-js-sdk] add missing grantedScopes property in AuthResponse interface

### DIFF
--- a/types/facebook-js-sdk/index.d.ts
+++ b/types/facebook-js-sdk/index.d.ts
@@ -189,6 +189,7 @@ declare namespace facebook {
         expiresIn: number;
         signedRequest: string;
         userID: string;
+        grantedScopes?: string;
     }
     
     interface StatusResponse {


### PR DESCRIPTION
according to the discussion with @sanpoChew, I added missing `grantedScopes` property in `AuthResponse` interface 

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:  
 - https://developers.facebook.com/docs/reference/javascript/FB.login/v3.0
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
