### PR TITLE
Allow readonly parameters to @storybook/addon-knobs

### DIFF
--- a/types/storybook__addon-knobs/index.d.ts
+++ b/types/storybook__addon-knobs/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/storybooks/storybook
 // Definitions by: Joscha Feth <https://github.com/joscha>
 //                 Martynas Kadisa <https://github.com/martynaskadisa>
+//                 A.MacLeay <https://github.com/amacleay>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.6
 
@@ -49,11 +50,11 @@ export function object<T>(name: string, value: T, groupId?: string): T;
 export type SelectValue = string | number;
 export function select<T extends string>(name: string, options: { [s: string]: string }, value: T, groupId?: string): T;
 export function select<T extends number>(name: string, options: { [s: number]: string }, value: T, groupId?: string): T;
-export function select<T extends SelectValue>(name: string, options: T[], value: T, groupId?: string): T;
+export function select<T extends SelectValue>(name: string, options: ReadonlyArray<T>, value: T, groupId?: string): T;
 
 export function date(name: string, value?: Date, groupId?: string): Date;
 
-export function array<T>(name: string, value: T[], separator?: string, groupId?: string): T[];
+export function array<T>(name: string, value: ReadonlyArray<T>, separator?: string, groupId?: string): T[];
 
 export function button(name: string, handler: () => any, groupId?: string): void;
 

--- a/types/storybook__addon-knobs/storybook__addon-knobs-tests.tsx
+++ b/types/storybook__addon-knobs/storybook__addon-knobs-tests.tsx
@@ -90,6 +90,14 @@ stories.add('dynamic knobs', () => {
   );
 });
 
+const readonlyOptionsArray: ReadonlyArray<string> = ['hi'];
+select('With readonly array', readonlyOptionsArray, readonlyOptionsArray[0]);
+
+const genericArray = array('With regular array', ['hi', 'there']);
+
+const userInputArray = array('With readonly array', readonlyOptionsArray);
+userInputArray.push('Make sure that the output is still mutable although the input need not be!');
+
 // groups
 const groupId = 'GROUP-ID1';
 


### PR DESCRIPTION
Since these functions don't modify their parameters, they may be
readonly. Non-breaking change as mutable arrays are still allowed as
well.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: relevant source code (note no mutations of `options.defaultValue`: https://github.com/storybooks/storybook/blob/release/3.4/addons/knobs/src/KnobManager.js#L17
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

