### PR TITLE
ioredis: add some missing overloads and methods

### DIFF
--- a/types/ioredis/index.d.ts
+++ b/types/ioredis/index.d.ts
@@ -6,6 +6,7 @@
 //                 Ebrahim <https://github.com/br8h>
 //                 Shahar Mor <https://github.com/shaharmor>
 //                 Whemoon Jang <https://github.com/palindrom615>
+//                 Francis Gulotta <https://github.com/reconbot>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -65,10 +66,23 @@ declare namespace IORedis {
 
         get(key: string, callback: (err: Error, res: string) => void): void;
         get(key: string): Promise<string>;
+
         getBuffer(key: string, callback: (err: Error, res: Buffer) => void): void;
         getBuffer(key: string): Promise<Buffer>;
 
-        set(key: string, value: any, ...args: any[]): any;
+        set(key: string, value: any, expiryMode?: string | any[], time?: number | string, setMode?: number | string): Promise<string>;
+
+        set(key: string, value: any, callback: (err: Error, res: string) => void): void;
+        set(key: string, value: any, setMode: string | any[], callback: (err: Error, res: string) => void): void;
+        set(key: string, value: any, expiryMode: string, time: number | string, callback: (err: Error, res: string) => void): void;
+        set(key: string, value: any, expiryMode: string, time: number | string, setMode: number | string, callback: (err: Error, res: string) => void): void;
+
+        setBuffer(key: string, value: any, expiryMode?: string | any[], time?: number | string, setMode?: number | string): Promise<Buffer>;
+
+        setBuffer(key: string, value: any, callback: (err: Error, res: Buffer) => void): void;
+        setBuffer(key: string, value: any, setMode: string, callback: (err: Error, res: Buffer) => void): void;
+        setBuffer(key: string, value: any, expiryMode: string, time: number, callback: (err: Error, res: Buffer) => void): void;
+        setBuffer(key: string, value: any, expiryMode: string, time: number | string, setMode: number | string, callback: (err: Error, res: Buffer) => void): void;
 
         setnx(key: string, value: any, callback: (err: Error, res: any) => void): void;
         setnx(key: string, value: any): Promise<any>;
