### PR TITLE
[@types/node] Correcting some Buffer interfaces

### DIFF
--- a/types/node/v8/index.d.ts
+++ b/types/node/v8/index.d.ts
@@ -22,6 +22,7 @@
 //                 Hoàng Văn Khải <https://github.com/KSXGitHub>
 //                 Lishude <https://github.com/islishude>
 //                 Andrew Makarov <https://github.com/r3nya>
+//                 Bruno Brant <https://github.com/HeavyStorm>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.1
 
@@ -184,18 +185,23 @@ declare var Buffer: {
      *
      * @param str String to store in buffer.
      * @param encoding encoding to use, optional.  Default is 'utf8'
+     *
+     * @deprecated Use Buffer.from(string[, encoding]) instead
      */
     new(str: string, encoding?: string): Buffer;
     /**
      * Allocates a new buffer of {size} octets.
      *
      * @param size count of octets to allocate.
+     * @deprecated Use Buffer.alloc() instead (also see Buffer.allocUnsafe())
      */
     new(size: number): Buffer;
     /**
      * Allocates a new buffer containing the given {array} of octets.
      *
      * @param array The octets to store.
+     * 
+     * @deprecated Use Buffer.from(array) instead.
      */
     new(array: Uint8Array): Buffer;
     /**
@@ -204,18 +210,26 @@ declare var Buffer: {
      *
      *
      * @param arrayBuffer The ArrayBuffer with which to share memory.
+     * @param byteOffset Index of first byte to expose. Default: 0.
+     * @param length Number of bytes to expose. Default: arrayBuffer.length - byteOffset
+     * 
+     * @deprecated Use Buffer.from(arrayBuffer[, byteOffset [, length]]) instead.
      */
-    new(arrayBuffer: ArrayBuffer): Buffer;
+    new(arrayBuffer: ArrayBuffer, byteOffset?: number, length?: number): Buffer;
     /**
      * Allocates a new buffer containing the given {array} of octets.
      *
      * @param array The octets to store.
+     * 
+     * @deprecated Use Buffer.from(array) instead.
      */
     new(array: any[]): Buffer;
     /**
      * Copies the passed {buffer} data onto a new {Buffer} instance.
      *
      * @param buffer The buffer to copy.
+     * 
+     * @deprecated Use Buffer.from(buffer) instead.
      */
     new(buffer: Buffer): Buffer;
     prototype: Buffer;
@@ -226,6 +240,8 @@ declare var Buffer: {
      * within the {arrayBuffer} that will be shared by the Buffer.
      *
      * @param arrayBuffer The .buffer property of a TypedArray or a new ArrayBuffer()
+     * @param byteOffset Index of first byte to expose. Default: 0.
+     * @param length Number of bytes to expose. Default: arrayBuffer.length - byteOffset
      */
     from(arrayBuffer: ArrayBuffer, byteOffset?: number, length?: number): Buffer;
     /**
@@ -271,11 +287,11 @@ declare var Buffer: {
      * @param totalLength Total length of the buffers when concatenated.
      *   If totalLength is not provided, it is read from the buffers in the list. However, this adds an additional loop to the function, so it is faster to provide the length explicitly.
      */
-    concat(list: Buffer[], totalLength?: number): Buffer;
+    concat(list: (Buffer | Uint8Array)[], totalLength?: number): Buffer;
     /**
      * The same as buf1.compare(buf2).
      */
-    compare(buf1: Buffer, buf2: Buffer): number;
+    compare(buf1: (Buffer | Uint8Array), buf2: (Buffer | Uint8Array)): number;
     /**
      * Allocates a new buffer of {size} octets.
      *

--- a/types/node/v8/node-tests.ts
+++ b/types/node/v8/node-tests.ts
@@ -388,6 +388,9 @@ function bufferTests() {
     console.log(Buffer.byteLength('xyz123', 'ascii'));
     var result1 = Buffer.concat([utf8Buffer, base64Buffer]);
     var result2 = Buffer.concat([utf8Buffer, base64Buffer], 9999999);
+    var uint8Buffer = new Uint8Array(10);
+    var result3 = Buffer.concat([utf8Buffer, uint8Buffer]);
+    var result3 = Buffer.concat([utf8Buffer, uint8Buffer], 9999999);
 
     // Class Methods: Buffer.swap16(), Buffer.swa32(), Buffer.swap64()
     {

--- a/types/node/v9/index.d.ts
+++ b/types/node/v9/index.d.ts
@@ -25,6 +25,7 @@
 //                 Alexander T. <https://github.com/a-tarasyuk>
 //                 Lishude <https://github.com/islishude>
 //                 Andrew Makarov <https://github.com/r3nya>
+//                 Bruno Brant <https://github.com/HeavyStorm>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /** inspector module types */
@@ -325,38 +326,51 @@ declare var Buffer: {
      *
      * @param str String to store in buffer.
      * @param encoding encoding to use, optional.  Default is 'utf8'
+     * 
+     * @deprecated Use Buffer.from(string[, encoding]) instead
      */
     new(str: string, encoding?: string): Buffer;
     /**
      * Allocates a new buffer of {size} octets.
      *
      * @param size count of octets to allocate.
+     * 
+     * @deprecated Use Buffer.alloc() instead (also see Buffer.allocUnsafe())
      */
     new(size: number): Buffer;
     /**
      * Allocates a new buffer containing the given {array} of octets.
      *
      * @param array The octets to store.
+     * 
+     * @deprecated Use Buffer.from(array) instead.
      */
     new(array: Uint8Array): Buffer;
     /**
      * Produces a Buffer backed by the same allocated memory as
      * the given {ArrayBuffer}.
      *
-     *
      * @param arrayBuffer The ArrayBuffer with which to share memory.
+     * @param byteOffset Index of first byte to expose. Default: 0.
+     * @param length Number of bytes to expose. Default: arrayBuffer.length - byteOffset
+     * 
+     * @deprecated Use Buffer.from(arrayBuffer[, byteOffset [, length]]) instead.
      */
-    new(arrayBuffer: ArrayBuffer): Buffer;
+    new(arrayBuffer: ArrayBuffer, byteOffset?: number, length?: number): Buffer;
     /**
      * Allocates a new buffer containing the given {array} of octets.
      *
      * @param array The octets to store.
+     * 
+     * @deprecated Use Buffer.from(array) instead.
      */
     new(array: any[]): Buffer;
     /**
      * Copies the passed {buffer} data onto a new {Buffer} instance.
      *
      * @param buffer The buffer to copy.
+     * 
+     * @deprecated Use Buffer.from(buffer) instead.
      */
     new(buffer: Buffer): Buffer;
     prototype: Buffer;
@@ -367,6 +381,8 @@ declare var Buffer: {
      * within the {arrayBuffer} that will be shared by the Buffer.
      *
      * @param arrayBuffer The .buffer property of a TypedArray or a new ArrayBuffer()
+     * @param byteOffset Index of first byte to expose. Default: 0.
+     * @param length Number of bytes to expose. Default: arrayBuffer.length - byteOffset
      */
     from(arrayBuffer: ArrayBuffer, byteOffset?: number, length?: number): Buffer;
     /**
@@ -412,11 +428,11 @@ declare var Buffer: {
      * @param totalLength Total length of the buffers when concatenated.
      *   If totalLength is not provided, it is read from the buffers in the list. However, this adds an additional loop to the function, so it is faster to provide the length explicitly.
      */
-    concat(list: Uint8Array[], totalLength?: number): Buffer;
+    concat(list: (Buffer | Uint8Array)[], totalLength?: number): Buffer;
     /**
      * The same as buf1.compare(buf2).
      */
-    compare(buf1: Uint8Array, buf2: Uint8Array): number;
+    compare(buf1: (Buffer | Uint8Array), buf2: (Buffer | Uint8Array)): number;
     /**
      * Allocates a new buffer of {size} octets.
      *
@@ -5679,24 +5695,24 @@ declare module "util" {
         readonly fatal: boolean;
         readonly ignoreBOM: boolean;
         constructor(
-          encoding?: string,
-          options?: { fatal?: boolean; ignoreBOM?: boolean }
+            encoding?: string,
+            options?: { fatal?: boolean; ignoreBOM?: boolean }
         );
         decode(
-          input?:
-            Int8Array
-            | Int16Array
-            | Int32Array
-            | Uint8Array
-            | Uint16Array
-            | Uint32Array
-            | Uint8ClampedArray
-            | Float32Array
-            | Float64Array
-            | DataView
-            | ArrayBuffer
-            | null,
-          options?: { stream?: boolean }
+            input?:
+                Int8Array
+                | Int16Array
+                | Int32Array
+                | Uint8Array
+                | Uint16Array
+                | Uint32Array
+                | Uint8ClampedArray
+                | Float32Array
+                | Float64Array
+                | DataView
+                | ArrayBuffer
+                | null,
+            options?: { stream?: boolean }
         ): string;
     }
 
@@ -6195,20 +6211,20 @@ declare module "async_hooks" {
     export function createHook(options: HookCallbacks): AsyncHook;
 
     export interface AsyncResourceOptions {
-      /**
-       * The ID of the execution context that created this async event.
-       * Default: `executionAsyncId()`
-       */
-      triggerAsyncId?: number;
+        /**
+         * The ID of the execution context that created this async event.
+         * Default: `executionAsyncId()`
+         */
+        triggerAsyncId?: number;
 
-      /**
-       * Disables automatic `emitDestroy` when the object is garbage collected.
-       * This usually does not need to be set (even if `emitDestroy` is called
-       * manually), unless the resource's `asyncId` is retrieved and the
-       * sensitive API's `emitDestroy` is called with it.
-       * Default: `false`
-       */
-      requireManualDestroy?: boolean;
+        /**
+         * Disables automatic `emitDestroy` when the object is garbage collected.
+         * This usually does not need to be set (even if `emitDestroy` is called
+         * manually), unless the resource's `asyncId` is retrieved and the
+         * sensitive API's `emitDestroy` is called with it.
+         * Default: `false`
+         */
+        requireManualDestroy?: boolean;
     }
 
     /**
@@ -6225,7 +6241,7 @@ declare module "async_hooks" {
          *   this async event (default: `executionAsyncId()`), or an
          *   AsyncResourceOptions object (since 9.3)
          */
-        constructor(type: string, triggerAsyncId?: number|AsyncResourceOptions);
+        constructor(type: string, triggerAsyncId?: number | AsyncResourceOptions);
 
         /**
          * Call AsyncHooks before callbacks.


### PR DESCRIPTION
- Only applied corrections to v9 and v8, there might be errors on previous versions.
- Both concat and compare accept both Uint8Array and Buffer instances.
- All buffer constructors are noew deprecated, as per the spec.
- One of the constructors have additional parameters that were previously ignored.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/docs/latest-v8.x/api/buffer.html#buffer_new_buffer_arraybuffer_byteoffset_length
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.