### PR TITLE
Lodash: `fp.mapValues`: fix inference with contextual type

### DIFF
--- a/types/lodash/lodash-tests.ts
+++ b/types/lodash/lodash-tests.ts
@@ -2796,6 +2796,12 @@ _.chain([1, 2, 3, 4]).unshift(5, 6); // $ExpectType LoDashExplicitWrapper<number
     fp.map("a", list); // $ExpectType number[]
     fp.map({ a: 42 }, list); // $ExpectType boolean[]
     fp.map(["a", 42], dictionary); // $ExpectType boolean[]
+
+    // Expect type of param x to be inferred as number from contextual type
+    const foo: (obj: number[]) => number[] = fp.map(
+        // $ExpectType (x: number) => number
+        x => x
+    );
 }
 
 // _.partition

--- a/types/lodash/lodash-tests.ts
+++ b/types/lodash/lodash-tests.ts
@@ -5536,6 +5536,12 @@ fp.now(); // $ExpectType number
     fp.mapValues(valueIterator)(numericDictionary); // $ExpectType Dictionary<boolean>
     fp.mapValues({ a: 42 })(numericDictionary); // $ExpectType Dictionary<boolean>
     fp.mapValues(value => "", abcObjectOrNull); // $ExpectType { a: string; b: string; c: string; }
+
+    // Expect type of param x to be inferred as number from contextual type
+    const foo: (obj: _.Dictionary<number>) => _.Dictionary<number> = fp.mapValues(
+        // $ExpectType (x: number) => number
+        x => x
+    );
 }
 
 // _.omit


### PR DESCRIPTION
I have added two tests, one for `fp.map` and one for `fp.mapValues`. The former passes, but the latter fails. I expect both to pass—`fp.mapValues` should work like `fp.map`.

How should I fix the overloads for `mapValues` so that its test will pass?

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.