### PR TITLE
Update redom-definitions on current state

### DIFF
--- a/types/redom/index.d.ts
+++ b/types/redom/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for redom 3.6
 // Project: https://github.com/redom/redom/
 // Definitions by: Rauli Laine <https://github.com/RauliL>
+//                 Felix Nehrke <https://github.com/nemoinho>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
@@ -12,10 +13,24 @@ export type RedomQueryArgument = RedomQueryArgumentValue | RedomQueryArgumentVal
 
 export interface RedomComponent {
     el: HTMLElement;
+
+    update?(item: any, index: number, data: any, context?: any): void;
+
+    onmount?(): void;
+
+    onremount?(): void;
+
+    onunmount?(): void;
 }
 
 export interface RedomComponentConstructor {
     new (): RedomComponent;
+}
+
+export class ListPool {
+    constructor(View: RedomComponentConstructor, key?: string, initData?: any);
+
+    update(data: any[], context?: any): void;
 }
 
 export class List implements RedomComponent {
@@ -24,6 +39,14 @@ export class List implements RedomComponent {
     constructor(parent: RedomQuery, View: RedomComponentConstructor, key?: string, initData?: any);
 
     update(data: any[], context?: any): void;
+
+    onmount?(): void;
+
+    onremount?(): void;
+
+    onunmount?(): void;
+
+    static extend(parent: RedomQuery, View: RedomComponentConstructor, key?: string, initData?: any): RedomComponentConstructor;
 }
 
 export class Place implements RedomComponent {
@@ -47,8 +70,10 @@ export interface RouterDictionary {
 }
 
 export function html(query: RedomQuery, ...args: RedomQueryArgument[]): HTMLElement;
+export function h(query: RedomQuery, ...args: RedomQueryArgument[]): HTMLElement;
 export function el(query: RedomQuery, ...args: RedomQueryArgument[]): HTMLElement;
 
+export function listPool(View: RedomComponentConstructor, key?: string, initData?: any): ListPool;
 export function list(parent: RedomQuery, View: RedomComponentConstructor, key?: string, initData?: any): List;
 
 export function mount(parent: RedomElement, child: RedomElement, before?: RedomElement): RedomElement;
@@ -65,5 +90,14 @@ export function setStyle(view: RedomElement, arg1: string | object, arg2?: strin
 export function setChildren(parent: RedomElement, children: RedomElement[]): void;
 
 export function svg(query: RedomQuery, ...args: RedomQueryArgument[]): SVGElement;
+export function s(query: RedomQuery, ...args: RedomQueryArgument[]): SVGElement;
 
 export function text(str: string): Text;
+
+export namespace list {
+    function extend(parent: RedomQuery, View: RedomComponentConstructor, key?: string, initData?: any): RedomComponentConstructor;
+}
+
+export namespace svg {
+    function extend(query: RedomQuery): RedomComponentConstructor;
+}

--- a/types/redom/redom-tests.ts
+++ b/types/redom/redom-tests.ts
@@ -4,13 +4,36 @@ const el1: HTMLElement = redom.el('');
 const el2: HTMLElement = redom.el('p', 'Hello, World!', (el: HTMLElement) => { el.setAttribute('ok', '!'); });
 const el3: HTMLElement = redom.html('p', 2, { color: 'red' });
 
-redom.mount(document.body!, el1);
-redom.mount(document.body!, el2, el1);
-redom.unmount(document.body!, el1);
+redom.mount(document.body, el1);
+redom.mount(document.body, el2, el1);
+redom.unmount(document.body, el1);
 
 redom.setAttr(el3, 'ok', '!');
 redom.setAttr(el3, { ok: '!' });
 redom.setStyle(el3, { color: 'blue' });
 redom.setChildren(el1, [el2, el3]);
 
-redom.mount(document.body!, redom.text('Hello, World!'));
+redom.mount(document.body, redom.text('Hello, World!'));
+
+class Td implements redom.RedomComponent {
+    el: HTMLElement;
+    constructor() {
+        this.el = redom.h('td');
+    }
+    update(value: any) {
+        this.el.textContent = value;
+    }
+    onmount() {
+        console.log('mounted td');
+    }
+}
+const Tr = redom.list.extend('tr', Td);
+const table = redom.list('table', Tr);
+table.onmount = () => console.log('mounted table');
+
+table.update([
+    [1, 2],
+    [3, 4],
+]);
+
+redom.mount(document.body, table);


### PR DESCRIPTION
* Add lifecycle-events

* Add exported alias `s()` and `h()`

* Add  definitions for ListPool, because it's exported in redom as well

* Add namespace for list and svg to enable `list.extend` as described in [redom-docs](https://redom.js.org/documentation/#list-extend)

---

Please fill in this template.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - https://redom.js.org/documentation/#list-extend
  - https://redom.js.org/documentation/#listpool
  - https://redom.js.org/documentation/#component-lifecycle
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.