### PR TITLE
[@types/styled-system] set devDependencies on styled-components

### DIFF
--- a/types/styled-system/package.json
+++ b/types/styled-system/package.json
@@ -1,6 +1,3 @@
 {
-    "private": true,
-    "dependencies": {
-        "styled-components": "^3.3.2"
-    }
+    "private": true
 }

--- a/types/styled-system/package.json
+++ b/types/styled-system/package.json
@@ -1,3 +1,6 @@
 {
-    "private": true
+    "private": true,
+    "devDependencies": {
+        "styled-components": "^3.3.2"
+    }
 }


### PR DESCRIPTION
Set devDependencies on <code>styled-components</code>, because <code>styled-components</code> unused in definition.