### PR TITLE
@types/paper | Added missing method in Group.hitTestAll 

### DIFF
--- a/types/paper/index.d.ts
+++ b/types/paper/index.d.ts
@@ -1,6 +1,8 @@
-// Type definitions for Paper.js v0.9.24
+// Type definitions for Paper.js v0.11.5
 // Project: http://paperjs.org/
-// Definitions by: Clark Stevenson <https://github.com/clark-stevenson>, Jon Lucas <https://github.com/Xakaloz>
+// Definitions by:  Clark Stevenson <https://github.com/clark-stevenson>,
+//                  Jon Lucas <https://github.com/Xakaloz>,
+//                  Sebastian Lopez <https://github.com/sebaswebdev>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 type NativeMouseEvent = MouseEvent;

--- a/types/paper/index.d.ts
+++ b/types/paper/index.d.ts
@@ -1409,6 +1409,25 @@ declare module paper {
         hitTest(point: Point, options?: { tolerance?: number; class?: string; fill?: boolean; stroke?: boolean; segments?: boolean; curves?: boolean; handles?: boolean; ends?: boolean; bounds?: boolean; center?: boolean; guides?: boolean; selected?: boolean; match?: (hit: HitResult) => boolean; }): HitResult;
 
         /**
+         * Perform a hit-test on the items contained within the project at the location of the specified point, returning all found hits.
+         * The options object allows you to control the specifics of the hit-test and may contain a combination of the following values:
+         * @param point - the point where the hit-test should be performed
+         * @param options.tolerance -the tolerance of the hit-test in points. Can also be controlled through paperScope.settings.hitTolerance
+         * @param options.class - only hit-test again a certain item class and its sub-classes: Group, Layer, Path, CompoundPath, Shape, Raster, PlacedSymbol, PointText, etc.
+         * @param options.fill - hit-test the fill of items.
+         * @param options.stroke - hit-test the stroke of path items, taking into account the setting of stroke color and width.
+         * @param options.segments - hit-test for segment.point of Path items.
+         * @param options.curves - hit-test the curves of path items, without taking the stroke color or width into account.
+         * @param options.handles - hit-test for the handles.  (segment.handleIn / segment.handleOut) of path segments.
+         * @param options.ends - only hit-test for the first or last segment points of open path items.
+         * @param options.bounds - hit-test the corners and side-centers of the bounding rectangle of items (item.bounds).
+         * @param options.center - hit-test the rectangle.center of the bounding rectangle of items (item.bounds).
+         * @param options.guides - hit-test items that have Item#guide set to true.
+         * @param options.selected - only hit selected items.
+         */
+        hitTestAll(point: Point, options?: { tolerance?: number; class?: string; fill?: boolean; stroke?: boolean; segments?: boolean; curves?: boolean; handles?: boolean; ends?: boolean; bounds?: boolean; center?: boolean; guides?: boolean; selected?: boolean; match?: (hit: HitResult) => boolean; }): HitResult[];
+
+        /**
          * Checks whether the item matches the criteria described by the given object, by iterating over all of its properties and matching against their values through matches(name, compare).
          * See project.getItems(match) for a selection of illustrated examples.
          * @param match - the criteria to match against.
@@ -3237,7 +3256,7 @@ declare module paper {
          * Deselects all selected items in the project.
          */
         deselectAll(): void;
-         
+
         /**
          * Adds the specified layer at the end of the this project’s layers list.
          */


### PR DESCRIPTION
Added definition for the method `hitTestAll() ` that was missing in the declaration file.
More info: http://paperjs.org/reference/group/#hittestall-point

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: http://paperjs.org/reference/group/#hittestall-point
- [X] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
