### PR TITLE
Fix incorrectly typed GatewayDest's component prop in react-gateway

### DIFF
--- a/types/react-gateway/GatewayDest.d.ts
+++ b/types/react-gateway/GatewayDest.d.ts
@@ -4,7 +4,7 @@ declare namespace GatewayDest {
     interface GatewayDestProps {
         name: string;
         tagName?: string;
-        component?: string | React.Component;
+        component?: string | React.ComponentClass;
     }
 }
 declare class GatewayDest extends React.Component<GatewayDest.GatewayDestProps> { }

--- a/types/react-gateway/react-gateway-tests.tsx
+++ b/types/react-gateway/react-gateway-tests.tsx
@@ -1,6 +1,14 @@
 import * as React from 'react';
 import { Gateway, GatewayProvider, GatewayDest } from 'react-gateway';
 
+class GatewayComponent extends React.Component {
+  render() {
+    return (
+      <div>{this.props.children}</div>
+    );
+  }
+}
+
 class ReactGateway extends React.Component<Gateway.GatewayProps> {
     render() {
         return (
@@ -17,7 +25,8 @@ class ReactGatewayProvider extends React.Component {
     render() {
         return (
             <GatewayProvider>
-                <GatewayDest name="test" />
+                <GatewayDest name="test" component={GatewayComponent} />
+                <GatewayDest name="test2" component="span" />
                 <div>
                     All the way down...
                     <div>
@@ -26,6 +35,7 @@ class ReactGatewayProvider extends React.Component {
                             Getting close...
                             <div>
                                 <ReactGateway into="test" />
+                                <ReactGateway into="test2" />
                             </div>
                         </div>
                     </div>

--- a/types/react-gateway/react-gateway-tests.tsx
+++ b/types/react-gateway/react-gateway-tests.tsx
@@ -27,6 +27,7 @@ class ReactGatewayProvider extends React.Component {
             <GatewayProvider>
                 <GatewayDest name="test" component={GatewayComponent} />
                 <GatewayDest name="test2" component="span" />
+                <GatewayDest name="test3" />
                 <div>
                     All the way down...
                     <div>
@@ -36,6 +37,7 @@ class ReactGatewayProvider extends React.Component {
                             <div>
                                 <ReactGateway into="test" />
                                 <ReactGateway into="test2" />
+                                <ReactGateway into="test3" />
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/cloudflare/react-gateway#react-native-example
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.

---

`GatewayDest` takes a prop `component` of type `React.ComponentClass` and not `React.Component`. This PR fixes it and also adds a test for it.