### PR TITLE
Add additional videojs player options

### DIFF
--- a/types/video.js/index.d.ts
+++ b/types/video.js/index.d.ts
@@ -23,26 +23,32 @@ declare namespace videojs {
 	const getPlugin: typeof Plugin.getPlugin;
 
 	interface PlayerOptions {
-		techOrder?: string[];
-		sourceOrder?: boolean;
-		html5?: any;
-		width?: number;
-		height?: number;
-		defaultVolume?: number;
+		aspectRatio?: string;
+		autoplay?: boolean;
+		autoSetup?: boolean;
 		children?: string[];
+		controls?: boolean;
+		defaultVolume?: number;
+		fluid?: boolean;
+		height?: number;
+		html5?: any;
+		inactivityTimeout?: number;
+		language?: string;
+		languages?: { [key: string]: string };
 		loop?: boolean;
 		muted?: boolean;
-		controls?: boolean;
-		src?: string;
-		autoplay?: boolean;
-		preload?: string;
-		sources?: Source[];
-		aspectRatio?: string;
-		fluid?: boolean;
-		language?: string;
+		nativeControlsForTouch?: boolean;
 		notSupportedMessage?: string;
+		playbackRates?: Array<number>;
 		plugins?: any;
 		poster?: string;
+		preload?: string;
+		sourceOrder?: boolean;
+		sources?: Source[];
+		src?: string;
+		techCanOverridePoster?: boolean;
+		techOrder?: string[];
+		width?: number;
 	}
 
 	interface Source {

--- a/types/video.js/index.d.ts
+++ b/types/video.js/index.d.ts
@@ -39,7 +39,7 @@ declare namespace videojs {
 		muted?: boolean;
 		nativeControlsForTouch?: boolean;
 		notSupportedMessage?: string;
-		playbackRates?: Array<number>;
+		playbackRates?: number[];
 		plugins?: any;
 		poster?: string;
 		preload?: string;


### PR DESCRIPTION
## What does this PR do?

It enumerates additional options for the `PlayerOptions` interface for video.js players. And it alphabetizes those options. 😇 

## Can you be more specific?

It adds options specified in the [official docs][1] such as `playbackRates` that aren't included in the current definitions.

## Why make these changes?

As far as I can tell, if I try to create a video.js player and specify something like `{playbackRates: [1, 1.5, 2]}` the compiler will complain because that option isn't enumerated in the interface. (But `playbackRates` is a valid option and the interface should reflect that.)

Source: http://docs.videojs.com/tutorial-options.html#videojs-specific-options

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://docs.videojs.com/tutorial-options.html#videojs-specific-options

[1]: http://docs.videojs.com/tutorial-options.html#videojs-specific-options