@@ -241,12 +255,16 @@ declare namespace IORedis {
 
         hset(key: string, field: string, value: any, callback: (err: Error, res: 0 | 1) => void): void;
         hset(key: string, field: string, value: any): Promise<0 | 1>;
+        hsetBuffer(key: string, field: string, value: any, callback: (err: Error, res: 0 | 1) => void): void;
+        hsetBuffer(key: string, field: string, value: any): Promise<Buffer>;
 
         hsetnx(key: string, field: string, value: any, callback: (err: Error, res: 0 | 1) => void): void;
         hsetnx(key: string, field: string, value: any): Promise<0 | 1>;
 
         hget(key: string, field: string, callback: (err: Error, res: string) => void): void;
         hget(key: string, field: string): Promise<string>;
+        hgetBuffer(key: string, field: string, callback: (err: Error, res: Buffer) => void): void;
+        hgetBuffer(key: string, field: string): Promise<Buffer>;
 
         hmset(key: string, field: string, value: any, ...args: string[]): Promise<0 | 1>;
         hmset(key: string, data: any, callback: (err: Error, res: 0 | 1) => void): void;
@@ -471,7 +489,15 @@ declare namespace IORedis {
         get(key: string, callback?: (err: Error, res: string) => void): Pipeline;
         getBuffer(key: string, callback?: (err: Error, res: Buffer) => void): Pipeline;
 
-        set(key: string, value: any, ...args: any[]): Pipeline;
+        set(key: string, value: any, callback?: (err: Error, res: string) => void): Pipeline;
+        set(key: string, value: any, setMode: string, callback?: (err: Error, res: string) => void): Pipeline;
+        set(key: string, value: any, expiryMode: string, time: number, callback?: (err: Error, res: string) => void): Pipeline;
+        set(key: string, value: any, expiryMode: string, time: number, setMode: string, callback?: (err: Error, res: string) => void): Pipeline;
+
+        setBuffer(key: string, value: any, callback?: (err: Error, res: Buffer) => void): Pipeline;
+        setBuffer(key: string, value: any, setMode: string, callback?: (err: Error, res: Buffer) => void): Pipeline;
+        setBuffer(key: string, value: any, expiryMode: string, time: number, callback?: (err: Error, res: Buffer) => void): Pipeline;
+        setBuffer(key: string, value: any, expiryMode: string, time: number, setMode: string, callback?: (err: Error, res: Buffer) => void): Pipeline;
 
         setnx(key: string, value: any, callback?: (err: Error, res: any) => void): Pipeline;
 
@@ -602,10 +628,12 @@ declare namespace IORedis {
         zrevrank(key: string, member: string, callback?: (err: Error, res: number) => void): Pipeline;
 
         hset(key: string, field: string, value: any, callback?: (err: Error, res: 0 | 1) => void): Pipeline;
+        hsetBuffer(key: string, field: string, value: any, callback?: (err: Error, res: Buffer) => void): Pipeline;
 
         hsetnx(key: string, field: string, value: any, callback?: (err: Error, res: 0 | 1) => void): Pipeline;
 
         hget(key: string, field: string, callback?: (err: Error, res: string) => void): Pipeline;
+        hgetBuffer(key: string, field: string, callback?: (err: Error, res: Buffer) => void): Pipeline;
 
         hmset(key: string, field: string, value: any, ...args: string[]): Pipeline;
         hmset(key: string, data: any, callback?: (err: Error, res: 0 | 1) => void): Pipeline;

--- a/types/ioredis/ioredis-tests.ts
+++ b/types/ioredis/ioredis-tests.ts
@@ -16,7 +16,20 @@ redis.sadd('set', 1, 3, 5, 7);
 redis.sadd('set', [1, 3, 5, 7]);
 
 // All arguments are passed directly to the redis server:
-redis.set('key', '100', 'EX', 10);
+redis.set('key', '100');
+redis.set('key', '100', 'XX');
+redis.set('key', '100', 'PX', 10);
+redis.set('key', '100', 'EX', 10, 'NX');
+redis.set('key', '100', 'NX', 'EX', 10);
+redis.set('key', '100', ['EX', 10, 'NX']);
+redis.setBuffer('key', '100', 'NX', 'EX', 10);
+
+redis.set('key', '100', (err, data) => {});
+redis.set('key', '100', 'XX', (err, data) => {});
+redis.set('key', '100', 'PX', 10, (err, data) => {});
+redis.set('key', '100', 'EX', 10, 'NX', (err, data) => {});
+redis.set('key', '100', ['EX', 10, 'NX'], (err, data) => {});
+redis.setBuffer('key', '100', 'NX', 'EX', 10, (err, data) => {});
 
 new Redis();       // Connect to 127.0.0.1:6379
 new Redis(6380);   // 127.0.0.1:6380
@@ -59,6 +72,10 @@ redis.on('messageBuffer', (channel: any, message: any) => {
 const pipeline = redis.pipeline();
 pipeline.set('foo', 'bar');
 pipeline.del('cc');
+pipeline.hset('hash', 'foo', 4);
+pipeline.hget('hash', 'foo');
+pipeline.hsetBuffer('hash', 'fooBuffer', 4);
+pipeline.hgetBuffer('hash', 'fooBuffer');
 pipeline.exec((err, results) => {
     // `err` is always null, and `results` is an array of responses
     // corresponding to the sequence of queued commands.


### PR DESCRIPTION
Added the following for base redis and pipeline methods 
- Corrected the `set()` method’s arguments and returns
- added the `setBuffer()` method
- added the `hsetBuffer()` method
- added the `hgetBuffer()` method

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.npmjs.com/package/ioredis#handle-binary-data
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
