### PR TITLE
Remove video.js export default and make source type optional

### DIFF
--- a/types/video.js/index.d.ts
+++ b/types/video.js/index.d.ts
@@ -10,7 +10,7 @@
 //                 Adam Eisenreich <https://github.com/AkxeOne>
 //                 Brian A. Danielak <https://github.com/briandk>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.1
+// TypeScript Version: 2.7
 
 // The Video.js API allows you to interact with the video through
 // Javascript, whether the browser is playing the video through HTML5

--- a/types/video.js/index.d.ts
+++ b/types/video.js/index.d.ts
@@ -8,6 +8,7 @@
 //                 Grzegorz Błaszczyk <https://github.com/gjanblaszczyk>
 //                 Stéphane Roucheray <https://github.com/sroucheray>
 //                 Adam Eisenreich <https://github.com/AkxeOne>
+//                 Brian A. Danielak <briandaniela.k+github@gmail.com>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.1
 

--- a/types/video.js/index.d.ts
+++ b/types/video.js/index.d.ts
@@ -8,7 +8,7 @@
 //                 Grzegorz Błaszczyk <https://github.com/gjanblaszczyk>
 //                 Stéphane Roucheray <https://github.com/sroucheray>
 //                 Adam Eisenreich <https://github.com/AkxeOne>
-//                 Brian A. Danielak <briandaniela.k+github@gmail.com>
+//                 Brian A. Danielak <https://github.com/briandk>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.1
 

--- a/types/video.js/index.d.ts
+++ b/types/video.js/index.d.ts
@@ -20,7 +20,7 @@ declare function videojs(
     options?: videojs.PlayerOptions,
     ready?: () => void
 ): videojs.Player;
