### PR TITLE
chai-http: Add methods keepOpen() and close() to the agent

### DIFF
--- a/types/chai-http/chai-http-tests.ts
+++ b/types/chai-http/chai-http-tests.ts
@@ -84,6 +84,10 @@ chai.request(app)
 	.then((res: ChaiHttp.Response) => chai.expect(res).to.have.status(200))
 	.catch((err: any) => { throw err; });
 
+chai.request(app)
+	.keepOpen()
+	.close((err: any) => { throw err; });
+
 const agent = chai.request.agent(app);
 
 agent
@@ -96,6 +100,8 @@ agent
 		return agent.get('/user/me')
 			.then((res: ChaiHttp.Response) => chai.expect(res).to.have.status(200));
 	});
+
+agent.close((err: any) => { throw err; });
 
 function test1() {
 	const req = chai.request(app).get('/');

--- a/types/chai-http/index.d.ts
+++ b/types/chai-http/index.d.ts
@@ -64,6 +64,8 @@ declare global {
 			del(url: string, callback?: (err: any, res: Response) => void): request.Request;
 			options(url: string, callback?: (err: any, res: Response) => void): request.Request;
 			patch(url: string, callback?: (err: any, res: Response) => void): request.Request;
+			keepOpen(): Agent;
+			close(callback?: (err: any) => void): Agent;
 		}
 
 		interface TypeComparison {


### PR DESCRIPTION
keepOpen() and close() are available both on the base request and on the
agent for controlling the lifetime of the server.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://www.chaijs.com/plugins/chai-http/
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
