### PR TITLE
Change the type of URLFetchRequestOptions.payload from string to Object

### DIFF
--- a/types/google-apps-script/google-apps-script-tests.ts
+++ b/types/google-apps-script/google-apps-script-tests.ts
@@ -25,3 +25,14 @@ function createAndSendDocument() {
 // Regression
 ScriptApp.getService().getUrl();
 CalendarApp.GuestStatus.NO;
+
+// test for URLFetchRequestOptions.payload
+import URLFetchRequestOptions = GoogleAppsScript.URL_Fetch.URLFetchRequestOptions;
+const postTest = (payload: Object): string => {
+  const url = 'http://httpbin.org/post';
+  const params: URLFetchRequestOptions = {
+    method: 'post',
+    payload: payload
+  };
+  return UrlFetchApp.fetch(url, params).getContentText();
+};

--- a/types/google-apps-script/google-apps-script.url-fetch.d.ts
+++ b/types/google-apps-script/google-apps-script.url-fetch.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Google Apps Script 2018-08-09
+// Type definitions for Google Apps Script 2018-08-08
 // Project: https://developers.google.com/apps-script/
 // Definitions by: motemen <https://github.com/motemen/>
 //                 takoyaki9n <https://github.com/takoyaki9n>
@@ -10,7 +10,7 @@
 declare namespace GoogleAppsScript {
   export module URL_Fetch {
     /**
-     * This class allows users to access specific information on HTTP response.
+     * This class allows users to access specific information on HTTP responses.
      * See also
      *
      * UrlFetchApp

--- a/types/google-apps-script/google-apps-script.url-fetch.d.ts
+++ b/types/google-apps-script/google-apps-script.url-fetch.d.ts
@@ -1,6 +1,7 @@
-// Type definitions for Google Apps Script 2018-07-11
+// Type definitions for Google Apps Script 2018-08-09
 // Project: https://developers.google.com/apps-script/
 // Definitions by: motemen <https://github.com/motemen/>
+//                 takoyaki9n <https://github.com/takoyaki9n>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference path="google-apps-script.types.d.ts" />
@@ -9,7 +10,7 @@
 declare namespace GoogleAppsScript {
   export module URL_Fetch {
     /**
-     * This class allows users to access specific information on HTTP responses.
+     * This class allows users to access specific information on HTTP response.
      * See also
      *
      * UrlFetchApp
@@ -47,7 +48,7 @@ declare namespace GoogleAppsScript {
        * payload. It can be a string, a byte array, or a JavaScript object. A JavaScript object will be
        * interpretted as a map of form field names to values, where the values can be either strings or blobs.
        */
-      payload?: string;
+      payload?: Object;
 
       /**
        * Deprecated. This instructs fetch to resolve the specified URL within the intranet linked to your

--- a/types/google-apps-script/google-apps-script.url-fetch.d.ts
+++ b/types/google-apps-script/google-apps-script.url-fetch.d.ts
@@ -48,7 +48,7 @@ declare namespace GoogleAppsScript {
        * payload. It can be a string, a byte array, or a JavaScript object. A JavaScript object will be
        * interpretted as a map of form field names to values, where the values can be either strings or blobs.
        */
-      payload?: Object;
+      payload?: string | object | Base.Blob;
 
       /**
        * Deprecated. This instructs fetch to resolve the specified URL within the intranet linked to your


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developers.google.com/apps-script/reference/url-fetch/url-fetch-app#fetchurl-params
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

Implementation Detail:
In the [document](https://developers.google.com/apps-script/reference/url-fetch/url-fetch-app#getrequesturl-params), the type of `payload` is defined as `String`. 
However, in the description, they say it is not restricted to string:
> the payload (that is, the POST body) for the request. Certain HTTP methods (for example, GET) do not accept a payload. It can be a string, a byte array, a blob, or a JavaScript object. A JavaScript object is interpreted as a map of form field names to values, where the values can be either strings or blobs. 

I changed the type of `payload` and wrote the following test code:
```TypeScript
import URLFetchRequestOptions = GoogleAppsScript.URL_Fetch.URLFetchRequestOptions;

declare var global: any;

const postTest = (payload: Object): string => {
  const url = 'http://httpbin.org/post';
  const params: URLFetchRequestOptions = {
    method: 'post',
    payload: payload
  };
  return UrlFetchApp.fetch(url, params).getContentText();
};

global.main = (): void => {
  const payload = {
    hello: 'world!'
  };
  Logger.log(JSON.parse(postTest(payload)).form);
  Logger.log(JSON.parse(postTest(JSON.stringify(payload))).form);
};
```
Then I got the following output:
```
[18-08-08 09:08:07:350 PDT] {hello=world!}
[18-08-08 09:08:07:463 PDT] {{"hello":"world!"}=}
```
This means that string payload wouldn't work for default `Content-Type: application/x-www-form-urlencoded`.