### PR TITLE
Updated Package.json to prevent redux-thunk 2.2.0 from being used

### DIFF
--- a/types/redux-testkit/package.json
+++ b/types/redux-testkit/package.json
@@ -2,6 +2,6 @@
 	"private": true,
 	"dependencies": {
 		"redux": "^3.6.0",
-		"redux-thunk": "^2.2.0"
+		"redux-thunk": "^2.3.0"
 	}
 }


### PR DESCRIPTION
Fix for pull request [27341](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/27341)
`package.json` was not updated and it will make projects fail for users who are using `redux-thunk 2.2.0`