### PR TITLE
Add type definitions for object.getownpropertydescriptors

### DIFF
--- a/types/object.getownpropertydescriptors/index.d.ts
+++ b/types/object.getownpropertydescriptors/index.d.ts
@@ -1,0 +1,19 @@
+// Type definitions for object.getownpropertydescriptors 2.0
+// Project: https://github.com/ljharb/object.getownpropertydescriptors#readme
+// Definitions by: Vitor Luiz Cavalcanti <https://github.com/VitorLuizC>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.2
+
+/**
+ * Returns an object containing all own property descriptors of an object
+ * @param o - Object that contains the properties and methods. This can be an object that you created or an existing Document Object Model (DOM) object.
+ */
+declare function getOwnPropertyDescriptors <T extends object>(o: T): { [K in keyof T]: TypedPropertyDescriptor<T[K]> } & PropertyDescriptorMap;
+
+declare namespace getOwnPropertyDescriptors {
+    function shim(): typeof getOwnPropertyDescriptors;
+    function getPolyfill(): typeof getOwnPropertyDescriptors;
+    function implementation(): typeof getOwnPropertyDescriptors;
+}
+
+export = getOwnPropertyDescriptors;

--- a/types/object.getownpropertydescriptors/object.getownpropertydescriptors-tests.ts
+++ b/types/object.getownpropertydescriptors/object.getownpropertydescriptors-tests.ts
@@ -1,0 +1,27 @@
+import descriptors = require('object.getownpropertydescriptors');
+
+descriptors({ language: 'TypeScript' });
+// => { language: TypedPropertyDescriptor<string>; }
+
+const { language } = descriptors({ language: 'TypeScript' });
+
+language;
+// => {
+//      writable: undefined | boolean,
+//      enumerable: undefined | boolean,
+//      configurable: undefined | boolean,
+//      get: undefined | (() => string),
+//      set: undefined | ((value: string) => void),
+//      value: undefined | string
+// }
+
+descriptors.shim();
+// => typeof descriptors
+
+const getOwnPropertyDescriptorsPolyfill = descriptors.getPolyfill();
+
+getOwnPropertyDescriptorsPolyfill({ name: 'object.getownpropertydescriptors' });
+// => { name: TypedPropertyDescriptor<string>; }
+
+descriptors.implementation();
+// => typeof descriptors

--- a/types/object.getownpropertydescriptors/tsconfig.json
+++ b/types/object.getownpropertydescriptors/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "object.getownpropertydescriptors-tests.ts"
+    ]
+}

--- a/types/object.getownpropertydescriptors/tslint.json
+++ b/types/object.getownpropertydescriptors/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

Add type definitions for `object.getownpropertydescriptors`.