### PR TITLE
[google-cloud__datastore] Move from namespace to static attributes

### DIFF
--- a/types/google-cloud__datastore/google-cloud__datastore-tests.ts
+++ b/types/google-cloud__datastore/google-cloud__datastore-tests.ts
@@ -72,7 +72,7 @@ const complexQuery = ds.createQuery('special_namespace', kind)
                        .offset(10);
 
 // Running queries:
-const queryCallback: QueryCallback = (err: Error, entities: TestEntity[]) => entities[0][Datastore.KEY];
+const queryCallback: QueryCallback = (err: Error, entities: TestEntity[]) => entities[0][ds.KEY];
 
 ds.runQuery(query, queryCallback);
 ds.runQuery(query, options, queryCallback);

--- a/types/google-cloud__datastore/index.d.ts
+++ b/types/google-cloud__datastore/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/googleapis/nodejs-datastore
 // Definitions by: Antoine Beauvais-Lacasse <https://github.com/beaulac>
 //                 Futa Ogawa <https://github.com/ogawa0071>
+//                 Thomas den Hollander <https://github.com/ThomasdenH>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.7
 
@@ -35,6 +36,15 @@ declare module '@google-cloud/datastore' {
     import { DatastoreTransaction } from '@google-cloud/datastore/transaction';
 
     class Datastore extends DatastoreRequest_ {
+        static readonly KEY: unique symbol;
+        static readonly MORE_RESULTS_AFTER_CURSOR: MoreResultsAfterCursor;
+        static readonly MORE_RESULTS_AFTER_LIMIT: MoreResultsAfterLimit;
+        static readonly NO_MORE_RESULTS: NoMoreResults;
+
+        static readonly Query: typeof DatastoreQuery;
+        static readonly DatastoreRequest: typeof DatastoreRequest_;
+        static readonly Transaction: typeof DatastoreTransaction;
+
         constructor(options?: InitOptions);
 
         readonly KEY: typeof Datastore.KEY;
@@ -79,17 +89,6 @@ declare module '@google-cloud/datastore' {
         projectId?: string;
         keyFilename?: string;
         credentials?: object;
-    }
-
-    namespace Datastore {
-        const KEY: unique symbol;
-        const MORE_RESULTS_AFTER_CURSOR: MoreResultsAfterCursor;
-        const MORE_RESULTS_AFTER_LIMIT: MoreResultsAfterLimit;
-        const NO_MORE_RESULTS: NoMoreResults;
-
-        const Query: typeof DatastoreQuery;
-        const DatastoreRequest: typeof DatastoreRequest_;
-        const Transaction: typeof DatastoreTransaction;
     }
 }
 


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

This PR changes two small things:
- The namespace `Datastore` is merged into the class `Datastore`, its attributes are now static members. This means there is only one property `Datastore`, simplifying reasoning about typing. The change should not have any external effect.
- The object member `Datastore#KEY` is now used in the tests, as well as the static class member `Datastore.KEY`.