### PR TITLE
use module instead of namespace for jest

### DIFF
--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -18,32 +18,37 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
-declare var beforeAll: jest.Lifecycle;
-declare var beforeEach: jest.Lifecycle;
-declare var afterAll: jest.Lifecycle;
-declare var afterEach: jest.Lifecycle;
-declare var describe: jest.Describe;
-declare var fdescribe: jest.Describe;
-declare var xdescribe: jest.Describe;
-declare var it: jest.It;
-declare var fit: jest.It;
-declare var xit: jest.It;
-declare var test: jest.It;
-declare var xtest: jest.It;
+export = jest;
+export as namespace jest;
 
-declare const expect: jest.Expect;
+declare global {
+    var beforeAll: jest.Lifecycle;
+    var beforeEach: jest.Lifecycle;
+    var afterAll: jest.Lifecycle;
+    var afterEach: jest.Lifecycle;
+    var describe: jest.Describe;
+    var fdescribe: jest.Describe;
+    var xdescribe: jest.Describe;
+    var it: jest.It;
+    var fit: jest.It;
+    var xit: jest.It;
+    var test: jest.It;
+    var xtest: jest.It;
 
-interface NodeRequire {
-    /**
-     * Returns the actual module instead of a mock, bypassing all checks on
-     * whether the module should receive a mock implementation or not.
-     */
-    requireActual(moduleName: string): any;
-    /**
-     * Returns a mock module instead of the actual module, bypassing all checks
-     * on whether the module should be required normally or not.
-     */
-    requireMock(moduleName: string): any;
+    const expect: jest.Expect;
+
+    interface NodeRequire {
+        /**
+         * Returns the actual module instead of a mock, bypassing all checks on
+         * whether the module should receive a mock implementation or not.
+         */
+        requireActual(moduleName: string): any;
+        /**
+         * Returns a mock module instead of the actual module, bypassing all checks
+         * on whether the module should be required normally or not.
+         */
+        requireMock(moduleName: string): any;
+    }
 }
 
 declare namespace jest {

--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -20,6 +20,7 @@
 
 export = jest;
 export as namespace jest;
+export as namespace jasmine;
 
 declare global {
     var beforeAll: jest.Lifecycle;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/Microsoft/TypeScript/issues/25480
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

--- 

This should fix https://github.com/Microsoft/TypeScript/issues/25480. But I never switched from a namespace to a module before. I don't know, if this will break something 🤔