### PR TITLE
Strophe for ts >= 2.1

### DIFF
--- a/types/strophe/index.d.ts
+++ b/types/strophe/index.d.ts
@@ -2,6 +2,7 @@
 // Project: http://strophe.im/strophejs/
 // Definitions by: David Deutsch <https://github.com/DavidKDeutsch>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.9
 
 export namespace Strophe {
     /** Constant: VERSION
@@ -1105,10 +1106,6 @@ declare global {
     const $msg: typeof _$msg;
     const $iq: typeof _$iq;
     const $pres: typeof _$pres;
-}
-
-declare module "Strophe" {
-  export = Strophe;
 }
 
 declare module "$build" {

--- a/types/strophe/index.d.ts
+++ b/types/strophe/index.d.ts
@@ -2,7 +2,7 @@
 // Project: http://strophe.im/strophejs/
 // Definitions by: David Deutsch <https://github.com/DavidKDeutsch>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.9
+// TypeScript Version: 2.1
 
 export namespace Strophe {
     /** Constant: VERSION

--- a/types/strophe/strophe-tests.ts
+++ b/types/strophe/strophe-tests.ts
@@ -10,7 +10,7 @@ function rawOutput(data: string): void {
     log('SENT: ' + data);
 }
 
-function onOwnMessage(msg: HTMLElement): boolean {
+function onOwnMessage(msg: Element): boolean {
 
     console.log(msg);
     var elems = msg.getElementsByTagName('own-message');


### PR DESCRIPTION
importing the Strophe types on a contemporary typescript-version, would give the following error:

```
    ERROR in [at-loader] ./node_modules/@types/strophe/index.d.ts:1111:3
        TS2666: Exports and export assignments are not permitted in module augmentations.
```

This is fixed in this PR.

For the reviewer: I added a // TypeScript Version: 2.1 header, to make sure that the tests fail without this change. Let me know if this has undesirable side-effects. 


Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: Reason explained in commit and PR.
- [x] Increase the version number in the header if appropriate. -> No version number in header.


