### PR TITLE
Listr: add missing ListrOptions

### DIFF
--- a/types/listr/index.d.ts
+++ b/types/listr/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for listr 0.13
+// Type definitions for listr 0.14
 // Project: https://github.com/samverschueren/listr#readme
 // Definitions by: Dusan Radovanovic <https://github.com/durad>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -17,6 +17,10 @@ declare namespace Listr {
     interface ListrOptions {
         concurrent?: boolean | number;
         exitOnError?: boolean;
+        showSubtasks?: boolean;
+        collapse?: boolean;
+        clearOutput?: boolean;
+        dateFormat?: boolean | string;
         renderer?: "silent" | "default" | "verbose" | ListrRenderer;
         nonTTYRenderer?: "silent" | "default" | "verbose" | ListrRenderer;
     }

--- a/types/listr/listr-tests.ts
+++ b/types/listr/listr-tests.ts
@@ -2,55 +2,58 @@ import Listr = require("listr");
 import * as fs from "fs";
 
 const tasks = new Listr([
-    {
-        title: 'Git',
-        task: () => {
-            return new Listr([
-                {
-                    title: 'Checking git status',
-                    task: () => new Promise(resolve => resolve())
-                        .then(result => {
-                        if (result !== '') {
-                            throw new Error('Unclean working tree. Commit or stash changes first.');
+        {
+            title: 'Git',
+            task: () => {
+                return new Listr([
+                        {
+                            title: 'Checking git status',
+                            task: () => new Promise(resolve => resolve())
+                                .then(result => {
+                                    if (result !== '') {
+                                        throw new Error('Unclean working tree. Commit or stash changes first.');
+                                    }
+                                })
+                        },
+                        {
+                            title: 'Checking remote history',
+                            task: () => new Promise(resolve => resolve())
+                                .then(result => {
+                                    if (result !== '0') {
+                                        throw new Error('Remote history differ. Please pull changes.');
+                                    }
+                                })
                         }
-                    })
-                },
-                {
-                    title: 'Checking remote history',
-                    task: () => new Promise(resolve => resolve())
-                        .then(result => {
-                        if (result !== '0') {
-                            throw new Error('Remote history differ. Please pull changes.');
-                        }
-                    })
-                }
-            ],
-            { concurrent: true });
-        }
-    },
-    {
-        title: 'Install package dependencies with Yarn',
-        task: (ctx, task) => new Promise(resolve => resolve())
-            .catch(() => {
-                ctx.yarn = false;
+                    ],
+                    {concurrent: true});
+            }
+        },
+        {
+            title: 'Install package dependencies with Yarn',
+            task: (ctx, task) => new Promise(resolve => resolve())
+                .catch(() => {
+                    ctx.yarn = false;
 
-                task.skip('Yarn not available, install it via `npm install -g yarn`');
-            })
-    },
+                    task.skip('Yarn not available, install it via `npm install -g yarn`');
+                })
+        },
+        {
+            title: 'Install package dependencies with npm',
+            enabled: ctx => ctx.yarn === false,
+            task: () => new Promise(resolve => resolve())
+        },
+        {
+            title: 'Run tests',
+            task: () => new Promise(resolve => resolve())
+        },
+        {
+            title: 'Publish package',
+            task: () => new Promise(resolve => resolve())
+        }
+    ],
     {
-        title: 'Install package dependencies with npm',
-        enabled: ctx => ctx.yarn === false,
-        task: () => new Promise(resolve => resolve())
-    },
-    {
-        title: 'Run tests',
-        task: () => new Promise(resolve => resolve())
-    },
-    {
-        title: 'Publish package',
-        task: () => new Promise(resolve => resolve())
-    }
-]);
+        collapse: false
+    });
 
 tasks.run().catch(err => {
 });
@@ -159,6 +162,19 @@ const tasks7 = new Listr([
         task: ctx => Promise.resolve(`${ctx.foo} ${ctx.bar}`)
     }
 ]);
+
+const tasks8 = new Listr([
+    {
+        title: 'Task 1',
+        task: () => Promise.resolve('Foo')
+    },
+    {
+        title: 'Task 2',
+        task: ctx => Promise.resolve('Clear output')
+    }
+], {
+    clearOutput: true
+});
 
 tasks.run({
     foo: 'bar'


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
* https://github.com/SamVerschueren/listr-update-renderer#options
* https://github.com/SamVerschueren/listr-verbose-renderer#options
* _Update renderer_ is the default one, and _verbose renderer_ is also installed as dependency of Listr
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
