### PR TITLE
Add location state as an optional parameter for Location types in History and React Router

### DIFF
--- a/types/history/index.d.ts
+++ b/types/history/index.d.ts
@@ -5,7 +5,7 @@
 // TypeScript Version: 2.3
 export as namespace History;
 
-export type Action = "PUSH" | "POP" | "REPLACE";
+export type Action = 'PUSH' | 'POP' | 'REPLACE;
 export type UnregisterCallback = () => void;
 
 export interface History {
@@ -41,30 +41,20 @@ export interface LocationDescriptorObject<S = LocationState> {
 }
 
 export namespace History {
-    export type LocationDescriptor<S = LocationState> =
-        | Path
-        | LocationDescriptorObject<S>;
+    export type LocationDescriptor<S = LocationState> = Path | LocationDescriptorObject<S>;
     export type LocationKey = string;
     export type LocationListener = (location: Location, action: Action) => void;
     export type LocationState = any;
     export type Path = string;
     export type Pathname = string;
     export type Search = string;
-    export type TransitionHook = (
-        location: Location,
-        callback: (result: any) => void
-    ) => any;
-    export type TransitionPromptHook = (
-        location: Location,
-        action: Action
-    ) => string | false | void;
+    export type TransitionHook = (location: Location, callback: (result: any) => void) => any;
+    export type TransitionPromptHook = (location: Location, action: Action) => string | false | void;
     export type Hash = string;
     export type Href = string;
 }
 
-export type LocationDescriptor<S = LocationState> = History.LocationDescriptor<
-    S
->;
+export type LocationDescriptor<S = LocationState> = History.LocationDescriptor<S>;
 export type LocationKey = History.LocationKey;
 export type LocationListener = History.LocationListener;
 export type LocationState = History.LocationState;

--- a/types/history/index.d.ts
+++ b/types/history/index.d.ts
@@ -5,7 +5,7 @@
 // TypeScript Version: 2.3
 export as namespace History;
 
-export type Action = 'PUSH' | 'POP' | 'REPLACE;
+export type Action = 'PUSH' | 'POP' | 'REPLACE';
 export type UnregisterCallback = () => void;
 
 export interface History {

--- a/types/history/index.d.ts
+++ b/types/history/index.d.ts
@@ -1,10 +1,11 @@
-// Type definitions for history 4.6.2
+// Type definitions for history 4.7.2
 // Project: https://github.com/mjackson/history
 // Definitions by: Sergey Buturlakin <https://github.com/sergey-buturlakin>, Nathan Brown <https://github.com/ngbrown>, Young Rok Kim <https://github.com/rokoroku>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
 export as namespace History;
 
-export type Action = 'PUSH' | 'POP' | 'REPLACE';
+export type Action = "PUSH" | "POP" | "REPLACE";
 export type UnregisterCallback = () => void;
 
 export interface History {
@@ -23,37 +24,47 @@ export interface History {
     createHref(location: LocationDescriptorObject): Href;
 }
 
-export interface Location {
+export interface Location<S = LocationState> {
     pathname: Pathname;
     search: Search;
-    state: LocationState;
+    state: S;
     hash: Hash;
     key?: LocationKey;
 }
 
-export interface LocationDescriptorObject {
+export interface LocationDescriptorObject<S = LocationState> {
     pathname?: Pathname;
     search?: Search;
-    state?: LocationState;
+    state?: S;
     hash?: Hash;
     key?: LocationKey;
 }
 
 export namespace History {
-    export type LocationDescriptor = Path | LocationDescriptorObject;
+    export type LocationDescriptor<S = LocationState> =
+        | Path
+        | LocationDescriptorObject<S>;
     export type LocationKey = string;
     export type LocationListener = (location: Location, action: Action) => void;
     export type LocationState = any;
     export type Path = string;
     export type Pathname = string;
     export type Search = string;
-    export type TransitionHook = (location: Location, callback: (result: any) => void) => any;
-    export type TransitionPromptHook = (location: Location, action: Action) => string | false | void;
+    export type TransitionHook = (
+        location: Location,
+        callback: (result: any) => void
+    ) => any;
+    export type TransitionPromptHook = (
+        location: Location,
+        action: Action
+    ) => string | false | void;
     export type Hash = string;
     export type Href = string;
 }
 
-export type LocationDescriptor = History.LocationDescriptor;
+export type LocationDescriptor<S = LocationState> = History.LocationDescriptor<
+    S
+>;
 export type LocationKey = History.LocationKey;
 export type LocationListener = History.LocationListener;
 export type LocationState = History.LocationState;

--- a/types/qhistory/index.d.ts
+++ b/types/qhistory/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/pshrmn/qhistory#readme
 // Definitions by: Diogo Franco <https://github.com/Kovensky>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 export as namespace qhistory;
 

--- a/types/react-router/index.d.ts
+++ b/types/react-router/index.d.ts
@@ -34,7 +34,7 @@ export interface RouterChildContext<P> {
       match: match<P>
     }
   };
-};
+}
 export interface MemoryRouterProps {
   initialEntries?: H.LocationDescriptor[];
   initialIndex?: number;
@@ -86,7 +86,7 @@ export class Route<T extends RouteProps = RouteProps> extends React.Component<T,
 export interface RouterProps {
   history: H.History;
 }
-export class Router extends React.Component<RouterProps, any> {}
+export class Router extends React.Component<RouterProps, any> { }
 
 export interface StaticRouterContext {
   url?: string;
@@ -116,7 +116,7 @@ export interface match<P> {
 // Omit taken from https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-8.html
 export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 
-export function matchPath<P>(pathname: string, props: RouteProps): match<P> | null;
+export function matchPath<P>(pathname: string, props: RouteProps, parent?: match<P> | null): match<P> | null;
 
 export function generatePath(pattern: string, params?: { [paramName: string]: string | number | boolean }): string;
 

--- a/types/react-router/index.d.ts
+++ b/types/react-router/index.d.ts
@@ -21,128 +21,107 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
-import * as React from "react";
-import * as H from "history";
+import * as React from 'react';
+import * as H from 'history';
 
 // This is the type of the context object that will be passed down to all children of
 // a `Router` component:
 export interface RouterChildContext<P> {
-    router: {
-        history: H.History;
-        route: {
-            location: H.Location;
-            match: match<P>;
-        };
-    };
-}
+  router: {
+    history: H.History
+    route: {
+      location: H.Location
+      match: match<P>
+    }
+  };
+};
 export interface MemoryRouterProps {
-    initialEntries?: H.LocationDescriptor[];
-    initialIndex?: number;
-    getUserConfirmation?: ((
-        message: string,
-        callback: (ok: boolean) => void
-    ) => void);
-    keyLength?: number;
+  initialEntries?: H.LocationDescriptor[];
+  initialIndex?: number;
+  getUserConfirmation?: ((message: string, callback: (ok: boolean) => void) => void);
+  keyLength?: number;
 }
 
-export class MemoryRouter extends React.Component<MemoryRouterProps, any> {}
+export class MemoryRouter extends React.Component<MemoryRouterProps, any> { }
 
 export interface PromptProps {
-    message: string | ((location: H.Location) => string | boolean);
-    when?: boolean;
+  message: string | ((location: H.Location) => string | boolean);
+  when?: boolean;
 }
-export class Prompt extends React.Component<PromptProps, any> {}
+export class Prompt extends React.Component<PromptProps, any> { }
 
 export interface RedirectProps {
-    to: H.LocationDescriptor;
-    push?: boolean;
-    from?: string;
-    path?: string;
-    exact?: boolean;
-    strict?: boolean;
+  to: H.LocationDescriptor;
+  push?: boolean;
+  from?: string;
+  path?: string;
+  exact?: boolean;
+  strict?: boolean;
 }
-export class Redirect extends React.Component<RedirectProps, any> {}
+export class Redirect extends React.Component<RedirectProps, any> { }
 
 export interface StaticContext {
-    statusCode?: number;
+  statusCode?: number;
 }
 
-export interface RouteComponentProps<
-    P,
-    C extends StaticContext = StaticContext,
-    S = H.LocationState
-> {
-    history: H.History;
-    location: H.Location<S>;
-    match: match<P>;
-    staticContext?: C;
+export interface RouteComponentProps<P, C extends StaticContext = StaticContext, S = H.LocationState> {
+  history: H.History;
+  location: H.Location<S>;
+  match: match<P>;
+  staticContext?: C;
 }
 
 export interface RouteProps {
-    location?: H.Location;
-    component?:
-        | React.ComponentType<RouteComponentProps<any>>
-        | React.ComponentType<any>;
-    render?: ((props: RouteComponentProps<any>) => React.ReactNode);
-    children?:
-        | ((props: RouteComponentProps<any>) => React.ReactNode)
-        | React.ReactNode;
-    path?: string;
-    exact?: boolean;
-    strict?: boolean;
+  location?: H.Location;
+  component?: React.ComponentType<RouteComponentProps<any>> | React.ComponentType<any>;
+  render?: ((props: RouteComponentProps<any>) => React.ReactNode);
+  children?: ((props: RouteComponentProps<any>) => React.ReactNode) | React.ReactNode;
+  path?: string;
+  exact?: boolean;
+  sensitive?: boolean;
+  strict?: boolean;
 }
-export class Route<T extends RouteProps = RouteProps> extends React.Component<
-    T,
-    any
-> {}
+export class Route<T extends RouteProps = RouteProps> extends React.Component<T, any> { }
 
 export interface RouterProps {
-    history: H.History;
+  history: H.History;
 }
 export class Router extends React.Component<RouterProps, any> {}
 
 export interface StaticRouterContext {
-    url?: string;
-    action?: "PUSH" | "REPLACE";
-    location?: object;
+  url?: string;
+  action?: 'PUSH' | 'REPLACE';
+  location?: object;
 }
 export interface StaticRouterProps {
-    basename?: string;
-    location?: string | object;
-    context?: StaticRouterContext;
+  basename?: string;
+  location?: string | object;
+  context?: StaticRouterContext;
 }
 
-export class StaticRouter extends React.Component<StaticRouterProps, any> {}
+export class StaticRouter extends React.Component<StaticRouterProps, any> { }
 export interface SwitchProps {
-    children?: React.ReactNode;
-    location?: H.Location;
+  children?: React.ReactNode;
+  location?: H.Location;
 }
-export class Switch extends React.Component<SwitchProps, any> {}
+export class Switch extends React.Component<SwitchProps, any> { }
 
 export interface match<P> {
-    params: P;
-    isExact: boolean;
-    path: string;
-    url: string;
+  params: P;
+  isExact: boolean;
+  path: string;
+  url: string;
 }
 
 // Omit taken from https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-8.html
 export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 
-export function matchPath<P>(
-    pathname: string,
-    props: RouteProps
-): match<P> | null;
+export function matchPath<P>(pathname: string, props: RouteProps): match<P> | null;
 
-export function generatePath(
-    pattern: string,
-    params?: { [paramName: string]: string | number | boolean }
-): string;
+export function generatePath(pattern: string, params?: { [paramName: string]: string | number | boolean }): string;
 
 // There is a known issue in TypeScript, which doesn't allow decorators to change the signature of the classes
 // they are decorating. Due to this, if you are using @withRouter decorator in your code,
 // you will see a bunch of errors from TypeScript. The current workaround is to use withRouter() as a function call
 // on a separate line instead of as a decorator.
-export function withRouter<P extends RouteComponentProps<any>>(
-    component: React.ComponentType<P>
-): React.ComponentClass<Omit<P, keyof RouteComponentProps<any>>>;
+export function withRouter<P extends RouteComponentProps<any>>(component: React.ComponentType<P>): React.ComponentClass<Omit<P, keyof RouteComponentProps<any>>>;

--- a/types/react-router/index.d.ts
+++ b/types/react-router/index.d.ts
@@ -21,107 +21,128 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
-import * as React from 'react';
-import * as H from 'history';
+import * as React from "react";
+import * as H from "history";
 
 // This is the type of the context object that will be passed down to all children of
 // a `Router` component:
 export interface RouterChildContext<P> {
-  router: {
-    history: H.History
-    route: {
-      location: H.Location
-      match: match<P>
-    }
-  };
+    router: {
+        history: H.History;
+        route: {
+            location: H.Location;
+            match: match<P>;
+        };
+    };
 }
 export interface MemoryRouterProps {
-  initialEntries?: H.LocationDescriptor[];
-  initialIndex?: number;
-  getUserConfirmation?: ((message: string, callback: (ok: boolean) => void) => void);
-  keyLength?: number;
+    initialEntries?: H.LocationDescriptor[];
+    initialIndex?: number;
+    getUserConfirmation?: ((
+        message: string,
+        callback: (ok: boolean) => void
+    ) => void);
+    keyLength?: number;
 }
 
-export class MemoryRouter extends React.Component<MemoryRouterProps, any> { }
+export class MemoryRouter extends React.Component<MemoryRouterProps, any> {}
 
 export interface PromptProps {
-  message: string | ((location: H.Location) => string | boolean);
-  when?: boolean;
+    message: string | ((location: H.Location) => string | boolean);
+    when?: boolean;
 }
-export class Prompt extends React.Component<PromptProps, any> { }
+export class Prompt extends React.Component<PromptProps, any> {}
 
 export interface RedirectProps {
-  to: H.LocationDescriptor;
-  push?: boolean;
-  from?: string;
-  path?: string;
-  exact?: boolean;
-  strict?: boolean;
+    to: H.LocationDescriptor;
+    push?: boolean;
+    from?: string;
+    path?: string;
+    exact?: boolean;
+    strict?: boolean;
 }
-export class Redirect extends React.Component<RedirectProps, any> { }
+export class Redirect extends React.Component<RedirectProps, any> {}
 
 export interface StaticContext {
-  statusCode?: number;
+    statusCode?: number;
 }
 
-export interface RouteComponentProps<P, C extends StaticContext = StaticContext> {
-  history: H.History;
-  location: H.Location;
-  match: match<P>;
-  staticContext?: C;
+export interface RouteComponentProps<
+    P,
+    C extends StaticContext = StaticContext,
+    S = H.LocationState
+> {
+    history: H.History;
+    location: H.Location<S>;
+    match: match<P>;
+    staticContext?: C;
 }
 
 export interface RouteProps {
-  location?: H.Location;
-  component?: React.ComponentType<RouteComponentProps<any>> | React.ComponentType<any>;
-  render?: ((props: RouteComponentProps<any>) => React.ReactNode);
-  children?: ((props: RouteComponentProps<any>) => React.ReactNode) | React.ReactNode;
-  path?: string;
-  exact?: boolean;
-  sensitive?: boolean;
-  strict?: boolean;
+    location?: H.Location;
+    component?:
+        | React.ComponentType<RouteComponentProps<any>>
+        | React.ComponentType<any>;
+    render?: ((props: RouteComponentProps<any>) => React.ReactNode);
+    children?:
+        | ((props: RouteComponentProps<any>) => React.ReactNode)
+        | React.ReactNode;
+    path?: string;
+    exact?: boolean;
+    strict?: boolean;
 }
-export class Route<T extends RouteProps = RouteProps> extends React.Component<T, any> { }
+export class Route<T extends RouteProps = RouteProps> extends React.Component<
+    T,
+    any
+> {}
 
 export interface RouterProps {
-  history: H.History;
+    history: H.History;
 }
-export class Router extends React.Component<RouterProps, any> { }
+export class Router extends React.Component<RouterProps, any> {}
 
 export interface StaticRouterContext {
-  url?: string;
-  action?: 'PUSH' | 'REPLACE';
-  location?: object;
+    url?: string;
+    action?: "PUSH" | "REPLACE";
+    location?: object;
 }
 export interface StaticRouterProps {
-  basename?: string;
-  location?: string | object;
-  context?: StaticRouterContext;
+    basename?: string;
+    location?: string | object;
+    context?: StaticRouterContext;
 }
 
-export class StaticRouter extends React.Component<StaticRouterProps, any> { }
+export class StaticRouter extends React.Component<StaticRouterProps, any> {}
 export interface SwitchProps {
-  children?: React.ReactNode;
-  location?: H.Location;
+    children?: React.ReactNode;
+    location?: H.Location;
 }
-export class Switch extends React.Component<SwitchProps, any> { }
+export class Switch extends React.Component<SwitchProps, any> {}
 
 export interface match<P> {
-  params: P;
-  isExact: boolean;
-  path: string;
-  url: string;
+    params: P;
+    isExact: boolean;
+    path: string;
+    url: string;
 }
 
 // Omit taken from https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-8.html
 export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 
-export function matchPath<P>(pathname: string, props: RouteProps, parent?: match<P> | null): match<P> | null;
+export function matchPath<P>(
+    pathname: string,
+    props: RouteProps
+): match<P> | null;
 
-export function generatePath(pattern: string, params?: { [paramName: string]: string | number | boolean }): string;
+export function generatePath(
+    pattern: string,
+    params?: { [paramName: string]: string | number | boolean }
+): string;
 
 // There is a known issue in TypeScript, which doesn't allow decorators to change the signature of the classes
 // they are decorating. Due to this, if you are using @withRouter decorator in your code,
 // you will see a bunch of errors from TypeScript. The current workaround is to use withRouter() as a function call
 // on a separate line instead of as a decorator.
-export function withRouter<P extends RouteComponentProps<any>>(component: React.ComponentType<P>): React.ComponentClass<Omit<P, keyof RouteComponentProps<any>>>;
+export function withRouter<P extends RouteComponentProps<any>>(
+    component: React.ComponentType<P>
+): React.ComponentClass<Omit<P, keyof RouteComponentProps<any>>>;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://reacttraining.com/react-router/native/api/Link/to-object `see documentation for state property of location object`
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
