### PR TITLE
@types/leaflet: Add property zoomControl to class Map

### DIFF
--- a/types/leaflet/index.d.ts
+++ b/types/leaflet/index.d.ts
@@ -1406,6 +1406,7 @@ export class Map extends Evented {
     scrollWheelZoom: Handler;
     tap?: Handler;
     touchZoom: Handler;
+    zoomControl: Control;
 
     options: MapOptions;
 }

--- a/types/leaflet/index.d.ts
+++ b/types/leaflet/index.d.ts
@@ -1406,7 +1406,7 @@ export class Map extends Evented {
     scrollWheelZoom: Handler;
     tap?: Handler;
     touchZoom: Handler;
-    zoomControl: Control;
+    zoomControl: Control.Zoom;
 
     options: MapOptions;
 }


### PR DESCRIPTION
Leaflet has a map property called zoomControl. This is useful for setting the position on these controls for the map. This is not available via the typings.

Example usage:

	map.zoomControl.setPosition('topright');

---
Sorry if this is not 100% correct in terms of the chage or the process, this is my first PR to DefinitelyTyped.

Please fill in this template.

- [ X ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ X ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ X ] Provide a URL to documentation or source code which provides context for the suggested changes: https://leafletjs.com/reference-1.3.2.html#map-property
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
