### PR TITLE
[@types/google-apps-script] Override Google Apps Script generated types (remove Object, add TSDoc comments)

### DIFF
--- a/types/google-apps-script/google-apps-script.card.d.ts
+++ b/types/google-apps-script/google-apps-script.card.d.ts
@@ -7,7 +7,7 @@
 /// <reference path="google-apps-script.gmail.d.ts" />
 
 declare namespace GoogleAppsScript {
-  export module Card_Service {
+  export module Card {
     /**
      * An action that enables interactivity within UI elements. The action does not happen directly on
      * the client but rather invokes an Apps Script callback function with optional parameters.
@@ -657,4 +657,4 @@ declare namespace GoogleAppsScript {
   }
 }
 
-declare var CardService: GoogleAppsScript.Card_Service.CardService;
+declare var CardService: GoogleAppsScript.Card.CardService;

--- a/types/google-apps-script/google-apps-script.drive.d.ts
+++ b/types/google-apps-script/google-apps-script.drive.d.ts
@@ -32,29 +32,104 @@ declare namespace GoogleAppsScript {
     export interface DriveApp {
       Access: typeof Access;
       Permission: typeof Permission;
+      /**
+       * Adds the given file to the root of the user's Drive.
+       * This method does not move the file out of its existing parent folder;
+       * a file can have more than one parent simultaneously.
+       */
       addFile(child: File): Folder;
+      /**
+       * Adds the given folder to the root of the user's Drive.
+       * This method does not move the folder out of its existing parent folder;
+       * a folder can have more than one parent simultaneously.
+       */
       addFolder(child: Folder): Folder;
+      /**
+       * Resumes a file iteration using a continuation token from a previous iterator.
+       * This method is useful if processing an iterator in one execution would exceed
+       * the maximum execution time. Continuation tokens are generally valid for one week.
+       */
       continueFileIterator(continuationToken: string): FileIterator;
+      /**
+       * Resumes a folder iteration using a continuation token from a previous iterator.
+       * This method is useful if processing an iterator in one execution would exceed
+       * the maximum execution time. Continuation tokens are generally valid for one week.
+       */
       continueFolderIterator(continuationToken: string): FolderIterator;
+      /** Creates a file in the root of the user's Drive from a given Blob of arbitrary data. */
       createFile(blob: Base.BlobSource): File;
+      /**
+       * Creates a text file in the root of the user's Drive with the given name
+       * and contents. Throws an exception if content is larger than 50 MB.
+       */
       createFile(name: string, content: string): File;
+      /**
+       * Creates a file in the root of the user's Drive with the given name, contents, and MIME type.
+       * Throws an exception if content is larger than 10MB.
+       */
       createFile(name: string, content: string, mimeType: string): File;
+      /** Creates a folder in the root of the user's Drive with the given name. */
       createFolder(name: string): Folder;
+      /**
+       * Gets the file with the given ID.
+       * Throws a scripting exception if the file does not exist or
+       * the user does not have permission to access it.
+       */
       getFileById(id: string): File;
+      /** Gets a collection of all files in the user's Drive. */
       getFiles(): FileIterator;
+      /** Gets a collection of all files in the user's Drive that have the given name. */
       getFilesByName(name: string): FileIterator;
+      /** Gets a collection of all files in the user's Drive that have the given MIME type. */
       getFilesByType(mimeType: string): FileIterator;
+      /**
+       * Gets the folder with the given ID. Throws a scripting exception if the folder
+       * does not exist or the user does not have permission to access it.
+       */
       getFolderById(id: string): Folder;
+      /** Gets a collection of all folders in the user's Drive. */
       getFolders(): FolderIterator;
+      /** Gets a collection of all folders in the user's Drive that have the given name. */
       getFoldersByName(name: string): FolderIterator;
+      /** Gets the folder at the root of the user's Drive. */
       getRootFolder(): Folder;
+      /** Gets the number of bytes the user is allowed to store in Drive. */
       getStorageLimit(): Integer;
+      /** Gets the number of bytes the user is currently storing in Drive. */
       getStorageUsed(): Integer;
+      /** Gets a collection of all the files in the trash of the user's Drive. */
       getTrashedFiles(): FileIterator;
+      /** Gets a collection of all the folders in the trash of the user's Drive. */
       getTrashedFolders(): FolderIterator;
+      /**
+       * Removes the given file from the root of the user's Drive.
+       * This method does not delete the file, but if a file is removed from all
+       * of its parents, it cannot be seen in Drive except by searching for it
+       * or using the "All items" view.
+       */
       removeFile(child: File): Folder;
+      /**
+       * Removes the given folder from the root of the user's Drive.
+       * This method does not delete the folder or its contents, but if a folder
+       * is removed from all of its parents, it cannot be seen in Drive except
+       * by searching for it or using the "All items" view.
+       */
       removeFolder(child: Folder): Folder;
+      /**
+       * Gets a collection of all files in the user's Drive that match the given search criteria.
+       * The search criteria are detailed the Google Drive SDK documentation.
+       * Note that the params argument is a query string that may contain string values,
+       * so take care to escape quotation marks correctly
+       * (for example "title contains 'Gulliver\\'s Travels'" or 'title contains "Gulliver\'s Travels"').
+       */
       searchFiles(params: string): FileIterator;
+      /**
+       * Gets a collection of all folders in the user's Drive that match the given search criteria.
+       * The search criteria are detailed the Google Drive SDK documentation.
+       * Note that the params argument is a query string that may contain string values,
+       * so take care to escape quotation marks correctly
+       * (for example "title contains 'Gulliver\\'s Travels'" or 'title contains "Gulliver\'s Travels"').
+       */
       searchFolders(params: string): FolderIterator;
     }
 
@@ -138,8 +213,18 @@ declare namespace GoogleAppsScript {
      *     }
      */
     export interface FileIterator {
+      /**
+       * Gets a token that can be used to resume this iteration at a later time.
+       * This method is useful if processing an iterator in one execution would
+       * exceed the maximum execution time. Continuation tokens are generally valid for one week.
+       */
       getContinuationToken(): string;
+      /** Determines whether calling next() will return an item. */
       hasNext(): boolean;
+      /**
+       * Gets the next item in the collection of files or folders.
+       * Throws an exception if no items remain.
+       */
       next(): File;
     }
 
@@ -249,13 +334,26 @@ declare namespace GoogleAppsScript {
      *     }
      */
     export interface User {
+      /** Gets the domain name associated with the user's account. */
       getDomain(): string;
+      /**
+       * Gets the user's email address. The user's email address is only available
+       * if the user has chosen to share the address from the Google+ account settings
+       * page, or if the user belongs to the same domain as the user running the script
+       * and the domain administrator has allowed all users within the domain to see
+       * other users' email addresses.
+       */
       getEmail(): string;
+      /** Gets the user's name. This method returns null if the user's name is not available. */
       getName(): string;
+      /** Gets the URL for the user's photo. This method returns null if the user's photo is not available. */
       getPhotoUrl(): string;
+      /**
+       * Gets the user's email address.
+       * @deprecated As of June 24, 2013, replaced by getEmail()
+       */
       getUserLoginId(): string;
     }
-
   }
 }
 

