### PR TITLE
Enhanced return type of Koa Middleware in types/koa-response-time

### DIFF
--- a/types/koa-response-time/index.d.ts
+++ b/types/koa-response-time/index.d.ts
@@ -1,8 +1,11 @@
 // Type definitions for koa-response-time 2.0
 // Project: https://github.com/koajs/response-time#readme
 // Definitions by: Thor Sedeke <https://github.com/thorsedeke>
+//                 Steven McDowall <https://github.com/sjmcdowall>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
-declare function koa_response_time(): any;
+import { Middleware } from 'koa';
+
+declare function koa_response_time(): Middleware;
 export = koa_response_time;


### PR DESCRIPTION
As a Koa Middleware, koa-response-time should indicate it returns a Middleware type not "any" which, in strict TS projects, causes warnings.

Please fill in this template.

- [X ] Use a meaningful title for the pull request. Include the name of the package modified.
- [X ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
