### PR TITLE
@types/graphql: is*Type() predicates can take null and undefined

### DIFF
--- a/types/graphql/graphql-tests.ts
+++ b/types/graphql/graphql-tests.ts
@@ -1,4 +1,4 @@
-import { isInputType, isOutputType } from 'graphql';
+import { assertInputType, isInputType, isOutputType } from 'graphql';
 
 ///////////////////////////
 // graphql               //
@@ -52,6 +52,8 @@ function language_visitor_tests() {
 function type_definition_tests() {
     isInputType(null);
     isOutputType(null);
+
+    assertInputType(null);
 }
 
 function type_directives_tests() {

--- a/types/graphql/graphql-tests.ts
+++ b/types/graphql/graphql-tests.ts
@@ -1,4 +1,4 @@
-import * as graphql from 'graphql';
+import { isInputType, isOutputType } from 'graphql';
 
 ///////////////////////////
 // graphql               //
@@ -50,7 +50,8 @@ function language_visitor_tests() {
 // graphql/type          //
 ///////////////////////////
 function type_definition_tests() {
-    // TODO
+    isInputType(null);
+    isOutputType(null);
 }
 
 function type_directives_tests() {

--- a/types/graphql/type/definition.d.ts
+++ b/types/graphql/type/definition.d.ts
@@ -38,35 +38,35 @@ export function assertType(type: any): GraphQLType;
 
 export function isScalarType(type: any): type is GraphQLScalarType;
 
-export function assertScalarType(type: GraphQLType): GraphQLScalarType;
+export function assertScalarType(type: any): GraphQLScalarType;
 
 export function isObjectType(type: any): type is GraphQLObjectType;
 
-export function assertObjectType(type: GraphQLType): GraphQLObjectType;
+export function assertObjectType(type: any): GraphQLObjectType;
 
 export function isInterfaceType(type: any): type is GraphQLInterfaceType;
 
-export function assertInterfaceType(type: GraphQLType): GraphQLInterfaceType;
+export function assertInterfaceType(type: any): GraphQLInterfaceType;
 
 export function isUnionType(type: any): type is GraphQLUnionType;
 
-export function assertUnionType(type: GraphQLType): GraphQLUnionType;
+export function assertUnionType(type: any): GraphQLUnionType;
 
 export function isEnumType(type: any): type is GraphQLEnumType;
 
-export function assertEnumType(type: GraphQLType): GraphQLEnumType;
+export function assertEnumType(type: any): GraphQLEnumType;
 
 export function isInputObjectType(type: any): type is GraphQLInputObjectType;
 
-export function assertInputObjectType(type: GraphQLType): GraphQLInputObjectType;
+export function assertInputObjectType(type: any): GraphQLInputObjectType;
 
 export function isListType(type: any): type is GraphQLList<any>;
 
-export function assertListType(type: GraphQLType): GraphQLList<any>;
+export function assertListType(type: any): GraphQLList<any>;
 
 export function isNonNullType(type: any): type is GraphQLNonNull<any>;
 
-export function assertNonNullType(type: GraphQLType): GraphQLNonNull<any>;
+export function assertNonNullType(type: any): GraphQLNonNull<any>;
 
 /**
  * These types may be used as input types for arguments and directives.
@@ -80,7 +80,7 @@ export type GraphQLInputType =
 
 export function isInputType(type: any): type is GraphQLInputType;
 
-export function assertInputType(type: GraphQLType): GraphQLInputType;
+export function assertInputType(type: any): GraphQLInputType;
 
 /**
  * These types may be used as output types as the result of fields.
@@ -103,7 +103,7 @@ export type GraphQLOutputType =
 
 export function isOutputType(type: any): type is GraphQLOutputType;
 
-export function assertOutputType(type: GraphQLType): GraphQLOutputType;
+export function assertOutputType(type: any): GraphQLOutputType;
 
 /**
  * These types may describe types which may be leaf values.
@@ -112,7 +112,7 @@ export type GraphQLLeafType = GraphQLScalarType | GraphQLEnumType;
 
 export function isLeafType(type: any): type is GraphQLLeafType;
 
-export function assertLeafType(type: GraphQLType): GraphQLLeafType;
+export function assertLeafType(type: any): GraphQLLeafType;
 
 /**
  * These types may describe the parent context of a selection set.
@@ -121,7 +121,7 @@ export type GraphQLCompositeType = GraphQLObjectType | GraphQLInterfaceType | Gr
 
 export function isCompositeType(type: any): type is GraphQLCompositeType;
 
-export function assertCompositeType(type: GraphQLType): GraphQLCompositeType;
+export function assertCompositeType(type: any): GraphQLCompositeType;
 
 /**
  * These types may describe the parent context of a selection set.
@@ -130,7 +130,7 @@ export type GraphQLAbstractType = GraphQLInterfaceType | GraphQLUnionType;
 
 export function isAbstractType(type: any): type is GraphQLAbstractType;
 
-export function assertAbstractType(type: GraphQLType): GraphQLAbstractType;
+export function assertAbstractType(type: any): GraphQLAbstractType;
 
 /**
  * List Modifier
@@ -190,7 +190,7 @@ export type GraphQLWrappingType = GraphQLList<any> | GraphQLNonNull<any>;
 
 export function isWrappingType(type: any): type is GraphQLWrappingType;
 
-export function assertWrappingType(type: GraphQLType): GraphQLWrappingType;
+export function assertWrappingType(type: any): GraphQLWrappingType;
 
 /**
  * These types can all accept null as a value.
@@ -206,7 +206,7 @@ export type GraphQLNullableType =
 
 export function isNullableType(type: any): type is GraphQLNullableType;
 
-export function assertNullableType(type: GraphQLType): GraphQLNullableType;
+export function assertNullableType(type: any): GraphQLNullableType;
 
 export function getNullableType(type: void): undefined;
 export function getNullableType<T extends GraphQLNullableType>(type: T): T;
@@ -225,7 +225,7 @@ export type GraphQLNamedType =
 
 export function isNamedType(type: any): type is GraphQLNamedType;
 
-export function assertNamedType(type: GraphQLType): GraphQLNamedType;
+export function assertNamedType(type: any): GraphQLNamedType;
 
 export function getNamedType(type: void): undefined;
 export function getNamedType(type: GraphQLType): GraphQLNamedType;

--- a/types/graphql/type/definition.d.ts
+++ b/types/graphql/type/definition.d.ts
@@ -32,39 +32,39 @@ export type GraphQLType =
     | GraphQLList<any>
     | GraphQLNonNull<any>;
 
-export function isType(type: any | null | undefined): type is GraphQLType;
+export function isType(type: any): type is GraphQLType;
 
 export function assertType(type: any): GraphQLType;
 
-export function isScalarType(type: GraphQLType | null | undefined): type is GraphQLScalarType;
+export function isScalarType(type: any): type is GraphQLScalarType;
 
 export function assertScalarType(type: GraphQLType): GraphQLScalarType;
 
-export function isObjectType(type: GraphQLType | null | undefined): type is GraphQLObjectType;
+export function isObjectType(type: any): type is GraphQLObjectType;
 
 export function assertObjectType(type: GraphQLType): GraphQLObjectType;
 
-export function isInterfaceType(type: GraphQLType | null | undefined): type is GraphQLInterfaceType;
+export function isInterfaceType(type: any): type is GraphQLInterfaceType;
 
 export function assertInterfaceType(type: GraphQLType): GraphQLInterfaceType;
 
-export function isUnionType(type: GraphQLType | null | undefined): type is GraphQLUnionType;
+export function isUnionType(type: any): type is GraphQLUnionType;
 
 export function assertUnionType(type: GraphQLType): GraphQLUnionType;
 
-export function isEnumType(type: GraphQLType | null | undefined): type is GraphQLEnumType;
+export function isEnumType(type: any): type is GraphQLEnumType;
 
 export function assertEnumType(type: GraphQLType): GraphQLEnumType;
 
-export function isInputObjectType(type: GraphQLType | null | undefined): type is GraphQLInputObjectType;
+export function isInputObjectType(type: any): type is GraphQLInputObjectType;
 
 export function assertInputObjectType(type: GraphQLType): GraphQLInputObjectType;
 
-export function isListType(type: GraphQLType | null | undefined): type is GraphQLList<any>;
+export function isListType(type: any): type is GraphQLList<any>;
 
 export function assertListType(type: GraphQLType): GraphQLList<any>;
 
-export function isNonNullType(type: GraphQLType | null | undefined): type is GraphQLNonNull<any>;
+export function isNonNullType(type: any): type is GraphQLNonNull<any>;
 
 export function assertNonNullType(type: GraphQLType): GraphQLNonNull<any>;
 
@@ -78,7 +78,7 @@ export type GraphQLInputType =
     | GraphQLList<any>
     | GraphQLNonNull<GraphQLScalarType | GraphQLEnumType | GraphQLInputObjectType | GraphQLList<any>>;
 
-export function isInputType(type: GraphQLType | null | undefined): type is GraphQLInputType;
+export function isInputType(type: any): type is GraphQLInputType;
 
 export function assertInputType(type: GraphQLType): GraphQLInputType;
 
@@ -101,7 +101,7 @@ export type GraphQLOutputType =
           | GraphQLList<any>
       >;
 
-export function isOutputType(type: GraphQLType | null | undefined): type is GraphQLOutputType;
+export function isOutputType(type: any): type is GraphQLOutputType;
 
 export function assertOutputType(type: GraphQLType): GraphQLOutputType;
 
@@ -110,7 +110,7 @@ export function assertOutputType(type: GraphQLType): GraphQLOutputType;
  */
 export type GraphQLLeafType = GraphQLScalarType | GraphQLEnumType;
 
-export function isLeafType(type: GraphQLType | null | undefined): type is GraphQLLeafType;
+export function isLeafType(type: any): type is GraphQLLeafType;
 
 export function assertLeafType(type: GraphQLType): GraphQLLeafType;
 
@@ -119,7 +119,7 @@ export function assertLeafType(type: GraphQLType): GraphQLLeafType;
  */
 export type GraphQLCompositeType = GraphQLObjectType | GraphQLInterfaceType | GraphQLUnionType;
 
-export function isCompositeType(type: GraphQLType | null | undefined): type is GraphQLCompositeType;
+export function isCompositeType(type: any): type is GraphQLCompositeType;
 
 export function assertCompositeType(type: GraphQLType): GraphQLCompositeType;
 
@@ -128,7 +128,7 @@ export function assertCompositeType(type: GraphQLType): GraphQLCompositeType;
  */
 export type GraphQLAbstractType = GraphQLInterfaceType | GraphQLUnionType;
 
-export function isAbstractType(type: GraphQLType | null | undefined): type is GraphQLAbstractType;
+export function isAbstractType(type: any): type is GraphQLAbstractType;
 
 export function assertAbstractType(type: GraphQLType): GraphQLAbstractType;
 
@@ -188,7 +188,7 @@ export class GraphQLNonNull<T extends GraphQLNullableType> {
 
 export type GraphQLWrappingType = GraphQLList<any> | GraphQLNonNull<any>;
 
-export function isWrappingType(type: GraphQLType | null | undefined): type is GraphQLWrappingType;
+export function isWrappingType(type: any): type is GraphQLWrappingType;
 
 export function assertWrappingType(type: GraphQLType): GraphQLWrappingType;
 
@@ -204,7 +204,7 @@ export type GraphQLNullableType =
     | GraphQLInputObjectType
     | GraphQLList<any>;
 
-export function isNullableType(type: GraphQLType | null | undefined): type is GraphQLNullableType;
+export function isNullableType(type: any): type is GraphQLNullableType;
 
 export function assertNullableType(type: GraphQLType): GraphQLNullableType;
 
@@ -223,7 +223,7 @@ export type GraphQLNamedType =
     | GraphQLEnumType
     | GraphQLInputObjectType;
 
-export function isNamedType(type: GraphQLType | null | undefined): type is GraphQLNamedType;
+export function isNamedType(type: any): type is GraphQLNamedType;
 
 export function assertNamedType(type: GraphQLType): GraphQLNamedType;
 

--- a/types/graphql/type/definition.d.ts
+++ b/types/graphql/type/definition.d.ts
@@ -32,39 +32,39 @@ export type GraphQLType =
     | GraphQLList<any>
     | GraphQLNonNull<any>;
 
-export function isType(type: any): type is GraphQLType;
+export function isType(type: any | null | undefined): type is GraphQLType;
 
 export function assertType(type: any): GraphQLType;
 
-export function isScalarType(type: GraphQLType): type is GraphQLScalarType;
+export function isScalarType(type: GraphQLType | null | undefined): type is GraphQLScalarType;
 
 export function assertScalarType(type: GraphQLType): GraphQLScalarType;
 
-export function isObjectType(type: GraphQLType): type is GraphQLObjectType;
+export function isObjectType(type: GraphQLType | null | undefined): type is GraphQLObjectType;
 
 export function assertObjectType(type: GraphQLType): GraphQLObjectType;
 
-export function isInterfaceType(type: GraphQLType): type is GraphQLInterfaceType;
+export function isInterfaceType(type: GraphQLType | null | undefined): type is GraphQLInterfaceType;
 
 export function assertInterfaceType(type: GraphQLType): GraphQLInterfaceType;
 
-export function isUnionType(type: GraphQLType): type is GraphQLUnionType;
+export function isUnionType(type: GraphQLType | null | undefined): type is GraphQLUnionType;
 
 export function assertUnionType(type: GraphQLType): GraphQLUnionType;
 
-export function isEnumType(type: GraphQLType): type is GraphQLEnumType;
+export function isEnumType(type: GraphQLType | null | undefined): type is GraphQLEnumType;
 
 export function assertEnumType(type: GraphQLType): GraphQLEnumType;
 
-export function isInputObjectType(type: GraphQLType): type is GraphQLInputObjectType;
+export function isInputObjectType(type: GraphQLType | null | undefined): type is GraphQLInputObjectType;
 
 export function assertInputObjectType(type: GraphQLType): GraphQLInputObjectType;
 
-export function isListType(type: GraphQLType): type is GraphQLList<any>;
+export function isListType(type: GraphQLType | null | undefined): type is GraphQLList<any>;
 
 export function assertListType(type: GraphQLType): GraphQLList<any>;
 
-export function isNonNullType(type: GraphQLType): type is GraphQLNonNull<any>;
+export function isNonNullType(type: GraphQLType | null | undefined): type is GraphQLNonNull<any>;
 
 export function assertNonNullType(type: GraphQLType): GraphQLNonNull<any>;
 
@@ -78,7 +78,7 @@ export type GraphQLInputType =
     | GraphQLList<any>
     | GraphQLNonNull<GraphQLScalarType | GraphQLEnumType | GraphQLInputObjectType | GraphQLList<any>>;
 
-export function isInputType(type: GraphQLType): type is GraphQLInputType;
+export function isInputType(type: GraphQLType | null | undefined): type is GraphQLInputType;
 
 export function assertInputType(type: GraphQLType): GraphQLInputType;
 
@@ -101,7 +101,7 @@ export type GraphQLOutputType =
           | GraphQLList<any>
       >;
 
-export function isOutputType(type: GraphQLType): type is GraphQLOutputType;
+export function isOutputType(type: GraphQLType | null | undefined): type is GraphQLOutputType;
 
 export function assertOutputType(type: GraphQLType): GraphQLOutputType;
 
@@ -110,7 +110,7 @@ export function assertOutputType(type: GraphQLType): GraphQLOutputType;
  */
 export type GraphQLLeafType = GraphQLScalarType | GraphQLEnumType;
 
-export function isLeafType(type: GraphQLType): type is GraphQLLeafType;
+export function isLeafType(type: GraphQLType | null | undefined): type is GraphQLLeafType;
 
 export function assertLeafType(type: GraphQLType): GraphQLLeafType;
 
@@ -119,7 +119,7 @@ export function assertLeafType(type: GraphQLType): GraphQLLeafType;
  */
 export type GraphQLCompositeType = GraphQLObjectType | GraphQLInterfaceType | GraphQLUnionType;
 
-export function isCompositeType(type: GraphQLType): type is GraphQLCompositeType;
+export function isCompositeType(type: GraphQLType | null | undefined): type is GraphQLCompositeType;
 
 export function assertCompositeType(type: GraphQLType): GraphQLCompositeType;
 
@@ -128,7 +128,7 @@ export function assertCompositeType(type: GraphQLType): GraphQLCompositeType;
  */
 export type GraphQLAbstractType = GraphQLInterfaceType | GraphQLUnionType;
 
-export function isAbstractType(type: GraphQLType): type is GraphQLAbstractType;
+export function isAbstractType(type: GraphQLType | null | undefined): type is GraphQLAbstractType;
 
 export function assertAbstractType(type: GraphQLType): GraphQLAbstractType;
 
@@ -188,7 +188,7 @@ export class GraphQLNonNull<T extends GraphQLNullableType> {
 
 export type GraphQLWrappingType = GraphQLList<any> | GraphQLNonNull<any>;
 
-export function isWrappingType(type: GraphQLType): type is GraphQLWrappingType;
+export function isWrappingType(type: GraphQLType | null | undefined): type is GraphQLWrappingType;
 
 export function assertWrappingType(type: GraphQLType): GraphQLWrappingType;
 
@@ -204,7 +204,7 @@ export type GraphQLNullableType =
     | GraphQLInputObjectType
     | GraphQLList<any>;
 
-export function isNullableType(type: GraphQLType): type is GraphQLNullableType;
+export function isNullableType(type: GraphQLType | null | undefined): type is GraphQLNullableType;
 
 export function assertNullableType(type: GraphQLType): GraphQLNullableType;
 
@@ -223,7 +223,7 @@ export type GraphQLNamedType =
     | GraphQLEnumType
     | GraphQLInputObjectType;
 
-export function isNamedType(type: GraphQLType): type is GraphQLNamedType;
+export function isNamedType(type: GraphQLType | null | undefined): type is GraphQLNamedType;
 
 export function assertNamedType(type: GraphQLType): GraphQLNamedType;
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://graphql.org/graphql-js/type/#isinputtype
- [ ] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.