### PR TITLE
@types/react-select Fix: MouseEventHandler is marked as a Generic type

### DIFF
--- a/types/react-select/lib/components/Option.d.ts
+++ b/types/react-select/lib/components/Option.d.ts
@@ -14,8 +14,8 @@ interface State {
 interface InnerProps {
   id: string;
   key: string;
-  onClick: MouseEventHandler;
-  onMouseOver: MouseEventHandler;
+  onClick: MouseEventHandler<any>;
+  onMouseOver: MouseEventHandler<any>;
   tabIndex: number;
 }
 export type OptionProps<OptionType> = PropsWithStyles &


### PR DESCRIPTION
Env:
```
{
  "react": "16.2.0",
}
```

Error(s) Encountered:
- .../Option.d.ts(17,12): error TS2314: Generic type 'MouseEventHandler' requires 1 type argument(s).

Fix:
- Treat MouseEventHandler as a generic.