### PR TITLE
Pass any as the state type to ComponentClass

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -60,8 +60,7 @@ declare namespace React {
 
     type Ref<T> = string | { bivarianceHack(instance: T | null): any }["bivarianceHack"] | RefObject<T>;
 
-    // tslint:disable-next-line:interface-over-type-literal
-    type ComponentState = any;
+    type ComponentState = {};
 
     interface Attributes {
         key?: Key;
@@ -356,7 +355,7 @@ declare namespace React {
         displayName?: string;
     }
 
-    interface ComponentClass<P = {}, S = ComponentState> extends StaticLifecycle<P, S> {
+    interface ComponentClass<P = {}, S = {}> extends StaticLifecycle<P, any> {
         new (props: P, context?: any): Component<P, S>;
         propTypes?: ValidationMap<P>;
         contextTypes?: ValidationMap<any>;

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -60,7 +60,6 @@ declare namespace React {
 
     type Ref<T> = string | { bivarianceHack(instance: T | null): any }["bivarianceHack"] | RefObject<T>;
 
-    // tslint:disable-next-line:interface-over-type-literal
     type ComponentState = any;
 
     interface Attributes {

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -61,7 +61,7 @@ declare namespace React {
     type Ref<T> = string | { bivarianceHack(instance: T | null): any }["bivarianceHack"] | RefObject<T>;
 
     // tslint:disable-next-line:interface-over-type-literal
-    type ComponentState = {};
+    type ComponentState = any;
 
     interface Attributes {
         key?: Key;
@@ -356,7 +356,7 @@ declare namespace React {
         displayName?: string;
     }
 
-    interface ComponentClass<P = {}, S = any> extends StaticLifecycle<P, S> {
+    interface ComponentClass<P = {}, S = ComponentState> extends StaticLifecycle<P, S> {
         new (props: P, context?: any): Component<P, S>;
         propTypes?: ValidationMap<P>;
         contextTypes?: ValidationMap<any>;

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -60,6 +60,7 @@ declare namespace React {
 
     type Ref<T> = string | { bivarianceHack(instance: T | null): any }["bivarianceHack"] | RefObject<T>;
 
+    // tslint:disable-next-line:interface-over-type-literal
     type ComponentState = {};
 
     interface Attributes {

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -61,7 +61,7 @@ declare namespace React {
     type Ref<T> = string | { bivarianceHack(instance: T | null): any }["bivarianceHack"] | RefObject<T>;
 
     // tslint:disable-next-line:interface-over-type-literal
-    type ComponentState = {};
+    type ComponentState = any;
 
     interface Attributes {
         key?: Key;
@@ -356,7 +356,7 @@ declare namespace React {
         displayName?: string;
     }
 
-    interface ComponentClass<P = {}, S = {}> extends StaticLifecycle<P, any> {
+    interface ComponentClass<P = {}, S = ComponentState> extends StaticLifecycle<P, S> {
         new (props: P, context?: any): Component<P, S>;
         propTypes?: ValidationMap<P>;
         contextTypes?: ValidationMap<any>;

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -18,6 +18,7 @@
 //                 Johann Rakotoharisoa <https://github.com/jrakotoharisoa>
 //                 Olivier Pascal <https://github.com/pascaloliv>
 //                 Martin Hochel <https://github.com/hotell>
+//                 Frank Li <https://github.com/franklixuefei>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -49,7 +50,7 @@ declare namespace React {
     // ----------------------------------------------------------------------
 
     type ReactType<P = any> = string | ComponentType<P>;
-    type ComponentType<P = {}> = ComponentClass<P> | StatelessComponent<P>;
+    type ComponentType<P = {}> = ComponentClass<P, any> | StatelessComponent<P>;
 
     type Key = string | number;
 

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -50,7 +50,7 @@ declare namespace React {
     // ----------------------------------------------------------------------
 
     type ReactType<P = any> = string | ComponentType<P>;
-    type ComponentType<P = {}> = ComponentClass<P, any> | StatelessComponent<P>;
+    type ComponentType<P = {}> = ComponentClass<P> | StatelessComponent<P>;
 
     type Key = string | number;
 
@@ -356,7 +356,7 @@ declare namespace React {
         displayName?: string;
     }
 
-    interface ComponentClass<P = {}, S = ComponentState> extends StaticLifecycle<P, S> {
+    interface ComponentClass<P = {}, S = any> extends StaticLifecycle<P, S> {
         new (props: P, context?: any): Component<P, S>;
         propTypes?: ValidationMap<P>;
         contextTypes?: ValidationMap<any>;


### PR DESCRIPTION
Pass any as the state type to ComponentClass.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

Context:
====

According to a previous commit - #27417, `ComponentState`, which is `{}`, has been explicitly passed to `StaticLifecycle` as the state type parameter from `ComponentClass`. However, consider the following code **(source: `withStyles.d.ts` from material-ui)**
```ts
export default function withStyles<ClassKey extends string>(
  style: StyleRulesCallback<ClassKey> | StyleRules<ClassKey>,
  options?: WithStylesOptions<ClassKey>,
): {
  <P extends ConsistentWith<P, StyledComponentProps<ClassKey>>>(
    component: React.ComponentType<P & WithStyles<ClassKey>>,
  ): React.ComponentType<Overwrite<P, StyledComponentProps<ClassKey>>>;
};
```
where a state type param is not explicitly passed to `React.ComponentType`. This results in the state type defaulting to `{}`, which further constrains that the type of the `state` parameter of `static getDerivedStateFromProps(props, state)` to be `{}`, which makes the compiler complain, however, something not readable.

Please take a look at a real example below:
```jsx
import * as React from "react";
import { Theme } from "@material-ui/core/styles/createMuiTheme";
import withStyles, {
  CSSProperties,
  WithStyles
} from "@material-ui/core/styles/withStyles";

interface State {
  test: string;
  test2: number;
}

const styles = (theme: Theme) => ({
  style1: {
    position: "relative"
  } as CSSProperties
});

class Test extends React.PureComponent<WithStyles<typeof styles>, State> {
  constructor(props: WithStyles<typeof styles>) {
    super(props);
    this.state = {
      test: "test",
      test2: 2
    };
  }

  static getDerivedStateFromProps(
    props: WithStyles<typeof styles>,
    state: State // we specifies a type other than {} here, which will cause a compiler error
  ): Partial<State> | null {
    return {
      test: '123'
    };
  }

  render() {
    return null;
  }
}

export default withStyles(styles)(Test); // <-- compiler error: Type 'typeof Test' provides no match for the signature '(props: Partial<WithTheme> & { classes: Record<"style1", string>; } & { children?: ReactNode; }, context?: any): ReactElement<any> | null'.

```
