### PR TITLE
Add default export function to moment-duration-format

### DIFF
--- a/types/moment-duration-format/index.d.ts
+++ b/types/moment-duration-format/index.d.ts
@@ -90,3 +90,5 @@ declare module "moment" {
 
     type TemplateFunction = ((this: DurationFormatSettings) => string);
 }
+
+    export default function momentDurationFormatSetup(moment: Moment): void;

--- a/types/moment-duration-format/index.d.ts
+++ b/types/moment-duration-format/index.d.ts
@@ -91,4 +91,4 @@ declare module "moment" {
     type TemplateFunction = ((this: DurationFormatSettings) => string);
 }
 
-    export default function momentDurationFormatSetup(moment: Moment): void;
+export default function momentDurationFormatSetup(moment: Moment): void;


### PR DESCRIPTION
Documentations 
https://github.com/jsmreese/moment-duration-format#module

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [-] Increase the version number in the header if appropriate.
- [-] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
