### PR TITLE
Updating interface for cursor acc. to new API

### DIFF
--- a/types/twit/index.d.ts
+++ b/types/twit/index.d.ts
@@ -264,7 +264,7 @@ declare module 'twit' {
       long?: number,
       follow?: boolean,
       include_email?: boolean,
-      cursor?: number,
+      cursor?: string,
       tweet_mode?: string,
       trim_user?: boolean,
       exclude_replies?: boolean,

--- a/types/twit/index.d.ts
+++ b/types/twit/index.d.ts
@@ -265,7 +265,7 @@ declare module 'twit' {
       long?: number,
       follow?: boolean,
       include_email?: boolean,
-      cursor?: string,
+      cursor?: number | string,
       tweet_mode?: string,
       trim_user?: boolean,
       exclude_replies?: boolean,

--- a/types/twit/index.d.ts
+++ b/types/twit/index.d.ts
@@ -4,6 +4,7 @@
 //                 lostfictions <https://github.com/lostfictions>
 //                 sapphiredev <https://github.com/sapphiredev>
 //                 abraham <https://github.com/abraham>
+//                 siwalik <https://github.com/siwalikm>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://developer.twitter.com/en/docs/direct-messages/sending-and-receiving/api-reference/list-events>

**Description of issue**
Twitter recently made changes to its API endpoints for Direct Messages. For getting a list of DMs, twitter used to return the last-message-id as a cursor for pagination before. Since the new release, twitter sends a random-string with a [next-cursor key](https://developer.twitter.com/en/docs/direct-messages/sending-and-receiving/api-reference/list-events#parameters) but this is of type string unlike before. This PR changes the interface type of **cursor**.