### PR TITLE
React-select : option multi renamed to isMulti

### DIFF
--- a/types/react-select/index.d.ts
+++ b/types/react-select/index.d.ts
@@ -410,7 +410,7 @@ export interface ReactSelectProps<TValue = OptionValues> extends React.Props<Rea
      * multi-value input
      * @default false
      */
-    multi?: boolean;
+    isMulti?: boolean;
     /**
      * field name, for hidden `<input>` tag
      */


### PR DESCRIPTION
In react-select, the option for multi selection is named isMulti, not multi as it was in the file before my merge request.
