### PR TITLE
[knex] Allow QueryBuilder in union parameters

### DIFF
--- a/types/knex/index.d.ts
+++ b/types/knex/index.d.ts
@@ -312,9 +312,9 @@ declare namespace Knex {
     }
 
     interface Union {
-        (callback: QueryCallback | QueryBuilder, wrap?: boolean): QueryBuilder;
-        (callbacks: (QueryCallback | QueryBuilder)[], wrap?: boolean): QueryBuilder;
-        (...callbacks: (QueryCallback | QueryBuilder)[]): QueryBuilder;
+        (callback: QueryCallback | QueryBuilder | Raw, wrap?: boolean): QueryBuilder;
+        (callbacks: (QueryCallback | QueryBuilder | Raw)[], wrap?: boolean): QueryBuilder;
+        (...callbacks: (QueryCallback | QueryBuilder | Raw)[]): QueryBuilder;
         // (...callbacks: QueryCallback[], wrap?: boolean): QueryInterface;
     }
 

--- a/types/knex/index.d.ts
+++ b/types/knex/index.d.ts
@@ -312,9 +312,9 @@ declare namespace Knex {
     }
 
     interface Union {
-        (callback: QueryCallback, wrap?: boolean): QueryBuilder;
-        (callbacks: QueryCallback[], wrap?: boolean): QueryBuilder;
-        (...callbacks: QueryCallback[]): QueryBuilder;
+        (callback: QueryCallback | QueryBuilder, wrap?: boolean): QueryBuilder;
+        (callbacks: (QueryCallback | QueryBuilder)[], wrap?: boolean): QueryBuilder;
+        (...callbacks: (QueryCallback | QueryBuilder)[]): QueryBuilder;
         // (...callbacks: QueryCallback[], wrap?: boolean): QueryInterface;
     }
 

--- a/types/knex/knex-tests.ts
+++ b/types/knex/knex-tests.ts
@@ -1145,3 +1145,19 @@ knex('characters')
     .whereIn(['name', 'class'], function() {
         this.select('name', 'class').from('characters');
     });
+
+knex('characters')
+    .select()
+    .where({ name: 'Bar', class: 'Fighter' })
+    .union(knex('characters').select().where({ name: 'Foo', class: 'Druid' }));
+knex('characters')
+    .select()
+    .where({ name: 'Bar', class: 'Fighter' })
+    .union([knex('characters').select().where({ name: 'Foo', class: 'Druid' })]);
+knex('characters')
+    .select()
+    .where({ name: 'Bar', class: 'Fighter' })
+    .union(
+        knex('characters').select().where({ name: 'Foo', class: 'Druid' }),
+        knex('characters').select().where({ name: 'Baz', class: 'Paladin' })
+    );


### PR DESCRIPTION
This isn't obvious from the code, but it seems the type of `this._statements` is

```typescript
Array<QueryBuilder | QueryCallback | Raw>
```

I'll see about putting together a PR to add more tests to `knex` for testing these cases. I've written some tests in a local checkout of `knex`, so I'm confident that this particular change is correct. I've also tested in the project I'm using `knex` with and it works like a charm!

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/tgriesser/knex/blob/master/src/query/builder.js#L526-L549
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
