### PR TITLE
google.visualization correct column index type

### DIFF
--- a/types/google.visualization/index.d.ts
+++ b/types/google.visualization/index.d.ts
@@ -88,7 +88,7 @@ declare namespace google {
             getColumnProperties(columnIndex: number): Properties;
             getColumnProperty(columnIndex: number, name: string): any;
             getColumnRange(columnIndex: number): { min: any; max: any };
-            getColumnRole(columnIndex: string): string;
+            getColumnRole(columnIndex: number): string;
             getColumnType(columnIndex: number): string;
             getDistinctValues(columnIndex: number): any[];
             getFilteredRows(filters: DataTableCellFilter[]): number[];


### PR DESCRIPTION
Changed `columnIndex` to be a number like all its neighbours. Looks like this one was just a mistake, passing a string to this function on current version of Google charts causes an exception.


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developers.google.com/chart/interactive/docs/reference#DataTable (already in file at head of block)
- [N/A] Increase the version number in the header if appropriate.
- [N/A] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

