### PR TITLE
[jquery.fileupload] fix add signature

### DIFF
--- a/types/jquery.fileupload/index.d.ts
+++ b/types/jquery.fileupload/index.d.ts
@@ -106,8 +106,8 @@ interface JQueryFileInputOptions {
      */
     redirectParamName?: string;
 
-	// The HTTP request method must be "POST" or "PUT"
-	type?: string,
+    // The HTTP request method must be "POST" or "PUT"
+    type?: string,
 
     /**
      * Set the following option to the location of a postMessage window,
@@ -199,7 +199,7 @@ interface JQueryFileInputOptions {
      * handlers using jQuery's Deferred callbacks:
      * data.submit().done(func).fail(func).always(func);
      */
-    add?:  (e: JQueryEventObject, data: JQueryFileInputOptions) => void;
+    add?:  (e: JQueryEventObject, data: JQueryFileUploadChangeObject) => void;
 
     // The plugin options are used as settings object for the ajax calls.
     // The following are jQuery ajax settings required for the file uploads:
@@ -209,7 +209,7 @@ interface JQueryFileInputOptions {
 
     cache?: boolean;
     timeout?: number;
-    
+
     active?: Function;
     progress?: (e: JQueryEventObject, data: JQueryFileUploadProgressObject) => void;
     send?: (e: JQueryEventObject, data: JQueryFileUploadProgressObject) => void;
@@ -217,13 +217,13 @@ interface JQueryFileInputOptions {
     // Validation
 
     /**
-    * The maximum allowed file size in bytes.
-    * Type: integer
-    * Default: undefined
-    * Example: 10000000 // 10 MB
-    * Note: This option has only an effect for browsers supporting the File API.
-    * @see https://github.com/blueimp/jQuery-File-Upload/wiki/Options#maxfilesize
-    */
+     * The maximum allowed file size in bytes.
+     * Type: integer
+     * Default: undefined
+     * Example: 10000000 // 10 MB
+     * Note: This option has only an effect for browsers supporting the File API.
+     * @see https://github.com/blueimp/jQuery-File-Upload/wiki/Options#maxfilesize
+     */
     maxFileSize?: number;
 
     // Other callbacks:
@@ -243,7 +243,7 @@ interface JQueryFileInputOptions {
     chunkfail?: (e: JQueryEventObject, data: JQueryFileUploadChunkObject) => void;
     chunkalways?: (e: JQueryEventObject, data: JQueryFileUploadChunkObject) => void;
 
-    // Others 
+    // Others
     url?: string;
     files?: any;
 
@@ -267,7 +267,23 @@ interface JQuerySupport {
     fileInput?: boolean;
 }
 
-interface JQueryFileUploadChangeObject {
+interface JqueryFileUploadEnhancedPromise<T> extends JQueryPromise<T>{
+    success: JQueryPromise<T>['done'],
+    error: JQueryPromise<T>['fail'],
+    complete: JQueryPromise<T>['always'],
+}
+
+interface JqueryFileUploadConvenienceObject {
+    abort: () => JqueryFileUploadEnhancedPromise<any>;
+    process: (resolveFunc?: Function, rejectFunc?: Function) => JqueryFileUploadEnhancedPromise<any>;
+    processing: () => JqueryFileUploadEnhancedPromise<any>;
+    progress: () => JqueryFileUploadEnhancedPromise<any>;
+    response: () => JqueryFileUploadEnhancedPromise<any>;
+    submit<T>():  JqueryFileUploadEnhancedPromise<T>;
+    state: () => JqueryFileUploadEnhancedPromise<any>;
+}
+
+interface JQueryFileUploadChangeObject extends JqueryFileUploadConvenienceObject {
     fileInput?: JQuery;
     fileInputClone?: JQuery;
     files: File[];

--- a/types/jquery.fileupload/index.d.ts
+++ b/types/jquery.fileupload/index.d.ts
@@ -209,7 +209,7 @@ interface JQueryFileInputOptions {
 
     cache?: boolean;
     timeout?: number;
-    
+
     active?: Function;
     progress?: (e: JQueryEventObject, data: JQueryFileUploadProgressObject) => void;
     send?: (e: JQueryEventObject, data: JQueryFileUploadProgressObject) => void;

--- a/types/jquery.fileupload/index.d.ts
+++ b/types/jquery.fileupload/index.d.ts
@@ -209,7 +209,7 @@ interface JQueryFileInputOptions {
 
     cache?: boolean;
     timeout?: number;
-
+    
     active?: Function;
     progress?: (e: JQueryEventObject, data: JQueryFileUploadProgressObject) => void;
     send?: (e: JQueryEventObject, data: JQueryFileUploadProgressObject) => void;

--- a/types/jquery.fileupload/index.d.ts
+++ b/types/jquery.fileupload/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for jQuery File Upload Plugin 5.40.1
+// Type definitions for jQuery File Upload Plugin 9.22.0
 // Project: https://github.com/blueimp/jQuery-File-Upload
 // Definitions by: Rob Alarcon <https://github.com/rob-alarcon/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/jquery.fileupload/index.d.ts
+++ b/types/jquery.fileupload/index.d.ts
@@ -6,7 +6,7 @@
 
 /// <reference types="jquery"/>
 
-// Interface options for the plugin 
+// Interface options for the plugin
 interface JQueryFileInputOptions {
 
     /**
@@ -199,7 +199,7 @@ interface JQueryFileInputOptions {
      * handlers using jQuery's Deferred callbacks:
      * data.submit().done(func).fail(func).always(func);
      */
-    add?:  (e: JQueryEventObject, data: JQueryFileUploadChangeObject) => void;
+    add?:  (e: JQueryEventObject, data: JqueryFileUploadAddObject) => void;
 
     // The plugin options are used as settings object for the ajax calls.
     // The following are jQuery ajax settings required for the file uploads:
@@ -263,14 +263,22 @@ interface JQuery {
     fileupload(action: string, message:string, settings: JQueryFileInputOptions | string): JQueryFileUpload;
 }
 
-interface JQuerySupport {
-    fileInput?: boolean;
-}
-
 interface JqueryFileUploadEnhancedPromise<T> extends JQueryPromise<T>{
     success: JQueryPromise<T>['done'],
     error: JQueryPromise<T>['fail'],
     complete: JQueryPromise<T>['always'],
+}
+
+interface JQuerySupport {
+    fileInput?: boolean;
+}
+
+interface JQueryFileUploadChangeObject {
+    fileInput?: JQuery;
+    fileInputClone?: JQuery;
+    files: File[];
+    form?: JQuery;
+    originalFiles: File[];
 }
 
 interface JqueryFileUploadConvenienceObject {
@@ -283,12 +291,8 @@ interface JqueryFileUploadConvenienceObject {
     state: () => JqueryFileUploadEnhancedPromise<any>;
 }
 
-interface JQueryFileUploadChangeObject extends JqueryFileUploadConvenienceObject {
-    fileInput?: JQuery;
-    fileInputClone?: JQuery;
-    files: File[];
-    form?: JQuery;
-    originalFiles: File[];
+interface JqueryFileUploadAddObject extends JQueryFileUploadChangeObject, JqueryFileUploadConvenienceObject {
+    paramName?: string | string[];
 }
 
 interface JQueryFileUploadProgressAllObject {


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)

(I didn't modify the tests; nobody has been maintaining them, and I wouldn't know where to begin)


- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] Increase the version number in the header if appropriate.

The old definition for `add` expects a `data` parameter of type `JQueryFileInputOptions`, but this is not correct. I suspect that whoever wrote the definition for that line saw `submit` in that interface and matched it with the `submit` method he saw coming through in the debugger, but this is a different `submit` method. The `data` object [prepared for the `add` callback](https://github.com/blueimp/jQuery-File-Upload/blob/a451d60bb8034e2736082e24cf7aa7f9dbed5b8a/js/jquery.fileupload.js#L1040) also has "convenience" methods (eg. [`submit`, `process`, `processing`](https://github.com/blueimp/jQuery-File-Upload/blob/a451d60bb8034e2736082e24cf7aa7f9dbed5b8a/js/jquery.fileupload.js#L651), etc), none of which are enumerated in the current definition file.

Changes:
* create a new `JqueryFileUploadConvenienceObject` interface with members for `abort`, `process`, `processing`, `progress`, `response`, `submit`, and `state`.
* create new `JqueryFileUploadEnhancedPromise`. This is simply a [JQueryPromise](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/574ea0954ec287413f4beb5233e06bca21899b24/types/jquery/v1/index.d.ts#L351) with [some aliases thrown in](https://github.com/blueimp/jQuery-File-Upload/blob/master/js/jquery.fileupload.js#L629).
* create a new `JqueryFileUploadAddObject` interface that extends `JqueryFileUploadConvenienceObject`, and `JqueryFileUploadAddObject`.
* modify the `add` definition to use the new `JqueryFileUploadAddObject`
* some minor whitespace fixes 