### PR TITLE
[@types/p-defer] update resolve and reject to have types that match implementation

### DIFF
--- a/types/p-defer/index.d.ts
+++ b/types/p-defer/index.d.ts
@@ -4,11 +4,11 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare namespace pDefer {
-	interface DeferredPromise<T> {
-		resolve<U>(value?: U | PromiseLike<U>): Promise<U>;
-		reject(reason: any): Promise<never>;
-		promise: Promise<T>;
-	}
+    interface DeferredPromise<T> {
+        resolve(value?: T | PromiseLike<T>): void;
+        reject(reason: any): void;
+        promise: Promise<T>;
+    }
 }
 
 declare function pDefer<T>(): pDefer.DeferredPromise<T>;

--- a/types/p-defer/p-defer-tests.ts
+++ b/types/p-defer/p-defer-tests.ts
@@ -1,13 +1,16 @@
 import pDefer = require('p-defer');
 
-function delay(deferred: pDefer.DeferredPromise<string>,  ms: number) {
+function delay(deferred: pDefer.DeferredPromise<string>, ms: number) {
     setTimeout(deferred.resolve, ms, '🦄');
     return deferred.promise;
 }
 
 let s: string;
-async function f() { s = await delay(pDefer<string>(), 100); }
+async function f() {
+    s = await delay(pDefer<string>(), 100);
+}
 
 async function u() {
-	const u: Promise<any> = pDefer().resolve();
+    const u: void = pDefer().resolve();
+    const r: void = pDefer().reject('oh no');
 }

--- a/types/p-defer/tslint.json
+++ b/types/p-defer/tslint.json
@@ -1,6 +1,8 @@
 {
     "extends": "dtslint/dt.json",
     "rules": {
-        "no-unnecessary-generics": false
+        "no-unnecessary-generics": false,
+        "void-return": false,
+        "no-void-expression": false
     }
 }


### PR DESCRIPTION
The main problem that this fixes is the return types of `resolve` and `reject`, which come directly
from the built-in Promise implementation, which guarantees that their return values are `undefined`
as per https://www.ecma-international.org/ecma-262/6.0/#sec-promise-resolve-functions point 13

This also fixes the argument type for `resolve`, because a new generic type should not be introduced to
an existing DeferredPromise

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/sindresorhus/p-defer/blob/master/index.js and https://www.ecma-international.org/ecma-262/6.0/#sec-promise-resolve-functions
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.