### PR TITLE
Add createButton types for googlepay

### DIFF
--- a/types/googlepay/googlepay-tests.ts
+++ b/types/googlepay/googlepay-tests.ts
@@ -32,11 +32,8 @@ function addGooglePayButton() {
         buttonType: 'short',
     };
     const client = getGooglePaymentsClient();
-    client.createButton(buttonOptions).then(button => {
-        document.appendChild(document.createElement('div').appendChild(button));
-    }).catch(err => {
-        console.error(err);
-    });
+    const button = client.createButton(buttonOptions);
+    document.appendChild(document.createElement('div').appendChild(button));
 }
 
 function getGooglePaymentDataConfiguration(): google.payments.api.PaymentDataRequest {

--- a/types/googlepay/googlepay-tests.ts
+++ b/types/googlepay/googlepay-tests.ts
@@ -26,11 +26,17 @@ function onGooglePayLoaded() {
 }
 
 function addGooglePayButton() {
-    const button = document.createElement('button');
-    button.className = 'google-pay';
-    button.appendChild(document.createTextNode('Google Pay'));
-    button.addEventListener('click', onGooglePaymentButtonClick);
-    document.appendChild(document.createElement('div').appendChild(button));
+    const buttonOptions: google.payments.api.ButtonOptions = {
+        onClick: onGooglePaymentButtonClick,
+        buttonColor: 'black',
+        buttonType: 'short',
+    };
+    const client = getGooglePaymentsClient();
+    client.createButton(buttonOptions).then(button => {
+        document.appendChild(document.createElement('div').appendChild(button));
+    }).catch(err => {
+        console.error(err);
+    });
 }
 
 function getGooglePaymentDataConfiguration(): google.payments.api.PaymentDataRequest {

--- a/types/googlepay/index.d.ts
+++ b/types/googlepay/index.d.ts
@@ -7,6 +7,8 @@ declare namespace google.payments.api {
     type AddressFormat = 'FULL' | 'MIN';
     type AllowedCardNetwork = 'AMEX' | 'DISCOVER' | 'JCB' | 'MASTERCARD' | 'VISA';
     type AllowedPaymentMethod = 'CARD' | 'TOKENIZED_CARD';
+    type ButtonColor = 'default' | 'black' | 'white';
+    type ButtonType = 'long' | 'short';
     type CardClass = 'CREDIT' | 'DEBIT';
     type CardInfo = CardInfoMin | CardInfoFull;
     type CardRequirements = CardRequirementsMin | CardRequirementsFull;
@@ -18,6 +20,12 @@ declare namespace google.payments.api {
     type UserAddress = UserAddressFull | UserAddressMin;
     type PaymentDataRequest = PaymentDataRequestMin | PaymentDataRequestFull;
     type PaymentData = PaymentDataMin | PaymentDataFull;
+
+    interface ButtonOptions {
+        onClick: EventListener;
+        buttonColor?: ButtonColor;
+        buttonType?: ButtonType;
+    }
 
     interface PaymentOptions {
         environment?: EnvironmentType;
@@ -151,6 +159,7 @@ declare namespace google.payments.api {
 
     class PaymentsClient {
         constructor(paymentOptions: PaymentOptions);
+        createButton(request: ButtonOptions): Promise<HTMLElement>;
         isReadyToPay(request: IsReadyToPayRequest): Promise<{result: boolean}>;
         loadPaymentData(request: PaymentDataRequestMin): Promise<PaymentDataMin>;
         loadPaymentData(request: PaymentDataRequestFull): Promise<PaymentDataFull>;

--- a/types/googlepay/index.d.ts
+++ b/types/googlepay/index.d.ts
@@ -160,7 +160,7 @@ declare namespace google.payments.api {
 
     class PaymentsClient {
         constructor(paymentOptions: PaymentOptions);
-        createButton(request: ButtonOptions): Promise<HTMLElement>;
+        createButton(request: ButtonOptions): HTMLElement;
         isReadyToPay(request: IsReadyToPayRequest): Promise<{result: boolean}>;
         loadPaymentData(request: PaymentDataRequestMin): Promise<PaymentDataMin>;
         loadPaymentData(request: PaymentDataRequestFull): Promise<PaymentDataFull>;

--- a/types/googlepay/index.d.ts
+++ b/types/googlepay/index.d.ts
@@ -1,6 +1,7 @@
-// Type definitions for Google Pay API 0.0
+// Type definitions for Google Pay API 0.1
 // Project: https://developers.google.com/pay/api/web/setup/
-// Definitions by: Florian Luccioni <https://github.com/Fluccioni>
+// Definitions by: Florian Luccioni <https://github.com/Fluccioni>,
+//                 Radu Raicea <https://github.com/Radu-Raicea>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare namespace google.payments.api {


### PR DESCRIPTION
New API changes added createButton, a method to request the creation of
a HTMLElement button.

Here's the [link](https://developers.google.com/pay/api/web/reference/client#createButton) to Google Pay's API Reference that contains `createButton`.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.