### PR TITLE
Add type definition for figlet

### DIFF
--- a/types/figlet/figlet-tests.ts
+++ b/types/figlet/figlet-tests.ts
@@ -1,0 +1,95 @@
+import figlet = require('figlet');
+
+figlet('abc', (err, str) => {
+  // $ExpectType Error | null
+  err;
+  // $ExpectType string | undefined
+  str;
+});
+figlet('My World', '1Row', (err, str) => {
+  // $ExpectType Error | null
+  err;
+  // $ExpectType string | undefined
+  str;
+});
+// $ExpectError
+figlet('fweGWEPewfe', 'What is the font? I cannot get it');
+// $ExpectError
+figlet('qweoqw');
+// $ExpectError
+figlet('qweoqw', '1Row');
+// $ExpectError
+figlet('qweoqw', '1Row', undefined as any, undefined as any);
+
+figlet.text('tokiyo tomare', (err, str) => {
+  // $ExpectType Error | null
+  err;
+  // $ExpectType string | undefined
+  str;
+});
+figlet.text('Hi', 'Flower Power', (err, str) => {
+  // $ExpectType Error | null
+  err;
+  // $ExpectType string | undefined
+  str;
+});
+figlet.text('Annyeong', {
+  font: 'Fun Face',
+  horizontalLayout: 'full',
+  verticalLayout: 'fitted',
+}, (err, str) => {
+  // $ExpectType Error | null
+  err;
+  // $ExpectType string | undefined
+  str;
+});
+figlet.text('Oreehe', {
+  font: 'Fun Face',
+  // $ExpectError
+  value: 'abc',
+}, undefined as any);
+// $ExpectError
+figlet.text('It cannot make sense');
+
+// $ExpectType string
+figlet.textSync('test text');
+// $ExpectType string
+figlet.textSync('text desu', 'Fuzzy');
+// $ExpectType string
+figlet.textSync('oho', {
+  font: 'Invita',
+});
+// $ExpectError
+figlet.textSync();
+
+figlet.metadata('JS Block Letters', (err, fontOptions, headerComment) => {
+  // $ExpectType Error | null
+  err;
+  // $ExpectType FontOptions | undefined
+  fontOptions;
+  // $ExpectType string | undefined
+  headerComment;
+});
+// $ExpectError
+figlet.metadata('This is random font name which cannot make sense', undefined as any);
+// $ExpectError
+figlet.metadata('Alligator', undefined as any, undefined as any);
+
+// $ExpectType Defaults
+figlet.defaults();
+// $ExpectType Defaults
+figlet.defaults({});
+// $ExpectType Defaults
+figlet.defaults({
+  font: 'Patorjk\'s Cheese'
+});
+
+figlet.fonts((err, fonts) => {
+  // $ExpectType Error | null
+  err;
+  // $ExpectType Fonts[] | undefined
+  fonts;
+});
+
+// $ExpectType Fonts[]
+figlet.fontsSync();

