### PR TITLE
react-sortable-tree missing prop 'shouldCopyOnOutsideDrop'

### DIFF
--- a/types/react-sortable-tree/index.d.ts
+++ b/types/react-sortable-tree/index.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: Wouter Hardeman <https://github.com/wouterhardeman>
 //                 Jovica Zoric <https://github.com/jzoric>
 //                 Kevin Perrine <https://github.com/kevinsperrine>
+//                 Alex Maclean <https://github.com/acemac>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 

--- a/types/react-sortable-tree/index.d.ts
+++ b/types/react-sortable-tree/index.d.ts
@@ -72,9 +72,9 @@ export interface OnDragPreviousAndNextLocation extends PreviousAndNextLocation {
 }
 
 export interface ShouldCopyData {
-    node: TreeItem,
-    prevPath: NumberArrayOrStringArray,
-    prevTreeIndex: number
+    node: TreeItem;
+    prevPath: NumberArrayOrStringArray;
+    prevTreeIndex: number;
 }
 
 export interface OnMovePreviousAndNextLocation extends PreviousAndNextLocation {

--- a/types/react-sortable-tree/index.d.ts
+++ b/types/react-sortable-tree/index.d.ts
@@ -72,7 +72,7 @@ export interface OnDragPreviousAndNextLocation extends PreviousAndNextLocation {
 }
 
 export interface ShouldCopyData {
-    node: TreeItem;
+    node: TreeNode;
     prevPath: NumberArrayOrStringArray;
     prevTreeIndex: number;
 }

--- a/types/react-sortable-tree/index.d.ts
+++ b/types/react-sortable-tree/index.d.ts
@@ -70,6 +70,12 @@ export interface OnDragPreviousAndNextLocation extends PreviousAndNextLocation {
     nextParent: TreeItem | null;
 }
 
+export interface ShouldCopyData {
+    node: TreeItem,
+    prevPath: NumberArrayOrStringArray,
+    prevTreeIndex: number
+}
+
 export interface OnMovePreviousAndNextLocation extends PreviousAndNextLocation {
     nextParentNode: TreeItem | null;
 }
@@ -186,6 +192,7 @@ export interface ReactSortableTreeProps {
     dndType?: string;
     placeholderRenderer?: PlaceholderRenderer;
     theme?: ThemeProps;
+    shouldCopyOnOutsideDrop?: boolean | ((data: ShouldCopyData) => boolean);
 }
 
 declare const SortableTree: React.ComponentClass<ReactSortableTreeProps>;

--- a/types/react-sortable-tree/react-sortable-tree-tests.tsx
+++ b/types/react-sortable-tree/react-sortable-tree-tests.tsx
@@ -69,11 +69,13 @@ class Test extends React.Component {
                     dndType="testNodeType"
                     placeholderRenderer={PlaceholderRenderer}
                     theme={theme}
+					shouldCopyOnOutsideDrop={true}
                 />
                 <SortableTreeWithoutDndContext
                     treeData={[{title: "Title", subtitle: "Subtitle", children: []}]}
                     onChange={(treeData: TreeItem[]) => {}}
                     style={{width: "100px"}}
+					shouldCopyOnOutsideDrop={() => false}
                 />
             </div>
         );


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/frontend-collective/react-sortable-tree
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