-export default videojs;
+export = videojs;
 export as namespace videojs;
 
 declare namespace videojs {

--- a/types/video.js/index.d.ts
+++ b/types/video.js/index.d.ts
@@ -77,8 +77,8 @@ declare namespace videojs {
     }
 
     interface Source {
-        type: string;
         src: string;
+        type?: string;
     }
 
     interface Dimensions {

--- a/types/video.js/index.d.ts
+++ b/types/video.js/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Video.js 6.2
+// Type definitions for Video.js 6.2.10
 // Project: https://github.com/videojs/video.js
 // Definitions by: Vincent Bortone <https://github.com/vbortone>
 //                 Simon Clériot <https://github.com/scleriot>

--- a/types/video.js/index.d.ts
+++ b/types/video.js/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Video.js 6.2.10
+// Type definitions for Video.js 6.2
 // Project: https://github.com/videojs/video.js
 // Definitions by: Vincent Bortone <https://github.com/vbortone>
 //                 Simon Clériot <https://github.com/scleriot>

--- a/types/video.js/tsconfig.json
+++ b/types/video.js/tsconfig.json
@@ -15,7 +15,8 @@
         ],
         "types": [],
         "noEmit": true,
-        "forceConsistentCasingInFileNames": true
+        "forceConsistentCasingInFileNames": true,
+        "esModuleInterop": true
     },
     "files": [
         "index.d.ts",

--- a/types/video.js/video.js-tests.ts
+++ b/types/video.js/video.js-tests.ts
@@ -76,8 +76,6 @@ videojs("example_video_1").ready(function() {
     testPlugin(this, {});
 });
 
-const;
-
 function testEvents(player: videojs.Player) {
     const myFunc = function(this: videojs.Player) {
         // Do something when the event is fired

--- a/types/video.js/video.js-tests.ts
+++ b/types/video.js/video.js-tests.ts
@@ -1,5 +1,4 @@
-import { video } from "video.js";
-import { PlayerOptions } from "./index";
+import videojs, { PlayerOptions } from "video.js";
 
 try {
     const testPlayerOptions: PlayerOptions = { controls: true };

--- a/types/video.js/video.js-tests.ts
+++ b/types/video.js/video.js-tests.ts
@@ -1,111 +1,130 @@
-import videojs from 'video.js';
+import { video } from "video.js";
+import { PlayerOptions } from "./index";
+
+try {
+    const testPlayerOptions: PlayerOptions = { controls: true };
+} finally {
+    null;
+}
 
 videojs("example_video_1").ready(function() {
-	// EXAMPLE: Start playing the video.
-	this.play();
+    // EXAMPLE: Start playing the video.
+    this.play();
 
-	this.pause();
+    this.pause();
 
-	const isPaused: boolean = this.paused();
-	const isPlaying: boolean = !this.paused();
+    const isPaused: boolean = this.paused();
+    const isPlaying: boolean = !this.paused();
 
-	this.src("http://www.example.com/path/to/video.mp4");
+    this.src("http://www.example.com/path/to/video.mp4");
 
-	this.src({ type: "video/mp4", src: "http://www.example.com/path/to/video.mp4" });
+    this.src({
+        type: "video/mp4",
+        src: "http://www.example.com/path/to/video.mp4"
+    });
 
-	this.src([
-		{ type: "video/mp4", src: "http://www.example.com/path/to/video.mp4" },
-		{ type: "video/webm", src: "http://www.example.com/path/to/video.webm" },
-		{ type: "video/ogg", src: "http://www.example.com/path/to/video.ogv" }
-	]);
+    this.src([
+        { type: "video/mp4", src: "http://www.example.com/path/to/video.mp4" },
+        {
+            type: "video/webm",
+            src: "http://www.example.com/path/to/video.webm"
+        },
+        { type: "video/ogg", src: "http://www.example.com/path/to/video.ogv" }
+    ]);
 
-	const whereYouAt: number = this.currentTime();
+    const whereYouAt: number = this.currentTime();
 
-	this.currentTime(120); // 2 minutes into the video
+    this.currentTime(120); // 2 minutes into the video
 
-	const howLongIsThis: number = this.duration();
+    const howLongIsThis: number = this.duration();
 
-	const bufferedTimeRange: TimeRanges = this.buffered();
+    const bufferedTimeRange: TimeRanges = this.buffered();
 
-	// Number of different ranges of time have been buffered. Usually 1.
-	const numberOfRanges: number = bufferedTimeRange.length;
+    // Number of different ranges of time have been buffered. Usually 1.
+    const numberOfRanges: number = bufferedTimeRange.length;
 
-	// Time in seconds when the first range starts. Usually 0.
-	const firstRangeStart: number = bufferedTimeRange.start(0);
+    // Time in seconds when the first range starts. Usually 0.
+    const firstRangeStart: number = bufferedTimeRange.start(0);
 
-	// Time in seconds when the first range ends
-	const firstRangeEnd: number = bufferedTimeRange.end(0);
+    // Time in seconds when the first range ends
+    const firstRangeEnd: number = bufferedTimeRange.end(0);
 
-	// Length in seconds of the first time range
-	const firstRangeLength: number = firstRangeEnd - firstRangeStart;
+    // Length in seconds of the first time range
+    const firstRangeLength: number = firstRangeEnd - firstRangeStart;
 
-	const howMuchIsDownloaded: number = this.bufferedPercent();
+    const howMuchIsDownloaded: number = this.bufferedPercent();
 
-	const howLoudIsIt: number = this.volume();
+    const howLoudIsIt: number = this.volume();
 
-	this.volume(0.5); // Set volume to half
+    this.volume(0.5); // Set volume to half
 
-	const howWideIsIt: number = this.width();
+    const howWideIsIt: number = this.width();
 
-	this.width(640);
+    this.width(640);
 
-	const howTallIsIt: number = this.height();
+    const howTallIsIt: number = this.height();
 
-	this.height(480);
+    this.height(480);
 
-	this.size(640, 480);
+    this.size(640, 480);
 
-	this.requestFullScreen();
+    this.requestFullScreen();
 
-	testEvents(this);
+    testEvents(this);
 
-	testComponents(this);
+    testComponents(this);
 
-	testPlugin(this, {});
+    testPlugin(this, {});
 });
 
+const;
+
 function testEvents(player: videojs.Player) {
-	const myFunc = function(this: videojs.Player) {
-		// Do something when the event is fired
-	};
-	player.on("error", myFunc);
-	// Removes the specified listener only.
-	player.off("error", myFunc);
+    const myFunc = function(this: videojs.Player) {
+        // Do something when the event is fired
+    };
+    player.on("error", myFunc);
+    // Removes the specified listener only.
+    player.off("error", myFunc);
 
-	const myFuncWithArg = function(this: videojs.Player, e: Event) {
-		// Do something when the event is fired
-	};
-	player.on("volumechange", myFuncWithArg);
-	// Removes all listeners for the given event type.
-	player.off("volumechange");
+    const myFuncWithArg = function(this: videojs.Player, e: Event) {
+        // Do something when the event is fired
+    };
+    player.on("volumechange", myFuncWithArg);
+    // Removes all listeners for the given event type.
+    player.off("volumechange");
 
-	player.on("loadeddata", () => { /* Some handler. */ });
-	// Removes all listeners.
-	player.off();
+    player.on("loadeddata", () => {
+        /* Some handler. */
+    });
+    // Removes all listeners.
+    player.off();
 }
 
 function testComponents(player: videojs.Player) {
-	class MyWindow extends videojs.getComponent('ModalDialog') {
-		myFunction() {
-			this.player().play();
-		}
-	}
+    class MyWindow extends videojs.getComponent("ModalDialog") {
+        myFunction() {
+            this.player().play();
+        }
+    }
 
-	const myWindow = new MyWindow(player, {});
-	myWindow.controlText('My text');
-	myWindow.open();
-	myWindow.close();
-	myWindow.myFunction();
+    const myWindow = new MyWindow(player, {});
+    myWindow.controlText("My text");
+    myWindow.open();
+    myWindow.close();
+    myWindow.myFunction();
 }
 
 function testPlugin(player: videojs.Player, options: {}) {
-	if (player.usingPlugin('uloztoExample')) { return; }
+    if (player.usingPlugin("uloztoExample")) {
+        return;
+    }
 
-	videojs.registerPlugin('uloztoExample', function({}: typeof options) {
-		this.play();
-		this.one('ended', () => {
-			// do something
-		});
-	});
-	(player as any).uloztoExample(options);
+    videojs.registerPlugin("uloztoExample", function({  }: typeof options) {
+        this.play();
+        this.one("ended", () => {
+            // do something
+        });
+    });
+    (player as any).uloztoExample(options);
 }


### PR DESCRIPTION
## What this changes:

1. Videojs will now behave like a default export, but it also exposes a namespace
    
    ```ts
    import videojs from "video.js"
    import { PlayerOptions } from "video.js"
    ```
2. Users don't have to specify a media/MIME type when working with `Source` types

## Why this change?

1. There was a previous breaking API changed that was merged as a patch release https://github.com/DefinitelyTyped/DefinitelyTyped/pull/27163#issuecomment-407461848
2. According to Mozilla MDN, browsers have a fallback behavior if [no source is specified][1].

[1]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/source#attr-type

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

