### PR TITLE
[numeral]: add missing type for localeData

### DIFF
--- a/types/numeral/index.d.ts
+++ b/types/numeral/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/adamwdraper/Numeral-js
 // Definitions by: Vincent Bortone <https://github.com/vbortone>
 //                 Behind The Math <https://github.com/BehindTheMath>
+//                 Kenneth Luján <https://github.com/klujanrosas>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 
@@ -51,12 +52,21 @@ interface Numeral {
 	version: string;
 	isNumeral: boolean;
 	options: NumeralJSOptions;
-	
+
 	/**
 	 * This function sets the current locale.  If no arguments are passed in,
 	 * it will simply return the current global locale key.
 	 */
 	locale(key?: string): string;
+
+	/**
+	 * This function provides access to the loaded locale data.  If
+	 * no arguments are passed in, it will simply return the current
+	 * global locale object.
+	 *
+	 * @param key Locale key, e.g 'es' for a spanish locale definition
+	 */
+	localeData(key?: string): NumeralJSLocale;
 
 	/**
 	 * Registers a language definition or a custom format definition.

--- a/types/numeral/numeral-tests.ts
+++ b/types/numeral/numeral-tests.ts
@@ -91,6 +91,18 @@ numeral.locale('fr');
 numeral.locale();
 // 'fr'
 
+// return the current locale data
+numeral.localeData()
+
+// return a specific locale data
+const localeData = numeral.localeData('es')
+
+// test accessing locale data
+const currencySymbol = localeData.currency.symbol
+const billionShorthand = localeData.abbreviations.billion
+const decimalDelimiter = localeData.delimiters.decimal
+const ordinalResult = localeData.ordinal(2)
+
 // test changing an option
 numeral.options.scalePercentBy100 = false
 numeral(50).format('0%')


### PR DESCRIPTION
This PR adds a missing declaration for `numeral`'s `localeData` function.

Which can be used like:
```ts
const localedata = numeral.localeData() // to get current locale data
const esLocaleData = numeral.localeData('es') // to get specific locale data
```

It's a fairly simple change.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: See [numeral src code](https://github.com/adamwdraper/Numeral-js/blob/7de892ffb438af6e63b9c4f6aff0c9bc3932f09f/src/numeral.js#L432)


