### PR TITLE
feat(webpack): fill Compiler- and Compilation-related fs types

### DIFF
--- a/types/webpack/index.d.ts
+++ b/types/webpack/index.d.ts
@@ -947,8 +947,8 @@ declare namespace webpack {
             childrenCounters: any;
             usedChunkIds: any;
             usedModuleIds: any;
-            fileTimestamps: Map<string, number> | undefined;
-            contextTimestamps: Map<string, number> | undefined;
+            fileTimestamps: Map<string, number>;
+            contextTimestamps: Map<string, number>;
             getStats(): Stats;
             addModule(module: CompilationModule, cacheGroup: any): any;
             // tslint:disable-next-line:ban-types

--- a/types/webpack/index.d.ts
+++ b/types/webpack/index.d.ts
@@ -1047,8 +1047,8 @@ declare namespace webpack {
 
         name: string;
         options: Configuration;
-        inputFileSystem: InputFileSystem | null;
-        outputFileSystem: OutputFileSystem | null;
+        inputFileSystem: InputFileSystem;
+        outputFileSystem: OutputFileSystem;
         fileTimestamps: Map<string, number>;
         contextTimestamps: Map<string, number>;
         run(handler: Compiler.Handler): void;

--- a/types/webpack/index.d.ts
+++ b/types/webpack/index.d.ts
@@ -947,6 +947,8 @@ declare namespace webpack {
             childrenCounters: any;
             usedChunkIds: any;
             usedModuleIds: any;
+            fileTimestamps: Map<string, number> | undefined;
+            contextTimestamps: Map<string, number> | undefined;
             getStats(): Stats;
             addModule(module: CompilationModule, cacheGroup: any): any;
             // tslint:disable-next-line:ban-types
@@ -1017,6 +1019,26 @@ declare namespace webpack {
         invalidate(): void;
     }
 
+    interface InputFileSystem {
+        purge(): void;
+        readFile: (path: string, callback: (err: Error, contents: Buffer) => void) => void;
+        readFileSync(path: string): Buffer;
+        readlink(path: string, callback: (err: Error, linkString: string) => void): void;
+        readlinkSync(path: string): string;
+        stat(path: string, callback: (err: Error, stats: any) => void): void;
+        statSync(path: string): any;
+    }
+
+    interface OutputFileSystem {
+        mkdir(path: string, callback: (err: Error) => void): void;
+        rmdir(path: string, callback: (err: Error) => void): void;
+        unlink(path: string, callback: (err: Error) => void): void;
+        join(...paths: string[]): string;
+        mkdirp: (path: string, callback: (err: Error) => void) => void;
+        purge(): void;
+        writeFile(path: string, data: any, callback: (err: Error) => void): void;
+    }
+
     class Compiler extends Tapable implements ICompiler {
         constructor();
 
@@ -1025,7 +1047,10 @@ declare namespace webpack {
 
         name: string;
         options: Configuration;
-        outputFileSystem: any;
+        inputFileSystem: InputFileSystem | null;
+        outputFileSystem: OutputFileSystem | null;
+        fileTimestamps: Map<string, number>;
+        contextTimestamps: Map<string, number>;
         run(handler: Compiler.Handler): void;
         watch(watchOptions: Compiler.WatchOptions, handler: Compiler.Handler): Compiler.Watching;
     }

--- a/types/webpack/index.d.ts
+++ b/types/webpack/index.d.ts
@@ -1021,7 +1021,7 @@ declare namespace webpack {
 
     interface InputFileSystem {
         purge(): void;
-        readFile: (path: string, callback: (err: Error, contents: Buffer) => void) => void;
+        readFile(path: string, callback: (err: Error, contents: Buffer) => void): void;
         readFileSync(path: string): Buffer;
         readlink(path: string, callback: (err: Error, linkString: string) => void): void;
         readlinkSync(path: string): string;
@@ -1030,12 +1030,12 @@ declare namespace webpack {
     }
 
     interface OutputFileSystem {
+        join(...paths: string[]): string;
         mkdir(path: string, callback: (err: Error) => void): void;
+        mkdirp(path: string, callback: (err: Error) => void): void;
+        purge(): void;
         rmdir(path: string, callback: (err: Error) => void): void;
         unlink(path: string, callback: (err: Error) => void): void;
-        join(...paths: string[]): string;
-        mkdirp: (path: string, callback: (err: Error) => void) => void;
-        purge(): void;
         writeFile(path: string, data: any, callback: (err: Error) => void): void;
     }
 

--- a/types/webpack/webpack-tests.ts
+++ b/types/webpack/webpack-tests.ts
@@ -158,11 +158,26 @@ declare const require: any;
 declare const path: any;
 configuration = {
     plugins: [
-        function(this: webpack.Compiler) {
-            this.plugin("done", stats => {
-                require("fs").writeFileSync(
+        function apply(this: webpack.Compiler) {
+            const prevTimestamps = new Map<string, number>();
+            const startTime = Date.now();
+
+            this.hooks.emit.tap("SomePlugin", (compilation: webpack.compilation.Compilation) => {
+                for (const filepath in compilation.fileTimestamps!.keys()) {
+                    const prevTimestamp = prevTimestamps.get(filepath) || startTime;
+                    const newTimestamp = compilation.fileTimestamps!.get(filepath) || Infinity;
+                    if (prevTimestamp < newTimestamp) {
+                        this.inputFileSystem!.readFileSync(filepath).toString('utf-8');
+                    }
+                }
+            });
+
+            this.hooks.afterEmit.tapAsync("afterEmit", (stats, callback) => {
+                this.outputFileSystem!.writeFile(
                     path.join(__dirname, "...", "stats.json"),
-                    JSON.stringify(stats.toJson()));
+                    JSON.stringify(stats.getStats().toJson()),
+                    callback
+                );
             });
         }
     ]

--- a/types/webpack/webpack-tests.ts
+++ b/types/webpack/webpack-tests.ts
@@ -167,13 +167,13 @@ configuration = {
                     const prevTimestamp = prevTimestamps.get(filepath) || startTime;
                     const newTimestamp = compilation.fileTimestamps!.get(filepath) || Infinity;
                     if (prevTimestamp < newTimestamp) {
-                        this.inputFileSystem!.readFileSync(filepath).toString('utf-8');
+                        this.inputFileSystem.readFileSync(filepath).toString('utf-8');
                     }
                 }
             });
 
             this.hooks.afterEmit.tapAsync("afterEmit", (stats, callback) => {
-                this.outputFileSystem!.writeFile(
+                this.outputFileSystem.writeFile(
                     path.join(__dirname, "...", "stats.json"),
                     JSON.stringify(stats.getStats().toJson()),
                     callback

--- a/types/webpack/webpack-tests.ts
+++ b/types/webpack/webpack-tests.ts
@@ -163,9 +163,9 @@ configuration = {
             const startTime = Date.now();
 
             this.hooks.emit.tap("SomePlugin", (compilation: webpack.compilation.Compilation) => {
-                for (const filepath in compilation.fileTimestamps!.keys()) {
+                for (const filepath in compilation.fileTimestamps.keys()) {
                     const prevTimestamp = prevTimestamps.get(filepath) || startTime;
-                    const newTimestamp = compilation.fileTimestamps!.get(filepath) || Infinity;
+                    const newTimestamp = compilation.fileTimestamps.get(filepath) || Infinity;
                     if (prevTimestamp < newTimestamp) {
                         this.inputFileSystem.readFileSync(filepath).toString('utf-8');
                     }


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: (See bottom of description)
- [X] Increase the version number in the header if appropriate.
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

---

Changes in this PR are related to a few Webpack Compiler and Compilation properties.

Adds definitions for following file timestamp properties:
* `Compiler.fileTimestamps`. See https://github.com/webpack/webpack/blob/v4.15.1/lib/Compiler.js#L138.
* `Compiler.contextTimestamps`. See https://github.com/webpack/webpack/blob/v4.15.1/lib/Compiler.js#L140.
* `Compilation.fileTimestamps`. See https://github.com/webpack/webpack/blob/v4.15.1/lib/Compilation.js#L467.
* `Compilation.contextTimestamps`. See https://github.com/webpack/webpack/blob/v4.15.1/lib/Compilation.js#L469.

Adds definitions for the following file system properties:
* `Compiler.inputFileSystem` — Roughly a subset of `fs` read features.
  See https://github.com/webpack/enhanced-resolve/blob/v4.1.0/lib/NodeJsInputFileSystem.js and https://github.com/webpack/memory-fs/blob/v0.4.1/lib/MemoryFileSystem.js.
* `Compiler.outputFileSystem` — Roughly a subset of `fs` output features.
  See https://github.com/webpack/webpack/blob/v4.15.1/lib/node/NodeOutputFileSystem.js#L9:7.

Both file system properties above, while initialized as `null`, have their value set almost immediately right after by Webpack, making them generally not `null` by the time the Compiler can be accessed. See https://github.com/webpack/webpack/blob/master/lib/webpack.js#L34.