### PR TITLE
Add type definitions for get-folder-size

### DIFF
--- a/types/get-folder-size/get-folder-size-tests.ts
+++ b/types/get-folder-size/get-folder-size-tests.ts
@@ -1,0 +1,5 @@
+import getFolderSize = require('get-folder-size');
+
+getFolderSize('.', (err: Error | null, size: number) => {});
+
+getFolderSize('.', /types/, (err: Error | null, size: number) => {});

--- a/types/get-folder-size/index.d.ts
+++ b/types/get-folder-size/index.d.ts
@@ -1,0 +1,9 @@
+// Type definitions for get-folder-size 2.0
+// Project: https://github.com/alessioalex/get-folder-size
+// Definitions by: Mariusz Szczepańczyk <https://github.com/mszczepanczyk>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export = getFolderSize;
+
+declare function getFolderSize(folder: string, callback: (err: Error | null, size: number) => void): void;
+declare function getFolderSize(folder: string, regexIgnorePattern: RegExp, callback: (err: Error | null, size: number) => void): void;

--- a/types/get-folder-size/tsconfig.json
+++ b/types/get-folder-size/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "get-folder-size-tests.ts"
+    ]
+}

--- a/types/get-folder-size/tslint.json
+++ b/types/get-folder-size/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
dtslint gives me:

```
Error: /Users/mariusz/src/DefinitelyTyped/types/get-folder-size/index.d.ts:6:1
ERROR: 6:1    strict-export-declare-modifiers  Prefer to explicitly write 'export' for an external module export. See: https://github.com/Microsoft/dtslint/blob/master/docs/strict-export-declare-modifiers.md
ERROR: 8:1    strict-export-declare-modifiers  Prefer 'export' to 'declare' in an external module. See: https://github.com/Microsoft/dtslint/blob/master/docs/strict-export-declare-modifiers.md
ERROR: 8:102  void-return                      Use the `void` type for return types only. Otherwise, use `undefined`. See: https://github.com/Microsoft/dtslint/blob/master/docs/void-return.md
ERROR: 9:1    strict-export-declare-modifiers  Prefer 'export' to 'declare' in an external module. See: https://github.com/Microsoft/dtslint/blob/master/docs/strict-export-declare-modifiers.md
ERROR: 9:130  void-return                      Use the `void` type for return types only. Otherwise, use `undefined`. See: https://github.com/Microsoft/dtslint/blob/master/docs/void-return.md
```

but I'm not sure what I can do about it. I see the same thing on lately merged definitions as well (e.g. deluge #26765).

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.