### PR TITLE
Numeral.js: Add access to options

### DIFF
--- a/types/numeral/index.d.ts
+++ b/types/numeral/index.d.ts
@@ -22,6 +22,14 @@ interface NumeralJSLocale {
 	};
 }
 
+interface NumeralJSOptions {
+	currentLocale: string;
+	zeroFormat: string;
+	nullFormat: string;
+	defaultFormat: string;
+	scalePercentBy100: boolean;
+}
+
 type RoundingFunction = (value: number) => number;
 
 // http://numeraljs.com/#custom-formats
@@ -41,7 +49,8 @@ interface Numeral {
 	(value?: any): Numeral;
 	version: string;
 	isNumeral: boolean;
-
+	options: NumeralJSOptions;
+	
 	/**
 	 * This function sets the current locale.  If no arguments are passed in,
 	 * it will simply return the current global locale key.

--- a/types/numeral/numeral-tests.ts
+++ b/types/numeral/numeral-tests.ts
@@ -90,3 +90,8 @@ numeral.locale('fr');
 // return the current locale
 numeral.locale();
 // 'fr'
+
+// test changing an option
+numeral.options.scalePercentBy100 = false
+numeral(50).formatCurrency('0%')
+// '50%'


### PR DESCRIPTION
Not possible to set options for numeral.js with current .d.ts.  Adding the following seems to get it working on my project so hoping it can be included at the DefinitelyTyped end.

Please fill in this template.

- [x ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ x] Test the change in your own code. (Compile and run.)
- [x ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x ] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/adamwdraper/Numeral-js/blob/master/src/numeral.js
- [x ] Increase the version number in the header if appropriate. (none found)
- [x ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.