### PR TITLE
Fix typings for zipcodes

### DIFF
--- a/types/zipcodes/index.d.ts
+++ b/types/zipcodes/index.d.ts
@@ -1,6 +1,6 @@
-// Type definitions for zipcodes 6.0
+// Type definitions for zipcodes 6.1
 // Project: https://github.com/davglass/zipcodes#readme
-// Definitions by: Brayden Lopez <https://github.com/headdetect>
+// Definitions by: Brayden Lopez <https://github.com/headdetect>, Dobes Vandermeer <https://github.com/dobesv>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 export as namespace ZipCodes;
@@ -14,18 +14,18 @@ export interface ZipCode {
     country: string;
 }
 
-export function lookup(zip: any): ZipCode;
+export function lookup(zip: string|number): ZipCode | undefined;
 
 export function lookupByName(city: string, state: string): ZipCode[];
 
 export function lookupByState(state: string): ZipCode[];
 
-export function distance(zipA: ZipCode, zipB: ZipCode): number;
+export function distance(zipA: string|number, zipB: string|number): number | null;
 
-export function radius(zip: ZipCode, miles: number, full: boolean): string | ZipCode[];
+export function radius(zip: string|number, miles: number, full: boolean): string[] | ZipCode[];
 
 export function toMiles(kilos: number): number;
 
 export function toKilometers(miles: number): number;
 
-export function lookupByCoords(lat: number, lon: number): ZipCode;
+export function lookupByCoords(lat: number, lon: number): string | null;

--- a/types/zipcodes/zipcodes-tests.ts
+++ b/types/zipcodes/zipcodes-tests.ts
@@ -18,19 +18,19 @@ const zipB: ZipCodes.ZipCode = {
   country: 'US'
 };
 
-ZipCodes.lookup(zipA); // $ExpectType ZipCode
+ZipCodes.lookup(zipA.zip); // $ExpectType ZipCode | undefined
 
 ZipCodes.lookupByName('Cupertino', 'CA'); // $ExpectType ZipCode[]
 
 ZipCodes.lookupByState('CA'); // $ExpectType ZipCode[]
 
-ZipCodes.distance(zipA, zipB); // $ExpectType number
+ZipCodes.distance(zipA.zip, zipB.zip); // $ExpectType number | null
 
-ZipCodes.radius(zipA, 1, true); // $ExpectType string | ZipCode[]
-ZipCodes.radius(zipA, 1, false); // $ExpectType string | ZipCode[]
+ZipCodes.radius(zipA.zip, 1, true); // $ExpectType ZipCode[] | string[]
+ZipCodes.radius(zipA.zip, 1, false); // $ExpectType ZipCode[] | string[]
 
 ZipCodes.toMiles(3); // $ExpectType number
 
 ZipCodes.toKilometers(3); // $ExpectType number
 
-ZipCodes.lookupByCoords(37.323, -122.0527); // $ExpectType ZipCode
+ZipCodes.lookupByCoords(37.323, -122.0527); // $ExpectType string | null


### PR DESCRIPTION
The typings didn't match the library.

* `lookup` takes a `string` (or a `number` if you so choose): https://github.com/davglass/zipcodes/blob/master/lib/index.js#L13
* `distance` takes two `string`s, not `ZipCode` objects: https://github.com/davglass/zipcodes/blob/master/lib/index.js#L56
* similarly, `radius` takes a string rather than a `ZipCode` object, and always returns an array (of `string`s or `ZipCode` objects): https://github.com/davglass/zipcodes/blob/master/lib/index.js#L80

