### PR TITLE
react-jsonschema-form: Fix incorrect typings for TitleField and DescriptionField

### DIFF
--- a/types/react-jsonschema-form/index.d.ts
+++ b/types/react-jsonschema-form/index.d.ts
@@ -5,6 +5,7 @@
 //                 Ivan Jiang <https://github.com/iplus26>
 //                 Kurt Preston <https://github.com/KurtPreston>
 //                 Philippe Bourdages <https://github.com/phbou72>
+//                 Lucian Buzzo <https://github.com/LucianBuzzo>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.6
 
@@ -133,8 +134,8 @@ declare module "react-jsonschema-form" {
     };
 
     export type ArrayFieldTemplateProps = {
-        DescriptionField: object;
-        TitleField: object;
+        DescriptionField: React.StatelessComponent<{ id: string, description: string | React.ReactElement<any> }>;
+        TitleField: React.StatelessComponent<{ id: string, title: string, required: boolean }>;
         canAdd: boolean;
         className: string;
         disabled: boolean;
@@ -166,8 +167,8 @@ declare module "react-jsonschema-form" {
     };
 
     export type ObjectFieldTemplateProps = {
-        DescriptionField: object;
-        TitleField: object;
+        DescriptionField: React.StatelessComponent<{ id: string, description: string | React.ReactElement<any> }>;
+        TitleField: React.StatelessComponent<{ id: string, title: string, required: boolean }>;
         title: string;
         description: string;
         properties: {


### PR DESCRIPTION
These props were originally typed as `object` but are in fact stateless react components.

change-type: patch

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
   - https://github.com/mozilla-services/react-jsonschema-form/blob/master/src/components/fields/TitleField.js
   - https://github.com/mozilla-services/react-jsonschema-form/blob/master/src/components/fields/DescriptionField.js
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
