### PR TITLE
Renaming react-select openAfterFocus prop to openOnClick

### DIFF
--- a/types/react-select/index.d.ts
+++ b/types/react-select/index.d.ts
@@ -459,10 +459,10 @@ export interface ReactSelectProps<TValue = OptionValues> extends React.Props<Rea
      * boolean to enable opening dropdown when focused
      * @default false
      */
-    openAfterFocus?: boolean;
+    openOnClick?: boolean;
     /**
      * open the options menu when the input gets focus (requires searchable = true)
-     * @default false
+     * @default true
      */
     openOnFocus?: boolean;
     /**


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: 
You can see the openOnClick property in the current README - https://github.com/JedWatson/react-select. You'll also notice the openAfterFocus property no longer exists. Past release notes mention the change here - https://github.com/JedWatson/react-select/blob/master/HISTORY.md#v100-rc10--2017-09-13
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
