### PR TITLE
google-cloud__pubsub - Added publish message attributes definition as attributes in publish() method can only have string-like values

### DIFF
--- a/types/google-cloud__pubsub/index.d.ts
+++ b/types/google-cloud__pubsub/index.d.ts
@@ -1,5 +1,5 @@
 // Type definitions for @google-cloud/pubsub 0.18
-// Project: https://github.com/GoogleCloudPlatform/google-cloud-node/tree/master/packages/pubsub
+// Project: https://github.com/googleapis/nodejs-pubsub
 // Definitions by: Paul Huynh <https://github.com/pheromonez>
 //                 LunaPg <https://github.com/LunaPg>
 //                 Marco Siviero <https://github.com/msiviero>
@@ -114,17 +114,17 @@ declare namespace PubSub {
         }
     }
 
-    interface Attributes {
-        [key: string]: string | Buffer | ArrayBuffer;
-    }
-
     interface Publisher {
         publish(data: Buffer, callback: Publisher.PublishCallback): void;
-        publish(data: Buffer, attributes: Attributes, callback: Publisher.PublishCallback): void;
-        publish(data: Buffer, attributes?: Attributes): Promise<string>;
+        publish(data: Buffer, attributes: Publisher.Attributes, callback: Publisher.PublishCallback): void;
+        publish(data: Buffer, attributes?: Publisher.Attributes): Promise<string>;
     }
     namespace Publisher {
         type PublishCallback = (error: Error | null, messageId: string) => void;
+
+        interface Attributes {
+            [key: string]: string | Buffer | ArrayBuffer;
+        }
     }
 
     interface Snapshot {

--- a/types/google-cloud__pubsub/index.d.ts
+++ b/types/google-cloud__pubsub/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/GoogleCloudPlatform/google-cloud-node/tree/master/packages/pubsub
 // Definitions by: Paul Huynh <https://github.com/pheromonez>
 //                 LunaPg <https://github.com/LunaPg>
+//                 Marco Siviero <https://github.com/msiviero>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
@@ -113,10 +114,14 @@ declare namespace PubSub {
         }
     }
 
+    interface Attributes {
+        [key: string]: string | Buffer | ArrayBuffer;
+    }
+
     interface Publisher {
         publish(data: Buffer, callback: Publisher.PublishCallback): void;
-        publish(data: Buffer, attributes: object, callback: Publisher.PublishCallback): void;
-        publish(data: Buffer, attributes?: object): Promise<string>;
+        publish(data: Buffer, attributes: Attributes, callback: Publisher.PublishCallback): void;
+        publish(data: Buffer, attributes?: Attributes): Promise<string>;
     }
     namespace Publisher {
         type PublishCallback = (error: Error | null, messageId: string) => void;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/googleapis/nodejs-pubsub/issues/177
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
