### PR TITLE
hapi: Fix tls typing from non-type "true" to boolean

### DIFF
--- a/types/hapi/index.d.ts
+++ b/types/hapi/index.d.ts
@@ -2905,7 +2905,7 @@ export interface ServerOptions {
      * Default value: none.
      * Used to create an HTTPS connection. The tls object is passed unchanged to the node HTTPS server as described in the node HTTPS documentation.
      */
-    tls?: true | https.RequestOptions;
+    tls?: boolean | https.RequestOptions;
 
     /**
      * Default value: constructed from runtime server information.

--- a/types/hapi/test/server/server-options.ts
+++ b/types/hapi/test/server/server-options.ts
@@ -103,7 +103,7 @@ const options: ServerOptions = {
         isSameSite: 'Strict',
         encoding: 'none'
     },
-    tls: undefined
+    tls: true
 };
 
 const server = new Server(options);

--- a/types/hapi/v16/index.d.ts
+++ b/types/hapi/v16/index.d.ts
@@ -766,7 +766,7 @@ export interface ServerConnectionOptions extends ConnectionConfigurationServerDe
     /** labels - a string or string array of labels used to server.select() specific connections matching the specified labels. Defaults to an empty array [] (no labels). */
     labels?: string | string[];
     /** tls - used to create an HTTPS connection. The tls object is passed unchanged as options to the node.js HTTPS server as described in the node.js HTTPS [documentation](https://nodejs.org/api/https.html#https_https_createserver_options_requestlistener})  . Set to true when passing a listener object that has been configured to use TLS directly. */
-    tls?: true | https.RequestOptions;
+    tls?: boolean | https.RequestOptions;
 }
 
 /**


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://hapijs.com/api#server.options.tls
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
