### PR TITLE
@types/react-select: Add missing property 'showNewOptionAtTop' to ReactCreatableSelectProps

### DIFF
--- a/types/react-select/index.d.ts
+++ b/types/react-select/index.d.ts
@@ -617,7 +617,7 @@ export interface ReactCreatableSelectProps<TValue = OptionValues> extends ReactS
     onNewOptionClick?: OnNewOptionClickHandler<TValue>;
 
     /**
-     * true: Show new option at top of list 
+     * true: Show new option at top of list
      * false: Show new option at bottom of list
      * @default true
      */

--- a/types/react-select/index.d.ts
+++ b/types/react-select/index.d.ts
@@ -615,7 +615,7 @@ export interface ReactCreatableSelectProps<TValue = OptionValues> extends ReactS
      * new option click handler: function (option) {}
      */
     onNewOptionClick?: OnNewOptionClickHandler<TValue>;
-                                      
+
     /**
      * true: Show new option at top of list 
      * false: Show new option at bottom of list

--- a/types/react-select/index.d.ts
+++ b/types/react-select/index.d.ts
@@ -615,6 +615,13 @@ export interface ReactCreatableSelectProps<TValue = OptionValues> extends ReactS
      * new option click handler: function (option) {}
      */
     onNewOptionClick?: OnNewOptionClickHandler<TValue>;
+                                      
+    /**
+     * true: Show new option at top of list 
+     * false: Show new option at bottom of list
+     * @default true
+     */
+    showNewOptionAtTop?: boolean;
 }
 
 export interface ReactAsyncSelectProps<TValue = OptionValues> extends ReactSelectProps<TValue> {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/JedWatson/react-select/tree/v1.x
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
