### PR TITLE
[agenda] Update types to version 2.0.0

### DIFF
--- a/types/agenda/agenda-tests.ts
+++ b/types/agenda/agenda-tests.ts
@@ -3,107 +3,97 @@ import { Db, Server } from "mongodb";
 
 var mongoConnectionString = "mongodb://127.0.0.1/agenda";
 
-var agenda = new Agenda({ db: { address: mongoConnectionString } });
+(async () => {
+    var agenda = new Agenda({ db: { address: mongoConnectionString } });
 
-agenda.define<{ foo: Error }>('delete old users', (job, done) => {
-    done(job.attrs.data.foo)
+    agenda.define<{ foo: Error }>('delete old users', (job, done) => {
+        done(job.attrs.data.foo)
+    });
+
+    agenda.on('ready', () => {
+        agenda.every('3 minutes', 'delete old users');
+
+        // Alternatively, you could also do:
+        agenda.every('*/3 * * * *', 'delete old users');
+
+        agenda.start();
+    });
+
+    agenda.define('send email report', { priority: 'high', concurrency: 10 }, (job, done) => {
+    });
+
+    agenda.on('ready', () => {
+        agenda.schedule('in 20 minutes', 'send email report', { to: 'admin@example.com' });
+        agenda.start();
+    });
+
+    agenda.on('ready', () => {
+        var weeklyReport = agenda.create('send email report', { to: 'another-guy@example.com' });
+        weeklyReport.repeatEvery('1 week').save();
+        agenda.start();
+    });
+
+    var agenda = new Agenda({ processEvery: '30 seconds' });
+
+    agenda.defaultConcurrency(5);
+
+    var agenda = new Agenda({ defaultConcurrency: 5 });
+
+    agenda.lockLimit(0);
+
+    var agenda = new Agenda({ lockLimit: 0 });
+
+    agenda.defaultLockLimit(0);
+
+    var agenda = new Agenda({ defaultLockLimit: 0 });
+
+    agenda.defaultLockLifetime(10000);
+
+    var agenda = new Agenda({ defaultLockLifetime: 10000 });
+
+    agenda.define('some long running job', function (job, done) {
+        done();
+    });
+
+    agenda.every('15 minutes', ['printAnalyticsReport', 'sendNotifications', 'updateUserRecords']);
+
+    agenda.schedule('tomorrow at noon', 'printAnalyticsReport', { userCount: 100 });
+
+    agenda.schedule('tomorrow at noon', ['printAnalyticsReport', 'sendNotifications', 'updateUserRecords']);
+
+    agenda.now('do the hokey pokey');
+
+    var job = agenda.create<{ userCount: number }>('printAnalyticsReport', { userCount: 100 });
+    await job.save();
+
+    const jobs = await agenda.jobs({ name: 'printAnalyticsReport' });
+
+    let numRemoved = await agenda.cancel({ name: 'printAnalyticsReport' });
+
+    numRemoved = await agenda.purge();
+
+    await agenda.stop();
+
+    await job.agenda.now('do the hokey pokey');
+
+    job.repeatEvery('10 minutes');
+
+    job.repeatAt('3:30pm');
+
+    job.schedule('tomorrow at 6pm');
+
+    job.priority('low');
+    job.priority(10);
+
+    job.unique({ 'data.type': 'active', 'data.userId': '123' });
+    job.fail('insuficient disk space');
+    job.fail(new Error('insufficient disk space'));
+    const job2 = await job.run();
+    await job.remove();
 });
-
-agenda.on('ready', () => {
-    agenda.every('3 minutes', 'delete old users');
-
-    // Alternatively, you could also do:
-    agenda.every('*/3 * * * *', 'delete old users');
-
-    agenda.start();
-});
-
-agenda.define('send email report', { priority: 'high', concurrency: 10 }, (job, done) => {
-});
-
-agenda.on('ready', () => {
-    agenda.schedule('in 20 minutes', 'send email report', { to: 'admin@example.com' });
-    agenda.start();
-});
-
-agenda.on('ready', () => {
-    var weeklyReport = agenda.create('send email report', { to: 'another-guy@example.com' });
-    weeklyReport.repeatEvery('1 week').save();
-    agenda.start();
-});
-
-var agenda = new Agenda({ processEvery: '30 seconds' });
-
-agenda.defaultConcurrency(5);
-
-var agenda = new Agenda({ defaultConcurrency: 5 });
-
-agenda.lockLimit(0);
-
-var agenda = new Agenda({ lockLimit: 0 });
-
-agenda.defaultLockLimit(0);
-
-var agenda = new Agenda({ defaultLockLimit: 0 });
-
-agenda.defaultLockLifetime(10000);
-
-var agenda = new Agenda({ defaultLockLifetime: 10000 });
-
-agenda.define('some long running job', function(job, done) {
-    done();
-});
-
-agenda.every('15 minutes', ['printAnalyticsReport', 'sendNotifications', 'updateUserRecords']);
-
-agenda.schedule('tomorrow at noon', 'printAnalyticsReport', { userCount: 100 });
-
-agenda.schedule('tomorrow at noon', ['printAnalyticsReport', 'sendNotifications', 'updateUserRecords']);
-
-agenda.now('do the hokey pokey');
-
-var job = agenda.create<{ userCount: number }>('printAnalyticsReport', { userCount: 100 });
-job.save(function(err) {
-    console.log("Job successfully saved");
-});
-
-agenda.jobs({ name: 'printAnalyticsReport' }, function(err, jobs) {
-    // Work with jobs (see below)
-});
-
-agenda.cancel({ name: 'printAnalyticsReport' }, function(err, numRemoved) {
-});
-
-agenda.purge(function(err, numRemoved) {
-});
-
-agenda.stop(function() {
-    process.exit(0);
-});
-
-job.agenda.now('do the hokey pokey');
-
-job.repeatEvery('10 minutes');
-
-job.repeatAt('3:30pm');
-
-job.schedule('tomorrow at 6pm');
-
-job.priority('low');
-job.priority(10);
-
-job.unique({ 'data.type': 'active', 'data.userId': '123' });
-job.fail('insuficient disk space');
-job.fail(new Error('insufficient disk space'));
-job.run(function(err, job) {
-    console.log("I don't know why you would need to do this...");
-});
-job.remove(function(err) {
-    if (!err) console.log("Successfully removed job from collection");
-})
 
 class ExtendedAgenda extends Agenda {
-    async start() {  }
+    async start() { }
 }
 
 const extendedAgenda: ExtendedAgenda = new ExtendedAgenda()

--- a/types/agenda/index.d.ts
+++ b/types/agenda/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Agenda v1.0.3
+// Type definitions for Agenda v2.0.0
 // Project: https://github.com/agenda/agenda
 // Definitions by: Meir Gottlieb <https://github.com/meirgottlieb>
 //                 Jeff Principe <https://github.com/princjef>
@@ -95,16 +95,14 @@ declare class Agenda extends EventEmitter {
     /**
      * Find all Jobs matching `query` and pass same back in cb().
      * @param query
-     * @param cb
      */
-    jobs<T extends Agenda.JobAttributesData = Agenda.JobAttributesData>(query: any, cb: ResultCallback<Agenda.Job<T>[]>): void;
+    jobs<T extends Agenda.JobAttributesData = Agenda.JobAttributesData>(query: any): Promise<void>;
 
     /**
      * Removes all jobs in the database without defined behaviors. Useful if you change a definition name and want
      * to remove old jobs.
-     * @param cb Called with the number of jobs removed.
      */
-    purge(cb?: ResultCallback<number>): void;
+    purge(): Promise<number>;
 
     /**
      * Defines a job with the name of jobName. When a job of job name gets run, it will be passed to fn(job, done).
@@ -123,46 +121,41 @@ declare class Agenda extends EventEmitter {
      * @param names The name or names of the job(s) to run.
      * @param data An optional argument that will be passed to the processing function under job.attrs.data.
      * @param options An optional argument that will be passed to job.repeatEvery.
-     * @param cb An optional callback function which will be called when the job has been persisted in the database.
      */
-    every<T extends Agenda.JobAttributesData = Agenda.JobAttributesData>(interval: number | string, names: string, data?: T, options?: any, cb?: ResultCallback<Agenda.Job<T>>): Agenda.Job<T>;
-    every<T extends Agenda.JobAttributesData = Agenda.JobAttributesData>(interval: number | string, names: string[], data?: T, options?: any, cb?: ResultCallback<Agenda.Job<T>[]>): Agenda.Job<T>[];
+    every<T extends Agenda.JobAttributesData = Agenda.JobAttributesData>(interval: number | string, names: string, data?: T, options?: any): Promise<Agenda.Job<T>>;
+    every<T extends Agenda.JobAttributesData = Agenda.JobAttributesData>(interval: number | string, names: string[], data?: T, options?: any): Promise<Agenda.Job<T>[]>;
 
     /**
      * Schedules a job to run name once at a given time.
      * @param when A Date or a String such as tomorrow at 5pm.
      * @param names The name or names of the job(s) to run.
      * @param data An optional argument that will be passed to the processing function under job.attrs.data.
-     * @param cb An optional callback function which will be called when the job has been persisted in the database.
      */
-    schedule<T extends Agenda.JobAttributesData = Agenda.JobAttributesData>(when: Date | string, names: string, data?: T, cb?: ResultCallback<Agenda.Job<T>>): Agenda.Job<T>;
-    schedule<T extends Agenda.JobAttributesData = Agenda.JobAttributesData>(when: Date | string, names: string[], data?: T, cb?: ResultCallback<Agenda.Job<T>[]>): Agenda.Job<T>[];
+    schedule<T extends Agenda.JobAttributesData = Agenda.JobAttributesData>(when: Date | string, names: string, data?: T): Promise<Agenda.Job<T>>;
+    schedule<T extends Agenda.JobAttributesData = Agenda.JobAttributesData>(when: Date | string, names: string[], data?: T): Promise<Agenda.Job<T>[]>;
 
     /**
      * Schedules a job to run name once immediately.
      * @param name The name of the job to run.
      * @param data An optional argument that will be passed to the processing function under job.attrs.data.
-     * @param cb An optional callback function which will be called when the job has been persisted in the database.
      */
-    now<T extends Agenda.JobAttributesData = Agenda.JobAttributesData>(name: string, data?: T, cb?: ResultCallback<Agenda.Job<T>>): Agenda.Job<T>;
+    now<T extends Agenda.JobAttributesData = Agenda.JobAttributesData>(name: string, data?: T): Promise<Agenda.Job<T>>;
 
     /**
      * Cancels any jobs matching the passed mongodb-native query, and removes them from the database.
      * @param query Mongodb native query.
-     * @param cb Called with the number of jobs removed.
      */
-    cancel(query: any, cb?: ResultCallback<number>): void;
+    cancel(query: any): Promise<number>;
 
     /**
      * Starts the job queue processing, checking processEvery time to see if there are new jobs.
      */
-    start(): void;
+    start(): Promise<void>;
 
     /**
      * Stops the job queue processing. Unlocks currently running jobs.
-     * @param cb Called after the job processing queue shuts down and unlocks all jobs.
      */
-    stop(cb: Callback): void;
+    stop(): Promise<void>;
 }
 
 declare namespace Agenda {
@@ -353,54 +346,53 @@ declare namespace Agenda {
          * @param options An optional argument that can include a timezone field. The timezone should be a string as
          * accepted by moment-timezone and is considered when using an interval in the cron string format.
          */
-        repeatEvery(interval: string | number, options?: { timezone?: string }): Job<T>
+        repeatEvery(interval: string | number, options?: { timezone?: string }): this
 
         /**
          * Specifies a time when the job should repeat. [Possible values](https://github.com/matthewmueller/date#examples).
          * @param time
          */
-        repeatAt(time: string): Job<T>
+        repeatAt(time: string): this
 
         /**
          * Disables the job.
          */
-        disable(): Job<T>;
+        disable(): this;
 
         /**
          * Enables the job.
          */
-        enable(): Job<T>;
+        enable(): this;
 
         /**
          * Ensure that only one instance of this job exists with the specified properties
          * @param value The properties associated with the job that must be unqiue.
          * @param opts
          */
-        unique(value: any, opts?: { insertOnly?: boolean }): Job<T>;
+        unique(value: any, opts?: { insertOnly?: boolean }): this;
 
         /**
          * Specifies the next time at which the job should run.
          * @param time The next time at which the job should run.
          */
-        schedule(time: string | Date): Job<T>;
+        schedule(time: string | Date): this;
 
         /**
          * Specifies the priority weighting of the job.
          * @param value The priority of the job (lowest|low|normal|high|highest|number).
          */
-        priority(value: string | number): Job<T>;
+        priority(value: string | number): this;
 
         /**
          * Sets job.attrs.failedAt to now, and sets job.attrs.failReason to reason.
          * @param reason A message or Error object that indicates why the job failed.
          */
-        fail(reason: string | Error): Job<T>;
+        fail(reason: string | Error): this;
 
         /**
          * Runs the given job and calls callback(err, job) upon completion. Normally you never need to call this manually
-         * @param cb Called when the job is completed.
          */
-        run(cb?: ResultCallback<Job<T>>): Job<T>;
+        run(): Promise<this>;
 
         /**
          * Returns true if the job is running; otherwise, returns false.
@@ -409,27 +401,24 @@ declare namespace Agenda {
 
         /**
          * Saves the job into the database.
-         * @param cb  Called when the job is saved.
          */
-        save(cb?: ResultCallback<Job<T>>): Job<T>;
+        save(): Promise<this>;
 
         /**
          * Removes the job from the database and cancels the job.
-         * @param cb Called after the job has beeb removed from the database.
          */
-        remove(cb?: Callback): void;
+        remove(): Promise<void>;
 
         /**
          * Resets the lock on the job. Useful to indicate that the job hasn't timed out when you have very long running
          * jobs.
-         * @param cb Called after the job has been saved to the database.
          */
-        touch(cb?: Callback): void;
+        touch(): Promise<this>;
 
         /**
          * Calculates next time the job should run
          */
-        computeNextRunAt(): Job<T>;
+        computeNextRunAt(): this;
     }
 
     interface JobOptions {


### PR DESCRIPTION
The latest major release of [`agenda`](https://github.com/agenda/agenda) has updated to make virtually all APIs promise-based rather than callback-based. This PR brings the types into alignment for the new version and cleans up some of the return types at the same time (such as properly typing methods that return `this` types).

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/agenda/agenda/blob/master/History.md#200--2018-07-19
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
