### PR TITLE
@types/nock | Remove restore() from nock.Scope

### DIFF
--- a/types/nock/index.d.ts
+++ b/types/nock/index.d.ts
@@ -81,7 +81,6 @@ declare namespace nock {
 
         done(): void;
         isDone(): boolean;
-        restore(): void;
         pendingMocks(): string[];
     }
 


### PR DESCRIPTION
restore only exists on the global `nock` object.
See here: https://github.com/nock/nock/search?utf8=%E2%9C%93&q=restore
and here: https://github.com/nock/nock/blob/master/lib/scope.js