### PR TITLE
Fix some typings for Bull package

### DIFF
--- a/types/bull/index.d.ts
+++ b/types/bull/index.d.ts
@@ -8,6 +8,7 @@
 //                 Oleg Repin <https://github.com/iamolegga>
 //                 David Koblas <https://github.com/koblas>
 //                 Bond Akinmade <https://github.com/bondz>
+//                 Wuha Team <https://github.com/wuha-team>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -534,7 +535,7 @@ declare namespace Bull {
      * Removes a given repeatable job. The RepeatOptions and JobId needs to be the same as the ones
      * used for the job when it was added.
      */
-    removeRepeatable(repeat: RepeatOptions & { jobId?: JobId }): Promise<void>;
+    removeRepeatable(repeat: (CronRepeatOptions | EveryRepeatOptions) & { jobId?: JobId }): Promise<void>;
 
     /**
      * Removes a given repeatable job. The RepeatOptions and JobId needs to be the same as the ones
@@ -542,7 +543,13 @@ declare namespace Bull {
      *
      * name: The name of the to be removed job
      */
-    removeRepeatable(name: string, repeat: RepeatOptions & { jobId?: JobId }): Promise<void>;
+    removeRepeatable(name: string, repeat: (CronRepeatOptions | EveryRepeatOptions) & { jobId?: JobId }): Promise<void>;
+
+    /**
+     * Returns a promise that will return an array of job instances of the given types.
+     * Optional parameters for range and ordering are provided.
+     */
+    getJobs(types: string[], start?: number, end?: number, asc?: boolean): Promise<Job[]>;
 
     /**
      * Returns a promise that resolves with the job counts for the given queue.


### PR DESCRIPTION
Add typings for `getJobs` and fix `removeRepeatable` 'repeat' param

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 

*getJobs*: [queuegetjobs](https://github.com/OptimalBits/bull/blob/master/REFERENCE.md#queuegetjobs)

*removeRepeatable*: [see RepeatOpts](https://github.com/OptimalBits/bull/blob/master/REFERENCE.md#queueremoverepeatable) 