### PR TITLE
Bull: Add types to some private functions

### DIFF
--- a/types/bull/index.d.ts
+++ b/types/bull/index.d.ts
@@ -9,6 +9,7 @@
 //                 David Koblas <https://github.com/koblas>
 //                 Bond Akinmade <https://github.com/bondz>
 //                 Wuha Team <https://github.com/wuha-team>
+//                 Alec Brunelle <https://github.com/aleccool213>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 

--- a/types/bull/v2/index.d.ts
+++ b/types/bull/v2/index.d.ts
@@ -56,12 +56,14 @@ declare module "bull" {
             finished(): Promise<void>;
 
             /**
-             * Moves a job to the completed queue and moves a new job from 'waiting' to 'active'.
+             * Moves a job to the `completed` queue. Pulls a job from 'waiting' to
+             * 'active' and returns a tuple containing the next jobs data and id. If no
+             * job is in the `waiting` queue, returns null.
              * @param returnValue The jobs success message.
              * @param ignoreLock True when wanting to ignore the redis lock on this job.
-             * @returns Returns the id of the pulled job.
+             * @returns Contains the next jobs data and id or null if job left in 'waiting' queue.
              */
-            moveToCompleted(returnValue: string, ignoreLock: boolean): Promise<string[]>;
+            moveToCompleted(returnValue: string, ignoreLock: boolean): Promise<string[] | null>;
 
             /**
              * Moves a job to the failed queue.

--- a/types/bull/v2/index.d.ts
+++ b/types/bull/v2/index.d.ts
@@ -54,6 +54,22 @@ declare module "bull" {
              * since pubsub does not give any guarantees.
              */
             finished(): Promise<void>;
+
+            /**
+             * Moves a job to the completed queue and moves a new job from 'waiting' to 'active'.
+             * @param returnValue The jobs success message.
+             * @param ignoreLock True when wanting to ignore the redis lock on this job.
+             * @returns Returns the id of the pulled job.
+             */
+            moveToCompleted(returnValue: string, ignoreLock: boolean): Promise<string[]>;
+
+            /**
+             * Moves a job to the failed queue.
+             * @param errorInfo The jobs error message.
+             * @param ignoreLock True when wanting to ignore the redis lock on this job.
+             * @returns void
+             */
+            moveToFailed(errorInfo: ErrorMessage, ignoreLock: boolean): Promise<void>;
         }
 
         export interface Backoff {
@@ -204,7 +220,7 @@ declare module "bull" {
              * Returns a promise that will return the job instance associated with the jobId parameter.
              * If the specified job cannot be located, the promise callback parameter will be set to null.
              */
-            getJob(jobId: string): Promise<Job>;
+            getJob(jobId: string): Promise<Job | null>;
 
             /**
              * Tells the queue remove all jobs created outside of a grace period in milliseconds.
@@ -217,6 +233,18 @@ declare module "bull" {
              * 'ready', 'error', 'activ', 'progress', 'completed', 'failed', 'paused', 'resumed', 'cleaned'
              */
             on(eventName: string, callback: EventCallback): void;
+
+            /**
+             * Moves the next job from 'waiting' to 'active'.
+             * Sets the processedOn timestamp to the current datetime.
+             * @param jobId If specified, will move a specific job from 'waiting' to 'active',
+             * @returns Returns the job moved from waiting to active queue.
+             */
+            getNextJob:(jobId?: string) => Promise<Job | null>;
+        }
+
+        interface ErrorMessage {
+            message: string;
         }
 
         interface EventCallback {


### PR DESCRIPTION
- Job.moveToCompleted
- Job.moveToFailed
- Queue.getNextJob
- Also add null possibility to Queue.getJob

Me and my team are using these functions to implement a multiple-repo job processor service (despite being told by the author that this pattern for Bull isn't [supported](https://github.com/OptimalBits/bull/issues/208#issuecomment-157497444) or [planned](https://github.com/OptimalBits/bull/issues/790#issuecomment-345387700)). We are manually moving jobs from state to state as the `process` function is not being used. Work for a job is being done in another repo and we are exposing these functions via an API. We know these functions are private currently but hopefully with this exposure and a future PR to the actual Bull repo, we can get these functions to be public. We have this working in production for hundreds of jobs per day and this pattern seems to be working just fine.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
- https://github.com/OptimalBits/bull/blob/742a86e0af0e7d829e7d9cea55b74e7f7e850938/lib/job.js#L182
- https://github.com/OptimalBits/bull/blob/742a86e0af0e7d829e7d9cea55b74e7f7e850938/lib/job.js#L203
- https://github.com/OptimalBits/bull/blob/742a86e0af0e7d829e7d9cea55b74e7f7e850938/lib/queue.js#L1055
