### PR TITLE
Add type definitions for react-notify-toast

### DIFF
--- a/types/react-notify-toast/index.d.ts
+++ b/types/react-notify-toast/index.d.ts
@@ -1,3 +1,9 @@
+// Type definitions for react-notify-toast 0.5.0
+// Project: https://github.com/jesusoterogomez/react-notify-toast
+// Definitions by: Klaas Cuvelier <https://github.com/klaascuvelier>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.6
+
 type reactNotifyToastType = 'success' | 'error' | 'warning' | 'custom';
 type reactNotifyToastColor = {
     background: string;

--- a/types/react-notify-toast/index.d.ts
+++ b/types/react-notify-toast/index.d.ts
@@ -1,0 +1,30 @@
+type reactNotifyToastType = 'success' | 'error' | 'warning' | 'custom';
+type reactNotifyToastColor = {
+    background: string;
+    text: string;
+};
+
+declare module 'react-notify-toast' {
+    class reactNotifyToast {
+        show(
+            text: string,
+            type?: reactNotifyToastType,
+            timeout?: number,
+            color?: reactNotifyToastColor
+        ): void;
+
+        hide(): void;
+        createShowQueue(): reactNotifyToast;
+    }
+
+    import * as React from 'react';
+
+    type NotificationProps = {
+        options: any;
+    };
+
+    export class Notification extends React.Component<NotificationProps, any> {}
+
+    export const notify: reactNotifyToast;
+    export default Notification;
+}

--- a/types/react-notify-toast/index.d.ts
+++ b/types/react-notify-toast/index.d.ts
@@ -1,36 +1,33 @@
-// Type definitions for react-notify-toast 0.5.0
+// Type definitions for react-notify-toast 0.5
 // Project: https://github.com/jesusoterogomez/react-notify-toast
 // Definitions by: Klaas Cuvelier <https://github.com/klaascuvelier>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.6
 
-type reactNotifyToastType = 'success' | 'error' | 'warning' | 'custom';
-type reactNotifyToastColor = {
+import * as React from 'react';
+
+interface reactNotifyToastColor {
     background: string;
     text: string;
-};
-
-declare module 'react-notify-toast' {
-    class reactNotifyToast {
-        show(
-            text: string,
-            type?: reactNotifyToastType,
-            timeout?: number,
-            color?: reactNotifyToastColor
-        ): void;
-
-        hide(): void;
-        createShowQueue(): reactNotifyToast;
-    }
-
-    import * as React from 'react';
-
-    type NotificationProps = {
-        options: any;
-    };
-
-    export class Notification extends React.Component<NotificationProps, any> {}
-
-    export const notify: reactNotifyToast;
-    export default Notification;
 }
+
+declare class reactNotifyToast {
+    show(
+        text: string,
+        type?: 'success' | 'error' | 'warning' | 'custom',
+        timeout?: number,
+        color?: reactNotifyToastColor
+    ): void;
+
+    hide(): void;
+    createShowQueue(): reactNotifyToast;
+}
+
+interface NotificationProps {
+    options: any;
+}
+
+export class Notification extends React.Component<NotificationProps, any> {}
+
+export const notify: reactNotifyToast;
+export default Notification;

--- a/types/react-notify-toast/react-notify-toast-tests.tsx
+++ b/types/react-notify-toast/react-notify-toast-tests.tsx
@@ -1,7 +1,7 @@
-import { Component } from 'react';
+import * as React from 'react';
 import Notification, { notify } from 'react-notify-toast';
 
-export class NotificationTest extends Component {
+export class NotificationTest extends React.Component {
     render() {
         return(<Notification options={{zIndex: 200, top: '15px'}} />);
     }

--- a/types/react-notify-toast/react-notify-toast-tests.tsx
+++ b/types/react-notify-toast/react-notify-toast-tests.tsx
@@ -1,0 +1,20 @@
+import { Component } from 'react';
+import Notification, { notify } from 'react-notify-toast';
+
+export class NotificationTest extends Component {
+  render() {
+    return(<Notification options={{zIndex: 200, top: '15px'}} />);
+  }
+}
+
+function testNotify() {
+    notify.show('show something');
+    notify.show('show error', 'error');
+    notify.show('show warning', 'warning', 100);
+
+    const queue = notify.createShowQueue();
+    queue.show('hi');
+    queue.show('test');
+
+    notify.hide();
+}

--- a/types/react-notify-toast/react-notify-toast-tests.tsx
+++ b/types/react-notify-toast/react-notify-toast-tests.tsx
@@ -2,9 +2,9 @@ import { Component } from 'react';
 import Notification, { notify } from 'react-notify-toast';
 
 export class NotificationTest extends Component {
-  render() {
-    return(<Notification options={{zIndex: 200, top: '15px'}} />);
-  }
+    render() {
+        return(<Notification options={{zIndex: 200, top: '15px'}} />);
+    }
 }
 
 function testNotify() {

--- a/types/react-notify-toast/tsconfig.json
+++ b/types/react-notify-toast/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "react-notify-toast-tests.ts"
+    ]
+}

--- a/types/react-notify-toast/tsconfig.json
+++ b/types/react-notify-toast/tsconfig.json
@@ -2,21 +2,24 @@
     "compilerOptions": {
         "module": "commonjs",
         "lib": [
-            "es6"
+            "es6",
+            "dom"
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
         "strictNullChecks": true,
+        "strictFunctionTypes": true,
         "baseUrl": "../",
         "typeRoots": [
             "../"
         ],
         "types": [],
         "noEmit": true,
-        "forceConsistentCasingInFileNames": true
+        "forceConsistentCasingInFileNames": true,
+        "jsx": "react"
     },
     "files": [
         "index.d.ts",
-        "react-notify-toast-tests.ts"
+        "react-notify-toast-tests.tsx"
     ]
 }

--- a/types/react-notify-toast/tslint.json
+++ b/types/react-notify-toast/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
