### PR TITLE
Add type definition for error-subclass

### DIFF
--- a/types/error-subclass/error-subclass-tests.ts
+++ b/types/error-subclass/error-subclass-tests.ts
@@ -1,0 +1,7 @@
+import ErrorSubclass from 'error-subclass';
+
+class ExampleError extends ErrorSubclass {
+    static displayName = 'ExampleError';
+}
+
+throw new ExampleError('Something went wrong!');

--- a/types/error-subclass/index.d.ts
+++ b/types/error-subclass/index.d.ts
@@ -1,0 +1,8 @@
+// Type definitions for error-subclass 2.2
+// Project: https://github.com/spudly/error-subclass#readme
+// Definitions by: Fitbit <https://github.com/fitbit>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export default class ErrorSubclass extends Error {
+    static displayName: string;
+}

--- a/types/error-subclass/tsconfig.json
+++ b/types/error-subclass/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "strictFunctionTypes": true
+    },
+    "files": [
+        "index.d.ts",
+        "error-subclass-tests.ts"
+    ]
+}

--- a/types/error-subclass/tslint.json
+++ b/types/error-subclass/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.