### PR TITLE
Adding definitions for fastGet, fastPut in ssh2-sftp-client

### DIFF
--- a/types/ssh2-sftp-client/index.d.ts
+++ b/types/ssh2-sftp-client/index.d.ts
@@ -1,6 +1,6 @@
-// Type definitions for ssh2-sftp-client 2.0
+// Type definitions for ssh2-sftp-client 2.3
 // Project: https://www.npmjs.com/package/ssh2-sftp-client
-// Definitions by: igrayson <https://github.com/igrayson>, Ascari Andrea <https://github.com/ascariandrea>
+// Definitions by: igrayson <https://github.com/igrayson>, Ascari Andrea <https://github.com/ascariandrea>, Kartik Malik <https://github.com/kartik2406>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 import * as ssh2 from 'ssh2';
@@ -11,7 +11,9 @@ declare class sftp {
   connect(options: ssh2.ConnectConfig): Promise<void>;
   list(remoteFilePath: string): Promise<sftp.FileInfo[]>;
   get(remoteFilePath: string, useCompression?: boolean, encoding?: string | null): Promise<NodeJS.ReadableStream>;
+  fastGet(remoteFilePath: string, localPath: string, options?: any): Promise<any>;
   put(input: string | Buffer | NodeJS.ReadableStream, remoteFilePath: string, useCompression?: boolean, encoding?: string): Promise<void>;
+  fastPut(localPath: string, emoteFilePath: string, options?: any): Promise<any>;
   mkdir(remoteFilePath: string, recursive?: boolean): Promise<void>;
   rmdir(remoteFilePath: string, recursive?: boolean): Promise<void>;
   delete(remoteFilePath: string): Promise<void>;

--- a/types/ssh2-sftp-client/index.d.ts
+++ b/types/ssh2-sftp-client/index.d.ts
@@ -4,16 +4,16 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 import * as ssh2 from 'ssh2';
-
+import * as ssh2Stream from 'ssh2-streams';
 export = sftp;
 
 declare class sftp {
   connect(options: ssh2.ConnectConfig): Promise<void>;
   list(remoteFilePath: string): Promise<sftp.FileInfo[]>;
   get(remoteFilePath: string, useCompression?: boolean, encoding?: string | null): Promise<NodeJS.ReadableStream>;
-  fastGet(remoteFilePath: string, localPath: string, options?: any): Promise<any>;
+  fastGet(remoteFilePath: string, localPath: string, options?: ssh2Stream.TransferOptions): Promise<any>;
   put(input: string | Buffer | NodeJS.ReadableStream, remoteFilePath: string, useCompression?: boolean, encoding?: string): Promise<void>;
-  fastPut(localPath: string, emoteFilePath: string, options?: any): Promise<any>;
+  fastPut(localPath: string, emoteFilePath: string, options?: ssh2Stream.TransferOptions): Promise<any>;
   mkdir(remoteFilePath: string, recursive?: boolean): Promise<void>;
   rmdir(remoteFilePath: string, recursive?: boolean): Promise<void>;
   delete(remoteFilePath: string): Promise<void>;

--- a/types/ssh2-sftp-client/index.d.ts
+++ b/types/ssh2-sftp-client/index.d.ts
@@ -11,9 +11,9 @@ declare class sftp {
   connect(options: ssh2.ConnectConfig): Promise<void>;
   list(remoteFilePath: string): Promise<sftp.FileInfo[]>;
   get(remoteFilePath: string, useCompression?: boolean, encoding?: string | null): Promise<NodeJS.ReadableStream>;
-  fastGet(remoteFilePath: string, localPath: string, options?: ssh2Stream.TransferOptions): Promise<any>;
+  fastGet(remoteFilePath: string, localPath: string, options?: ssh2Stream.TransferOptions): Promise<string>;
   put(input: string | Buffer | NodeJS.ReadableStream, remoteFilePath: string, useCompression?: boolean, encoding?: string): Promise<void>;
-  fastPut(localPath: string, emoteFilePath: string, options?: ssh2Stream.TransferOptions): Promise<any>;
+  fastPut(localPath: string, emoteFilePath: string, options?: ssh2Stream.TransferOptions): Promise<string>;
   mkdir(remoteFilePath: string, recursive?: boolean): Promise<void>;
   rmdir(remoteFilePath: string, recursive?: boolean): Promise<void>;
   delete(remoteFilePath: string): Promise<void>;

--- a/types/ssh2-sftp-client/ssh2-sftp-client-tests.ts
+++ b/types/ssh2-sftp-client/ssh2-sftp-client-tests.ts
@@ -15,9 +15,13 @@ client.get('/remote/path').then(stream => stream.read(0));
 client.get('/remote/path', true, 'utf8').then(stream => stream.read(0));
 client.get('/remote/path', true, null).then(stream => stream.read(0));
 
+client.fastGet('/remote/path', 'local/path').then(() => null);
+
 client.put('/local/path', '/remote/path').then(() => null);
 client.put(new Buffer('content'), '/remote/path').then(() => null);
 client.put(fs.createReadStream('Hello World'), '/remote/path').then(() => null);
+
+client.fastPut('/remote/path', 'local/path').then(() => null);
 
 client.mkdir('/remote/path/dir', true).then(() => null);
 client.rmdir('/remote/path/dir', true).then(() => null);


### PR DESCRIPTION
ssh2-sftp-client 2.3.0 adds support for 'ssh-streams' fastGet and fastPut method, however the typings file does not contain this information
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/mscdex/ssh2-streams/blob/master/SFTPStream.md>
- [X] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
