### PR TITLE
[backbone] Add CollectionSetOptions to the Collection.fetch interface

### DIFF
--- a/types/backbone/backbone-tests.ts
+++ b/types/backbone/backbone-tests.ts
@@ -398,7 +398,10 @@ namespace v1Changes {
     namespace Collection {
         function test_fetch() {
             var collection = new EmployeeCollection;
-            collection.fetch({ reset: true });
+            collection.fetch({ 
+                reset: true,
+                remove: false
+            });
         }
 
         function test_create() {

--- a/types/backbone/index.d.ts
+++ b/types/backbone/index.d.ts
@@ -1,6 +1,8 @@
 // Type definitions for Backbone 1.3.3
 // Project: http://backbonejs.org/
-// Definitions by: Boris Yankov <https://github.com/borisyankov>, Natan Vivo <https://github.com/nvivo>
+// Definitions by: Boris Yankov <https://github.com/borisyankov>
+//                 Natan Vivo <https://github.com/nvivo>
+//                 kenjiru <https://github.com/kenjiru>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -76,7 +78,7 @@ declare namespace Backbone {
     interface ModelDestroyOptions extends Waitable, PersistenceOptions {
     }
 
-    interface CollectionFetchOptions extends PersistenceOptions, Parseable {
+    interface CollectionFetchOptions extends PersistenceOptions, Parseable, CollectionSetOptions {
         reset?: boolean;
     }
 


### PR DESCRIPTION

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://backbonejs.org/#Collection-fetch

The Backbone documentation for `Collection.fetch` states the following:

> The behavior of `fetch` can be customized by using the available `set` options. 

And this is missing in the current version of the typings.

