### PR TITLE
kendo-ui: added missing drag and drop data definitions

### DIFF
--- a/types/kendo-ui/index.d.ts
+++ b/types/kendo-ui/index.d.ts
@@ -20299,16 +20299,19 @@ interface JQueryPromise<T> {
 
 interface JQuery {
 
+    data(key: any): any;
+
     kendoDraggable(): JQuery;
     kendoDraggable(options: kendo.ui.DraggableOptions): JQuery;
+    data(key: "kendoDraggable"): kendo.ui.Draggable;
 
     kendoDropTarget(): JQuery;
     kendoDropTarget(options: kendo.ui.DropTargetOptions): JQuery;
+    data(key: "kendoDropTarget"): kendo.ui.DropTarget;
 
     kendoDropTargetArea(): JQuery;
     kendoDropTargetArea(options: kendo.ui.DropTargetAreaOptions): JQuery;
-
-    data(key: any): any;
+    data(key: "kendoDropTargetArea"): kendo.ui.DropTargetArea;
 
     kendoAlert(): JQuery;
     kendoAlert(options: kendo.ui.AlertOptions): JQuery;


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
kendo-ui: added missing drag and drop data definitions
Drag and Drop components had missing definitions related to JQuery data

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://demos.telerik.com/kendo-ui/dragdrop/index>>
<<https://docs.telerik.com/kendo-ui/intro/installation/jquery-initialization>>