### PR TITLE
Eliminate double `Readonly` in `props`.

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -305,7 +305,7 @@ declare namespace React {
         // always pass children as variadic arguments to `createElement`.
         // In the future, if we can define its call signature conditionally
         // on the existence of `children` in `P`, then we should remove this.
-        readonly props: Readonly<{ children?: ReactNode }> & Readonly<P>;
+        readonly props: Readonly<{ children?: ReactNode } & P>;
         state: Readonly<S>;
         /**
          * @deprecated


### PR DESCRIPTION
There's really no need to separate the `Readonly` on each type. Otherwise, error messages get a little more annoying to read.

```tsx
export class Greet extends React.Component<{name: string}> {
    render() {
        const { naem } = this.props;
        return <div>Hello ${naem.toUpperCase()}!</div>
    }
}
```

That example gives

```
Type 'Readonly<{ children?: ReactNode; }> & Readonly<{ name: string; }>' has no property 'name' and no string index signature.
```

Now it gives

```
Type 'Readonly<{ children?: ReactNode; } & { name: string; }>' has no property 'naem' and no string index signature.
```