### PR TITLE
Add third parameter `parent` to matchPath, add prop `sensitive` to Route

### DIFF
--- a/types/react-router/index.d.ts
+++ b/types/react-router/index.d.ts
@@ -115,7 +115,7 @@ export interface match<P> {
 // Omit taken from https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-8.html
 export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 
-export function matchPath<P>(pathname: string, props: RouteProps): match<P> | null;
+export function matchPath<P>(pathname: string, props: RouteProps, parent?: match<P> | null): match<P> | null;
 
 export function generatePath(pattern: string, params?: { [paramName: string]: string | number | boolean }): string;
 

--- a/types/react-router/index.d.ts
+++ b/types/react-router/index.d.ts
@@ -78,6 +78,7 @@ export interface RouteProps {
   children?: ((props: RouteComponentProps<any>) => React.ReactNode) | React.ReactNode;
   path?: string;
   exact?: boolean;
+  sensitive?: boolean;
   strict?: boolean;
 }
 export class Route<T extends RouteProps = RouteProps> extends React.Component<T, any> { }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present). **Fails before my edit and fails afterwards.**

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/ReactTraining/react-router/blob/master/packages/react-router/modules/matchPath.js#L28 https://reacttraining.com/react-router/web/api/Route/sensitive-bool
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

Notes:
- matchPath takes a third parameter, see https://github.com/ReactTraining/react-router/blob/master/packages/react-router/modules/matchPath.js#L28
- Routes accept the prop `sensitive`, see https://reacttraining.com/react-router/web/api/Route/sensitive-bool