### PR TITLE
quill: fix signature for clipboard api

### DIFF
--- a/types/quill/index.d.ts
+++ b/types/quill/index.d.ts
@@ -43,7 +43,7 @@ export interface KeyboardStatic {
 }
 
 export interface ClipboardStatic {
-    convert(html: string|Blot): DeltaStatic;
+    convert(html?: string): DeltaStatic;
     addMatcher(selectorOrNodeType: string|number, callback: (node: any, delta: DeltaStatic) => DeltaStatic): void;
     dangerouslyPasteHTML(html: string, source?: Sources): void;
     dangerouslyPasteHTML(index: number, html: string, source?: Sources): void;

--- a/types/quill/quill-tests.ts
+++ b/types/quill/quill-tests.ts
@@ -148,6 +148,7 @@ function test_setHtmlContents() {
     const html = "<b>this is a bold text</b>";
     const delta = quillEditor.clipboard.convert(html);
     quillEditor.setContents(delta);
+    quillEditor.clipboard.convert();
 }
 
 function test_getSelection() {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/quilljs/quill/blob/96e38e92637b75b907579d0cc1b201920aebe38c/modules/clipboard.js#L75
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

Fixing the signature, a `Blot` isn't accept by looks of source/docs. Empty call is.