### PR TITLE
Updated type definitions for handlebars#registerPartials

### DIFF
--- a/types/handlebars/index.d.ts
+++ b/types/handlebars/index.d.ts
@@ -39,7 +39,7 @@ declare namespace Handlebars {
     export function registerHelper(name: HelperDeclareSpec): void;
     export function unregisterHelper(name: string): void;
 
-    export function registerPartial(name: string | any, fn?: Template): void;
+    export function registerPartial(name: string|any, fn?: Template): void;
     export function unregisterPartial(name: string): void;
 
     // TODO: replace Function with actual signature

--- a/types/handlebars/index.d.ts
+++ b/types/handlebars/index.d.ts
@@ -39,7 +39,8 @@ declare namespace Handlebars {
     export function registerHelper(name: HelperDeclareSpec): void;
     export function unregisterHelper(name: string): void;
 
-    export function registerPartial(name: string|any, fn?: Template): void;
+    export function registerPartial(name: string, fn: Template): void;
+    export function registerPartial(spec: { [name: string]: HandlebarsTemplateDelegate }): void;
     export function unregisterPartial(name: string): void;
 
     // TODO: replace Function with actual signature

--- a/types/handlebars/index.d.ts
+++ b/types/handlebars/index.d.ts
@@ -39,7 +39,7 @@ declare namespace Handlebars {
     export function registerHelper(name: HelperDeclareSpec): void;
     export function unregisterHelper(name: string): void;
 
-    export function registerPartial(name: string, fn: Template): void;
+    export function registerPartial(name: string | any, fn?: Template): void;
     export function unregisterPartial(name: string): void;
 
     // TODO: replace Function with actual signature


### PR DESCRIPTION
I just extended the types of the arguments for the #registerPartial function, because per the implementation that function is polymorphic. If the first argument is a string then the second must be a Template fn, but in case the first argument is an object then the second argument is discarded making it optional.

[The implementation in question](https://github.com/wycats/handlebars.js/blob/148b19182d70278237a62d8293db540483a0c46c/lib/handlebars/base.js#L49)
