### PR TITLE
Fix InferableComponentEnhancerWithProps type inference for StatelessComponent

### DIFF
--- a/types/react-redux/index.d.ts
+++ b/types/react-redux/index.d.ts
@@ -73,9 +73,9 @@ type Shared<
 // Will not pass through the injected props if they are passed in during
 // render. Also adds new prop requirements from TNeedsProps.
 export interface InferableComponentEnhancerWithProps<TInjectedProps, TNeedsProps> {
-	(
-		component: StatelessComponent<TInjectedProps>
-	): ComponentClass<TNeedsProps> & {WrappedComponent: StatelessComponent<TInjectedProps>}
+    <P extends Shared<TInjectedProps, P>>(
+		component: StatelessComponent<P>
+	): ComponentClass<Omit<P, keyof Shared<TInjectedProps, P>> & TNeedsProps> & {WrappedComponent: StatelessComponent<P>}
 	<P extends Shared<TInjectedProps, P>>(
 		component: ComponentType<P>
 	): ComponentClass<Omit<P, keyof Shared<TInjectedProps, P>> & TNeedsProps> & {WrappedComponent: ComponentType<P>}

--- a/types/react-redux/index.d.ts
+++ b/types/react-redux/index.d.ts
@@ -73,9 +73,6 @@ type Shared<
 // Will not pass through the injected props if they are passed in during
 // render. Also adds new prop requirements from TNeedsProps.
 export interface InferableComponentEnhancerWithProps<TInjectedProps, TNeedsProps> {
-    <P extends Shared<TInjectedProps, P>>(
-		component: StatelessComponent<P>
-	): ComponentClass<Omit<P, keyof Shared<TInjectedProps, P>> & TNeedsProps> & {WrappedComponent: StatelessComponent<P>}
 	<P extends Shared<TInjectedProps, P>>(
 		component: ComponentType<P>
 	): ComponentClass<Omit<P, keyof Shared<TInjectedProps, P>> & TNeedsProps> & {WrappedComponent: ComponentType<P>}

--- a/types/react-redux/react-redux-tests.tsx
+++ b/types/react-redux/react-redux-tests.tsx
@@ -832,7 +832,12 @@ namespace TestDispatchToPropsAsObject {
 	<Header />
 }
 
-namespace TestInferredFunctionalComponent {
+namespace TestInferredFunctionalComponentWithExplicitOwnProps {
+  type Props = {
+    title: string,
+    extraText: string,
+    onClick: () => void,
+  };
 
 	const Header = connect(
 		(
@@ -845,7 +850,30 @@ namespace TestInferredFunctionalComponent {
 		(dispatch) => ({
 			onClick: () => dispatch({ type: 'test' })
 		})
-	)(({ title, extraText, onClick }) => {
+	)(({ title, extraText, onClick }: Props) => {
+		return <h1 onClick={onClick}>{title} {extraText}</h1>;
+	});
+	<Header extraText='text'/>
+}
+
+namespace TestInferredFunctionalComponentWithImplicitOwnProps {
+
+  type Props = {
+    title: string,
+    extraText: string,
+    onClick: () => void,
+  };
+
+	const Header = connect(
+		(
+			{ app: { title }}: { app: { title: string }},
+		) => ({
+			title,
+		}),
+		(dispatch) => ({
+			onClick: () => dispatch({ type: 'test' })
+		})
+	)(({ title, extraText, onClick }: Props) => {
 		return <h1 onClick={onClick}>{title} {extraText}</h1>;
 	});
 	<Header extraText='text'/>


### PR DESCRIPTION
The inferred component should require the difference of props supplied by connect
and props needed by the component to be passed during render.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.