### PR TITLE
[papaparse] Fix missing namespace for an external interface

### DIFF
--- a/types/papaparse/index.d.ts
+++ b/types/papaparse/index.d.ts
@@ -5,8 +5,11 @@
 //                 João Loff <https://github.com/jfloff>
 //                 John Reilly <https://github.com/johnnyreilly>
 //                 Alberto Restifo <https://github.com/albertorestifo>
+//                 Behind The Math <https://github.com/BehindTheMath>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
+
+import "node";
 
 export as namespace Papa;
 
@@ -17,9 +20,9 @@ export function parse(csvString: string, config?: ParseConfig): ParseResult;
 
 export function parse(file: File, config?: ParseConfig): ParseResult;
 
-export function parse(stream: ReadableStream, config?: ParseConfig): ParseResult;
+export function parse(stream: NodeJS.ReadableStream, config?: ParseConfig): ParseResult;
 
-export function parse(stream: typeof NODE_STREAM_INPUT, config?: ParseConfig): ReadableStream;
+export function parse(stream: typeof NODE_STREAM_INPUT, config?: ParseConfig): NodeJS.ReadableStream;
 
 /**
  * Unparses javascript data objects and returns a csv string


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes:
The un-namespaced `ReadableStream` is defined in `lib.dom.d.ts`. The `ReadableStream` referenced here should be the one defined in `@types/node`. See https://github.com/mholt/PapaParse/blob/fb6f96ea9901b523b1b296bee8dbdba568a2fefc/papaparse.js#L249-L252