### PR TITLE
[web3] Updated `web3.utils.toWei()` Unit list and added default Unit value

### DIFF
--- a/types/web3/index.d.ts
+++ b/types/web3/index.d.ts
@@ -13,6 +13,7 @@
 //                 Baris Gumustas <https://github.com/matrushka>
 //                 André Vitor de Lima Matos <https://github.com/andrevmatos>
 //                 Levin Keller <https://github.com/levino>
+//                 Dmitry Radkovskiy <https://github.com/zlumer>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.4
 import BigNumber = require("bn.js");

--- a/types/web3/utils.d.ts
+++ b/types/web3/utils.d.ts
@@ -2,13 +2,18 @@ import BigNumber = require("bn.js");
 import * as us from "underscore";
 
 type Unit =
+    | "noether"
+    | "wei"
     | "kwei"
+    | "Kwei"
     | "femtoether"
     | "babbage"
     | "mwei"
+    | "Mwei"
     | "picoether"
     | "lovelace"
-    | "qwei"
+    | "gwei"
+    | "Gwei"
     | "nanoether"
     | "shannon"
     | "microether"
@@ -66,6 +71,7 @@ export default interface Utils {
     toDecimal(val: any): number;
     toHex(val: any): string;
     toUtf8(val: any): string;
-    toWei(val: string | number | BigNumber, unit: Unit): string | BigNumber;
+    toWei(val: string | number, unit?: Unit): string;
+    toWei(val: BigNumber, unit?: Unit): BigNumber;
     unitMap: any;
 }

--- a/types/web3/web3-tests.ts
+++ b/types/web3/web3-tests.ts
@@ -18,6 +18,6 @@ myContract.options.gasPrice = "20000000000000";
 myContract.options.gas = 5000000;
 
 const weiStr = web3.utils.toWei("100", "gwei");
-weiStr.endsWith(weiStr)
+weiStr.endsWith(weiStr);
 const weiBn = web3.utils.toWei(web3.utils.toBN("1"));
-weiBn.toNumber().toFixed(4)
+weiBn.toNumber().toFixed(4);

--- a/types/web3/web3-tests.ts
+++ b/types/web3/web3-tests.ts
@@ -16,3 +16,8 @@ const myContract = new web3.eth.Contract(
 myContract.options.from = "0x1234567890123456789012345678901234567891";
 myContract.options.gasPrice = "20000000000000";
 myContract.options.gas = 5000000;
+
+const weiStr = web3.utils.toWei("100", "gwei");
+weiStr.endsWith(weiStr)
+const weiBn = web3.utils.toWei(web3.utils.toBN("1"));
+weiBn.toNumber().toFixed(4)


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://web3js.readthedocs.io/en/1.0/web3-utils.html#towei