### PR TITLE
[@types/webvr-api] Make webvr-api work with Typescript 3

### DIFF
--- a/types/webvr-api/index.d.ts
+++ b/types/webvr-api/index.d.ts
@@ -133,8 +133,8 @@ declare var VRDisplay: {
 };
 
 interface VRLayer {
-    leftBounds?: number[] | null;
-    rightBounds?: number[] | null;
+    leftBounds?: number[] | Float32Array | null;
+    rightBounds?: number[] | Float32Array | null;
     source?: HTMLCanvasElement | null;
 }
 


### PR DESCRIPTION
Allow a Float32Array as leftBounds and rightBounds. This lets webvr-api work with typescript 3.0.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (No changes)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.mozilla.org/en-US/docs/Web/API/VRLayerInit/leftBounds
^ This url suggests that it can take an "array of four floats", of which a `Float32Array` is a valid type.
- [x] Increase the version number in the header if appropriate. (didn't increment version number, since it's for the same three.js version)