### PR TITLE
Add node-zopfli-es types

### DIFF
--- a/types/node-zopfli-es/index.d.ts
+++ b/types/node-zopfli-es/index.d.ts
@@ -1,10 +1,70 @@
 // Type definitions for node-zopfli-es 0.0
 // Project: https://github.com/jaeh/node-zopfli-es
-// Definitions by: My Self <https://github.com/me>
+// Definitions by: Alorel <https://github.com/Alorel>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
-import * as zopfli from 'node-zopfli';
+/// <reference types="node" />
 
-export = zopfli;
+import { Transform } from 'stream';
+
+declare class Zopfli extends Transform {
+    constructor(format?: Zopfli.Format, options?: Zopfli.Options);
+
+    static createGzip(options?: Zopfli.Options): Zopfli;
+    static createDeflate(options?: Zopfli.Options): Zopfli;
+    static createZlib(options?: Zopfli.Options): Zopfli;
+
+    static gzipSync(options?: Zopfli.Options): Buffer;
+    static deflateSync(options?: Zopfli.Options): Buffer;
+    static zlibSync(options?: Zopfli.Options): Buffer;
+
+    static deflate(input: Buffer, options: Zopfli.Options, cb: (err: Error, out: Buffer) => void): void;
+    static deflate(input: Buffer, cb: (err: Error, out: Buffer) => void): void;
+    static deflate(input: Buffer, options?: Zopfli.Options): Promise<Buffer>;
+
+    static gzip(input: Buffer, options: Zopfli.Options, cb: (err: Error, out: Buffer) => void): void;
+    static gzip(input: Buffer, cb: (err: Error, out: Buffer) => void): void;
+    static gzip(input: Buffer, options?: Zopfli.Options): Promise<Buffer>;
+
+    static zlib(input: Buffer, options: Zopfli.Options, cb: (err: Error, out: Buffer) => void): void;
+    static zlib(input: Buffer, cb: (err: Error, out: Buffer) => void): void;
+    static zlib(input: Buffer, options?: Zopfli.Options): Promise<Buffer>;
+
+    static compress(input: Buffer, format: Zopfli.Format, options: Zopfli.Options, cb: (err: Error, out: Buffer) => void): void;
+    static compress(input: Buffer, format: Zopfli.Format, cb: (err: Error, out: Buffer) => void): void;
+    static compress(input: Buffer, format: Zopfli.Format, options?: Zopfli.Options): Promise<Buffer>;
+}
+
+declare namespace Zopfli {
+    type Format = 'deflate' | 'gzip' | 'zlib';
+
+    interface Options {
+        verbose?: boolean;
+        verbose_more?: boolean;
+        /**
+         * Maximum amount of times to rerun forward and backward pass to optimize LZ77 compression cost.
+         * Good values: 10, 15 for small files, 5 for files over several MB in size or it will be too slow.
+         */
+        numiterations?: number;
+        /**
+         * If true, splits the data in multiple deflate blocks with optimal choice for the block boundaries.
+         * Block splitting gives better compression.
+         */
+        blocksplitting?: boolean;
+        /**
+         * If true, chooses the optimal block split points only after doing the iterative LZ77 compression.
+         * If false, chooses the block split points first, then does iterative LZ77 on each individual block.
+         * Depending on the file, either first or last gives the best compression.
+         */
+        blocksplittinglast?: boolean;
+        /**
+         * Maximum amount of blocks to split into (0 for unlimited,
+         * but this can give extreme results that hurt compression on some files).
+         */
+        blocksplittingmax?: number;
+    }
+}
+
+export = Zopfli;

--- a/types/node-zopfli-es/index.d.ts
+++ b/types/node-zopfli-es/index.d.ts
@@ -2,6 +2,8 @@
 // Project: https://github.com/jaeh/node-zopfli-es
 // Definitions by: My Self <https://github.com/me>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
 
 import * as zopfli from 'node-zopfli';
 

--- a/types/node-zopfli-es/index.d.ts
+++ b/types/node-zopfli-es/index.d.ts
@@ -2,7 +2,6 @@
 // Project: https://github.com/jaeh/node-zopfli-es
 // Definitions by: Alorel <https://github.com/Alorel>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
 /// <reference types="node" />

--- a/types/node-zopfli-es/index.d.ts
+++ b/types/node-zopfli-es/index.d.ts
@@ -1,0 +1,8 @@
+// Type definitions for node-zopfli-es 0.0
+// Project: https://github.com/jaeh/node-zopfli-es
+// Definitions by: My Self <https://github.com/me>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import * as zopfli from 'node-zopfli';
+
+export = zopfli;

--- a/types/node-zopfli-es/node-zopfli-es-tests.ts
+++ b/types/node-zopfli-es/node-zopfli-es-tests.ts
@@ -1,0 +1,51 @@
+import * as Zopfli from 'node-zopfli-es';
+import * as fs from 'fs';
+
+const opts: Zopfli.Options = {
+    verbose: true,
+    numiterations: 1
+};
+let input: Buffer = Buffer.from('foo');
+const read = fs.createReadStream('foo');
+const write = fs.createWriteStream('foo');
+
+function cb(e: Error, b: Buffer): void {}
+function then(b: Buffer): void {}
+
+Zopfli.zlib(input, cb);
+Zopfli.zlib(input, opts, cb);
+Zopfli.zlib(input, opts).then(then);
+Zopfli.zlib(input).then(then);
+
+Zopfli.gzip(input, cb);
+Zopfli.gzip(input, opts, cb);
+Zopfli.gzip(input, opts).then(then);
+Zopfli.gzip(input).then(then);
+
+Zopfli.deflate(input, cb);
+Zopfli.deflate(input, opts, cb);
+Zopfli.deflate(input, opts).then(then);
+Zopfli.deflate(input).then(then);
+
+Zopfli.compress(input, 'zlib', cb);
+Zopfli.compress(input, 'zlib', opts, cb);
+Zopfli.compress(input, 'zlib', opts).then(then);
+Zopfli.compress(input, 'zlib').then(then);
+
+input = Zopfli.gzipSync();
+input = Zopfli.gzipSync(opts);
+
+input = Zopfli.deflateSync();
+input = Zopfli.deflateSync(opts);
+
+input = Zopfli.zlibSync();
+input = Zopfli.zlibSync(opts);
+
+read.pipe(Zopfli.createGzip()).pipe(write);
+read.pipe(Zopfli.createGzip(opts)).pipe(write);
+
+read.pipe(Zopfli.createDeflate()).pipe(write);
+read.pipe(Zopfli.createDeflate(opts)).pipe(write);
+
+read.pipe(Zopfli.createZlib()).pipe(write);
+read.pipe(Zopfli.createZlib(opts)).pipe(write);

--- a/types/node-zopfli-es/tsconfig.json
+++ b/types/node-zopfli-es/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "node-zopfli-es-tests.ts"
+    ]
+}

--- a/types/node-zopfli-es/tslint.json
+++ b/types/node-zopfli-es/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.