### PR TITLE
bloomfilter: deserialization & .buckets type fix

### DIFF
--- a/types/bloomfilter/bloomfilter-tests.ts
+++ b/types/bloomfilter/bloomfilter-tests.ts
@@ -4,8 +4,14 @@ function test_bloomfilter() {
     const k = 2;
 
     const bloomFilter = new BloomFilter(m, k);
-    const array: Int32Array[] = bloomFilter.buckets;
+    const array: Int32Array = bloomFilter.buckets;
     const length: number = bloomFilter.buckets.length;
     bloomFilter.add('someString');
     const test: boolean = bloomFilter.test('someString');
+
+    const buckets: Int32Array = bloomFilter.buckets;
+    const bloom2 = new BloomFilter(buckets, k);
+
+    const a: Int32Array = new Int32Array(16);
+    a[3];
 }

--- a/types/bloomfilter/index.d.ts
+++ b/types/bloomfilter/index.d.ts
@@ -1,14 +1,29 @@
-// Type definitions for BloomFilter 0.1
+// Type definitions for BloomFilter 0.0
 // Project: https://github.com/jasondavies/bloomfilter.js
 // Definitions by: slawiko <https://github.com/slawiko>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 export class BloomFilter {
-    buckets: Int32Array[];
+    buckets: Int32Array;
 
-    constructor(m: number, k: number);
+    /**
+     * Create a new empty bloom filter of size m with hashes k or
+     * provide buckets as a number[] or Int32Array to deserialize a bloom filter
+     * @param mOrBucketsArray number of bits (will be rounded up to nearest 32), or buckets
+     * to deserialize into a filled bloomfilter
+     * @param k number of hashes
+     */
+    constructor(m: number | number[] | Int32Array, k: number);
 
+    /**
+     * Add a value to a bloom filter
+     * @param value
+     */
     add(value: any): void;
 
+    /**
+     * Test whether a value exists in a bloom filter. (False positives are
+     * possible, false negatives are not.)
+     */
     test(value: any): boolean;
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/jasondavies/bloomfilter.js/blob/master/bloomfilter.js>>
    - see line 25: buckets is Int32Array (not Int32Array[])
    - see comments lines 7-10 on deserializing overload, also code lines 14, 26 & 30
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

