### PR TITLE
Add definitions for promise-ftp, promise-ftp-common, and promise-sftp

### DIFF
--- a/types/promise-ftp-common/index.d.ts
+++ b/types/promise-ftp-common/index.d.ts
@@ -1,0 +1,25 @@
+// Type definitions for promise-ftp-common 1.1
+// Project: https://github.com/realtymaps/promise-ftp-common
+// Definitions by: coolreader18 <https://github.com/coolreader18>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.4
+
+export enum STATUSES {
+    NOT_YET_CONNECTED = "not yet connected",
+    CONNECTING = "connecting",
+    CONNECTED = "connected",
+    LOGGING_OUT = "logging out",
+    DISCONNECTING = "disconnecting",
+    DISCONNECTED = "disconnected",
+    RECONNECTING = "reconnecting"
+}
+export class FtpConnectionError extends Error {}
+export class FtpReconnectError extends Error {
+    constructor(
+        disconnectError?: string | Error,
+        connectError?: string | Error,
+        onCwd?: boolean
+    );
+    connectError: string | Error;
+    disconnectError: string | Error;
+}

--- a/types/promise-ftp-common/promise-ftp-common-tests.ts
+++ b/types/promise-ftp-common/promise-ftp-common-tests.ts
@@ -1,0 +1,16 @@
+import * as PromiseFtpCommon from "promise-ftp-common";
+
+// $ExpectType typeof STATUSES
+PromiseFtpCommon.STATUSES;
+
+// $ExpectType typeof FtpReconnectError
+PromiseFtpCommon.FtpReconnectError;
+
+// $ExpectType typeof FtpConnectionError
+PromiseFtpCommon.FtpConnectionError;
+
+// $ExpectType FtpReconnectError
+new PromiseFtpCommon.FtpReconnectError();
+
+// $ExpectType FtpConnectionError
+new PromiseFtpCommon.FtpConnectionError();

--- a/types/promise-ftp-common/tsconfig.json
+++ b/types/promise-ftp-common/tsconfig.json
@@ -9,7 +9,8 @@
         "typeRoots": ["../"],
         "types": [],
         "noEmit": true,
-        "forceConsistentCasingInFileNames": true
+        "forceConsistentCasingInFileNames": true,
+        "strictFunctionTypes": true
     },
     "files": ["index.d.ts", "promise-ftp-common-tests.ts"]
 }

--- a/types/promise-ftp-common/tsconfig.json
+++ b/types/promise-ftp-common/tsconfig.json
@@ -1,16 +1,15 @@
 {
     "compilerOptions": {
         "module": "commonjs",
-        "typeRoots": ["../"],
-        "baseUrl": "../",
-        "noEmit": true,
-        "forceConsistentCasingInFileNames": true,
-        "types": [],
-        "lib": ["es5"],
+        "lib": ["es6"],
         "noImplicitAny": true,
         "noImplicitThis": true,
         "strictNullChecks": true,
-        "strictFunctionTypes": true
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
     },
     "files": ["index.d.ts", "promise-ftp-common-tests.ts"]
 }

--- a/types/promise-ftp-common/tsconfig.json
+++ b/types/promise-ftp-common/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "typeRoots": ["../"],
+        "baseUrl": "../",
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "types": [],
+        "lib": ["es5"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true
+    },
+    "files": ["index.d.ts", "promise-ftp-common-tests.ts"]
+}

--- a/types/promise-ftp-common/tslint.json
+++ b/types/promise-ftp-common/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "dtslint/dt.json"
+}

--- a/types/promise-ftp/index.d.ts
+++ b/types/promise-ftp/index.d.ts
@@ -31,30 +31,35 @@ declare namespace PromiseFtp {
         553: "Requested action not taken / File name not allowed";
     }
     const ERROR_CODES: ERROR_CODES;
+    // tslint:disable-next-line strict-export-declare-modifiers
     export import FtpConnectionError = PromiseFtpCommon.FtpConnectionError;
+    // tslint:disable-next-line strict-export-declare-modifiers
     export import FtpReconnectError = PromiseFtpCommon.FtpReconnectError;
+    // tslint:disable-next-line strict-export-declare-modifiers
     export import STATUSES = PromiseFtpCommon.STATUSES;
 
     /**
      * Options for FtpPromise#connect()
      */
+    // tslint:disable-next-line strict-export-declare-modifiers
     export import Options = FtpClient.Options;
 
     /**
      * Element returned by FtpPromise#list()
      */
