### PR TITLE
lodash: iteratee shorthand should allow numbers and symbols

### DIFF
--- a/types/lodash/common/common.d.ts
+++ b/types/lodash/common/common.d.ts
@@ -179,16 +179,17 @@ declare module "../index" {
     }
 
     type NotVoid = {} | null | undefined;
+    type IterateeShorthand<T> = PropertyName | [PropertyName, any] | PartialDeep<T>;
     type ArrayIterator<T, TResult> = (value: T, index: number, collection: T[]) => TResult;
     type ListIterator<T, TResult> = (value: T, index: number, collection: List<T>) => TResult;
-    type ListIteratee<T> = ListIterator<T, NotVoid> | string | [string, any] | PartialDeep<T>;
-    type ListIterateeCustom<T, TResult> = ListIterator<T, TResult> | string | [string, any] | PartialDeep<T>;
+    type ListIteratee<T> = ListIterator<T, NotVoid> | IterateeShorthand<T>;
+    type ListIterateeCustom<T, TResult> = ListIterator<T, TResult> | IterateeShorthand<T>;
     type ListIteratorTypeGuard<T, S extends T> = (value: T, index: number, collection: List<T>) => value is S;
 
     // Note: key should be string, not keyof T, because the actual object may contain extra properties that were not specified in the type.
     type ObjectIterator<TObject, TResult> = (value: TObject[keyof TObject], key: string, collection: TObject) => TResult;
-    type ObjectIteratee<TObject> = ObjectIterator<TObject, NotVoid> | string | [string, any] | PartialDeep<TObject[keyof TObject]>;
-    type ObjectIterateeCustom<TObject, TResult> = ObjectIterator<TObject, TResult> | string | [string, any] | PartialDeep<TObject[keyof TObject]>;
+    type ObjectIteratee<TObject> = ObjectIterator<TObject, NotVoid> | IterateeShorthand<TObject[keyof TObject]>;
+    type ObjectIterateeCustom<TObject, TResult> = ObjectIterator<TObject, TResult> | IterateeShorthand<TObject[keyof TObject]>;
     type ObjectIteratorTypeGuard<TObject, S extends TObject[keyof TObject]> = (value: TObject[keyof TObject], key: string, collection: TObject) => value is S;
 
     type StringIterator<TResult> = (char: string, index: number, string: string) => TResult;
