### PR TITLE
fix(html-webpack-plugin): add complete set of current options

### DIFF
--- a/types/html-webpack-plugin/html-webpack-plugin-tests.ts
+++ b/types/html-webpack-plugin/html-webpack-plugin-tests.ts
@@ -22,6 +22,79 @@ const optionsArray: HtmlWebpackPlugin.Options[] = [
 	},
 	{
 		chunksSortMode: 'manual',
+	},
+	// All default params
+	{
+		template: 'default_index.ejs',
+		templateParameters: (compilation, assets, options) => {
+			return {
+				compilation,
+				webpack: compilation.getStats().toJson(),
+				// TODO: compilation.options not defined on @types/webpack
+				webpackConfig: {},
+				htmlWebpackPlugin: {
+					files: assets,
+					options
+				}
+			};
+		},
+		filename: 'index.html',
+		hash: false,
+		inject: true,
+		compile: true,
+		favicon: false,
+		minify: false,
+		cache: true,
+		showErrors: true,
+		chunks: 'all',
+		excludeChunks: [],
+		chunksSortMode: 'auto',
+		meta: {},
+		title: 'Webpack App',
+		xhtml: false
+	},
+	// Config from 'appcache' example
+	{
+		filename: 'index.html',
+		template: 'template.html',
+		minify: {
+		  removeComments: true,
+		  collapseWhitespace: true
+		}
+	},
+	// Config from 'custom-template' example
+	{
+		template: 'template.html'
+	},
+	// Config from 'favicon' example
+	{
+		title: 'HtmlWebpackPlugin example',
+		favicon: 'favicon.ico',
+		filename: 'favicon.html'
+	},
+	// Config from 'inline' example
+	{
+		inject: false,
+		cache: false,
+		template: 'template.jade',
+		filename: 'index.html',
+		favicon: 'favicon.ico',
+		title: 'Jade demo'
+	},
+	// Config from 'sort-manually' example
+	{
+		inject: true,
+		filename: 'first-file.html',
+		template: 'template.html',
+		chunksSortMode: 'manual',
+		chunks: ['a', 'b', 'c']
+	},
+	// Config from 'template-parameters' example
+	{
+		templateParameters: {
+		  foo: 'bar'
+		},
+		template: 'index.ejs'
 	}
 ];
 

--- a/types/html-webpack-plugin/index.d.ts
+++ b/types/html-webpack-plugin/index.d.ts
@@ -1,5 +1,5 @@
-// Type definitions for html-webpack-plugin 2.30
-// Project: https://github.com/ampedandwired/html-webpack-plugin
+// Type definitions for html-webpack-plugin 3.2
+// Project: https://github.com/jantimon/html-webpack-plugin
 // Definitions by: Simon Hartcher <https://github.com/deevus>
 //                 Benjamin Lim <https://github.com/bumbleblym>
 //                 Tomek Łaziuk <https://github.com/tlaziuk>
