### PR TITLE
react-flatpickr: Allow className to set on DatePicker

### DIFF
--- a/types/react-flatpickr/index.d.ts
+++ b/types/react-flatpickr/index.d.ts
@@ -12,6 +12,7 @@ export interface DateTimePickerProps {
     options?: flatpickr.Options.Options;
     onChange?: flatpickr.Options.Hook;
     value?: string;
+    className?: string;
 }
 
 export default class DatePicker extends Component<DateTimePickerProps> {}

--- a/types/react-flatpickr/react-flatpickr-tests.tsx
+++ b/types/react-flatpickr/react-flatpickr-tests.tsx
@@ -18,3 +18,5 @@ const onChange = (
 const onChangeElement = <DatePicker onChange={ onChange }/>;
 
 const valueElement = <DatePicker value={ 'Value' }/>;
+
+const classNameElement = <DatePicker className={ 'Class name' }/>;


### PR DESCRIPTION
As react flatpickr spreads all props, allow for className to be set.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/coderhaoxin/react-flatpickr/blob/master/lib/index.js#L115
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
