### PR TITLE
Lodash: `pickBy`: add overload for user defined type guards

### DIFF
--- a/types/lodash/common/object.d.ts
+++ b/types/lodash/common/object.d.ts
@@ -3145,6 +3145,14 @@ declare module "../index" {
         /**
          * @see _.pickBy
          */
+        pickBy<T extends object, S extends T[keyof T]>(
+            this: LoDashImplicitWrapper<T | null | undefined>,
+            predicate: ObjectIteratorTypeGuard<T, S>
+        ): LoDashImplicitWrapper<Dictionary<S>>;
+
+        /**
+         * @see _.pickBy
+         */
         pickBy<T>(
             this: LoDashImplicitWrapper<Dictionary<T> | null | undefined>,
             predicate?: ValueKeyIteratee<T>
@@ -3168,6 +3176,14 @@ declare module "../index" {
     }
 
     interface LoDashExplicitWrapper<TValue> {
+        /**
+         * @see _.pickBy
+         */
+        pickBy<T extends object, S extends T[keyof T]>(
+            this: LoDashExplicitWrapper<T | null | undefined>,
+            predicate: ObjectIteratorTypeGuard<T, S>
+        ): LoDashExplicitWrapper<Dictionary<S>>;
+
         /**
          * @see _.pickBy
          */

--- a/types/lodash/common/object.d.ts
+++ b/types/lodash/common/object.d.ts
@@ -3111,6 +3111,14 @@ declare module "../index" {
          * _.pickBy(object, _.isNumber);
          * // => { 'a': 1, 'c': 3 }
          */
+        pickBy<T extends object, S extends T[keyof T]>(
+            object: T | null | undefined,
+            predicate: ObjectIteratorTypeGuard<T, S>
+        ): Dictionary<S>;
+
+        /**
+         * @see _.pickBy
+         */
         pickBy<T>(
             object: Dictionary<T> | null | undefined,
             predicate?: ValueKeyIteratee<T>

--- a/types/lodash/fp.d.ts
+++ b/types/lodash/fp.d.ts
@@ -2882,22 +2882,28 @@ declare namespace _ {
     type LodashPick2x1 = <T>(object: T | null | undefined) => lodash.PartialDeep<T>;
     type LodashPick2x2<T> = (props: lodash.PropertyPath) => lodash.PartialDeep<T>;
     interface LodashPickBy {
-        <T>(predicate: lodash.ValueKeyIteratee<T>): LodashPickBy1x1<T>;
-        <T>(predicate: lodash.__, object: lodash.Dictionary<T> | null | undefined): LodashPickBy1x2<T>;
+        <T extends object, S extends T[keyof T]>(predicate: lodash.ValueIteratorTypeGuard<T[keyof T], S>): LodashPickBy1x1<T, S>;
+        <T extends object>(predicate: lodash.__, object: T | null | undefined): LodashPickBy1x2<T>;
+        <T extends object, S extends T[keyof T]>(predicate: lodash.ValueIteratorTypeGuard<T[keyof T], S>, object: T | null | undefined): lodash.Dictionary<S>;
+        <T>(predicate: lodash.ValueKeyIteratee<T>): LodashPickBy2x1<T>;
+        <T>(predicate: lodash.__, object: lodash.Dictionary<T> | null | undefined): LodashPickBy2x2<T>;
         <T>(predicate: lodash.ValueKeyIteratee<T>, object: lodash.Dictionary<T> | null | undefined): lodash.Dictionary<T>;
-        <T>(predicate: lodash.__, object: lodash.NumericDictionary<T> | null | undefined): LodashPickBy2x2<T>;
+        <T>(predicate: lodash.__, object: lodash.NumericDictionary<T> | null | undefined): LodashPickBy3x2<T>;
         <T>(predicate: lodash.ValueKeyIteratee<T>, object: lodash.NumericDictionary<T> | null | undefined): lodash.NumericDictionary<T>;
-        <T extends object>(predicate: lodash.__, object: T | null | undefined): LodashPickBy3x2<T>;
         <T extends object>(predicate: lodash.ValueKeyIteratee<T[keyof T]>, object: T | null | undefined): lodash.PartialObject<T>;
     }
-    interface LodashPickBy1x1<T> {
+    type LodashPickBy1x1<T, S> = (object: T | null | undefined) => lodash.Dictionary<S>;
+    interface LodashPickBy1x2<T> {
+        <S extends T[keyof T]>(predicate: lodash.ValueIteratorTypeGuard<T[keyof T], S>): lodash.Dictionary<S>;
+        (predicate: lodash.ValueKeyIteratee<T[keyof T]>): lodash.PartialObject<T>;
+    }
+    interface LodashPickBy2x1<T> {
         (object: lodash.Dictionary<T> | null | undefined): lodash.Dictionary<T>;
         (object: lodash.NumericDictionary<T> | null | undefined): lodash.NumericDictionary<T>;
         <T1 extends object>(object: T1 | null | undefined): lodash.PartialObject<T1>;
     }
-    type LodashPickBy1x2<T> = (predicate: lodash.ValueKeyIteratee<T>) => lodash.Dictionary<T>;
-    type LodashPickBy2x2<T> = (predicate: lodash.ValueKeyIteratee<T>) => lodash.NumericDictionary<T>;
-    type LodashPickBy3x2<T> = (predicate: lodash.ValueKeyIteratee<T[keyof T]>) => lodash.PartialObject<T>;
+    type LodashPickBy2x2<T> = (predicate: lodash.ValueKeyIteratee<T>) => lodash.Dictionary<T>;
+    type LodashPickBy3x2<T> = (predicate: lodash.ValueKeyIteratee<T>) => lodash.NumericDictionary<T>;
     interface LodashProp {
         <TObject extends object, TKey extends keyof TObject>(path: TKey | [TKey]): LodashProp1x1<TObject, TKey>;
         <TObject extends object>(path: lodash.__, object: TObject): LodashProp1x2<TObject>;

--- a/types/lodash/lodash-tests.ts
+++ b/types/lodash/lodash-tests.ts
@@ -5648,6 +5648,8 @@ fp.now(); // $ExpectType number
     const mixedDictionary: _.Dictionary<string | number> | null | undefined = anything;
 
     _.pickBy(mixedDictionary, (item: string | number): item is number => typeof item === "number"); // $ExpectType Dictionary<number>
+    _(mixedDictionary).pickBy((item: string | number): item is number => typeof item === "number"); // $ExpectType LoDashImplicitWrapper<Dictionary<number>>
+    _.chain(mixedDictionary).pickBy((item: string | number): item is number => typeof item === "number"); // $ExpectType LoDashExplicitWrapper<Dictionary<number>>
 }
 
 // _.result

--- a/types/lodash/lodash-tests.ts
+++ b/types/lodash/lodash-tests.ts
@@ -5644,6 +5644,10 @@ fp.now(); // $ExpectType number
     fp.pickBy(predicate, obj); // $ExpectType Partial<AbcObject>
     fp.pickBy(predicate2)(dictionary); // $ExpectType Dictionary<boolean>
     fp.pickBy(predicate2)(numericDictionary); // $ExpectType NumericDictionary<boolean>
+
+    const mixedDictionary: _.Dictionary<string | number> | null | undefined = anything;
+
+    _.pickBy(mixedDictionary, (item: string | number): item is number => typeof item === "number"); // $ExpectType Dictionary<number>
 }
 
 // _.result

--- a/types/lowdb/_lodash.d.ts
+++ b/types/lowdb/_lodash.d.ts
@@ -1293,6 +1293,10 @@ declare module "./index" {
             this: LoDashExplicitSyncWrapper<T | null | undefined>,
             ...props: _.PropertyPath[]
         ): LoDashExplicitSyncWrapper<_.PartialObject<T>>;
+        pickBy<T extends object, S extends T[keyof T]>(
+            this: LoDashExplicitSyncWrapper<T | null | undefined>,
+            predicate: _.ObjectIteratorTypeGuard<T, S>
+        ): LoDashExplicitSyncWrapper<_.Dictionary<S>>;
         pickBy<T>(
             this: LoDashExplicitSyncWrapper<_.Dictionary<T> | null | undefined>,
             predicate?: _.ValueKeyIteratee<T>
@@ -2877,6 +2881,10 @@ declare module "./index" {
             this: LoDashExplicitAsyncWrapper<T | null | undefined>,
             ...props: _.PropertyPath[]
         ): LoDashExplicitAsyncWrapper<_.PartialObject<T>>;
+        pickBy<T extends object, S extends T[keyof T]>(
+            this: LoDashExplicitAsyncWrapper<T | null | undefined>,
+            predicate: _.ObjectIteratorTypeGuard<T, S>
+        ): LoDashExplicitAsyncWrapper<_.Dictionary<S>>;
         pickBy<T>(
             this: LoDashExplicitAsyncWrapper<_.Dictionary<T> | null | undefined>,
             predicate?: _.ValueKeyIteratee<T>


### PR DESCRIPTION
Similar to the overloads we have for `filter`: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/d360bc9e009c58230bcf327c53410f9d550b3273/types/lodash/lodash-tests.ts#L1776

If this looks good, I will go ahead and complete the tests for the other Lodash variants.

For some reason, when trying to lint locally with these changes, I get a memory allocation error. However, I can see the correct type being returned by `pickBy` in my IDE.

/cc @aj-r 

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.