### PR TITLE
Modify three options missing from webpack-dev-middleware and webpack-hot-middleware

### DIFF
--- a/types/webpack-dev-middleware/index.d.ts
+++ b/types/webpack-dev-middleware/index.d.ts
@@ -24,7 +24,7 @@ declare namespace WebpackDevMiddleware {
 		lazy?: boolean;
 		watchOptions?: webpack.Options.WatchOptions;
 		publicPath: string;
-		index?: string;
+		index?: string | boolean;
 		headers?: {
 			[name: string]: string;
 		};

--- a/types/webpack-dev-middleware/index.d.ts
+++ b/types/webpack-dev-middleware/index.d.ts
@@ -33,7 +33,7 @@ declare namespace WebpackDevMiddleware {
 		serverSideRender?: boolean;
 		logger?: Logger;
 		filename?: string;
-		writeToDisk?: boolean;
+		writeToDisk?: boolean | ((filename: string) => boolean);
 	}
 
 	interface ReporterOptions {

--- a/types/webpack-dev-middleware/index.d.ts
+++ b/types/webpack-dev-middleware/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/webpack/webpack-dev-middleware
 // Definitions by: Benjamin Lim <https://github.com/bumbleblym>
 //                 reduckted <https://github.com/reduckted>
+//                 Chris Abrams <https://github.com/chrisabrams>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -32,6 +33,7 @@ declare namespace WebpackDevMiddleware {
 		serverSideRender?: boolean;
 		logger?: Logger;
 		filename?: string;
+		writeToDisk?: boolean;
 	}
 
 	interface ReporterOptions {

--- a/types/webpack-dev-middleware/webpack-dev-middleware-tests.ts
+++ b/types/webpack-dev-middleware/webpack-dev-middleware-tests.ts
@@ -23,6 +23,7 @@ webpackDevMiddlewareInstance = webpackDevMiddleware(compiler, {
 	},
 	reporter: null,
 	serverSideRender: false,
+	writeToDisk: false,
 });
 
 const app = express();

--- a/types/webpack-hot-middleware/index.d.ts
+++ b/types/webpack-hot-middleware/index.d.ts
@@ -1,6 +1,8 @@
 // Type definitions for webpack-hot-middleware 2.16
 // Project: https://github.com/glenjamin/webpack-hot-middleware#readme
-// Definitions by: Benjamin Lim <https://github.com/bumbleblym>, Ron Martinez <https://github.com/icylace>
+// Definitions by: Benjamin Lim <https://github.com/bumbleblym>
+//                 Ron Martinez <https://github.com/icylace>
+//                 Chris Abrams <https://github.com/chrisabrams>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -19,6 +21,7 @@ declare namespace WebpackHotMiddleware {
 		log?: false | Logger;
 		path?: string;
 		heartbeat?: number;
+		reload?: boolean;
 	}
 
 	type Logger = (message?: any, ...optionalParams: any[]) => void;

--- a/types/webpack-hot-middleware/webpack-hot-middleware-tests.ts
+++ b/types/webpack-hot-middleware/webpack-hot-middleware-tests.ts
@@ -10,6 +10,7 @@ webpackHotMiddlewareInstance = webpackHotMiddleware(compiler, {
 	log: console.log.bind(console),
 	path: '/__what',
 	heartbeat: 2000,
+	reload: false,
 });
 
 const app = express();


### PR DESCRIPTION
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:

[writeToDisk](https://github.com/webpack/webpack-dev-middleware#writetodisk) option added.
[reload](https://github.com/webpack-contrib/webpack-hot-middleware#client) option added.
[index](https://github.com/webpack/webpack-dev-middleware#index) option modified to be string or boolean.