### PR TITLE
[@types/node] Add AsyncIterableIterator.next() method.

### DIFF
--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -26,6 +26,7 @@
 //                 Lishude <https://github.com/islishude>
 //                 Andrew Makarov <https://github.com/r3nya>
 //                 Zane Hannan AU <https://github.com/ZaneHannanAU>
+//                 Nicolas Polomack <https://github.com/Hirevo>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /** inspector module types */
@@ -164,7 +165,9 @@ interface Iterator<T> {
     next(value?: any): IteratorResult<T>;
 }
 interface IteratorResult<T> { }
-interface AsyncIterableIterator<T> {}
+interface AsyncIterableIterator<T> {
+    next(value?: any): Promise<IteratorResult<T>>;
+}
 interface SymbolConstructor {
     readonly observable: symbol;
     readonly iterator: symbol;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes.
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

This PR fixes the following TypeScript issue I encountered with async iterators by using them in for-await-of loops:
```
error TS2519: An async iterator must have a 'next()' method.
```

This is the smallest sample code I could do that triggers the error:
```typescript
import { createReadStream } from "fs";

(async () => {
    const readable = createReadStream("./some_file.txt");
    
    for await (const chunk of readable) {
        // ...
    }
})();
```

The test suite didn't passed because of an issue with redux-form/v4.  
This is being adressed in PR #27212.