### PR TITLE
owl.carousel : Add autoHeight option

### DIFF
--- a/types/owl.carousel/index.d.ts
+++ b/types/owl.carousel/index.d.ts
@@ -61,6 +61,7 @@ declare namespace OwlCarousel {
         dotsContainer?: string | boolean;
         checkVisible?: boolean;
         slideTransition?: string;
+        autoHeight?: boolean;
         // CLASSES
         refreshClass?: string;
         loadingClass?: string;


### PR DESCRIPTION
Updated to add the missing "autoHeight" option as in the built-in plugin : http://owlcarousel2.github.io/OwlCarousel2/demos/autoheight.html 

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme]
- [x] Avoid [common mistakes]
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://owlcarousel2.github.io/OwlCarousel2/demos/autoheight.html
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
