### PR TITLE
Add types for extsprintf

### DIFF
--- a/types/extsprintf/extsprintf-tests.ts
+++ b/types/extsprintf/extsprintf-tests.ts
@@ -1,0 +1,8 @@
+import { sprintf, fprintf, printf } from "extsprintf";
+
+fprintf({write: (s: string) => {}}, '');
+fprintf({write: (s: string) => {}}, '', {}, [], null, 0, '');
+printf('');
+printf('', {}, [], null, 0, '');
+sprintf(''); // $ExpectType string
+sprintf('', {}, [], null, 0, ''); // $ExpectType string

--- a/types/extsprintf/index.d.ts
+++ b/types/extsprintf/index.d.ts
@@ -3,11 +3,8 @@
 // Definitions by: Alex Hankins <https://github.com/AlexHankins>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-/**
- * Importing this is rarely necessary.
- */
 export interface Stream {
-    write(str: string): any;
+    write(str: string): void;
 }
 
 export function fprintf(stream: Stream, format: string, ...args: any[]): any;

--- a/types/extsprintf/index.d.ts
+++ b/types/extsprintf/index.d.ts
@@ -1,0 +1,15 @@
+// Type definitions for extsprintf 1.4
+// Project: https://github.com/joyent/node-extsprintf#readme
+// Definitions by: Alex Hankins <https://github.com/AlexHankins>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/**
+ * Importing this is rarely necessary.
+ */
+export interface Stream {
+    write(str: string): any;
+}
+
+export function fprintf(stream: Stream, format: string, ...args: any[]): any;
+export function printf(format: string, ...args: any[]): any;
+export function sprintf(format: string, ...args: any[]): string;

--- a/types/extsprintf/tsconfig.json
+++ b/types/extsprintf/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "extsprintf-tests.ts"
+    ]
+}

--- a/types/extsprintf/tslint.json
+++ b/types/extsprintf/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [✓] Use a meaningful title for the pull request. Include the name of the package modified.
- [✓] Test the change in your own code. (Compile and run.)
- [✓] Add or edit tests to reflect the change. (Run with `npm test`.)
- [✓] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [✓] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [✓] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [✓] _The package does not already provide its own types_, or cannot have its `.d.ts` files generated via `--declaration`
- [✓] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [✓] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [✓] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
