### PR TITLE
[pluralize] Prevent using the library without having imported it

### DIFF
--- a/types/pluralize/index.d.ts
+++ b/types/pluralize/index.d.ts
@@ -75,3 +75,4 @@ declare namespace pluralize {
 }
 
 export = pluralize;
+export as namespace pluralize;

--- a/types/pluralize/index.d.ts
+++ b/types/pluralize/index.d.ts
@@ -1,79 +1,77 @@
 // Type definitions for pluralize
 // Project: https://www.npmjs.com/package/pluralize
 // Definitions by: Syu Kato <https://github.com/ukyo>
+//                 Karol Majewski <https://github.com/karol-majewski>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-interface PluralizeStatic {
-    /**
-     * Pluralize or singularize a word based on the passed in count.
-     *
-     * @param word
-     * @param count
-     * @param inclusive
-     */
-    (word: string, count?: number, inclusive?: boolean): string;
+/**
+ * Pluralize or singularize a word based on the passed in count.
+ *
+ * @param word
+ * @param count
+ * @param inclusive
+ */
+declare function pluralize(word: string, count?: number, inclusive?: boolean): string;
 
-    /**
-     * Pluralize a word based.
-     *
-     * @param word
-     */
-    plural(word: string): string;
+declare namespace pluralize {
+  /**
+   * Pluralize a word based.
+   *
+   * @param word
+   */
+  function plural(word: string): string;
 
-    /**
-     * Singularize a word based.
-     *
-     * @param word
-     */
-    singular(word: string): string;
+  /**
+   * Singularize a word based.
+   *
+   * @param word
+   */
+  function singular(word: string): string;
 
-    /**
-     * Add a pluralization rule to the collection.
-     *
-     * @param rule
-     * @param replacement
-     */
-    addPluralRule(rule: string|RegExp, replacemant: string): void;
+  /**
+   * Add a pluralization rule to the collection.
+   *
+   * @param rule
+   * @param replacement
+   */
+  function addPluralRule(rule: string | RegExp, replacemant: string): void;
 
-    /**
-     * Add a singularization rule to the collection.
-     *
-     * @param rule
-     * @param replacement
-     */
-    addSingularRule(rule: string|RegExp, replacemant: string): void;
+  /**
+   * Add a singularization rule to the collection.
+   *
+   * @param rule
+   * @param replacement
+   */
+  function addSingularRule(rule: string | RegExp, replacemant: string): void;
 
-    /**
-     * Add an irregular word definition.
-     *
-     * @param single
-     * @param plural
-     */
-    addIrregularRule(single: string, plural: string): void;
+  /**
+   * Add an irregular word definition.
+   *
+   * @param single
+   * @param plural
+   */
+  function addIrregularRule(single: string, plural: string): void;
 
-    /**
-     * Add an uncountable word rule.
-     *
-     * @param word
-     */
-    addUncountableRule(word: string|RegExp): void;
+  /**
+   * Add an uncountable word rule.
+   *
+   * @param word
+   */
+  function addUncountableRule(word: string | RegExp): void;
 
-    /**
-     * Test if provided word is plural.
-     *
-     * @param word
-     */
-    isPlural(word: string): boolean;
+  /**
+   * Test if provided word is plural.
+   *
+   * @param word
+   */
+  function isPlural(word: string): boolean;
 
-    /**
-     * Test if provided word is singular.
-     *
-     * @param word
-     */
-    isSingular(word: string): boolean;
+  /**
+   * Test if provided word is singular.
+   *
+   * @param word
+   */
+  function isSingular(word: string): boolean;
 }
 
-declare module "pluralize" {
-    export = pluralize;
-}
-declare var pluralize: PluralizeStatic;
+export = pluralize;


### PR DESCRIPTION
The current definition adds `pluralize` to the global namespace. This makes TypeScript allow using `pluralize` (both as a function and as a namespace) in your modules without having imported it, which in turns leads to runtime errors (`Uncaught ReferenceError: pluralize is not defined`).

The suggested change is to reflect how it really works — inside a module loader environment, one can use `pluralize` both as a namespace or call it, but it has to be imported like this:

```ts
import pluralize, { isSingular } from 'pluralize';

pluralize.isPlural('mashrooms'),
isSingular('mashrooms'),
```

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/blakeembrey/pluralize/blob/master/pluralize.js
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

