### PR TITLE
[@types/pretty-ms] Update to 3.2. Add opiton `keepDecimalsOnWholeSeconds`

### DIFF
--- a/types/pretty-ms/index.d.ts
+++ b/types/pretty-ms/index.d.ts
@@ -1,6 +1,7 @@
-// Type definitions for pretty-ms 3.0
+// Type definitions for pretty-ms 3.2
 // Project: https://github.com/sindresorhus/pretty-ms#readme
 // Definitions by: BendingBender <https://github.com/BendingBender>
+//                 ocboogie <https://github.com/ocboogie>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 export = prettyMs;
@@ -11,6 +12,7 @@ declare namespace prettyMs {
     interface PrettyMsOptions {
         secDecimalDigits?: number;
         msDecimalDigits?: number;
+        keepDecimalsOnWholeSeconds?: boolean;
         compact?: boolean;
         verbose?: boolean;
     }

--- a/types/pretty-ms/pretty-ms-tests.ts
+++ b/types/pretty-ms/pretty-ms-tests.ts
@@ -4,6 +4,7 @@ let str: string;
 str = prettyMs(133);
 str = prettyMs(1337, {compact: true});
 str = prettyMs(1335669000, {verbose: true});
+str = prettyMs(1335669000, {keepDecimalsOnWholeSeconds: true});
 str = prettyMs(1335669000, {secDecimalDigits: 1});
 str = prettyMs(1335669000, {msDecimalDigits: 2});
 str = prettyMs(new Date(2014, 0, 1, 10, 40).getTime() - new Date(2014, 0, 1, 10, 5).getTime());


### PR DESCRIPTION
Missing option keepDecimalsOnWholeSeconds

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/sindresorhus/pretty-ms#keepdecimalsonwholeseconds>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
