### PR TITLE
[slate] Adds <start/end/anchor/focus>Inline properties to Value

### DIFF
--- a/types/slate/index.d.ts
+++ b/types/slate/index.d.ts
@@ -4,6 +4,7 @@
 //                 Jamie Talbot <https://github.com/majelbstoat>
 //                 Jan Löbel <https://github.com/JanLoebel>
 //                 Brandon Shelton <https://github.com/YangusKhan>
+//                 Kalley Powell <https://github.com/kalley>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 import * as Immutable from 'immutable';
@@ -114,6 +115,11 @@ export class Value extends Immutable.Record({}) {
   readonly focusBlock: Block;
   readonly startBlock: Block;
   readonly endBlock: Block;
+
+  readonly anchorInline: Inline;
+  readonly focusInline: Inline;
+  readonly startInline: Inline;
+  readonly endInline: Inline;
 
   readonly marks: Immutable.Set<Mark>;
   readonly activeMarks: Immutable.Set<Mark>;


### PR DESCRIPTION
Adds some missing readonly properties on `Value`

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/ianstormtaylor/slate/blob/master/packages/slate/src/models/value.js#L392
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.