### PR TITLE
[react-i18next]: use React.ReactNode instead of JSX.Element in `I18n`'s children and `I18nextProvider`

### DIFF
--- a/types/react-i18next/index.d.ts
+++ b/types/react-i18next/index.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: Giedrius Grabauskas <https://github.com/GiedriusGrabauskas>
 //                 Simon Baumann <https://github.com/chnoch>
 //                 Benedict Etzel <https://github.com/beheh>
+//                 Wu Haotian <https://github.com/whtsky>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 

--- a/types/react-i18next/src/I18n.d.ts
+++ b/types/react-i18next/src/I18n.d.ts
@@ -15,7 +15,7 @@ export interface i18nProps {
     i18n?: i18n;
     initialI18nStore?: any;
     initialLanguage?: string;
-    children: (t: TranslationFunction, options: Options) => JSX.Element;
+    children: (t: TranslationFunction, options: Options) => React.ReactNode;
 }
 
 export default class I18n extends React.Component<i18nProps> { }

--- a/types/react-i18next/src/I18nextProvider.d.ts
+++ b/types/react-i18next/src/I18nextProvider.d.ts
@@ -6,7 +6,7 @@ export interface I18nextProviderProps {
     i18n: i18n;
     initialI18nStore?: any;
     initialLanguage?: string;
-    children: JSX.Element;
+    children: React.ReactNode;
 }
 
 export default class I18nextProvider extends React.Component<I18nextProviderProps> { }

--- a/types/react-i18next/test/react-i18next-tests.tsx
+++ b/types/react-i18next/test/react-i18next-tests.tsx
@@ -107,6 +107,10 @@ class App extends React.Component {
     <App/>
 </I18nextProvider>;
 
+<I18nextProvider i18n={i18n} initialLanguage={'en'} initialI18nStore={{}}>
+    123
+</I18nextProvider>;
+
 loadNamespaces({components: [App], i18n}).then(() => {
 }).catch(error => {
 });
@@ -180,6 +184,10 @@ interface CustomTranslateFunctionProps {
             </div>
         )
     }
+</I18n>;
+
+<I18n>
+    {t => '123'}
 </I18n>;
 
 const defaults: ReactI18NextOptions = {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.

---

`JSX.Element` does not accept string 