### PR TITLE
stripe: Card's cardholder name can be null

### DIFF
--- a/types/stripe/index.d.ts
+++ b/types/stripe/index.d.ts
@@ -4397,7 +4397,7 @@ declare namespace Stripe {
             /**
              * Cardholder name
              */
-            name: string;
+            name: string | null;
 
             /**
              * Uniquely identifies this particular card number. You can use this attribute to check


### PR DESCRIPTION
This change will cause compilation errors in user's code if strict null checks are enabled.

See example response in https://stripe.com/docs/api#retrieve_card

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://stripe.com/docs/api#retrieve_card
- [ ] Increase the version number in the header if appropriate.