### PR TITLE
Use ComponentType rather than ComponentClass in grid-styled definitions

### DIFF
--- a/types/grid-styled/index.d.ts
+++ b/types/grid-styled/index.d.ts
@@ -8,7 +8,7 @@
 
 export type Omit<T, K extends keyof T> = Pick<T, ({ [P in keyof T]: P } & { [P in K]: never } & { [x: string]: never, [x: number]: never })[keyof T]>;
 
-import { ComponentClass } from "react";
+import { ComponentType } from "react";
 import { StyledComponentClass } from "styled-components";
 
 export type ResponsiveProp = number | string | Array<string | number>;
@@ -39,7 +39,7 @@ export interface BoxProps
     extends Omit<React.HTMLProps<HTMLDivElement>, "width" | "wrap" | "is"> {
     flex?: ResponsiveProp;
     order?: ResponsiveProp;
-    is?: string | ComponentClass<any>;
+    is?: string | ComponentType<any>;
     alignSelf?: ResponsiveProp;
 }
 

--- a/types/grid-styled/index.d.ts
+++ b/types/grid-styled/index.d.ts
@@ -77,4 +77,4 @@ export const theme: Theme;
 export type DivProps = Omit<React.HTMLProps<HTMLDivElement>, "ref"> & {
     innerRef?: (el: HTMLDivElement) => any;
 };
-export const div: ComponentClass<DivProps>;
+export const div: ComponentType<DivProps>;

--- a/types/grid-styled/index.d.ts
+++ b/types/grid-styled/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for grid-styled 4.1
+// Type definitions for grid-styled 4.2
 // Project: https://github.com/jxnblk/grid-styled
 // Definitions by: Anton Vasin <https://github.com/antonvasin>
 //                 Victor Orlov <https://github.com/vittorio>


### PR DESCRIPTION
Update grid-styled BoxProps to accept React component classes or stateless functions

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
