### PR TITLE
Fix typings to support postmark.js package

### DIFF
--- a/types/postmark/index.d.ts
+++ b/types/postmark/index.d.ts
@@ -1,10 +1,10 @@
-// Type definitions for postmark 1.6.1
+// Type definitions for postmark 1.6
 // Project: http://wildbit.github.io/postmark.js
 // Definitions by: Ben Bayard <https://github.com/benbayard>, Sascha Wolff <https://github.com/justdoitsascha>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.4
 
-declare namespace Postmark {
+declare module Postmark {
     const defaults: Options;
 
     interface PostmarkError {

--- a/types/postmark/index.d.ts
+++ b/types/postmark/index.d.ts
@@ -1,12 +1,9 @@
-// Type definitions for postmark 1.4
+// Type definitions for postmark 1.6.1
 // Project: http://wildbit.github.io/postmark.js
-// Definitions by: Ben Bayard <https://github.com/benbayard>
+// Definitions by: Ben Bayard <https://github.com/benbayard>, Sascha Wolff <https://github.com/justdoitsascha>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.4
 
-export = postmark;
-
-declare const postmark: Postmark.Postmark;
 declare namespace Postmark {
     const defaults: Options;
 
@@ -666,3 +663,5 @@ declare namespace Postmark {
         WithReadTimeRecorded: number;
     }
 }
+
+export = Postmark;

--- a/types/postmark/postmark-tests.ts
+++ b/types/postmark/postmark-tests.ts
@@ -1,6 +1,8 @@
-import postmark = require('postmark');
+/// <reference path="index.d.ts" />
 
-declare var options: typeof postmark.defaults;
+import { AdminClient, Client, Options } from 'postmark';
+
+declare var options: Options;
 const message = { To: 'me', From: 'you' };
 const templateMessage = {...message, TemplateId: '1'};
 const filter = { offset: 0 };
@@ -13,8 +15,8 @@ const templateValidator = {
 
 declare function callback(err: any, data: any): undefined;
 
-const client = new postmark.Client('124345', options);
-const adminClient = new postmark.AdminClient('1123235', options);
+const client = new Client('124345', options);
+const adminClient = new AdminClient('1123235', options);
 
 client.send(message, callback);
 client.sendEmailWithTemplate(templateMessage, callback);

--- a/types/postmark/postmark-tests.ts
+++ b/types/postmark/postmark-tests.ts
@@ -1,5 +1,3 @@
-/// <reference path="index.d.ts" />
-
 import { AdminClient, Client, Options } from 'postmark';
 
 declare var options: Options;


### PR DESCRIPTION
The Typings didn't work correctly with postmark.js 1.6.1, so I fixed it.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Increase the version number in the header if appropriate.
