### PR TITLE
Gapi - Use 'any | boolean' for error result as in the official documentation

### DIFF
--- a/types/gapi/index.d.ts
+++ b/types/gapi/index.d.ts
@@ -247,7 +247,7 @@ declare namespace gapi.client {
     }
 
     interface HttpRequestRejected {
-        result: any;
+        result: any | boolean;
         body: string;
         headers?: any[];
         status?: number;

--- a/types/gapi/index.d.ts
+++ b/types/gapi/index.d.ts
@@ -247,11 +247,7 @@ declare namespace gapi.client {
     }
 
     interface HttpRequestRejected {
-        result: {
-            error: {
-                message: string;
-            }
-        };
+        result: any;
         body: string;
         headers?: any[];
         status?: number;


### PR DESCRIPTION
- When using promises for gapi, the official documentation is not specific about the result type.

https://developers.google.com/api-client-library/javascript/features/promises#using-promises

