### PR TITLE
[whatwg-streams] Fixes for readable byte streams

### DIFF
--- a/types/whatwg-streams/index.d.ts
+++ b/types/whatwg-streams/index.d.ts
@@ -84,7 +84,7 @@ declare class ReadableByteStreamController<R = ArrayBufferView> {
     readonly desiredSize: number | null;
 
     close(): void;
-    enqueue(chunk: R): void;
+    enqueue(chunk: ArrayBufferView): void;
     error(e: any): void;
 }
 

--- a/types/whatwg-streams/index.d.ts
+++ b/types/whatwg-streams/index.d.ts
@@ -89,7 +89,7 @@ declare class ReadableByteStreamController<R = ArrayBufferView> {
 }
 
 declare class ReadableStreamBYOBRequest<R = ArrayBufferView> {
-    readonly view: R;
+    readonly view: Uint8Array;
 
     respond(bytesWritten: number): void;
     respondWithNewView(view: ArrayBufferView): void;

--- a/types/whatwg-streams/index.d.ts
+++ b/types/whatwg-streams/index.d.ts
@@ -12,9 +12,9 @@ export interface ReadableStreamSource<R = ArrayBufferView> {
     cancel?(reason: any): void | Promise<any>;
 }
 
-export interface ReadableByteStreamSource<R = ArrayBufferView> {
-    start?(controller: ReadableByteStreamController<R>): void | Promise<any>;
-    pull?(controller: ReadableByteStreamController<R>): void | Promise<any>;
+export interface ReadableByteStreamSource {
+    start?(controller: ReadableByteStreamController): void | Promise<any>;
+    pull?(controller: ReadableByteStreamController): void | Promise<any>;
     cancel?(reason: any): void | Promise<any>;
 
     type: "bytes";
@@ -39,7 +39,7 @@ export interface WritableReadablePair<T extends WritableStream<any>, U extends R
 
 declare class ReadableStream<R = ArrayBufferView> {
     constructor(underlyingSource?: ReadableStreamSource<R>, strategy?: QueuingStrategy<R>);
-    constructor(underlyingSource?: ReadableByteStreamSource<R>, strategy?: QueuingStrategy<R>);
+    constructor(underlyingSource?: ReadableByteStreamSource, strategy?: QueuingStrategy<R>);
 
     readonly locked: boolean;
 
@@ -79,8 +79,8 @@ declare class ReadableStreamDefaultController<R = ArrayBufferView> {
     error(e: any): void;
 }
 
-declare class ReadableByteStreamController<R = ArrayBufferView> {
-    readonly byobRequest: ReadableStreamBYOBRequest<R> | undefined;
+declare class ReadableByteStreamController {
+    readonly byobRequest: ReadableStreamBYOBRequest | undefined;
     readonly desiredSize: number | null;
 
     close(): void;
@@ -88,7 +88,7 @@ declare class ReadableByteStreamController<R = ArrayBufferView> {
     error(e: any): void;
 }
 
-declare class ReadableStreamBYOBRequest<R = ArrayBufferView> {
+declare class ReadableStreamBYOBRequest {
     readonly view: Uint8Array;
 
     respond(bytesWritten: number): void;

--- a/types/whatwg-streams/index.d.ts
+++ b/types/whatwg-streams/index.d.ts
@@ -80,7 +80,7 @@ declare class ReadableStreamDefaultController<R = ArrayBufferView> {
 }
 
 declare class ReadableByteStreamController<R = ArrayBufferView> {
-    readonly byobRequest: ReadableStreamBYOBRequest<R>;
+    readonly byobRequest: ReadableStreamBYOBRequest<R> | undefined;
     readonly desiredSize: number | null;
 
     close(): void;

--- a/types/whatwg-streams/index.d.ts
+++ b/types/whatwg-streams/index.d.ts
@@ -37,6 +37,11 @@ export interface WritableReadablePair<T extends WritableStream<any>, U extends R
     readable: U;
 }
 
+export interface ReadResult<T> {
+    done: boolean;
+    value: T;
+}
+
 declare class ReadableStream<R = ArrayBufferView> {
     constructor(underlyingSource?: ReadableStreamSource<R>, strategy?: QueuingStrategy<R>);
     constructor(underlyingSource?: ReadableByteStreamSource, strategy?: QueuingStrategy<R>);
@@ -57,7 +62,7 @@ declare class ReadableStreamDefaultReader<R = ArrayBufferView> {
     readonly closed: Promise<void>;
 
     cancel(reason: any): Promise<void>;
-    read(): Promise<IteratorResult<R>>;
+    read(): Promise<ReadResult<R>>;
     releaseLock(): void;
 }
 
@@ -67,7 +72,7 @@ declare class ReadableStreamBYOBReader<R = ArrayBufferView> {
     readonly closed: Promise<void>;
 
     cancel(reason: any): Promise<void>;
-    read<T extends ArrayBufferView>(view: T): Promise<IteratorResult<T>>;
+    read<T extends ArrayBufferView>(view: T): Promise<ReadResult<T>>;
     releaseLock(): void;
 }
 

--- a/types/whatwg-streams/whatwg-streams-tests.ts
+++ b/types/whatwg-streams/whatwg-streams-tests.ts
@@ -187,14 +187,14 @@ function makeReadableByteFileStream(filename: string) {
         pull(controller: ReadableByteStreamController) {
             // Even when the consumer is using the default reader, the auto-allocation
             // feature allocates a buffer and passes it to us via byobRequest.
-            const v = controller.byobRequest.view;
+            const v = controller.byobRequest!.view;
 
             return fs.read(fd, <any>v.buffer, v.byteOffset, v.byteLength, position).then(bytesRead => {
                 if (bytesRead === 0) {
                     return fs.close(fd).then(() => controller.close());
                 } else {
                     position += bytesRead;
-                    controller.byobRequest.respond(bytesRead);
+                    controller.byobRequest!.respond(bytesRead);
                 }
             });
         },


### PR DESCRIPTION
This PR makes the type definitions for readable byte streams match the spec more closely. An overview of the changes:
* `ReadableByteStreamController.enqueue` accepts any `ArrayBufferView`.  
[Step 5](https://streams.spec.whatwg.org/#rbs-controller-enqueue) only requires `chunk` to have a `[[ViewedArrayBuffer]]` internal slot, which exactly matches [`ArrayBuffer.isView`](https://www.ecma-international.org/ecma-262/9.0/index.html#sec-arraybuffer.isview). Different chunks can have different types, as long as each of them is *some* kind of `ArrayBufferView`.
* `ReadableStreamBYOBRequest.view` is always a `Uint8Array`.  
[Step 2b](https://streams.spec.whatwg.org/#rbs-controller-byob-request) always constructs a `Uint8Array`. It will never be a different kind of `ArrayBufferView`.
* `ReadableByteStreamController.byobRequest` may be `undefined`.  
[Step 2](https://streams.spec.whatwg.org/#rbs-controller-byob-request) only constructs a BYOB request when `[[pendingPullIntos]]` is not empty. If it is empty, no BYOB request is constructed.
* Remove unused type parameter on `ReadableByteStreamSource` and related classes.  
As demonstrated by the above changes, readable byte streams aren't generic according to the spec, so there's no use for the `R` type parameter.

I've also included a small ergonomic fix for users targeting ES5:
* Replace `IteratorResult` with own interface to avoid dependency on ES2015 types.  
Previously, we used `IteratorResult<T>` in the return type of `read()`, but this type is not available when compiling with `--lib es5`. I've added a `ReadResult<T>` type which is just a copy of `IteratorResult<T>`, so the type definitions also work in ES5. 😄 

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [https://streams.spec.whatwg.org]
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
