### PR TITLE
spotify-web-playback-sdk: Add not_ready event

### DIFF
--- a/types/spotify-web-playback-sdk/index.d.ts
+++ b/types/spotify-web-playback-sdk/index.d.ts
@@ -100,15 +100,15 @@ declare namespace Spotify {
         getVolume(): Promise<number>;
         nextTrack(): Promise<void>;
 
-        addListener(event: 'ready', cb: PlaybackInstanceListener): void;
+        addListener(event: 'ready' | 'not_ready', cb: PlaybackInstanceListener): void;
         addListener(event: 'player_state_changed', cb: PlaybackStateListener): void;
         addListener(event: ErrorTypes, cb: ErrorListener): void;
-        on(event: 'ready', cb: PlaybackInstanceListener): void;
+        on(event: 'ready' | 'not_ready', cb: PlaybackInstanceListener): void;
         on(event: 'player_state_changed', cb: PlaybackStateListener): void;
         on(event: ErrorTypes, cb: ErrorListener): void;
 
         removeListener(
-            event: 'ready' | 'player_state_changed' | ErrorTypes,
+            event: 'ready' | 'not_ready' | 'player_state_changed' | ErrorTypes,
             cb?: ErrorListener | PlaybackInstanceListener | PlaybackStateListener,
         ): void;
 

--- a/types/spotify-web-playback-sdk/index.d.ts
+++ b/types/spotify-web-playback-sdk/index.d.ts
@@ -1,9 +1,10 @@
-// Type definitions for spotify-web-playback-sdk 0.1
+// Type definitions for spotify-web-playback-sdk 0.2
 // Project: https://beta.developer.spotify.com/documentation/web-playback-sdk/reference/
 // Definitions by: Festify Dev Team <https://github.com/Festify>
 //                 Marcus Weiner <https://github.com/mraerino>
 //                 Moritz Gunz <https://github.com/NeoLegends>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.1
 
 interface Window {
     onSpotifyWebPlaybackSDKReady(): void;
@@ -91,6 +92,11 @@ declare namespace Spotify {
     type PlaybackInstanceListener = (inst: WebPlaybackInstance) => void;
     type PlaybackStateListener = (s: PlaybackState) => void;
 
+    type AddListenerFn =
+        & ((event: 'ready' | 'not_ready', cb: PlaybackInstanceListener) => void)
+        & ((event: 'player_state_changed', cb: PlaybackStateListener) => void)
+        & ((event: ErrorTypes, cb: ErrorListener) => void);
+
     class SpotifyPlayer {
         constructor(options: PlayerInit);
 
@@ -100,12 +106,8 @@ declare namespace Spotify {
         getVolume(): Promise<number>;
         nextTrack(): Promise<void>;
 
-        addListener(event: 'ready' | 'not_ready', cb: PlaybackInstanceListener): void;
-        addListener(event: 'player_state_changed', cb: PlaybackStateListener): void;
-        addListener(event: ErrorTypes, cb: ErrorListener): void;
-        on(event: 'ready' | 'not_ready', cb: PlaybackInstanceListener): void;
-        on(event: 'player_state_changed', cb: PlaybackStateListener): void;
-        on(event: ErrorTypes, cb: ErrorListener): void;
+        addListener: AddListenerFn;
+        on: AddListenerFn;
 
         removeListener(
             event: 'ready' | 'not_ready' | 'player_state_changed' | ErrorTypes,

--- a/types/spotify-web-playback-sdk/index.d.ts
+++ b/types/spotify-web-playback-sdk/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for spotify-web-playback-sdk 0.2
+// Type definitions for spotify-web-playback-sdk 0.1
 // Project: https://beta.developer.spotify.com/documentation/web-playback-sdk/reference/
 // Definitions by: Festify Dev Team <https://github.com/Festify>
 //                 Marcus Weiner <https://github.com/mraerino>

--- a/types/spotify-web-playback-sdk/spotify-web-playback-sdk-tests.ts
+++ b/types/spotify-web-playback-sdk/spotify-web-playback-sdk-tests.ts
@@ -24,6 +24,10 @@ player.addListener("ready", (data) => {
     console.log("The Web Playback SDK is ready to play music!");
 });
 
+player.addListener("not_ready", ({ device_id }) => {
+    console.log("The Web Playback SDK is not ready to play music!");
+});
+
 player.getCurrentState().then((playbackState: Spotify.PlaybackState | null) => {
     if (playbackState) {
         const { current_track, next_tracks } = playbackState.track_window;
@@ -70,6 +74,11 @@ player.nextTrack().then(() => {
 });
 
 player.on("ready", (data: Spotify.WebPlaybackInstance) => {
+    const { device_id } = data;
+    console.log("Connected with Device ID", device_id);
+});
+
+player.on("not_ready", (data: Spotify.WebPlaybackInstance) => {
     const { device_id } = data;
     console.log("Connected with Device ID", device_id);
 });


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.spotify.com/documentation/web-playback-sdk/reference/#event-not-ready
- [X] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
