### PR TITLE
[redux-form/v4] Fix build by adding package.json

### DIFF
--- a/types/redux-form/v4/package.json
+++ b/types/redux-form/v4/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "redux": "^3.6.0"
+    }
+}


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

In #27207 following errors have been reported:
```
redux-form/v4 failing:
Error: /home/travis/build/DefinitelyTyped/DefinitelyTyped/types/redux-form/v4/index.d.ts:467:17
ERROR: 467:17  use-default-type-parameter  This is the default value for this type parameter, so it can be omitted.
ERROR: 476:52  use-default-type-parameter  This is the default value for this type parameter, so it can be omitted.
ERROR: 476:69  use-default-type-parameter  This is the default value for this type parameter, so it can be omitted.
```

I'm quite sure that this was introduced via #26977. I expect there is no need for old redux-form typings to be adapted to latest redux package therefore I added a package.json link in redux-form/v6.

