### PR TITLE
Recompose: fix `...WithConfig` module locations

### DIFF
--- a/types/recompose/index.d.ts
+++ b/types/recompose/index.d.ts
@@ -661,37 +661,22 @@ declare module 'recompose/hoistStatics' {
 // https://github.com/acdlite/recompose/blob/master/docs/API.md#componentfromstream
 declare module 'recompose/componentFromStream' {
     import { componentFromStream } from 'recompose';
+    export { componentFromStreamWithConfig } from 'recompose';
     export default componentFromStream;
-}
-
-// https://github.com/acdlite/recompose/blob/master/docs/API.md#componentfromstreamwithconfig
-declare module 'recompose/componentFromStreamWithConfig' {
-    import { componentFromStreamWithConfig } from 'recompose';
-    export default componentFromStreamWithConfig;
 }
 
 // https://github.com/acdlite/recompose/blob/master/docs/API.md#mappropsstream
 declare module 'recompose/mapPropsStream' {
     import { mapPropsStream } from 'recompose';
+    export { mapPropsStreamWithConfig } from 'recompose';
     export default mapPropsStream;
-}
-
-// https://github.com/acdlite/recompose/blob/master/docs/API.md#mappropsstreamwithconfig
-declare module 'recompose/mapPropsStreamWithConfig' {
-    import { mapPropsStreamWithConfig } from 'recompose';
-    export default mapPropsStreamWithConfig;
 }
 
 // https://github.com/acdlite/recompose/blob/master/docs/API.md#createeventhandler
 declare module 'recompose/createEventHandler' {
     import { createEventHandler } from 'recompose';
+    export { createEventHandlerWithConfig } from 'recompose';
     export default createEventHandler;
-}
-
-// https://github.com/acdlite/recompose/blob/master/docs/API.md#createeventhandlerwithconfig
-declare module 'recompose/createEventHandlerWithConfig' {
-    import { createEventHandlerWithConfig } from 'recompose';
-    export default createEventHandlerWithConfig;
 }
 
 // https://github.com/acdlite/recompose/blob/master/docs/API.md#setobservableconfig

--- a/types/recompose/recompose-tests.tsx
+++ b/types/recompose/recompose-tests.tsx
@@ -62,12 +62,9 @@ import createSinkStandalone from "recompose/createSink";
 import componentFromPropStandalone from "recompose/componentFromProp";
 import nestStandalone from "recompose/nest";
 import hoistStaticsStandalone from "recompose/hoistStatics";
-import componentFromStreamStandalone from "recompose/componentFromStream";
-import componentFromStreamWithConfigStandalone from "recompose/componentFromStreamWithConfig";
-import mapPropsStreamStandalone from "recompose/mapPropsStream";
-import mapPropsStreamWithConfigStandalone from "recompose/mapPropsStreamWithConfig";
-import createEventHandlerStandalone from "recompose/createEventHandler";
-import createEventHandlerWithConfigStandalone from "recompose/createEventHandlerWithConfig";
+import componentFromStreamStandalone, { componentFromStreamWithConfig as componentFromStreamWithConfigStandalone } from "recompose/componentFromStream";
+import mapPropsStreamStandalone, { mapPropsStreamWithConfig as mapPropsStreamWithConfigStandalone } from "recompose/mapPropsStream";
+import createEventHandlerStandalone, { createEventHandlerWithConfig as createEventHandlerWithConfigStandalone } from "recompose/createEventHandler";
 import setObservableConfigStandalone from "recompose/setObservableConfig";
 
 function testMapProps() {


### PR DESCRIPTION
`...WithConfig` helpers do not have their own standalone module. Instead, they are found inside the standalone module of the corresponding helper, e.g. instead of

``` js
import mapPropsStreamWithConfigStandalone from "recompose/mapPropsStreamWithConfig";
```

we have

``` js
import { mapPropsStreamWithConfig } from "recompose/mapPropsStream";
```

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://unpkg.com/recompose@0.27.1/mapPropsStream.js
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.