### PR TITLE
[material__menu] Corrected parameter type for MDCMenu.setAnchorCorner()

### DIFF
--- a/types/material__menu/foundation.d.ts
+++ b/types/material__menu/foundation.d.ts
@@ -40,7 +40,7 @@ export default class MDCMenuFoundation extends MDCFoundation<MDCMenuFoundation> 
     /**
      * @param corner Default anchor corner alignment of top-left menu corner.
      */
-    setAnchorCorner(corner: Corner): void;
+    setAnchorCorner(corner: number): void;
 
     /**
      * @param margin 4-plet of margins from anchor.

--- a/types/material__menu/index.d.ts
+++ b/types/material__menu/index.d.ts
@@ -39,7 +39,7 @@ export class MDCMenu extends MDCComponent<MDCMenuAdapter, MDCMenuFoundation> {
     /**
      * @param corner Default anchor corner alignment of top-left menu corner.
      */
-    setAnchorCorner(corner: Corner): void;
+    setAnchorCorner(corner: number): void;
 
     setAnchorMargin(margin: AnchorMargin): void;
 


### PR DESCRIPTION
The `MDCMenu.setAnchorCorner()` method expects a number, based on one of the static properties of `Corner`, e.g. `Corner.TOP_RIGHT`, rather than a Corner instance, as currently specified.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://material.io/develop/web/components/menus/
