### PR TITLE
Added the "ImageryClarity" Basemaps

### DIFF
--- a/types/esri-leaflet/index.d.ts
+++ b/types/esri-leaflet/index.d.ts
@@ -44,6 +44,7 @@ declare module 'leaflet' {
             | 'GrayLabels'
             | 'DarkGrayLabels'
             | 'ImageryLabels'
+            | 'ImageryClarity'
             | 'ImageryTransportation'
             | 'ShadedReliefLabels'
             | 'TerrainLabels';


### PR DESCRIPTION
The current version of this file is missing the "ImageryClartiy" basemap option, despite the fact the esri-leaflet supports it.
