### PR TITLE
[react-copy-write] Fix custom readonly type breaking with arrays of objects

### DIFF
--- a/types/react-copy-write/index.d.ts
+++ b/types/react-copy-write/index.d.ts
@@ -7,21 +7,17 @@
 
 import { Component } from 'react';
 
-type DeepReadonly<T> = {
-    readonly [P in keyof T]: DeepReadonly<T[P]>;
-};
-
 // It'd be nice if this could somehow be improved! Perhaps we need variadic
 // kinds plus infer keyword? Alternatively unions may solve our issue if we had
 // the ability to restrict type widening.
 type AnyDeepMemberOfState<T> = any;
 
-type MutateFn<T> = (draft: T, state: DeepReadonly<T>) => void;
+type MutateFn<T> = (draft: T, state: Readonly<T>) => void;
 type Mutator<T> = (mutator: MutateFn<T>) => void;
 
 type SelectorFn<T> = (state: T) => AnyDeepMemberOfState<T>;
 
-type RenderFn<T> = (...state: Array<DeepReadonly<ReturnType<SelectorFn<T>>>>) => JSX.Element | JSX.Element[] | null;
+type RenderFn<T> = (...state: Array<Readonly<ReturnType<SelectorFn<T>>>>) => JSX.Element | JSX.Element[] | null;
 
 interface ConsumerPropsBase<T> {
     select?: Array<SelectorFn<T>>;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/aweary/react-copy-write/issues/21#issuecomment-404599753 (and preceding comments)

I haven't incremented the version as this is a fix to the typings rather than an update for the library API; is this correct?
