### PR TITLE
Stripe: added trial_from_plan to ISubscriptionCustCreationOptions interface

### DIFF
--- a/types/stripe/index.d.ts
+++ b/types/stripe/index.d.ts
@@ -4680,6 +4680,12 @@ declare namespace Stripe {
             trial_period_days?: number;
 
             /**
+             * Indicates if a plan’s trial_period_days should be applied to the subscription. Setting trial_end per subscription is preferred, 
+             * and this defaults to false. Setting this flag to true together with trial_end is not allowed.
+             */
+            trial_from_plan?: boolean;
+
+            /**
              * List of subscription items, each with an attached plan.
              */
             items?: ISubscriptionCreationItem[];


### PR DESCRIPTION
This property was added to the Stripe API on 2018-05-21

[Stripe API Change Log](https://stripe.com/docs/upgrades#2018-05-21)
[Stripe API Docs](https://stripe.com/docs/api#create_subscription-trial_from_plan)

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
