### PR TITLE
Made function argument to jest.Mock.mockImplementation optional

### DIFF
--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -775,7 +775,7 @@ declare namespace jest {
          *
          * Note: `jest.fn(implementation)` is a shorthand for `jest.fn().mockImplementation(implementation)`.
          */
-        mockImplementation(fn: (...args: any[]) => any): Mock<T>;
+        mockImplementation(fn?: (...args: any[]) => any): Mock<T>;
         /**
          * Accepts a function that will be used as an implementation of the mock for one call to the mocked function.
          * Can be chained so that multiple function calls produce different results.

--- a/types/jest/jest-tests.ts
+++ b/types/jest/jest-tests.ts
@@ -298,6 +298,7 @@ spy2.mockReset();
 
 const spy3Mock: jest.Mock<() => string> = spy3
     .mockImplementation(() => "")
+    .mockImplementation()
     .mockImplementation((arg: {}) => arg)
     .mockImplementation((...args: string[]) => args.join(""))
     .mockImplementationOnce(() => "")


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: Calling `jest.spyOn(o, "method").mockImplementation()` with no argument is the easiest way of disabling jest's default behaviour that spies call the underlying method that they are spying on. Before this change it was necessary to type `jest.spyOn(o, "method").mockImplementation(() => null)` to satisfy TS. The Jest [docs for Mock.mockImplementation](https://jest-bot.github.io/jest/docs/mock-function-api.html#mockfnmockimplementationfn) don't explicitly say that the argument is optional, but they do say that `mockFn.mockImplementation(implementation)` is equivalent to `jest.fn(implementation)`, and the docs for [jest.fn()](https://jest-bot.github.io/jest/docs/jest-object.html#jestfnimplementation) do show that the argument is optional. Also, it works!
- [ ] Increase the version number in the header if appropriate. (not required)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
