### PR TITLE
[JSForce] Update types for methods in the SObject class

### DIFF
--- a/types/jsforce/connection.d.ts
+++ b/types/jsforce/connection.d.ts
@@ -10,8 +10,16 @@ import { Metadata } from './api/metadata';
 import { Bulk } from './bulk';
 import { Cache } from './cache'
 import { OAuth2, Streaming } from '.';
+import { HttpApiOptions } from './http-api'
 
-export type Callback<T> = (err: Error, result: T) => void;
+export type Callback<T> = (err: Error | null, result: T) => void;
+// The type for these options was determined by looking at the usage
+// of the options object in Connection.create and other methods
+// go to http://jsforce.github.io/jsforce/doc/connection.js.html#line568
+// and search for options
+export interface RestApiOptions {
+    headers?: { [x: string]: string }
+}
 
 // These are pulled out because according to http://jsforce.github.io/jsforce/doc/connection.js.html#line49
 // the oauth options can either be in the `oauth2` proeprty OR spread across the main connection
@@ -93,24 +101,24 @@ export type ConnectionEvent = "refresh";
  */
 export abstract class BaseConnection extends EventEmitter {
     _baseUrl(): string;
-    request(info: RequestInfo | string, options?: Object, callback?: (err: Error, Object: object) => void): Promise<Object>;
+    request(info: RequestInfo | string, options?: HttpApiOptions, callback?: (err: Error, Object: object) => void): Promise<Object>;
     query<T>(soql: string, options?: ExecuteOptions, callback?: (err: Error, result: QueryResult<T>) => void): Query<QueryResult<T>>;
     queryMore<T>(locator: string, options?: ExecuteOptions, callback?: (err: Error, result: QueryResult<T>) => void): Promise<QueryResult<T>>;
-    create<T>(type: string, records: Record<T> | Array<Record<T>>, options?: Object,
+    create<T>(type: string, records: Record<T> | Array<Record<T>>, options?: RestApiOptions,
         callback?: (err: Error, result: RecordResult | RecordResult[]) => void): Promise<(RecordResult | RecordResult[])>;
-    insert<T>(type: string, records: Record<T> | Array<Record<T>>, options?: Object,
+    insert<T>(type: string, records: Record<T> | Array<Record<T>>, options?: RestApiOptions,
         callback?: (err: Error, result: RecordResult | RecordResult[]) => void): Promise<(RecordResult | RecordResult[])>;
-    retrieve<T>(type: string, ids: string | string[], options?: Object,
+    retrieve<T>(type: string, ids: string | string[], options?: RestApiOptions,
         callback?: (err: Error, result: Record<T> | Array<Record<T>>) => void): Promise<(Record<T> | Array<Record<T>>)>;
-    update<T>(type: string, records: Record<T> | Array<Record<T>>, options?: Object,
+    update<T>(type: string, records: Record<T> | Array<Record<T>>, options?: RestApiOptions,
         callback?: (err: Error, result: RecordResult | Array<Record<T>>) => void): Promise<(RecordResult | RecordResult[])>;
-    upsert<T>(type: string, records: Record<T> | Array<Record<T>>, extIdField: string, options?: Object,
+    upsert<T>(type: string, records: Record<T> | Array<Record<T>>, extIdField: string, options?: RestApiOptions,
         callback?: (err: Error, result: RecordResult | RecordResult[]) => void): Promise<(RecordResult | RecordResult[])>;
-    del<T>(type: string, ids: string | string[], options?: Object,
+    del<T>(type: string, ids: string | string[], options?: RestApiOptions,
         callback?: (err: Error, result: RecordResult | RecordResult[]) => void): Promise<(RecordResult | RecordResult[])>;
-    delete<T>(type: string, ids: string | string[], options?: Object,
+    delete<T>(type: string, ids: string | string[], options?: RestApiOptions,
         callback?: (err: Error, result: RecordResult | RecordResult[]) => void): Promise<(RecordResult | RecordResult[])>;
-    destroy<T>(type: string, ids: string | string[], options?: Object,
+    destroy<T>(type: string, ids: string | string[], options?: RestApiOptions,
         callback?: (err: Error, result: RecordResult | RecordResult[]) => void): Promise<(RecordResult | RecordResult[])>;
     describe$: {
         /** Returns a value from the cache if it exists, otherwise calls Connection.describe */
@@ -124,7 +132,8 @@ export abstract class BaseConnection extends EventEmitter {
         clear(): void;
     }
     describeGlobal<T>(callback?: (err: Error, result: DescribeGlobalResult) => void): Promise<DescribeGlobalResult>;
-    sobject<T>(resource: string): SObject<T>;
+    // we want any object to be accepted if the user doesn't decide to give an explicit type
+    sobject<T = object>(resource: string): SObject<T>;
 }
 
 export class Connection extends BaseConnection {

--- a/types/jsforce/global.d.ts
+++ b/types/jsforce/global.d.ts
@@ -1,1 +1,0 @@
-export type Callback<T> = (err: Error | null, ret: T) => void;

--- a/types/jsforce/global.d.ts
+++ b/types/jsforce/global.d.ts
@@ -1,0 +1,1 @@
+export type Callback<T> = (err: Error | null, ret: T) => void;

--- a/types/jsforce/http-api.d.ts
+++ b/types/jsforce/http-api.d.ts
@@ -1,0 +1,5 @@
+export interface HttpApiOptions {
+    responseType?: string;
+    transport?: object;
+    noContentResponse?: object
+}

--- a/types/jsforce/index.d.ts
+++ b/types/jsforce/index.d.ts
@@ -6,7 +6,7 @@
 //                 Tim Noonan <https://github.com/tnoonan-salesforce>
 //                 Abraham White <https://github.com/whiteabelincoln>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 export * from './api/analytics';
 export * from './api/chatter';

--- a/types/jsforce/jsforce-tests.ts
+++ b/types/jsforce/jsforce-tests.ts
@@ -4,12 +4,9 @@ import * as express from 'express';
 import * as glob from 'glob';
 
 import * as sf from 'jsforce';
-
-export interface DummyRecord {
-    thing: boolean;
-    other: number;
-    person: string;
-}
+import { RecordReference, Record } from 'jsforce/record';
+import { SObject } from 'jsforce/salesforce-object';
+import { RecordResult } from 'jsforce/record-result';
 
 const salesforceConnection: sf.Connection = new sf.Connection({
     instanceUrl: '',
@@ -20,7 +17,304 @@ const salesforceConnection: sf.Connection = new sf.Connection({
     },
 });
 
-salesforceConnection.sobject<DummyRecord>("Dummy").select(["thing", "other"]);
+async function testSObject(connection: sf.Connection) {
+    interface DummyRecord {
+        thing: boolean;
+        other: number;
+        person: string;
+    }
+
+    const dummySObject: SObject<DummyRecord> = connection.sobject<DummyRecord>('Dummy');
+
+    // currently untyped, but some future change may make this stricter
+    const restApiOptions = {
+        headers: { Bearer: 'I have no idea what this wants' }
+    };
+
+    { // Test SObject.record
+        // $ExpectType RecordReference<DummyRecord>
+        dummySObject.record('50130000000014C');
+    }
+
+    { // Test SObject.retrieve
+        // with single id
+        // $ExpectType Record<DummyRecord>
+        await dummySObject.retrieve('50130000000014C');
+        // with single id and rest api options
+        // $ExpectType Record<DummyRecord>
+        await dummySObject.retrieve('50130000000014C', restApiOptions);
+
+        // with single id and callback
+        dummySObject.retrieve('50130000000014C', restApiOptions, (err, res) => {
+            err; // $ExpectType Error | null
+            res; // $ExpectType Record<DummyRecord>
+        });
+
+        // with ids array
+        // $ExpectType Record<DummyRecord>[]
+        await dummySObject.retrieve(['IIIIDDD']);
+        // with ids array and rest api options
+        // $ExpectType Record<DummyRecord>[]
+        await dummySObject.retrieve(['IIIIDDD'], restApiOptions);
+
+        // with ids array and callback
+        dummySObject.retrieve(['50130000000014C'], restApiOptions, (err, res) => {
+            err; // $ExpectType Error | null
+            res; // $ExpectType Record<DummyRecord>[]
+        });
+
+        salesforceConnection.sobject<any>("ContentVersion").retrieve("world", {
+            test: "test"
+        }, (err, ret) => {
+            err; // $ExpectType Error | null
+            ret; // $ExpectType any
+        });
+    }
+
+    { // Test SObject.update
+        // if we require that records have an id field this will fail
+        // //$ExpectError
+        await dummySObject.update({ thing: false });
+
+        // If we require that the records have an Id field
+        // await dummySObject.update({ thing: false, Id: 'asdf' }); // $ExpectType RecordResult
+
+        // invalid field
+        // $ExpectError
+        await dummySObject.update({ asdf: false });
+
+        // with rest api options
+        // $ExpectType RecordResult
+        await dummySObject.update({ thing: false }, restApiOptions);
+
+        // with callback
+        dummySObject.update({ thing: false }, (err, res) => {
+            err; // $ExpectType Error | null
+            res; // $ExpectType RecordResult
+        });
+
+        dummySObject.update({ thing: false }, restApiOptions, (err, res) => {
+            err; // $ExpectType Error | null
+            res; // $ExpectType RecordResult
+        });
+
+        // with multiple records
+        // $ExpectType RecordResult[]
+        await dummySObject.update([{ thing: false }]);
+
+        // with multiple records and api options
+        // $ExpectType RecordResult[]
+        await dummySObject.update([{ thing: false }], restApiOptions);
+
+        // with multiple records and callback
+        dummySObject.update([{ thing: false }], restApiOptions, (err, res) => {
+            err; // $ExpectType Error | null
+            res; // $ExpectType RecordResult[]
+        });
+
+        dummySObject.update([{ thing: false }], (err, res) => {
+            err; // $ExpectType Error | null
+            res; // $ExpectType RecordResult[]
+        });
+    }
+
+    { // Test SObject.updated
+        // $ExpectType UpdatedRecordsInfo
+        await dummySObject.updated(new Date(), new Date());
+
+        // $ExpectType UpdatedRecordsInfo
+        await dummySObject.updated(new Date(), 'hi');
+
+        // $ExpectType UpdatedRecordsInfo
+        await dummySObject.updated('hi', new Date());
+
+        // $ExpectType UpdatedRecordsInfo
+        await dummySObject.updated('hi', 'hi');
+
+        dummySObject.updated(new Date(), 'hi', (err, ret) => {
+            err; // $ExpectType Error | null
+            ret; // $ExpectType UpdatedRecordsInfo
+        });
+    }
+
+    { // Test SObject.upsert
+        const updateData = {
+            Id: 'Some ID',
+            thing: true,
+            other: 1,
+            person: 'hi'
+        };
+        // $ExpectType RecordResult
+        await dummySObject.upsert(updateData, 'Id');
+
+        // $ExpectType RecordResult
+        await dummySObject.upsert(updateData, 'Id', restApiOptions);
+
+        // $ExpectType RecordResult[]
+        await dummySObject.upsert([updateData], 'Id');
+
+        // $ExpectType RecordResult[]
+        await dummySObject.upsert([updateData], 'Id', restApiOptions);
+
+        dummySObject.upsert(updateData, 'Id', (err, ret) => {
+            err; // $ExpectType Error | null
+            ret; // $ExpectType RecordResult
+        });
+
+        dummySObject.upsert(updateData, 'Id', restApiOptions, (err, ret) => {
+            err; // $ExpectType Error | null
+            ret; // $ExpectType RecordResult
+        });
+
+        dummySObject.upsert([updateData], 'Id', (err, ret) => {
+            err; // $ExpectType Error | null
+            ret; // $ExpectType RecordResult[]
+        });
+
+        dummySObject.upsert([updateData], 'Id', restApiOptions, (err, ret) => {
+            err; // $ExpectType Error | null
+            ret; // $ExpectType RecordResult[]
+        });
+    }
+
+    { // Test SObject.find
+    }
+
+    { // Test SObject.findOne
+        salesforceConnection.sobject("ContentVersion").findOne<any>({ Id: '' }, (err, contentVersion) => {
+            err; // $ExpectType Error | null
+            contentVersion; // $ExpectType any
+        });
+    }
+
+    { // Test SObject.select
+
+        dummySObject.select(["thing", "other"]);
+
+        // note the following should never compile:
+        // $ExpectError
+        dummySObject.select(["lol"]);
+    }
+
+    { // Test SObject.create
+        // $ExpectType RecordResult
+        await dummySObject.create({
+            thing: true,
+            other: 1,
+            person: 'hi'
+        });
+
+        // $ExpectType RecordResult
+        await dummySObject.create({
+            thing: true,
+            other: 1,
+            person: 'hi'
+        }, restApiOptions);
+
+        // $ExpectType RecordResult[]
+        await dummySObject.create([{
+            thing: true,
+            other: 1,
+            person: 'hi'
+        }]);
+
+        // $ExpectType RecordResult[]
+        await dummySObject.create([{
+            thing: true,
+            other: 1,
+            person: 'hi'
+        }], restApiOptions);
+
+        dummySObject.create([{
+            thing: true,
+            other: 1,
+            person: 'hi'
+        }], (err, ret) => {
+            err; // $ExpectType Error | null
+            ret; // $ExpectType RecordResult[]
+        });
+
+        dummySObject.create([{
+            thing: true,
+            other: 1,
+            person: 'hi'
+        }], restApiOptions, (err, ret) => {
+            err; // $ExpectType Error | null
+            ret; // $ExpectType RecordResult[]
+        });
+
+        salesforceConnection.sobject("Account").create({
+            Name: "Test Acc 2",
+            BillingStreet: "Maplestory street",
+            BillingPostalCode: "ME4 666"
+        }, (err, ret) => {
+            err; // $ExpectType Error | null
+            ret; // $ExpectType RecordResult
+        });
+
+        // callback and rest api options
+        salesforceConnection.sobject("ContentVersion").create({
+            OwnerId: '',
+            Title: 'hello',
+            PathOnClient: './hello-world.jpg',
+            VersionData: '{ Test: Data }'
+        }, restApiOptions, (err, ret) => {
+            err; // $ExpectType Error | null
+            ret; // $ExpectType RecordResult
+        });
+
+        salesforceConnection.sobject("ContentDocumentLink").create({
+            ContentDocumentId: '',
+            LinkedEntityId: '',
+            ShareType: "I"
+        }, (err, ret) => {
+            err; // $ExpectType Error | null
+            ret; // $ExpectType RecordResult
+        });
+    }
+
+    { // Test SObject.destroy and aliases
+        // $ExpectType RecordResult
+        await dummySObject.del('Id');
+        // $ExpectType RecordResult
+        await dummySObject.destroy('Id');
+        // $ExpectType RecordResult
+        await dummySObject.delete('Id');
+
+        // $ExpectType RecordResult[]
+        await dummySObject.del(['Id']);
+        // $ExpectType RecordResult[]
+        await dummySObject.destroy(['Id']);
+        // $ExpectType RecordResult[]
+        await dummySObject.delete(['Id']);
+
+        dummySObject.del('Id', (err, ret) => {
+            err; // $ExpectType Error | null
+            ret; // $ExpectType RecordResult
+        });
+        dummySObject.destroy('Id', (err, ret) => {
+            err; // $ExpectType Error | null
+            ret; // $ExpectType RecordResult
+        });
+        dummySObject.delete('Id', (err, ret) => {
+            err; // $ExpectType Error | null
+            ret; // $ExpectType RecordResult
+        });
+
+        dummySObject.del(['Id'], (err, ret) => {
+            err; // $ExpectType Error | null
+            ret; // $ExpectType RecordResult[]
+        });
+        dummySObject.destroy(['Id'], (err, ret) => {
+            err; // $ExpectType Error | null
+            ret; // $ExpectType RecordResult[]
+        });
+        dummySObject.delete(['Id'], (err, ret) => {
+            err; // $ExpectType Error | null
+            ret; // $ExpectType RecordResult[]
+        });
+    }
+}
 
 const requestInfo: sf.RequestInfo = {
     body: '',
@@ -37,51 +331,6 @@ const queryOptions: sf.ExecuteOptions = {
     scanAll: true
 };
 salesforceConnection.query('SELECT Id, Name FROM Account', queryOptions);
-
-// note the following should never compile:
-// salesforceConnection.sobject<DummyRecord>("Dummy").select(["lol"]);
-
-salesforceConnection.sobject("Account").create({
-    Name: "Test Acc 2",
-    BillingStreet: "Maplestory street",
-    BillingPostalCode: "ME4 666"
-}, (err: Error, ret: sf.RecordResult | sf.RecordResult[]) => {
-    if (err || !Array.isArray(ret) && !ret.success) {
-        return;
-    }
-});
-
-salesforceConnection.sobject("ContentVersion").create({
-    OwnerId: '',
-    Title: 'hello',
-    PathOnClient: './hello-world.jpg',
-    VersionData: '{ Test: Data }'
-}, (err: Error, ret: sf.RecordResult | sf.RecordResult[]) => {
-    if (err || !Array.isArray(ret) && !ret.success) {
-        return;
-    }
-});
-
-salesforceConnection.sobject<any>("ContentVersion").retrieve("world", {
-    test: "test"
-}, (err: Error, ret) => {
-    if (err) {
-        return;
-    }
-});
-
-salesforceConnection.sobject("ContentVersion").findOne<any>({ Id: '' }, (err, contentVersion) => {
-});
-
-salesforceConnection.sobject("ContentDocumentLink").create({
-    ContentDocumentId: '',
-    LinkedEntityId: '',
-    ShareType: "I"
-}, (err: Error, ret: sf.RecordResult | sf.RecordResult[]) => {
-    if (err || !Array.isArray(ret) && !ret.success) {
-        return;
-    }
-});
 
 sf.Date.YESTERDAY;
 
@@ -230,7 +479,7 @@ async function testChatter(conn: sf.Connection): Promise<void> {
         },
         feedElementType: 'FeedItem',
         subjectId: 'me'
-    }, (err: Error, result: any) => {
+    }, (err: Error | null, result: any) => {
         if (err) {
             throw err;
         }
@@ -242,7 +491,7 @@ async function testChatter(conn: sf.Connection): Promise<void> {
                     text: 'This is new comment on the post'
                 }]
             }
-        }, (err: Error, result: any) => {
+        }, (err: Error | null, result: any) => {
             if (err) {
                 throw err;
             }
@@ -366,13 +615,15 @@ async function testDescribe() {
         object.fields.forEach(field => {
             const type: sf.FieldType = field.type;
             // following should never compile
-            // const fail = type === 'hey'
+            // $ExpectError
+            const fail = type === 'hey';
 
             const isString = type === 'string';
         });
 
         // following should never compile (if StrictNullChecks is on)
-        // object.keyPrefix.length;
+        // $ExpectError
+        object.keyPrefix.length;
 
         console.log(`${sobject.name} Label: `, object.label);
 

--- a/types/jsforce/jsforce-tests.ts
+++ b/types/jsforce/jsforce-tests.ts
@@ -273,6 +273,92 @@ async function testSObject(connection: sf.Connection) {
         });
     }
 
+    { // Test SObject.createBulk
+        // $ExpectType Batch
+        dummySObject.createBulk();
+        // $ExpectType Batch
+        dummySObject.createBulk('hi.csv');
+        // $ExpectType Batch
+        dummySObject.createBulk([{ Id: 'hi', thing: true, other: 1, person: 'you' }]);
+        // $ExpectType Batch
+        dummySObject.createBulk([{ Id: 'hi', thing: true, other: 1, person: 'you' }], (err, res) => {
+            err; // $ExpectType Error | null
+            res; // $ExpectType RecordResult[]
+        });
+        dummySObject.createBulk('hi.csv', (err, res) => {
+            err; // $ExpectType Error | null
+            res; // $ExpectType RecordResult[]
+        });
+    }
+
+    { // Test SObject.deleteBulk and aliases
+        // $ExpectType Batch
+        dummySObject.deleteBulk();
+        // $ExpectType Batch
+        dummySObject.deleteBulk('hi.csv');
+        // $ExpectType Batch
+        dummySObject.deleteBulk([{ Id: 'hi', thing: true, other: 1, person: 'you' }]);
+        // $ExpectType Batch
+        dummySObject.deleteBulk([{ Id: 'hi', thing: true, other: 1, person: 'you' }], (err, res) => {
+            err; // $ExpectType Error | null
+            res; // $ExpectType RecordResult[]
+        });
+        dummySObject.deleteBulk('hi.csv', (err, res) => {
+            err; // $ExpectType Error | null
+            res; // $ExpectType RecordResult[]
+        });
+
+        // $ExpectType Batch
+        dummySObject.destroyBulk();
+        // $ExpectType Batch
+        dummySObject.destroyBulk('hi.csv');
+        // $ExpectType Batch
+        dummySObject.destroyBulk([{ Id: 'hi', thing: true, other: 1, person: 'you' }]);
+        // $ExpectType Batch
+        dummySObject.destroyBulk([{ Id: 'hi', thing: true, other: 1, person: 'you' }], (err, res) => {
+            err; // $ExpectType Error | null
+            res; // $ExpectType RecordResult[]
+        });
+        dummySObject.destroyBulk('hi.csv', (err, res) => {
+            err; // $ExpectType Error | null
+            res; // $ExpectType RecordResult[]
+        });
+    }
+
+    { // Test SObject.deleteHardBulk and aliases
+        // $ExpectType Batch
+        dummySObject.deleteHardBulk();
+        // $ExpectType Batch
+        dummySObject.deleteHardBulk('hi.csv');
+        // $ExpectType Batch
+        dummySObject.deleteHardBulk([{ Id: 'hi', thing: true, other: 1, person: 'you' }]);
+        // $ExpectType Batch
+        dummySObject.deleteHardBulk([{ Id: 'hi', thing: true, other: 1, person: 'you' }], (err, res) => {
+            err; // $ExpectType Error | null
+            res; // $ExpectType RecordResult[]
+        });
+        dummySObject.deleteHardBulk('hi.csv', (err, res) => {
+            err; // $ExpectType Error | null
+            res; // $ExpectType RecordResult[]
+        });
+
+        // $ExpectType Batch
+        dummySObject.destroyHardBulk();
+        // $ExpectType Batch
+        dummySObject.destroyHardBulk('hi.csv');
+        // $ExpectType Batch
+        dummySObject.destroyHardBulk([{ Id: 'hi', thing: true, other: 1, person: 'you' }]);
+        // $ExpectType Batch
+        dummySObject.destroyHardBulk([{ Id: 'hi', thing: true, other: 1, person: 'you' }], (err, res) => {
+            err; // $ExpectType Error | null
+            res; // $ExpectType RecordResult[]
+        });
+        dummySObject.destroyHardBulk('hi.csv', (err, res) => {
+            err; // $ExpectType Error | null
+            res; // $ExpectType RecordResult[]
+        });
+    }
+
     { // Test SObject.destroy and aliases
         // $ExpectType RecordResult
         await dummySObject.del('Id');

--- a/types/jsforce/quick-action.d.ts
+++ b/types/jsforce/quick-action.d.ts
@@ -1,0 +1,52 @@
+import { Callback } from './global';
+import { Record } from './record';
+
+export class QuickAction {
+    /**
+     * Retrieve default field values in the action for the given record
+     * @param contextId Id of record
+     * @param callback Callback function
+     */
+    defaultValues(contextId: string, callback?: Callback<Record>): Promise<Record>;
+    /** Retrieve default field values in the action */
+    defaultValues(callback?: Callback<Record>): Promise<Record>;
+    /**
+     * Describe the action's information (including layout, etc.)
+     * @param callback Callback function
+     */
+    describe(callback?: Callback<QuickActionDescribeInfo>): Promise<QuickActionDescribeInfo>;
+    /**
+     * Execute the action for given context id and record information
+     * @param contextId Context record ID of the action
+     * @param record Input record information for the action
+     * @param callback Callback function
+     */
+    execute<T>(contextId: string, record: Record<T>, callback?: Callback<QuickActionResult>): Promise<QuickActionResult>;
+}
+
+// TODO: figure out the actual shape of this. the docs don't have it
+export type QuickActionResult = object;
+
+export interface QuickActionInfo {
+    /** Type of the action (e.g. Create, Update, Post, LogACall) */
+    type: string;
+    /** Name of the action */
+    name: string;
+    /** Label of the action */
+    label: string;
+    /** Endpoint URL information of the action */
+    urls: object;
+}
+
+export interface QuickActionDescribeInfo {
+    /** Object type used for the action */
+    contextSobjectType: string;
+    /** Object type of the action to target */
+    targetSobjectType: string;
+    /** Field name in the target object which refers parent(context) object record ID */
+    targetParentField: string;
+    /** Record type of the targeted record */
+    targetRecordTypeId: string;
+    /** Layout sections that comprise an action */
+    layout: object;
+}

--- a/types/jsforce/quick-action.d.ts
+++ b/types/jsforce/quick-action.d.ts
@@ -1,4 +1,4 @@
-import { Callback } from './global';
+import { Callback } from './connection';
 import { Record } from './record';
 
 export class QuickAction {

--- a/types/jsforce/salesforce-object.d.ts
+++ b/types/jsforce/salesforce-object.d.ts
@@ -5,79 +5,97 @@ import { DescribeSObjectResult } from './describe-result';
 import { Query } from './query';
 import { Record, RecordReference } from './record';
 import { RecordResult } from './record-result';
-import { Connection } from './connection';
+import { Connection, Callback } from './connection';
 import { SalesforceId } from './salesforce-id';
 import { Batch, BatchResultInfo } from './batch';
+import { QuickAction, QuickActionInfo } from './quick-action';
 
 export class SObject<T> {
     record(id: SalesforceId): RecordReference<T>;
-    retrieve(id: SalesforceId, options?: Object, callback?: (err: Error, record: Record<T>) => void): Promise<Record<T>>;
-    retrieve(ids: SalesforceId[], options?: Object, callback?: (err: Error, ret: Array<Record<T>>) => void): Promise<Array<Record<T>>>;
-    update(record: Partial<T>, options?: Object, callback?: (err: Error, ret: RecordResult) => void): Promise<RecordResult>;
-    update(records: Array<Partial<T>>, options?: Object, callback?: (err: Error, ret: RecordResult[]) => void): Promise<RecordResult[]>;
-    updateBulk(input?: Record[] | stream.Stream | string, callback?: (err: Error, ret: RecordResult[]) => void): Batch;
-    updated(start: string | Date, end: string | Date, callback?: (err: Error, ret: UpdatedRecordsInfo) => void): Promise<UpdatedRecordsInfo>;
-    upsert(records: Record<T>, extIdField: SalesforceId, options?: Object, callback?: (err: Error, ret: RecordResult) => void): Promise<RecordResult>;
-    upsert(records: Array<Record<T>>, extIdField: SalesforceId, options?: Object, callback?: (err: Error, ret: RecordResult[]) => void): Promise<RecordResult[]>;
-    upsertBulk(input?: Array<Record<T>> | stream.Stream | string, callback?: (err: Error, ret: RecordResult[] | BatchResultInfo[]) => void): Batch;
+    retrieve(id: SalesforceId, options?: Object, callback?: Callback<Record<T>>): Promise<Record<T>>;
+    retrieve(ids: SalesforceId[], options?: Object, callback?: Callback<Array<Record<T>>>): Promise<Array<Record<T>>>;
+    update(record: Partial<T>, options?: Object, callback?: Callback<RecordResult>): Promise<RecordResult>;
+    update(records: Array<Partial<T>>, options?: Object, callback?: Callback<RecordResult[]>): Promise<RecordResult[]>;
+    // FIXME: should input really be optional? the documentation says so, but how can you actually update without it?
+    updateBulk(input?: Record[] | stream.Stream | string, callback?: Callback<RecordResult[]>): Batch;
+    updated(start: string | Date, end: string | Date, callback?: Callback<UpdatedRecordsInfo>): Promise<UpdatedRecordsInfo>;
+    upsert(records: Record<T>, extIdField: SalesforceId, options?: Object, callback?: Callback<RecordResult>): Promise<RecordResult>;
+    upsert(records: Array<Record<T>>, extIdField: SalesforceId, options?: Object, callback?: Callback<RecordResult[]>): Promise<RecordResult[]>;
+    upsertBulk(input?: Array<Record<T>> | stream.Stream | string, callback?: Callback<RecordResult[] | BatchResultInfo[]>): Batch;
 
-    find<T>(query?: any, callback?: (err: Error, ret: T[]) => void): Query<T[]>;
-    find<T>(query?: any, fields?: Object | string[] | string, callback?: (err: Error, ret: T[]) => void): Query<T[]>;
-    find<T>(query?: any, fields?: Object | string[] | string, options?: Object, callback?: (err: Error, ret: T[]) => void): Query<T[]>;
+    find<T>(query?: object | string, callback?: Callback<Array<Record<T>>>): Query<Array<Record<T>>>;
+    find<T>(query?: object | string, fields?: Object | string[] | string, callback?: Callback<Array<Record<T>>>): Query<Array<Record<T>>>;
+    find<T>(query?: object | string, fields?: Object | string[] | string, options?: FindOptions, callback?: Callback<Array<Record<T>>>): Query<Array<Record<T>>>;
 
-    findOne<T>(query?: any, callback?: (err: Error, ret: T) => void): Query<T>;
-    findOne<T>(query?: any, fields?: Object | string[] | string, callback?: (err: Error, ret: T) => void): Query<T>;
-    findOne<T>(query?: any, fields?: Object | string[] | string, options?: Object, callback?: (err: Error, ret: T) => void): Query<T>;
+    findOne<T>(query?: object | string, callback?: Callback<Record<T>>): Query<Record<T>>;
+    findOne<T>(query?: object | string, fields?: Object | string[] | string, callback?: Callback<Record<T>>): Query<Record<T>>;
+    findOne<T>(query?: object | string, fields?: Object | string[] | string, options?: FindOptions, callback?: Callback<Record<T>>): Query<Record<T>>;
 
     approvalLayouts$: {
         /** Returns a value from the cache if it exists, otherwise calls SObject.approvalLayouts */
-        (callback?: (err: Error, layoutInfo: ApprovalLayoutInfo) => void): ApprovalLayoutInfo;
+        (callback?: Callback<ApprovalLayoutInfo>): ApprovalLayoutInfo;
         clear(): void;
     }
-    approvalLayouts(callback?: (layoutInfo: ApprovalLayoutInfo) => void): Promise<ApprovalLayoutInfo>;
-    bulkload(operation: string, options?: { extIdField?: string }, input?: Array<Record<T>> | stream.Stream | string, callback?: (err: Error, ret: RecordResult[]) => void): Batch;
+    approvalLayouts(callback?: Callback<ApprovalLayoutInfo>): Promise<ApprovalLayoutInfo>;
+    bulkload(operation: string, options?: { extIdField?: string }, input?: Array<Record<T>> | stream.Stream | string, callback?: Callback<RecordResult[]>): Batch;
     compactLayouts$: {
         /** Returns a value from the cache if it exists, otherwise calls SObject.compactLayouts */
-        (callback?: (err: Error, layoutInfo: CompactLayoutInfo) => void): CompactLayoutInfo;
+        (callback?: Callback<CompactLayoutInfo>): CompactLayoutInfo;
         clear(): void;
     }
-    compactLayouts(callback?: CompactLayoutInfo): Promise<CompactLayoutInfo>;
-    count(conditions?: Object | string, callback?: (err: Error, num: number) => void): Query<number>;
-    create(options: any | any[], callback?: (err: Error, ret: RecordResult | RecordResult[]) => void): Promise<RecordResult | RecordResult[]>;
-    createBulk(input?: Array<Record<T>> | stream.Stream | string, callback?: (err: Error, ret: RecordResult) => void): Batch;
-    del(id: string, callback?: (err: Error, ret: RecordResult) => void): Promise<RecordResult>;
-    del(ids: string[], callback?: (err: Error, ret: RecordResult[]) => void): Promise<RecordResult[]>;
-    destroy(id: string, callback?: (err: Error, ret: RecordResult) => void): Promise<RecordResult>;
-    destroy(ids: string[], callback?: (err: Error, ret: RecordResult[]) => void): Promise<RecordResult[]>;
-    delete(id: string, callback?: (err: Error, ret: RecordResult) => void): Promise<RecordResult>;
-    delete(ids: string[], callback?: (err: Error, ret: RecordResult[]) => void): Promise<RecordResult[]>;
-    deleteBulk(input?: Array<Record<T>> | stream.Stream | string, callback?: (err: Error, ret: RecordResult) => void): Batch;
-    destroyBulk(input?: Array<Record<T>> | stream.Stream | string, callback?: (err: Error, ret: RecordResult) => void): Batch;
-    destroyHardBulk(input?: Array<Record<T>> | stream.Stream | string, callback?: (err: Error, ret: RecordResult) => void): Batch;
-    deleted(start: Date | string, end: Date | string, callback?: (info: DeletedRecordsInfo) => void): Promise<DeletedRecordsInfo>;
-    deleteHardBulk(input?: Array<Record<T>> | stream.Stream | string, callback?: (err: Error, ret: RecordResult) => void): Batch;
-    describe(callback?: (err: Error, ret: DescribeSObjectResult) => void): Promise<DescribeSObjectResult>;
+    compactLayouts(callback?: Callback<CompactLayoutInfo>): Promise<CompactLayoutInfo>;
+    count(conditions?: Object | string, callback?: Callback<number>): Query<number>;
+    create(record: Record<T>, options: object, callback?: Callback<RecordResult>): Promise<RecordResult>;
+    create(record: Record<T>, callback?: Callback<RecordResult>): Promise<RecordResult>;
+    create(record: Array<Record<T>>, options: object, callback?: Callback<RecordResult[]>): Promise<RecordResult[]>;
+    create(record: Array<Record<T>>, callback?: Callback<RecordResult[]>): Promise<RecordResult[]>;
+    // FIXME: why does the callback return a single RecordResult instead of an array as in the documentation?
+    createBulk(input?: Array<Record<T>> | stream.Stream | string, callback?: Callback<RecordResult>): Batch;
+    del(id: string, callback?: Callback<RecordResult>): Promise<RecordResult>;
+    del(ids: string[], callback?: Callback<RecordResult[]>): Promise<RecordResult[]>;
+    destroy(id: string, callback?: Callback<RecordResult>): Promise<RecordResult>;
+    destroy(ids: string[], callback?: Callback<RecordResult[]>): Promise<RecordResult[]>;
+    delete(id: string, callback?: Callback<RecordResult>): Promise<RecordResult>;
+    delete(ids: string[], callback?: Callback<RecordResult[]>): Promise<RecordResult[]>;
+    // FIXME: why does the callback return a single RecordResult instead of an array as in the documentation?
+    deleteBulk(input?: Array<Record<T>> | stream.Stream | string, callback?: Callback<RecordResult>): Batch;
+    // FIXME: why does the callback return a single RecordResult instead of an array as in the documentation?
+    destroyBulk(input?: Array<Record<T>> | stream.Stream | string, callback?: Callback<RecordResult>): Batch;
+    // FIXME: why does the callback return a single RecordResult instead of an array as in the documentation?
+    destroyHardBulk(input?: Array<Record<T>> | stream.Stream | string, callback?: Callback<RecordResult>): Batch;
+    deleted(start: Date | string, end: Date | string, callback?: Callback<DeletedRecordsInfo>): Promise<DeletedRecordsInfo>;
+    // FIXME: why does the callback return a single RecordResult instead of an array as in the documentation?
+    deleteHardBulk(input?: Array<Record<T>> | stream.Stream | string, callback?: Callback<RecordResult>): Batch;
+    describe(callback?: Callback<DescribeSObjectResult>): Promise<DescribeSObjectResult>;
     describe$: {
         /** Returns a value from the cache if it exists, otherwise calls SObject.describe */
-        (callback?: (err: Error, ret: DescribeSObjectResult) => void): DescribeSObjectResult;
+        (callback?: Callback<DescribeSObjectResult>): DescribeSObjectResult;
         clear(): void;
     }
-    insert(options: any | any[], callback?: (err: Error, ret: RecordResult | RecordResult[]) => void): Promise<RecordResult | RecordResult[]>;
-    insertBulk(input?: Array<Record<T>> | stream.Stream | string, callback?: (err: Error, ret: RecordResult) => void): Batch;
+    insert(record: Record<T>, callback?: Callback<RecordResult>): Promise<RecordResult>;
+    insert(records: Array<Record<T>>, callback?: Callback<RecordResult[]>): Promise<RecordResult[]>;
+    insertBulk(input?: Array<Record<T>> | stream.Stream | string, callback?: Callback<RecordResult>): Batch;
     /** Returns a value from the cache if it exists, otherwise calls SObject.layouts */
     layouts$: {
-        (layoutName?: string, callback?: (err: Error, info: LayoutInfo) => void): LayoutInfo;
+        (layoutName?: string, callback?: Callback<LayoutInfo>): LayoutInfo;
         clear(): void;
     }
-    layouts(layoutName?: string, callback?: (err: Error, info: LayoutInfo) => void): Promise<LayoutInfo>;
+    layouts(layoutName?: string, callback?: Callback<LayoutInfo>): Promise<LayoutInfo>;
     listview(id: string): ListView;
-    listviews(callback?: (err: Error, info: ListViewsInfo) => void): Promise<ListViewsInfo>;
+    listviews(callback?: Callback<ListViewsInfo>): Promise<ListViewsInfo>;
     quickAction(actionName: string): QuickAction;
-    quickActions(callback?: (err: Error, info: any) => void): Promise<any>;
-    recent(callback?: (err: Error, ret: RecordResult) => void): Promise<RecordResult>;
-    select(callback?: (err: Error, ret: T[]) => void): Query<T[]>;
+    quickActions(callback?: Callback<QuickActionInfo[]>): Promise<QuickActionInfo[]>;
+    // FIXME: why does the callback return a single RecordResult instead of an array as in the documentation?
+    recent(callback?: Callback<RecordResult>): Promise<RecordResult>;
+    select(callback?: Callback<T[]>): Query<T[]>;
     // TODO:use a typed pluck to turn `fields` into a subset of T's fields so that the output is slimmed down appropriately
-    select(fields?: {[P in keyof T]: boolean}  | Array<(keyof T)> | (keyof T), callback?: (err: Error, ret: Array<Partial<T>>) => void): Query<Array<Partial<T>>>;
+    select(fields?: {[P in keyof T]: boolean}  | Array<(keyof T)> | (keyof T), callback?: Callback<Array<Partial<T>>>): Query<Array<Partial<T>>>;
+}
+
+export interface FindOptions {
+    limit?: number;
+    offset?: number;
+    skip?: number;
 }
 
 export interface UpdatedRecordsInfo {
@@ -114,4 +132,5 @@ export class ListView {
 }
 
 export class ListViewsInfo { }
-export class QuickAction { }
+// TODO: Remove this export
+export { QuickAction } // for compatibility if anyone had imported it from this file

--- a/types/jsforce/salesforce-object.d.ts
+++ b/types/jsforce/salesforce-object.d.ts
@@ -15,6 +15,7 @@ export class SObject<T> {
     retrieve(ids: SalesforceId[], options?: Object, callback?: (err: Error, ret: Array<Record<T>>) => void): Promise<Array<Record<T>>>;
     update(record: Partial<T>, options?: Object, callback?: (err: Error, ret: RecordResult) => void): Promise<RecordResult>;
     update(records: Array<Partial<T>>, options?: Object, callback?: (err: Error, ret: RecordResult[]) => void): Promise<RecordResult[]>;
+    updated(start: string | Date, end: string | Date, callback?: (err: Error, ret: UpdatedRecordsInfo) => void): Promise<UpdatedRecordsInfo>;
     upsert(records: Record<T>, extIdField: SalesforceId, options?: Object, callback?: (err: Error, ret: RecordResult) => void): Promise<RecordResult>;
     upsert(records: Array<Record<T>>, extIdField: SalesforceId, options?: Object, callback?: (err: Error, ret: RecordResult[]) => void): Promise<RecordResult[]>;
     upsertBulk(input?: Array<Record<T>> | stream.Stream | string, callback?: (err: Error, ret: RecordResult[] | BatchResultInfo[]) => void): Batch;
@@ -73,6 +74,11 @@ export class SObject<T> {
     select(callback?: (err: Error, ret: T[]) => void): Query<T[]>;
     // TODO:use a typed pluck to turn `fields` into a subset of T's fields so that the output is slimmed down appropriately
     select(fields?: {[P in keyof T]: boolean}  | Array<(keyof T)> | (keyof T), callback?: (err: Error, ret: Array<Partial<T>>) => void): Query<Array<Partial<T>>>;
+}
+
+export interface UpdatedRecordsInfo {
+    latestDateCovered: string;
+    ids: string[];
 }
 
 export interface ApprovalLayoutInfo {

--- a/types/jsforce/salesforce-object.d.ts
+++ b/types/jsforce/salesforce-object.d.ts
@@ -30,14 +30,14 @@ export class SObject<T> {
 
     approvalLayouts$: {
         /** Returns a value from the cache if it exists, otherwise calls SObject.approvalLayouts */
-        (callback?: (layoutInfo: ApprovalLayoutInfo) => void): ApprovalLayoutInfo;
+        (callback?: (err: Error, layoutInfo: ApprovalLayoutInfo) => void): ApprovalLayoutInfo;
         clear(): void;
     }
     approvalLayouts(callback?: (layoutInfo: ApprovalLayoutInfo) => void): Promise<ApprovalLayoutInfo>;
     bulkload(operation: string, options?: { extIdField?: string }, input?: Array<Record<T>> | stream.Stream[] | string[], callback?: (err: Error, ret: RecordResult) => void): Batch;
     compactLayouts$: {
         /** Returns a value from the cache if it exists, otherwise calls SObject.compactLayouts */
-        (callback?: CompactLayoutInfo): CompactLayoutInfo;
+        (callback?: (err: Error, layoutInfo: CompactLayoutInfo) => void): CompactLayoutInfo;
         clear(): void;
     }
     compactLayouts(callback?: CompactLayoutInfo): Promise<CompactLayoutInfo>;

--- a/types/jsforce/salesforce-object.d.ts
+++ b/types/jsforce/salesforce-object.d.ts
@@ -15,6 +15,7 @@ export class SObject<T> {
     retrieve(ids: SalesforceId[], options?: Object, callback?: (err: Error, ret: Array<Record<T>>) => void): Promise<Array<Record<T>>>;
     update(record: Partial<T>, options?: Object, callback?: (err: Error, ret: RecordResult) => void): Promise<RecordResult>;
     update(records: Array<Partial<T>>, options?: Object, callback?: (err: Error, ret: RecordResult[]) => void): Promise<RecordResult[]>;
+    updateBulk(input?: Record[] | stream.Stream | string, callback?: (err: Error, ret: RecordResult[]) => void): Batch;
     updated(start: string | Date, end: string | Date, callback?: (err: Error, ret: UpdatedRecordsInfo) => void): Promise<UpdatedRecordsInfo>;
     upsert(records: Record<T>, extIdField: SalesforceId, options?: Object, callback?: (err: Error, ret: RecordResult) => void): Promise<RecordResult>;
     upsert(records: Array<Record<T>>, extIdField: SalesforceId, options?: Object, callback?: (err: Error, ret: RecordResult[]) => void): Promise<RecordResult[]>;

--- a/types/jsforce/salesforce-object.d.ts
+++ b/types/jsforce/salesforce-object.d.ts
@@ -45,10 +45,10 @@ export class SObject<T> {
     }
     compactLayouts(callback?: Callback<CompactLayoutInfo>): Promise<CompactLayoutInfo>;
     count(conditions?: Object | string, callback?: Callback<number>): Query<number>;
-    create(record: Record<T>, options: object, callback?: Callback<RecordResult>): Promise<RecordResult>;
-    create(record: Record<T>, callback?: Callback<RecordResult>): Promise<RecordResult>;
-    create(record: Array<Record<T>>, options: object, callback?: Callback<RecordResult[]>): Promise<RecordResult[]>;
-    create(record: Array<Record<T>>, callback?: Callback<RecordResult[]>): Promise<RecordResult[]>;
+    create(record: T, options: object, callback?: Callback<RecordResult>): Promise<RecordResult>;
+    create(record: T, callback?: Callback<RecordResult>): Promise<RecordResult>;
+    create(record: Array<T>, options: object, callback?: Callback<RecordResult[]>): Promise<RecordResult[]>;
+    create(record: Array<T>, callback?: Callback<RecordResult[]>): Promise<RecordResult[]>;
     // FIXME: why does the callback return a single RecordResult instead of an array as in the documentation?
     createBulk(input?: Array<Record<T>> | stream.Stream | string, callback?: Callback<RecordResult>): Batch;
     del(id: string, callback?: Callback<RecordResult>): Promise<RecordResult>;

--- a/types/jsforce/salesforce-object.d.ts
+++ b/types/jsforce/salesforce-object.d.ts
@@ -19,9 +19,9 @@ export class SObject<T> {
     upsert(records: Array<Record<T>>, extIdField: SalesforceId, options?: Object, callback?: (err: Error, ret: RecordResult[]) => void): Promise<RecordResult[]>;
     upsertBulk(input?: Array<Record<T>> | stream.Stream | string, callback?: (err: Error, ret: RecordResult[] | BatchResultInfo[]) => void): Batch;
 
-    find<T>(query?: any, callback?: (err: Error, ret: T[]) => void): Query<T>;
-    find<T>(query?: any, fields?: Object | string[] | string, callback?: (err: Error, ret: T[]) => void): Query<T>;
-    find<T>(query?: any, fields?: Object | string[] | string, options?: Object, callback?: (err: Error, ret: T[]) => void): Query<T>;
+    find<T>(query?: any, callback?: (err: Error, ret: T[]) => void): Query<T[]>;
+    find<T>(query?: any, fields?: Object | string[] | string, callback?: (err: Error, ret: T[]) => void): Query<T[]>;
+    find<T>(query?: any, fields?: Object | string[] | string, options?: Object, callback?: (err: Error, ret: T[]) => void): Query<T[]>;
 
     findOne<T>(query?: any, callback?: (err: Error, ret: T) => void): Query<T>;
     findOne<T>(query?: any, fields?: Object | string[] | string, callback?: (err: Error, ret: T) => void): Query<T>;

--- a/types/jsforce/salesforce-object.d.ts
+++ b/types/jsforce/salesforce-object.d.ts
@@ -35,7 +35,7 @@ export class SObject<T> {
         clear(): void;
     }
     approvalLayouts(callback?: (layoutInfo: ApprovalLayoutInfo) => void): Promise<ApprovalLayoutInfo>;
-    bulkload(operation: string, options?: { extIdField?: string }, input?: Array<Record<T>> | stream.Stream[] | string[], callback?: (err: Error, ret: RecordResult) => void): Batch;
+    bulkload(operation: string, options?: { extIdField?: string }, input?: Array<Record<T>> | stream.Stream | string, callback?: (err: Error, ret: RecordResult[]) => void): Batch;
     compactLayouts$: {
         /** Returns a value from the cache if it exists, otherwise calls SObject.compactLayouts */
         (callback?: (err: Error, layoutInfo: CompactLayoutInfo) => void): CompactLayoutInfo;

--- a/types/jsforce/salesforce-object.d.ts
+++ b/types/jsforce/salesforce-object.d.ts
@@ -43,9 +43,9 @@ export class SObject<T> {
     count(conditions?: Object | string, callback?: (err: Error, num: number) => void): Promise<number>;
     create(options: any | any[], callback?: (err: Error, ret: RecordResult | RecordResult[]) => void): Promise<RecordResult | RecordResult[]>;
     createBulk(input?: Array<Record<T>> | stream.Stream | string, callback?: (err: Error, ret: RecordResult) => void): Batch;
-    del(ids: string | string[], callback?: (err: Error, ret: any) => void): void;
-    destroy(ids: string | string[], callback?: (err: Error, ret: any) => void): void;
-    delete(ids: string | string[], callback?: (err: Error, ret: any) => void): void;
+    del(ids: string | string[], callback?: (err: Error, ret: any) => void): Promise<RecordResult | RecordResult[]>;
+    destroy(ids: string | string[], callback?: (err: Error, ret: any) => void): Promise<RecordResult | RecordResult[]>;
+    delete(ids: string | string[], callback?: (err: Error, ret: any) => void): Promise<RecordResult | RecordResult[]>;
     deleteBulk(input?: Array<Record<T>> | stream.Stream | string, callback?: (err: Error, ret: RecordResult) => void): Batch;
     destroyBulk(input?: Array<Record<T>> | stream.Stream | string, callback?: (err: Error, ret: RecordResult) => void): Batch;
     destroyHardBulk(input?: Array<Record<T>> | stream.Stream | string, callback?: (err: Error, ret: RecordResult) => void): Batch;

--- a/types/jsforce/salesforce-object.d.ts
+++ b/types/jsforce/salesforce-object.d.ts
@@ -5,22 +5,29 @@ import { DescribeSObjectResult } from './describe-result';
 import { Query } from './query';
 import { Record, RecordReference } from './record';
 import { RecordResult } from './record-result';
-import { Connection, Callback } from './connection';
+import { Connection, RestApiOptions, Callback } from './connection';
 import { SalesforceId } from './salesforce-id';
 import { Batch, BatchResultInfo } from './batch';
 import { QuickAction, QuickActionInfo } from './quick-action';
 
 export class SObject<T> {
     record(id: SalesforceId): RecordReference<T>;
-    retrieve(id: SalesforceId, options?: Object, callback?: Callback<Record<T>>): Promise<Record<T>>;
-    retrieve(ids: SalesforceId[], options?: Object, callback?: Callback<Array<Record<T>>>): Promise<Array<Record<T>>>;
-    update(record: Partial<T>, options?: Object, callback?: Callback<RecordResult>): Promise<RecordResult>;
-    update(records: Array<Partial<T>>, options?: Object, callback?: Callback<RecordResult[]>): Promise<RecordResult[]>;
+    retrieve(id: SalesforceId, callback?: Callback<Record<T>>): Promise<Record<T>>;
+    retrieve(id: SalesforceId, options?: object, callback?: Callback<Record<T>>): Promise<Record<T>>;
+    retrieve(ids: SalesforceId[], callback?: Callback<Array<Record<T>>>): Promise<Array<Record<T>>>;
+    retrieve(ids: SalesforceId[], options?: object, callback?: Callback<Array<Record<T>>>): Promise<Array<Record<T>>>;
+    // Should update require that the record Id field be provided?
+    update(record: Partial<T>, callback?: Callback<RecordResult>): Promise<RecordResult>;
+    update(record: Partial<T>, options?: RestApiOptions, callback?: Callback<RecordResult>): Promise<RecordResult>;
+    update(records: Array<Partial<T>>, callback?: Callback<RecordResult[]>): Promise<RecordResult[]>;
+    update(records: Array<Partial<T>>, options?: RestApiOptions, callback?: Callback<RecordResult[]>): Promise<RecordResult[]>;
     // FIXME: should input really be optional? the documentation says so, but how can you actually update without it?
     updateBulk(input?: Record[] | stream.Stream | string, callback?: Callback<RecordResult[]>): Batch;
     updated(start: string | Date, end: string | Date, callback?: Callback<UpdatedRecordsInfo>): Promise<UpdatedRecordsInfo>;
-    upsert(records: Record<T>, extIdField: SalesforceId, options?: Object, callback?: Callback<RecordResult>): Promise<RecordResult>;
-    upsert(records: Array<Record<T>>, extIdField: SalesforceId, options?: Object, callback?: Callback<RecordResult[]>): Promise<RecordResult[]>;
+    upsert(records: Record<T>, extIdField: string, callback?: Callback<RecordResult>): Promise<RecordResult>;
+    upsert(records: Record<T>, extIdField: string, options?: RestApiOptions, callback?: Callback<RecordResult>): Promise<RecordResult>;
+    upsert(records: Array<Record<T>>, extIdField: string, callback?: Callback<RecordResult[]>): Promise<RecordResult[]>;
+    upsert(records: Array<Record<T>>, extIdField: string, options?: RestApiOptions, callback?: Callback<RecordResult[]>): Promise<RecordResult[]>;
     upsertBulk(input?: Array<Record<T>> | stream.Stream | string, callback?: Callback<RecordResult[] | BatchResultInfo[]>): Batch;
 
     find<T>(query?: object | string, callback?: Callback<Array<Record<T>>>): Query<Array<Record<T>>>;
@@ -45,9 +52,9 @@ export class SObject<T> {
     }
     compactLayouts(callback?: Callback<CompactLayoutInfo>): Promise<CompactLayoutInfo>;
     count(conditions?: Object | string, callback?: Callback<number>): Query<number>;
-    create(record: T, options: object, callback?: Callback<RecordResult>): Promise<RecordResult>;
+    create(record: T, options?: RestApiOptions, callback?: Callback<RecordResult>): Promise<RecordResult>;
     create(record: T, callback?: Callback<RecordResult>): Promise<RecordResult>;
-    create(record: Array<T>, options: object, callback?: Callback<RecordResult[]>): Promise<RecordResult[]>;
+    create(record: Array<T>, options?: RestApiOptions, callback?: Callback<RecordResult[]>): Promise<RecordResult[]>;
     create(record: Array<T>, callback?: Callback<RecordResult[]>): Promise<RecordResult[]>;
     // FIXME: why does the callback return a single RecordResult instead of an array as in the documentation?
     createBulk(input?: Array<Record<T>> | stream.Stream | string, callback?: Callback<RecordResult>): Batch;

--- a/types/jsforce/salesforce-object.d.ts
+++ b/types/jsforce/salesforce-object.d.ts
@@ -21,7 +21,7 @@ export class SObject<T> {
     update(record: Partial<T>, options?: RestApiOptions, callback?: Callback<RecordResult>): Promise<RecordResult>;
     update(records: Array<Partial<T>>, callback?: Callback<RecordResult[]>): Promise<RecordResult[]>;
     update(records: Array<Partial<T>>, options?: RestApiOptions, callback?: Callback<RecordResult[]>): Promise<RecordResult[]>;
-    // FIXME: should input really be optional? the documentation says so, but how can you actually update without it?
+    // should input really be optional? the documentation says so, but how can you actually update without it?
     updateBulk(input?: Record[] | stream.Stream | string, callback?: Callback<RecordResult[]>): Batch;
     updated(start: string | Date, end: string | Date, callback?: Callback<UpdatedRecordsInfo>): Promise<UpdatedRecordsInfo>;
     upsert(records: Record<T>, extIdField: string, callback?: Callback<RecordResult>): Promise<RecordResult>;
@@ -51,28 +51,23 @@ export class SObject<T> {
         clear(): void;
     }
     compactLayouts(callback?: Callback<CompactLayoutInfo>): Promise<CompactLayoutInfo>;
-    count(conditions?: Object | string, callback?: Callback<number>): Query<number>;
+    count(conditions?: object | string, callback?: Callback<number>): Query<number>;
     create(record: T, options?: RestApiOptions, callback?: Callback<RecordResult>): Promise<RecordResult>;
     create(record: T, callback?: Callback<RecordResult>): Promise<RecordResult>;
     create(record: Array<T>, options?: RestApiOptions, callback?: Callback<RecordResult[]>): Promise<RecordResult[]>;
     create(record: Array<T>, callback?: Callback<RecordResult[]>): Promise<RecordResult[]>;
-    // FIXME: why does the callback return a single RecordResult instead of an array as in the documentation?
-    createBulk(input?: Array<Record<T>> | stream.Stream | string, callback?: Callback<RecordResult>): Batch;
+    createBulk(input?: Array<Record<T>> | stream.Stream | string, callback?: Callback<RecordResult[]>): Batch;
     del(id: string, callback?: Callback<RecordResult>): Promise<RecordResult>;
     del(ids: string[], callback?: Callback<RecordResult[]>): Promise<RecordResult[]>;
     destroy(id: string, callback?: Callback<RecordResult>): Promise<RecordResult>;
     destroy(ids: string[], callback?: Callback<RecordResult[]>): Promise<RecordResult[]>;
     delete(id: string, callback?: Callback<RecordResult>): Promise<RecordResult>;
     delete(ids: string[], callback?: Callback<RecordResult[]>): Promise<RecordResult[]>;
-    // FIXME: why does the callback return a single RecordResult instead of an array as in the documentation?
-    deleteBulk(input?: Array<Record<T>> | stream.Stream | string, callback?: Callback<RecordResult>): Batch;
-    // FIXME: why does the callback return a single RecordResult instead of an array as in the documentation?
-    destroyBulk(input?: Array<Record<T>> | stream.Stream | string, callback?: Callback<RecordResult>): Batch;
-    // FIXME: why does the callback return a single RecordResult instead of an array as in the documentation?
-    destroyHardBulk(input?: Array<Record<T>> | stream.Stream | string, callback?: Callback<RecordResult>): Batch;
+    deleteBulk(input?: Array<Record<T>> | stream.Stream | string, callback?: Callback<RecordResult[]>): Batch;
+    destroyBulk(input?: Array<Record<T>> | stream.Stream | string, callback?: Callback<RecordResult[]>): Batch;
+    destroyHardBulk(input?: Array<Record<T>> | stream.Stream | string, callback?: Callback<RecordResult[]>): Batch;
     deleted(start: Date | string, end: Date | string, callback?: Callback<DeletedRecordsInfo>): Promise<DeletedRecordsInfo>;
-    // FIXME: why does the callback return a single RecordResult instead of an array as in the documentation?
-    deleteHardBulk(input?: Array<Record<T>> | stream.Stream | string, callback?: Callback<RecordResult>): Batch;
+    deleteHardBulk(input?: Array<Record<T>> | stream.Stream | string, callback?: Callback<RecordResult[]>): Batch;
     describe(callback?: Callback<DescribeSObjectResult>): Promise<DescribeSObjectResult>;
     describe$: {
         /** Returns a value from the cache if it exists, otherwise calls SObject.describe */
@@ -81,7 +76,7 @@ export class SObject<T> {
     }
     insert(record: Record<T>, callback?: Callback<RecordResult>): Promise<RecordResult>;
     insert(records: Array<Record<T>>, callback?: Callback<RecordResult[]>): Promise<RecordResult[]>;
-    insertBulk(input?: Array<Record<T>> | stream.Stream | string, callback?: Callback<RecordResult>): Batch;
+    insertBulk(input?: Array<Record<T>> | stream.Stream | string, callback?: Callback<RecordResult[]>): Batch;
     /** Returns a value from the cache if it exists, otherwise calls SObject.layouts */
     layouts$: {
         (layoutName?: string, callback?: Callback<LayoutInfo>): LayoutInfo;
@@ -92,8 +87,7 @@ export class SObject<T> {
     listviews(callback?: Callback<ListViewsInfo>): Promise<ListViewsInfo>;
     quickAction(actionName: string): QuickAction;
     quickActions(callback?: Callback<QuickActionInfo[]>): Promise<QuickActionInfo[]>;
-    // FIXME: why does the callback return a single RecordResult instead of an array as in the documentation?
-    recent(callback?: Callback<RecordResult>): Promise<RecordResult>;
+    recent(callback?: Callback<RecordResult[]>): Promise<RecordResult[]>;
     select(callback?: Callback<T[]>): Query<T[]>;
     // TODO:use a typed pluck to turn `fields` into a subset of T's fields so that the output is slimmed down appropriately
     select(fields?: {[P in keyof T]: boolean}  | Array<(keyof T)> | (keyof T), callback?: Callback<Array<Partial<T>>>): Query<Array<Partial<T>>>;

--- a/types/jsforce/salesforce-object.d.ts
+++ b/types/jsforce/salesforce-object.d.ts
@@ -42,7 +42,7 @@ export class SObject<T> {
         clear(): void;
     }
     compactLayouts(callback?: CompactLayoutInfo): Promise<CompactLayoutInfo>;
-    count(conditions?: Object | string, callback?: (err: Error, num: number) => void): Promise<number>;
+    count(conditions?: Object | string, callback?: (err: Error, num: number) => void): Query<number>;
     create(options: any | any[], callback?: (err: Error, ret: RecordResult | RecordResult[]) => void): Promise<RecordResult | RecordResult[]>;
     createBulk(input?: Array<Record<T>> | stream.Stream | string, callback?: (err: Error, ret: RecordResult) => void): Batch;
     del(ids: string | string[], callback?: (err: Error, ret: any) => void): Promise<RecordResult | RecordResult[]>;

--- a/types/jsforce/salesforce-object.d.ts
+++ b/types/jsforce/salesforce-object.d.ts
@@ -45,9 +45,12 @@ export class SObject<T> {
     count(conditions?: Object | string, callback?: (err: Error, num: number) => void): Query<number>;
     create(options: any | any[], callback?: (err: Error, ret: RecordResult | RecordResult[]) => void): Promise<RecordResult | RecordResult[]>;
     createBulk(input?: Array<Record<T>> | stream.Stream | string, callback?: (err: Error, ret: RecordResult) => void): Batch;
-    del(ids: string | string[], callback?: (err: Error, ret: any) => void): Promise<RecordResult | RecordResult[]>;
-    destroy(ids: string | string[], callback?: (err: Error, ret: any) => void): Promise<RecordResult | RecordResult[]>;
-    delete(ids: string | string[], callback?: (err: Error, ret: any) => void): Promise<RecordResult | RecordResult[]>;
+    del(id: string, callback?: (err: Error, ret: RecordResult) => void): Promise<RecordResult>;
+    del(ids: string[], callback?: (err: Error, ret: RecordResult[]) => void): Promise<RecordResult[]>;
+    destroy(id: string, callback?: (err: Error, ret: RecordResult) => void): Promise<RecordResult>;
+    destroy(ids: string[], callback?: (err: Error, ret: RecordResult[]) => void): Promise<RecordResult[]>;
+    delete(id: string, callback?: (err: Error, ret: RecordResult) => void): Promise<RecordResult>;
+    delete(ids: string[], callback?: (err: Error, ret: RecordResult[]) => void): Promise<RecordResult[]>;
     deleteBulk(input?: Array<Record<T>> | stream.Stream | string, callback?: (err: Error, ret: RecordResult) => void): Batch;
     destroyBulk(input?: Array<Record<T>> | stream.Stream | string, callback?: (err: Error, ret: RecordResult) => void): Batch;
     destroyHardBulk(input?: Array<Record<T>> | stream.Stream | string, callback?: (err: Error, ret: RecordResult) => void): Batch;


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <<http://jsforce.github.io/jsforce/doc/SObject.html>>

Updates various methods under the SObject class. The catalyst for this pull request was the SObject.destroy method and aliases, which did not return promises like the [documentation](http://jsforce.github.io/jsforce/doc/SObject.html#destroy) indicates.

Also adds the SObject.updated and SObject.updateBulk methods, fixes the signature for SObject.bulkload to match the documentation, fixes the return types for SObject.find to match the callback value and the documentation, and fixes the callback types for some SObject caching methods that were obviously wrong.