### PR TITLE
@types/jest: toMatchSnapshot updated for property matchers

### DIFF
--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -394,7 +394,7 @@ declare namespace jest {
          *
          * @param actual The value to apply matchers against.
          */
-        (actual: any): Matchers<void>;
+        <T = any>(actual: T): Matchers<T>;
         /**
          * Matches anything but null or undefined. You can use it inside `toEqual` or `toBeCalledWith` instead
          * of a literal value. For example, if you want to check that a mock function is called with a
@@ -651,6 +651,11 @@ declare namespace jest {
          * Used to check that a JavaScript object matches a subset of the properties of an object
          */
         toMatchObject(expected: {} | any[]): R;
+        /**
+         * This ensures that a value matches the most recent snapshot with property matchers.
+         * Check out [the Snapshot Testing guide](http://facebook.github.io/jest/docs/snapshot-testing.html) for more information.
+         */
+        toMatchSnapshot<T extends {[P in keyof R]: Expect['any']}>(propertyMatchers: Partial<T>, snapshotName?: string): R;
         /**
          * This ensures that a value matches the most recent snapshot.
          * Check out [the Snapshot Testing guide](http://facebook.github.io/jest/docs/snapshot-testing.html) for more information.

--- a/types/jest/jest-tests.ts
+++ b/types/jest/jest-tests.ts
@@ -610,6 +610,12 @@ describe("", () => {
 
         expect({}).toMatchSnapshot();
         expect({}).toMatchSnapshot("snapshotName");
+        expect({ abc: "def" }).toMatchSnapshot({ abc: expect.any(String) }, "snapshotName");
+        expect({
+            one: 1,
+            two: "2",
+            date: new Date(),
+        }).toMatchSnapshot({ one: expect.any(Number), date: expect.any(Date) });
 
         expect(jest.fn()).toReturn();
 


### PR DESCRIPTION
This PR updates `toMatchSnapshot` in jest for the changes in version 23. This PR is an updated version with the great review feedback of @Hotell in #26747 (which is closed). 

@Hotell This is what you proposed. Is there anything to change or is it fine this way?

Solved #26746
https://facebook.github.io/jest/docs/en/expect.html#tomatchsnapshotpropertymatchers-snapshotname
