### PR TITLE
[hapi] Correct the server.table() return type

### DIFF
--- a/types/hapi/index.d.ts
+++ b/types/hapi/index.d.ts
@@ -3790,7 +3790,7 @@ export class Server extends Podium {
      * * path - the route path.
      * [See docs](https://github.com/hapijs/hapi/blob/master/API.md#-servertablehost)
      */
-    table(host?: string): Array<{settings: ServerRoute; method: Util.HTTP_METHODS_PARTIAL_LOWERCASE, path: string}>; // TODO I am not sure if the ServerRoute is the object expected here
+    table(host?: string): RequestRoute[];
 }
 
 /* + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + +

--- a/types/hapi/test/server/server-table.ts
+++ b/types/hapi/test/server/server-table.ts
@@ -19,4 +19,11 @@ server.route({
 server.start();
 const table = server.table();
 console.log(table);
+console.log(table[0].method);
+console.log(table[0].path);
+console.log(table[0].vhost);
+console.log(table[0].realm);
+console.log(table[0].settings);
+console.log(table[0].fingerprint);
+console.log(table[0].auth);
 console.log('Server started at: ' + server.info.uri);


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: see below
- [] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

Hi humans !

The return type of the table function seems to be wrong.
Here is why I think it's wrong: 
The table function calls [Call.router.table](https://github.com/hapijs/hapi/blob/6287f7c093922f2a41fcea791c9e9815b514a544/lib/server.js#L502)
This methods return routes [here](https://github.com/hapijs/call/blob/master/lib/index.js#L334)
The routes array are filled with [records](https://github.com/hapijs/call/blob/master/lib/index.js#L52)
These records really look like to a [RequestRoute ](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/hapi/index.d.ts#L286)to me.
