### PR TITLE
feat(webpack): add compilation dependency sets

### DIFF
--- a/types/webpack/index.d.ts
+++ b/types/webpack/index.d.ts
@@ -949,6 +949,9 @@ declare namespace webpack {
             usedModuleIds: any;
             fileTimestamps: Map<string, number>;
             contextTimestamps: Map<string, number>;
+            fileDependencies: SortableSet<string>;
+            contextDependencies: SortableSet<string>;
+            missingDependencies: SortableSet<string>;
             hash?: string;
             getStats(): Stats;
             addModule(module: CompilationModule, cacheGroup: any): any;
@@ -1038,6 +1041,13 @@ declare namespace webpack {
         rmdir(path: string, callback: (err: Error) => void): void;
         unlink(path: string, callback: (err: Error) => void): void;
         writeFile(path: string, data: any, callback: (err: Error) => void): void;
+    }
+
+    interface SortableSet<T> extends Set<T> {
+        sortWith(sortFn: (a: T, b: T) => number): void;
+        sort(): void;
+        getFromCache(fn: (set: SortableSet<T>) => T[]): T[];
+        getFromUnorderedCache(fn: (set: SortableSet<T>) => string|number|T[]): any;
     }
 
     class Compiler extends Tapable implements ICompiler {

--- a/types/webpack/webpack-tests.ts
+++ b/types/webpack/webpack-tests.ts
@@ -172,6 +172,10 @@ configuration = {
                 }
             });
 
+            compiler.hooks.afterCompile.tap("SomePlugin", (compilation: webpack.compilation.Compilation) => {
+                ['path/to/extra/dep', 'another/extra/dep'].forEach(path => compilation.fileDependencies.add(path));
+              });
+
             this.hooks.afterEmit.tapAsync("afterEmit", (stats, callback) => {
                 this.outputFileSystem.writeFile(
                     path.join(__dirname, "...", "stats.json"),


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: (See below)
- [X] Increase the version number in the header if appropriate.
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

---

- Added `Compilation` dependency properties. See https://github.com/webpack/webpack/blob/v4.16.3/lib/Compilation.js#L2150.
- These properties are of a SortableSet type, which is defined at https://github.com/webpack/webpack/blob/v4.16.3/lib/util/SortableSet.js. Interface added to describe that type.
