### PR TITLE
Add type definitions for flush-write-stream

### DIFF
--- a/types/flush-write-stream/flush-write-stream-tests.ts
+++ b/types/flush-write-stream/flush-write-stream-tests.ts
@@ -1,0 +1,18 @@
+import writer = require("flush-write-stream");
+
+const stream = writer(write, flush);
+
+stream.on("finish", () => console.log("finished"));
+
+stream.write("hello");
+stream.write("world");
+stream.end();
+
+function write(data: any, encoding: string, callback: (error?: Error) => void): void {
+    console.log("Writing", data.toString());
+    callback();
+}
+
+function flush(callback: (error?: Error) => void): void {
+    setTimeout(callback, 1000);
+}

--- a/types/flush-write-stream/index.d.ts
+++ b/types/flush-write-stream/index.d.ts
@@ -1,0 +1,23 @@
+// Type definitions for flush-write-stream 1.0
+// Project: https://github.com/mafintosh/flush-write-stream
+// Definitions by: Daniel Cassidy <https://github.com/djcsdy>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types="node"/>
+
+import { Writable, WritableOptions } from "stream";
+
+type Callback = (error?: Error) => void;
+type Write = (chunk: any, encoding: string, callback: Callback) => void;
+type Flush = (callback: Callback) => void;
+
+declare const WriteStream: {
+    (opts: WritableOptions, write: Write, flush?: Flush): Writable;
+    (write: Write, flush?: Flush): Writable;
+    new(opts: WritableOptions, write: Write, flush?: Flush): Writable;
+    new(write: Write, flush?: Flush): Writable;
+    obj(opts: WritableOptions, write: Write, flush?: Flush): Writable;
+    obj(write: Write, flush?: Flush): Writable;
+};
+
+export = WriteStream;

--- a/types/flush-write-stream/tsconfig.json
+++ b/types/flush-write-stream/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "flush-write-stream-tests.ts"
+    ]
+}

--- a/types/flush-write-stream/tslint.json
+++ b/types/flush-write-stream/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

Adds type definitions for [flush-write-stream](https://github.com/mafintosh/flush-write-stream).