### PR TITLE
[@types/react-file-reader] Add type definitions for react-file-reader

### DIFF
--- a/types/react-file-reader/index.d.ts
+++ b/types/react-file-reader/index.d.ts
@@ -1,0 +1,30 @@
+// Type definitions for react-file-reader
+// Project: https://www.npmjs.com/package/react-file-reader
+// Definitions by: Luke Schoen <https://github.com/ltfschoen>
+//                 Jaco Greeff <https://github.com/jacogr>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.8
+
+///<reference types="react" />
+
+import React, { Component, ReactElement } from "react";
+
+export type FileTypes = '.csv' | '.zip' | '.json' | 'image/*';
+
+declare module "react-file-reader" {
+    interface ReactFileReaderProps {
+        fileTypes: FileTypes | Array<FileTypes>
+        multipleFiles: boolean,
+        base64: boolean,
+        disabled: boolean,
+        handleFiles: (event: React.SyntheticEvent<any>, fileList: ReadonlyArray<FileList>) => void;
+        children: any;
+    }
+
+    interface FileReader {
+        new(): FileReader;
+    }
+
+    export class ReactFileReader extends React.Component<ReactFileReaderProps> {
+    }
+}

--- a/types/react-file-reader/index.d.ts
+++ b/types/react-file-reader/index.d.ts
@@ -13,16 +13,12 @@ export type FileTypes = '.csv' | '.zip' | '.json' | 'image/*';
 
 declare module "react-file-reader" {
     interface ReactFileReaderProps {
-        fileTypes: FileTypes | Array<FileTypes>
-        multipleFiles: boolean,
-        base64: boolean,
-        disabled: boolean,
+        fileTypes: FileTypes | FileTypes[];
+        multipleFiles: boolean;
+        base64: boolean;
+        disabled: boolean;
         handleFiles: (event: React.SyntheticEvent<any>, fileList: ReadonlyArray<FileList>) => void;
         children: any;
-    }
-
-    interface FileReader {
-        new(): FileReader;
     }
 
     export class ReactFileReader extends React.Component<ReactFileReaderProps> {

--- a/types/react-file-reader/react-file-reader-tests.tsx
+++ b/types/react-file-reader/react-file-reader-tests.tsx
@@ -1,0 +1,39 @@
+import * as React from 'react';
+import ReactFileReader from 'react-file-reader';
+
+class MyComponent extends React.Component {
+  handleUploadedFiles = (event: React.SyntheticEvent<any>, fileList: ReactFileReader.FileList[]) => {
+    const fileToUpload: File = fileList[0];
+    console.log('File to upload:', fileToUpload);
+    const fileReader: FileReader = new FileReader();
+
+    fileReader.onload = (e) => {
+      try {
+        if (typeof e !== undefined && e.target !== null) {
+          const fileContents: any = JSON.parse(e.target.result);
+          console.log('File contents:', fileContents);
+        }
+      } catch (e) {
+        console.error('Error uploading file: ', e);
+      }
+    };
+
+    fileReader.readAsText(fileToUpload);
+  }
+
+  render(): React.ReactElement<{}> {
+    return (
+      <form>
+        <label htmlFor="my-file-input">Upload a File: </label>
+        <ReactFileReader
+          fileTypes={['.json']}
+          base64={false}
+          multipleFiles={false}
+          handleFiles={this.handleUploadedFiles}
+        >
+          <button>Select a file!</button>
+        </ReactFileReader>
+      </form>
+    );
+  }
+}

--- a/types/react-file-reader/tsconfig.json
+++ b/types/react-file-reader/tsconfig.json
@@ -1,0 +1,28 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "target": "es6",
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": false,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "jsx": "react"
+    },
+    "files": [
+        "index.d.ts",
+        "react-file-reader-tests.tsx"
+    ],
+    "baseUrl": "types",
+    "typeRoots": ["types"]
+}

--- a/types/react-file-reader/tsconfig.json
+++ b/types/react-file-reader/tsconfig.json
@@ -8,7 +8,7 @@
         "target": "es6",
         "noImplicitAny": true,
         "noImplicitThis": true,
-        "strictNullChecks": false,
+        "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/react-file-reader/tslint.json
+++ b/types/react-file-reader/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [.] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [.] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [?] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [?] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/GrillWork/react-file-reader
- [.] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

