### PR TITLE
[i18next] Fix dir() return type to be "ltr" | "rtl"

### DIFF
--- a/types/i18next/index.d.ts
+++ b/types/i18next/index.d.ts
@@ -493,7 +493,7 @@ declare namespace i18next {
         /**
          * Returns rtl or ltr depending on languages read direction.
          */
-        dir(lng?: string): void;
+        dir(lng?: string): "ltr" | "rtl";
 
         /**
          * Exposes interpolation.format function added on init.

--- a/types/i18next/v2/index.d.ts
+++ b/types/i18next/v2/index.d.ts
@@ -128,7 +128,7 @@ declare namespace i18n {
 
         loadLanguages(lngs: string[], callback?: () => void): void;
 
-        dir(lng?: string): string;
+        dir(lng?: string): "ltr" | "rtl";
 
         createInstance(options?: Options, callback?: (err: any, t: TranslationFunction) => void): I18n;
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - Documentation: https://www.i18next.com/overview/api#dir 
  - Source code: https://github.com/i18next/i18next/blob/dd9cabcebc8a5919abad2c40c7be0bc65a94afca/src/i18next.js#L275-L287
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
