### PR TITLE
Revert "Add useNewUrlParser parameter to mongoose" as the same was added already in #27050 

### DIFF
--- a/types/mongoose/index.d.ts
+++ b/types/mongoose/index.d.ts
@@ -357,8 +357,6 @@ declare module "mongoose" {
     domainsEnabled?: boolean;
     /** How long driver keeps waiting for servers to come back up (default: Number.MAX_VALUE) */
     bufferMaxEntries?: number;
-    /** Use new url parser (default: false). */
-    useNewUrlParser?: boolean
 
     /** additional SSL configuration options */
     /** Array of valid certificates either as Buffers or Strings */


### PR DESCRIPTION
Seems there was a race in adding `useNewUrlParser` between #27050 and #27067 resulting in 
```
Error in mongoose
Error: /home/travis/build/DefinitelyTyped/DefinitelyTyped/types/mongoose/index.d.ts:361:5
ERROR: 361:5  expect  TypeScript@next compile error: 
Duplicate identifier 'useNewUrlParser'.
ERROR: 384:5  expect  TypeScript@next compile error: 
Duplicate identifier 'useNewUrlParser'.
```
