### PR TITLE
Chrome: Add optional property initiator on ResourceRequest

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -7383,6 +7383,10 @@ declare namespace chrome.webRequest {
         type: ResourceType;
         /** The time when this signal is triggered, in milliseconds since the epoch. */
         timeStamp: number;
+        /** The origin where the request was initiated. This does not change through redirects. If this is an opaque origin, the string 'null' will be used.
+         * @since Since Chrome 63.
+        */
+        initiator?: string;
     }
 
     export interface WebRequestDetails extends ResourceRequest {

--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -7383,6 +7383,8 @@ declare namespace chrome.webRequest {
         type: ResourceType;
         /** The time when this signal is triggered, in milliseconds since the epoch. */
         timeStamp: number;
+        /** Since Chrome 63. The origin where the request was initiated. This does not change through redirects. If this is an opaque origin, the string 'null' will be used. */
+        initiator?: string;
     }
 
     export interface WebRequestDetails extends ResourceRequest {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.chrome.com/extensions/webRequest#event-onErrorOccurred
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
