### PR TITLE
Add refInput prop to react-native-text-input-mask

### DIFF
--- a/types/react-native-text-input-mask/index.d.ts
+++ b/types/react-native-text-input-mask/index.d.ts
@@ -12,6 +12,7 @@ export type onChangeTextCallback = (formatted: string, extracted: string) => voi
 export interface TextInputMaskProps extends ReactNative.ViewProps, ReactNative.TextInputIOSProps, ReactNative.TextInputAndroidProps, ReactNative.AccessibilityProps {
     maskDefaultValue?: boolean;
     mask: string;
+    refInput: ReactNative.Ref<ReactNative.TextInput>;
     onChangeText: onChangeTextCallback;
 
     // Export standard TextInputProps from here on.


### PR DESCRIPTION
There is refInput prop that not described in typings. Here is proof:
https://github.com/react-native-community/react-native-text-input-mask/blob/master/index.js#L54