### PR TITLE
Add type definitions for the WebAssembly Web API

### DIFF
--- a/types/webassembly-web-api/index.d.ts
+++ b/types/webassembly-web-api/index.d.ts
@@ -1,0 +1,17 @@
+// Type definitions for the WebAssembly Web API v1
+// Project: https://webassembly.org/
+// Definitions by: Johannes Henninger <https://github.com/jhenninger>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.2
+
+/// <reference types="webassembly-js-api" />
+
+/**
+ *  The WebAssembly Web API defines extensions to the JavaScript API made
+ *  available specifically in web browsers. See [WebAssembly Web
+ *  API](https://www.w3.org/TR/wasm-web-api-1/) for more information.
+ */
+declare namespace WebAssembly {
+    function compileStreaming(source: Response | Promise<Response>): Promise<Module>;
+    function instantiateStreaming(source: Response | Promise<Response>, importObject?: any): Promise<ResultObject>;
+}

--- a/types/webassembly-web-api/tsconfig.json
+++ b/types/webassembly-web-api/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "webassembly-web-api-tests.ts"
+    ]
+}

--- a/types/webassembly-web-api/tslint.json
+++ b/types/webassembly-web-api/tslint.json
@@ -1,0 +1,6 @@
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "dt-header": false
+    }
+}

--- a/types/webassembly-web-api/webassembly-web-api-tests.ts
+++ b/types/webassembly-web-api/webassembly-web-api-tests.ts
@@ -1,0 +1,18 @@
+const response: Response = new Response();
+const promise: Promise<Response> = Promise.resolve(response);
+
+// CompileStreaming - taking Response
+// $ExpectType Promise<Module>
+WebAssembly.compileStreaming(response);
+
+// CompileStreaming - taking Promise<Response>
+// $ExpectType Promise<Module>
+WebAssembly.compileStreaming(promise);
+
+// InstantiateStreaming - taking Response
+// $ExpectType Promise<ResultObject>
+WebAssembly.instantiateStreaming(response);
+
+// InstantiateStreaming - taking Promise<Response>
+// $ExpectType Promise<ResultObject>
+WebAssembly.instantiateStreaming(promise);


### PR DESCRIPTION
This PR adds type definitions for the WebAssembly Web API. The Web API extends the WebAssembly JS API (for which type definitions already exist) with functions for streaming compilation and instantiation of WASM modules.

See https://webassembly.github.io/spec/

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.