### PR TITLE
Change Xrm.Utility.lookupObjects to return array

### DIFF
--- a/types/xrm/index.d.ts
+++ b/types/xrm/index.d.ts
@@ -970,7 +970,7 @@ declare namespace Xrm {
          * Opens a lookup control to select one or more items.
          * @param lookupOptions Defines the options for opening the lookup dialog
          */
-        lookupObjects(lookupOptions: LookupOptions): Async.PromiseLike<LookupValue>;
+        lookupObjects(lookupOptions: LookupOptions): Async.PromiseLike<LookupValue[]>;
 
         /**
          * Refreshes the parent grid containing the specified record.


### PR DESCRIPTION
The [documentation](https://docs.microsoft.com/en-us/dynamics365/customer-engagement/developer/clientapi/reference/xrm-utility/lookupobjects) says the function returns an object but it actually returns an array of LookupValue items. Which makes sense considering you can select multiple records.