### PR TITLE
added missing context param in angular-gettext's gettext.getPlural()

### DIFF
--- a/types/angular-gettext/angular-gettext-tests.ts
+++ b/types/angular-gettext/angular-gettext-tests.ts
@@ -24,6 +24,8 @@ angular.module("myApp").controller("helloController", function (gettextCatalog: 
 
 angular.module("myApp").controller("helloController", function (gettextCatalog: angular.gettext.gettextCatalog) {
   var myString2: string = gettextCatalog.getPlural(3, "Bird", "Birds");
+  var myStringWithScope: string = gettextCatalog.getPlural(4, "{{color}} Bird", "{{color}} Birds", {color: 'Blue'});
+  var myStringWithContext: string = gettextCatalog.getPlural(5, "pick", "picks", null, 'noun');
 });
 
 angular.module("myApp").controller("helloController", function (gettextCatalog: angular.gettext.gettextCatalog) {

--- a/types/angular-gettext/index.d.ts
+++ b/types/angular-gettext/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for angular-gettext v2.1.0
+// Type definitions for angular-gettext v2.1.1
 // Project: https://angular-gettext.rocketeer.be/
 // Definitions by: Ákos Lukács <https://github.com/AkosLukacs>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -66,7 +66,7 @@ declare module 'angular' {
       getString(string: string, scope?: any, context?: string): string;
 
       /** Translate a plural string with the given context. */
-      getPlural(n: number, string: string, stringPlural: string, context?: any): string;
+      getPlural(n: number, string: string, stringPlural: string, scope?: any, context?: string): string;
 
       /** Load a set of translation strings from a given URL.This should be a JSON catalog generated with grunt-angular-gettext. More details https://angular-gettext.rocketeer.be/dev-guide/lazy-loading/ */
       loadRemote(url: string): ng.IHttpPromise<any>;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:  
  although it is not specified in documentation (https://angular-gettext.rocketeer.be/dev-guide/api/angular-gettext/), it is available in code (https://github.com/rubenv/angular-gettext/blob/master/src/catalog.js#L265)
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
