### PR TITLE
added label back to redux form typings

### DIFF
--- a/types/redux-form/lib/Field.d.ts
+++ b/types/redux-form/lib/Field.d.ts
@@ -37,6 +37,7 @@ export interface CommonFieldProps extends CommonFieldInputProps {
 
 export interface BaseFieldProps<P = {}> extends Partial<CommonFieldProps> {
     name: string;
+    label?: string;
     component?: ComponentType<WrappedFieldProps & P> | "input" | "select" | "textarea";
     format?: Formatter | null;
     normalize?: Normalizer;
@@ -72,6 +73,7 @@ export class Field<P = GenericFieldHTMLAttributes | BaseFieldProps> extends Comp
 export interface WrappedFieldProps {
     input: WrappedFieldInputProps;
     meta: WrappedFieldMetaProps;
+    label?: string;
 }
 
 export interface WrappedFieldInputProps extends CommonFieldInputProps {

--- a/types/redux-form/redux-form-tests.tsx
+++ b/types/redux-form/redux-form-tests.tsx
@@ -110,6 +110,7 @@ interface MyFieldCustomProps {
 type MyFieldProps = MyFieldCustomProps & WrappedFieldProps;
 const MyField: React.StatelessComponent<MyFieldProps> = ({
     children,
+    label,
     input,
     meta,
     foo


### PR DESCRIPTION
This was previously functional before [another author broke](https://github.com/DefinitelyTyped/DefinitelyTyped/commit/7d909e1f5650a74f6902e55d87d9f89ab8369d88#diff-8660c114875b2bcc521dde6cbc2d84d9) the library.  While the original author is correct that label isn't an immediate prop onto Field in Redux-Forms, he is incorrect in the sense that it actually is functional, and it actually is causing issues in production for our application by removing these props.  I've also open [another PR](https://github.com/erikras/redux-form/pull/4166) with Redux-Forms to actually add label to the prop list.

There is also a completely viable use case for having a label passed to redux forms.  If you are dynamically building input fields with redux-forms that have the implementation broken into multiple areas, then you wouldn't have access to actually hard code a label.  For example:

```
export const TextInput = ({ input, label, meta: { touched, error, warning } }: WrappedFieldProps) => {
    return (
        <React.Fragment>
            <input
                {...input}
                className='form-control'
                type="text"
                placeholder={'Enter ' + label}
            />
            {touched && ((error && <span>{error}</span>) || (warning && <span>{warning}</span>))}
        </React.Fragment>
    )
}
```

Say you make a generic input component that is using the label for placeholder text.  If it's a generic input that is handling multiple fields, then you have to be able to associate which is which.  You can't use `input.name` either due to the FieldsArray component and the way it structures it's naming convention.  Also, to add another layer of complexity, our application has dynamic labeling based on some customizations.  If you don't have the ability to know at certain component layers what that label might be, it's nice to have say a customization component that can dynamically decide what that label should be, and then later access it within your WrappedFieldProps.

It's worth noting that if it's used in the [Redux-Forms examples](https://redux-form.com/7.4.2/examples/syncvalidation/) **it's probably intended by the author of the repository to use it.**  This was added previously in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/21204 and https://github.com/DefinitelyTyped/DefinitelyTyped/pull/24041

---------
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.) *NOTE: I am getting `File name must be camelCase` both before and after my change*
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/commit/7d909e1f5650a74f6902e55d87d9f89ab8369d88#diff-8660c114875b2bcc521dde6cbc2d84d9
This unit of work broke production code.  While the author was correct that field didn't take it in, it actually is functional with redux-forms, therefore should be on the interface.
- [ ] Increase the version number in the header if appropriate.  
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.