### PR TITLE
mapbox-gl: Changed to UMD module

### DIFF
--- a/types/mapbox-gl/index.d.ts
+++ b/types/mapbox-gl/index.d.ts
@@ -6,6 +6,9 @@
 
 /// <reference types="geojson" />
 
+export = mapboxgl;
+export as namespace mapboxgl;
+
 declare namespace mapboxgl {
     let accessToken: string;
     let version: string;
@@ -1285,12 +1288,4 @@ declare namespace mapboxgl {
         'hillshade-accent-color'?: string | Expression;
         'hillshade-accent-color-transition'?: Transition;
     }
-}
-
-declare module 'mapbox-gl' {
-    export = mapboxgl;
-}
-
-declare module 'mapbox-gl/dist/mapbox-gl' {
-    export = mapboxgl;
 }


### PR DESCRIPTION
Please check related issue: https://github.com/Microsoft/TypeScript/issues/26309

With this change using mapbox-gl without import in a module will throw an error:  `[ts] 'mapboxgl' refers to a UMD global, but the current file is a module. Consider adding an import instead.`

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.typescriptlang.org/docs/handbook/modules.html#umd-modules
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
