### PR TITLE
auth0-js: added mode to AuthorizeOptions

### DIFF
--- a/types/auth0-js/index.d.ts
+++ b/types/auth0-js/index.d.ts
@@ -762,6 +762,7 @@ export interface AuthorizeOptions {
     audience?: string;
 	language?: string;
 	prompt?: string;
+    mode?: "login" | "signUp";
 }
 
 export interface CheckSessionOptions extends AuthorizeOptions {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://community.auth0.com/t/passing-initialscreen-to-lock-from-webauth/6906
- [ ] Increase the version number in the header if appropriate.

Based on the documentation linked above, `AuthorizeOptions` supports a `mode` argument. I tested it locally and it works - it adds the mode to `config.extraParams.mode` in the hosted lock page.

I didn't increase the version number because I am not sure I should. npm says the latest version is `8.11.4` but `index.d.ts` doesn't specify that so I am not sure how that's calculated for this package. If someone tells me, I am happy to update to `8.11.5`

Also, I followed the tabbing convention of the rest of the file (2 spaces) but didn't fix the tabs for the two lines above. Not sure if I should have.

Thanks,

Igor