### PR TITLE
react-dropzone: accept can also take an array

### DIFF
--- a/types/react-dropzone/index.d.ts
+++ b/types/react-dropzone/index.d.ts
@@ -6,7 +6,8 @@
 //                 Ben Bayard <https://github.com/benbayard>,
 //                 Karol Janyst <https://github.com/LKay>,
 //                 Andris Causs <https://github.com/codeaid>,
-//                 Juraj Husar <https://github.com/jurosh>
+//                 Juraj Husar <https://github.com/jurosh>,
+//                 Monroe Ekilah <https://github.com/ekilah>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -19,9 +20,10 @@ export interface ImageFile extends File {
 export type DropFileEventHandler = (acceptedOrRejected: ImageFile[], event: DragEvent<HTMLDivElement>) => void;
 export type DropFilesEventHandler = (accepted: ImageFile[], rejected: ImageFile[], event: DragEvent<HTMLDivElement>) => void;
 
-type PickedAttributes = "accept" | "className" | "multiple" | "name" | "onClick" | "onDragStart" | "onDragEnter" | "onDragOver" | "onDragLeave" | "style";
+type PickedAttributes = "className" | "multiple" | "name" | "onClick" | "onDragStart" | "onDragEnter" | "onDragOver" | "onDragLeave" | "style";
 
 export interface DropzoneProps extends Pick<InputHTMLAttributes<HTMLDivElement>, PickedAttributes> {
+    accept?: string | ReadonlyArray<string>;
     disableClick?: boolean;
     disabled?: boolean;
     disablePreview?: boolean;

--- a/types/react-dropzone/react-dropzone-tests.tsx
+++ b/types/react-dropzone/react-dropzone-tests.tsx
@@ -14,9 +14,11 @@ class Test extends React.Component {
 
   handleDropFiles = (accepted: File[], rejected: File[], event: DragEvent<HTMLDivElement>) => {};
 
-  handleDefault = (e: SyntheticEvent<HTMLDivElement>) => {}
+  handleDefault = (e: SyntheticEvent<HTMLDivElement>) => {};
 
-  handleFileDialog = () => {}
+  handleFileDialog = () => {};
+
+  accept: string | ReadonlyArray<string> = ["*.png", "application/pdf"];
 
   render() {
     return (
@@ -47,7 +49,7 @@ class Test extends React.Component {
           disableClick
           disabled
           multiple={false}
-          accept="*.png"
+          accept={this.accept}
           name="dropzone"
           inputProps={{ id : "dropzone" }}
         />


### PR DESCRIPTION
https://github.com/react-dropzone/react-dropzone/blob/master/README.md links to https://react-dropzone.netlify.com/#proptypes which describes the `accept` prop as optional and accepts:

> One of type: string, string[]

comes from https://github.com/okonet/attr-accept 's ability to take an array of strings.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://react-dropzone.netlify.com/#proptypes>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
