### PR TITLE
[jexl] TransformFunction accepts multiple args

### DIFF
--- a/types/jexl/index.d.ts
+++ b/types/jexl/index.d.ts
@@ -6,7 +6,7 @@
 
 // Currently maintained by https://github.com/TomFrost/Jexl
 
-type TransformFunction = (value: any, args?: object) => any;
+type TransformFunction = (value: any, ...args: any[]) => any;
 
 type BinaryOpFunction = (left: any, right: any) => any;
 

--- a/types/jexl/index.d.ts
+++ b/types/jexl/index.d.ts
@@ -54,12 +54,9 @@ declare class Jexl {
      * @param name The name of the transform function, as it will be used
      *      within Jexl expressions
      * @param fn The function to be executed when this transform is
-     *      invoked.  It will be provided with two arguments:
+     *      invoked.  It will be provided with at least one argument:
      *          - {*} value: The value to be transformed
-     *          - {{}} args: The arguments for this transform
-     *          - {function} cb: A callback function to be called with an error
-     *            if the transform fails, or a null first argument and the
-     *            transformed value as the second argument on success.
+     *          - {...*} args: The arguments for this transform
      */
     addTransform(name: string, fn: TransformFunction): void;
 

--- a/types/jexl/jexl-tests.ts
+++ b/types/jexl/jexl-tests.ts
@@ -61,6 +61,12 @@ jexl.addTransform('getStat', (val, stat) => {
 jexl.eval('name.last|getStat("weight")', context, (err, res) => {
 });
 
+// Transform with multiple arguments
+// $ExpectType void
+jexl.addTransform('substring', (val: string, start: number, end?: number) => {
+    return val.substring(start, end);
+});
+
 // Add your own (a)synchronous operators
 // Here's a case-insensitive string equality
 // $ExpectType void


### PR DESCRIPTION
The jexl documentation only has examples of zero- and one-argument Transforms, but internally all args are passed through with `Function.prototype.apply`.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/TomFrost/Jexl/blob/master/lib/evaluator/handlers.js#L142
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
