### PR TITLE
fork-ts-checker-webpack-plugin: Don't limit Options.logger to the Console type

### DIFF
--- a/types/fork-ts-checker-webpack-plugin/fork-ts-checker-webpack-plugin-tests.ts
+++ b/types/fork-ts-checker-webpack-plugin/fork-ts-checker-webpack-plugin-tests.ts
@@ -21,4 +21,16 @@ config = {
     ]
 };
 
+config = {
+    plugins: [
+        new ForkTsCheckerWebpackPlugin({
+            logger: {
+                error: message => console.error(message),
+                warn: message => console.warn(message),
+                info: message => console.info(message),
+            }
+        })
+    ]
+};
+
 export default config;

--- a/types/fork-ts-checker-webpack-plugin/index.d.ts
+++ b/types/fork-ts-checker-webpack-plugin/index.d.ts
@@ -73,6 +73,12 @@ declare namespace ForkTsCheckerWebpackPlugin {
 
     type Formatter = (message: NormalizedMessage, useColors: boolean) => string;
 
+    interface Logger {
+        error(message?: any): void;
+        warn(message?: any): void;
+        info(message?: any): void;
+    }
+
     interface Options {
         tsconfig?: string;
         tslint?: string | true;
@@ -81,7 +87,7 @@ declare namespace ForkTsCheckerWebpackPlugin {
         ignoreDiagnostics?: number[];
         ignoreLints?: string[];
         colors?: boolean;
-        logger?: Console;
+        logger?: Logger;
         formatter?: 'default' | 'codeframe' | Formatter;
         formatterOptions?: {
             highlightCode?: boolean


### PR DESCRIPTION
Changed `Options.logger` to accept any object implementing the following methods: `error`, `warn`, `info`.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/Realytics/fork-ts-checker-webpack-plugin/blob/eca9b1ed42fd0572fe323df29c6aaf17f9a1f45c/README.md#options
- [ ] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
