### PR TITLE
material__menu CornerBit interface is wrong

### DIFF
--- a/types/material__menu/constants.d.ts
+++ b/types/material__menu/constants.d.ts
@@ -67,11 +67,11 @@ export interface CornerBit extends MDCNumbers {
  */
 export interface Corner extends MDCNumbers {
   TOP_LEFT: 0;
-  TOP_RIGHT: CornerBit["RIGHT"];
-  BOTTOM_LEFT: CornerBit["BOTTOM"];
-  BOTTOM_RIGHT: CornerBit["BOTTOM"] | CornerBit["RIGHT"];
-  TOP_START: CornerBit["FLIP_RTL"];
-  TOP_END: CornerBit["FLIP_RTL"] | CornerBit["RIGHT"];
-  BOTTOM_START: CornerBit["BOTTOM"] | CornerBit["FLIP_RTL"];
-  BOTTOM_END: CornerBit["BOTTOM"] | CornerBit["RIGHT"] | CornerBit["FLIP_RTL"];
+  TOP_RIGHT: 4;
+  TOP_START: 8;
+  TOP_END: 12;
+  BOTTOM_LEFT: 1;
+  BOTTOM_RIGHT: 5;
+  BOTTOM_START: 9;
+  BOTTOM_END: 13;
 }

--- a/types/material__menu/constants.d.ts
+++ b/types/material__menu/constants.d.ts
@@ -66,12 +66,12 @@ export interface CornerBit extends MDCNumbers {
  * Likewise END maps to RIGHT or LEFT depending on the directionality.
  */
 export interface Corner extends MDCNumbers {
-  TOP_LEFT: 0;
-  TOP_RIGHT: 4;
-  TOP_START: 8;
-  TOP_END: 12;
-  BOTTOM_LEFT: 1;
-  BOTTOM_RIGHT: 5;
-  BOTTOM_START: 9;
-  BOTTOM_END: 13;
+    TOP_LEFT: 0;
+    TOP_RIGHT: 4;
+    BOTTOM_LEFT: 1;
+    BOTTOM_RIGHT: 5;
+    TOP_START: 8;
+    TOP_END: 12;
+    BOTTOM_START: 9;
+    BOTTOM_END: 13;
 }


### PR DESCRIPTION
fix: The const Corner that this interface shall describe is using | as bitwise operator, in the interface description | is logical or though, so the interface is wrong.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/material-components/material-components-web/blob/master/packages/mdc-menu/constants.js
- [ ] Increase the version number in the header if appropriate.

