### PR TITLE
[@types/jquery] fix: let jQuery's insertAfter / insertBefore accept Node and JQuery<Node>

### DIFF
--- a/types/jquery/index.d.ts
+++ b/types/jquery/index.d.ts
@@ -22,7 +22,7 @@
 //                 Dick van den Brink <https://github.com/DickvdBrink>
 //                 Thomas Schulz <https://github.com/King2500>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.4
 
 declare module 'jquery' {
     export = jQuery;

--- a/types/jquery/index.d.ts
+++ b/types/jquery/index.d.ts
@@ -22,7 +22,7 @@
 //                 Dick van den Brink <https://github.com/DickvdBrink>
 //                 Thomas Schulz <https://github.com/King2500>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.4
+// TypeScript Version: 2.3
 
 declare module 'jquery' {
     export = jQuery;
@@ -4327,7 +4327,7 @@ interface JQuery<TElement = HTMLElement> extends Iterable<TElement> {
      * @see \`{@link https://api.jquery.com/insertAfter/ }\`
      * @since 1.0
      */
-    insertAfter<E extends Node>(target: JQuery.Selector | JQuery.htmlString | JQuery.TypeOrArray<E> | JQuery<E>): this;
+    insertAfter(target: JQuery.Selector | JQuery.htmlString | JQuery.TypeOrArray<Node> | JQuery<Node>): this;
     /**
      * Insert every element in the set of matched elements before the target.
      *
@@ -4336,7 +4336,7 @@ interface JQuery<TElement = HTMLElement> extends Iterable<TElement> {
      * @see \`{@link https://api.jquery.com/insertBefore/ }\`
      * @since 1.0
      */
-    insertBefore<E extends Node>(target: JQuery.Selector | JQuery.htmlString | JQuery.TypeOrArray<E> | JQuery<E>): this;
+    insertBefore(target: JQuery.Selector | JQuery.htmlString | JQuery.TypeOrArray<Node> | JQuery<Node>): this;
     /**
      * Check the current matched set of elements against a selector, element, or jQuery object and return
      * true if at least one of these elements matches the given arguments.

--- a/types/jquery/index.d.ts
+++ b/types/jquery/index.d.ts
@@ -4327,7 +4327,7 @@ interface JQuery<TElement = HTMLElement> extends Iterable<TElement> {
      * @see \`{@link https://api.jquery.com/insertAfter/ }\`
      * @since 1.0
      */
-    insertAfter(target: JQuery.Selector | JQuery.htmlString | JQuery.TypeOrArray<Element> | JQuery): this;
+    insertAfter<E extends Node>(target: JQuery.Selector | JQuery.htmlString | JQuery.TypeOrArray<E> | JQuery<E>): this;
     /**
      * Insert every element in the set of matched elements before the target.
      *
@@ -4336,7 +4336,7 @@ interface JQuery<TElement = HTMLElement> extends Iterable<TElement> {
      * @see \`{@link https://api.jquery.com/insertBefore/ }\`
      * @since 1.0
      */
-    insertBefore(target: JQuery.Selector | JQuery.htmlString | JQuery.TypeOrArray<Element> | JQuery): this;
+    insertBefore<E extends Node>(target: JQuery.Selector | JQuery.htmlString | JQuery.TypeOrArray<E> | JQuery<E>): this;
     /**
      * Check the current matched set of elements against a selector, element, or jQuery object and return
      * true if at least one of these elements matches the given arguments.

--- a/types/jquery/jquery-tests.ts
+++ b/types/jquery/jquery-tests.ts
@@ -5655,6 +5655,12 @@ function JQuery() {
 
             // $ExpectType JQuery<HTMLElement>
             $('span').insertAfter($('p'));
+
+            // $ExpectType JQuery<HTMLElement>
+            $('span').insertAfter(new Text('hello!'));
+
+            // $ExpectType JQuery<HTMLElement>
+            $('span').insertAfter($(new Text('hello!')));
         }
 
         function insertBefore() {
@@ -5672,6 +5678,12 @@ function JQuery() {
 
             // $ExpectType JQuery<HTMLElement>
             $('span').insertBefore($('p'));
+
+            // $ExpectType JQuery<HTMLElement>
+            $('span').insertBefore(new Text('hello!'));
+
+            // $ExpectType JQuery<HTMLElement>
+            $('span').insertBefore($(new Text('hello!')));
         }
 
         function prependTo() {

--- a/types/jquery/test/longdesc-tests.ts
+++ b/types/jquery/test/longdesc-tests.ts
@@ -762,12 +762,32 @@ function longdesc() {
         $('h2').insertAfter($('.container'));
     }
 
+    function insert_after_2() {
+        const foo = document.querySelector('.foo')!;
+        $('h2').insertAfter(foo);
+    }
+
+    function insert_after_3() {
+        const foo = document.querySelector('.foo')!;
+        $('h2').insertAfter($(foo));
+    }
+
     function insert_before_0() {
         $('<p>Test</p>').insertBefore('.inner');
     }
 
     function insert_before_1() {
         $('h2').insertBefore($('.container'));
+    }
+
+    function insert_before_2() {
+        const foo = document.querySelector('.foo')!;
+        $('h2').insertBefore(foo);
+    }
+
+    function insert_before_3() {
+        const foo = document.querySelector('.foo')!;
+        $('h2').insertBefore($(foo));
     }
 
     function is_0() {

--- a/types/jquery/test/longdesc-tests.ts
+++ b/types/jquery/test/longdesc-tests.ts
@@ -762,32 +762,12 @@ function longdesc() {
         $('h2').insertAfter($('.container'));
     }
 
-    function insert_after_2() {
-        const foo = document.querySelector('.foo')!;
-        $('h2').insertAfter(foo);
-    }
-
-    function insert_after_3() {
-        const foo = document.querySelector('.foo')!;
-        $('h2').insertAfter($(foo));
-    }
-
     function insert_before_0() {
         $('<p>Test</p>').insertBefore('.inner');
     }
 
     function insert_before_1() {
         $('h2').insertBefore($('.container'));
-    }
-
-    function insert_before_2() {
-        const foo = document.querySelector('.foo')!;
-        $('h2').insertBefore(foo);
-    }
-
-    function insert_before_3() {
-        const foo = document.querySelector('.foo')!;
-        $('h2').insertBefore($(foo));
     }
 
     function is_0() {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- <del>[ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>></del>
- <del>[ ] Increase the version number in the header if appropriate.</del>
-<del> [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.</del>

---


<del>As `insertBefore(x as JQuery<Element>)` is valid , `insertBefore(x as JQuery<HTMLElement>)` but it doesn't compile. The signature should be ones in this pull-request, as the test code suggests.</del>

<ins>After review: As @leonard-thieu  pointed out, all I need are `Node` and `JQuery<Node>`, so just change dts to accept them.

The error that the PR will fix:

```
test/longdesc-tests.ts:790:30 - error TS2345: Argument of type 'JQuery<Element>' is not assignable to parameter of type 'string | Element | Node | HTMLElement | JQuery<HTMLElement> | (Element | Node | HTMLElement)[]'.
  Type 'JQuery<Element>' is not assignable to type 'JQuery<HTMLElement>'.
```