### PR TITLE
[agenda] Correct the promise resolution type for jobs method

### DIFF
--- a/types/agenda/agenda-tests.ts
+++ b/types/agenda/agenda-tests.ts
@@ -67,6 +67,9 @@ var mongoConnectionString = "mongodb://127.0.0.1/agenda";
     await job.save();
 
     const jobs = await agenda.jobs({ name: 'printAnalyticsReport' });
+    jobs.forEach((job) => {
+        job.save();
+    });
 
     let numRemoved = await agenda.cancel({ name: 'printAnalyticsReport' });
 

--- a/types/agenda/index.d.ts
+++ b/types/agenda/index.d.ts
@@ -96,7 +96,7 @@ declare class Agenda extends EventEmitter {
      * Find all Jobs matching `query` and pass same back in cb().
      * @param query
      */
-    jobs<T extends Agenda.JobAttributesData = Agenda.JobAttributesData>(query: any): Promise<void>;
+    jobs<T extends Agenda.JobAttributesData = Agenda.JobAttributesData>(query: any): Promise<Agenda.Job<T>[]>;
 
     /**
      * Removes all jobs in the database without defined behaviors. Useful if you change a definition name and want


### PR DESCRIPTION
Fixing the promise resolution type for [Agenda#jobs](https://github.com/agenda/agenda/blob/master/lib/agenda/jobs.js) method.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/agenda/agenda/blob/0840588935edfb79c49b8f47f3d76083d7836f8d/lib/agenda/jobs.js#L14
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
