### PR TITLE
[generic-pool] Use void instead of undefined to represent lack of value.

### DIFF
--- a/types/generic-pool/generic-pool-tests.ts
+++ b/types/generic-pool/generic-pool-tests.ts
@@ -11,8 +11,8 @@ const factory = {
             resolve(conn);
         });
     },
-    destroy: (conn: Connection): Promise<undefined> => {
-        return new Promise<undefined>(resolve => {
+    destroy: (conn: Connection): Promise<void> => {
+        return new Promise<void>(resolve => {
             conn.connected = false;
             resolve();
         });
@@ -53,7 +53,7 @@ pool.acquire()
         return pool.destroy(conn);
     }).then(() => {
         return pool.clear();
-    }).then((results: undefined[]) => {
+    }).then(() => {
     });
 
 pool.on('factoryCreateError', (err: Error) => {

--- a/types/generic-pool/index.d.ts
+++ b/types/generic-pool/index.d.ts
@@ -20,14 +20,14 @@ export class Pool<T> extends EventEmitter {
     acquire(priority?: number): PromiseLike<T>;
     release(resource: T): void;
     destroy(resource: T): void;
-    drain(): PromiseLike<undefined>;
-    clear(): PromiseLike<undefined[]>;
+    drain(): PromiseLike<void>;
+    clear(): PromiseLike<void>;
     use<U>(cb: (resource: T) => U): PromiseLike<U>;
 }
 
 export interface Factory<T> {
     create(): PromiseLike<T>;
-    destroy(client: T): PromiseLike<undefined>;
+    destroy(client: T): PromiseLike<void>;
     validate?(client: T): PromiseLike<boolean>;
 }
 


### PR DESCRIPTION
Using undefined means async functions must have a `return undefined;` rather than omitting the return value altogether, as would be the most natural thing to do in such functions.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/coopernurse/node-pool/blob/72b31a434c7b05ad879b2ace9830a9aa9fbba002/lib/Pool.js#L137-L145
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.