### PR TITLE
Add types for json-rpc-error

### DIFF
--- a/types/json-rpc-error/index.d.ts
+++ b/types/json-rpc-error/index.d.ts
@@ -1,0 +1,32 @@
+// Type definitions for json-rpc-error 2.0
+// Project: https://github.com/claudijo/json-rpc-error
+// Definitions by: Leonid Logvinov <https://github.com/LogvinovLeon>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.4
+
+declare class JsonRpcError extends Error {
+    constructor(message: string, code: number, data?: string);
+}
+
+declare namespace JsonRpcError {
+    class ParseError extends JsonRpcError {
+        constructor();
+    }
+    class InvalidRequest extends JsonRpcError {
+        constructor();
+    }
+    class InvalidParams extends JsonRpcError {
+        constructor();
+    }
+    class InternalError extends JsonRpcError {
+        constructor(err?: Error | string);
+    }
+    class MethodNotFound extends JsonRpcError {
+        constructor();
+    }
+    class ServerError extends JsonRpcError {
+        constructor(code: number);
+    }
+}
+
+export = JsonRpcError;

--- a/types/json-rpc-error/json-rpc-error-tests.ts
+++ b/types/json-rpc-error/json-rpc-error-tests.ts
@@ -1,0 +1,9 @@
+import * as JsonRpcError from "json-rpc-error";
+
+new JsonRpcError("err", 42);
+new JsonRpcError.InternalError("error");
+new JsonRpcError.ServerError(42);
+new JsonRpcError.MethodNotFound();
+new JsonRpcError.InvalidParams();
+new JsonRpcError.InvalidRequest();
+new JsonRpcError.ParseError();

--- a/types/json-rpc-error/tsconfig.json
+++ b/types/json-rpc-error/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": ["index.d.ts", "json-rpc-error-tests.ts"]
+}

--- a/types/json-rpc-error/tslint.json
+++ b/types/json-rpc-error/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
