### PR TITLE
stripe: Update Card to support tagged union

### DIFF
--- a/types/stripe/index.d.ts
+++ b/types/stripe/index.d.ts
@@ -10,6 +10,7 @@
 //                 Thomas Bruun <https://github.com/bruun>
 //                 Gal Talmor <https://github.com/galtalmor>
 //                 Hunter Tunnicliff <https://github.com/htunnicliff>
+//                 Tyler Jones <https://github.com/squirly>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
@@ -4338,7 +4339,7 @@ declare namespace Stripe {
             /**
              * Value is 'card'
              */
-            object: string;
+            object: 'card';
 
             /**
              * The card number


### PR DESCRIPTION
This allows differentiating between a BankAccount and Card payment method
when using type unions, which are leveraged by the stripe typings.

See https://stripe.com/docs/api#card_object-object

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://stripe.com/docs/api#card_object-object
- [ ] Increase the version number in the header if appropriate.