### PR TITLE
Lodash: `negate`: fix for user defined type guard

### DIFF
--- a/types/lodash/common/function.d.ts
+++ b/types/lodash/common/function.d.ts
@@ -843,6 +843,7 @@ declare module "../index" {
         negate(predicate: () => boolean): () => boolean;
         negate<A1>(predicate: (a1: A1) => boolean): (a1: A1) => boolean;
         negate<A1, A2>(predicate: (a1: A1, a2: A2) => boolean): (a1: A1, a2: A2) => boolean;
+        negate(predicate: (...args: any[]) => any): (...args: any[]) => boolean;
     }
 
     interface LoDashWrapper<TValue> {

--- a/types/lodash/common/function.d.ts
+++ b/types/lodash/common/function.d.ts
@@ -840,7 +840,8 @@ declare module "../index" {
          * @param predicate The predicate to negate.
          * @return Returns the new function.
          */
-        negate<T extends (...args: any[]) => any>(predicate: T): T;
+        negate<A1>(predicate: (a1: A1) => boolean): (a1: A1) => boolean;
+        negate<A1, A2>(predicate: (a1: A1, a2: A2) => boolean): (a1: A1, a2: A2) => boolean;
     }
 
     interface LoDashWrapper<TValue> {

--- a/types/lodash/common/function.d.ts
+++ b/types/lodash/common/function.d.ts
@@ -846,11 +846,24 @@ declare module "../index" {
         negate(predicate: (...args: any[]) => any): (...args: any[]) => boolean;
     }
 
-    interface LoDashWrapper<TValue> {
+    interface LoDashImplicitWrapper<TValue> {
         /**
          * @see _.negate
          */
-        negate(): this;
+        negate(this: LoDashImplicitWrapper<() => boolean>): LoDashImplicitWrapper<() => boolean>;
+        negate<A1>(this: LoDashImplicitWrapper<(a1: A1) => boolean>): LoDashImplicitWrapper<(a1: A1) => boolean>;
+        negate<A1, A2>(this: LoDashImplicitWrapper<(a1: A1, a2: A2) => boolean>): LoDashImplicitWrapper<(a1: A1, a2: A2) => boolean>;
+        negate(this: LoDashImplicitWrapper<(...args: any[]) => any>): LoDashImplicitWrapper<(...args: any[]) => boolean>;
+    }
+
+    interface LoDashExplicitWrapper<TValue> {
+        /**
+         * @see _.negate
+         */
+        negate(this: LoDashExplicitWrapper<() => boolean>): LoDashExplicitWrapper<() => boolean>;
+        negate<A1>(this: LoDashExplicitWrapper<(a1: A1) => boolean>): LoDashExplicitWrapper<(a1: A1) => boolean>;
+        negate<A1, A2>(this: LoDashExplicitWrapper<(a1: A1, a2: A2) => boolean>): LoDashExplicitWrapper<(a1: A1, a2: A2) => boolean>;
+        negate(this: LoDashExplicitWrapper<(...args: any[]) => any>): LoDashExplicitWrapper<(...args: any[]) => boolean>;
     }
 
     // once

--- a/types/lodash/common/function.d.ts
+++ b/types/lodash/common/function.d.ts
@@ -840,6 +840,7 @@ declare module "../index" {
          * @param predicate The predicate to negate.
          * @return Returns the new function.
          */
+        negate(predicate: () => boolean): () => boolean;
         negate<A1>(predicate: (a1: A1) => boolean): (a1: A1) => boolean;
         negate<A1, A2>(predicate: (a1: A1, a2: A2) => boolean): (a1: A1, a2: A2) => boolean;
     }

--- a/types/lodash/fp.d.ts
+++ b/types/lodash/fp.d.ts
@@ -300,7 +300,12 @@ declare namespace _ {
     }
     type LodashCloneWith2x1<T, TResult> = (value: T) => TResult | T;
     type LodashCompact = <T>(array: lodash.List<T | null | undefined | false | "" | 0> | null | undefined) => T[];
-    type LodashNegate = <T extends (...args: any[]) => any>(predicate: T) => T;
+    interface LodashNegate {
+        (predicate: () => boolean): () => boolean;
+        <A1>(predicate: (a1: A1) => boolean): (a1: A1) => boolean;
+        <A1, A2>(predicate: (a1: A1, a2: A2) => boolean): (a1: A1, a2: A2) => boolean;
+        (predicate: (...args: any[]) => any): (...args: any[]) => boolean;
+    }
     interface LodashFlowRight {
         <R2, R1>(f2: (a: R1) => R2, f1: () => R1): () => R2;
         <R3, R2, R1>(f3: (a: R2) => R3, f2: (a: R1) => R2, f1: () => R1): () => R3;

--- a/types/lodash/lodash-tests.ts
+++ b/types/lodash/lodash-tests.ts
@@ -3516,6 +3516,10 @@ fp.now(); // $ExpectType number
     _((a1: number, a2: number): boolean => true).negate(); // $ExpectType LoDashImplicitWrapper<(a1: number, a2: number) => boolean>
     _.chain((a1: number, a2: number): boolean => true).negate(); // $ExpectType LoDashExplicitWrapper<(a1: number, a2: number) => boolean>
     fp.negate((a1: number, a2: number): boolean => true); // $ExpectType (a1: number, a2: number) => boolean
+
+    const userDefinedTypeGuard = (item: any): item is number => typeof item === "number";
+
+    _.negate(userDefinedTypeGuard); // $ExpectType (a1: any) => boolean
 }
 
 // _.once

--- a/types/lodash/lodash-tests.ts
+++ b/types/lodash/lodash-tests.ts
@@ -3520,8 +3520,14 @@ fp.now(); // $ExpectType number
     const userDefinedTypeGuard = (item: any): item is number => typeof item === "number";
 
     _.negate(userDefinedTypeGuard); // $ExpectType (a1: any) => boolean
+    _(userDefinedTypeGuard).negate(); // $ExpectType LoDashImplicitWrapper<(a1: any) => boolean>
+    _.chain(userDefinedTypeGuard).negate(); // $ExpectType LoDashExplicitWrapper<(a1: any) => boolean>
+    fp.negate(userDefinedTypeGuard); // $ExpectType (a1: any) => boolean
 
     _.negate((a1: number, a2: number, a3: number): boolean => true); // $ExpectType (...args: any[]) => boolean
+    _((a1: number, a2: number, a3: number): boolean => true).negate(); // $ExpectType LoDashImplicitWrapper<(...args: any[]) => boolean>
+    _.chain((a1: number, a2: number, a3: number): boolean => true).negate(); // $ExpectType LoDashExplicitWrapper<(...args: any[]) => boolean>
+    fp.negate((a1: number, a2: number, a3: number): boolean => true); // $ExpectType (...args: any[]) => boolean
 }
 
 // _.once

--- a/types/lodash/lodash-tests.ts
+++ b/types/lodash/lodash-tests.ts
@@ -3520,6 +3520,8 @@ fp.now(); // $ExpectType number
     const userDefinedTypeGuard = (item: any): item is number => typeof item === "number";
 
     _.negate(userDefinedTypeGuard); // $ExpectType (a1: any) => boolean
+
+    _.negate((a1: number, a2: number, a3: number): boolean => true); // $ExpectType (...args: any[]) => boolean
 }
 
 // _.once

--- a/types/lowdb/_lodash.d.ts
+++ b/types/lowdb/_lodash.d.ts
@@ -805,6 +805,10 @@ declare module "./index" {
             ...args: any[]
         ): LoDashExplicitSyncWrapper<number>;
         memoize(resolver?: (...args: any[]) => any): LoDashExplicitSyncWrapper<TValue & _.MemoizedFunction>;
+        negate(this: LoDashExplicitSyncWrapper<() => boolean>): LoDashExplicitSyncWrapper<() => boolean>;
+        negate<A1>(this: LoDashExplicitSyncWrapper<(a1: A1) => boolean>): LoDashExplicitSyncWrapper<(a1: A1) => boolean>;
+        negate<A1, A2>(this: LoDashExplicitSyncWrapper<(a1: A1, a2: A2) => boolean>): LoDashExplicitSyncWrapper<(a1: A1, a2: A2) => boolean>;
+        negate(this: LoDashExplicitSyncWrapper<(...args: any[]) => any>): LoDashExplicitSyncWrapper<(...args: any[]) => boolean>;
         overArgs(...transforms: Array<_.Many<(...args: any[]) => any>>): LoDashExplicitSyncWrapper<(...args: any[]) => any>;
         partial: _.ExplicitPartial;
         partialRight: _.ExplicitPartialRight;
@@ -2389,6 +2393,10 @@ declare module "./index" {
             ...args: any[]
         ): LoDashExplicitAsyncWrapper<number>;
         memoize(resolver?: (...args: any[]) => any): LoDashExplicitAsyncWrapper<TValue & _.MemoizedFunction>;
+        negate(this: LoDashExplicitAsyncWrapper<() => boolean>): LoDashExplicitAsyncWrapper<() => boolean>;
+        negate<A1>(this: LoDashExplicitAsyncWrapper<(a1: A1) => boolean>): LoDashExplicitAsyncWrapper<(a1: A1) => boolean>;
+        negate<A1, A2>(this: LoDashExplicitAsyncWrapper<(a1: A1, a2: A2) => boolean>): LoDashExplicitAsyncWrapper<(a1: A1, a2: A2) => boolean>;
+        negate(this: LoDashExplicitAsyncWrapper<(...args: any[]) => any>): LoDashExplicitAsyncWrapper<(...args: any[]) => boolean>;
         overArgs(...transforms: Array<_.Many<(...args: any[]) => any>>): LoDashExplicitAsyncWrapper<(...args: any[]) => any>;
         partial: _.ExplicitPartial;
         partialRight: _.ExplicitPartialRight;


### PR DESCRIPTION
Currently, if `negate` is given a predicate that returns a user defined type guard, `negate`'s return function will continue to reflect this. However, by negating the predicate, the type guard no longer stands.

Ideally the type guard would be inverted, but I'm not sure this is possible in TypeScript.

In the absence of that, we can just strip the type guard.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.