### PR TITLE
@types/jest: Add inline snapshot matchers

### DIFF
--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Jest 23.1
+// Type definitions for Jest 23.3
 // Project: http://facebook.github.io/jest/
 // Definitions by: Asana <https://asana.com>
 //                 Ivo Stratev <https://github.com/NoHomey>
@@ -15,6 +15,7 @@
 //                 Jeff Lau <https://github.com/UselessPickles>
 //                 Andrew Makarov <https://github.com/r3nya>
 //                 Martin Hochel <https://github.com/hotell>
+//                 Sebastian Sebald <https://github.com/sebald>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -662,6 +663,18 @@ declare namespace jest {
          */
         toMatchSnapshot(snapshotName?: string): R;
         /**
+         * This ensures that a value matches the most recent snapshot with property matchers.
+         * Instead of writing the snapshot value to a .snap file, it will be written into the source code automatically.
+         * Check out [the Snapshot Testing guide](http://facebook.github.io/jest/docs/snapshot-testing.html) for more information.
+         */
+        toMatchInlineSnapshot<T extends {[P in keyof R]: Expect['any']}>(propertyMatchers: Partial<T>, snapshot?: string): R;
+        /**
+         * This ensures that a value matches the most recent snapshot with property matchers.
+         * Instead of writing the snapshot value to a .snap file, it will be written into the source code automatically.
+         * Check out [the Snapshot Testing guide](http://facebook.github.io/jest/docs/snapshot-testing.html) for more information.
+         */
+        toMatchInlineSnapshot(snapshot?: string): R;
+        /**
          * Ensure that a mock function has returned (as opposed to thrown) at least once.
          */
         toReturn(): R;
@@ -689,6 +702,11 @@ declare namespace jest {
          * Used to test that a function throws a error matching the most recent snapshot when it is called.
          */
         toThrowErrorMatchingSnapshot(): R;
+        /**
+         * Used to test that a function throws a error matching the most recent snapshot when it is called.
+         * Instead of writing the snapshot value to a .snap file, it will be written into the source code automatically.
+         */
+        toThrowErrorMatchingInlineSnapshot(snapshot?: string): R;
     }
 
     interface Constructable {

--- a/types/jest/jest-tests.ts
+++ b/types/jest/jest-tests.ts
@@ -617,6 +617,15 @@ describe("", () => {
             date: new Date(),
         }).toMatchSnapshot({ one: expect.any(Number), date: expect.any(Date) });
 
+        expect({}).toMatchInlineSnapshot();
+        expect({}).toMatchInlineSnapshot("snapshot");
+        expect({ abc: "def" }).toMatchInlineSnapshot({ abc: expect.any(String) }, "snapshot");
+        expect({
+            one: 1,
+            two: "2",
+            date: new Date(),
+        }).toMatchInlineSnapshot({ one: expect.any(Number), date: expect.any(Date) });
+
         expect(jest.fn()).toReturn();
 
         expect(jest.fn()).toReturnTimes(0);
@@ -640,6 +649,15 @@ describe("", () => {
         expect(willThrow).toThrowErrorMatchingSnapshot();
         expect(jest.fn()).toThrowErrorMatchingSnapshot();
         expect(jest.fn(willThrow)).toThrowErrorMatchingSnapshot();
+
+        expect(() => {}).toThrowErrorMatchingInlineSnapshot();
+        expect(() => {}).toThrowErrorMatchingInlineSnapshot('Error Message');
+        expect(willThrow).toThrowErrorMatchingInlineSnapshot();
+        expect(willThrow).toThrowErrorMatchingInlineSnapshot('Error Message');
+        expect(jest.fn()).toThrowErrorMatchingInlineSnapshot();
+        expect(jest.fn()).toThrowErrorMatchingInlineSnapshot('Error Message');
+        expect(jest.fn(willThrow)).toThrowErrorMatchingInlineSnapshot();
+        expect(jest.fn(willThrow)).toThrowErrorMatchingInlineSnapshot('Error Message');
 
         /* not */
 


### PR DESCRIPTION
Add the following matchers:

- `toMatchInlineSnapshot`
- `toThrowErrorMatchingInlineSnapshot`

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/facebook/jest/pull/6380
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
