### PR TITLE
[react-navigation] Adding support for parameters in NavigationInjectedProps

### DIFF
--- a/types/react-navigation/index.d.ts
+++ b/types/react-navigation/index.d.ts
@@ -1160,8 +1160,8 @@ export const HeaderBackButton: React.ComponentClass<HeaderBackButtonProps>;
  */
 export const Header: React.ComponentClass<HeaderProps>;
 
-export interface NavigationInjectedProps {
-  navigation: NavigationScreenProp<NavigationState>;
+export interface NavigationInjectedProps<P = NavigationParams> {
+  navigation: NavigationScreenProp<NavigationState, P>;
 }
 
 export function withNavigation<T = {}>(

--- a/types/react-navigation/react-navigation-tests.tsx
+++ b/types/react-navigation/react-navigation-tests.tsx
@@ -553,7 +553,7 @@ const MyFocusedComponentInstance = <MyFocusedComponentWithNavigationFocus
 
 // Test Screen with params
 
-interface MyScreenParams { unknown: string; }
+interface MyScreenParams { title: string; }
 class MyScreen extends React.Component<NavigationInjectedProps<MyScreenParams>> {
     render() {
         const title = this.props.navigation.getParam('title');

--- a/types/react-navigation/react-navigation-tests.tsx
+++ b/types/react-navigation/react-navigation-tests.tsx
@@ -550,3 +550,13 @@ const MyFocusedComponentWithNavigationFocus = withNavigationFocus<MyFocusedCompo
 const MyFocusedComponentInstance = <MyFocusedComponentWithNavigationFocus
     expectsFocus={true} onRef={ref => { const backButtonRef = ref; }}
 />;
+
+// Test Screen with params
+
+interface MyScreenParams { unknown: string; }
+class MyScreen extends React.Component<NavigationInjectedProps<MyScreenParams>> {
+    render() {
+        const title = this.props.navigation.getParam('title');
+        return <button title={title} onClick={() => { this.props.navigation.goBack(); }} />;
+    }
+}


### PR DESCRIPTION
`NavigationScreenProp` has optional support for parameter typing. This PR exposes the generic type to `NavigationInjectedProps`.

Source code reference: https://github.com/react-navigation/react-navigation/blob/master/src/views/withNavigationFocus.js

Test Plan:
- I exposed the generic parameter and made it optional.
- I added a failing test in fb0ff0923ac8389631aa7cd4d63c2a5e02a3888c and saw it throw a reasonable error
- I fixed the parameter type and saw the test passing again.

There are also other tests present already that assure that everything still works as expected when the parameter type is not passed.