### PR TITLE
Fix issue with stampit when using TS to check JavaScript

### DIFF
--- a/types/stampit/index.d.ts
+++ b/types/stampit/index.d.ts
@@ -133,13 +133,16 @@ interface Options {
     composers?: Composer[];
 }
 
+/** Stampit Composable for main stampit() function */
+type StampitComposable = stampit.Stamp | Descriptor | Options;
+
 /**
  * Return a factory (aka Stamp) function that will produce new objects using the
  * prototypes that are passed in or composed.
  * @param options Stampit options object containing refs, methods,
  * init, props, statics, configurations, and property descriptors.
  */
-declare function stampit(stamp: stampit.Stamp | Options, options?: Options): stampit.Stamp;
+declare function stampit(...composables: StampitComposable[]): stampit.Stamp;
 
 declare namespace stampit {
     /**

--- a/types/stampit/index.d.ts
+++ b/types/stampit/index.d.ts
@@ -139,7 +139,7 @@ interface Options {
  * @param options Stampit options object containing refs, methods,
  * init, props, statics, configurations, and property descriptors.
  */
-declare function stampit(options?: Options): stampit.Stamp;
+declare function stampit(stamp: stampit.Stamp | Options, options?: Options): stampit.Stamp;
 
 declare namespace stampit {
     /**


### PR DESCRIPTION
**Caveat: This has not been tested within a TypeScript library.** My knowledge of TypeScript is limited, so this has not been tested.  hence, I suggest @lummish and/or @koresar review this PR.

## What it's fixing

Currently I get the following error with the vanilla stampit example below, it applies to the `const Fighter = stampit(Character(...` line and TypeScript highlights the problem across the whole function: `Expected 0-1 arguments, but got 2`

Example taken from main stampit example. 
```JavaScript
import stampit from 'stampit';

const Character = stampit({
  props: {
    name: null,
    health: 100,
  },
  init({ name = this.name }) {
    this.name = name;
  },
});

const Fighter = stampit(Character, {
  props: {
    stamina: 100,
  },
  init({ stamina = this.stamina }) {
    this.stamina = stamina;
  },
  methods: {
    fight() {
      console.log(`${this.name} takes a mighty swing!`);
      this.stamina--;
    },
  },
});
```

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
