### PR TITLE
fuzzaldrin-plus@0.6.0: Update definitions

### DIFF
--- a/types/fuzzaldrin-plus/fuzzaldrin-plus-tests.ts
+++ b/types/fuzzaldrin-plus/fuzzaldrin-plus-tests.ts
@@ -12,8 +12,8 @@ const candidates = [
     'Install'
 ]
 const objectCandidates = candidates.map(s => ({ foo: s }))
-const options: fz.IFuzzaldrinPlusOptions = { allowErrors: true }
-const filterOptions: fz.IFuzzaldrinPlusFilterOptions = {
+const options: fz.IOptions = { allowErrors: true }
+const filterOptions: fz.IFilterOptions = {
     allowErrors: true,
     key: 'foo'
 }
@@ -170,9 +170,7 @@ fz.wrap(items, 'me')
 fz.prepareQuery()
 
 // $ExpectError
-const incorrectOptions: fz.IFuzzaldrinPlusFilterOptions = {
-    allowErrors: 'not a boolean'
-}
+const incorrectOptions: fz.IFilterOptions = { allowErrors: 'not a boolean' }
 
 // $ExpectError
 fz.filter(candidates, 'install', { allowErrors: 'not a boolean' })

--- a/types/fuzzaldrin-plus/fuzzaldrin-plus-tests.ts
+++ b/types/fuzzaldrin-plus/fuzzaldrin-plus-tests.ts
@@ -1,4 +1,8 @@
-import * as fz from "fuzzaldrin-plus";
+import * as fz from 'fuzzaldrin-plus'
+
+//
+// Simple use cases
+// ----------------------------------------------------------------------
 
 const candidates = [
     'Find And Replace: Select All',
@@ -7,14 +11,203 @@ const candidates = [
     'Application: Install Update',
     'Install'
 ]
-const objectCandidates = candidates.map(s => ({ foo: s }));
+const objectCandidates = candidates.map(s => ({ foo: s }))
+const options: fz.IFuzzaldrinPlusOptions = { allowErrors: true }
+const filterOptions: fz.IFuzzaldrinPlusFilterOptions = {
+    allowErrors: true,
+    key: 'foo'
+}
 
-fz.filter(candidates, 'install');
-fz.filter(objectCandidates, 'install', { key: 'foo' });
+fz.filter(candidates, 'install')
+fz.filter(candidates, 'install', options)
+fz.filter(candidates, 'install', filterOptions)
+fz.filter(objectCandidates, 'install', { key: 'foo' })
 
-const prepQuery = fz.prepQuery('install');
-fz.score('Application: Install Update', 'install');
-fz.score('Application: Install Update', 'install', prepQuery);
+const preparedQuery: fz.Query = fz.prepareQuery('install')
 
-fz.match('Application: Install Update', 'install');
-fz.match('Application: Install Update', 'install', prepQuery);
+fz.score('Maybe', 'me')
+fz.score('Maybe', 'me', undefined)
+fz.score('Maybe', 'me', null)
+fz.score('Maybe', 'me', {})
+fz.score('Maybe', 'me', { allowErrors: true })
+fz.score('Application: Install Update', 'install')
+fz.score('Application: Install Update', 'install', { preparedQuery })
+
+fz.match('Maybe', 'me')
+fz.match('Application: Install Update', 'install')
+fz.match('Application: Install Update', 'install', { preparedQuery })
+
+fz.wrap('Maybe', 'me')
+
+//
+// Complex filter cases, using all the options
+// ----------------------------------------------------------------------
+
+fz.filter(['Maybe', 'Me'], 'me')
+fz.filter(['Maybe', 'Me'], 'me', undefined)
+fz.filter(['Maybe', 'Me'], 'me', null)
+fz.filter(['Maybe', 'Me'], 'me', {})
+fz.filter(['Maybe', 'Me'], 'me', { allowErrors: true })
+fz.filter(['Maybe', 'Me'], 'me', { key: 'key' })
+fz.filter(['Maybe', 'Me'], 'me', {
+    preparedQuery: fz.prepareQuery('me')
+})
+fz.filter(['Maybe', 'Me'], 'me', {
+    allowErrors: true,
+    usePathScoring: true
+})
+fz.filter(['Maybe', 'Me'], 'me', {
+    allowErrors: true,
+    usePathScoring: true,
+    useExtensionBonus: true
+})
+fz.filter(['Maybe', 'Me'], 'me', {
+    allowErrors: true,
+    usePathScoring: true,
+    useExtensionBonus: true,
+    pathSeparator: '/'
+})
+fz.filter(['Maybe', 'Me'], 'me', {
+    allowErrors: true,
+    usePathScoring: true,
+    useExtensionBonus: true,
+    pathSeparator: '\\',
+    optCharRegEx: new RegExp('')
+})
+fz.filter(['Maybe', 'Me'], 'me', {
+    allowErrors: true,
+    usePathScoring: true,
+    useExtensionBonus: true,
+    pathSeparator: '\\',
+    optCharRegEx: new RegExp(''),
+    wrap: {
+        tagOpen: '<span>',
+        tagClass: '',
+        tagClose: '</span>'
+    }
+})
+fz.filter(['Maybe', 'Me'], 'me', {
+    allowErrors: true,
+    usePathScoring: true,
+    useExtensionBonus: true,
+    pathSeparator: '\\',
+    optCharRegEx: new RegExp(''),
+    wrap: {
+        tagOpen: '<span>',
+        tagClass: '',
+        tagClose: '</span>'
+    },
+    maxResults: 10
+})
+fz.filter(['Maybe', 'Me'], 'me', {
+    allowErrors: true,
+    usePathScoring: true,
+    useExtensionBonus: true,
+    pathSeparator: '\\',
+    optCharRegEx: new RegExp(''),
+    wrap: {
+        tagOpen: '<span>',
+        tagClass: '',
+        tagClose: '</span>'
+    },
+    maxResults: 10,
+    maxInners: 10
+})
+fz.filter([{ title: 'Maybe' }, { title: 'Me' }], 'me', {
+    allowErrors: true,
+    usePathScoring: true,
+    useExtensionBonus: true,
+    pathSeparator: '\\',
+    optCharRegEx: new RegExp(''),
+    wrap: {
+        tagOpen: '<span>',
+        tagClass: '',
+        tagClose: '</span>'
+    },
+    maxResults: 10,
+    maxInners: 10,
+    key: 'title'
+})
+fz.filter([{ title: 'Maybe' }, { title: 'Me' }], 'me', {
+    allowErrors: true,
+    key: 'title'
+})
+fz.filter([{ title: 'Maybe' }, { title: 'Me' }], 'me', {
+    key: 'title'
+})
+
+/**
+ * ======================================================================
+ * Incorrect Usage:
+ * ======================================================================
+ */
+
+// $ExpectError
+fz.score()
+// $ExpectError
+fz.match()
+// $ExpectError
+fz.wrap()
+// $ExpectError
+fz.prepareQuery()
+// $ExpectError
+fz.score('Maybe', 'me', true)
+// $ExpectError
+fz.score('Maybe', 'me', 'string')
+// $ExpectError
+fz.score('Maybe', 'me', 1)
+
+const items = ['Maybe', 'Me']
+// $ExpectError
+fz.score(items, 'me')
+// $ExpectError
+fz.score('Maybe', 'me', { unknownProperty: true })
+// $ExpectError
+fz.match(items, 'me')
+// $ExpectError
+fz.wrap(items, 'me')
+// $ExpectError
+fz.prepareQuery()
+
+// $ExpectError
+const incorrectOptions: fz.IFuzzaldrinPlusFilterOptions = {
+    allowErrors: 'not a boolean'
+}
+
+// $ExpectError
+fz.filter(candidates, 'install', { allowErrors: 'not a boolean' })
+fz.filter([{ title: 'Maybe' }, { title: 'Me' }], 'me', {
+    // $ExpectError
+    incorrectProperty: true,
+    key: 'title'
+})
+
+// $ExpectError
+fz.score('Maybe', 'me', undefined, options)
+// $ExpectError
+fz.match('Maybe', 'me', undefined, options)
+
+// $ExpectError
+fz.filter()
+// $ExpectError
+fz.filter('not an array', 'query')
+// $ExpectError
+fz.filter(['Maybe', 'Me'], 'me', { allowErrors: 'not a boolean' })
+// $ExpectError
+fz.filter(['Maybe', 'Me'], 'me', { key: true })
+// $ExpectError
+fz.filter(['Maybe', 'Me'], 'me', { preparedQuery: {} })
+// $ExpectError
+fz.filter([{ title: 'Maybe' }, { title: 'Me' }], 'me', {
+    key: 1
+})
+// $ExpectError
+fz.filter([{ title: 'Maybe' }, { title: 'Me' }], 'me', {
+    allowErrors: 'not a boolean',
+    key: 1
+})
+// $ExpectError
+fz.filter([{ title: 'Maybe' }, { title: 'Me' }], 'me', {
+    allowErrors: 'not a boolean',
+    key: 'title'
+})

--- a/types/fuzzaldrin-plus/index.d.ts
+++ b/types/fuzzaldrin-plus/index.d.ts
@@ -4,6 +4,7 @@
 //                  Jason Killian <https://github.com/jkillian>
 //                  Ronald Rey <https://github.com/reyronald>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.4
 
 export as namespace fuzzaldrin
 
@@ -11,7 +12,7 @@ export class Query {
     $$__internal: Symbol
 }
 
-export interface IFuzzaldrinPlusOptions {
+export interface IOptions {
     allowErrors?: boolean
     usePathScoring?: boolean
     useExtensionBonus?: boolean
@@ -21,7 +22,7 @@ export interface IFuzzaldrinPlusOptions {
     preparedQuery?: Query
 }
 
-export type IFuzzaldrinPlusFilterOptions = IFuzzaldrinPlusOptions & {
+export type IFilterOptions = IOptions & {
     key?: string
     maxResults?: number
     maxInners?: number
@@ -30,24 +31,9 @@ export type IFuzzaldrinPlusFilterOptions = IFuzzaldrinPlusOptions & {
 export function filter<T>(
     data: T[],
     query: string,
-    options?: IFuzzaldrinPlusFilterOptions
+    options?: IFilterOptions
 ): T[]
-export function score(
-    str: string,
-    query: string,
-    options?: IFuzzaldrinPlusOptions
-): number
-export function match(
-    str: string,
-    query: string,
-    options?: IFuzzaldrinPlusOptions
-): number[]
-export function wrap(
-    str: string,
-    query: string,
-    options?: IFuzzaldrinPlusOptions
-): string
-export function prepareQuery(
-    query: string,
-    options?: IFuzzaldrinPlusOptions
-): Query
+export function score(str: string, query: string, options?: IOptions): number
+export function match(str: string, query: string, options?: IOptions): number[]
+export function wrap(str: string, query: string, options?: IOptions): string
+export function prepareQuery(query: string, options?: IOptions): Query

--- a/types/fuzzaldrin-plus/index.d.ts
+++ b/types/fuzzaldrin-plus/index.d.ts
@@ -1,29 +1,53 @@
-// Type definitions for fuzzaldrin-plus
+// Type definitions for fuzzaldrin-plus 0.6.0
 // Project: https://github.com/jeancroy/fuzzaldrin-plus/
-// Definitions by: Jean Christophe Roy <https://github.com/jeancroy>, Jason Killian <https://github.com/jkillian>
+// Definitions by:  Jean Christophe Roy <https://github.com/jeancroy>,
+//                  Jason Killian <https://github.com/jkillian>
+//                  Ronald Rey <https://github.com/reyronald>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-export as namespace fuzzaldrin;
+export as namespace fuzzaldrin
 
-export interface IQueryOptions {
-    pathSeparator?: string;
-    optCharRegEx?: RegExp;
+export class Query {
+    $$__internal: Symbol
 }
 
-export interface IScoringOptions extends IQueryOptions {
-    allowErrors?: boolean;
-    isPath?: boolean;
-    useExtensionBonus?: boolean;
+export interface IFuzzaldrinPlusOptions {
+    allowErrors?: boolean
+    usePathScoring?: boolean
+    useExtensionBonus?: boolean
+    pathSeparator?: '/' | '\\' | string
+    optCharRegEx?: RegExp
+    wrap?: { tagOpen?: string; tagClass?: string; tagClose?: string }
+    preparedQuery?: Query
 }
 
-export interface IFilterOptions extends IScoringOptions {
-    key?: string;
-    maxResults?: number;
+export type IFuzzaldrinPlusFilterOptions = IFuzzaldrinPlusOptions & {
+    key?: string
+    maxResults?: number
+    maxInners?: number
 }
 
-export type PreparedQuery = { __internalAPIBrand: string; };
-
-export function filter<T>(data: T[], query: string, options?: IFilterOptions): T[];
-export function score(str: string, query: string, preparedQuery?: PreparedQuery, options?: IScoringOptions): number;
-export function match(str: string, query: string, preparedQuery?: PreparedQuery, options?: IScoringOptions): number[];
-export function prepQuery(query: string, options?: IQueryOptions): PreparedQuery;
+export function filter<T>(
+    data: T[],
+    query: string,
+    options?: IFuzzaldrinPlusFilterOptions
+): T[]
+export function score(
+    str: string,
+    query: string,
+    options?: IFuzzaldrinPlusOptions
+): number
+export function match(
+    str: string,
+    query: string,
+    options?: IFuzzaldrinPlusOptions
+): number[]
+export function wrap(
+    str: string,
+    query: string,
+    options?: IFuzzaldrinPlusOptions
+): string
+export function prepareQuery(
+    query: string,
+    options?: IFuzzaldrinPlusOptions
+): Query


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.) ~I'm getting `Error: amqp-connection-manager depends on amqplib but has a lower required TypeScript version.`, haven't figured out why yet, will check later. UPDATE: It's because of #27238, should be fixed when either #27257 or #27244 gets merged.~
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/desktop/desktop/issues/5152
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

---

The existing type definitions are outdated. I noticed this recently while working on a feature using this package. Some additional context: https://github.com/desktop/desktop/issues/5152.

Also worked on the Flow definitions simultaneously, for reference: https://github.com/flow-typed/flow-typed/pull/2499

/cc @jeancroy, @jkillian, @iAmWillShepherd @shiftkey 
