### PR TITLE
pino accepts NodeJS.WritableStream streams too

### DIFF
--- a/types/pino/index.d.ts
+++ b/types/pino/index.d.ts
@@ -19,7 +19,7 @@ export = P;
  * relative protocol is enabled. Default: process.stdout
  * @returns a new logger instance.
  */
-declare function P(optionsOrStream?: P.LoggerOptions | stream.Writable | stream.Duplex | stream.Transform): P.Logger;
+declare function P(optionsOrStream?: P.LoggerOptions | stream.Writable | stream.Duplex | stream.Transform | NodeJS.WritableStream): P.Logger;
 
 /**
  * @param [options]: an options object
@@ -27,7 +27,7 @@ declare function P(optionsOrStream?: P.LoggerOptions | stream.Writable | stream.
  * relative protocol is enabled. Default: process.stdout
  * @returns a new logger instance.
  */
-declare function P(options: P.LoggerOptions, stream: stream.Writable | stream.Duplex | stream.Transform): P.Logger;
+declare function P(options: P.LoggerOptions, stream: stream.Writable | stream.Duplex | stream.Transform | NodeJS.WritableStream): P.Logger;
 
 declare namespace P {
     /**

--- a/types/pino/pino-tests.ts
+++ b/types/pino/pino-tests.ts
@@ -93,3 +93,6 @@ log.level = 'info';
 
 pino.levels.values.error === 50;
 pino.levels.labels[50] === 'error';
+
+const logstderr: pino.Logger = pino(process.stderr);
+logstderr.error('on stderr instead of stdout');


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/pinojs/pino/blob/master/pino.js#L278>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

----

The pino logger factory function accepts standard node writable streams -- after all, the default is `process.stdout`, but the existing type definitions don't allow passing such objects.  So add `NodeJS.WritableStream` to the type definitions where the other stream types are accepted.