### PR TITLE
Elasticsearch - Add ignoreUnavailable param to delete indices

### DIFF
--- a/types/elasticsearch/elasticsearch-tests.ts
+++ b/types/elasticsearch/elasticsearch-tests.ts
@@ -44,6 +44,13 @@ client.indices.delete({
 }, (error) => {
 });
 
+client.indices.delete({
+  index: 'test_index',
+  ignoreUnavailable: true
+}).then((body) => {
+}, (error) => {
+});
+
 client.deleteByQuery({
   index: 'test_index',
   type: 'test_type',

--- a/types/elasticsearch/index.d.ts
+++ b/types/elasticsearch/index.d.ts
@@ -1143,6 +1143,7 @@ export interface IndicesDeleteParams extends GenericParams {
     timeout?: TimeSpan;
     masterTimeout?: TimeSpan;
     index: NameList;
+    ignoreUnavailable?: boolean;
 }
 
 export interface IndicesDeleteAliasParams extends GenericParams {


### PR DESCRIPTION
Adding the optional parameter **ignoreUnavailable** to allow trying to remove an index even if it does not exists.

Url with the **Elasticsearch documentation** https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/current/api-reference.html#api-indices-delete