### PR TITLE
ioredis: doesn't use bluebird by default

### DIFF
--- a/types/ioredis/index.d.ts
+++ b/types/ioredis/index.d.ts
@@ -17,7 +17,6 @@
 
 /// <reference types="node" />
 
-import Promise = require('bluebird');
 import tls = require('tls');
 
 interface RedisStatic {

--- a/types/ioredis/ioredis-tests.ts
+++ b/types/ioredis/ioredis-tests.ts
@@ -125,9 +125,6 @@ redis.multi([
     // results = [[null, 'OK'], [null, 'bar']]
 });
 
-redis.Promise.onPossiblyUnhandledRejection((error) => {
-});
-
 const keys = ['foo', 'bar'];
 redis.mget(...keys);
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/luin/ioredis#plugging-in-your-own-promises-library Also not in the package.json's deps.
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

This comes up more with typescript 3 and the new extensions to Promise in esnext not allowing bluebird promises to be used as promises. But it's wrong so.. that too.