### PR TITLE
@types/react-native - Add missing property textContentType for TextInputIOSProps.

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -1009,6 +1009,54 @@ export interface TextInputIOSProps {
      * If false, disables spell-check style (i.e. red underlines). The default value is inherited from autoCorrect
      */
     spellCheck?: boolean;
+
+
+    /**
+     * Give the keyboard and the system information about the expected
+     * semantic meaning for the content that users enter.
+     *
+     * For iOS 11+ you can set `textContentType` to `username` or `password` to
+     * enable autofill of login details from the device keychain.
+     *
+     * To disable autofill, set textContentType to `none`.
+     *
+     * Possible values for `textContentType` are:
+     *
+     *  - `'none'`
+     *  - `'URL'`
+     *  - `'addressCity'`
+     *  - `'addressCityAndState'`
+     *  - `'addressState'`
+     *  - `'countryName'`
+     *  - `'creditCardNumber'`
+     *  - `'emailAddress'`
+     *  - `'familyName'`
+     *  - `'fullStreetAddress'`
+     *  - `'givenName'`
+     *  - `'jobTitle'`
+     *  - `'location'`
+     *  - `'middleName'`
+     *  - `'name'`
+     *  - `'namePrefix'`
+     *  - `'nameSuffix'`
+     *  - `'nickname'`
+     *  - `'organizationName'`
+     *  - `'postalCode'`
+     *  - `'streetAddressLine1'`
+     *  - `'streetAddressLine2'`
+     *  - `'sublocality'`
+     *  - `'telephoneNumber'`
+     *  - `'username'`
+     *  - `'password'`
+     *
+     */
+    textContentType?: "none" | "URL" | "addressCity" | "addressCityAndState" |
+        "addressState" | "countryName" | "creditCardNumber" | "emailAddress" |
+        "familyName" | "fullStreetAddress" | "givenName" | "jobTitle" |
+        "location" | "middleName" | "name" | "namePrefix" | "nameSuffix" |
+        "nickname" | "organizationName" | "postalCode" | "streetAddressLine1" |
+        "streetAddressLine2" | "sublocality" | "telephoneNumber" | "username" |
+        "password";
 }
 
 /**

--- a/types/react-native/test/index.tsx
+++ b/types/react-native/test/index.tsx
@@ -547,6 +547,7 @@ class TextInputTest extends React.Component<{}, {username: string}> {
 
                 <TextInput
                     ref={input => this.username = input}
+                    textContentType="username"
                     value={this.state.username}
                     onChangeText={this.handleUsernameChange}
                 />


### PR DESCRIPTION
Add missing property `textContentType` for `TextInputIOSProps`.

Sorry for opening the PR twice (I closed the old one), but the previous PR failed (linting issue) and I force-pushed to my PR branch (should have just pushed).

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://facebook.github.io/react-native/docs/textinput#textcontenttype
- [] Increase the version number in the header if appropriate.
- [] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

