### PR TITLE
[redux-form] expose selectors generic types

### DIFF
--- a/types/redux-form/lib/selectors.d.ts
+++ b/types/redux-form/lib/selectors.d.ts
@@ -1,10 +1,20 @@
 import { FormErrors, GetFormState } from "../index";
 
-export type DataSelector<FormData = {}, State = {}> = (formName: string, getFormState?: GetFormState) => (state: State) => FormData;
-export type ErrorSelector<FormData = {}, State = {}> = (formName: string, getFormState?: GetFormState) => (state: State) => FormErrors<FormData>;
-export type BooleanSelector<State = {}> = (formName: string, getFormState?: GetFormState) => (state: State) => boolean;
-export type NamesSelector<State = {}> = (getFormState?: GetFormState) => (state: State) => string[];
-export type FormOrFieldsBooleanSelector<State = {}> = (formName: string, getFormState?: GetFormState) => (state: State, ...fields: string[]) => boolean;
+export interface DataSelector<FormData = {}, State = {}> {
+  (formName: string, getFormState?: GetFormState): (state: State) => FormData;
+}
+export interface ErrorSelector<FormData = {}, State = {}> {
+  (formName: string, getFormState?: GetFormState): (state: State) => FormErrors<FormData>;
+}
+export interface BooleanSelector<State = {}> {
+  (formName: string, getFormState?: GetFormState): (state: State) => boolean;
+}
+export interface NamesSelector<State = {}> {
+  (getFormState?: GetFormState): (state: State) => string[];
+}
+export interface FormOrFieldsBooleanSelector<State = {}> {
+  (formName: string, getFormState?: GetFormState): (state: State, ...fields: string[]) => boolean;
+}
 
 export const getFormValues: DataSelector;
 export const getFormInitialValues: DataSelector;

--- a/types/redux-form/tslint.json
+++ b/types/redux-form/tslint.json
@@ -2,6 +2,7 @@
     "extends": "dtslint/dt.json",
     "rules": {
         "no-object-literal-type-assertion": false,
-        "strict-export-declare-modifiers": false
+        "strict-export-declare-modifiers": false,
+        "callable-types": false
     }
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 

---

trying to use type arguments in selector types results in type argument error

```typescript
export type ErrorSelector<FormData = {}, State = {}> = (formName: string, getFormState?: GetFormState) => (state: State) => FormErrors<FormData>;
export const getFormSyncErrors: ErrorSelector;
```
```typescript
import CheckoutFormData from './CheckoutFormData';
import PageState from './PageState';

const Form = connect(
  state => ({
    errors: getFormSyncErrors<CheckoutFormData, PageState>('form')(state) // <- type argument error
  })
)(reduxForm({
  form: 'form',
})(Component));
```

This PR changes selector definitions from types to interfaces, allowing passing in types on the function