### PR TITLE
Fix mathjs Unit interface.

### DIFF
--- a/types/mathjs/index.d.ts
+++ b/types/mathjs/index.d.ts
@@ -2662,7 +2662,7 @@ declare namespace math {
         toJSON(): MathJSON;
         formatUnits(): string;
         format(options: FormatOptions): string;
-        splitUnit(parts: Array<string | Unit>): Unit[];
+        splitUnit(parts: ReadonlyArray<string | Unit>): Unit[];
     }
 
     interface CreateUnitOptions {

--- a/types/mathjs/index.d.ts
+++ b/types/mathjs/index.d.ts
@@ -2647,7 +2647,6 @@ declare namespace math {
     interface Unit {
         valueOf(): string;
         clone(): Unit;
-        isDerived(): boolean;
         hasBase(base: any): boolean;
         equalBase(unit: Unit): boolean;
         equals(unit: Unit): boolean;
@@ -2658,13 +2657,12 @@ declare namespace math {
         to(unit: string): Unit;
         toNumber(unit: string): number;
         toNumeric(unit: string): number | Fraction | BigNumber;
+        toSI(): Unit;
         toString(): string;
         toJSON(): MathJSON;
         formatUnits(): string;
         format(options: FormatOptions): string;
-        parse(str: DOMStringList): Unit;
-        isValuelessUnit(name: string): boolean;
-        fromJSON(json: MathJSON): Unit;
+        splitUnit(parts: Array<string | Unit>): Unit[];
     }
 
     interface CreateUnitOptions {

--- a/types/mathjs/mathjs-tests.ts
+++ b/types/mathjs/mathjs-tests.ts
@@ -339,6 +339,12 @@ Units examples
 
 	// the expression parser supports units too
 	math.eval('2 inch to cm');
+
+	// units can be converted to SI
+	math.unit('1 inch').toSI();
+
+	// units can be split into other units
+	math.unit('1 m').splitUnit(['ft', 'in']);
 }
 
 /*


### PR DESCRIPTION
- Remove `Unit` class methods from the `Unit` instance interface.
- Add some missing `Unit` instance methods referenced in the mathjs docs.

One notable problem this resolves is that mathjs types were not
importable in Node without the DOM library due to the `Unit.parse`
signature referring to `DOMStringList`.

Note that mathjs does in fact expose the `Unit` class object under `math.type.Unit`, but that seems like an implementation detail that probably doesn't need to be exposed directly in these types.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://mathjs.org/docs/datatypes/units.html . Also, see https://github.com/josdejong/mathjs/blob/v5.0.3/src/type/unit/Unit.js , for example, L233 (`parse`, a class method that is currently exposed on the `Unit` interface) and L1190 (`splitUnit`, an instance method mentioned in the docs that is not currently exposed on the `Unit` interface).
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
