### PR TITLE
[@types/google-cloud__storage] Fix `getSignedUrl()` method

### DIFF
--- a/types/google-cloud__storage/google-cloud__storage-tests.ts
+++ b/types/google-cloud__storage/google-cloud__storage-tests.ts
@@ -204,7 +204,7 @@ export class TestFile {
     }
 
     /** Get a signed URL to allow limited time access to the file */
-    getSignedUrl(config?: SignedUrlConfig): Promise<[string]> {
+    getSignedUrl(config: SignedUrlConfig): Promise<[string]> {
         return this.file.getSignedUrl(config);
     }
 

--- a/types/google-cloud__storage/index.d.ts
+++ b/types/google-cloud__storage/index.d.ts
@@ -130,7 +130,7 @@ declare namespace Storage {
         get(): Promise<[File, ApiResponse]>;
         getMetadata(): Promise<[FileMetadata, ApiResponse]>;
         getSignedPolicy(options?: SignedPolicyOptions): Promise<[SignedPolicy]>;
-        getSignedUrl(config?: SignedUrlConfig): Promise<[string]>;
+        getSignedUrl(config: SignedUrlConfig): Promise<[string]>;
         makePrivate(options?: FilePrivateOptions): Promise<[ApiResponse]>;
         makePublic(): Promise<[ApiResponse]>;
         move(destination: string | Bucket | File): Promise<[File, ApiResponse]>;
@@ -196,7 +196,7 @@ declare namespace Storage {
         cname?: string;
         contentMd5?: string;
         contentType?: string;
-        expires?: number | string;
+        expires: any;
         extensionHeaders?: { [key: string]: string };
         promptSaveAs?: string;
         responseDisposition?: string;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://cloud.google.com/nodejs/docs/reference/storage/1.7.x/File#getSignedUrl
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
