### PR TITLE
[@types/parse-git-config] sync with latest api changes

### DIFF
--- a/types/parse-git-config/index.d.ts
+++ b/types/parse-git-config/index.d.ts
@@ -36,10 +36,10 @@ interface Parse {
      * If no arguments are passed, the .git/config file relative to process.cwd() is used.
      */
     sync(options?: (Options | object) | string): Config;
-    /**
-     * Returns an object with only the properties that had ini-style keys converted to objects.
-     */
-    keys(config: Config): Config;
+	/**
+	 * Returns an object with only the properties that had ini-style keys converted to objects.
+	 */
+	expandKeys(config: Config): Config;
 }
 
 // no-empty-interface is disabled for a better debugging experience. Empty interfaces are used to alias a type alias.

--- a/types/parse-git-config/index.d.ts
+++ b/types/parse-git-config/index.d.ts
@@ -49,6 +49,8 @@ interface Options extends Pick<_Options, keyof _Options> { }
 interface _Options {
     cwd: string;
     path: string;
+    include?: boolean;
+    expandKeys?: boolean;
 }
 
 type ParseCallback = ((err: Error | null, config: Config) => void);

--- a/types/parse-git-config/index.d.ts
+++ b/types/parse-git-config/index.d.ts
@@ -36,10 +36,10 @@ interface Parse {
      * If no arguments are passed, the .git/config file relative to process.cwd() is used.
      */
     sync(options?: (Options | object) | string): Config;
-	/**
-	 * Returns an object with only the properties that had ini-style keys converted to objects.
-	 */
-	expandKeys(config: Config): Config;
+    /**
+     * Returns an object with only the properties that had ini-style keys converted to objects.
+     */
+    expandKeys(config: Config): Config;
 }
 
 // no-empty-interface is disabled for a better debugging experience. Empty interfaces are used to alias a type alias.

--- a/types/parse-git-config/parse-git-config-tests.ts
+++ b/types/parse-git-config/parse-git-config-tests.ts
@@ -99,12 +99,12 @@ function test_sync() {
     }
 }
 
-function test_keys() {
+function test_expandKeys() {
     const config = {
         'foo "bar"': { doStuff: true },
         'foo "baz"': { doStuff: true }
     };
-    const keys = parse.keys(config);
+    const keys = parse.expandKeys(config);
 
     keys.foo.bar.doStuff === true;
     keys.foo.baz.doStuff === true;


### PR DESCRIPTION
Change types to have latest api in https://github.com/jonschlinkert/parse-git-config

P.S: current README wasn't updated after ```keys()``` method removal, PR already exist to fix that:
https://github.com/jonschlinkert/parse-git-config/pull/11
and there is only ```expandKeys()``` method left:
https://github.com/jonschlinkert/parse-git-config/blob/master/index.js#L149