### PR TITLE
[snapsvg] Make handler optional for un... methods

### DIFF
--- a/types/snapsvg/index.d.ts
+++ b/types/snapsvg/index.d.ts
@@ -203,16 +203,16 @@ declare namespace Snap {
         touchcancel(handler: (event: MouseEvent) => void, thisArg?: any): Snap.Element;
 
         unclick(handler?: (event: MouseEvent) => void): Snap.Element;
-        undblclick(handler: (event: MouseEvent) => void): Snap.Element;
-        unmousedown(handler: (event: MouseEvent) => void): Snap.Element;
-        unmousemove(handler: (event: MouseEvent) => void): Snap.Element;
-        unmouseout(handler: (event: MouseEvent) => void): Snap.Element;
-        unmouseover(handler: (event: MouseEvent) => void): Snap.Element;
-        unmouseup(handler: (event: MouseEvent) => void): Snap.Element;
-        untouchstart(handler: (event: MouseEvent) => void): Snap.Element;
-        untouchmove(handler: (event: MouseEvent) => void): Snap.Element;
-        untouchend(handler: (event: MouseEvent) => void): Snap.Element;
-        untouchcancel(handler: (event: MouseEvent) => void): Snap.Element;
+        undblclick(handler?: (event: MouseEvent) => void): Snap.Element;
+        unmousedown(handler?: (event: MouseEvent) => void): Snap.Element;
+        unmousemove(handler?: (event: MouseEvent) => void): Snap.Element;
+        unmouseout(handler?: (event: MouseEvent) => void): Snap.Element;
+        unmouseover(handler?: (event: MouseEvent) => void): Snap.Element;
+        unmouseup(handler?: (event: MouseEvent) => void): Snap.Element;
+        untouchstart(handler?: (event: MouseEvent) => void): Snap.Element;
+        untouchmove(handler?: (event: MouseEvent) => void): Snap.Element;
+        untouchend(handler?: (event: MouseEvent) => void): Snap.Element;
+        untouchcancel(handler?: (event: MouseEvent) => void): Snap.Element;
 
         hover(hoverInHandler: (event: MouseEvent) => void, hoverOutHandler: (event: MouseEvent) => void, thisArg?: any): Snap.Element;
         hover(hoverInHandler: (event: MouseEvent) => void, hoverOutHandler: (event: MouseEvent) => void, inThisArg?: any, outThisArg?: any): Snap.Element;


### PR DESCRIPTION
For `unclick` the handler argument was already marked as optional. As in snapsvg's [implementation of the `un...` methods](https://github.com/adobe-webplatform/Snap.svg/blob/master/src/mouse.js#L340) there is no difference in how the various events are handled, the handler should also be optional for the other event types. I tried this with `undblclick` in particular, and it works as expected (removes all `dblclick` events).

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/adobe-webplatform/Snap.svg/blob/master/src/mouse.js#L340
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.