### PR TITLE
`node-fetch`: correct `Headers.raw` type

### DIFF
--- a/types/node-fetch/index.d.ts
+++ b/types/node-fetch/index.d.ts
@@ -102,7 +102,7 @@ export class Headers implements Iterable<[string, string]> {
     get(name: string): string | null;
     getAll(name: string): string[];
     has(name: string): boolean;
-    raw(): { [k: string]: string[] | string };
+    raw(): { [k: string]: string[] };
     set(name: string, value: string): void;
 
     // Iterator methods

--- a/types/node-fetch/index.d.ts
+++ b/types/node-fetch/index.d.ts
@@ -102,7 +102,7 @@ export class Headers implements Iterable<[string, string]> {
     get(name: string): string | null;
     getAll(name: string): string[];
     has(name: string): boolean;
-    raw(): { [k: string]: string[] | string };
+    raw(): { [k: string]: string[] | string | undefined };
     set(name: string, value: string): void;
 
     // Iterator methods

--- a/types/node-fetch/index.d.ts
+++ b/types/node-fetch/index.d.ts
@@ -102,7 +102,7 @@ export class Headers implements Iterable<[string, string]> {
     get(name: string): string | null;
     getAll(name: string): string[];
     has(name: string): boolean;
-    raw(): { [k: string]: string };
+    raw(): { [k: string]: string[] | string };
     set(name: string, value: string): void;
 
     // Iterator methods

--- a/types/node-fetch/index.d.ts
+++ b/types/node-fetch/index.d.ts
@@ -102,7 +102,7 @@ export class Headers implements Iterable<[string, string]> {
     get(name: string): string | null;
     getAll(name: string): string[];
     has(name: string): boolean;
-    raw(): { [k: string]: string[] | string | undefined };
+    raw(): { [k: string]: string[] | string };
     set(name: string, value: string): void;
 
     // Iterator methods

--- a/types/node-fetch/node-fetch-tests.ts
+++ b/types/node-fetch/node-fetch-tests.ts
@@ -71,3 +71,9 @@ function handlePromise(promise: Promise<Response>, isArrayBuffer: boolean = fals
 		console.log(text);
 	});
 }
+
+function test_headersRaw() {
+	const headers = new Headers();
+	const myHeader = 'foo';
+	headers.raw()[myHeader]; // $ExpectType string;
+}

--- a/types/node-fetch/node-fetch-tests.ts
+++ b/types/node-fetch/node-fetch-tests.ts
@@ -75,5 +75,5 @@ function handlePromise(promise: Promise<Response>, isArrayBuffer: boolean = fals
 function test_headersRaw() {
 	const headers = new Headers();
 	const myHeader = 'foo';
-	headers.raw()[myHeader]; // $ExpectType string[] | string;
+	headers.raw()[myHeader]; // $ExpectType string | string[]
 }

--- a/types/node-fetch/node-fetch-tests.ts
+++ b/types/node-fetch/node-fetch-tests.ts
@@ -75,5 +75,5 @@ function handlePromise(promise: Promise<Response>, isArrayBuffer: boolean = fals
 function test_headersRaw() {
 	const headers = new Headers();
 	const myHeader = 'foo';
-	headers.raw()[myHeader]; // $ExpectType string | string[] | undefined
+	headers.raw()[myHeader]; // $ExpectType string[] | string;
 }

--- a/types/node-fetch/node-fetch-tests.ts
+++ b/types/node-fetch/node-fetch-tests.ts
@@ -75,5 +75,5 @@ function handlePromise(promise: Promise<Response>, isArrayBuffer: boolean = fals
 function test_headersRaw() {
 	const headers = new Headers();
 	const myHeader = 'foo';
-	headers.raw()[myHeader]; // $ExpectType string | string[]
+	headers.raw()[myHeader]; // $ExpectType string[]
 }

--- a/types/node-fetch/node-fetch-tests.ts
+++ b/types/node-fetch/node-fetch-tests.ts
@@ -75,5 +75,5 @@ function handlePromise(promise: Promise<Response>, isArrayBuffer: boolean = fals
 function test_headersRaw() {
 	const headers = new Headers();
 	const myHeader = 'foo';
-	headers.raw()[myHeader]; // $ExpectType string[] | string;
+	headers.raw()[myHeader]; // $ExpectType string | string[] | undefined
 }

--- a/types/node-fetch/node-fetch-tests.ts
+++ b/types/node-fetch/node-fetch-tests.ts
@@ -75,5 +75,5 @@ function handlePromise(promise: Promise<Response>, isArrayBuffer: boolean = fals
 function test_headersRaw() {
 	const headers = new Headers();
 	const myHeader = 'foo';
-	headers.raw()[myHeader]; // $ExpectType string;
+	headers.raw()[myHeader]; // $ExpectType string[] | string;
 }

--- a/types/node-fetch/node-fetch-tests.ts
+++ b/types/node-fetch/node-fetch-tests.ts
@@ -44,7 +44,7 @@ function test_fetchUrlWithRequestObject() {
 	const request: Request = new Request("http://www.andlabs.net/html5/uCOR.php", requestOptions);
 	const timeout: number = request.timeout;
 	const size: number = request.size;
-	const agent: Agent = request.agent;
+	const agent: Agent | undefined = request.agent;
 	const protocol: string = request.protocol;
 
 	handlePromise(fetch(request));

--- a/types/node-fetch/tsconfig.json
+++ b/types/node-fetch/tsconfig.json
@@ -7,7 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
-        "strictNullChecks": false,
+        "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",
         "typeRoots": [


### PR DESCRIPTION
`Headers.raw` value type was `string`, but it can be `undefined` and `string[]` (e.g. for multiple `set-cookie` response headers).

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.