### PR TITLE
Recompose: `Subscribable` generic does not capture RxJS `Observable`

### DIFF
--- a/types/recompose/package.json
+++ b/types/recompose/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "rxjs": "^6.2.2"
+    }
+}

--- a/types/recompose/recompose-tests.tsx
+++ b/types/recompose/recompose-tests.tsx
@@ -1,3 +1,4 @@
+import * as RxJS from 'rxjs';
 import * as React from "react";
 import {
     // Higher-order components
@@ -385,6 +386,16 @@ function testWithObservableConfig() {
   let createEventHandlerMost = createEventHandlerWithConfig(mostConfig)
   let { handler: handler, stream: stream } = createEventHandler()
   createEventHandlerMost = createEventHandler
+}
+
+function testWithRxJSConfig() {
+    const mapPropsStreamRxjs = mapPropsStreamWithConfig(rxjsconfig);
+    type OwnProps = { a: number; };
+    type StreamProps = { b: number; };
+    const transformFn = (_props: RxJS.Observable<OwnProps>): RxJS.Observable<StreamProps> => RxJS.of({ b: 1 });
+    const enhancer = mapPropsStreamRxjs(transformFn)
+    // $ExpectType ComponentEnhancer<OwnProps, StreamProps>
+    enhancer
 }
 
 function testOnlyUpdateForKeys() {


### PR DESCRIPTION
When using stream helpers e.g. `mapPropsStream`, the `Subscribable` generic does not capture RxJS `Observable`. I have added a failing test to demontrate this issue.

This fails with:

```
Error: /Users/OliverJAsh/Development/DefinitelyTyped/types/recompose/recompose-tests.tsx:398:5
ERROR: 398:5  expect  Expected type to be:
  ComponentEnhancer<OwnProps, StreamProps>
got:
  ComponentEnhancer<{}, {}>
```

Here is a smaller example of the problem:

``` ts
declare function identitySubscribable<T>(
  subscribable: Subscribable<T>,
): Subscribable<T>;

declare const props$: Observable<OwnProps>;

const subscribable = identitySubscribable(props$);
// $ExpectType Subscribable<OwnProps>
// but got Subscribable{}>
subscribable;

// No type error, as expected :-)
const props2$: Subscribable<OwnProps> = props$;
```

Why is the generic not inferred (and thus falling back to `{}`)?

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.