### PR TITLE
d3-hierarchy: strictNullChecks

### DIFF
--- a/types/d3-hierarchy/d3-hierarchy-tests.ts
+++ b/types/d3-hierarchy/d3-hierarchy-tests.ts
@@ -13,8 +13,10 @@ import * as d3Hierarchy from 'd3-hierarchy';
 // -----------------------------------------------------------------------
 
 let num: number;
+let numOrUndefined: number | undefined;
 let size: [number, number];
-let idString: string;
+let sizeOrNull: [number, number] | null;
+let idString: string | undefined;
 
 // -----------------------------------------------------------------------
 // Hierarchy
@@ -47,16 +49,20 @@ let hierarchyRootDatum: HierarchyDatum = {
     ]
 };
 
-let hierarchyNodeArray: Array<d3Hierarchy.HierarchyNode<HierarchyDatum>>;
+let hierarchyNodeArray: Array<d3Hierarchy.HierarchyNode<HierarchyDatum>> = [];
+let hierarchyNodeArrayOrUndefined: Array<d3Hierarchy.HierarchyNode<HierarchyDatum>> | undefined;
 let hierarchyNode: d3Hierarchy.HierarchyNode<HierarchyDatum>;
 
-let hierarchyPointNodeArray: Array<d3Hierarchy.HierarchyPointNode<HierarchyDatumWithParentId>>;
+let hierarchyPointNodeArray: Array<d3Hierarchy.HierarchyPointNode<HierarchyDatumWithParentId>> = [];
+let hierarchyPointNodeArrayOrUndefined: Array<d3Hierarchy.HierarchyPointNode<HierarchyDatumWithParentId>> | undefined;
 let hierarchyPointNode: d3Hierarchy.HierarchyPointNode<HierarchyDatumWithParentId>;
 
-let hierarchyRectangularNodeArray: Array<d3Hierarchy.HierarchyRectangularNode<HierarchyDatumWithParentId>>;
+let hierarchyRectangularNodeArray: Array<d3Hierarchy.HierarchyRectangularNode<HierarchyDatumWithParentId>> = [];
+let hierarchyRectangularNodeArrayOrUndefined: Array<d3Hierarchy.HierarchyRectangularNode<HierarchyDatumWithParentId>> | undefined;
 let hierarchyRectangularNode: d3Hierarchy.HierarchyRectangularNode<HierarchyDatumWithParentId>;
 
-let hierarchyCircularNodeArray: Array<d3Hierarchy.HierarchyCircularNode<HierarchyDatumWithParentId>>;
+let hierarchyCircularNodeArray: Array<d3Hierarchy.HierarchyCircularNode<HierarchyDatumWithParentId>> = [];
+let hierarchyCircularNodeArrayOrUndefined: Array<d3Hierarchy.HierarchyCircularNode<HierarchyDatumWithParentId>> | undefined;
 let hierarchyCircularNode: d3Hierarchy.HierarchyCircularNode<HierarchyDatumWithParentId>;
 
 // Create Hierarchy Layout Root Node =====================================
@@ -64,6 +70,10 @@ let hierarchyCircularNode: d3Hierarchy.HierarchyCircularNode<HierarchyDatumWithP
 let hierarchyRootNode: d3Hierarchy.HierarchyNode<HierarchyDatum>;
 
 hierarchyRootNode = d3Hierarchy.hierarchy(hierarchyRootDatum);
