### PR TITLE
mongoose: add context to the ModelFindByIdAndUpdateOptions

### DIFF
--- a/types/mongoose/index.d.ts
+++ b/types/mongoose/index.d.ts
@@ -2983,6 +2983,8 @@ declare module "mongoose" {
     rawResult?: boolean;
     /** overwrites the schema's strict mode option for this update */
     strict?: boolean;
+    /** The context option lets you set the value of this in update validators to the underlying query. */
+    context?: string;
   }
 
   interface ModelFindOneAndUpdateOptions extends ModelFindByIdAndUpdateOptions {


### PR DESCRIPTION
I added the missing `context` option for mongoose inside this object: `ModelFindByIdAndUpdateOptions`.

Here is the mongoose documentation about that missing option: http://mongoosejs.com/docs/validation.html#the-context-option

Thanks a lot for your review