### PR TITLE
react-widgets: Fix DateTimePicker parse type

### DIFF
--- a/types/react-widgets/lib/DateTimePicker.d.ts
+++ b/types/react-widgets/lib/DateTimePicker.d.ts
@@ -77,7 +77,7 @@ interface DateTimePickerProps extends ReactWidgetsCommonDropdownProps<DateTimePi
      * parsing yourself. When parse is unspecified and the format prop is a String parse will
      * automatically use that format as its default
      */
-    parse?: (str: string) => Date | string[];
+    parse?: ((str: string) => Date) | string[] | string;
     /**
      * The starting and lowest level view the calendar can navigate down to.
      * @enum "month" "year" "decade" "century"


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/jquense/react-widgets/blob/master/packages/react-widgets/src/DateTimePicker.js
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
