### PR TITLE
Remove geolocation because it conflicts with dom types

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -652,27 +652,6 @@ type GeoOptions = {
     useSignificantChanges?: boolean;
 };
 
-type GeolocationReturnType = {
-    coords: {
-        latitude: number;
-        longitude: number;
-        altitude: number | null;
-        accuracy: number;
-        altitudeAccuracy: number | null;
-        heading: number | null;
-        speed: number | null;
-    };
-    timestamp: number;
-};
-
-type GeolocationError = {
-    code: number;
-    message: string;
-    PERMISSION_DENIED: number;
-    POSITION_UNAVAILABLE: number;
-    TIMEOUT: number;
-};
-
 interface PerpectiveTransform {
     perspective: number;
 }
@@ -8426,38 +8405,6 @@ export interface I18nManagerStatic {
     forceRTL: (forceRTL: boolean) => {};
 }
 
-export interface GeolocationStatic {
-    /**
-     * Invokes the success callback once with the latest location info.  Supported
-     * options: timeout (ms), maximumAge (ms), enableHighAccuracy (bool)
-     * On Android, this can return almost immediately if the location is cached or
-     * request an update, which might take a while.
-     */
-    getCurrentPosition(
-        geo_success: (position: GeolocationReturnType) => void,
-        geo_error?: (error: GeolocationError) => void,
-        geo_options?: GeoOptions
-    ): void;
-
-    /**
-     * Invokes the success callback whenever the location changes.  Supported
-     * options: timeout (ms), maximumAge (ms), enableHighAccuracy (bool), distanceFilter(m)
-     */
-    watchPosition(
-        success: (position: GeolocationReturnType) => void,
-        error?: (error: GeolocationError) => void,
-        options?: GeoOptions
-    ): number;
-
-    clearWatch(watchID: number): void;
-
-    stopObserving(): void;
-
-    requestAuthorization(): void;
-
-    setRNConfiguration(config: GeoConfiguration): void;
-}
-
 export interface OpenCameraDialogOptions {
     /** Defaults to false */
     videoMode?: boolean;
@@ -8743,9 +8690,6 @@ export type Clipboard = ClipboardStatic;
 export const DatePickerAndroid: DatePickerAndroidStatic;
 export type DatePickerAndroid = DatePickerAndroidStatic;
 
-export const Geolocation: GeolocationStatic;
-export type Geolocation = GeolocationStatic;
-
 /** http://facebook.github.io/react-native/blog/2016/08/19/right-to-left-support-for-react-native-apps.html */
 export const I18nManager: I18nManagerStatic;
 export type I18nManager = I18nManagerStatic;
@@ -8949,7 +8893,6 @@ declare global {
      */
     interface Navigator {
         readonly product: string;
-        readonly geolocation: Geolocation;
     }
 
     const navigator: Navigator;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/24573
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

Original source of the issue: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/24573

Background for this change:
React Native is using same geolocation api as the browser: https://facebook.github.io/react-native/docs/geolocation Also react-native types depend on dom(browser) types. react-native types had typed Geolocation without problems. Now when upgrading from TS 2.7.2 -> 2.8.1 dom types have added geolocation too to the navigator object: https://github.com/Microsoft/TypeScript/compare/v2.7.2%E2%80%A6v2.8.1

So now there is a conflict since BOTH dom and react-native are defining global navigator.

Possible solutions:
1. Remove dom types 🔴 cant because react-native uses dom types (and many other libraries that you can use with react-native)
2. extend navigator object and override properties 🔴 cant because in TS you can only merge types but not override
3. Remove geolocation types from react-native(this PR) 🔵 we could do this since geolocation api should be almost same as in browser. This is the reason they did it like this that the api is the same
4. Remove navigator from global namespace in react native itself and make it as normal import 🔵 maybe but of course this would need breaking changes to the actual source code, not just types.

What do you guys think?
