### PR TITLE
fix: add missing syntax type

### DIFF
--- a/types/stylelint/index.d.ts
+++ b/types/stylelint/index.d.ts
@@ -5,7 +5,7 @@
 
 export type FormatterType = "json" | "string" | "verbose";
 
-export type SyntaxType = "scss" | "less" | "sugarss";
+export type SyntaxType = "scss" | "sass" | "less" | "sugarss";
 
 export interface LinterOptions {
     code?: string;


### PR DESCRIPTION
https://github.com/stylelint/stylelint/blob/master/docs/user-guide/node-api.md#syntax