### PR TITLE
CodeMirror: make EditorChangeCancellable.update optional, define KeyMap type

### DIFF
--- a/types/codemirror/index.d.ts
+++ b/types/codemirror/index.d.ts
@@ -15,7 +15,7 @@ declare function CodeMirror(callback: (host: HTMLElement) => void , options?: Co
 declare namespace CodeMirror {
     export var Doc : CodeMirror.DocConstructor;
     export var Pos: CodeMirror.PositionConstructor;
-    export var Pass: any;
+    export var Pass: {toString(): "CodeMirror.PASS"};
 
     function countColumn(line: string, index: number | null, tabSize: number): number;
     function fromTextArea(host: HTMLTextAreaElement, options?: EditorConfiguration): CodeMirror.EditorFromTextArea;
@@ -129,6 +129,10 @@ declare namespace CodeMirror {
         state: any;
     }
 
+    interface KeyMap {
+        [keyName: string]: false | string | ((instance: Editor) => void | typeof Pass);
+    }
+
     interface Editor {
 
         /** Tells you whether the editor currently has focus. */
@@ -159,11 +163,11 @@ declare namespace CodeMirror {
         Maps added in this way have a higher precedence than the extraKeys and keyMap options, and between them,
         the maps added earlier have a lower precedence than those added later, unless the bottom argument was passed,
         in which case they end up below other keymaps added with this method. */
-        addKeyMap(map: any, bottom?: boolean): void;
+        addKeyMap(map: string | KeyMap, bottom?: boolean): void;
 
         /** Disable a keymap added with addKeyMap.Either pass in the keymap object itself , or a string,
         which will be compared against the name property of the active keymaps. */
-        removeKeyMap(map: any): void;
+        removeKeyMap(map: string | KeyMap): void;
 
         /** Enable a highlighting overlay.This is a stateless mini - mode that can be used to add extra highlighting.
         For example, the search add - on uses it to highlight the term that's currently being searched.
@@ -781,7 +785,7 @@ declare namespace CodeMirror {
         keyMap?: string;
 
         /** Can be used to specify extra keybindings for the editor, alongside the ones defined by keyMap. Should be either null, or a valid keymap value. */
-        extraKeys?: any;
+        extraKeys?: string | KeyMap;
 
         /** Whether CodeMirror should scroll or wrap for long lines. Defaults to false (scroll). */
         lineWrapping?: boolean;

--- a/types/codemirror/index.d.ts
+++ b/types/codemirror/index.d.ts
@@ -716,8 +716,9 @@ declare namespace CodeMirror {
     }
 
     interface EditorChangeCancellable extends CodeMirror.EditorChange {
-        /** may be used to modify the change. All three arguments to update are optional, and can be left off to leave the existing value for that field intact. */
-        update(from?: CodeMirror.Position, to?: CodeMirror.Position, text?: string[]): void;
+        /** may be used to modify the change. All three arguments to update are optional, and can be left off to leave the existing value for that field intact.
+        If the change came from undo/redo, `update` is undefined and the change cannot be modified. */
+        update?(from?: CodeMirror.Position, to?: CodeMirror.Position, text?: string[]): void;
 
         cancel(): void;
     }

--- a/types/codemirror/test/index.ts
+++ b/types/codemirror/test/index.ts
@@ -4,7 +4,18 @@ var myCodeMirror: CodeMirror.Editor = CodeMirror(document.body);
 
 var myCodeMirror2: CodeMirror.Editor = CodeMirror(document.body, {
     value: "function myScript(){return 100;}\n",
-    mode: "javascript"
+    mode: "javascript",
+    extraKeys: {
+        Enter: (cm) => { console.log("save"); },
+        Esc: (cm) => { return CodeMirror.Pass; }
+    }
+});
+
+// $ExpectError
+var myCodeMirror2_1: CodeMirror.Editor = CodeMirror(document.body, {
+    extraKeys: {
+        "Shift-Enter": (cm) => { return 42; }  // not a valid return value
+    }
 });
 
 var range = myCodeMirror2.findWordAt(CodeMirror.Pos(0, 2));

--- a/types/codemirror/test/index.ts
+++ b/types/codemirror/test/index.ts
@@ -13,9 +13,9 @@ var head = range.head;
 var from = range.from();
 var to = range.to();
 
-var myTextArea: HTMLTextAreaElement;
+var myTextArea: HTMLTextAreaElement = undefined!;
 var myCodeMirror3: CodeMirror.Editor = CodeMirror(function (elt) {
-    myTextArea.parentNode.replaceChild(elt, myTextArea);
+    myTextArea.parentNode!.replaceChild(elt, myTextArea);
 }, { value: myTextArea.value });
 
 var myCodeMirror4: CodeMirror.Editor = CodeMirror.fromTextArea(myTextArea);

--- a/types/codemirror/test/index.ts
+++ b/types/codemirror/test/index.ts
@@ -67,6 +67,15 @@ myCodeMirror.on(
   (instance: CodeMirror.Editor, line: CodeMirror.LineHandle, element: HTMLElement) => { }
 );
 
+myCodeMirror.on(
+  "beforeChange",
+  (instance: CodeMirror.Editor, change: CodeMirror.EditorChangeCancellable) => {
+    // $ExpectError
+    change.update();
+    if (change.update != null) change.update();
+  }
+);
+
 CodeMirror.registerHelper("lint", "javascript", {});
 
 myCodeMirror.isReadOnly();

--- a/types/codemirror/tsconfig.json
+++ b/types/codemirror/tsconfig.json
@@ -7,7 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
-        "strictNullChecks": false,
+        "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",
         "typeRoots": [


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: [EditorChangeCancellable.update](https://codemirror.net/doc/manual.html#event_beforeChange), [key maps](https://codemirror.net/doc/manual.html#keymaps)
- [X] Increase the version number in the header if appropriate.
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