--- a/types/figlet/index.d.ts
+++ b/types/figlet/index.d.ts
@@ -1,0 +1,423 @@
+// Type definitions for figlet 1.2
+// Project: https://github.com/patorjk/figlet.js
+// Definitions by: Junyoung Clare Jang <https://github.com/Ailrun>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+// TypeScript Version: 2.1
+
+declare namespace figlet {
+    type Fonts =
+        | '1Row'
+        | '3-D'
+        | '3D Diagonal'
+        | '3D-ASCII'
+        | '3x5'
+        | '4Max'
+        | '5 Line Oblique'
+        | 'AMC 3 Line'
+        | 'AMC 3 Liv1'
+        | 'AMC AAA01'
+        | 'AMC Neko'
+        | 'AMC Razor'
+        | 'AMC Razor2'
+        | 'AMC Slash'
+        | 'AMC Slider'
+        | 'AMC Thin'
+        | 'AMC Tubes'
+        | 'AMC Untitled'
+        | 'ANSI Shadow'
+        | 'ASCII New Roman'
+        | 'Acrobatic'
+        | 'Alligator'
+        | 'Alligator2'
+        | 'Alpha'
+        | 'Alphabet'
+        | 'Arrows'
+        | 'Avatar'
+        | 'B1FF'
+        | 'B1FF'
+        | 'Banner'
+        | 'Banner3-D'
+        | 'Banner3'
+        | 'Banner4'
+        | 'Barbwire'
+        | 'Basic'
+        | 'Bear'
+        | 'Bell'
+        | 'Benjamin'
+        | 'Big Chief'
+        | 'Big Money-ne'
+        | 'Big Money-nw'
+        | 'Big Money-se'
+        | 'Big Money-sw'
+        | 'Big'
+        | 'Bigfig'
+        | 'Binary'
+        | 'Block'
+        | 'Blocks'
+        | 'Bloody'
+        | 'Bolger'
+        | 'Braced'
+        | 'Bright'
+        | 'Broadway KB'
+        | 'Broadway'
+        | 'Bubble'
+        | 'Bulbhead'
+        | 'Caligraphy'
+        | 'Caligraphy2'
+        | 'Calvin S'
+        | 'Cards'
+        | 'Catwalk'
+        | 'Chiseled'
+        | 'Chunky'
+        | 'Coinstak'
+        | 'Cola'
+        | 'Colossal'
+        | 'Computer'
+        | 'Contessa'
+        | 'Contrast'
+        | 'Cosmike'
+        | 'Crawford'
+        | 'Crawford2'
+        | 'Crazy'
+        | 'Cricket'
+        | 'Cursive'
+        | 'Cyberlarge'
+        | 'Cybermedium'
+        | 'Cybersmall'
+        | 'Cygnet'
+        | 'DANC4'
+        | 'DOS Rebel'
+        | 'DWhistled'
+        | 'Dancing Font'
+        | 'Decimal'
+        | 'Def Leppard'
+        | 'Delta Corps Priest 1'
+        | 'Diamond'
+        | 'Diet Cola'
+        | 'Digital'
+        | 'Doh'
+        | 'Doom'
+        | 'Dot Matrix'
+        | 'Double Shorts'
+        | 'Double'
+        | 'Dr Pepper'
+        | 'Efti Chess'
+        | 'Efti Font'
+        | 'Efti Italic'
+        | 'Efti Piti'
+        | 'Efti Robot'
+        | 'Efti Wall'
+        | 'Efti Water'
+        | 'Electronic'
+        | 'Elite'
+        | 'Epic'
+        | 'Fender'
+        | 'Filter'
+        | 'Fire Font-k'
+        | 'Fire Font-s'
+        | 'Flipped'
+        | 'Flower Power'
+        | 'Four Tops'
+        | 'Fraktur'
+        | 'Fun Face'
+        | 'Fun Faces'
+        | 'Fuzzy'
+        | 'Georgi16'
+        | 'Georgia11'
+        | 'Ghost'
+        | 'Ghoulish'
+        | 'Glenyn'
+        | 'Goofy'
+        | 'Gothic'
+        | 'Graceful'
+        | 'Gradient'
+        | 'Graffiti'
+        | 'Greek'
+        | 'Heart Left'
+        | 'Heart Right'
+        | 'Henry 3D'
+        | 'Hex'
+        | 'Hieroglyphs'
+        | 'Hollywood'
+        | 'Horizontal Left'
+        | 'Horizontal Right'
+        | 'ICL-1900'
+        | 'Impossible'
+        | 'Invita'
+        | 'Isometric1'
+        | 'Isometric2'
+        | 'Isometric3'
+        | 'Isometric4'
+        | 'Italic'
+        | 'Ivrit'
+        | 'JS Block Letters'
+        | 'JS Bracket Letters'
+        | 'JS Capital Curves'
+        | 'JS Cursive'
+        | 'JS Stick Letters'
+        | 'Jacky'
+        | 'Jazmine'
+        | 'Jerusalem'
+        | 'Katakana'
+        | 'Kban'
+        | 'Keyboard'
+        | 'Knob'
+        | 'Konto Slant'
+        | 'Konto'
+        | 'LCD'
+        | 'Larry 3D 2'
+        | 'Larry 3D'
+        | 'Lean'
+        | 'Letters'
+        | 'Lil Devil'
+        | 'Line Blocks'
+        | 'Linux'
+        | 'Lockergnome'
+        | 'Madrid'
+        | 'Marquee'
+        | 'Maxfour'
+        | 'Merlin1'
+        | 'Merlin2'
+        | 'Mike'
+        | 'Mini'
+        | 'Mirror'
+        | 'Mnemonic'
+        | 'Modular'
+        | 'Morse'
+        | 'Morse2'
+        | 'Moscow'
+        | 'Mshebrew210'
+        | 'Muzzle'
+        | 'NScript'
+        | 'NT Greek'
+        | 'NV Script'
+        | 'Nancyj-Fancy'
+        | 'Nancyj-Improved'
+        | 'Nancyj-Underlined'
+        | 'Nancyj'
+        | 'Nipples'
+        | 'O8'
+        | 'OS2'
+        | 'Octal'
+        | 'Ogre'
+        | 'Old Banner'
+        | 'Patorjk\'s Cheese'
+        | 'Patorjk-HeX'
+        | 'Pawp'
+        | 'Peaks Slant'
+        | 'Peaks'
+        | 'Pebbles'
+        | 'Pepper'
+        | 'Poison'
+        | 'Puffy'
+        | 'Puzzle'
+        | 'Pyramid'
+        | 'Rammstein'
+        | 'Rectangles'
+        | 'Red Phoenix'
+        | 'Relief'
+        | 'Relief2'
+        | 'Reverse'
+        | 'Roman'
+        | 'Rot13'
+        | 'Rot13'
+        | 'Rotated'
+        | 'Rounded'
+        | 'Rowan Cap'
+        | 'Rozzo'
+        | 'Runic'
+        | 'Runyc'
+        | 'S Blood'
+        | 'SL Script'
+        | 'Santa Clara'
+        | 'Script'
+        | 'Serifcap'
+        | 'Shadow'
+        | 'Shimrod'
+        | 'Short'
+        | 'Slant Relief'
+        | 'Slant'
+        | 'Slide'
+        | 'Small Caps'
+        | 'Small Isometric1'
+        | 'Small Keyboard'
+        | 'Small Poison'
+        | 'Small Script'
+        | 'Small Shadow'
+        | 'Small Slant'
+        | 'Small Tengwar'
+        | 'Small'
+        | 'Soft'
+        | 'Speed'
+        | 'Spliff'
+        | 'Stacey'
+        | 'Stampate'
+        | 'Stampatello'
+        | 'Standard'
+        | 'Star Strips'
+        | 'Star Wars'
+        | 'Stellar'
+        | 'Stforek'
+        | 'Stick Letters'
+        | 'Stop'
+        | 'Straight'
+        | 'Stronger Than All'
+        | 'Sub-Zero'
+        | 'Swamp Land'
+        | 'Swan'
+        | 'Sweet'
+        | 'THIS'
+        | 'Tanja'
+        | 'Tengwar'
+        | 'Term'
+        | 'Test1'
+        | 'The Edge'
+        | 'Thick'
+        | 'Thin'
+        | 'Thorned'
+        | 'Three Point'
+        | 'Ticks Slant'
+        | 'Ticks'
+        | 'Tiles'
+        | 'Tinker-Toy'
+        | 'Tombstone'
+        | 'Train'
+        | 'Trek'
+        | 'Tsalagi'
+        | 'Tubular'
+        | 'Twisted'
+        | 'Two Point'
+        | 'USA Flag'
+        | 'Univers'
+        | 'Varsity'
+        | 'Wavy'
+        | 'Weird'
+        | 'Wet Letter'
+        | 'Whimsy'
+        | 'Wow'
+        ;
+
+    type KerningMethods =
+        | 'default'
+        | 'full'
+        | 'fitted'
+        | 'controlled smushing'
+        | 'universal smushing'
+        ;
+    type PrintDirection = number;
+
+    interface FittingRules {
+        vLayout: number;
+        vRule5: boolean;
+        vRule4: boolean;
+        vRule3: boolean;
+        vRule2: boolean;
+        vRule1: boolean;
+        hLayout: number;
+        hRule6: boolean;
+        hRule5: boolean;
+        hRule4: boolean;
+        hRule3: boolean;
+        hRule2: boolean;
+        hRule1: boolean;
+    }
+
+    interface Options {
+        font?: Fonts;
+        horizontalLayout?: KerningMethods;
+        verticalLayout?: KerningMethods;
+        printDirection?: PrintDirection;
+        showHardBlanks?: boolean;
+    }
+    interface FontOptions {
+        hardBlank: string;
+        height: number;
+        baseline: number;
+        maxLength: number;
+        oldLayout: number;
+        numCommentLines: number;
+        printDirection: PrintDirection;
+        fullLayout: number | null;
+        codeTagCount: number | null;
+        fittingRules: FittingRules;
+    }
+    interface Defaults {
+        font: Fonts;
+        fontPath: string;
+    }
+
+    interface TextMethod {
+        (
+            txt: string,
+            cb: (error: Error | null, result?: string) => void,
+        ): void;
+        (
+            txt: string,
+            font: Fonts,
+            cb: (error: Error | null, result?: string) => void,
+        ): void;
+        (
+            txt: string,
+            // tslint:disable-next-line: unified-signatures
+            options: Options | undefined,
+            cb: (error: Error | null, result?: string) => void,
+        ): void;
+    }
+
+    interface TextSyncMethod {
+        (
+            txt: string,
+            font?: Fonts,
+        ): string;
+        (
+            txt: string,
+            // tslint:disable-next-line: unified-signatures
+            options: Options,
+        ): string;
+    }
+
+    interface Figlet extends TextMethod {
+        text: TextMethod;
+        textSync: TextSyncMethod;
+        metadata(
+            font: Fonts,
+            cb: (error: Error | null, fontOptions?: FontOptions, headerComment?: string) => void,
+        ): void;
+        defaults(opt?: Partial<Defaults>): Defaults;
+        loadFont(
+            font: Fonts,
+            cb: (error: Error | null, fontOptions?: FontOptions) => void,
+        ): void;
+        /**
+         * @todo
+         * Use 'node' namespace to add following methods only in node environment.
+         */
+        /**
+         * @warn
+         * This method works in node environment only.
+         * In browser environment, this method does not work.
+         */
+        loadFontSync(
+            font: Fonts,
+        ): FontOptions;
+        /**
+         * @warn
+         * This method exists in node environment only.
+         * In browser environment, this method does not exist.
+         */
+        fonts(
+            cb: (error: Error | null, fontList?: Fonts[]) => void,
+        ): void;
+        /**
+         * @warn
+         * This method exists in node environment only.
+         * In browser environment, this method does not exist.
+         */
+        fontsSync(): Fonts[];
+    }
+}
+declare const figlet: figlet.Figlet;
+
+export as namespace figlet;
+export = figlet;

