### PR TITLE
JQuery: HTMLSelectElement and arrays

### DIFF
--- a/types/jquery/index.d.ts
+++ b/types/jquery/index.d.ts
@@ -130,7 +130,6 @@ interface JQueryStatic {
      * @since 1.0
      * @since 1.4
      */
-    // Using a unified signature is not possible due to a TypeScript 2.4 bug (DefinitelyTyped#27810)
     // tslint:disable-next-line:no-unnecessary-generics
     <TElement extends HTMLElement = HTMLElement>(html: JQuery.htmlString, ownerDocument_attributes?: Document | JQuery.PlainObject): JQuery<TElement>;
     /**
@@ -141,7 +140,6 @@ interface JQueryStatic {
      * @see \`{@link https://api.jquery.com/jQuery/ }\`
      * @since 1.0
      */
-    // Using a unified signature is not possible due to a TypeScript 2.4 bug (DefinitelyTyped#27810)
     // tslint:disable-next-line:no-unnecessary-generics
     <TElement extends Element = HTMLElement>(selector: JQuery.Selector, context?: Element | Document | JQuery): JQuery<TElement>;
     /**
@@ -152,6 +150,7 @@ interface JQueryStatic {
      * @see \`{@link https://api.jquery.com/jQuery/ }\`
      * @since 1.0
      */
+    // Using a unified signature is not possible due to a TypeScript 2.4 bug (DefinitelyTyped#27810)
     // tslint:disable-next-line:unified-signatures
     <T extends Element>(element: T): JQuery<T>;
     /**
@@ -162,6 +161,7 @@ interface JQueryStatic {
      * @see \`{@link https://api.jquery.com/jQuery/ }\`
      * @since 1.0
      */
+    // Using a unified signature is not possible due to a TypeScript 2.4 bug (DefinitelyTyped#27810)
     // tslint:disable-next-line:unified-signatures
     <T extends Element>(elementArray: T[]): JQuery<T>;
     /**

--- a/types/jquery/index.d.ts
+++ b/types/jquery/index.d.ts
@@ -146,32 +146,21 @@ interface JQueryStatic {
      * Return a collection of matched elements either found in the DOM based on passed argument(s) or created
      * by passing an HTML string.
      *
-     * @param element A DOM element to wrap in a jQuery object.
+     * @param element_elementArray A DOM element to wrap in a jQuery object.
+     *                             An array containing a set of DOM elements to wrap in a jQuery object.
      * @see \`{@link https://api.jquery.com/jQuery/ }\`
      * @since 1.0
      */
-    // tslint:disable-next-line:unified-signatures
-    <T extends Element>(element: T): JQuery<T>;
-    /**
-     * Return a collection of matched elements either found in the DOM based on passed argument(s) or created
-     * by passing an HTML string.
-     *
-     * @param elementArray An array containing a set of DOM elements to wrap in a jQuery object.
-     * @see \`{@link https://api.jquery.com/jQuery/ }\`
-     * @since 1.0
-     */
-    // tslint:disable-next-line:unified-signatures
-    <T extends Element>(elementArray: ArrayLike<T>): JQuery<T>;
+    <T extends Element>(element_elementArray: T | T[]): JQuery<T>;
     /**
      * Return a collection of matched elements either found in the DOM based on passed argument(s) or created
      * by passing an HTML string.
      *
      * @param selection An existing jQuery object to clone.
-     *                  An array not containing a set of DOM elements.
      * @see \`{@link https://api.jquery.com/jQuery/ }\`
      * @since 1.0
      */
-    <T>(selection: ArrayLike<T>): JQuery<T>;
+    <T>(selection: JQuery<T>): JQuery<T>;
     /**
      * Binds a function to be executed when the DOM has finished loading.
      *

--- a/types/jquery/index.d.ts
+++ b/types/jquery/index.d.ts
@@ -130,6 +130,7 @@ interface JQueryStatic {
      * @since 1.0
      * @since 1.4
      */
+    // Using a unified signature is not possible due to a TypeScript 2.4 bug (DefinitelyTyped#27810)
     // tslint:disable-next-line:no-unnecessary-generics
     <TElement extends HTMLElement = HTMLElement>(html: JQuery.htmlString, ownerDocument_attributes?: Document | JQuery.PlainObject): JQuery<TElement>;
     /**
@@ -140,6 +141,7 @@ interface JQueryStatic {
      * @see \`{@link https://api.jquery.com/jQuery/ }\`
      * @since 1.0
      */
+    // Using a unified signature is not possible due to a TypeScript 2.4 bug (DefinitelyTyped#27810)
     // tslint:disable-next-line:no-unnecessary-generics
     <TElement extends Element = HTMLElement>(selector: JQuery.Selector, context?: Element | Document | JQuery): JQuery<TElement>;
     /**

--- a/types/jquery/index.d.ts
+++ b/types/jquery/index.d.ts
@@ -146,21 +146,32 @@ interface JQueryStatic {
      * Return a collection of matched elements either found in the DOM based on passed argument(s) or created
      * by passing an HTML string.
      *
-     * @param element_elementArray A DOM element to wrap in a jQuery object.
-     *                             An array containing a set of DOM elements to wrap in a jQuery object.
+     * @param element A DOM element to wrap in a jQuery object.
      * @see \`{@link https://api.jquery.com/jQuery/ }\`
      * @since 1.0
      */
-    <T extends Element>(element_elementArray: T | ArrayLike<T>): JQuery<T>;
+    // tslint:disable-next-line:unified-signatures
+    <T extends Element>(element: T): JQuery<T>;
+    /**
+     * Return a collection of matched elements either found in the DOM based on passed argument(s) or created
+     * by passing an HTML string.
+     *
+     * @param elementArray An array containing a set of DOM elements to wrap in a jQuery object.
+     * @see \`{@link https://api.jquery.com/jQuery/ }\`
+     * @since 1.0
+     */
+    // tslint:disable-next-line:unified-signatures
+    <T extends Element>(elementArray: ArrayLike<T>): JQuery<T>;
     /**
      * Return a collection of matched elements either found in the DOM based on passed argument(s) or created
      * by passing an HTML string.
      *
      * @param selection An existing jQuery object to clone.
+     *                  An array not containing a set of DOM elements.
      * @see \`{@link https://api.jquery.com/jQuery/ }\`
      * @since 1.0
      */
-    <T>(selection: JQuery<T>): JQuery<T>;
+    <T>(selection: ArrayLike<T>): JQuery<T>;
     /**
      * Binds a function to be executed when the DOM has finished loading.
      *

--- a/types/jquery/index.d.ts
+++ b/types/jquery/index.d.ts
@@ -146,22 +146,22 @@ interface JQueryStatic {
      * Return a collection of matched elements either found in the DOM based on passed argument(s) or created
      * by passing an HTML string.
      *
-     * @param element_elementArray A DOM element to wrap in a jQuery object.
+     * @param element A DOM element to wrap in a jQuery object.
      * @see \`{@link https://api.jquery.com/jQuery/ }\`
      * @since 1.0
      */
     // tslint:disable-next-line:unified-signatures
-    <T extends Element>(element_elementArray: T): JQuery<T>;
+    <T extends Element>(element: T): JQuery<T>;
     /**
      * Return a collection of matched elements either found in the DOM based on passed argument(s) or created
      * by passing an HTML string.
      *
-     * @param element_elementArray An array containing a set of DOM elements to wrap in a jQuery object.
+     * @param elementArray An array containing a set of DOM elements to wrap in a jQuery object.
      * @see \`{@link https://api.jquery.com/jQuery/ }\`
      * @since 1.0
      */
     // tslint:disable-next-line:unified-signatures
-    <T extends Element>(element_elementArray: T[]): JQuery<T>;
+    <T extends Element>(elementArray: T[]): JQuery<T>;
     /**
      * Return a collection of matched elements either found in the DOM based on passed argument(s) or created
      * by passing an HTML string.

--- a/types/jquery/index.d.ts
+++ b/types/jquery/index.d.ts
@@ -147,11 +147,21 @@ interface JQueryStatic {
      * by passing an HTML string.
      *
      * @param element_elementArray A DOM element to wrap in a jQuery object.
-     *                             An array containing a set of DOM elements to wrap in a jQuery object.
      * @see \`{@link https://api.jquery.com/jQuery/ }\`
      * @since 1.0
      */
-    <T extends Element>(element_elementArray: T | T[]): JQuery<T>;
+    // tslint:disable-next-line:unified-signatures
+    <T extends Element>(element_elementArray: T): JQuery<T>;
+    /**
+     * Return a collection of matched elements either found in the DOM based on passed argument(s) or created
+     * by passing an HTML string.
+     *
+     * @param element_elementArray An array containing a set of DOM elements to wrap in a jQuery object.
+     * @see \`{@link https://api.jquery.com/jQuery/ }\`
+     * @since 1.0
+     */
+    // tslint:disable-next-line:unified-signatures
+    <T extends Element>(element_elementArray: T[]): JQuery<T>;
     /**
      * Return a collection of matched elements either found in the DOM based on passed argument(s) or created
      * by passing an HTML string.

--- a/types/jquery/jquery-tests.ts
+++ b/types/jquery/jquery-tests.ts
@@ -42,7 +42,7 @@ function JQueryStatic() {
         $([new HTMLParagraphElement()]);
 
         // $ExpectType JQuery<{ foo: string; hello: string; }>
-        $({ foo: 'baz', hello: 'world' });
+        $({ foo: 'bar', hello: 'world' });
 
         // $ExpectType JQuery<SVGSVGElement>
         $($(document.createElementNS("http://www.w3.org/2000/svg", "svg")));

--- a/types/jquery/jquery-tests.ts
+++ b/types/jquery/jquery-tests.ts
@@ -69,6 +69,18 @@ function JQueryStatic() {
         // $ExpectType JQuery<Element>
         $<Element>();
 
+        // $ExpectType JQuery<HTMLSelectElement>
+        $(new HTMLSelectElement());
+
+        // $ExpectType JQuery<HTMLSelectElement>
+        $([new HTMLSelectElement()]);
+
+        // $ExpectType JQuery<HTMLSelectElement[]>
+        $([[new HTMLSelectElement()]]);
+
+        // $ExpectType JQuery<HTMLSelectElement[][]>
+        $([[[new HTMLSelectElement()]]]);
+
         // https://github.com/DefinitelyTyped/DefinitelyTyped/issues/19597#issuecomment-378218432
         function issue_19597_378218432() {
             const myDiv = $(document.createElement('div'));

--- a/types/jquery/jquery-tests.ts
+++ b/types/jquery/jquery-tests.ts
@@ -42,7 +42,7 @@ function JQueryStatic() {
         $([new HTMLParagraphElement()]);
 
         // $ExpectType JQuery<{ foo: string; hello: string; }>
-        $({ foo: 'bar', hello: 'world' });
+        $({ foo: 'baz', hello: 'world' });
 
         // $ExpectType JQuery<SVGSVGElement>
         $($(document.createElementNS("http://www.w3.org/2000/svg", "svg")));

--- a/types/jquery/jquery-tests.ts
+++ b/types/jquery/jquery-tests.ts
@@ -75,12 +75,6 @@ function JQueryStatic() {
         // $ExpectType JQuery<HTMLSelectElement>
         $([new HTMLSelectElement()]);
 
-        // $ExpectType JQuery<HTMLSelectElement[]>
-        $([[new HTMLSelectElement()]]);
-
-        // $ExpectType JQuery<HTMLSelectElement[][]>
-        $([[[new HTMLSelectElement()]]]);
-
         // https://github.com/DefinitelyTyped/DefinitelyTyped/issues/19597#issuecomment-378218432
         function issue_19597_378218432() {
             const myDiv = $(document.createElement('div'));

--- a/types/jquery/test/example-tests.ts
+++ b/types/jquery/test/example-tests.ts
@@ -10,7 +10,7 @@ function examples() {
     }
 
     function add_2() {
-        $('p').clone().add('<span>Again</span>').appendTo(document.body);
+        $('p').clone().add('<span>Again</span>').appendTo(document.body!);
     }
 
     function add_3() {
@@ -1365,7 +1365,7 @@ function examples() {
     }
 
     function each_0() {
-        $(document.body).click(function() {
+        $(document.body!).click(function() {
             $('div').each(function(i) {
                 if (this.style.color !== 'blue') {
                     this.style.color = 'blue';
@@ -1648,7 +1648,7 @@ function examples() {
     }
 
     function fade_in_0() {
-        $(document.body).click(function() {
+        $(document.body!).click(function() {
             $('div:hidden:first').fadeIn('slow');
         });
     }
@@ -1927,7 +1927,7 @@ function examples() {
     }
 
     function get_0() {
-        $('*', document.body).click(function(event) {
+        $('*', document.body!).click(function(event) {
             event.stopPropagation();
             var domElement = $(this).get(0);
             $('span:first').text('Clicked on - ' + domElement.nodeName);
@@ -2043,7 +2043,7 @@ function examples() {
 
     function hide_3() {
         for (var i = 0; i < 5; i++) {
-            $('<div>').appendTo(document.body);
+            $('<div>').appendTo(document.body!);
         }
         $('div').click(function() {
             $(this).hide(2000, function() {
@@ -2320,8 +2320,8 @@ function examples() {
     }
 
     function jQuery_contains_0() {
-        $.contains(document.documentElement, document.body); // true
-        $.contains(document.body, document.documentElement); // false
+        $.contains(document.documentElement!, document.body!); // true
+        $.contains(document.body!, document.documentElement!); // false
     }
 
     function jQuery_data_0() {
@@ -2731,7 +2731,7 @@ function examples() {
 
     function jQuery_is_xml_doc_0() {
         jQuery.isXMLDoc(document); // false
-        jQuery.isXMLDoc(document.body); // false
+        jQuery.isXMLDoc(document.body!); // false
     }
 
     function jQuery_make_array_0() {
@@ -2741,7 +2741,7 @@ function examples() {
         var arr = jQuery.makeArray(elems);
         // Use an Array method on list of dom elements
         arr.reverse();
-        $(arr).appendTo(document.body);
+        $(arr).appendTo(document.body!);
     }
 
     function jQuery_make_array_1() {
@@ -3120,7 +3120,7 @@ function examples() {
     }
 
     function jQuery_queue_1() {
-        $(document.body).click(function() {
+        $(document.body!).click(function() {
             var divs = $('div')
                 .show('slow')
                 .animate({ left: '+=200' }, 2000);
@@ -3262,7 +3262,7 @@ function examples() {
     }
 
     function jQuery_3() {
-        $(document.body).css('background', 'black');
+        $(document.body!).css('background', 'black');
     }
 
     function jQuery_4(myForm: HTMLFormElement) {
@@ -3382,9 +3382,9 @@ function examples() {
     }
 
     function length_0() {
-        $(document.body)
+        $(document.body!)
             .click(function() {
-                $(document.body).append($('<div>'));
+                $(document.body!).append($('<div>'));
                 var n = $('div').length;
                 $('span').text('There are ' + n + ' divs.' +
                     'Click to add more.');
@@ -3757,7 +3757,7 @@ function examples() {
     }
 
     function offset_1() {
-        $('*', document.body).click(function(event) {
+        $('*', document.body!).click(function(event) {
             var offset = $(this).offset()!;
             event.stopPropagation();
             $('#result').text(this.tagName +
@@ -3938,7 +3938,7 @@ function examples() {
     }
 
     function parent_1() {
-        $('*', document.body).each(function() {
+        $('*', document.body!).each(function() {
             var parentTag = $(this).parent().get(0).tagName;
             $(this).prepend(document.createTextNode(parentTag + ' > '));
         });
@@ -4134,7 +4134,7 @@ function examples() {
     }
 
     function queue_1() {
-        $(document.body).click(function() {
+        $(document.body!).click(function() {
             $('div')
                 .show('slow')
                 .animate({ left: '+=200' }, 2000)
@@ -4311,9 +4311,9 @@ function examples() {
     }
 
     function scroll_0() {
-        $('p').clone().appendTo(document.body);
-        $('p').clone().appendTo(document.body);
-        $('p').clone().appendTo(document.body);
+        $('p').clone().appendTo(document.body!);
+        $('p').clone().appendTo(document.body!);
+        $('p').clone().appendTo(document.body!);
         $(window).scroll(function() {
             $('span').css('display', 'inline').fadeOut('slow');
         });
@@ -4478,7 +4478,7 @@ function examples() {
     }
 
     function slide_down_0() {
-        $(document.body).click(function() {
+        $(document.body!).click(function() {
             if ($('div:first').is(':hidden')) {
                 $('div').slideDown('slow');
             } else {
@@ -4520,7 +4520,7 @@ function examples() {
     }
 
     function slide_up_0() {
-        $(document.body).click(function() {
+        $(document.body!).click(function() {
             if ($('div:first').is(':hidden')) {
                 $('div').show('slow');
             } else {

--- a/types/jquery/test/example-tests.ts
+++ b/types/jquery/test/example-tests.ts
@@ -10,7 +10,7 @@ function examples() {
     }
 
     function add_2() {
-        $('p').clone().add('<span>Again</span>').appendTo(document.body!);
+        $('p').clone().add('<span>Again</span>').appendTo(document.body);
     }
 
     function add_3() {
@@ -1365,7 +1365,7 @@ function examples() {
     }
 
     function each_0() {
-        $(document.body!).click(function() {
+        $(document.body).click(function() {
             $('div').each(function(i) {
                 if (this.style.color !== 'blue') {
                     this.style.color = 'blue';
@@ -1648,7 +1648,7 @@ function examples() {
     }
 
     function fade_in_0() {
-        $(document.body!).click(function() {
+        $(document.body).click(function() {
             $('div:hidden:first').fadeIn('slow');
         });
     }
@@ -1927,7 +1927,7 @@ function examples() {
     }
 
     function get_0() {
-        $('*', document.body!).click(function(event) {
+        $('*', document.body).click(function(event) {
             event.stopPropagation();
             var domElement = $(this).get(0);
             $('span:first').text('Clicked on - ' + domElement.nodeName);
@@ -2043,7 +2043,7 @@ function examples() {
 
     function hide_3() {
         for (var i = 0; i < 5; i++) {
-            $('<div>').appendTo(document.body!);
+            $('<div>').appendTo(document.body);
         }
         $('div').click(function() {
             $(this).hide(2000, function() {
@@ -2320,8 +2320,8 @@ function examples() {
     }
 
     function jQuery_contains_0() {
-        $.contains(document.documentElement!, document.body!); // true
-        $.contains(document.body!, document.documentElement!); // false
+        $.contains(document.documentElement!, document.body); // true
+        $.contains(document.body, document.documentElement!); // false
     }
 
     function jQuery_data_0() {
@@ -2731,7 +2731,7 @@ function examples() {
 
     function jQuery_is_xml_doc_0() {
         jQuery.isXMLDoc(document); // false
-        jQuery.isXMLDoc(document.body!); // false
+        jQuery.isXMLDoc(document.body); // false
     }
 
     function jQuery_make_array_0() {
@@ -2741,7 +2741,7 @@ function examples() {
         var arr = jQuery.makeArray(elems);
         // Use an Array method on list of dom elements
         arr.reverse();
-        $(arr).appendTo(document.body!);
+        $(arr).appendTo(document.body);
     }
 
     function jQuery_make_array_1() {
@@ -3120,7 +3120,7 @@ function examples() {
     }
 
     function jQuery_queue_1() {
-        $(document.body!).click(function() {
+        $(document.body).click(function() {
             var divs = $('div')
                 .show('slow')
                 .animate({ left: '+=200' }, 2000);
@@ -3262,7 +3262,7 @@ function examples() {
     }
 
     function jQuery_3() {
-        $(document.body!).css('background', 'black');
+        $(document.body).css('background', 'black');
     }
 
     function jQuery_4(myForm: HTMLFormElement) {
@@ -3382,9 +3382,9 @@ function examples() {
     }
 
     function length_0() {
-        $(document.body!)
+        $(document.body)
             .click(function() {
-                $(document.body!).append($('<div>'));
+                $(document.body).append($('<div>'));
                 var n = $('div').length;
                 $('span').text('There are ' + n + ' divs.' +
                     'Click to add more.');
@@ -3757,7 +3757,7 @@ function examples() {
     }
 
     function offset_1() {
-        $('*', document.body!).click(function(event) {
+        $('*', document.body).click(function(event) {
             var offset = $(this).offset()!;
             event.stopPropagation();
             $('#result').text(this.tagName +
@@ -3938,7 +3938,7 @@ function examples() {
     }
 
     function parent_1() {
-        $('*', document.body!).each(function() {
+        $('*', document.body).each(function() {
             var parentTag = $(this).parent().get(0).tagName;
             $(this).prepend(document.createTextNode(parentTag + ' > '));
         });
@@ -4134,7 +4134,7 @@ function examples() {
     }
 
     function queue_1() {
-        $(document.body!).click(function() {
+        $(document.body).click(function() {
             $('div')
                 .show('slow')
                 .animate({ left: '+=200' }, 2000)
@@ -4311,9 +4311,9 @@ function examples() {
     }
 
     function scroll_0() {
-        $('p').clone().appendTo(document.body!);
-        $('p').clone().appendTo(document.body!);
-        $('p').clone().appendTo(document.body!);
+        $('p').clone().appendTo(document.body);
+        $('p').clone().appendTo(document.body);
+        $('p').clone().appendTo(document.body);
         $(window).scroll(function() {
             $('span').css('display', 'inline').fadeOut('slow');
         });
@@ -4478,7 +4478,7 @@ function examples() {
     }
 
     function slide_down_0() {
-        $(document.body!).click(function() {
+        $(document.body).click(function() {
             if ($('div:first').is(':hidden')) {
                 $('div').slideDown('slow');
             } else {
@@ -4520,7 +4520,7 @@ function examples() {
     }
 
     function slide_up_0() {
-        $(document.body!).click(function() {
+        $(document.body).click(function() {
             if ($('div:first').is(':hidden')) {
                 $('div').show('slow');
             } else {

--- a/types/jquery/test/longdesc-tests.ts
+++ b/types/jquery/test/longdesc-tests.ts
@@ -1339,13 +1339,13 @@ function longdesc() {
     }
 
     function jquery_data_0() {
-        jQuery.data(document.body, 'foo', 52);
-        jQuery.data(document.body, 'bar', 'test');
+        jQuery.data(document.body!, 'foo', 52);
+        jQuery.data(document.body!, 'bar', 'test');
     }
 
     function jquery_data_1() {
-        alert(jQuery.data(document.body, 'foo'));
-        alert(jQuery.data(document.body));
+        alert(jQuery.data(document.body!, 'foo'));
+        alert(jQuery.data(document.body!));
     }
 
     function jquery_each_0() {

--- a/types/jquery/test/longdesc-tests.ts
+++ b/types/jquery/test/longdesc-tests.ts
@@ -1339,13 +1339,13 @@ function longdesc() {
     }
 
     function jquery_data_0() {
-        jQuery.data(document.body!, 'foo', 52);
-        jQuery.data(document.body!, 'bar', 'test');
+        jQuery.data(document.body, 'foo', 52);
+        jQuery.data(document.body, 'bar', 'test');
     }
 
     function jquery_data_1() {
-        alert(jQuery.data(document.body!, 'foo'));
-        alert(jQuery.data(document.body!));
+        alert(jQuery.data(document.body, 'foo'));
+        alert(jQuery.data(document.body));
     }
 
     function jquery_each_0() {

--- a/types/select2/select2-tests.ts
+++ b/types/select2/select2-tests.ts
@@ -774,7 +774,7 @@ const selectedData: Select2.OptionData[] = $("#mySelect2").select2("data");
 // jQuery Generic
 
 declare let select: HTMLSelectElement;
-const $select: JQuery<HTMLSelectElement> = $(select) as JQuery<HTMLSelectElement>;
+const $select: JQuery<HTMLSelectElement> = $(select);
 
 select = $select.select2().get(0);
 select = $select.select2({tags: true}).get(0);


### PR DESCRIPTION
Following a major change in typescript dom library Microsoft/TypeScript#25944, a problem appeared in select2 tests (#27792) that may come from the jQuery type definition.

In typescript@next `lib.dom.d.ts`, the `HTMLSelectElement` definition has changed from:
```typescript
interface HTMLSelectElement extends HTMLElement {
    // ...
    length: number;
    [name: string]: any;
}
```
to
```typescript
interface HTMLSelectElement extends HTMLElement {
    // ...
    length: number;
    [name: number]: HTMLOptionElement | HTMLOptGroupElement;
}
```
Thereby, `HTMLSelectElement` is now a `ArrayLike<HTMLOptionElement | HTMLOptGroupElement>`.

This has as consequence that `$(new HTMLSelectElement())` is now inferred as `JQuery<HTMLOptionElement | HTMLOptGroupElement>` instead of `JQuery<HTMLSelectElement>`.
This is because of the definition:
```typescript
    <T extends Element>(element_elementArray: T | ArrayLike<T>): JQuery<T>;
```
the `ArrayLike<T>` has been considered instead of the `T` in or case.

One way to solve this is to break the method in two:
```typescript
    <T extends Element>(element_elementArray: T): JQuery<T>;
    <T extends Element>(element_elementArray: ArrayLike<T>): JQuery<T>;
```
Such that `T` always has "priority" on `ArrayLike<T>`. As the code: [init.js](https://github.com/jquery/jquery/blob/c9aae3565edc840961ecbeee77fb0cb367c46702/src/core/init.js#L103-L118).

~~In parallel to this, I discovered another problem. The expression `$([[new HTMLParagraphElement()]])` is wrongly inferred as `JQuery<HTMLParagraphElement[][]>` instead of `JQuery<HTMLParagraphElement[]>`. This can be solved by adding a method ```<T>(object: ArrayLike<T>): JQuery<T>;```~~

In summary, I propose to change:

```typescript
interface JQueryStatic {
    //...
    <T extends Element>(element_elementArray: T | ArrayLike<T>): JQuery<T>;
    // Edit: ~~<T>(selection: JQuery<T>): JQuery<T>;~~
}
```
by 
```typescript
interface JQueryStatic {
    //...
    <T extends Element>(element: T): JQuery<T>;
    <T extends Element>(elementArray: ArrayLike<T>): JQuery<T>;
    // Edit: ~~<T>(array: ArrayLike<T>): JQuery<T>;~~
}
```

~~As `JQuery<.>` is an `ArrayLike`, the `<T>(selection: JQuery<T>): JQuery<T>` is redundant.~~

Also add the following tests:

```typescript
// $ExpectType JQuery<HTMLSelectElement>
$(new HTMLSelectElement());

// $ExpectType JQuery<HTMLSelectElement>
$([new HTMLSelectElement()]);
```

CI build fail is related to HTMLElement missing style and innerHTML property (Microsoft/TypeScript#26123), and other libraries who are not update for typescript@next yet.
