### PR TITLE
sip.js: Added transportOptions property to ConfigurationParameters

### DIFF
--- a/types/sip.js/index.d.ts
+++ b/types/sip.js/index.d.ts
@@ -231,6 +231,16 @@ export namespace WebRTC {
     }
 }
 
+export interface TransportOptions {
+    wsServers?: string | Array<string>;
+    connectionTimeout?: number;
+    maxReconnectionAttempts?: number;
+    reconnectionTimeout?: number;
+    keepAliveInterval?: number;
+    keepAliveDebounce?: number;
+    traceSip?: number;
+}
+
 /* Parameters */
 export interface ConfigurationParameters {
     uri?: string;
@@ -276,6 +286,7 @@ export interface ConfigurationParameters {
     userAgentString?: string;
     wsServerMaxReconnection?: number;
     wsServerReconnectionTimeout?: number;
+    transportOptions?: TransportOptions;
 }
 
 export interface SimpleConfigurationParameters {

--- a/types/sip.js/index.d.ts
+++ b/types/sip.js/index.d.ts
@@ -232,7 +232,7 @@ export namespace WebRTC {
 }
 
 export interface TransportOptions {
-    wsServers?: string | Array<string>;
+    wsServers?: string | string[];
     connectionTimeout?: number;
     maxReconnectionAttempts?: number;
     reconnectionTimeout?: number;


### PR DESCRIPTION
On sip.js 0.11 in order to specify custom websocket servers property **transportOptions** of UserAgent config should be used.

Added it to ConfigurationParameters with new interface TransportOptions while kept wsServers of ConfigurationParameters in place for compatibility with older versions.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://sipjs.com/api/0.11.0/ws_transport_configuration_parameters
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
