### PR TITLE
[@types/puppeteer] Add missing waitForResponse & waitForRequest types

### DIFF
--- a/types/puppeteer/index.d.ts
+++ b/types/puppeteer/index.d.ts
@@ -899,6 +899,16 @@ export interface FrameBase {
     ...args: any[]
   ): Promise<any>;
 
+  waitForRequest(
+    urlOrPredicate: string | ((req: Request) => boolean),
+    options?: { timeout?: number }
+  ): Promise<Request>;
+
+  waitForResponse(
+    urlOrPredicate: string | ((res: Response) => boolean),
+    options?: { timeout?: number }
+  ): Promise<Response>;
+
   waitForSelector(
     selector: string,
     options?: { visible?: boolean; hidden?: boolean; timeout?: number }


### PR DESCRIPTION
Add missing waitForResponse & waitForRequest types

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [N/A] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://pptr.dev/#?product=Puppeteer&version=v1.6.0&show=api-pagewaitforrequesturlorpredicate-options
- [N/A] Increase the version number in the header if appropriate.
- [N/A] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
