### PR TITLE
@types/graphql: Make GraphQLNonNull and GraphQLList structurally different

### DIFF
--- a/types/graphql/graphql-tests.ts
+++ b/types/graphql/graphql-tests.ts
@@ -1,4 +1,4 @@
-import * as graphql from 'graphql';
+import { GraphQLType, GraphQLInt, isNamedType, isNonNullType, isListType } from 'graphql';
 
 ///////////////////////////
 // graphql               //
@@ -179,4 +179,19 @@ function utilities_typeFromAST_tests() {
 
 function utilities_valueFromAST_tests() {
     // TODOS
+}
+
+declare function summonType(): GraphQLType;
+
+function definition_tests() {
+    const x: GraphQLType = summonType();
+
+    if (isNamedType(x))
+        return x.name; // x: GraphQLNamedType
+
+    if (isNonNullType(x))
+        return x.ofType;
+
+    if (isListType(x))
+        return x.ofType;
 }

--- a/types/graphql/type/definition.d.ts
+++ b/types/graphql/type/definition.d.ts
@@ -151,6 +151,7 @@ export function assertAbstractType(type: GraphQLType): GraphQLAbstractType;
  *
  */
 export class GraphQLList<T extends GraphQLType> {
+    readonly __kind?: 'list'; // to differentiate from GraphQLNonNull
     readonly ofType: T;
     constructor(type: T);
     toString(): string;
@@ -179,6 +180,7 @@ export class GraphQLList<T extends GraphQLType> {
  * Note: the enforcement of non-nullability occurs within the executor.
  */
 export class GraphQLNonNull<T extends GraphQLNullableType> {
+    readonly __kind?: 'non-null'; // to differentiate from GraphQLList
     readonly ofType: T;
     constructor(type: T);
     toString(): string;


### PR DESCRIPTION
GraphQLNonNull and GraphQLList are structurally the same. This makes it difficult (impossible?) to use type narrowing with `isListType()` and `isNonNullType()`.  As suggested by the solution [here](https://stackoverflow.com/questions/51547169/structural-typing-and-user-defined-type-guards/), I am adding a property to differentiate between the two.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://stackoverflow.com/questions/51547169/structural-typing-and-user-defined-type-guards
- [ ] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.