### PR TITLE
[node] Fix typings for various child_process methods

### DIFF
--- a/types/hexo-util/index.d.ts
+++ b/types/hexo-util/index.d.ts
@@ -7,7 +7,7 @@
 /// <reference types="node" />
 
 import { Transform } from "stream";
-import { SpawnOptions } from 'child_process';
+import { SpawnOptions, StdioOptions } from 'child_process';
 
 export class CacheStream extends Transform {
     destroy(): void;
@@ -79,11 +79,11 @@ export interface hexoSpawnDisableEncodingOptions extends SpawnOptions {
 }
 
 export interface hexoSpawnOverrideStdioOptions extends hexoSpawnOptions {
-    stdio: any[] | string;
+    stdio: StdioOptions;
 }
 
 export interface hexoSpawnDisableEncodingAndOverrideStdioOptions extends hexoSpawnDisableEncodingOptions {
-    stdio: any[] | string;
+    stdio: StdioOptions;
 }
 
 export function spawn(command: string, args: string[], options: hexoSpawnDisableEncodingAndOverrideStdioOptions): Promise<Buffer | undefined>;

--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -2343,6 +2343,7 @@ declare module "child_process" {
     export function fork(modulePath: string, args?: ReadonlyArray<string>, options?: ForkOptions): ChildProcess;
 
     export interface SpawnSyncOptions {
+        argv0?: string; // Not specified in the docs
         cwd?: string;
         input?: string | Buffer | Uint8Array;
         stdio?: StdioOptions;

--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -2190,7 +2190,7 @@ declare module "child_process" {
         keepOpen?: boolean;
     }
 
-    export type StdioOptions = "pipe" | "ignore" | "inherit" | Array<("pipe" | "ipc" | "ignore" | stream.Stream | number)>;
+    export type StdioOptions = "pipe" | "ignore" | "inherit" | Array<("pipe" | "ipc" | "ignore" | stream.Stream | number | null | undefined)>;
 
     export interface SpawnOptions {
         cwd?: string;

--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -2190,11 +2190,13 @@ declare module "child_process" {
         keepOpen?: boolean;
     }
 
+    export type StdioOptions = "pipe" | "ignore" | "inherit" | Array<("pipe" | "ipc" | "ignore" | stream.Stream | number)>;
+
     export interface SpawnOptions {
-        argv0?: string;
         cwd?: string;
-        env?: any;
-        stdio?: any;
+        env?: NodeJS.ProcessEnv;
+        argv0?: string;
+        stdio?: StdioOptions;
         detached?: boolean;
         uid?: number;
         gid?: number;
@@ -2207,7 +2209,7 @@ declare module "child_process" {
 
     export interface ExecOptions {
         cwd?: string;
-        env?: any;
+        env?: NodeJS.ProcessEnv;
         shell?: string;
         timeout?: number;
         maxBuffer?: number;
@@ -2262,7 +2264,7 @@ declare module "child_process" {
 
     export interface ExecFileOptions {
         cwd?: string;
-        env?: any;
+        env?: NodeJS.ProcessEnv;
         timeout?: number;
         maxBuffer?: number;
         killSignal?: string;
@@ -2329,32 +2331,31 @@ declare module "child_process" {
 
     export interface ForkOptions {
         cwd?: string;
-        env?: any;
+        env?: NodeJS.ProcessEnv;
         execPath?: string;
         execArgv?: string[];
         silent?: boolean;
-        stdio?: any[];
+        stdio?: StdioOptions;
+        windowsVerbatimArguments?: boolean;
         uid?: number;
         gid?: number;
-        windowsVerbatimArguments?: boolean;
     }
     export function fork(modulePath: string, args?: ReadonlyArray<string>, options?: ForkOptions): ChildProcess;
 
     export interface SpawnSyncOptions {
-        argv0?: string;
         cwd?: string;
-        input?: string | Buffer;
-        stdio?: any;
-        env?: any;
+        input?: string | Buffer | Uint8Array;
+        stdio?: StdioOptions;
+        env?: NodeJS.ProcessEnv;
         uid?: number;
         gid?: number;
         timeout?: number;
-        killSignal?: string;
+        killSignal?: string | number;
         maxBuffer?: number;
         encoding?: string;
         shell?: boolean | string;
-        windowsHide?: boolean;
         windowsVerbatimArguments?: boolean;
+        windowsHide?: boolean;
     }
     export interface SpawnSyncOptionsWithStringEncoding extends SpawnSyncOptions {
         encoding: BufferEncoding;
@@ -2381,14 +2382,14 @@ declare module "child_process" {
 
     export interface ExecSyncOptions {
         cwd?: string;
-        input?: string | Buffer;
-        stdio?: any;
-        env?: any;
+        input?: string | Buffer | Uint8Array;
+        stdio?: StdioOptions;
+        env?: NodeJS.ProcessEnv;
         shell?: string;
         uid?: number;
         gid?: number;
         timeout?: number;
-        killSignal?: string;
+        killSignal?: string | number;
         maxBuffer?: number;
         encoding?: string;
         windowsHide?: boolean;
@@ -2406,16 +2407,17 @@ declare module "child_process" {
 
     export interface ExecFileSyncOptions {
         cwd?: string;
-        input?: string | Buffer;
-        stdio?: any;
-        env?: any;
+        input?: string | Buffer | Uint8Array;
+        stdio?: StdioOptions;
+        env?: NodeJS.ProcessEnv;
         uid?: number;
         gid?: number;
         timeout?: number;
-        killSignal?: string;
+        killSignal?: string | number;
         maxBuffer?: number;
         encoding?: string;
         windowsHide?: boolean;
+        shell?: boolean | string;
     }
     export interface ExecFileSyncOptionsWithStringEncoding extends ExecFileSyncOptions {
         encoding: BufferEncoding;

--- a/types/node/node-tests.ts
+++ b/types/node/node-tests.ts
@@ -2322,6 +2322,7 @@ namespace child_process_tests {
         childProcess.exec("echo test", { windowsHide: true });
         childProcess.spawn("echo", ["test"], { windowsHide: true });
         childProcess.spawn("echo", ["test"], { windowsHide: true, argv0: "echo-test" });
+        childProcess.spawn("echo", ["test"], { stdio: [0xdeadbeef, undefined, "pipe"] });
         childProcess.spawnSync("echo test");
         childProcess.spawnSync("echo test", {windowsVerbatimArguments: false});
     }

--- a/types/node/node-tests.ts
+++ b/types/node/node-tests.ts
@@ -2325,6 +2325,7 @@ namespace child_process_tests {
         childProcess.spawn("echo", ["test"], { stdio: [0xdeadbeef, undefined, "pipe"] });
         childProcess.spawnSync("echo test");
         childProcess.spawnSync("echo test", {windowsVerbatimArguments: false});
+        childProcess.spawnSync("echo test", {windowsVerbatimArguments: false, argv0: "echo-test"});
     }
 
     {

--- a/types/node/node-tests.ts
+++ b/types/node/node-tests.ts
@@ -2324,7 +2324,6 @@ namespace child_process_tests {
         childProcess.spawn("echo", ["test"], { windowsHide: true, argv0: "echo-test" });
         childProcess.spawnSync("echo test");
         childProcess.spawnSync("echo test", {windowsVerbatimArguments: false});
-        childProcess.spawnSync("echo test", {windowsVerbatimArguments: false, argv0: "echo-test"});
     }
 
     {


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: [npm child_process docs](https://nodejs.org/api/child_process.html)
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.


Required minimal changes outside of Node.  Build appears to be broken but [it's TS@next's fault](https://github.com/Microsoft/types-publisher/issues/478) as far as I can tell.