### PR TITLE
Add types for capture-console

### DIFF
--- a/types/capture-console/capture-console-tests.ts
+++ b/types/capture-console/capture-console-tests.ts
@@ -1,0 +1,53 @@
+import * as captureconsole from "capture-console";
+
+captureconsole.capture(process.stdout, () => { }); // $ExpectType string[]
+captureconsole.capture(process.stdout, {}, () => { }); // $ExpectType string[]
+captureconsole.capture(process.stdout, { quiet: true }, () => { }); // $ExpectType string[]
+
+captureconsole.capture([process.stdout, process.stdin], () => { }); // $ExpectType string[]
+captureconsole.capture([process.stdout, process.stdin], {}, () => { }); // $ExpectType string[]
+captureconsole.capture([process.stdout, process.stdin], { quiet: true }, () => { }); // $ExpectType string[]
+
+captureconsole.captureStderr(() => { }); // $ExpectType string
+captureconsole.captureStderr({}, () => { }); // $ExpectType string
+captureconsole.captureStderr({ quiet: true }, () => { }); // $ExpectType string
+
+captureconsole.captureStdio(() => { }); // $ExpectType { stdout: string; stderr: string; }
+captureconsole.captureStdio({}, () => { }); // $ExpectType { stdout: string; stderr: string; }
+captureconsole.captureStdio({ quiet: true }, () => { }); // $ExpectType { stdout: string; stderr: string; }
+
+captureconsole.captureStdout(() => { }); // $ExpectType string
+captureconsole.captureStdout({}, () => { }); // $ExpectType string
+captureconsole.captureStdout({ quiet: true }, () => { }); // $ExpectType string
+
+captureconsole.hook(process.stdout, (string: string, encoding?: string, fd?: (error?: any) => void) => { }); // $ExpectType () => boolean
+captureconsole.hook(process.stdout, {}, (string: string, encoding?: string, fd?: (error?: any) => void) => { }); // $ExpectType () => boolean
+captureconsole.hook(process.stdout, { quiet: true }, (string: string, encoding?: string, fd?: (error?: any) => void) => { }); // $ExpectType () => boolean
+
+captureconsole.intercept(process.stdout, () => { }); // $ExpectType string[]
+captureconsole.intercept(process.stdout, {}, () => { }); // $ExpectType string[]
+captureconsole.intercept(process.stdout, { quiet: true }, () => { }); // $ExpectType string[]
+
+captureconsole.interceptStderr(() => { }); // $ExpectType string
+captureconsole.interceptStderr({}, () => { }); // $ExpectType string
+captureconsole.interceptStderr({ quiet: true }, () => { }); // $ExpectType string
+
+captureconsole.interceptStdio(() => { }); // $ExpectType { stdout: string; stderr: string; }
+captureconsole.interceptStdio({}, () => { }); // $ExpectType { stdout: string; stderr: string; }
+captureconsole.interceptStdio({ quiet: true }, () => { }); // $ExpectType { stdout: string; stderr: string; }
+
+captureconsole.interceptStdout(() => { }); // $ExpectType string
+captureconsole.interceptStdout({}, () => { }); // $ExpectType string
+captureconsole.interceptStdout({ quiet: true }, () => { }); // $ExpectType string
+
+captureconsole.startCapture(process.stdout, (string: string, encoding?: string, fd?: (error?: any) => void) => { }); // $ExpectType boolean
+captureconsole.startCapture(process.stdout, {}, (string: string, encoding?: string, fd?: (error?: any) => void) => { }); // $ExpectType boolean
+captureconsole.startCapture(process.stdout, { quiet: true }, (string: string, encoding?: string, fd?: (error?: any) => void) => { }); // $ExpectType boolean
+
+captureconsole.startIntercept(process.stdout, () => { }); // $ExpectType boolean
+captureconsole.startIntercept(process.stdout, {}, () => { }); // $ExpectType boolean
+captureconsole.startIntercept(process.stdout, { quiet: true }, () => { }); // $ExpectType boolean
+
+captureconsole.stopCapture(process.stdout); // $ExpectType boolean
+
+captureconsole.stopIntercept(process.stdout); // $ExpectType boolean

