### PR TITLE
[@types/google.picker] Fix signature of Picker.setCallback()

### DIFF
--- a/types/google.picker/index.d.ts
+++ b/types/google.picker/index.d.ts
@@ -83,7 +83,7 @@ declare namespace google {
          */
         export interface Picker {
             isVisible(): boolean;
-            setCallback():Picker;
+            setCallback(method:Function):Picker;
             setRelayUrl(url:string):Picker;
             setVisible(visible:boolean):Picker;
         }


### PR DESCRIPTION
The `setCallback` function on `Picker` should actually accept a callback.

Ref: https://developers.google.com/picker/docs/reference#Picker
See also: `PickerBuilder.setCallback(method:Function)` (L39)