### PR TITLE
PropTypes: fix Type 'Requireable<T>' is not assignable to type 'Validator<T | undefined>'

### DIFF
--- a/types/prop-types/index.d.ts
+++ b/types/prop-types/index.d.ts
@@ -17,7 +17,7 @@ export type InferPropsInner<V> = { [K in keyof V]: InferType<V[K]>; };
 
 export interface Validator<T> {
     (props: object, propName: string, componentName: string, location: string, propFullName: string): Error | null;
-    [nominalTypeHack]?: T;
+    [nominalTypeHack]?: T | null;
 }
 
 export interface Requireable<T> extends Validator<T | undefined | null> {

--- a/types/react/test/index.ts
+++ b/types/react/test/index.ts
@@ -16,7 +16,8 @@ import * as DOM from "react-dom-factories";
 
 interface Props extends React.Attributes {
     hello: string;
-    world?: string | null;
+    world_undefined?: string;
+    world_undefined_null?: string | null;
     foo: number;
 }
 
@@ -119,7 +120,8 @@ class ModernComponent extends React.Component<Props, State, Snapshot>
     implements MyComponent, React.ChildContextProvider<ChildContext> {
     static propTypes: React.ValidationMap<Props> = {
         hello: PropTypes.string.isRequired,
-        world: PropTypes.string,
+        world_undefined: PropTypes.string,
+        world_undefined_null: PropTypes.string,
         foo: PropTypes.number.isRequired,
         key: <PropTypes.Validator<string | number | undefined>> PropTypes.oneOfType([PropTypes.number, PropTypes.string])
     };


### PR DESCRIPTION
See #28015

Without the fix:
```TypeScript
interface Props {
  hello?: string;
}

const Hello: React.SFC<Props> = props => <div>hello={props.hello}</div>;

Hello.propTypes = { // <= error
  hello: PropTypes.string
};
```

```
Type '{ hello: Requireable<string>; }' is not assignable to type 'ValidationMap<Props>'.
  Types of property 'hello' are incompatible.
    Type 'Requireable<string>' is not assignable to type 'Validator<string | undefined>'
```

Fix:
```TypeScript
// this:
export interface Validator<T> {
    // ...
    [nominalTypeHack]?: T;
}

// should be:
export interface Validator<T> {
    // ...
    [nominalTypeHack]?: T | null;
}
```

Please review carefully, not sure this is the best way.

Edit:
Reminder about PropTypes: [optional](https://github.com/facebook/prop-types#usage) prop types means undefined at runtime, not null, see https://codepen.io/tkrotoff/pen/BPvdzP