### PR TITLE
[jquery] `offset` can accept a partial `Coordinates` object.

### DIFF
--- a/types/jquery/index.d.ts
+++ b/types/jquery/index.d.ts
@@ -4704,7 +4704,7 @@ interface JQuery<TElement = HTMLElement> extends Iterable<TElement> {
      * @see \`{@link https://api.jquery.com/offset/ }\`
      * @since 1.4
      */
-    offset(coordinates: JQuery.Coordinates | ((this: TElement, index: number, coords: JQuery.Coordinates) => JQuery.Coordinates)): this;
+    offset(coordinates: JQuery.CoordinatesPartial | ((this: TElement, index: number, coords: JQuery.Coordinates) => JQuery.CoordinatesPartial)): this;
     /**
      * Get the current coordinates of the first element in the set of matched elements, relative to the document.
      *
@@ -8333,6 +8333,12 @@ declare namespace JQuery {
         left: number;
         top: number;
     }
+
+    // Workaround for TypeScript 2.3 which does not have support for weak types handling.
+    type CoordinatesPartial =
+        Pick<Coordinates, 'left'> |
+        Pick<Coordinates, 'top'> |
+        { [key: string]: never; };
 
     interface ValHook<TElement> {
         get?(elem: TElement): any;

--- a/types/jquery/jquery-tests.ts
+++ b/types/jquery/jquery-tests.ts
@@ -2757,6 +2757,18 @@ function JQuery() {
             });
 
             // $ExpectType JQuery<HTMLElement>
+            $('p').offset({
+                left: 20
+            });
+
+            // $ExpectType JQuery<HTMLElement>
+            $('p').offset({});
+
+            // Weak type test. This may be removed if the TypeScript requirement is increased to 2.4+.
+            // $ExpectError
+            $('p').offset(20);
+
+            // $ExpectType JQuery<HTMLElement>
             $('p').offset(function(index, coords) {
                 // $ExpectType HTMLElement
                 this;
@@ -2767,6 +2779,20 @@ function JQuery() {
 
                 return {
                     left: 20,
+                    top: 50
+                };
+            });
+
+            // $ExpectType JQuery<HTMLElement>
+            $('p').offset(function(index, coords) {
+                // $ExpectType HTMLElement
+                this;
+                // $ExpectType number
+                index;
+                // $ExpectType Coordinates
+                coords;
+
+                return {
                     top: 50
                 };
             });


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
https://jsfiddle.net/leonard_thieu/xpvt214o/454224/
- ~~Increase the version number in the header if appropriate.~~
- ~~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.~~

---

This PR allows `offset` to accept a partial `Coordinates` object. Check the fiddle linked above for a demonstration of this behavior. Since `@types/jquery` supports TypeScript 2.3 which doesn't have support for weak types handling, `Partial<Coordinates>` could not be used as it would be a weak type.

Fixes #27294