--- a/types/figlet/index.d.ts
+++ b/types/figlet/index.d.ts
@@ -347,77 +347,60 @@ declare namespace figlet {
         fontPath: string;
     }
 
-    interface TextMethod {
-        (
-            txt: string,
-            cb: (error: Error | null, result?: string) => void,
-        ): void;
-        (
-            txt: string,
-            font: Fonts,
-            cb: (error: Error | null, result?: string) => void,
-        ): void;
-        (
-            txt: string,
-            // tslint:disable-next-line: unified-signatures
-            options: Options | undefined,
-            cb: (error: Error | null, result?: string) => void,
-        ): void;
-    }
+    function text(txt: string, cb: (error: Error | null, result?: string) => void): void;
+    function text(txt: string, font: Fonts, cb: (error: Error | null, result?: string) => void): void;
+    /**
+     * @desc
+     * This `unified-signatures` is disabled because `Fonts` type is too long
+     */
+    // tslint:disable-next-line: unified-signatures
+    function text(txt: string, options: Options | undefined, cb: (error: Error | null, result?: string) => void): void;
 
-    interface TextSyncMethod {
-        (
-            txt: string,
-            font?: Fonts,
-        ): string;
-        (
-            txt: string,
-            // tslint:disable-next-line: unified-signatures
-            options: Options,
-        ): string;
-    }
+    function textSync(txt: string, font?: Fonts): string;
+    /**
+     * @desc
+     * This `unified-signatures` is disabled because `Fonts` type is too long
+     */
+    // tslint:disable-next-line: unified-signatures
+    function textSync(txt: string, options: Options): string;
 
