### PR TITLE
[react-tracking] The callback variant also passes arguments.

### DIFF
--- a/types/react-tracking/index.d.ts
+++ b/types/react-tracking/index.d.ts
@@ -50,7 +50,7 @@ interface Options<T> {
     process?(ownTrackingData: T): T | Falsy;
 }
 
-export type TrackingInfo<T, P, S> = T | ((props: P, state: S) => T);
+export type TrackingInfo<T, P, S> = T | ((props: P, state: S, args: any[any]) => T);
 
 // Duplicated from ES6 lib to remove the `void` typing, otherwise `track` can’t be used as a HOC function that passes
 // through a JSX component that be used without casting.

--- a/types/react-tracking/test/react-tracking-with-types-tests.tsx
+++ b/types/react-tracking/test/react-tracking-with-types-tests.tsx
@@ -30,10 +30,15 @@ class ClassPage extends React.Component<Props, State> {
     // ... other stuff
     }
 
+    @track((_props, _state, [e]: [React.MouseEvent]) => ({ event: `drag started at ${e.screenX}x${e.screenY}` }))
+    handleDrag(event: React.MouseEvent) {
+        // no-op
+    }
+
     @track((props, state) => ({ event: `got ${props.someProp} and clicked ${state.isClicked}` }))
     render() {
         return (
-            <button onClick={this.handleClick}>
+            <button onClick={this.handleClick} onDrag={this.handleDrag}>
                 Click Me!
             </button>
         );

--- a/types/react-tracking/test/react-tracking-without-types-tests.tsx
+++ b/types/react-tracking/test/react-tracking-without-types-tests.tsx
@@ -14,6 +14,11 @@ class ClassPage extends React.Component<any> {
     // ... other stuff
     }
 
+    @track((_props, _state, [e]) => ({ event: `drag started at ${e.screenX}x${e.screenY}` }))
+    handleDrag(event: any) {
+        // no-op
+    }
+
     // Only need to cast this to `any` because the settings for this project is to disallow implicit `any`.
     @track((props: any, state: any) => ({ event: `got ${props.someProp} and clicked ${state.isClicked}` }))
     render() {


### PR DESCRIPTION
As per the docs, we can also access the arguments passed to the decorated method: https://github.com/NYTimes/react-tracking#advanced-usage