--- a/types/google-apps-script/google-apps-script.forms.d.ts
+++ b/types/google-apps-script/google-apps-script.forms.d.ts
@@ -151,6 +151,9 @@ declare namespace GoogleAppsScript {
      *     checkBoxItem.setValidation(checkBoxValidation);
      */
     export interface CheckboxValidation {
+      requireSelectAtLeast(number: Integer): CheckboxValidation;
+      requireSelectAtMost(number: Integer): CheckboxValidation;
+      requireSelectExactly(number: Integer): CheckboxValidation;
     }
 
     /**

--- a/types/google-apps-script/google-apps-script.gmail.d.ts
+++ b/types/google-apps-script/google-apps-script.gmail.d.ts
@@ -119,13 +119,72 @@ declare namespace GoogleAppsScript {
      * A user-created draft message in a user's Gmail account.
      */
     export interface GmailDraft {
+      /**
+       * Deletes this draft message.
+       */
       deleteDraft(): void;
+      /**
+       * Gets the ID of this draft message.
+       */
       getId(): string;
+      /**
+       * Returns a GmailMessage representing this draft.
+       */
       getMessage(): GmailMessage;
+      /**
+       * Returns the ID of the `GmailMessage` representing this draft.
+       */
       getMessageId(): string;
+      /**
+       * Sends this draft email message.
+       */
       send(): GmailMessage;
+      /**
+       * Replaces the contents of this draft message.
+       */
       update(recipient: string, subject: string, body: string): GmailDraft;
-      update(recipient: string, subject: string, body: string, options: Object): GmailDraft;
+      /**
+       * Replaces the contents of this draft message using optional arguments.
+       */
+      update(recipient: string, subject: string, body: string, options: GmailDraftOptions): GmailDraft;
+    }
+
+    /**
+     * Options for a Gmail draft.
+     */
+    export type GmailDraftOptions = {
+      /**
+       * An array of files to send with the email.
+       */
+      attachments?: Base.BlobSource[];
+      /**
+       * A comma-separated list of email addresses to BCC.
+       */
+      bcc?: string;
+      /**
+       * A comma-separated list of email addresses to CC.
+       */
+      cc?: string;
+      /**
+       * The address that the email should be sent from, which must be one of the values returned by `GmailApp.getAliases()`.
+       */
+      from?: string;
+      /**
+       * If set, devices capable of rendering HTML will use it instead of the required body argument; you can add an optional `inlineImages` field in HTML body if you have inlined images for your email.
+       */
+      htmlBody?: string;
+      /**
+       * A JavaScript object containing a mapping from image key (`String`) to image data (`BlobSource`) ; this assumes that the `htmlBody` parameter is used and contains references to these images in the format `<img src="cid:imageKey" />`.
+       */
+      inlineImages?: { [imageKey: string]: Base.BlobSource };
+      /**
+       * The name of the sender of the email (default: the user's name).
+       */
+      name?: string;
+      /**
+       * An email address to use as the default reply-to address (default: the user's email address).
+       */
+      replyTo?: string;
     }
 
     /**
@@ -148,11 +207,11 @@ declare namespace GoogleAppsScript {
      */
     export interface GmailMessage {
       createDraftReply(body: string): GmailDraft;
-      createDraftReply(body: string, options: Object): GmailDraft;
+      createDraftReply(body: string, options: GmailDraftOptions): GmailDraft;
       createDraftReplyAll(body: string): GmailDraft;
-      createDraftReplyAll(body: string, options: Object): GmailDraft;
+      createDraftReplyAll(body: string, options: GmailDraftOptions): GmailDraft;
       forward(recipient: string): GmailMessage;
-      forward(recipient: string, options: Object): GmailMessage;
+      forward(recipient: string, options: GmailDraftOptions): GmailMessage;
       getAttachments(): GmailAttachment[];
       getBcc(): string;
       getBody(): string;
@@ -178,9 +237,9 @@ declare namespace GoogleAppsScript {
       moveToTrash(): GmailMessage;
       refresh(): GmailMessage;
       reply(body: string): GmailMessage;
-      reply(body: string, options: Object): GmailMessage;
+      reply(body: string, options: GmailDraftOptions): GmailMessage;
       replyAll(body: string): GmailMessage;
-      replyAll(body: string, options: Object): GmailMessage;
+      replyAll(body: string, options: GmailDraftOptions): GmailMessage;
       star(): GmailMessage;
       unstar(): GmailMessage;
     }
@@ -191,9 +250,9 @@ declare namespace GoogleAppsScript {
     export interface GmailThread {
       addLabel(label: GmailLabel): GmailThread;
       createDraftReply(body: string): GmailDraft;
-      createDraftReply(body: string, options: Object): GmailDraft;
+      createDraftReply(body: string, options: GmailDraftOptions): GmailDraft;
       createDraftReplyAll(body: string): GmailDraft;
-      createDraftReplyAll(body: string, options: Object): GmailDraft;
+      createDraftReplyAll(body: string, options: GmailDraftOptions): GmailDraft;
       getFirstMessageSubject(): string;
       getId(): string;
       getLabels(): GmailLabel[];
@@ -220,11 +279,10 @@ declare namespace GoogleAppsScript {
       refresh(): GmailThread;
       removeLabel(label: GmailLabel): GmailThread;
       reply(body: string): GmailThread;
-      reply(body: string, options: Object): GmailThread;
+      reply(body: string, options: GmailDraftOptions): GmailThread;
       replyAll(body: string): GmailThread;
-      replyAll(body: string, options: Object): GmailThread;
+      replyAll(body: string, options: GmailDraftOptions): GmailThread;
     }
-
   }
 }
 

--- a/types/google-apps-script/google-apps-script.url-fetch.d.ts
+++ b/types/google-apps-script/google-apps-script.url-fetch.d.ts
@@ -25,6 +25,61 @@ declare namespace GoogleAppsScript {
       getResponseCode(): Integer;
     }
 
+    export interface URLFetchRequestOptions {
+      /**
+       * the content type (defaults to 'application/x-www-form-urlencoded'). Another example of content
+       * type is 'application/xml; charset=utf-8'.
+       */
+      contentType?: string;
+
+      /**
+       * a JavaScript key/value map of HTTP headers for the request
+       */
+      headers?: Object;
+
+      /**
+       * the HTTP method for the request: get, delete, patch, post, or put. The default is get.
+       */
+      method?: 'get' | 'delete' | 'patch' | 'post' | 'put';
+
+      /**
+       * the payload (e.g. POST body) for the request. Certain HTTP methods (e.g. GET) do not accept a
+       * payload. It can be a string, a byte array, or a JavaScript object. A JavaScript object will be
+       * interpretted as a map of form field names to values, where the values can be either strings or blobs.
+       */
+      payload?: string;
+
+      /**
+       * Deprecated. This instructs fetch to resolve the specified URL within the intranet linked to your
+       * domain through (deprecated) SDC
+       */
+      useIntranet?: boolean;
+
+      /**
+       * if this is set to false, the fetch will ignore any invalid certificates for HTTPS requests.
+       * The default is true.
+       */
+      validateHttpsCertificates?: boolean;
+
+      /**
+       * if this is set to false, the fetch not automatically follow HTTP redirects; it will return
+       * the original HTTP response. The default is true.
+       */
+      followRedirects?: boolean;
+
+      /**
+       * if this is set to true, the fetch will not throw an exception if the response code indicates
+       * failure, and will instead return the HTTPResponse (default: false)
+       */
+      muteHttpExceptions?: boolean;
+
+      /**
+       * if this is set to false, reserved characters in the URL will not be escaped (default: true)
+       */
+      escaping?: boolean;
+    }
+
+
     /**
      * Fetch resources and communicate with other hosts over the Internet.
      *
@@ -47,11 +102,9 @@ declare namespace GoogleAppsScript {
      * Setting explicit scopes
      */
     export interface UrlFetchApp {
-      fetch(url: string): HTTPResponse;
-      fetch(url: string, params: Object): HTTPResponse;
+      fetch(url: string, params?: URLFetchRequestOptions): HTTPResponse;
       fetchAll(requests: Object[]): HTTPResponse[];
-      getRequest(url: string): Object;
-      getRequest(url: string, params: Object): Object;
+      getRequest(url: string, params?: URLFetchRequestOptions): Object;
     }
 
   }

--- a/types/google-apps-script/index.d.ts
+++ b/types/google-apps-script/index.d.ts
@@ -3,11 +3,10 @@
 // Definitions by: motemen <https://github.com/motemen>, grant <https://github.com/grant>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-
 /// <reference path="google-apps-script.base.d.ts"/>
 /// <reference path="google-apps-script.cache.d.ts"/>
 /// <reference path="google-apps-script.calendar.d.ts"/>
-/// <reference path="google-apps-script.card-service.d.ts"/>
+/// <reference path="google-apps-script.card.d.ts"/>
 /// <reference path="google-apps-script.charts.d.ts"/>
 /// <reference path="google-apps-script.contacts.d.ts"/>
 /// <reference path="google-apps-script.content.d.ts"/>
@@ -33,4 +32,3 @@
 /// <reference path="google-apps-script.url-fetch.d.ts"/>
 /// <reference path="google-apps-script.utilities.d.ts"/>
 /// <reference path="google-apps-script.xml-service.d.ts"/>
-


### PR DESCRIPTION
This change renames `Card_Service` back to `Card`, removes some `Object` types, and updates doc comments. Ref: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/27235#issuecomment-406059127

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
```
Testing...
google-apps-script-oauth2 OK
google-adwords-scripts OK
google-apps-script OK
````
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
```
> definitely-typed@0.0.2 lint /DefinitelyTyped
> dtslint types "google-apps-script"
```

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developers.google.com/apps-script/reference/
- [x] Increase the version number in the header if appropriate.
  - Not increased
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
