### PR TITLE
fix(extend): improve signature of interface ExpectExtendMap

### DIFF
--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -342,7 +342,7 @@ declare namespace jest {
     }
 
     interface ExpectExtendMap {
-        [key: string]: (this: MatcherUtils, received: any, ...actual: any[]) => { message(): string, pass: boolean } | Promise<{ message(): string, pass: boolean }>;
+        [key: string]: (this: MatcherUtils, received: any, ...actual: any[]) => { message(): string | (() => string), pass: boolean } | Promise<{ message(): string, pass: boolean }>;
     }
 
     interface SnapshotSerializerOptions {


### PR DESCRIPTION
Jest custom matcher support both `string` and `() => string` for message property 
> https://github.com/facebook/jest/blob/d3a6a7400a89b857a63d939fc5664ae8a2dfbbb2/packages/expect/src/index.js#L351

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/facebook/jest/blob/d3a6a7400a89b857a63d939fc5664ae8a2dfbbb2/packages/expect/src/index.js#L351
- [ ] Increase the version number in the header if appropriate.

Linked to https://github.com/Ninja-Squad/ngx-speculoos/issues/49