+    // tslint:disable-next-line strict-export-declare-modifiers
     export import ListingElement = FtpClient.ListingElement;
 }
 
 declare class PromiseFtp {
     /**
-     * The raw underlying FtpClient instance
+     * The underlying FtpClient instance
      */
     rawClient: FtpClient;
 
     getConnectionStatus(): PromiseFtpCommon.STATUSES;
     /**
-     * Connects to an FTP server.
+     * Connect to an FTP server.
      */
     connect: (options: PromiseFtp.Options) => Promise<string>;
 
@@ -64,7 +69,7 @@ declare class PromiseFtp {
     reconnect: () => Promise<string>;
 
     /**
-     * Closes the connection to the server after any/all enqueued
+     * Close the connection to the server after any/all enqueued
      * commands have been executed.
      * @returns a promise that resolves with the last error recieved if there
      * was an error, true if there was an error but the client didn't recieve it,
@@ -73,12 +78,12 @@ declare class PromiseFtp {
     end(): Promise<Error | boolean>;
 
     /**
-     * Closes the connection to the server immediately.
+     * Close the connection to the server immediately.
      */
     destroy(): boolean;
 
     /**
-     * Retrieves the directory listing of path.
+     * Retrieve the directory listing of path.
      * @param path - defaults to the current working directory.
      * @param useCompression - defaults to false.
      * @returns the contents of the specified directory
@@ -88,6 +93,7 @@ declare class PromiseFtp {
 
     /**
      * Optional "standard" commands (RFC 959)
+     * Retrieve the directory listing of path.
      * Similar to `#list()`, except the directory is temporarily changed to path to
      * retrieve the directory listing. This is useful for servers that do not
      * handle characters like spaces and quotes in directory names well for the
@@ -104,7 +110,7 @@ declare class PromiseFtp {
     listSafe(useCompression: boolean): FtpClient.ListingElement[];
 
     /**
-     * Retrieves a file at path from the server.
+     * Retrieve a file at path from the server.
      * @param path - the path of the file to get.
      * @param useCompression - defaults to false.
      * @returns a stream which empties to the contents of the specified file.
@@ -112,7 +118,7 @@ declare class PromiseFtp {
     get(path: string, useCompression?: boolean): Promise<NodeJS.ReadableStream>;
 
     /**
-     * Sends data to the server to be stored as destPath.
+     * Send data to the server to be stored as a file.
      * @param input - can be a ReadableStream, a Buffer, or a path to a local file.
      * @param destPath - the path of the file to write to.
      * @param useCompression - defaults to false.
@@ -124,8 +130,7 @@ declare class PromiseFtp {
     ): Promise<void>;
 
     /**
-     * Same as `#put()`, except if destPath already exists, it will beappended to
-     * instead of overwritten.
+     * Create a new file on the server or append to one that already exists.
      * @param input - can be a ReadableStream, a Buffer, or a pathto a local file.
      * @param destPath - the path of the file to create or append to.
      * @param useCompression - defaults to false.
@@ -137,7 +142,7 @@ declare class PromiseFtp {
     ): Promise<void>;
 
     /**
-     * Renames oldPath to newPath on the server.
+     * Rename a file on the server.
      * @param oldPath - the old path of the file.
      * @param newPath - the new path to move it to.
      */
@@ -154,7 +159,7 @@ declare class PromiseFtp {
     delete: (path: string) => Promise<void>;
 
     /**
-     * Changes the current working directory.
+     * Change the current working directory.
      * @param cwd - the path to change the CWD to.
      * @returns the current directory if the server replies with the path in the
      * response text, otherwise undefined.
@@ -162,35 +167,35 @@ declare class PromiseFtp {
     cwd(path: string): Promise<string | undefined>;
 
     /**
-     * Aborts the current data transfer (e.g. from `#get()`, `#put()`, or `#list()`)
+     * Abort the current data transfer (e.g. from `#get()`, `#put()`, or `#list()`)
      */
     abort(): Promise<void>;
 
     /**
-     * Sends command using SITE
+     * Send command using SITE.
      * @param command - the command to send, e.g 'CHMOD 755 foo' or 'QUOTA'.
      */
     site(command: string): Promise<{ text: string; code: number }>;
 
     /**
-     * Retrieves human-readable information about the server's status.
+     * Retrieve human-readable information about the server's status.
      * @returns a string with the server's status.
      */
     status: () => Promise<string>;
 
     /**
-     * Sets the transfer data type to ASCII.
+     * Set the transfer data type to ASCII.
      */
     ascii(): Promise<void>;
 
     /**
-     * Sets the transfer data type to binary (default at time of connection).
+     * Set the transfer data type to binary (default at time of connection).
      */
     binary(): Promise<void>;
 
     /**
      * Optional "standard" commands (RFC 959)
-     * Creates a new directory, path, on the server.
+     * Create a new directory on the server.
      * @param path - the path of the new directory.
      * @param recursive - enables a `mkdir -p` algorithm, defaults to false.
      */
@@ -198,7 +203,7 @@ declare class PromiseFtp {
 
     /**
      * Optional "standard" commands (RFC 959)
-     * Removes a directory, path, on the server.
+     * Remove a directory on the server.
      * @param path - the path of the directory to remove.
      * @param recursive - enables deleting the directory if not empty, defaults to false.
      */
@@ -206,28 +211,27 @@ declare class PromiseFtp {
 
     /**
      * Optional "standard" commands (RFC 959)
-     * Changes the working directory to the parent of the current directory,
-     * like `cd ..`.
+     * Change the working directory to the parent of the current directory.
+     * Like `cd ..`.
      */
     cdup(): Promise<void>;
 
     /**
      * Optional "standard" commands (RFC 959)
-     * Retrieves the current working directory.
-     * @returns the cwd.
+     * Retrieve the current working directory.
      */
     pwd(): Promise<string>;
 
     /**
      * Optional "standard" commands (RFC 959)
-     * Retrieves information about the system.
+     * Retrieve information about the system running the server.
      * @returns the server's OS.
      */
     system(): Promise<string>;
 
     /**
      * Extended commands (RFC 3659)
-     * Retrieves the size of path
+     * Retrieve the size of a file on the server.
      * @param path - the path of the file whose size is to be retrieved.
      * @returns the size of the specified file.
      */
@@ -235,8 +239,8 @@ declare class PromiseFtp {
 
     /**
      * Extended commands (RFC 3659)
-     * Retrieves the last modified date and time for path.
-     * @param path - the path of the file or directory whose modified date is to
+     * Retrieve the last modified date and time for a file or directory.
+     * @param path - the path of the file/directory whose modified date is to
      * be retrieved.
      * @returns the last modified date at the specified path.
      */
@@ -244,7 +248,7 @@ declare class PromiseFtp {
 
     /**
      * Extended commands (RFC 3659)
-     * Sets the file byte offset for the next file transfer action (get/put).
+     * Set the file byte offset for the next file transfer action (get/put).
      * @param byteOffset - The file byte offset.
      */
     restart(byteOffset: number): Promise<void>;

--- a/types/promise-ftp/index.d.ts
+++ b/types/promise-ftp/index.d.ts
@@ -1,0 +1,253 @@
+// Type definitions for promise-ftp 1.3
+// Project: https://github.com/realtymaps/promise-ftp
+// Definitions by: coolreader18 <https://github.com/coolreader18>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.4
+
+/// <reference types="node" />
+
+import * as FtpClient from "ftp";
+import * as PromiseFtpCommon from "promise-ftp-common";
+import * as Promise from "bluebird";
+
+declare namespace PromiseFtp {
+    interface ERROR_CODES {
+        421: "Service not available, closing control connection";
+        425: "Can't open data connection";
+        426: "Connection closed, transfer aborted";
+        450: "Requested file action not taken / File unavailable (e.g., file busy)";
+        451: "Requested action aborted: local error in processing";
+        452: "Requested action not taken / Insufficient storage space in system";
+        500: "Syntax error / Command unrecognized";
+        501: "Syntax error in parameters or arguments";
+        502: "Command not implemented";
+        503: "Bad sequence of commands";
+        504: "Command not implemented for that parameter";
+        530: "Not logged in";
+        532: "Need account for storing files";
+        550: "Requested action not taken / File unavailable (e.g., file not found, no access)";
+        551: "Requested action aborted: page type unknown";
+        552: "Requested file action aborted / Exceeded storage allocation (for current directory or dataset)";
+        553: "Requested action not taken / File name not allowed";
+    }
+    const ERROR_CODES: ERROR_CODES;
+    export import FtpConnectionError = PromiseFtpCommon.FtpConnectionError;
+    export import FtpReconnectError = PromiseFtpCommon.FtpReconnectError;
+    export import STATUSES = PromiseFtpCommon.STATUSES;
+
+    /**
+     * Options for FtpPromise#connect()
+     */
+    export import Options = FtpClient.Options;
+
+    /**
+     * Element returned by FtpPromise#list()
+     */
+    export import ListingElement = FtpClient.ListingElement;
+}
+
+declare class PromiseFtp {
+    /**
+     * The raw underlying FtpClient instance
+     */
+    rawClient: FtpClient;
+
+    getConnectionStatus(): PromiseFtpCommon.STATUSES;
+    /**
+     * Connects to an FTP server.
+     */
+    connect: (options: PromiseFtp.Options) => Promise<string>;
+
+    /**
+     * Reconnect with the same options as previously connected with `#connect()`.
+     */
+    reconnect: () => Promise<string>;
+
+    /**
+     * Closes the connection to the server after any/all enqueued
+     * commands have been executed.
+     * @returns a promise that resolves with the last error recieved if there
+     * was an error, true if there was an error but the client didn't recieve it,
+     * or false if there was no error.
+     */
+    end(): Promise<Error | boolean>;
+
+    /**
+     * Closes the connection to the server immediately.
+     */
+    destroy(): boolean;
+
+    /**
+     * Retrieves the directory listing of path.
+     * @param path - defaults to the current working directory.
+     * @param useCompression - defaults to false.
+     * @returns the contents of the specified directory
+     */
+    list(path?: string, useCompression?: boolean): FtpClient.ListingElement[];
+    list(useCompression: boolean): FtpClient.ListingElement[];
+
+    /**
+     * Optional "standard" commands (RFC 959)
+     * Similar to `#list()`, except the directory is temporarily changed to path to
+     * retrieve the directory listing. This is useful for servers that do not
+     * handle characters like spaces and quotes in directory names well for the
+     * LIST command. This function is "optional" because it relies on `#pwd()`
+     * being available.
+     * @param path - defaults to the current working directory.
+     * @param useCompression - defaults to false.
+     * @returns the contents of the specified directory
+     */
+    listSafe(
+        path?: string,
+        useCompression?: boolean
+    ): FtpClient.ListingElement[];
+    listSafe(useCompression: boolean): FtpClient.ListingElement[];
+
+    /**
+     * Retrieves a file at path from the server.
+     * @param path - the path of the file to get.
+     * @param useCompression - defaults to false.
+     * @returns a stream which empties to the contents of the specified file.
+     */
+    get(path: string, useCompression?: boolean): Promise<NodeJS.ReadableStream>;
+
+    /**
+     * Sends data to the server to be stored as destPath.
+     * @param input - can be a ReadableStream, a Buffer, or a path to a local file.
+     * @param destPath - the path of the file to write to.
+     * @param useCompression - defaults to false.
+     */
+    put(
+        input: NodeJS.ReadableStream | Buffer | string,
+        destPath: string,
+        useCompression?: boolean
+    ): Promise<void>;
+
+    /**
+     * Same as `#put()`, except if destPath already exists, it will beappended to
+     * instead of overwritten.
+     * @param input - can be a ReadableStream, a Buffer, or a pathto a local file.
+     * @param destPath - the path of the file to create or append to.
+     * @param useCompression - defaults to false.
+     */
+    append(
+        input: NodeJS.ReadableStream | Buffer | string,
+        destPath: string,
+        useCompression?: boolean
+    ): Promise<void>;
+
+    /**
+     * Renames oldPath to newPath on the server.
+     * @param oldPath - the old path of the file.
+     * @param newPath - the new path to move it to.
+     */
+    rename: (oldPath: string, newPath: string) => Promise<void>;
+
+    /**
+     * Logout the user from the server.
+     */
+    logout: () => Promise<void>;
+
+    /**
+     * Delete a file on the server.
+     */
+    delete: (path: string) => Promise<void>;
+
+    /**
+     * Changes the current working directory.
+     * @param cwd - the path to change the CWD to.
+     * @returns the current directory if the server replies with the path in the
+     * response text, otherwise undefined.
+     */
+    cwd(path: string): Promise<string | undefined>;
+
+    /**
+     * Aborts the current data transfer (e.g. from `#get()`, `#put()`, or `#list()`)
+     */
+    abort(): Promise<void>;
+
+    /**
+     * Sends command using SITE
+     * @param command - the command to send, e.g 'CHMOD 755 foo' or 'QUOTA'.
+     */
+    site(command: string): Promise<{ text: string; code: number }>;
+
+    /**
+     * Retrieves human-readable information about the server's status.
+     * @returns a string with the server's status.
+     */
+    status: () => Promise<string>;
+
+    /**
+     * Sets the transfer data type to ASCII.
+     */
+    ascii(): Promise<void>;
+
+    /**
+     * Sets the transfer data type to binary (default at time of connection).
+     */
+    binary(): Promise<void>;
+
+    /**
+     * Optional "standard" commands (RFC 959)
+     * Creates a new directory, path, on the server.
+     * @param path - the path of the new directory.
+     * @param recursive - enables a `mkdir -p` algorithm, defaults to false.
+     */
+    mkdir(path: string, recursive?: boolean): Promise<void>;
+
+    /**
+     * Optional "standard" commands (RFC 959)
+     * Removes a directory, path, on the server.
+     * @param path - the path of the directory to remove.
+     * @param recursive - enables deleting the directory if not empty, defaults to false.
+     */
+    rmdir(path: string, recursive?: boolean): Promise<void>;
+
+    /**
+     * Optional "standard" commands (RFC 959)
+     * Changes the working directory to the parent of the current directory,
+     * like `cd ..`.
+     */
+    cdup(): Promise<void>;
+
+    /**
+     * Optional "standard" commands (RFC 959)
+     * Retrieves the current working directory.
+     * @returns the cwd.
+     */
+    pwd(): Promise<string>;
+
+    /**
+     * Optional "standard" commands (RFC 959)
+     * Retrieves information about the system.
+     * @returns the server's OS.
+     */
+    system(): Promise<string>;
+
+    /**
+     * Extended commands (RFC 3659)
+     * Retrieves the size of path
+     * @param path - the path of the file whose size is to be retrieved.
+     * @returns the size of the specified file.
+     */
+    size(path: string): Promise<number>;
+
+    /**
+     * Extended commands (RFC 3659)
+     * Retrieves the last modified date and time for path.
+     * @param path - the path of the file or directory whose modified date is to
+     * be retrieved.
+     * @returns the last modified date at the specified path.
+     */
+    lastMod(path: string): Promise<Date>;
+
+    /**
+     * Extended commands (RFC 3659)
+     * Sets the file byte offset for the next file transfer action (get/put).
+     * @param byteOffset - The file byte offset.
+     */
+    restart(byteOffset: number): Promise<void>;
+}
+
+export = PromiseFtp;

--- a/types/promise-ftp/promise-ftp-tests.ts
+++ b/types/promise-ftp/promise-ftp-tests.ts
@@ -1,0 +1,4 @@
+import * as PromiseFtp from "promise-ftp";
+
+// $ExpectType FtpConnectionError
+new PromiseFtp.FtpConnectionError();

--- a/types/promise-ftp/promise-ftp-tests.ts
+++ b/types/promise-ftp/promise-ftp-tests.ts
@@ -1,4 +1,4 @@
-import * as PromiseFtp from "promise-ftp";
+import PromiseFtp = require("promise-ftp");
 
 // $ExpectType FtpConnectionError
 new PromiseFtp.FtpConnectionError();

--- a/types/promise-ftp/tsconfig.json
+++ b/types/promise-ftp/tsconfig.json
@@ -1,16 +1,15 @@
 {
     "compilerOptions": {
         "module": "commonjs",
-        "typeRoots": ["../"],
-        "baseUrl": "../",
-        "noEmit": true,
-        "forceConsistentCasingInFileNames": true,
-        "types": [],
-        "lib": ["es5"],
+        "lib": ["es6"],
         "noImplicitAny": true,
         "noImplicitThis": true,
         "strictNullChecks": true,
-        "strictFunctionTypes": true
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
     },
     "files": ["index.d.ts", "promise-ftp-tests.ts"]
 }

--- a/types/promise-ftp/tsconfig.json
+++ b/types/promise-ftp/tsconfig.json
@@ -9,7 +9,8 @@
         "typeRoots": ["../"],
         "types": [],
         "noEmit": true,
-        "forceConsistentCasingInFileNames": true
+        "forceConsistentCasingInFileNames": true,
+        "strictFunctionTypes": true
     },
     "files": ["index.d.ts", "promise-ftp-tests.ts"]
 }

--- a/types/promise-ftp/tsconfig.json
+++ b/types/promise-ftp/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "typeRoots": ["../"],
+        "baseUrl": "../",
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "types": [],
+        "lib": ["es5"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true
+    },
+    "files": ["index.d.ts", "promise-ftp-tests.ts"]
+}

--- a/types/promise-ftp/tslint.json
+++ b/types/promise-ftp/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "dtslint/dt.json"
+}

--- a/types/promise-sftp/index.d.ts
+++ b/types/promise-sftp/index.d.ts
@@ -1,0 +1,606 @@
+// Type definitions for promise-sftp 1.3
+// Project: https://github.com/realtymaps/promise-sftp
+// Definitions by: coolreader18 <https://github.com/coolreader18>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.4
+
+/// <reference types="node" />
+/// <reference types="ssh2" />
+/// <reference types="bluebird" />
+/// <reference types="ssh2-streams" />
+
+import * as PromiseFtpCommon from "promise-ftp-common";
+import * as Promise from "bluebird";
+import * as ssh2 from "ssh2";
+import * as ssh2Streams from "ssh2-streams";
+import * as fs from "fs";
+
+declare namespace PromiseSftp {
+    enum ERROR_CODES {
+        OK,
+        EOF,
+        NO_SUCH_FILE,
+        PERMISSION_DENIED,
+        FAILURE,
+        BAD_MESSAGE,
+        NO_CONNECTION,
+        CONNECTION_LOST,
+        OP_UNSUPPORTED,
+        INVALID_HANDLE,
+        NO_SUCH_PATH,
+        FILE_ALREADY_EXISTS,
+        WRITE_PROTECT,
+        NO_MEDIA,
+        NO_SPACE_ON_FILESYSTEM,
+        QUOTA_EXCEEDED,
+        UNKNOWN_PRINCIPAL,
+        LOCK_CONFLICT,
+        DIR_NOT_EMPTY,
+        NOT_A_DIRECTORY,
+        INVALID_FILENAME,
+        LINK_LOOP,
+        CANNOT_DELETE,
+        INVALID_PARAMETER,
+        FILE_IS_A_DIRECTORY,
+        BYTE_RANGE_LOCK_CONFLICT,
+        BYTE_RANGE_LOCK_REFUSED,
+        DELETE_PENDING,
+        FILE_CORRUPT,
+        OWNER_INVALID,
+        GROUP_INVALID,
+        NO_MATCHING_BYTE_RANGE_LOCK
+    }
+    export import FtpConnectionError = PromiseFtpCommon.FtpConnectionError;
+    export import FtpReconnectError = PromiseFtpCommon.FtpReconnectError;
+    export import STATUSES = PromiseFtpCommon.STATUSES;
+
+    /**
+     * Options for SftpPromise#connect()
+     */
+    // @ts-ignore
+    interface Options extends ssh2.ConnectConfig {
+        /**
+         * When using password-based user authentication, set this option to
+         * handle password change requests. If this option isn't set, and the
+         * server requests a password change, I haven't tested what will happen.
+         */
+        changePassword?: (message: string, language: string) => Promise<string>;
+
+        /**
+         * Whether to attempt to automatically reconnect using the existing
+         * config if the connection is unexpectedly closed. Auto-reconnection is
+         * lazy, and so will wait until a command needs to be issued before
+         * attempting to reconnect.
+         */
+        autoReconnect?: boolean;
+
+        /**
+         * Path and name of a file containing a private key as would be passed
+         * to the privateKey option. If privateKey is also set, priority is
+         * given to the privateKey option.
+         */
+        privateKeyFile?: string;
+
+        /**
+         * Set this option to a function to try keyboard-interactive user
+         * authentication if primary user authentication method fails.
+         *
+         * NOTE: This function may be called more than once, with the same or different prompts.
+         * @param name - is generally what you'd use as a header or GUI window
+         * title to describe the purpose of the `prompts`
+         */
+        tryKeyboard?: (
+            name: string,
+            instructions: string,
+            instructionsLang: string,
+            prompts: {
+                /** The query to pose to the user */
+                prompt: string;
+                /** Whether the user's input should be displayed on-screen */
+                echo: boolean;
+            }[]
+        ) => (string | Promise<string>)[] | Promise<string[]>;
+
+        /** Alias for `username` */
+        user?: string;
+
+        /** Alias for `readyTimeout` */
+        connTimeout?: number;
+
+        /** Alias for `readyTimeout` */
+        pasvTimeout?: number;
+
+        /** Alias for `keepaliveInterval` */
+        keepalive?: number;
+    }
+
+    /** Output of `PromiseSftp#list()` */
+    interface DirectoryListing {
+        /** `d` for directory, `-` for file, and `l` for symlink only on *NIX. */
+        type: "d" | "-" | "l";
+
+        /** The name of the entry. */
+        name: string;
+
+        /** The last modified date of the entry. */
+        date: Date;
+
+        /** The various permissions for this entry. *NIX only */
+        rights?: {
+            user: string;
+            group: string;
+            other: string;
+        };
+
+        /** The user name or ID that this entry belongs to. *NIX only */
+        owner?: string;
+
+        /** The group name or ID that this entry belongs to. *NIX only */
+        group?: string;
+
+        /** For symlink entries, this is the symlink's target. *NIX only */
+        target?: string;
+
+        /** True if the sticky bit is set for this entry */
+        sticky?: boolean;
+    }
+
+    /** Options for `PromiseSftp#fast{Get,Put}` */
+    interface FastOptions {
+        /**
+         * Number of concurrent reads
+         * @default 25
+         */
+        concurrency?: number;
+
+        /**
+         * Size of each read in bytes
+         * @default 32768
+         */
+        chunkSize: number;
+
+        /** Called every time a part of a file is transferred */
+        step?: (totalTransferred: number, chunk: number, total: number) => void;
+    }
+
+    /** From the [statvfs struct](http://linux.die.net/man/2/statvfs). */
+    interface Statvfs {
+        /** file system block size */
+        f_bsize: number;
+        /** fragment size */
+        f_frsize: number;
+        /** size of fs in f_frsize units */
+        f_blocks: number;
+        /** free blocks */
+        f_bfree: number;
+        /** free blocks for unprivileged users */
+        f_bavail: number;
+        /** inodes */
+        f_files: number;
+        /** free inodes */
+        f_ffree: number;
+        /** free inodes for unprivileged users */
+        f_favail: number;
+        /** file system ID */
+        f_fsid: number;
+        /** mount flags */
+        f_flag: number;
+        /** maximum filename length */
+        f_namemax: number;
+    }
+}
+
+declare class PromiseSftp {
+    /**
+     * Connects to an SFTP server; returned promise resolves to the server's
+     * greeting message. If multiple authentication methods are available based
+     * on the passed config, they are attempted in the following order: Password
+     * > Private Key > Agent > keyboard-interactive (if tryKeyboard is set) >
+     * Host-based > None. NOTE: many of the config properties below are NOT
+     * relevant for promise-ftp. However, all promise-ftp connect options will
+     * work here, except for secure, secureOptions, and preserveCwd.
+     */
+    connect(options: PromiseSftp.Options): null | ssh2.SFTPWrapper;
+
+    /**
+     * Connects to an SFTP server using the config from the most recent call to
+     * #connect().
+     * @returns promise that resolves to the server's greeting message.
+     */
+    reconnect(): Promise<string>;
+
+    /**
+     * Closes the connection to the server after any/all enqueued commands have
+     * been executed.
+     * @returns a promise that resolves to whether or not there was an error
+     * associated with closing the connection.
+     */
+    end(): Promise<boolean>;
+
+    /** Alias to `#end()` */
+    logout(): Promise<boolean>;
+
+    /**
+     * Closes the connection to the server immediately.
+     * @returns whether the connection was connected prior to the call to **destroy()**.
+     */
+    destroy(): boolean;
+
+    /**
+     * @returns a string describing the current connection state.
+     */
+    getConnectionStatus(): PromiseSftp.STATUSES;
+
+    /**
+     * Retrieves a directory listing.
+     * @param path - The path of the directory to get the listing of.
+     */
+    list(path?: string): Promise<PromiseSftp.DirectoryListing>;
+
+    /** Alias to `#list()` */
+    listSafe(path: string): Promise<PromiseSftp.DirectoryListing>;
+
+    /**
+     * Retrieve a file from the server.
+     * @param path - The file to retrieve from the server.
+     */
+    get(path: string): Promise<NodeJS.ReadableStream>;
+
+    /**
+     * Sends data to the server.
+     * @param destPath - The file to store the data in. If string the path to a
+     * local file.
+     */
+    put(
+        input: NodeJS.ReadableStream | Buffer | string,
+        destPath: string
+    ): Promise<void>;
+
+    /**
+     * Same as `#append()`, but appends to `destPath` if it already exists.
+     */
+    append(
+        input: NodeJS.ReadableStream | Buffer | string,
+        destPath: string
+    ): Promise<void>;
+
+    /**
+     * Renames/moves one file/directory to another on the server.
+     * @param oldPath - The source file/directory.
+     * @param newPath - The destination file/directory.
+     */
+    rename(oldPath: string, newPath: string): Promise<void>;
+
+    /**
+     * Create a new directory.
+     * @param path - The path to create a new directory at.
+     * @param recursive - Enables a `mkdir -p` algorithm, defaults to false.
+     * @param attributes - The attributes to use when creating directories.
+     */
+    mkdir(
+        path: string,
+        recursive?: boolean,
+        attributes?: ssh2Streams.InputAttributes
+    ): Promise<void>;
+    mkdir(path: string, attributes: ssh2Streams.InputAttributes): Promise<void>;
+
+    /**
+     * Remove a directory on the server.
+     * @param path - The path of the directory to remove.
+     */
+    rmdir(path: string): Promise<void>;
+
+    /**
+     * Retrieve the size of a file on the server.
+     * @param path - The path to the file to retrieve the size of.
+     */
+    size(path: string): Promise<number>;
+
+    /**
+     * Retrieve the last modified date of a file on the server.
+     * @param path - The path to the file to get the last modified date of.
+     */
+    lastMod(path: string): Date;
+
+    /**
+     * Sets the file byte offset for the next file transfer action initiated via
+     * #get() or #put() to `byteOffset`.
+     */
+    restart(byteOffset: number): Promise<void>;
+
+    /**
+     * Download a file from the server using parallel reads for faster throughput.
+     * @param remotePath - The path to the remote file to read from.
+     * @param localPath - The path to the local file to write to.
+     */
+    fastGet(
+        remotePath: string,
+        localPath: string,
+        options?: PromiseSftp.FastOptions
+    ): Promise<void>;
+
+    /**
+     * Upload a file to the server using parallel reads for faster throughput.
+     * @param localPath - The path to the local file to read from.
+     * @param remotePath - The path to the remote file to write to.
+     */
+    fastPut(
+        localPath: string,
+        remotePath: string,
+        options?: PromiseSftp.FastOptions
+    ): Promise<void>;
+
+    /**
+     * Creates a read stream from a file on the server.
+     * @param path - The path of the file to create a read stream from.
+     * @returns a new `ReadableStream` for `path`.
+     */
+    createReadStream(
+        path: string,
+        options?:
+            | string
+            | {
+                  flags?: string;
+                  encoding?: string;
+                  fd?: number;
+                  mode?: number;
+                  autoClose?: boolean;
+                  start?: number;
+                  end?: number;
+                  highWaterMark?: number;
+              }
+    ): Promise<NodeJS.ReadableStream>;
+
+    /**
+     * Creates a write stream to a file on the server.
+     * @param path - The path of the file to create a write stream to.
+     * @returns a new `WriteableStream` for `path`.
+     */
+    createWriteStream(
+        path: string,
+        options?:
+            | string
+            | {
+                  flags?: string;
+                  encoding?: string;
+                  fd?: number;
+                  mode?: number;
+                  autoClose?: boolean;
+                  start?: number;
+                  end?: number;
+                  highWaterMark?: number;
+              }
+    ): Promise<NodeJS.WritableStream>;
+
+    /**
+     * Opens a file on the server.
+     * @param filename - The path of the file to open.
+     * @param mode - Any of the modes supported by `fs.open()`.
+     * @returns a promise that resolves to a `Buffer` containing a handle to the file.
+     */
+    open(
+        filename: string,
+        mode: string | number,
+        attributes?: ssh2Streams.InputAttributes
+    ): Promise<Buffer>;
+
+    /**
+     * Close a resource on the server.
+     * @param handle - A file handle returned from `#open()` or `#opendir()`.
+     */
+    close(handle: Buffer): Promise<void>;
+
+    /**
+     * Read binary data from a file on the server to a buffer.
+     * @param handle - A file handle returned from `#open()` or `#opendir()`.
+     * @param buffer - The buffer to write to.
+     * @param offset - The offset from the start of the buffer to begin writing to.
+     * @param length - The number of bytes to read from the resource.
+     * @param position - The position of the file to begin reading from.
+     */
+    read(
+        handle: Buffer,
+        buffer: Buffer,
+        offset: number,
+        length: number,
+        position: number
+    ): Promise<{
+        /** The number of bytes successfully read */
+        bytesRead: number;
+
+        /** The buffer passed to `#read()`, but offset-adjusted */
+        buffer: Buffer;
+
+        /** The position passed to `#read()` */
+        position: number;
+    }>;
+
+    /**
+     * Write binary data from a buffer to a file on the server.
+     * @param handle - A file handle returned from `#open()` or `#opendir()`.
+     * @param buffer - The buffer to read from.
+     * @param offset - The offset from the start of the buffer to begin reading from.
+     * @param length - The number of bytes to read from the buffer.
+     * @param position - The position of the file to begin writing to.
+     */
+    read(
+        handle: Buffer,
+        buffer: Buffer,
+        offset: number,
+        length: number,
+        position: number
+    ): Promise<void>;
+
+    /**
+     * Retrieves attributes from a resource on the server.
+     * @param handle - A file handle returned from `#open()` or `#opendir()`
+     */
+    fstat(handle: Buffer): Promise<ssh2Streams.Stats>;
+
+    /**
+     * Set the attributes for a resource on the server.
+     * @param handle - A resource handle returned from `#open()` or `#fopen()`.
+     */
+    fsetstat(handle: Buffer, attributes: ssh2Streams.Attributes): Promise<void>;
+
+    /**
+     * Set the access and modified times for a resource on the server.
+     * @param handle - A resource handle returned from `#open()` or `#fopen()`.
+     * @param atime - A Date or unix timestamp representing the new access time for the resource
+     * @param mtime - A Date or unix timestamp representing the new modify time for the resource
+     */
+    futimes(
+        handle: Buffer,
+        atime: Date | number,
+        mtime: Date | number
+    ): Promise<void>;
+
+    /**
+     * Set the ownership for a resource on the server.
+     * @param handle - A resource handle returned from `#open()` or `#fopen()`.
+     * @param uid - The id of the new owner user.
+     * @param gid - The id of the new owner group.
+     */
+    fchown(handle: Buffer, uid: number, gid: number): Promise<void>;
+
+    /**
+     * Set the mode for a resource on the server.
+     * @param handle - A resource handle returned from `#open()` or `#fopen()`.
+     * @param mode - The new mode, a number or a string with an octal number.
+     */
+    fchmod(handle: Buffer, mode: number | string): Promise<void>;
+
+    /**
+     * Open a directory on the server.
+     * @param path - The path of the directory to open.
+     * @returns a buffer with the handle of the opened directory.
+     */
+    opendir(path: string): Promise<Buffer>;
+
+    /**
+     * Read a directory on the server.
+     * @param location - The path of the directory to read or a handle returned from `#opendir()`.
+     */
+    readdir(
+        location: Buffer | string
+    ): Promise<{
+        filename: string;
+        longname: string;
+        attrs: ssh2Streams.Attributes;
+    }>;
+
+    /**
+     * Remove a file or symlink on the server.
+     * @param path - The path of the file/symlink to remove.
+     */
+    unlink(path: string): Promise<void>;
+
+    /** Alias for `#unlink()` */
+    remove(path: string): Promise<void>;
+
+    /**
+     * Retrieve attributes for a resource on the server.
+     * @param path - The path to the resource to retrieve the attributes of.
+     */
+    stat(path: string): Promise<ssh2Streams.Stats>;
+
+    /**
+     * Retrieve attributes for a resource on the server. If the resource is a
+     * symlink, it retrieves the stats for the link itself instead of the
+     * resource it refers to.
+     * @param path - The path to the resource to retrieve the attributes of.
+     */
+    lstat(path: string): Promise<ssh2Streams.Stats>;
+
+    /**
+     * Set the attributes of a resource on the server.
+     * @param path - The path to the resource to set the attributes of.
+     * @param attributes - The new attributes for the resource.
+     */
+    setstat(path: string, attributes: ssh2Streams.Attributes): Promise<void>;
+
+    /**
+     * Set the access and modified times for a resource on the server.
+     * @param path - The path of the resource to set times of.
+     * @param atime - A Date or unix timestamp representing the new access time for the resource
+     * @param mtime - A Date or unix timestamp representing the new modify time for the resource
+     */
+    utimes(
+        path: string,
+        atime: Date | number,
+        mtime: Date | number
+    ): Promise<void>;
+
+    /**
+     * Set the ownership for a resource on the server.
+     * @param path - The path to the resource to change ownership of.
+     * @param uid - The id of the new owner user.
+     * @param gid - The id of the new owner group.
+     */
+    chown(path: string, uid: number, gid: number): Promise<void>;
+
+    /**
+     * Set the mode for a resource on the server.
+     * @param path - The path of the resource to set the mode of.
+     * @param mode - The new mode, a number or a string with an octal number.
+     */
+    fchmod(handle: string, mode: number | string): Promise<void>;
+
+    /**
+     * Read the target of a symlink on the server.
+     * @param path - The path of the symlink to read the target of.
+     */
+    readlink(path: string): Promise<string>;
+
+    /**
+     * Create a symlink on the server.
+     * @param targetPath - The path to the target of the symlink.
+     * @param linkPath - The path of the new symlink.
+     */
+    symlink(targetPath: string, linkPath: string): Promise<void>;
+
+    /**
+     * Get the absolute path from a relative path on the server.
+     * @param path - The path to get the absolute path of.
+     */
+    realpath(path: string): Promise<string>;
+
+    /**
+     * **OpenSSH extension**
+     * Performs POSIX rename(3) on a resource on the server.
+     * @param srcPath - The original path of the resource.
+     * @param destPath - The new path to rename the resource to.
+     */
+    ext_openssh_rename(srcPath: string, destPath: string): Promise<void>;
+
+    /**
+     * **OpenSSH extension**
+     * Perform POSIX fstatvfs(2) on a resource on the server.
+     * @param path - The path to get the statvfs of.
+     */
+    ext_openssh_statvfs(path: string): Promise<PromiseSftp.Statvfs>;
+
+    /**
+     * **OpenSSH extension**
+     * Perform POSIX fstatvfs(2) on a resource on the server.
+     * @param handle - A resource handle returned from `#open()` or `#fopen()`.
+     */
+    ext_openssh_fstatvfs(handle: Buffer): Promise<PromiseSftp.Statvfs>;
+
+    /**
+     * **OpenSSH extension**
+     * Performs POSIX link(2) to create a hard link on the server.
+     * @param targetPath - The path of a file to hardlink from.
+     * @param linkPath - The path of the newly created hardlink.
+     */
+    ext_openssh_hardlink(targetPath: string, linkPath: string): Promise<void>;
+
+    /**
+     * **OpenSSH extension**
+     * Perform POSIX fsync(3) on a resource on the server.
+     * @param handle - A resource handle returned from `#open()` or `#fopen()`.
+     */
+    ext_openssh_fsync(handle: Buffer): Promise<void>;
+}
+
+export = PromiseSftp;

--- a/types/promise-sftp/index.d.ts
+++ b/types/promise-sftp/index.d.ts
@@ -5,9 +5,6 @@
 // TypeScript Version: 2.4
 
 /// <reference types="node" />
-/// <reference types="ssh2" />
-/// <reference types="bluebird" />
-/// <reference types="ssh2-streams" />
 
 import * as PromiseFtpCommon from "promise-ftp-common";
 import * as Promise from "bluebird";
@@ -50,15 +47,17 @@ declare namespace PromiseSftp {
         GROUP_INVALID,
         NO_MATCHING_BYTE_RANGE_LOCK
     }
+    // tslint:disable-next-line strict-export-declare-modifiers
     export import FtpConnectionError = PromiseFtpCommon.FtpConnectionError;
+    // tslint:disable-next-line strict-export-declare-modifiers
     export import FtpReconnectError = PromiseFtpCommon.FtpReconnectError;
+    // tslint:disable-next-line strict-export-declare-modifiers
     export import STATUSES = PromiseFtpCommon.STATUSES;
 
     /**
      * Options for SftpPromise#connect()
      */
-    // @ts-ignore
-    interface Options extends ssh2.ConnectConfig {
+    type Options = ssh2.ConnectConfig & {
         /**
          * When using password-based user authentication, set this option to
          * handle password change requests. If this option isn't set, and the
@@ -93,13 +92,13 @@ declare namespace PromiseSftp {
             name: string,
             instructions: string,
             instructionsLang: string,
-            prompts: {
+            prompts: Array<{
                 /** The query to pose to the user */
                 prompt: string;
                 /** Whether the user's input should be displayed on-screen */
                 echo: boolean;
-            }[]
-        ) => (string | Promise<string>)[] | Promise<string[]>;
+            }>
+        ) => Array<string | Promise<string>> | Promise<string[]>;
 
         /** Alias for `username` */
         user?: string;
@@ -112,7 +111,7 @@ declare namespace PromiseSftp {
 
         /** Alias for `keepaliveInterval` */
         keepalive?: number;
-    }
+    };
 
     /** Output of `PromiseSftp#list()` */
     interface DirectoryListing {
@@ -544,7 +543,7 @@ declare class PromiseSftp {
      * @param path - The path of the resource to set the mode of.
      * @param mode - The new mode, a number or a string with an octal number.
      */
-    fchmod(handle: string, mode: number | string): Promise<void>;
+    chmod(path: string, mode: number | string): Promise<void>;
 
     /**
      * Read the target of a symlink on the server.

--- a/types/promise-sftp/promise-sftp-tests.ts
+++ b/types/promise-sftp/promise-sftp-tests.ts
@@ -1,4 +1,4 @@
-import * as PromiseSftp from "promise-sftp";
+import PromiseSftp = require("promise-sftp");
 
 const sftp = new PromiseSftp();
 

--- a/types/promise-sftp/promise-sftp-tests.ts
+++ b/types/promise-sftp/promise-sftp-tests.ts
@@ -1,0 +1,9 @@
+import * as PromiseSftp from "promise-sftp";
+
+const sftp = new PromiseSftp();
+
+// $ExpectType destroy
+sftp.destroy;
+
+// $ExpectType STATUSES
+PromiseSftp.STATUSES;

--- a/types/promise-sftp/promise-sftp-tests.ts
+++ b/types/promise-sftp/promise-sftp-tests.ts
@@ -2,8 +2,8 @@ import * as PromiseSftp from "promise-sftp";
 
 const sftp = new PromiseSftp();
 
-// $ExpectType destroy
+// $ExpectType () => boolean
 sftp.destroy;
 
-// $ExpectType STATUSES
+// $ExpectType typeof STATUSES
 PromiseSftp.STATUSES;

--- a/types/promise-sftp/tsconfig.json
+++ b/types/promise-sftp/tsconfig.json
@@ -9,7 +9,8 @@
         "typeRoots": ["../"],
         "types": [],
         "noEmit": true,
-        "forceConsistentCasingInFileNames": true
+        "forceConsistentCasingInFileNames": true,
+        "strictFunctionTypes": true
     },
     "files": ["index.d.ts", "promise-sftp-tests.ts"]
 }

--- a/types/promise-sftp/tsconfig.json
+++ b/types/promise-sftp/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "typeRoots": ["../"],
+        "baseUrl": "../",
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "types": [],
+        "lib": ["es5"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true
+    },
+    "files": ["index.d.ts", "promise-sftp-tests.ts"]
+}

--- a/types/promise-sftp/tsconfig.json
+++ b/types/promise-sftp/tsconfig.json
@@ -1,16 +1,15 @@
 {
     "compilerOptions": {
         "module": "commonjs",
-        "typeRoots": ["../"],
-        "baseUrl": "../",
-        "noEmit": true,
-        "forceConsistentCasingInFileNames": true,
-        "types": [],
-        "lib": ["es5"],
+        "lib": ["es6"],
         "noImplicitAny": true,
         "noImplicitThis": true,
         "strictNullChecks": true,
-        "strictFunctionTypes": true
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
     },
     "files": ["index.d.ts", "promise-sftp-tests.ts"]
 }

--- a/types/promise-sftp/tslint.json
+++ b/types/promise-sftp/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "dtslint/dt.json"
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
