### PR TITLE
three.js - Add missing generateMipmaps field from WebGLRenderTargetOptions

### DIFF
--- a/types/three/three-core.d.ts
+++ b/types/three/three-core.d.ts
@@ -5738,6 +5738,7 @@ export interface WebGLRenderTargetOptions {
     anisotropy?: number; // 1;
     depthBuffer?: boolean; // true;
     stencilBuffer?: boolean; // true;
+    generateMipmaps?: boolean; // true;
 }
 
 export class WebGLRenderTarget extends EventDispatcher {


### PR DESCRIPTION
Add missing generateMipmaps field from WebGLRenderTargetOptions

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
https://github.com/mrdoob/three.js/pull/14000/files