### PR TITLE
bootstrap: `document.body` is possibly 'null' in TypeScript@next

### DIFF
--- a/types/bootstrap/bootstrap-tests.ts
+++ b/types/bootstrap/bootstrap-tests.ts
@@ -1,3 +1,5 @@
+declare let aHtmlElement: HTMLElement;
+
 // --------------------------------------------------------------------------------------
 // Alert
 // --------------------------------------------------------------------------------------
@@ -78,7 +80,7 @@ $("#collapse").collapse({
 });
 
 $("#collapse").collapse({
-    parent: document.body,
+    parent: aHtmlElement,
 });
 
 $("#collapse").collapse({
@@ -122,11 +124,11 @@ $("#dropdown").dropdown({
 });
 
 $("#dropdown").dropdown({
-    boundary: document.body,
+    boundary: aHtmlElement,
 });
 
 $("#dropdown").dropdown({
-    reference: document.body,
+    reference: aHtmlElement,
 });
 
 // --------------------------------------------------------------------------------------
@@ -340,5 +342,5 @@ $("#tooltip").tooltip({
 });
 
 $("#tooltip").tooltip({
-    boundary: document.body,
+    boundary: aHtmlElement,
 });


### PR DESCRIPTION
I used `document.body` in the tests just as an easy way to get a `HTMLElement` object. This is not a real use case. In this PR, I added a global temporary `HTMLElement` object in the tests to make the intention clear.

I'm against adding `null` to some of the properties. This is not documented and there is no real case scenario for this.