### PR TITLE
webpack: depend on @types/tapable@^1.0.0

### DIFF
--- a/types/webpack/package.json
+++ b/types/webpack/package.json
@@ -1,6 +1,7 @@
 {
     "private": true,
     "dependencies": {
+        "@types/tapable": "^1.0.0",
         "source-map": "^0.6.0"
     }
 }


### PR DESCRIPTION
The issue in https://github.com/DefinitelyTyped/DefinitelyTyped/issues/24239 is that it's possible to run into a situation where your project depends on both `@types/webpack@^4` and `@types/tapable@^0` at the same time. Example here: https://github.com/elliottsj/rush-pnpm-types-test

This example is a monorepo project using [rush](https://rushjs.io/) and [pnpm](https://pnpm.js.org/). Due to the way rush and pnpm work, the package bar-webpack-plugin ends up depending on `@types/webpack@^4` and `@types/tapable@^0`. This is valid behaviour from the perspective of rush and pnpm because `@types/webpack` can depend on _any_ version of `@types/tapable`.

By instead having `@types/webpack` specify a minimum version of `@types/tapable`, pnpm will respect that constraint and install the correct version of tapable.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)

  I've "tested" the change by copying the [published package.json](https://unpkg.com/@types/webpack@4.4.7/package.json) into my local DefinitelyTyped repo and changing `"@types/tapable": "*"` to `"@types/tapable": "^1.0.0"`, then specifying `"@types/webpack": "file:../path/to/DefinitelyTyped/types/webpack"` in my project.

- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/24239
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.