### PR TITLE
Fixed issue introduced in redux-thunk 2.3.0

### DIFF
--- a/types/redux-testkit/index.d.ts
+++ b/types/redux-testkit/index.d.ts
@@ -31,7 +31,7 @@ export function Selector(selector: (state: any, action: any) => any): {
 	execute(state: any, ...args: any[]): any;
 };
 
-export function Thunk(thunkFunc: ThunkAction<any, any, any>, extraArg?: any): ThunkTestkit & {
+export function Thunk(thunkFunc: ThunkAction<any, any, any, any>, extraArg?: any): ThunkTestkit & {
 	withState(state: any): ThunkTestkit;
 };
 


### PR DESCRIPTION
This is a fix to the issue [Generic type 'ThunkAction' requires 4 type argument(s)](https://github.com/DefinitelyTyped/DefinitelyTyped/issues/27338)

Everything is described in there.
