### PR TITLE
@types/vexflow: Add new definitions from Vexflow PR 634, NoteSubGroup class

### DIFF
--- a/types/vexflow/index.d.ts
+++ b/types/vexflow/index.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: Roman Quiring <https://github.com/rquiring>
 //                 Sebastian Haas <https://github.com/sebastianhaas>
 //                 Basti Hoffmann <https://github.com/bohoffi>
+//                 Simon Schmid <https://github.com/sschmidTU>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 //inconsistent namespace: this is a helper funtion from tables.js and should not pollute the global namespace!
@@ -553,6 +554,7 @@ declare namespace Vex {
             setYShift(y : number) : Modifier;
             setXShift(x : number) : void; //inconsistent type: void -> Modifier
             draw() : void;
+            alignSubNotesWithNote(subNotes : Note[], note : Note) : void;
         }
 
         namespace Modifier {
@@ -689,6 +691,11 @@ declare namespace Vex {
             preFormat() : NoteHead;
             draw() : void;
         }
+
+        class NoteSubGroup extends Modifier {
+			constructor(subnotes : Note[]);
+			preFormat() : void;
+		}
 
         class Ornament extends Modifier {
             constructor(type : string);
@@ -1295,6 +1302,10 @@ declare namespace Vex {
             getWidth() : number;
             getX() : number;
             setX(x : number) : TickContext;
+            getXBase() : number;
+            setXBase(xBase : number) : void;
+            getXOffset() : number;
+            setXOffset(xOffset : number) : void;
             getPixelsUsed() : number;
             setPixelsUsed(pixelsUsed : number) : TickContext;
             setPadding(padding : number) : TickContext;

--- a/types/vexflow/index.d.ts
+++ b/types/vexflow/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for VexFlow v1.2.84
+// Type definitions for VexFlow v1.2.85
 // Project: http://vexflow.com
 // Definitions by: Roman Quiring <https://github.com/rquiring>
 //                 Sebastian Haas <https://github.com/sebastianhaas>

--- a/types/vexflow/index.d.ts
+++ b/types/vexflow/index.d.ts
@@ -695,7 +695,7 @@ declare namespace Vex {
         class NoteSubGroup extends Modifier {
 			constructor(subnotes : Note[]);
 			preFormat() : void;
-		}
+        }
 
         class Ornament extends Modifier {
             constructor(type : string);


### PR DESCRIPTION
adds new definitions from [Vexflow PR 634](https://github.com/0xfe/vexflow/pull/634/) ([now released as new Vexflow version 1.24.85](https://github.com/0xfe/vexflow/commit/1a8a5f70397517c55dacad40942d82e8e3d70919)).
adds previously existing class NoteSubGroup

Please squash commits, only the first is significant and well titled.

Template:
- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Not needed)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

I'm changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/0xfe/vexflow/pull/634/files>
- [X] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. (no substantial changes)
