### PR TITLE
Add new (partial) typings for npm 'di' github 'node-di'

### DIFF
--- a/types/di/di-tests.ts
+++ b/types/di/di-tests.ts
@@ -1,0 +1,21 @@
+import * as di from "di";
+
+const emptyInjector = new di.Injector();
+const moduleSpecifications = [{}];
+const fullInjector = new di.Injector(moduleSpecifications);
+const childInjector = new di.Injector(moduleSpecifications, emptyInjector);
+
+const dep: {} = fullInjector.get('foo');
+
+const factory = (context: {}, deps: Array<{}>) => {
+	return {};
+};
+
+const invoked: {} = fullInjector.invoke(factory, {});
+
+const oldTimeyClass = {prototype: {}};
+
+const instance: {} = fullInjector.instantiate(oldTimeyClass);
+
+const anotherChildInjector: di.Injector =
+		fullInjector.createChild(moduleSpecifications);

--- a/types/di/index.d.ts
+++ b/types/di/index.d.ts
@@ -1,0 +1,15 @@
+// Type definitions for di 0.0
+// Project: https://github.com/vojtajina/node-di
+// Definitions by: John J Barton <https://github.com/johnjbarton>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.8
+
+/// <reference types="node" />
+
+export class Injector {
+    get(dep: string): {};
+    invoke(fn: (context: {}, deps: Array<{}>) => {}, context: {}): {};
+    instantiate({prototype: {}}): {};
+    createChild(modules: Array<{}>): Injector;
+    constructor(modules?: Array<{}>, parent?: Injector);
+}

--- a/types/di/tsconfig.json
+++ b/types/di/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "di-tests.ts"
+    ]
+}

--- a/types/di/tslint.json
+++ b/types/di/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
These typings are adequate for the primary user of di, karma-runner.
The underlying project is deprecated and we will move to a new di system,
but these typings help document where we are today.

Please fill in this template.

- [ x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ x] Test the change in your own code. (Compile and run.)
- [ x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).


- [ x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