--- a/types/capture-console/index.d.ts
+++ b/types/capture-console/index.d.ts
@@ -1,0 +1,190 @@
+// Type definitions for capture-console 1.0
+// Project: https://github.com/zackehh/capture-console
+// Definitions by: Auston Zahrt <https://github.com/AustonZ>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types="node"/>
+
+/**
+ * Options controlling behavior when capturing
+ */
+export interface CaptureOptions {
+    /**
+     * Option to silence the output going to the console
+     */
+    quiet?: boolean;
+}
+
+/**
+ * Executes the provided function with the output
+ * on the provided streams.
+ */
+export function capture(
+    streams: ReadonlyArray<NodeJS.WritableStream> | NodeJS.WritableStream,
+    exec: () => void
+): string[];
+
+/**
+ * Executes the provided function with the output
+ * on the provided streams. Accepts options to silence
+ * the output going to the console.
+ */
+export function capture(
+    streams: ReadonlyArray<NodeJS.WritableStream> | NodeJS.WritableStream,
+    opts: CaptureOptions,
+    exec: () => void
+): string[];
+
+/**
+ * Captures stderr for the provided execution scope.
+ */
+export function captureStderr(exec: () => void): string;
+
+/**
+ * Captures stderr for the provided execution scope.
+ */
+export function captureStderr(opts: CaptureOptions, exec: () => void): string;
+
+/**
+ * Captures stdout and stderr into an object for
+ * the provided execution scope.
+ */
+export function captureStdio(exec: () => void): { stdout: string; stderr: string; };
+
+/**
+ * Captures stdout and stderr into an object for
+ * the provided execution scope.
+ */
+export function captureStdio(opts: CaptureOptions, exec: () => void): { stdout: string; stderr: string; };
+
+/**
+ * Captures stdout for the provided execution scope.
+ */
+export function captureStdout(exec: () => void): string;
+
+/**
+ * Captures stdout for the provided execution scope.
+ */
+export function captureStdout(opts: CaptureOptions, exec: () => void): string;
+
+/**
+ * Listens to a provided stream, and executes the provided
+ * function for every write call. Accepts options to silence
+ * the output going to the console.
+ *
+ * Returns a function to call when you wish to stop listening
+ * to the call.
+ */
+export function hook(
+    stream: NodeJS.WritableStream,
+    exec: (
+        string: string,
+        encoding?: string,
+        fd?: (error?: any) => void
+    ) => void
+): () => boolean;
+
+/**
+ * Listens to a provided stream, and executes the provided
+ * function for every write call. Accepts options to silence
+ * the output going to the console.
+ *
+ * Returns a function to call when you wish to stop listening
+ * to the call.
+ */
+export function hook(
+    stream: NodeJS.WritableStream,
+    opts: CaptureOptions,
+    exec: (
+        string: string,
+        encoding?: string,
+        fd?: (error?: any) => void
+    ) => void
+): () => boolean;
+
+/**
+ * Delegate to #capture with a quiet passthrough.
+ */
+export function intercept(stream: NodeJS.WritableStream, exec: () => void): string[];
+
+/**
+ * Delegate to #capture with a quiet passthrough.
+ */
+export function intercept(stream: NodeJS.WritableStream, opts: CaptureOptions, exec: () => void): string[];
+
+/**
+ * Delegate to #captureStderr with a quiet passthrough.
+ */
+export function interceptStderr(exec: () => void): string;
+
+/**
+ * Delegate to #captureStderr with a quiet passthrough.
+ */
+export function interceptStderr(opts: CaptureOptions, exec: () => void): string;
+
+/**
+ * Delegate to #captureStdio with a quiet passthrough.
+ */
+export function interceptStdio(exec: () => void): { stdout: string; stderr: string; };
+
+/**
+ * Delegate to #captureStdio with a quiet passthrough.
+ */
+export function interceptStdio(opts: CaptureOptions, exec: () => void): { stdout: string; stderr: string; };
+
+/**
+ * Delegate to #captureStdout with a quiet passthrough.
+ */
+export function interceptStdout(exec: () => void): string;
+
+/**
+ * Delegate to #captureStdout with a quiet passthrough.
+ */
+export function interceptStdout(opts: CaptureOptions, exec: () => void): string;
+
+/**
+ * Starts a capture on the provided stream using the
+ * provided options and stream execution.
+ */
+export function startCapture(
+    stream: NodeJS.WritableStream,
+    exec: (
+        string: string,
+        encoding?: string,
+        fd?: (error?: any) => void
+    ) => void
+): boolean;
+
+/**
+ * Starts a capture on the provided stream using the
+ * provided options and stream execution.
+ */
+export function startCapture(
+    stream: NodeJS.WritableStream,
+    opts: CaptureOptions,
+    exec: (
+        string: string,
+        encoding?: string,
+        fd?: (error?: any) => void
+    ) => void
+): boolean;
+
+/**
+ * Delegate to #startCapture with a quiet passthrough.
+ */
+export function startIntercept(stream: NodeJS.WritableStream, exec: () => void): boolean;
+
+/**
+ * Delegate to #startCapture with a quiet passthrough.
+ */
+export function startIntercept(stream: NodeJS.WritableStream, opts: CaptureOptions, exec: () => void): boolean;
+
+/**
+ * Stops a capture on the provided stream.
+ */
+export function stopCapture(stream: NodeJS.WritableStream): boolean;
+
+/**
+ * Delegate to #stopCapture with a quiet passthrough.
+ */
+export function stopIntercept(stream: NodeJS.WritableStream): boolean;

--- a/types/capture-console/tsconfig.json
+++ b/types/capture-console/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "strictFunctionTypes": true
+    },
+    "files": [
+        "index.d.ts",
+        "capture-console-tests.ts"
+    ]
+}

--- a/types/capture-console/tslint.json
+++ b/types/capture-console/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Adds type definitions for the NPM package "capture-console" v1.0.1

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.