### PR TITLE
[JSS] Export the JSS class declaration

### DIFF
--- a/types/jss/index.d.ts
+++ b/types/jss/index.d.ts
@@ -104,13 +104,13 @@ export interface RuleOptions {
 	className: string;
 }
 export declare class SheetsRegistry {
-    constructor();
-    registry: ReadonlyArray<StyleSheet>;
-    readonly index: number;
-    add(sheet: StyleSheet): void;
-    reset(): void;
-    remove(sheet: StyleSheet): void;
-    toString(options?: ToCssOptions): string;
+	constructor();
+	registry: ReadonlyArray<StyleSheet>;
+	readonly index: number;
+	add(sheet: StyleSheet): void;
+	reset(): void;
+	remove(sheet: StyleSheet): void;
+	toString(options?: ToCssOptions): string;
 }
 export type CreateStyleSheetOptions<Name extends string = any> = Partial<{
 	media: string;
@@ -121,7 +121,7 @@ export type CreateStyleSheetOptions<Name extends string = any> = Partial<{
 	generateClassName: GenerateClassName<Name>;
 	classNamePrefix: string;
 }>;
-declare class JSS {
+export declare class JSS {
 	constructor(options?: Partial<JSSOptions>);
 	createStyleSheet<Name extends string>(
 		styles: Partial<Styles<Name>>,

--- a/types/jss/jss-tests.ts
+++ b/types/jss/jss-tests.ts
@@ -1,12 +1,10 @@
 // API docs at http://cssinjs.org/js-api
 
-import { ObserverOrNext } from 'indefinite-observable';
 import {
 	create as createJSS,
 	SheetsRegistry,
 	default as sharedInstance,
 } from 'jss';
-import * as csstype from 'csstype';
 
 const jss = createJSS().setup({});
 jss.use({}, {}); // $ExpectType JSS
@@ -14,7 +12,7 @@ jss.use({}, {}); // $ExpectType JSS
 const styleSheet = jss.createStyleSheet<string>(
 	{
 		ruleWithMockObservable: {
-			subscribe: (observer: ObserverOrNext<csstype.PropertiesHyphen>) => {
+			subscribe: observer => {
 				const next = typeof observer === 'function' ? observer : observer.next;
 				next({ background: 'blue', display: 'flex' });
 				next({ invalidKey: 'blueish' }); // $ExpectError
@@ -23,7 +21,7 @@ const styleSheet = jss.createStyleSheet<string>(
 				next({ 'align-items': 'center' });
 				next({ alignItems: 'center' }); // $ExpectError
 				return {
-					unsubscribe() { }
+					unsubscribe() {}
 				};
 			}
 		},
@@ -97,7 +95,7 @@ const secondStyleSheet = jss.createStyleSheet(
 		ruleWithMockObservable: {
 			subscribe() {
 				return {
-					unsubscribe() { }
+					unsubscribe() {}
 				};
 			}
 		},
@@ -120,6 +118,6 @@ sheetsRegistry.index; // $ExpectType number
 sheetsRegistry.index = 5; // $ExpectError
 sheetsRegistry.toString(); // $ExpectType string
 // With css options
-sheetsRegistry.toString({ indent: 5 }); // $ExpectType string
+sheetsRegistry.toString({indent: 5}); // $ExpectType string
 
 sheetsRegistry.reset();

--- a/types/jss/jss-tests.ts
+++ b/types/jss/jss-tests.ts
@@ -1,10 +1,12 @@
 // API docs at http://cssinjs.org/js-api
 
+import { ObserverOrNext } from 'indefinite-observable';
 import {
 	create as createJSS,
 	SheetsRegistry,
 	default as sharedInstance,
 } from 'jss';
+import * as csstype from 'csstype';
 
 const jss = createJSS().setup({});
 jss.use({}, {}); // $ExpectType JSS
@@ -12,7 +14,7 @@ jss.use({}, {}); // $ExpectType JSS
 const styleSheet = jss.createStyleSheet<string>(
 	{
 		ruleWithMockObservable: {
-			subscribe: observer => {
+			subscribe: (observer: ObserverOrNext<csstype.PropertiesHyphen>) => {
 				const next = typeof observer === 'function' ? observer : observer.next;
 				next({ background: 'blue', display: 'flex' });
 				next({ invalidKey: 'blueish' }); // $ExpectError
@@ -21,7 +23,7 @@ const styleSheet = jss.createStyleSheet<string>(
 				next({ 'align-items': 'center' });
 				next({ alignItems: 'center' }); // $ExpectError
 				return {
-					unsubscribe() {}
+					unsubscribe() { }
 				};
 			}
 		},
@@ -95,7 +97,7 @@ const secondStyleSheet = jss.createStyleSheet(
 		ruleWithMockObservable: {
 			subscribe() {
 				return {
-					unsubscribe() {}
+					unsubscribe() { }
 				};
 			}
 		},
@@ -118,6 +120,6 @@ sheetsRegistry.index; // $ExpectType number
 sheetsRegistry.index = 5; // $ExpectError
 sheetsRegistry.toString(); // $ExpectType string
 // With css options
-sheetsRegistry.toString({indent: 5}); // $ExpectType string
+sheetsRegistry.toString({ indent: 5 }); // $ExpectType string
 
 sheetsRegistry.reset();


### PR DESCRIPTION
to: @appsforartists @frenic @pelotom 

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

It's not possible to use the `JSS` type as an annotation, which would be super useful for something like:

```
constructor(jss: JSS) {
  this.jss = jss;
}
```

Right now I'm doing `type JSS = ReturnType<typeof create>;` just to infer the class.