### PR TITLE
[couchbase]: Ensure OpCallback is composable with normal callbacks

### DIFF
--- a/types/couchbase/couchbase-tests.ts
+++ b/types/couchbase/couchbase-tests.ts
@@ -31,6 +31,11 @@ bucket.manager().createPrimaryIndex(function() {
     });
 });
 
+// Ensure bucket.upsert is composable with normal callbacks
+function composable(callback: (err?: Error) => void) {
+    bucket.upsert('key', {value: 1}, callback);
+}
+
 // From https://developer.couchbase.com/documentation/server/current/sdk/nodejs/n1ql-queries-with-sdk.html
 function n1ql_a() {
     const n1qlquery = N1qlQuery.fromString('SELECT name, email FROM users WHERE name=$1');

--- a/types/couchbase/index.d.ts
+++ b/types/couchbase/index.d.ts
@@ -2019,10 +2019,10 @@ declare namespace Bucket {
      */
     interface OpCallback {
         /**
-         * @param error The error for the operation. This can either be an Error object or a value which evaluates to false (null, undefined, 0 or false).
+         * @param error The error for the operation. This can either be an Error object or a value which evaluates to false.
          * @param result The result of the operation that was executed. This usually contains at least a cas property, and on some operations will contain a value property as well.
          */
-        (error: CouchbaseError | number, result: any): void;
+        (error: CouchbaseError | null, result: any): void;
     }
 
     /**


### PR DESCRIPTION
The documentation gets weird about the API promising to return *some* kind of value that evaluates to false, even if that might be the number zero. The original types author expressed that as `CouchbaseError | number`, but that makes it seem like the result could be some non-zero number.

I don't know whether the library actually issues `callback(0)` calls, but to make it play better with normal callbacks `(err?: Error)`, we will act as if it uses null instead of zero.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - http://docs.couchbase.com/sdk-api/couchbase-node-client-2.4.5/Bucket.html#.OpCallback__anchor
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
