### PR TITLE
[moment-timezone] Fix zone method return type

### DIFF
--- a/types/moment-timezone/index.d.ts
+++ b/types/moment-timezone/index.d.ts
@@ -36,7 +36,7 @@ declare module "moment" {
         (date: moment.Moment, timezone: string): moment.Moment;
         (date: any, timezone: string): moment.Moment;
 
-        zone(timezone: string): MomentZone;
+        zone(timezone: string): MomentZone | null;
 
         add(packedZoneString: string): void;
         add(packedZoneString: string[]): void;


### PR DESCRIPTION
The method `moment.tz.zone()` returns `null` or a `MomentZone`: https://momentjs.com/timezone/docs/#/data-loading/checking-if-a-zone-exists/

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