+
+hierarchyRootNode = d3Hierarchy.hierarchy(hierarchyRootDatum, (d) => {
+    return d.children;
+});
 
 hierarchyRootNode = d3Hierarchy.hierarchy(hierarchyRootDatum, (d) => {
     return d.children || null;
@@ -79,10 +89,11 @@ num = hierarchyRootNode.height;
 
 // children, parent ------------------------------------------------------
 
-hierarchyNodeArray = hierarchyRootNode.children;
+hierarchyNodeArrayOrUndefined = hierarchyRootNode.children;
 
-let parentNode: d3Hierarchy.HierarchyNode<HierarchyDatum>;
+let parentNode: d3Hierarchy.HierarchyNode<HierarchyDatum> | null;
 parentNode = hierarchyNodeArray.length ? hierarchyNodeArray[0].parent : null;
+parentNode = hierarchyNodeArray[0].parent;
 
 // id --------------------------------------------------------------------
 
@@ -119,19 +130,19 @@ hierarchyNode = link.target;
 
 hierarchyRootNode = hierarchyRootNode.sum((d) => d.val);
 
-num = hierarchyRootNode.value;
+numOrUndefined = hierarchyRootNode.value;
 
 // count() and value ----------------------------------------------------------
 
 hierarchyRootNode = hierarchyRootNode.count();
 
-num = hierarchyRootNode.value;
+numOrUndefined = hierarchyRootNode.value;
 
 // sort ---------------------------------------------------------------------
 
 hierarchyRootNode = hierarchyRootNode.sort((a, b) => {
     console.log('Raw values in data of a and b:', a.data.val, ' and ', b.data.val); // a and b are of type HierarchyNode<HierarchyDatum>
-    return b.height - a.height || b.value - a.value;
+    return b.height - a.height || b.value! - a.value!;
 });
 
 // each(), eachAfter(), eachBefore() ----------------------------------------
@@ -161,12 +172,12 @@ copiedHierarchyNode = hierarchyRootNode.copy();
 // -----------------------------------------------------------------------
 
 interface HierarchyDatumWithParentId extends HierarchyDatum {
-    parentId: string;
+    parentId: string | null;
 }
 
 interface TabularHierarchyDatum {
     name: string;
-    parentId: string;
+    parentId: string | null;
     val: number;
 }
 
@@ -178,7 +189,7 @@ tabularData = [
     { name: 'n121', parentId: 'n12', val: 30 }
 ];
 
-let idStringAccessor: (d: TabularHierarchyDatum, i?: number, data?: TabularHierarchyDatum[]) => (string | null | '' | undefined);
+let idStringAccessor: (d: TabularHierarchyDatum, i: number, data: TabularHierarchyDatum[]) => (string | null | '' | undefined);
 
 // Create Stratify Operator  ---------------------------------------------
 
@@ -217,7 +228,8 @@ idStringAccessor = stratificatorizer.parentId();
 
 // Use Stratify Operator  ------------------------------------------------
 
-const stratifiedRootNode: d3Hierarchy.HierarchyNode<HierarchyDatumWithParentId> = stratificatorizer(tabularData);
+const stratifiedRootNode: d3Hierarchy.HierarchyNode<TabularHierarchyDatum> = stratificatorizer(tabularData);
+const pId: string | null = stratifiedRootNode.data.parentId;
 
 // -----------------------------------------------------------------------
 // Cluster
@@ -235,12 +247,12 @@ clusterLayout = d3Hierarchy.cluster<HierarchyDatumWithParentId>();
 
 clusterLayout = clusterLayout.size([200, 200]);
 
-size = clusterLayout.size();
+sizeOrNull = clusterLayout.size();
 
 // nodeSize() ------------------------------------------------------------
 
 clusterLayout = clusterLayout.nodeSize([10, 10]);
-size = clusterLayout.nodeSize();
+sizeOrNull = clusterLayout.nodeSize();
 
 // separation() ----------------------------------------------------------
 
@@ -272,10 +284,11 @@ num = clusterRootNode.height;
 
 // children, parent ------------------------------------------------------
 
-hierarchyPointNodeArray = clusterRootNode.children;
+hierarchyPointNodeArrayOrUndefined = clusterRootNode.children;
 
-let parentPointNode: d3Hierarchy.HierarchyPointNode<HierarchyDatumWithParentId>;
+let parentPointNode: d3Hierarchy.HierarchyPointNode<HierarchyDatumWithParentId> | null;
 parentPointNode = hierarchyPointNodeArray.length ? hierarchyPointNodeArray[0].parent : null;
+parentPointNode = hierarchyPointNodeArray[0].parent;
 
 // id --------------------------------------------------------------------
 
@@ -312,20 +325,20 @@ hierarchyPointNode = pointLink.target;
 
 clusterRootNode = clusterRootNode.sum((d) => d.val);
 
-num = clusterRootNode.value;
+numOrUndefined = clusterRootNode.value;
 
 // count() and value ----------------------------------------------------------
 
 clusterRootNode = clusterRootNode.count();
 
-num = clusterRootNode.value;
+numOrUndefined = clusterRootNode.value;
 
 // sort ---------------------------------------------------------------------
 
 clusterRootNode = clusterRootNode.sort((a, b) => {
     console.log('x-coordinates of a:', a.x, ' and b:', b.x); // a and b are of type HierarchyPointNode<HierarchyDatumWithParentId>
     console.log('Raw values in data of a and b:', a.data.val, ' and ', b.data.val); // a and b are of type HierarchyPointNode<HierarchyDatumWithParentId>
-    return b.height - a.height || b.value - a.value;
+    return b.height - a.height || b.value! - a.value!;
 });
 
 // each(), eachAfter(), eachBefore() ----------------------------------------
@@ -366,12 +379,12 @@ treeLayout = d3Hierarchy.tree<HierarchyDatumWithParentId>();
 
 treeLayout = treeLayout.size([200, 200]);
 
-size = treeLayout.size();
+sizeOrNull = treeLayout.size();
 
 // nodeSize() ------------------------------------------------------------
 
 treeLayout = treeLayout.nodeSize([10, 10]);
-size = treeLayout.nodeSize();
+sizeOrNull = treeLayout.nodeSize();
 
 // separation() ----------------------------------------------------------
 
@@ -547,10 +560,11 @@ num = treemapRootNode.height;
 
 // children, parent ------------------------------------------------------
 
-hierarchyRectangularNodeArray = treemapRootNode.children;
+hierarchyRectangularNodeArrayOrUndefined = treemapRootNode.children;
 
-let parentRectangularNode: d3Hierarchy.HierarchyRectangularNode<HierarchyDatumWithParentId>;
+let parentRectangularNode: d3Hierarchy.HierarchyRectangularNode<HierarchyDatumWithParentId> | null;
 parentRectangularNode = hierarchyRectangularNodeArray.length ? hierarchyRectangularNodeArray[0].parent : null;
+parentRectangularNode = hierarchyRectangularNodeArray[0].parent;
 
 // id --------------------------------------------------------------------
 
@@ -587,19 +601,19 @@ hierarchyRectangularNode = rectangularLink.target;
 
 treemapRootNode = treemapRootNode.sum((d) => d.val);
 
-num = treemapRootNode.value;
+numOrUndefined = treemapRootNode.value;
 
 // count() and value ----------------------------------------------------------
 
 treemapRootNode = treemapRootNode.count();
 
-num = treemapRootNode.value;
+numOrUndefined = treemapRootNode.value;
 // sort ---------------------------------------------------------------------
 
 treemapRootNode = treemapRootNode.sort((a, b) => {
     console.log('x0-coordinates of a:', a.x0, ' and b:', b.x0); // a and b are of type HierarchyRectangularNode<HierarchyDatumWithParentId>
     console.log('Raw values in data of a and b:', a.data.val, ' and ', b.data.val); // a and b are of type HierarchyRectangularNode<HierarchyDatumWithParentId>
-    return b.height - a.height || b.value - a.value;
+    return b.height - a.height || b.value! - a.value!;
 });
 
 // each(), eachAfter(), eachBefore() ----------------------------------------
@@ -664,7 +678,9 @@ partitionRootNode = partitionLayout(stratifiedRootNode);
 // Pack
 // -----------------------------------------------------------------------
 
-let numberCircularNodeAccessor: (node: d3Hierarchy.HierarchyCircularNode<HierarchyDatumWithParentId>) => number;
+type CircularAccessor = (node: d3Hierarchy.HierarchyCircularNode<HierarchyDatumWithParentId>) => number;
+let numberCircularNodeAccessor: CircularAccessor;
+let numberCircularNodeAccessorOrNull: CircularAccessor | null;
 
 // Create pack layout generator =======================================
 
@@ -682,13 +698,15 @@ size = packLayout.size();
 
 // radius() ------------------------------------------------------------
 
+packLayout = packLayout.radius(null);
+
 packLayout = packLayout.radius((node) => {
     console.log('Radius property of node before completing accessor: ', node.r); // node is of type HierarchyCircularNode<HierarchyDatumWithParentId>
     console.log('Parent id of node: ', node.data.parentId); // node is of type HierarchyCircularNode<HierarchyDatumWithParentId>
-    return node.value;
+    return node.value!;
 });
 
-numberCircularNodeAccessor = packLayout.radius();
+numberCircularNodeAccessorOrNull = packLayout.radius();
 
 // padding() ----------------------------------------------------------------
 
@@ -697,7 +715,7 @@ packLayout = packLayout.padding(1);
 packLayout = packLayout.padding((node) => {
     console.log('Radius property of node: ', node.r); // node is of type HierarchyCircularNode<HierarchyDatumWithParentId>
     console.log('Parent id of node: ', node.data.parentId); // node is of type HierarchyCircularNode<HierarchyDatumWithParentId>
-    return node.value > 10 ? 2 : 1;
+    return node.value! > 10 ? 2 : 1;
 });
 
 numberCircularNodeAccessor = packLayout.padding();
@@ -724,10 +742,11 @@ num = packRootNode.height;
 
 // children, parent ------------------------------------------------------
 
-hierarchyCircularNodeArray = packRootNode.children;
+hierarchyCircularNodeArrayOrUndefined = packRootNode.children;
 
-let parentCircularNode: d3Hierarchy.HierarchyCircularNode<HierarchyDatumWithParentId>;
+let parentCircularNode: d3Hierarchy.HierarchyCircularNode<HierarchyDatumWithParentId> | null;
 parentCircularNode = hierarchyCircularNodeArray.length ? hierarchyCircularNodeArray[0].parent : null;
+parentCircularNode = hierarchyCircularNodeArray[0].parent;
 
 // id --------------------------------------------------------------------
 
@@ -764,19 +783,20 @@ hierarchyCircularNode = circularLink.target;
 
 packRootNode = packRootNode.sum((d) => d.val);
 
-num = packRootNode.value;
+numOrUndefined = packRootNode.value;
 
 // count() and value ----------------------------------------------------------
 
 packRootNode = packRootNode.count();
 
-num = packRootNode.value;
+numOrUndefined = packRootNode.value;
+
 // sort ---------------------------------------------------------------------
 
 packRootNode = packRootNode.sort((a, b) => {
     console.log('radius of a:', a.r, ' and b:', b.r); // a and b are of type HierarchyCircularNode<HierarchyDatumWithParentId>
     console.log('Raw values in data of a and b:', a.data.val, ' and ', b.data.val); // a and b are of type HierarchyCircularNode<HierarchyDatumWithParentId>
-    return b.height - a.height || b.value - a.value;
+    return b.height - a.height || b.value! - a.value!;
 });
 
 // each(), eachAfter(), eachBefore() ----------------------------------------

--- a/types/d3-hierarchy/d3-hierarchy-tests.ts
+++ b/types/d3-hierarchy/d3-hierarchy-tests.ts
@@ -104,17 +104,17 @@ idString = hierarchyRootNode.id;
 const ancestors: Array<d3Hierarchy.HierarchyNode<HierarchyDatum>> = hierarchyRootNode.ancestors();
 const descendants: Array<d3Hierarchy.HierarchyNode<HierarchyDatum>> = hierarchyRootNode.descendants();
 
-// leaves() ---------------------------------------------------------------
+// leaves() --------------------------------------------------------------
 
 hierarchyNodeArray = hierarchyRootNode.leaves();
 
-// path() -------------------------------------------------------------------
+// path() ----------------------------------------------------------------
 
 hierarchyNode = descendants[descendants.length - 1];
 
 const path: Array<d3Hierarchy.HierarchyNode<HierarchyDatum>> = hierarchyRootNode.path(hierarchyNode);
 
-// links() and HierarchyLink<...> ------------------------------------------
+// links() and HierarchyLink<...> ----------------------------------------
 
 let links: Array<d3Hierarchy.HierarchyLink<HierarchyDatum>>;
 
@@ -126,26 +126,26 @@ link = links[0];
 hierarchyNode = link.source;
 hierarchyNode = link.target;
 
-// sum() and value ----------------------------------------------------------
+// sum() and value -------------------------------------------------------
 
 hierarchyRootNode = hierarchyRootNode.sum((d) => d.val);
 
 numOrUndefined = hierarchyRootNode.value;
 
-// count() and value ----------------------------------------------------------
+// count() and value -----------------------------------------------------
 
 hierarchyRootNode = hierarchyRootNode.count();
 
 numOrUndefined = hierarchyRootNode.value;
 
-// sort ---------------------------------------------------------------------
+// sort ------------------------------------------------------------------
 
 hierarchyRootNode = hierarchyRootNode.sort((a, b) => {
     console.log('Raw values in data of a and b:', a.data.val, ' and ', b.data.val); // a and b are of type HierarchyNode<HierarchyDatum>
     return b.height - a.height || b.value! - a.value!;
 });
 
-// each(), eachAfter(), eachBefore() ----------------------------------------
+// each(), eachAfter(), eachBefore() -------------------------------------
 
 hierarchyRootNode = hierarchyRootNode.each((node) => {
     console.log('Raw value of node:', node.data.val); // node type is HierarchyNode<HierarchyDatum>
@@ -162,7 +162,7 @@ hierarchyRootNode = hierarchyRootNode.eachBefore((node) => {
     console.log('Aggregated value of node:', node.value); // node type is HierarchyNode<HierarchyDatum>
 });
 
-// copy() --------------------------------------------------------------------
+// copy() ----------------------------------------------------------------
 
 let copiedHierarchyNode: d3Hierarchy.HierarchyNode<HierarchyDatum>;
 copiedHierarchyNode = hierarchyRootNode.copy();
@@ -299,17 +299,17 @@ idString = clusterRootNode.id;
 const pointNodeAncestors: Array<d3Hierarchy.HierarchyPointNode<HierarchyDatumWithParentId>> = clusterRootNode.ancestors();
 const pointNodeDescendants: Array<d3Hierarchy.HierarchyPointNode<HierarchyDatumWithParentId>> = clusterRootNode.descendants();
 
-// leaves() ---------------------------------------------------------------
+// leaves() --------------------------------------------------------------
 
 hierarchyPointNodeArray = clusterRootNode.leaves();
 
-// path() -------------------------------------------------------------------
+// path() ----------------------------------------------------------------
 
 hierarchyPointNode = pointNodeDescendants[pointNodeDescendants.length - 1];
 
 const clusterPath: Array<d3Hierarchy.HierarchyPointNode<HierarchyDatumWithParentId>> = clusterRootNode.path(hierarchyPointNode);
 
-// links() and HierarchyPointLink<...> ------------------------------------------
+// links() and HierarchyPointLink<...> -----------------------------------
 
 let pointLinks: Array<d3Hierarchy.HierarchyPointLink<HierarchyDatumWithParentId>>;
 
@@ -321,19 +321,19 @@ pointLink = pointLinks[0];
 hierarchyPointNode = pointLink.source;
 hierarchyPointNode = pointLink.target;
 
-// sum() and value ----------------------------------------------------------
+// sum() and value -------------------------------------------------------
 
 clusterRootNode = clusterRootNode.sum((d) => d.val);
 
 numOrUndefined = clusterRootNode.value;
 
-// count() and value ----------------------------------------------------------
+// count() and value -----------------------------------------------------
 
 clusterRootNode = clusterRootNode.count();
 
 numOrUndefined = clusterRootNode.value;
 
-// sort ---------------------------------------------------------------------
+// sort ------------------------------------------------------------------
 
 clusterRootNode = clusterRootNode.sort((a, b) => {
     console.log('x-coordinates of a:', a.x, ' and b:', b.x); // a and b are of type HierarchyPointNode<HierarchyDatumWithParentId>
@@ -341,7 +341,7 @@ clusterRootNode = clusterRootNode.sort((a, b) => {
     return b.height - a.height || b.value! - a.value!;
 });
 
-// each(), eachAfter(), eachBefore() ----------------------------------------
+// each(), eachAfter(), eachBefore() -------------------------------------
 
 clusterRootNode = clusterRootNode.each((node) => {
     console.log('ParentId:', node.data.parentId); // node type is HierarchyPointNode<HierarchyDatumWithParentId>
@@ -358,7 +358,7 @@ clusterRootNode = clusterRootNode.eachBefore((node) => {
     console.log('X-coordinate of node:', node.x); // node type is HierarchyPointNode<HierarchyDatumWithParentId>
 });
 
-// copy() --------------------------------------------------------------------
+// copy() ----------------------------------------------------------------
 
 let copiedClusterNode: d3Hierarchy.HierarchyPointNode<HierarchyDatumWithParentId>;
 copiedClusterNode = clusterRootNode.copy();
@@ -367,13 +367,13 @@ copiedClusterNode = clusterRootNode.copy();
 // Tree
 // -----------------------------------------------------------------------
 
-// Create tree layout generator =======================================
+// Create tree layout generator ==========================================
 
 let treeLayout: d3Hierarchy.TreeLayout<HierarchyDatumWithParentId>;
 
 treeLayout = d3Hierarchy.tree<HierarchyDatumWithParentId>();
 
-// Configure tree layout generator ====================================
+// Configure tree layout generator =======================================
 
 // size() ----------------------------------------------------------------
 
@@ -437,13 +437,13 @@ treemapLayout = treemapLayout.size([400, 200]);
 
 size = treemapLayout.size();
 
-// round() ------------------------------------------------------------
+// round() ---------------------------------------------------------------
 
 treemapLayout = treemapLayout.round(true);
 
 let roundFlag: boolean = treemapLayout.round();
 
-// padding() ----------------------------------------------------------------
+// padding() -------------------------------------------------------------
 
 treemapLayout = treemapLayout.padding(1);
 treemapLayout = treemapLayout.padding((node) => {
@@ -453,7 +453,7 @@ treemapLayout = treemapLayout.padding((node) => {
 
 numberRectangularNodeAccessor = treemapLayout.padding();
 
-// paddingInner() ----------------------------------------------------------------
+// paddingInner() --------------------------------------------------------
 
 treemapLayout = treemapLayout.paddingInner(1);
 treemapLayout = treemapLayout.paddingInner((node) => {
@@ -463,7 +463,7 @@ treemapLayout = treemapLayout.paddingInner((node) => {
 
 numberRectangularNodeAccessor = treemapLayout.paddingInner();
 
-// paddingOuter() ----------------------------------------------------------------
+// paddingOuter() --------------------------------------------------------
 
 treemapLayout = treemapLayout.paddingOuter(1);
 treemapLayout = treemapLayout.paddingOuter((node) => {
@@ -473,7 +473,7 @@ treemapLayout = treemapLayout.paddingOuter((node) => {
 
 numberRectangularNodeAccessor = treemapLayout.paddingOuter();
 
-// paddingTop() ----------------------------------------------------------------
+// paddingTop() ----------------------------------------------------------
 
 treemapLayout = treemapLayout.paddingTop(1);
 treemapLayout = treemapLayout.paddingTop((node) => {
@@ -483,7 +483,7 @@ treemapLayout = treemapLayout.paddingTop((node) => {
 
 numberRectangularNodeAccessor = treemapLayout.paddingTop();
 
-// paddingRight() ----------------------------------------------------------------
+// paddingRight() --------------------------------------------------------
 
 treemapLayout = treemapLayout.paddingRight(1);
 treemapLayout = treemapLayout.paddingRight((node) => {
@@ -493,7 +493,7 @@ treemapLayout = treemapLayout.paddingRight((node) => {
 
 numberRectangularNodeAccessor = treemapLayout.paddingRight();
 
-// paddingBottom() ----------------------------------------------------------------
+// paddingBottom() -------------------------------------------------------
 
 treemapLayout = treemapLayout.paddingBottom(1);
 treemapLayout = treemapLayout.paddingBottom((node) => {
@@ -503,7 +503,7 @@ treemapLayout = treemapLayout.paddingBottom((node) => {
 
 numberRectangularNodeAccessor = treemapLayout.paddingBottom();
 
-// paddingLeft() ----------------------------------------------------------------
+// paddingLeft() ---------------------------------------------------------
 
 treemapLayout = treemapLayout.paddingLeft(1);
 treemapLayout = treemapLayout.paddingLeft((node) => {
@@ -543,7 +543,7 @@ tilingFactoryFn = d3Hierarchy.treemapResquarify.ratio(2);
 
 treemapLayout.tile(d3Hierarchy.treemapResquarify.ratio(2));
 
-// Use HierarchyRectangularNode ================================================
+// Use HierarchyRectangularNode ==========================================
 
 // x and y coordinates ---------------------------------------------------
 
@@ -575,17 +575,17 @@ idString = treemapRootNode.id;
 const rectangularNodeAncestors: Array<d3Hierarchy.HierarchyRectangularNode<HierarchyDatumWithParentId>> = treemapRootNode.ancestors();
 const rectangularNodeDescendants: Array<d3Hierarchy.HierarchyRectangularNode<HierarchyDatumWithParentId>> = treemapRootNode.descendants();
 
-// leaves() ---------------------------------------------------------------
+// leaves() --------------------------------------------------------------
 
 hierarchyRectangularNodeArray = treemapRootNode.leaves();
 
-// path() -------------------------------------------------------------------
+// path() ----------------------------------------------------------------
 
 hierarchyRectangularNode = rectangularNodeDescendants[rectangularNodeDescendants.length - 1];
 
 const treemapPath: Array<d3Hierarchy.HierarchyRectangularNode<HierarchyDatumWithParentId>> = treemapRootNode.path(hierarchyRectangularNode);
 
-// links() and HierarchyRectangularLink<...> ------------------------------------------
+// links() and HierarchyRectangularLink<...> -----------------------------
 
 let rectangularLinks: Array<d3Hierarchy.HierarchyRectangularLink<HierarchyDatumWithParentId>>;
 
@@ -597,18 +597,18 @@ rectangularLink = rectangularLinks[0];
 hierarchyRectangularNode = rectangularLink.source;
 hierarchyRectangularNode = rectangularLink.target;
 
-// sum() and value ----------------------------------------------------------
+// sum() and value -------------------------------------------------------
 
 treemapRootNode = treemapRootNode.sum((d) => d.val);
 
 numOrUndefined = treemapRootNode.value;
 
-// count() and value ----------------------------------------------------------
+// count() and value -----------------------------------------------------
 
 treemapRootNode = treemapRootNode.count();
 
 numOrUndefined = treemapRootNode.value;
-// sort ---------------------------------------------------------------------
+// sort ------------------------------------------------------------------
 
 treemapRootNode = treemapRootNode.sort((a, b) => {
     console.log('x0-coordinates of a:', a.x0, ' and b:', b.x0); // a and b are of type HierarchyRectangularNode<HierarchyDatumWithParentId>
@@ -616,7 +616,7 @@ treemapRootNode = treemapRootNode.sort((a, b) => {
     return b.height - a.height || b.value! - a.value!;
 });
 
-// each(), eachAfter(), eachBefore() ----------------------------------------
+// each(), eachAfter(), eachBefore() -------------------------------------
 
 treemapRootNode = treemapRootNode.each((node) => {
     console.log('ParentId:', node.data.parentId); // node type is HierarchyRectangularNode<HierarchyDatumWithParentId>
@@ -633,7 +633,7 @@ treemapRootNode = treemapRootNode.eachBefore((node) => {
     console.log('X0-coordinate of node:', node.x0); // node type is HierarchyRectangularNode<HierarchyDatumWithParentId>
 });
 
-// copy() --------------------------------------------------------------------
+// copy() ----------------------------------------------------------------
 
 let copiedTreemapNode: d3Hierarchy.HierarchyRectangularNode<HierarchyDatumWithParentId>;
 copiedTreemapNode = treemapRootNode.copy();
@@ -642,13 +642,13 @@ copiedTreemapNode = treemapRootNode.copy();
 // Partition
 // -----------------------------------------------------------------------
 
-// Create partition layout generator =======================================
+// Create partition layout generator =====================================
 
 let partitionLayout: d3Hierarchy.PartitionLayout<HierarchyDatumWithParentId>;
 
 partitionLayout = d3Hierarchy.partition<HierarchyDatumWithParentId>();
 
-// Configure partition layout generator ====================================
+// Configure partition layout generator ==================================
 
 // size() ----------------------------------------------------------------
 
@@ -656,19 +656,19 @@ partitionLayout = partitionLayout.size([400, 200]);
 
 size = partitionLayout.size();
 
-// round() ------------------------------------------------------------
+// round() ---------------------------------------------------------------
 
 partitionLayout = partitionLayout.round(true);
 
 roundFlag = partitionLayout.round();
 
-// padding() ----------------------------------------------------------------
+// padding() -------------------------------------------------------------
 
 partitionLayout = partitionLayout.padding(1);
 
 num = partitionLayout.padding();
 
-// Use partition layout generator ==========================================
+// Use partition layout generator ========================================
 
 let partitionRootNode: d3Hierarchy.HierarchyRectangularNode<HierarchyDatumWithParentId>;
 
@@ -682,13 +682,13 @@ type CircularAccessor = (node: d3Hierarchy.HierarchyCircularNode<HierarchyDatumW
 let numberCircularNodeAccessor: CircularAccessor;
 let numberCircularNodeAccessorOrNull: CircularAccessor | null;
 
-// Create pack layout generator =======================================
+// Create pack layout generator ==========================================
 
 let packLayout: d3Hierarchy.PackLayout<HierarchyDatumWithParentId>;
 
 packLayout = d3Hierarchy.pack<HierarchyDatumWithParentId>();
 
-// Configure pack layout generator ====================================
+// Configure pack layout generator =======================================
 
 // size() ----------------------------------------------------------------
 
@@ -696,7 +696,7 @@ packLayout = packLayout.size([400, 400]);
 
 size = packLayout.size();
 
-// radius() ------------------------------------------------------------
+// radius() --------------------------------------------------------------
 
 packLayout = packLayout.radius(null);
 
@@ -708,7 +708,7 @@ packLayout = packLayout.radius((node) => {
 
 numberCircularNodeAccessorOrNull = packLayout.radius();
 
-// padding() ----------------------------------------------------------------
+// padding() -------------------------------------------------------------
 
 packLayout = packLayout.padding(1);
 
@@ -720,15 +720,15 @@ packLayout = packLayout.padding((node) => {
 
 numberCircularNodeAccessor = packLayout.padding();
 
-// Use partition layout generator ==========================================
+// Use partition layout generator ========================================
 
 let packRootNode: d3Hierarchy.HierarchyCircularNode<HierarchyDatumWithParentId>;
 
 packRootNode = packLayout(stratifiedRootNode);
 
-// Use HierarchyCircularNode ================================================
+// Use HierarchyCircularNode =============================================
 
-// x and y coordinates and radius r ------------------------------------------
+// x and y coordinates and radius r --------------------------------------
 
 num = packRootNode.x;
 num = packRootNode.y;
@@ -757,17 +757,17 @@ idString = packRootNode.id;
 const circularNodeAncestors: Array<d3Hierarchy.HierarchyCircularNode<HierarchyDatumWithParentId>> = packRootNode.ancestors();
 const circularNodeDescendants: Array<d3Hierarchy.HierarchyCircularNode<HierarchyDatumWithParentId>> = packRootNode.descendants();
 
-// leaves() ---------------------------------------------------------------
+// leaves() --------------------------------------------------------------
 
 hierarchyCircularNodeArray = packRootNode.leaves();
 
-// path() -------------------------------------------------------------------
+// path() ----------------------------------------------------------------
 
 hierarchyCircularNode = circularNodeDescendants[circularNodeDescendants.length - 1];
 
 const packPath: Array<d3Hierarchy.HierarchyCircularNode<HierarchyDatumWithParentId>> = packRootNode.path(hierarchyCircularNode);
 
-// links() and HierarchyRectangularLink<...> ------------------------------------------
+// links() and HierarchyRectangularLink<...> -----------------------------
 
 let circularLinks: Array<d3Hierarchy.HierarchyCircularLink<HierarchyDatumWithParentId>>;
 
@@ -779,19 +779,19 @@ circularLink = circularLinks[0];
 hierarchyCircularNode = circularLink.source;
 hierarchyCircularNode = circularLink.target;
 
-// sum() and value ----------------------------------------------------------
+// sum() and value -------------------------------------------------------
 
 packRootNode = packRootNode.sum((d) => d.val);
 
 numOrUndefined = packRootNode.value;
 
-// count() and value ----------------------------------------------------------
+// count() and value -----------------------------------------------------
 
 packRootNode = packRootNode.count();
 
 numOrUndefined = packRootNode.value;
 
-// sort ---------------------------------------------------------------------
+// sort ------------------------------------------------------------------
 
 packRootNode = packRootNode.sort((a, b) => {
     console.log('radius of a:', a.r, ' and b:', b.r); // a and b are of type HierarchyCircularNode<HierarchyDatumWithParentId>
@@ -799,7 +799,7 @@ packRootNode = packRootNode.sort((a, b) => {
     return b.height - a.height || b.value! - a.value!;
 });
 
-// each(), eachAfter(), eachBefore() ----------------------------------------
+// each(), eachAfter(), eachBefore() -------------------------------------
 
 packRootNode = packRootNode.each((node) => {
     console.log('ParentId:', node.data.parentId); // node type is HierarchyCircularNode<HierarchyDatumWithParentId>
@@ -816,7 +816,7 @@ packRootNode = packRootNode.eachBefore((node) => {
     console.log('Radius of node:', node.r); // node type is HierarchyCircularNode<HierarchyDatumWithParentId>
 });
 
-// copy() --------------------------------------------------------------------
+// copy() ----------------------------------------------------------------
 
 let copiedPackNode: d3Hierarchy.HierarchyCircularNode<HierarchyDatumWithParentId>;
 copiedPackNode = packRootNode.copy();

--- a/types/d3-hierarchy/index.d.ts
+++ b/types/d3-hierarchy/index.d.ts
@@ -576,7 +576,7 @@ export interface TreemapLayout<Datum> {
  */
 export function treemap<Datum>(): TreemapLayout<Datum>;
 
-// Tiling functions -----------------------------------------------------------------------
+// Tiling functions ------------------------------------------------------
 
 /**
  * Recursively partitions the specified nodes into an approximately-balanced binary tree,

--- a/types/d3-hierarchy/index.d.ts
+++ b/types/d3-hierarchy/index.d.ts
@@ -154,7 +154,7 @@ export interface HierarchyNode<Datum> {
  * Must return an array of data representing the children, and return null or undefined if the current datum has no children.
  * If children is not specified, it defaults to: `(d) => d.children`.
  */
-export function hierarchy<Datum>(data: Datum, children?: (d: Datum) => (Datum[] | null)): HierarchyNode<Datum>;
+export function hierarchy<Datum>(data: Datum, children?: (d: Datum) => (Datum[] | null | undefined)): HierarchyNode<Datum>;
 
 // -----------------------------------------------------------------------
 // Stratify
@@ -182,7 +182,7 @@ export interface StratifyOperator<Datum> {
      *
      * @param id The id accessor.
      */
-    id(id: (d: Datum, i?: number, data?: Datum[]) => (string | null | '' | undefined)): this;
+    id(id: (d: Datum, i: number, data: Datum[]) => (string | null | '' | undefined)): this;
 
     /**
      * Returns the current parent id accessor, which defaults to: `(d) => d.parentId`.
@@ -197,7 +197,7 @@ export interface StratifyOperator<Datum> {
      *
      * @param parentId The parent id accessor.
      */
-    parentId(parentId: (d: Datum, i?: number, data?: Datum[]) => (string | null | '' | undefined)): this;
+    parentId(parentId: (d: Datum, i: number, data: Datum[]) => (string | null | '' | undefined)): this;
 }
 
 /**
@@ -748,7 +748,7 @@ export interface PackLayout<Datum> {
      *
      * @param radius The specified radius accessor.
      */
-    radius(radius: (node: HierarchyCircularNode<Datum>) => number): this;
+    radius(radius: null | ((node: HierarchyCircularNode<Datum>) => number)): this;
 
     /**
      * Returns the current size, which defaults to [1, 1].

--- a/types/d3-hierarchy/tsconfig.json
+++ b/types/d3-hierarchy/tsconfig.json
@@ -7,7 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
-        "strictNullChecks": false,
+        "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/d3-shape/d3-shape-tests.ts
+++ b/types/d3-shape/d3-shape-tests.ts
@@ -1184,7 +1184,7 @@ interface SymbolDatum {
 let customSymbol: d3Shape.SymbolType;
 
 customSymbol = {
-    draw(context: CanvasPathMethods, size: number): void {
+    draw(context: d3Shape.CanvasPath_D3Shape, size: number): void {
         // draw custom symbol using canvas path methods
     }
 };

--- a/types/d3-shape/index.d.ts
+++ b/types/d3-shape/index.d.ts
@@ -8,6 +8,27 @@
 import { Path } from 'd3-path';
 
 // -----------------------------------------------------------------------------------
+// Shared Types and Interfaces
+// -----------------------------------------------------------------------------------
+
+/**
+ * @deprecated
+ * This interface is used to bridge the gap between two incompatible versions of TypeScript (see [#25944](https://github.com/Microsoft/TypeScript/pull/25944)).
+ * Use `CanvasPathMethods` instead with TS <= 3.0 and `CanvasPath` with TS >= 3.1.
+ */
+export interface CanvasPath_D3Shape {
+    arc(x: number, y: number, radius: number, startAngle: number, endAngle: number, anticlockwise?: boolean): void;
+    arcTo(x1: number, y1: number, x2: number, y2: number, radius: number): void;
+    bezierCurveTo(cp1x: number, cp1y: number, cp2x: number, cp2y: number, x: number, y: number): void;
+    closePath(): void;
+    ellipse(x: number, y: number, radiusX: number, radiusY: number, rotation: number, startAngle: number, endAngle: number, anticlockwise?: boolean): void;
+    lineTo(x: number, y: number): void;
+    moveTo(x: number, y: number): void;
+    quadraticCurveTo(cpx: number, cpy: number, x: number, y: number): void;
+    rect(x: number, y: number, w: number, h: number): void;
+}
+
+// -----------------------------------------------------------------------------------
 // Arc Generator
 // -----------------------------------------------------------------------------------
 
@@ -2264,13 +2285,13 @@ export function linkRadial<This, LinkDatum, NodeDatum>(): LinkRadial<This, LinkD
  */
 export interface SymbolType {
     /**
-     * Renders this symbol type to the specified context with the specified size in square pixels. The context implements the CanvasPathMethods interface.
+     * Renders this symbol type to the specified context with the specified size in square pixels. The context implements the CanvasPath interface.
      * (Note that this is a subset of the CanvasRenderingContext2D interface!)
      *
-     * @param context A rendering context implementing CanvasPathMethods.
+     * @param context A rendering context implementing CanvasPath.
      * @param size Size of the symbol to draw.
      */
-    draw(context: CanvasPathMethods, size: number): void;
+    draw(context: CanvasPath_D3Shape, size: number): void;
 }
 
 /**

--- a/types/d3kit/d3kit-tests.ts
+++ b/types/d3kit/d3kit-tests.ts
@@ -64,7 +64,7 @@ function test_abstract_plate() {
     let sel: d3.Selection<d3.BaseType, any, d3.BaseType, any>;
 
     // create a div, append to body, return Node as type Element
-    el = document.body!.appendChild(document.createElement('div')) as Element;
+    el = document.body.appendChild(document.createElement('div')) as Element;
 
     // create example of options
     margins = { top: 20, right: 20, bottom: 20, left: 20};
@@ -193,7 +193,7 @@ function test_abstract_chart() {
     let plate: d3kit.AbstractPlate;
 
     // create a div, append to body, return Node as type Element
-    el = document.body!.appendChild(document.createElement('div')) as Element;
+    el = document.body.appendChild(document.createElement('div')) as Element;
 
     // create examples of margins, offsets, options, fit options, watch options
     margins = { top: 20, right: 20, bottom: 20, left: 20};
@@ -285,7 +285,7 @@ function test_svg_chart() {
     let plate: d3kit.SvgPlate;
 
     // create a div, append to body, return Node as type Element
-    el = document.body!.appendChild(document.createElement('div')) as Element;
+    el = document.body.appendChild(document.createElement('div')) as Element;
 
     // create examples of margins, offsets, options, fit options, watch options
     margins = { top: 20, right: 20, bottom: 20, left: 20};
@@ -326,7 +326,7 @@ function test_canvas_chart() {
     let context: CanvasRenderingContext2D;
 
     // create a div, append to body, return Node as type Element
-    el = document.body!.appendChild(document.createElement('div')) as Element;
+    el = document.body.appendChild(document.createElement('div')) as Element;
 
     // create examples of margins, offsets, options, fit options, watch options
     margins = { top: 20, right: 20, bottom: 20, left: 20};
@@ -362,7 +362,7 @@ function test_hybrid_chart() {
     let context: CanvasRenderingContext2D;
 
     // create a div, append to body, return Node as type Element
-    el = document.body!.appendChild(document.createElement('div')) as Element;
+    el = document.body.appendChild(document.createElement('div')) as Element;
 
     // create examples of margins, offsets, options, fit options, watch options
     margins = { top: 20, right: 20, bottom: 20, left: 20};

--- a/types/d3kit/d3kit-tests.ts
+++ b/types/d3kit/d3kit-tests.ts
@@ -64,7 +64,7 @@ function test_abstract_plate() {
     let sel: d3.Selection<d3.BaseType, any, d3.BaseType, any>;
 
     // create a div, append to body, return Node as type Element
-    el = document.body.appendChild(document.createElement('div')) as Element;
+    el = document.body!.appendChild(document.createElement('div')) as Element;
 
     // create example of options
     margins = { top: 20, right: 20, bottom: 20, left: 20};
@@ -193,7 +193,7 @@ function test_abstract_chart() {
     let plate: d3kit.AbstractPlate;
 
     // create a div, append to body, return Node as type Element
-    el = document.body.appendChild(document.createElement('div')) as Element;
+    el = document.body!.appendChild(document.createElement('div')) as Element;
 
     // create examples of margins, offsets, options, fit options, watch options
     margins = { top: 20, right: 20, bottom: 20, left: 20};
@@ -285,7 +285,7 @@ function test_svg_chart() {
     let plate: d3kit.SvgPlate;
 
     // create a div, append to body, return Node as type Element
-    el = document.body.appendChild(document.createElement('div')) as Element;
+    el = document.body!.appendChild(document.createElement('div')) as Element;
 
     // create examples of margins, offsets, options, fit options, watch options
     margins = { top: 20, right: 20, bottom: 20, left: 20};
@@ -326,7 +326,7 @@ function test_canvas_chart() {
     let context: CanvasRenderingContext2D;
 
     // create a div, append to body, return Node as type Element
-    el = document.body.appendChild(document.createElement('div')) as Element;
+    el = document.body!.appendChild(document.createElement('div')) as Element;
 
     // create examples of margins, offsets, options, fit options, watch options
     margins = { top: 20, right: 20, bottom: 20, left: 20};
@@ -362,7 +362,7 @@ function test_hybrid_chart() {
     let context: CanvasRenderingContext2D;
 
     // create a div, append to body, return Node as type Element
-    el = document.body.appendChild(document.createElement('div')) as Element;
+    el = document.body!.appendChild(document.createElement('div')) as Element;
 
     // create examples of margins, offsets, options, fit options, watch options
     margins = { top: 20, right: 20, bottom: 20, left: 20};


### PR DESCRIPTION
Activate strict null check for d3-hierarchy: see `hierarchy(.)` and `radius(.)`.

For strict function: in `id` and `parentId` removed the `?`.

I have nothing to add for TS 2.3.

Align dashes at column 75.

Related: #23611 and #27619.