@@ -19,64 +19,113 @@ declare class HtmlWebpackPlugin extends Plugin {
 declare namespace HtmlWebpackPlugin {
 	type MinifyOptions = HtmlMinifierOptions;
 
-	/**
-	 * It is assumed that each [chunk] contains at least the properties "id"
-	 * (containing the chunk id) and "parents" (array containing the ids of the
-	 * parent chunks).
-	 *
-	 * @todo define in webpack
-	 */
-	interface Chunk {
-		id: string;
-		parents: string[];
-		[propName: string]: any;
+	interface TemplateParametersAssets {
+		/** The public path */
+		publicPath: string;
+		/** Will contain all js & css files by chunk */
+		chunks: {};
+		/** Will contain all js files */
+		js: string[];
+		/** Will contain all css files */
+		css: string[];
+		/** Will contain a favicon if it exists */
+		favicon?: string;
+		/** Will contain amn appcache manifest file if it exists */
+		manifest?: string;
 	}
 
-	type ChunkComparator = (a: Chunk, b: Chunk) => number;
-
 	interface Options {
-		/** `true | false` if `true` (default) try to emit the file only if it was changed. */
+		/**
+		 * Emit the file only if it was changed.
+		 * Default: `true`.
+		 */
 		cache?: boolean;
 		/**
 		 * Allows to control how chunks should be sorted before they are included to the html.
-		 * Allowed values: 'none' | 'auto' | 'dependency' |'manual' | {function} - default: 'auto'
+		 * Default: `'auto'`.
 		 */
-		chunksSortMode?: 'none' | 'auto' | 'dependency' | 'manual' | ChunkComparator;
-		/** Allows you to add only some chunks (e.g. only the unit-test chunk) */
-		chunks?: string[];
-		/** Allows you to skip some chunks (e.g. don't add the unit-test chunk) */
+		chunksSortMode?:
+			'none'
+			| 'auto'
+			| 'dependency'
+			| 'manual'
+			| ((a: compilation.Chunk, b: compilation.Chunk) => number);
+		/**
+		 * Allows you to add only some chunks (e.g. only the unit-test chunk).
+		 * Default: 'all'.
+		 */
+		chunks?: 'all' | string[];
+		/**
+		 * Allows you to skip some chunks (e.g. don't add the unit-test chunk).
+		 * Default: `[]`.
+		 */
 		excludeChunks?: string[];
-		/** Adds the given favicon path to the output html. */
-		favicon?: string;
+		/**
+		 * Adds the given favicon path to the output html.
+		 * Default: `false`.
+		 */
+		favicon?: false | string;
 		/**
 		 * The file to write the HTML to.
-		 * Defaults to index.html. You can specify a subdirectory here too (eg: `assets/admin.html`).
+		 * You can specify a subdirectory here too (eg: `assets/admin.html`).
+		 * Default: `'index.html'`.
 		 */
 		filename?: string;
 		/**
-		 * `true | false` if `true` then append a unique webpack compilation hash to all included scripts and css files.
+		 * If true then append a unique webpack compilation hash to all included scripts and CSS files.
 		 * This is useful for cache busting.
+		 * Default: `false`.
 		 */
 		hash?: boolean;
 		/**
-		 * `true | 'head' | 'body' | false`
 		 * Inject all assets into the given template or templateContent.
 		 * When passing true or 'body' all javascript resources will be placed at the bottom of the body element.
 		 * 'head' will place the scripts in the head element.
+		 * Default: `true`.
 		 */
 		inject?: 'body' | 'head' | boolean;
 		/**
-		 * `{...} | false` Pass a html-minifier options object to minify the output.
+		 * Allows to inject meta-tags, e.g. meta: `{viewport: 'width=device-width, initial-scale=1, shrink-to-fit=no'}`.
+		 * Default: `{}`.
+		 */
+		meta?: false | { [name: string]: any };
+		/**
+		 * Pass a html-minifier options object to minify the output.
 		 * https://github.com/kangax/html-minifier#options-quick-reference
+		 * Default: `false`.
 		 */
 		minify?: false | MinifyOptions;
-		/** `true | false` if `true` (default) errors details will be written into the html page. */
+		/**
+		 * Errors details will be written into the HTML page.
+		 * Default: `true`.
+		 */
 		showErrors?: boolean;
-		/** Webpack require path to the template. Please see the docs for details. */
+		/**
+		 * The `webpack` require path to the template.
+		 * @see https://github.com/jantimon/html-webpack-plugin/blob/master/docs/template-option.md
+		 */
 		template?: string;
-		/** The title to use for the generated HTML document. */
+		/**
+		 * Allow to use a html string instead of reading from a file.
+		 * Default: `false`, meaning the `template` option should be used instead.
+		 */
+		templateContent?: false | string | Promise<string>;
+		/**
+		 * Allows to overwrite the parameters used in the template.
+		 */
+		templateParameters?:
+			false
+			| ((compilation: compilation.Compilation, assets: TemplateParametersAssets, options: Options) => any)
+			| { [key: string]: any };
+		/**
+		 * The title to use for the generated HTML document.
+		 * Default: `'Webpack App'`.
+		 */
 		title?: string;
-		/** `true | false` If `true` render the link tags as self-closing, XHTML compliant. Default is `false` */
+		/**
+		 * If true render the link tags as self-closing (XHTML compliant).
+		 * Default: `false`.
+		 */
 		xhtml?: boolean;
 		/**
 		 * In addition to the options actually used by this plugin, you can use this hash to pass arbitrary data through


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: _(see below)_
- [X] Increase the version number in the header if appropriate.
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

---

- Updated repo address to current: https://github.com/jantimon/html-webpack-plugin.
- Options being added are up to date to version 3.2 of `html-webpack-plugin`. However, all of the options previously listed are backwards compatible: https://github.com/jantimon/html-webpack-plugin/blob/master/CHANGELOG.md#320-2018-04-03.
- Default parameters and complete at https://github.com/jantimon/html-webpack-plugin/blob/master/index.js#L21.
- Helper interface for TemplateParametersAssets inferred from https://github.com/jantimon/html-webpack-plugin/blob/master/index.js#L422.
- Tests updated to reflect options as provided in the`html-webpack-plugin` repo examples: https://github.com/jantimon/html-webpack-plugin/tree/master/examples.
- Removed deprecated `type`s
