### PR TITLE
[joi] Add missing type to ObjectSchema::pattern()

### DIFF
--- a/types/joi/index.d.ts
+++ b/types/joi/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for joi v13.3.0
+// Type definitions for joi v13.4.0
 // Project: https://github.com/hapijs/joi
 // Definitions by: Bart van der Schoor <https://github.com/Bartvds>
 //                 Laurence Dougal Myers <https://github.com/laurence-myers>

--- a/types/joi/index.d.ts
+++ b/types/joi/index.d.ts
@@ -753,8 +753,11 @@ export interface ObjectSchema extends AnySchema {
 
     /**
      * Specify validation rules for unknown keys matching a pattern.
+	 *
+	 * @param pattern - a pattern that can be either a regular expression or a joi schema that will be tested against the unknown key names
+	 * @param schema - the schema object matching keys must validate against
      */
-    pattern(regex: RegExp, schema: SchemaLike): this;
+    pattern(pattern: RegExp | SchemaLike, schema: SchemaLike): this;
 
     /**
      * Defines an all-or-nothing relationship between keys where if one of the peers is present, all of them are required as well.


### PR DESCRIPTION
Add type alternative to first argument of `ObjectSchema::pattern()` as stated in [api doc](https://github.com/hapijs/joi/blob/v13.4.0/API.md#objectpatternpattern-schema).