### PR TITLE
Add explicit typing for $.fn.dataTable.ext property.

### DIFF
--- a/types/datatables.net/datatables.net-tests.ts
+++ b/types/datatables.net/datatables.net-tests.ts
@@ -1073,3 +1073,92 @@ const util_1: boolean = dt.any();
 const util_2: number = dt.count();
 
 //#endregion "Methods-Util"
+
+//#region "ExtSettings"
+
+const ext_classes_settings: DataTables.ExtClassesSettings = {
+};
+const ext_classes_settings_full: DataTables.ExtClassesSettings = {
+    sFilter: "",
+    sFilterInput: "",
+    sFooterTH: "",
+    sHeaderTH: "",
+    sInfo: "",
+    sJUIFooter: "",
+    sJUIHeader: "",
+    sLength: "",
+    sLengthSelect: "",
+    sNoFooter: "",
+    sPageButton: "",
+    sPageButtonActive: "",
+    sPageButtonDisabled: "",
+    sPaging: "",
+    sProcessing: "",
+    sRowEmpty: "",
+    sScrollBody: "",
+    sScrollFoot: "",
+    sScrollFootInner: "",
+    sScrollHead: "",
+    sScrollHeadInner: "",
+    sScrollWrapper: "",
+    sSortable: "",
+    sSortableAsc: "",
+    sSortableDesc: "",
+    sSortableNone: "",
+    sSortAsc: "",
+    sSortColumn: "",
+    sSortDesc: "",
+    sSortIcon: "",
+    sSortJUI: "",
+    sSortJUIAsc: "",
+    sSortJUIAscAllowed: "",
+    sSortJUIDesc: "",
+    sSortJUIDescAllowed: "",
+    sSortJUIWrapper: "",
+    sStripeEven: "",
+    sStripeOdd: "",
+    sTable: "",
+    sWrapper: ""
+};
+
+const ext_type_settings: DataTables.ExtTypeSettings = {
+    detect: [],
+    search: {},
+    order: {}
+};
+ext_type_settings.detect.push((d: string, s: DataTables.Settings) => {
+    return null;
+});
+ext_type_settings.detect.push((d: string, s: DataTables.Settings) => {
+    return "";
+});
+
+const ext_settings: DataTables.ExtSettings = {
+    aTypes: [],
+    afnFiltering: [],
+    afnSortData: {},
+    aoFeatures: [],
+    builder: "",
+    classes: ext_classes_settings,
+    errMode: "",
+    feature: [],
+    fnVersionCheck: (version: string) => "",
+    iApiIndex: 0,
+    internal: {},
+    legacy: {},
+    oApi: {},
+    oJUIClasses: {},
+    oPagination: {},
+    oSort: {},
+    oStdClasses: ext_classes_settings,
+    ofnSearch: {},
+    order: {},
+    pager: {},
+    renderer: {},
+    sVersion: "",
+    search: [],
+    selector: {},
+    type: ext_type_settings
+};
+
+ //#endregion "ExtSettings"

--- a/types/datatables.net/index.d.ts
+++ b/types/datatables.net/index.d.ts
@@ -2026,7 +2026,10 @@ declare namespace DataTables {
         sVersion: string;
         search: any[];
         selector: object;
-        type: object;
+        /**
+         * Type based plug-ins.
+         */
+        type: ExtTypeSettings;
     }
 
     interface ExtClassesSettings {
@@ -2208,4 +2211,36 @@ declare namespace DataTables {
         sJUIFooter?: string;
     }
     //#endregion "ext internal"
+
+    interface ExtTypeSettings {
+        /**
+         * Type detection functions for plug-in development.
+         *
+         * @see https://datatables.net/manual/plug-ins/type-detection
+         */
+        detect: FunctionExtTypeSettingsDetect[];
+        /**
+         * Type based ordering functions for plug-in development.
+         *
+         * @see https://datatables.net/manual/plug-ins/sorting
+         * @default {}
+         */
+        order: object;
+        /**
+         * Type based search formatting for plug-in development.
+         *
+         * @default {}
+         * @example
+         *   $.fn.dataTable.ext.type.search['title-numeric'] = function ( d ) {
+         *     return d.replace(/\n/g," ").replace( /<.*?>/g, "" );
+         *   }
+         */
+        search: object;
+    }
+
+    /**
+     * @param data Data from the column cell to be analysed.
+     * @param DataTables settings object.
+     */
+    type FunctionExtTypeSettingsDetect = (data: any, settings: Settings) => (string | null);
 }


### PR DESCRIPTION
Fixes #27734

- [ x ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ x ] Test the change in your own code. (Compile and run.)
- [ x ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ x ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ x ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ x ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [ x ] Provide a URL to documentation or source code which provides context for the suggested changes: [Type detection plug-in develop](https://datatables.net/manual/plug-ins/type-detection)
[Ordering plug-in development](https://datatables.net/manual/plug-ins/sorting)
- [ x ] Increase the version number in the header if appropriate.
- [ x ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
