### PR TITLE
Fix type of mongodb.connect function

### DIFF
--- a/types/mongodb/index.d.ts
+++ b/types/mongodb/index.d.ts
@@ -24,9 +24,9 @@ import { ObjectID } from 'bson';
 import { EventEmitter } from 'events';
 import { Readable, Writable } from "stream";
 
-export function connect(uri: string, options?: MongoClientOptions): Promise<Db>;
-export function connect(uri: string, callback: MongoCallback<Db>): void;
-export function connect(uri: string, options: MongoClientOptions, callback: MongoCallback<Db>): void;
+export function connect(uri: string, options?: MongoClientOptions): Promise<MongoClient>;
+export function connect(uri: string, callback: MongoCallback<MongoClient>): void;
+export function connect(uri: string, options: MongoClientOptions, callback: MongoCallback<MongoClient>): void;
 
 export { Binary, DBRef, Decimal128, Double, Long, MaxKey, MinKey, ObjectID, ObjectId, Timestamp } from 'bson';
 

--- a/types/mongodb/mongodb-tests.ts
+++ b/types/mongodb/mongodb-tests.ts
@@ -2,6 +2,8 @@
 import mongodb = require('mongodb');
 var MongoClient = mongodb.MongoClient;
 
+const connectionString = 'mongodb://127.0.0.1:27017/test';
+
 var format = require('util').format;
 let options: mongodb.MongoClientOptions = {
     authSource: ' ',
@@ -30,7 +32,7 @@ let options: mongodb.MongoClientOptions = {
     promoteBuffers: false,
     useNewUrlParser: false
 }
-MongoClient.connect('mongodb://127.0.0.1:27017/test', options, function (err: mongodb.MongoError, client: mongodb.MongoClient) {
+MongoClient.connect(connectionString, options, function (err: mongodb.MongoError, client: mongodb.MongoClient) {
     if (err) throw err;
     const db = client.db('test');
     var collection = db.collection('test_insert');
@@ -166,3 +168,11 @@ MongoClient.connect('mongodb://127.0.0.1:27017/test', options, function (err: mo
         const res: mongodb.Cursor<TestCollection> = testCollection.find({ _id: 123 });
     }
 })
+
+let testFunc = async () => {
+    let testClient: mongodb.MongoClient;
+    testClient = await mongodb.connect(connectionString);
+};
+
+mongodb.connect(connectionString, (err: mongodb.MongoError, client: mongodb.MongoClient) => {});
+mongodb.connect(connectionString, options, (err: mongodb.MongoError, client: mongodb.MongoClient) => {});


### PR DESCRIPTION
It had never been updated from 2.x. Fixes #23548.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/mongodb/node-mongodb-native/blob/master/CHANGES_3.0.0.md#api-changes

(It's one of the last things listed before the "Other Changes" section)
- [ ] ~~Increase the version number in the header if appropriate.~~
- [ ] ~~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.~~