### PR TITLE
redux-form: Remove `label` from Field interface

### DIFF
--- a/types/redux-form/lib/Field.d.ts
+++ b/types/redux-form/lib/Field.d.ts
@@ -37,7 +37,6 @@ export interface CommonFieldProps extends CommonFieldInputProps {
 
 export interface BaseFieldProps<P = {}> extends Partial<CommonFieldProps> {
     name: string;
-    label?: string;
     component?: ComponentType<WrappedFieldProps & P> | "input" | "select" | "textarea";
     format?: Formatter | null;
     normalize?: Normalizer;
@@ -73,7 +72,6 @@ export class Field<P = GenericFieldHTMLAttributes | BaseFieldProps> extends Comp
 export interface WrappedFieldProps {
     input: WrappedFieldInputProps;
     meta: WrappedFieldMetaProps;
-    label?: string;
 }
 
 export interface WrappedFieldInputProps extends CommonFieldInputProps {

--- a/types/redux-form/redux-form-tests.tsx
+++ b/types/redux-form/redux-form-tests.tsx
@@ -110,7 +110,6 @@ interface MyFieldCustomProps {
 type MyFieldProps = MyFieldCustomProps & WrappedFieldProps;
 const MyField: React.StatelessComponent<MyFieldProps> = ({
     children,
-    label,
     input,
     meta,
     foo


### PR DESCRIPTION
This was added to DefinitelyTyped in PRs #21204 and #24041. However,
both reasons given are incorrect: this prop is indeed featured in the
examples, but only used for a sample component also defined for demo
purposes. `props.label` is not a part of the `redux-form` `<Field/>`
API, and as such shouldn't be included.

One reason is because `props.label` should be up to users to implement.
If a user wants `props.label` to support React nodes instead of just
strings, they can no longer just extend DefinitelyTyped interfaces
because this causes an incompatibility with the set string type.

I realize this change might cause backwards compatibility issues for
users who are already using a `label` prop, as it's a ubiquitous
pattern. Looking for input on how to properly proceed with this. Thanks!

------

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.) *NOTE: I am getting `File name must be camelCase` both before and after my change*
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/erikras/redux-form/blob/master/src/createField.js ctrl-F label; no result
- [ ] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.