### PR TITLE
mongoose: countDocuments and estimatedDocumentCount definitions added

### DIFF
--- a/types/mongoose/index.d.ts
+++ b/types/mongoose/index.d.ts
@@ -9,6 +9,7 @@
 //                 vologa <https://github.com/vologab>
 //                 jussikinnula <https://github.com/jussikinnula>
 //                 ondratra <https://github.com/ondratra>
+//                 alfirin <https://github.com/alfirin>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -378,7 +379,7 @@ declare module "mongoose" {
     /** Passed directly through to tls.createSecureContext. See https://nodejs.org/dist/latest-v9.x/docs/api/tls.html#tls_tls_createsecurecontext_options for more info. */
     ciphers?: string;
     ecdhCurve?: string;
-    
+
     /** Flag for using new URL string parser instead of current (deprecated) one */
     useNewUrlParser?: boolean;
 
@@ -1602,11 +1603,39 @@ declare module "mongoose" {
     count(criteria: any, callback?: (err: any, count: number) => void): Query<number>;
 
     /**
-     * Counts number of matching documents in a database collection.
-     * @param criteria mongodb selector
-     */
+     * Specifies this query as a `countDocuments()` query. Behaves like `count()`,
+     * except it always does a full collection scan when passed an empty filter `{}`.
+     *
+     * There are also minor differences in how `countDocuments()` handles
+     * [`$where` and a couple geospatial operators](http://mongodb.github.io/node-mongodb-native/3.1/api/Collection.html#countDocuments).
+     * versus `count()`.
+     *
+     * Passing a `callback` executes the query.
+     *
+     * This function triggers the following middleware.
+     *
+     * - `countDocuments()`
+     *
+     *
+     * @param {Object} [criteria] mongodb selector
+     * @param {Function} [callback] optional params are (error, count)
+     * @return {Query} this
+    */
     countDocuments(callback?: (err: any, count: number) => void): Query<number>;
     countDocuments(criteria: any, callback?: (err: any, count: number) => void): Query<number>;
+
+    /**
+     * Estimates the number of documents in the MongoDB collection. Faster than
+     * using `countDocuments()` for large collections because
+     * `estimatedDocumentCount()` uses collection metadata rather than scanning
+     * the entire collection.
+     *
+     * @param {Object} [options] passed transparently to the [MongoDB driver](http://mongodb.github.io/node-mongodb-native/3.1/api/Collection.html#estimatedDocumentCount)
+     * @param {Function} [callback] optional params are (error, count)
+     * @return {Query} this
+     */
+    estimatedDocumentCount(callback?: (err: any, count: number) => void): Query<number>;
+    estimatedDocumentCount(options: any, callback?: (err: any, count: number) => void): Query<number>;
 
     /**
      * Returns a wrapper around a mongodb driver cursor. A Query<T>Cursor exposes a
@@ -2588,6 +2617,34 @@ declare module "mongoose" {
 
     /** Counts number of matching documents in a database collection. */
     count(conditions: any, callback?: (err: any, count: number) => void): Query<number>;
+
+    /**
+     * Counts number of documents matching `criteria` in a database collection.
+     *
+     * If you want to count all documents in a large collection,
+     * use the `estimatedDocumentCount()` instead.
+     * If you call `countDocuments({})`, MongoDB will always execute
+     * a full collection scan and **not** use any indexes.
+     *
+     * @param {Object} filter
+     * @param {Function} [callback]
+     * @return {Query}
+     */
+    countDocuments(callback?: (err: any, count: number) => void): Query<number>;
+    countDocuments(criteria: any, callback?: (err: any, count: number) => void): Query<number>;
+
+    /**
+     * Estimates the number of documents in the MongoDB collection. Faster than
+     * using `countDocuments()` for large collections because
+     * `estimatedDocumentCount()` uses collection metadata rather than scanning
+     * the entire collection.
+     *
+     * @param {Object} [options]
+     * @param {Function} [callback]
+     * @return {Query}
+     */
+    estimatedDocumentCount(callback?: (err: any, count: number) => void): Query<number>;
+    estimatedDocumentCount(options: any, callback?: (err: any, count: number) => void): Query<number>;
 
     /**
      * Shortcut for saving one or more documents to the database. MyModel.create(docs)


### PR DESCRIPTION
I added three missing definitions for mongoose.
Two for the Model and one for the Query.

Here are the links for all three added definitions:
- [Model.countDocuments](https://github.com/Automattic/mongoose/blob/863bc9ab0a3db8fb0260f9acc8e48288a405be76/lib/model.js#L1749)
- [Model.estimatedDocumentCount](https://github.com/Automattic/mongoose/blob/863bc9ab0a3db8fb0260f9acc8e48288a405be76/lib/model.js#L1720)
- [Query.estimatedDocumentCount](https://github.com/Automattic/mongoose/blob/971311e7db07102b4853416d08142302c30fee68/lib/query.js#L2030)

Thanks a lot for your review