@@ -207,10 +208,10 @@ declare module "../index" {
     type MemoVoidDictionaryIterator<T, TResult> = (acc: TResult, curr: T, key: string, dict: Dictionary<T>) => void;
     type MemoVoidIteratorCapped<T, TResult> = (acc: TResult, curr: T) => void;
 
-    type ValueIteratee<T> = ((value: T) => NotVoid) | string | [string, any] | PartialDeep<T>;
-    type ValueIterateeCustom<T, TResult> = ((value: T) => TResult) | string | [string, any] | PartialDeep<T>;
+    type ValueIteratee<T> = ((value: T) => NotVoid) | IterateeShorthand<T>;
+    type ValueIterateeCustom<T, TResult> = ((value: T) => TResult) | IterateeShorthand<T>;
     type ValueIteratorTypeGuard<T, S extends T> = (value: T) => value is S;
-    type ValueKeyIteratee<T> = ((value: T, key: string) => NotVoid) | string | [string, any] | PartialDeep<T>;
+    type ValueKeyIteratee<T> = ((value: T, key: string) => NotVoid) | IterateeShorthand<T>;
     type Comparator<T> = (a: T, b: T) => boolean;
     type Comparator2<T1, T2> = (a: T1, b: T2) => boolean;
 
@@ -263,6 +264,6 @@ declare module "../index" {
     type DictionaryIteratorTypeGuard<T, S extends T> = ObjectIteratorTypeGuard<Dictionary<T>, S>;
     // NOTE: keys of objects at run time are always strings, even when a NumericDictionary is being iterated.
     type NumericDictionaryIterator<T, TResult> = (value: T, key: string, collection: NumericDictionary<T>) => TResult;
-    type NumericDictionaryIteratee<T> = NumericDictionaryIterator<T, NotVoid> | string | [string, any] | PartialDeep<T>;
-    type NumericDictionaryIterateeCustom<T, TResult> = NumericDictionaryIterator<T, TResult> | string | [string, any] | PartialDeep<T>;
+    type NumericDictionaryIteratee<T> = NumericDictionaryIterator<T, NotVoid> | IterateeShorthand<T>;
+    type NumericDictionaryIterateeCustom<T, TResult> = NumericDictionaryIterator<T, TResult> | IterateeShorthand<T>;
 }

--- a/types/lodash/lodash-tests.ts
+++ b/types/lodash/lodash-tests.ts
@@ -2539,65 +2539,67 @@ _.chain([1, 2, 3, 4]).unshift(5, 6); // $ExpectType LoDashExplicitWrapper<number
 // _.keyBy
 {
     const valueIterator = (value: AbcObject) => "";
+    const subKey: string | number | symbol = anything;
 
     _.keyBy("abcd"); // $ExpectType Dictionary<string>
     _.keyBy("abcd", stringIterator); // $ExpectType Dictionary<string>
     _.keyBy(list); // $ExpectType Dictionary<AbcObject>
     _.keyBy(list, valueIterator); // $ExpectType Dictionary<AbcObject>
-    _.keyBy(list, "a"); // $ExpectType Dictionary<AbcObject>
+    _.keyBy(list, subKey); // $ExpectType Dictionary<AbcObject>
     _.keyBy(list, { a: 42 }); // $ExpectType Dictionary<AbcObject>
     _.keyBy(dictionary); // $ExpectType Dictionary<AbcObject>
     _.keyBy(dictionary, valueIterator); // $ExpectType Dictionary<AbcObject>
-    _.keyBy(dictionary, "a"); // $ExpectType Dictionary<AbcObject>
+    _.keyBy(dictionary, subKey); // $ExpectType Dictionary<AbcObject>
     _.keyBy(dictionary, { a: 42 }); // $ExpectType Dictionary<AbcObject>
     _.keyBy(numericDictionary); // $ExpectType Dictionary<AbcObject>
     _.keyBy(numericDictionary, valueIterator); // $ExpectType Dictionary<AbcObject>
     _.keyBy(numericDictionary, "a"); // $ExpectType Dictionary<AbcObject>
+    _.keyBy(numericDictionary, subKey); // $ExpectType Dictionary<AbcObject>
     _.keyBy(numericDictionary, { a: 42 }); // $ExpectType Dictionary<AbcObject>
 
     _("abcd").keyBy(); // $ExpectType LoDashImplicitWrapper<Dictionary<string>>
     _("abcd").keyBy(stringIterator); // $ExpectType LoDashImplicitWrapper<Dictionary<string>>
     _(list).keyBy(); // $ExpectType LoDashImplicitWrapper<Dictionary<AbcObject>>
     _(list).keyBy(valueIterator); // $ExpectType LoDashImplicitWrapper<Dictionary<AbcObject>>
-    _(list).keyBy("a"); // $ExpectType LoDashImplicitWrapper<Dictionary<AbcObject>>
+    _(list).keyBy(subKey); // $ExpectType LoDashImplicitWrapper<Dictionary<AbcObject>>
     _(list).keyBy({ a: 42 }); // $ExpectType LoDashImplicitWrapper<Dictionary<AbcObject>>
     _(dictionary).keyBy(); // $ExpectType LoDashImplicitWrapper<Dictionary<AbcObject>>
     _(dictionary).keyBy(valueIterator); // $ExpectType LoDashImplicitWrapper<Dictionary<AbcObject>>
-    _(dictionary).keyBy("a"); // $ExpectType LoDashImplicitWrapper<Dictionary<AbcObject>>
+    _(dictionary).keyBy(subKey); // $ExpectType LoDashImplicitWrapper<Dictionary<AbcObject>>
     _(dictionary).keyBy({ a: 42 }); // $ExpectType LoDashImplicitWrapper<Dictionary<AbcObject>>
     _(numericDictionary).keyBy(); // $ExpectType LoDashImplicitWrapper<Dictionary<AbcObject>>
     _(numericDictionary).keyBy(valueIterator); // $ExpectType LoDashImplicitWrapper<Dictionary<AbcObject>>
-    _(numericDictionary).keyBy("a"); // $ExpectType LoDashImplicitWrapper<Dictionary<AbcObject>>
+    _(numericDictionary).keyBy(subKey); // $ExpectType LoDashImplicitWrapper<Dictionary<AbcObject>>
     _(numericDictionary).keyBy({ a: 42 }); // $ExpectType LoDashImplicitWrapper<Dictionary<AbcObject>>
 
     _.chain("abcd").keyBy(); // $ExpectType LoDashExplicitWrapper<Dictionary<string>>
     _.chain("abcd").keyBy(stringIterator); // $ExpectType LoDashExplicitWrapper<Dictionary<string>>
     _.chain(list).keyBy(); // $ExpectType LoDashExplicitWrapper<Dictionary<AbcObject>>
     _.chain(list).keyBy(valueIterator); // $ExpectType LoDashExplicitWrapper<Dictionary<AbcObject>>
-    _.chain(list).keyBy("a"); // $ExpectType LoDashExplicitWrapper<Dictionary<AbcObject>>
+    _.chain(list).keyBy(subKey); // $ExpectType LoDashExplicitWrapper<Dictionary<AbcObject>>
     _.chain(list).keyBy({ a: 42 }); // $ExpectType LoDashExplicitWrapper<Dictionary<AbcObject>>
     _.chain(dictionary).keyBy(); // $ExpectType LoDashExplicitWrapper<Dictionary<AbcObject>>
     _.chain(dictionary).keyBy(valueIterator); // $ExpectType LoDashExplicitWrapper<Dictionary<AbcObject>>
-    _.chain(dictionary).keyBy("a"); // $ExpectType LoDashExplicitWrapper<Dictionary<AbcObject>>
+    _.chain(dictionary).keyBy(subKey); // $ExpectType LoDashExplicitWrapper<Dictionary<AbcObject>>
     _.chain(dictionary).keyBy({ a: 42 }); // $ExpectType LoDashExplicitWrapper<Dictionary<AbcObject>>
     _.chain(numericDictionary).keyBy(); // $ExpectType LoDashExplicitWrapper<Dictionary<AbcObject>>
     _.chain(numericDictionary).keyBy(valueIterator); // $ExpectType LoDashExplicitWrapper<Dictionary<AbcObject>>
-    _.chain(numericDictionary).keyBy("a"); // $ExpectType LoDashExplicitWrapper<Dictionary<AbcObject>>
+    _.chain(numericDictionary).keyBy(subKey); // $ExpectType LoDashExplicitWrapper<Dictionary<AbcObject>>
     _.chain(numericDictionary).keyBy({ a: 42 }); // $ExpectType LoDashExplicitWrapper<Dictionary<AbcObject>>
 
     fp.keyBy(valueIterator, list); // $ExpectType Dictionary<AbcObject>
     fp.keyBy(valueIterator)(list); // $ExpectType Dictionary<AbcObject>
-    fp.keyBy("a", list); // $ExpectType Dictionary<AbcObject>
+    fp.keyBy(subKey, list); // $ExpectType Dictionary<AbcObject>
     fp.keyBy({ a: 42 }, list); // $ExpectType Dictionary<AbcObject>
-    fp.keyBy(["a", 42], list); // $ExpectType Dictionary<AbcObject>
+    fp.keyBy([subKey, 42], list); // $ExpectType Dictionary<AbcObject>
     fp.keyBy(valueIterator, dictionary); // $ExpectType Dictionary<AbcObject>
-    fp.keyBy("a", dictionary); // $ExpectType Dictionary<AbcObject>
+    fp.keyBy(subKey, dictionary); // $ExpectType Dictionary<AbcObject>
     fp.keyBy({ a: 42 }, dictionary); // $ExpectType Dictionary<AbcObject>
-    fp.keyBy(["a", 42], dictionary); // $ExpectType Dictionary<AbcObject>
+    fp.keyBy([subKey, 42], dictionary); // $ExpectType Dictionary<AbcObject>
     fp.keyBy(valueIterator, numericDictionary); // $ExpectType Dictionary<AbcObject>
-    fp.keyBy("a", numericDictionary); // $ExpectType Dictionary<AbcObject>
+    fp.keyBy(subKey, numericDictionary); // $ExpectType Dictionary<AbcObject>
     fp.keyBy({ a: 42 }, numericDictionary); // $ExpectType Dictionary<AbcObject>
-    fp.keyBy(["a", 42], numericDictionary); // $ExpectType Dictionary<AbcObject>
+    fp.keyBy([subKey, 42], numericDictionary); // $ExpectType Dictionary<AbcObject>
 }
 
 // _.invoke
@@ -3026,74 +3028,76 @@ _.chain([1, 2, 3, 4]).unshift(5, 6); // $ExpectType LoDashExplicitWrapper<number
 
 // _.some
 {
+    const subKey: string | number | symbol = anything;
+
     _.some(list); // $ExpectType boolean
     _.some(list, listIterator); // $ExpectType boolean
-    _.some(list, "a"); // $ExpectType boolean
-    _.some(list, ["a", 42]); // $ExpectType boolean
+    _.some(list, subKey); // $ExpectType boolean
+    _.some(list, [subKey, 42]); // $ExpectType boolean
     _.some(list, { a: 42 }); // $ExpectType boolean
 
     _.some(dictionary); // $ExpectType boolean
     _.some(dictionary, dictionaryIterator); // $ExpectType boolean
-    _.some(dictionary, "a"); // $ExpectType boolean
-    _.some(dictionary, ["a", 42]); // $ExpectType boolean
+    _.some(dictionary, subKey); // $ExpectType boolean
+    _.some(dictionary, [subKey, 42]); // $ExpectType boolean
     _.some(dictionary, { a: 42 }); // $ExpectType boolean
 
     _.some(numericDictionary); // $ExpectType boolean
     _.some(numericDictionary, numericDictionaryIterator); // $ExpectType boolean
-    _.some(numericDictionary, "a"); // $ExpectType boolean
-    _.some(numericDictionary, ["a", 42]); // $ExpectType boolean
+    _.some(numericDictionary, subKey); // $ExpectType boolean
+    _.some(numericDictionary, [subKey, 42]); // $ExpectType boolean
     _.some(numericDictionary, { a: 42 }); // $ExpectType boolean
 
     _(list).some(); // $ExpectType boolean
     _(list).some(listIterator); // $ExpectType boolean
-    _(list).some("a"); // $ExpectType boolean
-    _(list).some(["a", 42]); // $ExpectType boolean
+    _(list).some(subKey); // $ExpectType boolean
+    _(list).some([subKey, 42]); // $ExpectType boolean
     _(list).some({ a: 42 }); // $ExpectType boolean
 
     _(dictionary).some(); // $ExpectType boolean
     _(dictionary).some(dictionaryIterator); // $ExpectType boolean
-    _(dictionary).some("a"); // $ExpectType boolean
-    _(dictionary).some(["a", 42]); // $ExpectType boolean
+    _(dictionary).some(subKey); // $ExpectType boolean
+    _(dictionary).some([subKey, 42]); // $ExpectType boolean
     _(dictionary).some({ a: 42 }); // $ExpectType boolean
 
     _(numericDictionary).some(); // $ExpectType boolean
     _(numericDictionary).some(numericDictionaryIterator); // $ExpectType boolean
-    _(numericDictionary).some("a"); // $ExpectType boolean
-    _(numericDictionary).some(["a", 42]); // $ExpectType boolean
+    _(numericDictionary).some(subKey); // $ExpectType boolean
+    _(numericDictionary).some([subKey, 42]); // $ExpectType boolean
     _(numericDictionary).some({ a: 42 }); // $ExpectType boolean
 
     _.chain(list).some(); // $ExpectType LoDashExplicitWrapper<boolean>
     _.chain(list).some(listIterator); // $ExpectType LoDashExplicitWrapper<boolean>
-    _.chain(list).some("a"); // $ExpectType LoDashExplicitWrapper<boolean>
-    _.chain(list).some(["a", 42]); // $ExpectType LoDashExplicitWrapper<boolean>
+    _.chain(list).some(subKey); // $ExpectType LoDashExplicitWrapper<boolean>
+    _.chain(list).some([subKey, 42]); // $ExpectType LoDashExplicitWrapper<boolean>
     _.chain(list).some({ a: 42 }); // $ExpectType LoDashExplicitWrapper<boolean>
 
     _.chain(dictionary).some(); // $ExpectType LoDashExplicitWrapper<boolean>
     _.chain(dictionary).some(dictionaryIterator); // $ExpectType LoDashExplicitWrapper<boolean>
-    _.chain(dictionary).some("a"); // $ExpectType LoDashExplicitWrapper<boolean>
-    _.chain(dictionary).some(["a", 42]); // $ExpectType LoDashExplicitWrapper<boolean>
+    _.chain(dictionary).some(subKey); // $ExpectType LoDashExplicitWrapper<boolean>
+    _.chain(dictionary).some([subKey, 42]); // $ExpectType LoDashExplicitWrapper<boolean>
     _.chain(dictionary).some({ a: 42 }); // $ExpectType LoDashExplicitWrapper<boolean>
 
     _.chain(numericDictionary).some(); // $ExpectType LoDashExplicitWrapper<boolean>
     _.chain(numericDictionary).some(numericDictionaryIterator); // $ExpectType LoDashExplicitWrapper<boolean>
-    _.chain(numericDictionary).some("a"); // $ExpectType LoDashExplicitWrapper<boolean>
-    _.chain(numericDictionary).some(["a", 42]); // $ExpectType LoDashExplicitWrapper<boolean>
+    _.chain(numericDictionary).some(subKey); // $ExpectType LoDashExplicitWrapper<boolean>
+    _.chain(numericDictionary).some([subKey, 42]); // $ExpectType LoDashExplicitWrapper<boolean>
     _.chain(numericDictionary).some({ a: 42 }); // $ExpectType LoDashExplicitWrapper<boolean>
 
     fp.some(valueIterator, list); // $ExpectType boolean
-    fp.some("a")(list); // $ExpectType boolean
+    fp.some(subKey)(list); // $ExpectType boolean
     fp.some({ a: 42 }, list); // $ExpectType boolean
-    fp.some(["a", 42], list); // $ExpectType boolean
+    fp.some([subKey, 42], list); // $ExpectType boolean
 
     fp.some(valueIterator, dictionary); // $ExpectType boolean
-    fp.some("a")(dictionary); // $ExpectType boolean
+    fp.some(subKey)(dictionary); // $ExpectType boolean
     fp.some({ a: 42 })(dictionary); // $ExpectType boolean
-    fp.some(["a", 42])(dictionary); // $ExpectType boolean
+    fp.some([subKey, 42])(dictionary); // $ExpectType boolean
 
     fp.some(valueIterator, numericDictionary); // $ExpectType boolean
-    fp.some("a")(numericDictionary); // $ExpectType boolean
+    fp.some(subKey)(numericDictionary); // $ExpectType boolean
     fp.some({ a: 42 })(numericDictionary); // $ExpectType boolean
-    fp.some(["a", 42])(numericDictionary); // $ExpectType boolean
+    fp.some([subKey, 42])(numericDictionary); // $ExpectType boolean
 }
 
 // _.sortBy


### PR DESCRIPTION
Fixes #27578.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: N/A
- [ ] Increase the version number in the header if appropriate. N/A
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
