### PR TITLE
timezone-js: timezoneJS.Date.toString have a handy format parameter so we daclare it

### DIFF
--- a/types/timezone-js/index.d.ts
+++ b/types/timezone-js/index.d.ts
@@ -19,7 +19,7 @@ export declare class Date {
     setTimezone: (timezone: string) => void;
 
     // regular Date members
-    toString(): string;
+    toString(format?:string): string;
     toDateString(): string;
     toTimeString(): string;
     toLocaleString(): string;


### PR DESCRIPTION
as it can be seen at https://github.com/mde/timezone-js/blob/master/src/date.js#L495

the Date.toString has a format parameter that is heavily used all over the code. The other parameter is to internal data structure that is not really practical to expose 

This is a minor, backward compatible change.

