### PR TITLE
[@mapbox/geo-viewport] fix small oversight

### DIFF
--- a/types/mapbox__geo-viewport/index.d.ts
+++ b/types/mapbox__geo-viewport/index.d.ts
@@ -12,4 +12,4 @@ export type BoundingBox = [number, number, number, number];
 
 export function viewport(bounds: BoundingBox, dimensions: [number, number], minzoom?: number, maxzoom?: number, tileSize?: number): GeoViewport;
 
-export function bounds(viewport: { lon: number; lat: number }, zoom: number, dimensions: [number, number], tileSize?: number): BoundingBox;
+export function bounds(viewport: { lon: number; lat: number } | [number, number], zoom: number, dimensions: [number, number], tileSize?: number): BoundingBox;

--- a/types/mapbox__geo-viewport/mapbox__geo-viewport-tests.ts
+++ b/types/mapbox__geo-viewport/mapbox__geo-viewport-tests.ts
@@ -11,3 +11,5 @@ const boundingBox = bounds({
     lon: 100,
     lat: 200,
 }, 14, [640, 480]);
+
+const boundingBox2 = bounds([100, 200], 14, [640, 480]);


### PR DESCRIPTION
Small oversight in the original PR, bounds takes either an object or an array as viewport input.