### PR TITLE
dd-trace - add custom logger support

### DIFF
--- a/types/dd-trace/dd-trace-tests.ts
+++ b/types/dd-trace/dd-trace-tests.ts
@@ -5,6 +5,10 @@ const tracer = ddTrace.init({
     service: 'MyLovelyService',
     hostname: 'localhost',
     port: 8126,
+    logger: {
+        debug: msg => { },
+        error: err => { }
+    }
 });
 
 tracer

--- a/types/dd-trace/index.d.ts
+++ b/types/dd-trace/index.d.ts
@@ -91,6 +91,16 @@ interface TracerOptions {
      * @default true
      */
     plugins?: boolean;
+
+    /**
+     * Custom logger to be used by the tracer (if debug = true),
+     * should support debug() and error() methods
+     * see https://datadog.github.io/dd-trace-js/#custom-logging__anchor
+     */
+    logger?: {
+        debug: (message: string) => void
+        error: (err: Error) => void
+    };
 }
 
 interface ExperimentalOptions {
@@ -135,5 +145,5 @@ interface TraceOptions {
     /**
      * Global tags that should be assigned to every span.
      */
-    tags?: { [key: string]: any; } | string;
+    tags?: { [key: string]: any } | string;
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
DataDog Trace allows support for passing in a custom logger during init: https://datadog.github.io/dd-trace-js/#custom-logging__anchor
- [x] Increase the version number in the header if appropriate.
not needed, adding optional property, non-breaking change
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
not needed, small change