### PR TITLE
yup: setLocale is no longer in a separate file

### DIFF
--- a/types/yup/index.d.ts
+++ b/types/yup/index.d.ts
@@ -12,6 +12,7 @@ export function addMethod<T extends Schema<any>>(schemaCtor: AnySchemaConstructo
 export function ref(path: string, options?: { contextPrefix: string }): Ref;
 export function lazy<T>(fn: (value: T) => Schema<T>): Lazy;
 export function ValidationError(errors: string | string[], value: any, path: string, type?: any): ValidationError;
+export function setLocale(customLocale: LocaleObject): void;
 
 export const mixed: MixedSchemaConstructor;
 export const string: StringSchemaConstructor;

--- a/types/yup/lib/customLocale.d.ts
+++ b/types/yup/lib/customLocale.d.ts
@@ -1,5 +1,0 @@
-import {
-  LocaleObject,
-} from "../index";
-
-export function setLocale(customLocale: LocaleObject): void;

--- a/types/yup/tsconfig.json
+++ b/types/yup/tsconfig.json
@@ -18,7 +18,6 @@
     },
     "files": [
         "index.d.ts",
-        "lib/customLocale.d.ts",
         "yup-tests.ts"
     ]
 }

--- a/types/yup/yup-tests.ts
+++ b/types/yup/yup-tests.ts
@@ -1,5 +1,4 @@
 import * as yup from 'yup';
-import { setLocale } from 'yup/lib/customLocale';
 
 // tslint:disable-next-line:no-duplicate-imports
 import { reach, date, Schema, ObjectSchema, ValidationError, MixedSchema, SchemaDescription, TestOptions, ValidateOptions, NumberSchema, TestContext } from 'yup';
@@ -289,7 +288,7 @@ const validateOptions: ValidateOptions = {
     }
 };
 
-setLocale({
+yup.setLocale({
     number: { max: "Max message", min: "Min message" },
     string: { email: "String message"}
 });


### PR DESCRIPTION
`setLocale` is now longer in a separate file, but exported with the other functions. This is not in the Changelog, but got it from here: https://github.com/jquense/yup/issues/260#issuecomment-411930836

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/jquense/yup/issues/260#issuecomment-411930836
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.