### PR TITLE
[vis] Make node and edge interfaces inherit from their options

### DIFF
--- a/types/vis/index.d.ts
+++ b/types/vis/index.d.ts
@@ -9,6 +9,7 @@
 //                 Adam Lewis <https://github.com/supercargo>
 //                 Alex Soh <https://github.com/takato1314>
 //                 Oleksii Kachura <https://github.com/alex-kachura>
+//                 dcop <https://github.com/dcop>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 import { MomentInput, MomentFormatSpecification, Moment } from 'moment';
@@ -1685,19 +1686,11 @@ export interface Data {
   edges?: Edge[] | DataSet<Edge>;
 }
 
-export interface Node {
-  group?: string;
+export interface Node extends NodeOptions {
   id?: IdType;
-  label?: string;
-  x?: number;
-  y?: number;
-  fixed?: boolean;
-  image?: string | Image;
-  shape?: string;
-  color?: string | Color;
 }
 
-export interface Edge {
+export interface Edge extends EdgeOptions {
   from?: IdType;
   to?: IdType;
   id?: IdType;
@@ -1823,8 +1816,6 @@ export interface NodeOptions {
     color?: string,
   };
 
-  id?: string;
-
   image?: string | Image;
 
   label?: string;
@@ -1906,13 +1897,9 @@ export interface EdgeOptions {
     mono?: string | FontOptions,
   };
 
-  from?: number | string;
-
   hidden?: boolean;
 
   hoverWidth?: number; // please note, hoverWidth could be also a function. This case is not represented here
-
-  id?: string;
 
   label?: string;
 
@@ -1938,8 +1925,6 @@ export interface EdgeOptions {
   };
 
   title?: string;
-
-  to?: number | string;
 
   value?: number;
 


### PR DESCRIPTION
Node and Edge interfaces should inherit from NodeOptions and EdgeOptions. These Options are meant to be global, so properties such as "id", "from" and "to" should exist only on Node and Edge interfaces. Plus, in this way it's possible to use all properties defined on parent interface.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://visjs.org/docs/network/nodes.html and http://visjs.org/docs/network/edges.html
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.