### PR TITLE
Fix wrong return types in yesql pg and mysql functions

### DIFF
--- a/types/yesql/index.d.ts
+++ b/types/yesql/index.d.ts
@@ -13,8 +13,8 @@ declare function readSqlFiles(
 ): string;
 
 declare namespace readSqlFiles {
-    function pg(query: string): (data: object) => string;
-    function mysql(query: string): (data: object) => string;
+    function pg(query: string): (data: object) => {text: string, values: any[]};
+    function mysql(query: string): (data: object) => {sql: string, values: any[]};
 }
 
 export = readSqlFiles;

--- a/types/yesql/yesql-tests.ts
+++ b/types/yesql/yesql-tests.ts
@@ -4,14 +4,14 @@ yesql(''); // $ExpectType string
 yesql('', {pg: true}); // $ExpectType string
 yesql('', {type: 'mysql'}); // $ExpectType string
 
-yesql.pg(''); // $ExpectType (data: object) => string
-yesql.pg('')({}); // $ExpectType string
+yesql.pg(''); // $ExpectType (data: object) => { text: string; values: any[]; }
+yesql.pg('')({}); // $ExpectType { text: string; values: any[]; }
 
 yesql.pg('')('demo'); // $ExpectError
 yesql.pg('')(42); // $ExpectError
 
-yesql.mysql(''); // $ExpectType (data: object) => string
-yesql.mysql('')({}); // $ExpectType string
+yesql.mysql(''); // $ExpectType (data: object) => { sql: string; values: any[]; }
+yesql.mysql('')({}); // $ExpectType { sql: string; values: any[]; }
 
 yesql.mysql('')('demo'); // $ExpectError
 yesql.mysql('')(42); // $ExpectError


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/pihvi/yesql/blob/master/yesql.js#L28 and https://github.com/pihvi/yesql/blob/master/yesql.js#L47
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
