### PR TITLE
[rollup-plugin-json](feat): bump version, rollup dependency, add jsdoc

### DIFF
--- a/types/rollup-plugin-json/index.d.ts
+++ b/types/rollup-plugin-json/index.d.ts
@@ -1,14 +1,27 @@
-// Type definitions for rollup-plugin-json 2.3
+// Type definitions for rollup-plugin-json 3.0
 // Project: https://github.com/rollup/rollup-plugin-json#readme
 // Definitions by: Andy Mockler <https://github.com/asmockler>
+//                 Martin Hochel <https://github.com/hotell>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
 
 import { Plugin } from 'rollup';
 
 export interface Options {
+    /**
+     *  All JSON files will be parsed by default, but you can also specifically include/exclude files
+     */
     include?: string | string[];
     exclude?: string | string[];
+    /**
+     *  for tree-shaking, properties will be declared as variables, using either `var` or `const`
+     *  @default false
+     */
     preferConst?: boolean;
+    /**
+     * specify indentation for the generated default export — defaults to '\t'
+     * @default '\t'
+     */
     indent?: string;
 }
 

--- a/types/rollup-plugin-json/package.json
+++ b/types/rollup-plugin-json/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "rollup": "^0.54.0"
+        "rollup": "^0.63.4"
     }
 }

--- a/types/rollup-plugin-json/rollup-plugin-json-tests.ts
+++ b/types/rollup-plugin-json/rollup-plugin-json-tests.ts
@@ -1,3 +1,5 @@
 import json from 'rollup-plugin-json';
 
 json(); // $ExpectType Plugin
+
+json({preferConst: true, indent: '  '}); // $ExpectType Plugin


### PR DESCRIPTION
- bumps to latest rollup, which changed definitions ( prior to this change rollup definition required source-map ) which is not the case anymore

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.