-    interface Figlet extends TextMethod {
-        text: TextMethod;
-        textSync: TextSyncMethod;
-        metadata(
-            font: Fonts,
-            cb: (error: Error | null, fontOptions?: FontOptions, headerComment?: string) => void,
-        ): void;
-        defaults(opt?: Partial<Defaults>): Defaults;
-        loadFont(
-            font: Fonts,
-            cb: (error: Error | null, fontOptions?: FontOptions) => void,
-        ): void;
-        /**
-         * @todo
-         * Use 'node' namespace to add following methods only in node environment.
-         */
-        /**
-         * @warn
-         * This method works in node environment only.
-         * In browser environment, this method does not work.
-         */
-        loadFontSync(
-            font: Fonts,
-        ): FontOptions;
-        /**
-         * @warn
-         * This method exists in node environment only.
-         * In browser environment, this method does not exist.
-         */
-        fonts(
-            cb: (error: Error | null, fontList?: Fonts[]) => void,
-        ): void;
-        /**
-         * @warn
-         * This method exists in node environment only.
-         * In browser environment, this method does not exist.
-         */
-        fontsSync(): Fonts[];
-    }
+    function metadata(font: Fonts, cb: (error: Error | null, fontOptions?: FontOptions, headerComment?: string) => void): void;
+
+    function defaults(opt?: Partial<Defaults>): Defaults;
+
+    function loadFont(font: Fonts, cb: (error: Error | null, fontOptions?: FontOptions) => void): void;
+    /**
+     * @todo
+     * Use 'node' namespace to add following methods only in node environment.
+     */
+    /**
+     * @warn
+     * This method works in node environment only.
+     * In browser environment, this method does not work.
+     */
+    function loadFontSync(font: Fonts): FontOptions;
+    /**
+     * @warn
+     * This method exists in node environment only.
+     * In browser environment, this method does not exist.
+     */
+    function fonts(cb: (error: Error | null, fontList?: Fonts[]) => void): void;
+    /**
+     * @warn
+     * This method exists in node environment only.
+     * In browser environment, this method does not exist.
+     */
+    function fontsSync(): Fonts[];
 }
-declare const figlet: figlet.Figlet;
+
+declare function figlet(txt: string, cb: (error: Error | null, result?: string) => void): void;
+declare function figlet(txt: string, font: figlet.Fonts, cb: (error: Error | null, result?: string) => void): void;
+/**
+ * @desc
+ * This `unified-signatures` is disabled because `Fonts` type is too long
+ */
+// tslint:disable-next-line: unified-signatures
+declare function figlet(txt: string, options: figlet.Options | undefined, cb: (error: Error | null, result?: string) => void): void;
 
 export as namespace figlet;
 export = figlet;

--- a/types/figlet/tsconfig.json
+++ b/types/figlet/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "figlet-tests.ts"
+    ]
+}

--- a/types/figlet/tslint.json
+++ b/types/figlet/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "dtslint/dt.json"
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
  It fails because of other packages. (namely, `schwifty`)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
