### PR TITLE
[@types/aws-lambda] Add Firehose lambda event and transformation helpers

### DIFF
--- a/types/aws-lambda/aws-lambda-tests.ts
+++ b/types/aws-lambda/aws-lambda-tests.ts
@@ -741,7 +741,7 @@ context.fail(error);
 context.fail(str);
 
 /* Handler */
-let handler: AWSLambda.Handler = (event: any, context: AWSLambda.Context, cb: AWSLambda.Callback) => { };
+const handler: AWSLambda.Handler = (event: any, context: AWSLambda.Context, cb: AWSLambda.Callback) => { };
 
 /* In node8.10 runtime, handlers may return a promise for the result value, so existing async
  * handlers that return Promise<void> before calling the callback will now have a `null` result.
@@ -749,7 +749,7 @@ let handler: AWSLambda.Handler = (event: any, context: AWSLambda.Context, cb: AW
  * since the upgrade effort should be pretty low in most cases, and it points them at a nicer solution.
  */
 // $ExpectError
-let legacyAsyncHandler: AWSLambda.APIGatewayProxyHandler = async (
+const legacyAsyncHandler: AWSLambda.APIGatewayProxyHandler = async (
     event: AWSLambda.APIGatewayProxyEvent,
     context: AWSLambda.Context,
     cb: AWSLambda.Callback<AWSLambda.APIGatewayProxyResult>,
@@ -757,7 +757,7 @@ let legacyAsyncHandler: AWSLambda.APIGatewayProxyHandler = async (
     cb(null, { statusCode: 200, body: 'No longer valid' });
 };
 
-let node8AsyncHandler: AWSLambda.APIGatewayProxyHandler = async (
+const node8AsyncHandler: AWSLambda.APIGatewayProxyHandler = async (
     event: AWSLambda.APIGatewayProxyEvent,
     context: AWSLambda.Context,
     cb: AWSLambda.Callback<AWSLambda.APIGatewayProxyResult>,
@@ -765,7 +765,7 @@ let node8AsyncHandler: AWSLambda.APIGatewayProxyHandler = async (
     return { statusCode: 200, body: 'Is now valid!' };
 };
 
-let inferredHandler: AWSLambda.S3Handler = (event, context, cb) => {
+const inferredHandler: AWSLambda.S3Handler = (event, context, cb) => {
     // $ExpectType S3Event
     event;
     str = event.Records[0].eventName;
@@ -782,35 +782,35 @@ let inferredHandler: AWSLambda.S3Handler = (event, context, cb) => {
 };
 
 // Test using default Callback type still works.
-let defaultCallbackHandler: AWSLambda.APIGatewayProxyHandler = (event: AWSLambda.APIGatewayEvent, context: AWSLambda.Context, cb: AWSLambda.Callback) => { };
+const defaultCallbackHandler: AWSLambda.APIGatewayProxyHandler = (event: AWSLambda.APIGatewayEvent, context: AWSLambda.Context, cb: AWSLambda.Callback) => { };
 
 // Specific types
 let s3Handler: AWSLambda.S3Handler = (event: AWSLambda.S3Event, context: AWSLambda.Context, cb: AWSLambda.Callback<void>) => {};
 // Test old name
-let s3CreateHandler: AWSLambda.S3Handler = (event: AWSLambda.S3CreateEvent, context: AWSLambda.Context, cb: AWSLambda.Callback<void>) => {};
+const s3CreateHandler: AWSLambda.S3Handler = (event: AWSLambda.S3CreateEvent, context: AWSLambda.Context, cb: AWSLambda.Callback<void>) => {};
 s3Handler = s3CreateHandler;
 
-let dynamoDBStreamHandler: AWSLambda.DynamoDBStreamHandler = (event: AWSLambda.DynamoDBStreamEvent, context: AWSLambda.Context, cb: AWSLambda.Callback<void>) => {};
+const dynamoDBStreamHandler: AWSLambda.DynamoDBStreamHandler = (event: AWSLambda.DynamoDBStreamEvent, context: AWSLambda.Context, cb: AWSLambda.Callback<void>) => {};
 
-let snsHandler: AWSLambda.SNSHandler = (event: AWSLambda.SNSEvent, context: AWSLambda.Context, cb: AWSLambda.Callback<void>) => {};
+const snsHandler: AWSLambda.SNSHandler = (event: AWSLambda.SNSEvent, context: AWSLambda.Context, cb: AWSLambda.Callback<void>) => {};
 
-let cognitoUserPoolHandler: AWSLambda.CognitoUserPoolTriggerHandler = (event: AWSLambda.CognitoUserPoolEvent, context: AWSLambda.Context, cb: AWSLambda.Callback<void>) => {};
+const cognitoUserPoolHandler: AWSLambda.CognitoUserPoolTriggerHandler = (event: AWSLambda.CognitoUserPoolEvent, context: AWSLambda.Context, cb: AWSLambda.Callback<void>) => {};
 
-let cloudFormationCustomResourceHandler: AWSLambda.CloudFormationCustomResourceHandler =
+const cloudFormationCustomResourceHandler: AWSLambda.CloudFormationCustomResourceHandler =
     (event: AWSLambda.CloudFormationCustomResourceEvent, context: AWSLambda.Context, cb: AWSLambda.Callback<void>) => {};
 
-let cloudWatchLogsHandler: AWSLambda.CloudWatchLogsHandler = (event: AWSLambda.CloudWatchLogsEvent, context: AWSLambda.Context, cb: AWSLambda.Callback<void>) => {};
+const cloudWatchLogsHandler: AWSLambda.CloudWatchLogsHandler = (event: AWSLambda.CloudWatchLogsEvent, context: AWSLambda.Context, cb: AWSLambda.Callback<void>) => {};
 
-let scheduledHandler: AWSLambda.ScheduledHandler = (event: AWSLambda.ScheduledEvent, context: AWSLambda.Context, cb: AWSLambda.Callback<void>) => {};
+const scheduledHandler: AWSLambda.ScheduledHandler = (event: AWSLambda.ScheduledEvent, context: AWSLambda.Context, cb: AWSLambda.Callback<void>) => {};
 
 let apiGtwProxyHandler: AWSLambda.APIGatewayProxyHandler = (event: AWSLambda.APIGatewayProxyEvent, context: AWSLambda.Context, cb: AWSLambda.APIGatewayProxyCallback) => { };
 // Test old names
-let proxyHandler: AWSLambda.ProxyHandler = (event: AWSLambda.APIGatewayEvent, context: AWSLambda.Context, cb: AWSLambda.ProxyCallback) => { };
+const proxyHandler: AWSLambda.ProxyHandler = (event: AWSLambda.APIGatewayEvent, context: AWSLambda.Context, cb: AWSLambda.ProxyCallback) => { };
 apiGtwProxyHandler = proxyHandler;
 
-let codePipelineHandler: AWSLambda.CodePipelineHandler = (event: AWSLambda.CodePipelineEvent, context: AWSLambda.Context, cb: AWSLambda.Callback<void>) => {};
+const codePipelineHandler: AWSLambda.CodePipelineHandler = (event: AWSLambda.CodePipelineEvent, context: AWSLambda.Context, cb: AWSLambda.Callback<void>) => {};
 
-let cloudFrontRequestHandler: AWSLambda.CloudFrontRequestHandler = (event: AWSLambda.CloudFrontRequestEvent, context: AWSLambda.Context, cb: AWSLambda.CloudFrontRequestCallback) => {
+const cloudFrontRequestHandler: AWSLambda.CloudFrontRequestHandler = (event: AWSLambda.CloudFrontRequestEvent, context: AWSLambda.Context, cb: AWSLambda.CloudFrontRequestCallback) => {
     cb();
     cb(null);
     cb(new Error(''));
@@ -820,14 +820,14 @@ let cloudFrontRequestHandler: AWSLambda.CloudFrontRequestHandler = (event: AWSLa
     cb(null, { });
 };
 
-let cloudFrontResponseHandler: AWSLambda.CloudFrontResponseHandler = (event: AWSLambda.CloudFrontResponseEvent, context: AWSLambda.Context, cb: AWSLambda.CloudFrontResponseCallback) => { };
+const cloudFrontResponseHandler: AWSLambda.CloudFrontResponseHandler = (event: AWSLambda.CloudFrontResponseEvent, context: AWSLambda.Context, cb: AWSLambda.CloudFrontResponseCallback) => { };
 
-let customAuthorizerHandler: AWSLambda.CustomAuthorizerHandler = (event: AWSLambda.CustomAuthorizerEvent, context: AWSLambda.Context, cb: AWSLambda.CustomAuthorizerCallback) => { };
+const customAuthorizerHandler: AWSLambda.CustomAuthorizerHandler = (event: AWSLambda.CustomAuthorizerEvent, context: AWSLambda.Context, cb: AWSLambda.CustomAuthorizerCallback) => { };
 
 interface CustomEvent { eventString: string; eventBool: boolean; }
 interface CustomResult { resultString: string; resultBool?: boolean; }
 type CustomCallback = AWSLambda.Callback<CustomResult>;
-let customHandler: AWSLambda.Handler<CustomEvent, CustomResult> = (event, context, cb) => {
+const customHandler: AWSLambda.Handler<CustomEvent, CustomResult> = (event, context, cb) => {
     // $ExpectType CustomEvent
     event;
     str = event.eventString;
@@ -841,9 +841,9 @@ let customHandler: AWSLambda.Handler<CustomEvent, CustomResult> = (event, contex
     cb(null, { resultString: bool });
 };
 
-let kinesisStreamHandler: AWSLambda.KinesisStreamHandler = (event: AWSLambda.KinesisStreamEvent, context: AWSLambda.Context, cb: AWSLambda.Callback<void>) => { };
+const kinesisStreamHandler: AWSLambda.KinesisStreamHandler = (event: AWSLambda.KinesisStreamEvent, context: AWSLambda.Context, cb: AWSLambda.Callback<void>) => { };
 
-let SQSMessageHandler: AWSLambda.SQSHandler = (event: AWSLambda.SQSEvent, context: AWSLambda.Context, cb: AWSLambda.Callback<void>) => { };
+const SQSMessageHandler: AWSLambda.SQSHandler = (event: AWSLambda.SQSEvent, context: AWSLambda.Context, cb: AWSLambda.Callback<void>) => { };
 
 // See https://docs.aws.amazon.com/lambda/latest/dg/eventsources.html#eventsources-sqs
 const SQSEvent: AWSLambda.SQSEvent = {
@@ -867,7 +867,7 @@ const SQSEvent: AWSLambda.SQSEvent = {
     ]
 };
 
-let SQSMessageLegacyAsyncHandler: AWSLambda.SQSHandler = async (
+const SQSMessageLegacyAsyncHandler: AWSLambda.SQSHandler = async (
     event: AWSLambda.SQSEvent,
     context: AWSLambda.Context,
     cb: AWSLambda.Callback<void>,
@@ -886,7 +886,7 @@ let SQSMessageLegacyAsyncHandler: AWSLambda.SQSHandler = async (
     cb(new Error());
 };
 
-let SQSMessageNode8AsyncHandler: AWSLambda.SQSHandler = async (
+const SQSMessageNode8AsyncHandler: AWSLambda.SQSHandler = async (
     event: AWSLambda.SQSEvent,
     context: AWSLambda.Context
 ) => {
@@ -898,4 +898,48 @@ let SQSMessageNode8AsyncHandler: AWSLambda.SQSHandler = async (
     context;
     str = context.functionName;
     return;
+};
+
+const FirehoseNode8AsyncEventHandler: AWSLambda.FirehoseTransformationHandler = async (
+    event: AWSLambda.FirehoseEvent,
+    context: AWSLambda.Context
+) => {
+    // $ExpectType FirehoseEvent
+    event;
+    str = event.records[0].recordId;
+
+    // $ExpectType Context
+    context;
+    str = context.functionName;
+    return {
+        records: [
+            {
+                recordId: str,
+                result: 'Ok' as AWSLambda.FirehoseRecordTransformationStatus,
+                data: 'eyJmb28iOiJiYXIifQ==',
+            }
+        ]
+    };
+};
+const FirehoseEventHandler: AWSLambda.FirehoseTransformationHandler = (
+    event: AWSLambda.FirehoseEvent,
+    context: AWSLambda.Context,
+    callback: AWSLambda.Callback
+) => {
+    // $ExpectType FirehoseEvent
+    event;
+    str = event.records[0].recordId;
+
+    // $ExpectType Context
+    context;
+    str = context.functionName;
+    callback(null, {
+        records: [
+            {
+                recordId: event.records[0].recordId,
+                result: 'Ok' as AWSLambda.FirehoseRecordTransformationStatus,
+                data: 'eyJmb28iOiJiYXIifQ==',
+            }
+        ]
+    });
 };

--- a/types/aws-lambda/aws-lambda-tests.ts
+++ b/types/aws-lambda/aws-lambda-tests.ts
@@ -905,7 +905,7 @@ const firehoseEventHandler: AWSLambda.FirehoseTransformationHandler = (
     context: AWSLambda.Context,
     callback: AWSLambda.FirehoseTransformationCallback
 ) => {
-    // $ExpectType FirehoseEvent
+    // $ExpectType FirehoseTransformationEvent
     event;
     str = event.records[0].recordId;
 

--- a/types/aws-lambda/aws-lambda-tests.ts
+++ b/types/aws-lambda/aws-lambda-tests.ts
@@ -900,31 +900,10 @@ const SQSMessageNode8AsyncHandler: AWSLambda.SQSHandler = async (
     return;
 };
 
-const FirehoseNode8AsyncEventHandler: AWSLambda.FirehoseTransformationHandler = async (
-    event: AWSLambda.FirehoseEvent,
-    context: AWSLambda.Context
-) => {
-    // $ExpectType FirehoseEvent
-    event;
-    str = event.records[0].recordId;
-
-    // $ExpectType Context
-    context;
-    str = context.functionName;
-    return {
-        records: [
-            {
-                recordId: str,
-                result: 'Ok' as AWSLambda.FirehoseRecordTransformationStatus,
-                data: 'eyJmb28iOiJiYXIifQ==',
-            }
-        ]
-    };
-};
-const FirehoseEventHandler: AWSLambda.FirehoseTransformationHandler = (
-    event: AWSLambda.FirehoseEvent,
+const firehoseEventHandler: AWSLambda.FirehoseTransformationHandler = (
+    event: AWSLambda.FirehoseTransformationEvent,
     context: AWSLambda.Context,
-    callback: AWSLambda.Callback
+    callback: AWSLambda.FirehoseTransformationCallback
 ) => {
     // $ExpectType FirehoseEvent
     event;

--- a/types/aws-lambda/index.d.ts
+++ b/types/aws-lambda/index.d.ts
@@ -649,6 +649,7 @@ export interface KinesisStreamEvent {
 // Kinesis Data Firehose Event
 // https://docs.aws.amazon.com/lambda/latest/dg/eventsources.html#eventsources-kinesis-firehose
 // https://docs.aws.amazon.com/firehose/latest/dev/data-transformation.html
+// https://aws.amazon.com/blogs/compute/amazon-kinesis-firehose-data-transformation-with-aws-lambda/
 // Examples in the lambda blueprints
 export interface FirehoseEvent {
     invocationId: string;

--- a/types/aws-lambda/index.d.ts
+++ b/types/aws-lambda/index.d.ts
@@ -651,19 +651,17 @@ export interface KinesisStreamEvent {
 // https://docs.aws.amazon.com/firehose/latest/dev/data-transformation.html
 // https://aws.amazon.com/blogs/compute/amazon-kinesis-firehose-data-transformation-with-aws-lambda/
 // Examples in the lambda blueprints
-export interface FirehoseEvent {
+export interface FirehoseTransformationEvent {
     invocationId: string;
     deliveryStreamArn: string;
     region: string;
-    records: FirehoseRecord[];
+    records: FirehoseTransformationEventRecord[];
 }
 
-export interface FirehoseRecord {
+export interface FirehoseTransformationEventRecord {
     recordId: string;
     approximateArrivalTimestamp: number;
-    /**
-     * Base64 encoded
-     */
+    /** Base64 encoded */
     data: string;
     kinesisRecordMetadata?: FirehoseRecordMetadata;
 }
@@ -677,29 +675,16 @@ export interface FirehoseRecordMetadata {
 }
 
 export type FirehoseRecordTransformationStatus = 'Ok' | 'Dropped' | 'ProcessingFailed';
-export interface FirehoseTransformedRecord {
+
+export interface FirehoseTransformationResultRecord {
     recordId: string;
     result: FirehoseRecordTransformationStatus;
-    /**
-     * Encode in Base64
-     */
+    /** Encode in Base64 */
     data: string;
 }
 
-export interface FirehoseTransformationResponse {
-    records: FirehoseTransformedRecord[];
-}
-
-// S3 Firehose Record Transformation Failed
-// https://docs.aws.amazon.com/firehose/latest/dev/data-transformation.html
-export interface FirehoseFailedRecordTransformationResponse {
-    attemptsMade: number;
-    arrivalTimestamp: string;
-    errorCode: string;
-    errorMessage: string;
-    attemptEndingTimestamp: string;
-    rawData: string;
-    lambdaArn: string;
+export interface FirehoseTransformationResult {
+    records: FirehoseTransformationResultRecord[];
 }
 
 // SQS
@@ -814,7 +799,8 @@ export type CloudFrontResponseCallback = Callback<CloudFrontResponseResult>;
 
 export type KinesisStreamHandler = Handler<KinesisStreamEvent, void>;
 
-export type FirehoseTransformationHandler = Handler<FirehoseEvent, FirehoseTransformationResponse>;
+export type FirehoseTransformationCallback = Callback<FirehoseTransformationResult>;
+export type FirehoseTransformationHandler = Handler<FirehoseTransformationEvent, FirehoseTransformationResult>;
 
 export type CustomAuthorizerHandler = Handler<CustomAuthorizerEvent, CustomAuthorizerResult>;
 export type CustomAuthorizerCallback = Callback<CustomAuthorizerResult>;

--- a/types/aws-lambda/index.d.ts
+++ b/types/aws-lambda/index.d.ts
@@ -20,6 +20,7 @@
 //                 Aneil Mallavarapu <https://github.com/aneilbaboo>
 //                 Jeremy Nagel <https://github.com/jeznag>
 //                 Louis Larry <https://github.com/louislarry>
+//                 Daniel Papukchiev <https://github.com/dpapukchiev>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -212,27 +213,27 @@ export type S3CreateEvent = S3Event; // old name
 export interface CognitoUserPoolTriggerEvent {
     version: number;
     triggerSource:
-        | "PreSignUp_SignUp"
-        | "PostConfirmation_ConfirmSignUp"
-        | "PreAuthentication_Authentication"
-        | "PostAuthentication_Authentication"
-        | "CustomMessage_SignUp"
-        | "CustomMessage_AdminCreateUser"
-        | "CustomMessage_ResendCode"
-        | "CustomMessage_ForgotPassword"
-        | "CustomMessage_UpdateUserAttribute"
-        | "CustomMessage_VerifyUserAttribute"
-        | "CustomMessage_Authentication"
-        | "DefineAuthChallenge_Authentication"
-        | "CreateAuthChallenge_Authentication"
-        | "VerifyAuthChallengeResponse_Authentication"
-        | "PreSignUp_AdminCreateUser"
-        | "PostConfirmation_ConfirmForgotPassword"
-        | "TokenGeneration_HostedAuth"
-        | "TokenGeneration_Authentication"
-        | "TokenGeneration_NewPasswordChallenge"
-        | "TokenGeneration_AuthenticateDevice"
-        | "TokenGeneration_RefreshTokens";
+    | "PreSignUp_SignUp"
+    | "PostConfirmation_ConfirmSignUp"
+    | "PreAuthentication_Authentication"
+    | "PostAuthentication_Authentication"
+    | "CustomMessage_SignUp"
+    | "CustomMessage_AdminCreateUser"
+    | "CustomMessage_ResendCode"
+    | "CustomMessage_ForgotPassword"
+    | "CustomMessage_UpdateUserAttribute"
+    | "CustomMessage_VerifyUserAttribute"
+    | "CustomMessage_Authentication"
+    | "DefineAuthChallenge_Authentication"
+    | "CreateAuthChallenge_Authentication"
+    | "VerifyAuthChallengeResponse_Authentication"
+    | "PreSignUp_AdminCreateUser"
+    | "PostConfirmation_ConfirmForgotPassword"
+    | "TokenGeneration_HostedAuth"
+    | "TokenGeneration_Authentication"
+    | "TokenGeneration_NewPasswordChallenge"
+    | "TokenGeneration_AuthenticateDevice"
+    | "TokenGeneration_RefreshTokens";
     region: string;
     userPoolId: string;
     userName?: string;
@@ -241,8 +242,8 @@ export interface CognitoUserPoolTriggerEvent {
         clientId: string;
     };
     request: {
-        userAttributes: {[key: string]: string};
-        validationData?: {[key: string]: string};
+        userAttributes: { [key: string]: string };
+        validationData?: { [key: string]: string };
         codeParameter?: string;
         usernameParameter?: string;
         newDeviceUsed?: boolean;
@@ -252,8 +253,8 @@ export interface CognitoUserPoolTriggerEvent {
             challengeMetaData?: string;
         }>;
         challengeName?: string;
-        privateChallengeParameters?: {[key: string]: string};
-        challengeAnswer?: {[key: string]: string};
+        privateChallengeParameters?: { [key: string]: string };
+        challengeAnswer?: { [key: string]: string };
     };
     response: {
         autoConfirmUser?: boolean;
@@ -263,8 +264,8 @@ export interface CognitoUserPoolTriggerEvent {
         challengeName?: string;
         issueTokens?: boolean;
         failAuthentication?: boolean;
-        publicChallengeParameters?: {[key: string]: string};
-        privateChallengeParameters?: {[key: string]: string};
+        publicChallengeParameters?: { [key: string]: string };
+        privateChallengeParameters?: { [key: string]: string };
         challengeMetaData?: string;
         answerCorrect?: boolean;
     };
@@ -550,7 +551,7 @@ export interface CodePipelineEvent {
             inputArtifacts: Artifact[];
             outputArtifacts: Artifact[];
             artifactCredentials: Credentials;
-            encryptionKey?: EncryptionKey & {type: 'KMS'};
+            encryptionKey?: EncryptionKey & { type: 'KMS' };
             continuationToken?: string;
         };
     };
@@ -645,6 +646,61 @@ export interface KinesisStreamEvent {
     Records: KinesisStreamRecord[];
 }
 
+// Kinesis Data Firehose Event
+// https://docs.aws.amazon.com/lambda/latest/dg/eventsources.html#eventsources-kinesis-firehose
+// https://docs.aws.amazon.com/firehose/latest/dev/data-transformation.html
+// Examples in the lambda blueprints
+export interface FirehoseEvent {
+    invocationId: string;
+    deliveryStreamArn: string;
+    region: string;
+    records: FirehoseRecord[];
+}
+
+export interface FirehoseRecord {
+    recordId: string;
+    approximateArrivalTimestamp: number;
+    /**
+     * Base64 encoded
+     */
+    data: string;
+    kinesisRecordMetadata?: FirehoseRecordMetadata;
+}
+
+export interface FirehoseRecordMetadata {
+    shardId: string;
+    partitionKey: string;
+    approximateArrivalTimestamp: string;
+    sequenceNumber: string;
+    subsequenceNumber: string;
+}
+
+export type FirehoseRecordTransformationStatus = 'Ok' | 'Dropped' | 'ProcessingFailed';
+export interface FirehoseTransformedRecord {
+    recordId: string;
+    result: FirehoseRecordTransformationStatus;
+    /**
+     * Encode in Base64
+     */
+    data: string;
+}
+
+export interface FirehoseTransformationResponse {
+    records: FirehoseTransformedRecord[];
+}
+
+// S3 Firehose Record Transformation Failed
+// https://docs.aws.amazon.com/firehose/latest/dev/data-transformation.html
+export interface FirehoseFailedRecordTransformationResponse {
+    attemptsMade: number;
+    arrivalTimestamp: string;
+    errorCode: string;
+    errorMessage: string;
+    attemptEndingTimestamp: string;
+    rawData: string;
+    lambdaArn: string;
+}
+
 // SQS
 // https://docs.aws.amazon.com/lambda/latest/dg/invoking-lambda-function.html#supported-event-source-sqs
 export interface SQSRecord {
@@ -657,7 +713,7 @@ export interface SQSRecord {
     eventSource: string;
     eventSourceARN: string;
     awsRegion: string;
-  }
+}
 
 export interface SQSEvent {
     Records: SQSRecord[];
@@ -757,7 +813,7 @@ export type CloudFrontResponseCallback = Callback<CloudFrontResponseResult>;
 
 export type KinesisStreamHandler = Handler<KinesisStreamEvent, void>;
 
-// TODO: Kinesis Firehose
+export type FirehoseTransformationHandler = Handler<FirehoseEvent, FirehoseTransformationResponse>;
 
 export type CustomAuthorizerHandler = Handler<CustomAuthorizerEvent, CustomAuthorizerResult>;
 export type CustomAuthorizerCallback = Callback<CustomAuthorizerResult>;


### PR DESCRIPTION
This adds types for the missing Firehose lambda event. This event is part of a transformation process that occurs in the middle of a stream, where events can be transformed and/or enriched. The firehose event contains the base64 encoded version of the original message. After processing each original record has to be returned along with a status indicating if the record should continue, if it should be dropped intentionally or an error occurred during processing.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
  - [Kinesis Data Firehose Event](https://docs.aws.amazon.com/lambda/latest/dg/eventsources.html#eventsources-kinesis-firehose)
  - [Firehose event transformation guide](https://docs.aws.amazon.com/firehose/latest/dev/data-transformation.html)
  - [Article on how to implement in a lambda function](https://aws.amazon.com/blogs/compute/amazon-kinesis-firehose-data-transformation-with-aws-lambda/)