### PR TITLE
Numjs -- Slice can take a number array as an argument for 2D arrays

### DIFF
--- a/types/numjs/index.d.ts
+++ b/types/numjs/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for numjs 0.14
 // Project: https://github.com/nicolaspanel/numjs#readme
 // Definitions by: taoqf <https://github.com/taoqf>
+//                 matt <https://github.com/mattmm3d>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -12,7 +13,7 @@ export type NdType<T> = BaseNdArray.DataType | BaseNdArray.Data<T>;
 export interface NdArray<T = number> extends BaseNdArray<T> {
 	ndim: number;
 	T: NdArray<T>;
-	slice(...args: number[]): NdArray<T>;
+	slice(...args: Array<number|number[]>): NdArray<T>;
 
 	/**
 	 * Return a copy of the array collapsed into one dimension using row-major order (C-style)


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.npmjs.com/package/numjs#slicing-and-striding
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
