### PR TITLE
[mssql] Update declaration to include method to create Transaction from ConnectionPool

### DIFF
--- a/types/mssql/index.d.ts
+++ b/types/mssql/index.d.ts
@@ -201,6 +201,7 @@ export declare class ConnectionPool extends events.EventEmitter {
     public close(): Promise<void>;
     public close(callback: (err: any) => void): void;
     public request(): Request;
+    public transaction(): Transaction;
 }
 
 export declare class ConnectionError implements Error {
@@ -297,6 +298,7 @@ export declare class Transaction extends events.EventEmitter {
     public commit(callback: (err?: any) => void): void;
     public rollback(): Promise<void>;
     public rollback(callback: (err?: any) => void): void;
+    public request(): Request;
 }
 
 export declare class TransactionError implements Error {


### PR DESCRIPTION
Updated types for ConnectionPool and Transaction to include the transaction and request methods respectively as defined in the library:
https://github.com/tediousjs/node-mssql/blob/master/lib/base.js