### PR TITLE
[prop-types] Minor changes to support TS3

### DIFF
--- a/types/prop-types/index.d.ts
+++ b/types/prop-types/index.d.ts
@@ -34,7 +34,6 @@ export interface Validator<T> {
 
 export interface Requireable<T> extends Validator<T | undefined | null> {
     isRequired: Validator<NonNullable<T>>;
-    [nominalTypeHack]?: T;
 }
 
 export type ValidationMap<T> = { [K in keyof T]-?: Validator<T[K]> };

--- a/types/prop-types/index.d.ts
+++ b/types/prop-types/index.d.ts
@@ -29,7 +29,7 @@ export interface Validator<T> {
         location: string,
         propFullName: string,
     ): Error | null;
-    [nominalTypeHack]?: T | undefined | null;
+    [nominalTypeHack]?: T | null;
 }
 
 export interface Requireable<T> extends Validator<T | undefined | null> {

--- a/types/prop-types/index.d.ts
+++ b/types/prop-types/index.d.ts
@@ -9,27 +9,39 @@ import { ReactNode, ReactElement } from 'react';
 
 export const nominalTypeHack: unique symbol;
 
-export type IsOptional<T> = undefined | null extends T ? true : undefined extends T ? true : null extends T ? true : false;
+export type IsOptional<T> = undefined | null extends T
+    ? true
+    : undefined extends T ? true : null extends T ? true : false;
 
-export type RequiredKeys<V> = { [K in keyof V]: V[K] extends Validator<infer T> ? IsOptional<T> extends true ? never : K : never }[keyof V];
+export type RequiredKeys<V> = {
+    [K in keyof V]: V[K] extends Validator<infer T>
+        ? IsOptional<T> extends true ? never : K
+        : never
+}[keyof V];
 export type OptionalKeys<V> = Exclude<keyof V, RequiredKeys<V>>;
-export type InferPropsInner<V> = { [K in keyof V]: InferType<V[K]>; };
+export type InferPropsInner<V> = { [K in keyof V]: InferType<V[K]> };
 
 export interface Validator<T> {
-    (props: object, propName: string, componentName: string, location: string, propFullName: string): Error | null;
-    [nominalTypeHack]?: T;
+    (
+        props: object,
+        propName: string,
+        componentName: string,
+        location: string,
+        propFullName: string,
+    ): Error | null;
+    [nominalTypeHack]?: T | undefined | null;
 }
 
 export interface Requireable<T> extends Validator<T | undefined | null> {
     isRequired: Validator<NonNullable<T>>;
+    [nominalTypeHack]?: T;
 }
 
 export type ValidationMap<T> = { [K in keyof T]-?: Validator<T[K]> };
 
 export type InferType<V> = V extends Validator<infer T> ? T : any;
-export type InferProps<V> =
-    & InferPropsInner<Pick<V, RequiredKeys<V>>>
-    & Partial<InferPropsInner<Pick<V, OptionalKeys<V>>>>;
+export type InferProps<V> = InferPropsInner<Pick<V, RequiredKeys<V>>> &
+    Partial<InferPropsInner<Pick<V, OptionalKeys<V>>>>;
 
 export const any: Requireable<any>;
 export const array: Requireable<any[]>;
@@ -43,9 +55,11 @@ export const element: Requireable<ReactElement<any>>;
 export const symbol: Requireable<symbol>;
 export function instanceOf<T>(expectedClass: new (...args: any[]) => T): Requireable<T>;
 export function oneOf<T>(types: T[]): Requireable<T>;
-export function oneOfType<T extends Validator<any>>(types: T[]): Requireable<NonNullable<InferType<T>>>;
+export function oneOfType<T extends Validator<any>>(
+    types: T[],
+): Requireable<NonNullable<InferType<T>>>;
 export function arrayOf<T>(type: Validator<T>): Requireable<T[]>;
-export function objectOf<T>(type: Validator<T>): Requireable<{ [K in keyof any]: T; }>;
+export function objectOf<T>(type: Validator<T>): Requireable<{ [K in keyof any]: T }>;
 export function shape<P extends ValidationMap<any>>(type: P): Requireable<InferProps<P>>;
 
 /**
@@ -58,4 +72,10 @@ export function shape<P extends ValidationMap<any>>(type: P): Requireable<InferP
  * @param componentName Name of the component for error messages.
  * @param getStack Returns the component stack.
  */
-export function checkPropTypes(typeSpecs: any, values: any, location: string, componentName: string, getStack?: () => any): void;
+export function checkPropTypes(
+    typeSpecs: any,
+    values: any,
+    location: string,
+    componentName: string,
+    getStack?: () => any,
+): void;

--- a/types/prop-types/prop-types-tests.ts
+++ b/types/prop-types/prop-types-tests.ts
@@ -104,7 +104,7 @@ const propTypesWithoutAnnotation = {
     objectOf: PropTypes.objectOf(PropTypes.number.isRequired).isRequired,
     shape: PropTypes.shape(innerProps).isRequired,
     optionalNumber: PropTypes.number,
-    customProp: (() => null) as PropTypes.Validator<typeof uniqueType | undefined>
+    customProp: customPropFunc,
 };
 
 const partialPropTypes = {

--- a/types/prop-types/prop-types-tests.ts
+++ b/types/prop-types/prop-types-tests.ts
@@ -48,6 +48,10 @@ const arrayOfTypes = [PropTypes.string, PropTypes.bool, PropTypes.shape({
 })];
 type PropTypesMap = PropTypes.ValidationMap<Props>;
 
+const customPropFunc: PropTypes.Validator<typeof uniqueType> = () => null;
+
+(customPropFunc as PropTypes.Requireable<typeof uniqueType>).isRequired = () => null;
+
 // TS checking
 const propTypes: PropTypesMap = {
     any: PropTypes.any,
@@ -74,7 +78,7 @@ const propTypes: PropTypesMap = {
     objectOf: PropTypes.objectOf(PropTypes.number.isRequired).isRequired,
     shape: PropTypes.shape(innerProps).isRequired,
     optionalNumber: PropTypes.number,
-    customProp: (() => null) as PropTypes.Validator<typeof uniqueType | undefined>
+    customProp: customPropFunc,
 };
 
 // JS checking


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: (notes below)
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

# Why

I'm currently in the process of upgrading a project to TS3, a project that utilizes PropTypes and TS interfaces in parallel. Once upgrading to TS3, the compiler is spewing tons of these errors:

```
src/components/AppLoader/index.tsx:68:1 - error TS2322: Type '{ centered: Requireable<boolean>; children: Validator<string | number | boolean | {} | ReactElement<any> | ReactNodeArray | ReactPortal>; failureText: Validator<string | number | ... 4 more ... | ReactPortal>; ... 6 more ...; themeName: Requireable<...>; }' is not assignable to type 'ValidationMap<AppLoaderProps & WithStylesProps>'.
  Types of property 'centered' are incompatible.
    Type 'Requireable<boolean>' is not assignable to type 'Validator<boolean | undefined>'.
        Types of property '[nominalTypeHack]' are incompatible.
          Type 'boolean | null | undefined' is not assignable to type 'boolean | undefined'.
            Type 'null' is not assignable to type 'boolean | undefined'.

68 AppLoader.propTypes = {
   ~~~~~~~~~~~~~~~~~~~
```

The component looked like the following:

```js
export interface AppLoaderProps {
  centered?: boolean;
}

AppLoader.defaultProps = {
  centered: false,
};

AppLoader.propTypes = {
  centered: PropTypes.bool,
};
```

Updating the `nominalHack` to also support `null` seemed to resolve the issue.