### PR TITLE
[node] bump inspector types to 6.2 (v8/v9) and 6.7 (v10)

### DIFF
--- a/types/node/inspector.d.ts
+++ b/types/node/inspector.d.ts
@@ -15,26 +15,1075 @@ declare module "inspector" {
         params: T;
     }
 
-    export namespace Schema {
+    export namespace Console {
         /**
-         * Description of the protocol domain.
+         * Console message.
          */
-        export interface Domain {
+        export interface ConsoleMessage {
             /**
-             * Domain name.
+             * Message source.
              */
-            name: string;
+            source: string;
             /**
-             * Domain version.
+             * Message severity.
              */
-            version: string;
+            level: string;
+            /**
+             * Message text.
+             */
+            text: string;
+            /**
+             * URL of the message origin.
+             */
+            url?: string;
+            /**
+             * Line number in the resource that generated this message (1-based).
+             */
+            line?: number;
+            /**
+             * Column number in the resource that generated this message (1-based).
+             */
+            column?: number;
         }
 
-        export interface GetDomainsReturnType {
+        export interface MessageAddedEventDataType {
             /**
-             * List of supported domains.
+             * Console message that has been added.
              */
-            domains: Schema.Domain[];
+            message: Console.ConsoleMessage;
+        }
+    }
+
+    export namespace Debugger {
+        /**
+         * Breakpoint identifier.
+         */
+        export type BreakpointId = string;
+
+        /**
+         * Call frame identifier.
+         */
+        export type CallFrameId = string;
+
+        /**
+         * Location in the source code.
+         */
+        export interface Location {
+            /**
+             * Script identifier as reported in the `Debugger.scriptParsed`.
+             */
+            scriptId: Runtime.ScriptId;
+            /**
+             * Line number in the script (0-based).
+             */
+            lineNumber: number;
+            /**
+             * Column number in the script (0-based).
+             */
+            columnNumber?: number;
+        }
+
+        /**
+         * Location in the source code.
+         * @experimental
+         */
+        export interface ScriptPosition {
+            lineNumber: number;
+            columnNumber: number;
+        }
+
+        /**
+         * JavaScript call frame. Array of call frames form the call stack.
+         */
+        export interface CallFrame {
+            /**
+             * Call frame identifier. This identifier is only valid while the virtual machine is paused.
+             */
+            callFrameId: Debugger.CallFrameId;
+            /**
+             * Name of the JavaScript function called on this call frame.
+             */
+            functionName: string;
+            /**
+             * Location in the source code.
+             */
+            functionLocation?: Debugger.Location;
+            /**
+             * Location in the source code.
+             */
+            location: Debugger.Location;
+            /**
+             * JavaScript script name or url.
+             */
+            url: string;
+            /**
+             * Scope chain for this call frame.
+             */
+            scopeChain: Debugger.Scope[];
+            /**
+             * `this` object for this call frame.
+             */
+            this: Runtime.RemoteObject;
+            /**
+             * The value being returned, if the function is at return point.
+             */
+            returnValue?: Runtime.RemoteObject;
+        }
+
+        /**
+         * Scope description.
+         */
+        export interface Scope {
+            /**
+             * Scope type.
+             */
+            type: string;
+            /**
+             * Object representing the scope. For `global` and `with` scopes it represents the actual
+object; for the rest of the scopes, it is artificial transient object enumerating scope
+variables as its properties.
+             */
+            object: Runtime.RemoteObject;
+            name?: string;
+            /**
+             * Location in the source code where scope starts
+             */
+            startLocation?: Debugger.Location;
+            /**
+             * Location in the source code where scope ends
+             */
+            endLocation?: Debugger.Location;
+        }
+
+        /**
+         * Search match for resource.
+         */
+        export interface SearchMatch {
+            /**
+             * Line number in resource content.
+             */
+            lineNumber: number;
+            /**
+             * Line with match content.
+             */
+            lineContent: string;
+        }
+
+        export interface BreakLocation {
+            /**
+             * Script identifier as reported in the `Debugger.scriptParsed`.
+             */
+            scriptId: Runtime.ScriptId;
+            /**
+             * Line number in the script (0-based).
+             */
+            lineNumber: number;
+            /**
+             * Column number in the script (0-based).
+             */
+            columnNumber?: number;
+            type?: string;
+        }
+
+        export interface ContinueToLocationParameterType {
+            /**
+             * Location to continue to.
+             */
+            location: Debugger.Location;
+            targetCallFrames?: string;
+        }
+
+        export interface EvaluateOnCallFrameParameterType {
+            /**
+             * Call frame identifier to evaluate on.
+             */
+            callFrameId: Debugger.CallFrameId;
+            /**
+             * Expression to evaluate.
+             */
+            expression: string;
+            /**
+             * String object group name to put result into (allows rapid releasing resulting object handles
+using `releaseObjectGroup`).
+             */
+            objectGroup?: string;
+            /**
+             * Specifies whether command line API should be available to the evaluated expression, defaults
+to false.
+             */
+            includeCommandLineAPI?: boolean;
+            /**
+             * In silent mode exceptions thrown during evaluation are not reported and do not pause
+execution. Overrides `setPauseOnException` state.
+             */
+            silent?: boolean;
+            /**
+             * Whether the result is expected to be a JSON object that should be sent by value.
+             */
+            returnByValue?: boolean;
+            /**
+             * Whether preview should be generated for the result.
+             * @experimental
+             */
+            generatePreview?: boolean;
+            /**
+             * Whether to throw an exception if side effect cannot be ruled out during evaluation.
+             */
+            throwOnSideEffect?: boolean;
+        }
+
+        export interface GetPossibleBreakpointsParameterType {
+            /**
+             * Start of range to search possible breakpoint locations in.
+             */
+            start: Debugger.Location;
+            /**
+             * End of range to search possible breakpoint locations in (excluding). When not specified, end
+of scripts is used as end of range.
+             */
+            end?: Debugger.Location;
+            /**
+             * Only consider locations which are in the same (non-nested) function as start.
+             */
+            restrictToFunction?: boolean;
+        }
+
+        export interface GetScriptSourceParameterType {
+            /**
+             * Id of the script to get source for.
+             */
+            scriptId: Runtime.ScriptId;
+        }
+
+        export interface GetStackTraceParameterType {
+            stackTraceId: Runtime.StackTraceId;
+        }
+
+        export interface PauseOnAsyncCallParameterType {
+            /**
+             * Debugger will pause when async call with given stack trace is started.
+             */
+            parentStackTraceId: Runtime.StackTraceId;
+        }
+
+        export interface RemoveBreakpointParameterType {
+            breakpointId: Debugger.BreakpointId;
+        }
+
+        export interface RestartFrameParameterType {
+            /**
+             * Call frame identifier to evaluate on.
+             */
+            callFrameId: Debugger.CallFrameId;
+        }
+
+        export interface SearchInContentParameterType {
+            /**
+             * Id of the script to search in.
+             */
+            scriptId: Runtime.ScriptId;
+            /**
+             * String to search for.
+             */
+            query: string;
+            /**
+             * If true, search is case sensitive.
+             */
+            caseSensitive?: boolean;
+            /**
+             * If true, treats string parameter as regex.
+             */
+            isRegex?: boolean;
+        }
+
+        export interface SetAsyncCallStackDepthParameterType {
+            /**
+             * Maximum depth of async call stacks. Setting to `0` will effectively disable collecting async
+call stacks (default).
+             */
+            maxDepth: number;
+        }
+
+        export interface SetBlackboxPatternsParameterType {
+            /**
+             * Array of regexps that will be used to check script url for blackbox state.
+             */
+            patterns: string[];
+        }
+
+        export interface SetBlackboxedRangesParameterType {
+            /**
+             * Id of the script.
+             */
+            scriptId: Runtime.ScriptId;
+            positions: Debugger.ScriptPosition[];
+        }
+
+        export interface SetBreakpointParameterType {
+            /**
+             * Location to set breakpoint in.
+             */
+            location: Debugger.Location;
+            /**
+             * Expression to use as a breakpoint condition. When specified, debugger will only stop on the
+breakpoint if this expression evaluates to true.
+             */
+            condition?: string;
+        }
+
+        export interface SetBreakpointByUrlParameterType {
+            /**
+             * Line number to set breakpoint at.
+             */
+            lineNumber: number;
+            /**
+             * URL of the resources to set breakpoint on.
+             */
+            url?: string;
+            /**
+             * Regex pattern for the URLs of the resources to set breakpoints on. Either `url` or
+`urlRegex` must be specified.
+             */
+            urlRegex?: string;
+            /**
+             * Script hash of the resources to set breakpoint on.
+             */
+            scriptHash?: string;
+            /**
+             * Offset in the line to set breakpoint at.
+             */
+            columnNumber?: number;
+            /**
+             * Expression to use as a breakpoint condition. When specified, debugger will only stop on the
+breakpoint if this expression evaluates to true.
+             */
+            condition?: string;
+        }
+
+        export interface SetBreakpointsActiveParameterType {
+            /**
+             * New value for breakpoints active state.
+             */
+            active: boolean;
+        }
+
+        export interface SetPauseOnExceptionsParameterType {
+            /**
+             * Pause on exceptions mode.
+             */
+            state: string;
+        }
+
+        export interface SetReturnValueParameterType {
+            /**
+             * New return value.
+             */
+            newValue: Runtime.CallArgument;
+        }
+
+        export interface SetScriptSourceParameterType {
+            /**
+             * Id of the script to edit.
+             */
+            scriptId: Runtime.ScriptId;
+            /**
+             * New content of the script.
+             */
+            scriptSource: string;
+            /**
+             * If true the change will not actually be applied. Dry run may be used to get result
+description without actually modifying the code.
+             */
+            dryRun?: boolean;
+        }
+
+        export interface SetSkipAllPausesParameterType {
+            /**
+             * New value for skip pauses state.
+             */
+            skip: boolean;
+        }
+
+        export interface SetVariableValueParameterType {
+            /**
+             * 0-based number of scope as was listed in scope chain. Only 'local', 'closure' and 'catch'
+scope types are allowed. Other scopes could be manipulated manually.
+             */
+            scopeNumber: number;
+            /**
+             * Variable name.
+             */
+            variableName: string;
+            /**
+             * New variable value.
+             */
+            newValue: Runtime.CallArgument;
+            /**
+             * Id of callframe that holds variable.
+             */
+            callFrameId: Debugger.CallFrameId;
+        }
+
+        export interface StepIntoParameterType {
+            /**
+             * Debugger will issue additional Debugger.paused notification if any async task is scheduled
+before next pause.
+             * @experimental
+             */
+            breakOnAsyncCall?: boolean;
+        }
+
+        export interface EnableReturnType {
+            /**
+             * Unique identifier of the debugger.
+             * @experimental
+             */
+            debuggerId: Runtime.UniqueDebuggerId;
+        }
+
+        export interface EvaluateOnCallFrameReturnType {
+            /**
+             * Object wrapper for the evaluation result.
+             */
+            result: Runtime.RemoteObject;
+            /**
+             * Exception details.
+             */
+            exceptionDetails?: Runtime.ExceptionDetails;
+        }
+
+        export interface GetPossibleBreakpointsReturnType {
+            /**
+             * List of the possible breakpoint locations.
+             */
+            locations: Debugger.BreakLocation[];
+        }
+
+        export interface GetScriptSourceReturnType {
+            /**
+             * Script source.
+             */
+            scriptSource: string;
+        }
+
+        export interface GetStackTraceReturnType {
+            stackTrace: Runtime.StackTrace;
+        }
+
+        export interface RestartFrameReturnType {
+            /**
+             * New stack trace.
+             */
+            callFrames: Debugger.CallFrame[];
+            /**
+             * Async stack trace, if any.
+             */
+            asyncStackTrace?: Runtime.StackTrace;
+            /**
+             * Async stack trace, if any.
+             * @experimental
+             */
+            asyncStackTraceId?: Runtime.StackTraceId;
+        }
+
+        export interface SearchInContentReturnType {
+            /**
+             * List of search matches.
+             */
+            result: Debugger.SearchMatch[];
+        }
+
+        export interface SetBreakpointReturnType {
+            /**
+             * Id of the created breakpoint for further reference.
+             */
+            breakpointId: Debugger.BreakpointId;
+            /**
+             * Location this breakpoint resolved into.
+             */
+            actualLocation: Debugger.Location;
+        }
+
+        export interface SetBreakpointByUrlReturnType {
+            /**
+             * Id of the created breakpoint for further reference.
+             */
+            breakpointId: Debugger.BreakpointId;
+            /**
+             * List of the locations this breakpoint resolved into upon addition.
+             */
+            locations: Debugger.Location[];
+        }
+
+        export interface SetScriptSourceReturnType {
+            /**
+             * New stack trace in case editing has happened while VM was stopped.
+             */
+            callFrames?: Debugger.CallFrame[];
+            /**
+             * Whether current call stack  was modified after applying the changes.
+             */
+            stackChanged?: boolean;
+            /**
+             * Async stack trace, if any.
+             */
+            asyncStackTrace?: Runtime.StackTrace;
+            /**
+             * Async stack trace, if any.
+             * @experimental
+             */
+            asyncStackTraceId?: Runtime.StackTraceId;
+            /**
+             * Exception details if any.
+             */
+            exceptionDetails?: Runtime.ExceptionDetails;
+        }
+
+        export interface BreakpointResolvedEventDataType {
+            /**
+             * Breakpoint unique identifier.
+             */
+            breakpointId: Debugger.BreakpointId;
+            /**
+             * Actual breakpoint location.
+             */
+            location: Debugger.Location;
+        }
+
+        export interface PausedEventDataType {
+            /**
+             * Call stack the virtual machine stopped on.
+             */
+            callFrames: Debugger.CallFrame[];
+            /**
+             * Pause reason.
+             */
+            reason: string;
+            /**
+             * Object containing break-specific auxiliary properties.
+             */
+            data?: {};
+            /**
+             * Hit breakpoints IDs
+             */
+            hitBreakpoints?: string[];
+            /**
+             * Async stack trace, if any.
+             */
+            asyncStackTrace?: Runtime.StackTrace;
+            /**
+             * Async stack trace, if any.
+             * @experimental
+             */
+            asyncStackTraceId?: Runtime.StackTraceId;
+            /**
+             * Just scheduled async call will have this stack trace as parent stack during async execution.
+This field is available only after `Debugger.stepInto` call with `breakOnAsynCall` flag.
+             * @experimental
+             */
+            asyncCallStackTraceId?: Runtime.StackTraceId;
+        }
+
+        export interface ScriptFailedToParseEventDataType {
+            /**
+             * Identifier of the script parsed.
+             */
+            scriptId: Runtime.ScriptId;
+            /**
+             * URL or name of the script parsed (if any).
+             */
+            url: string;
+            /**
+             * Line offset of the script within the resource with given URL (for script tags).
+             */
+            startLine: number;
+            /**
+             * Column offset of the script within the resource with given URL.
+             */
+            startColumn: number;
+            /**
+             * Last line of the script.
+             */
+            endLine: number;
+            /**
+             * Length of the last line of the script.
+             */
+            endColumn: number;
+            /**
+             * Specifies script creation context.
+             */
+            executionContextId: Runtime.ExecutionContextId;
+            /**
+             * Content hash of the script.
+             */
+            hash: string;
+            /**
+             * Embedder-specific auxiliary data.
+             */
+            executionContextAuxData?: {};
+            /**
+             * URL of source map associated with script (if any).
+             */
+            sourceMapURL?: string;
+            /**
+             * True, if this script has sourceURL.
+             */
+            hasSourceURL?: boolean;
+            /**
+             * True, if this script is ES6 module.
+             */
+            isModule?: boolean;
+            /**
+             * This script length.
+             */
+            length?: number;
+            /**
+             * JavaScript top stack frame of where the script parsed event was triggered if available.
+             * @experimental
+             */
+            stackTrace?: Runtime.StackTrace;
+        }
+
+        export interface ScriptParsedEventDataType {
+            /**
+             * Identifier of the script parsed.
+             */
+            scriptId: Runtime.ScriptId;
+            /**
+             * URL or name of the script parsed (if any).
+             */
+            url: string;
+            /**
+             * Line offset of the script within the resource with given URL (for script tags).
+             */
+            startLine: number;
+            /**
+             * Column offset of the script within the resource with given URL.
+             */
+            startColumn: number;
+            /**
+             * Last line of the script.
+             */
+            endLine: number;
+            /**
+             * Length of the last line of the script.
+             */
+            endColumn: number;
+            /**
+             * Specifies script creation context.
+             */
+            executionContextId: Runtime.ExecutionContextId;
+            /**
+             * Content hash of the script.
+             */
+            hash: string;
+            /**
+             * Embedder-specific auxiliary data.
+             */
+            executionContextAuxData?: {};
+            /**
+             * True, if this script is generated as a result of the live edit operation.
+             * @experimental
+             */
+            isLiveEdit?: boolean;
+            /**
+             * URL of source map associated with script (if any).
+             */
+            sourceMapURL?: string;
+            /**
+             * True, if this script has sourceURL.
+             */
+            hasSourceURL?: boolean;
+            /**
+             * True, if this script is ES6 module.
+             */
+            isModule?: boolean;
+            /**
+             * This script length.
+             */
+            length?: number;
+            /**
+             * JavaScript top stack frame of where the script parsed event was triggered if available.
+             * @experimental
+             */
+            stackTrace?: Runtime.StackTrace;
+        }
+    }
+
+    export namespace HeapProfiler {
+        /**
+         * Heap snapshot object id.
+         */
+        export type HeapSnapshotObjectId = string;
+
+        /**
+         * Sampling Heap Profile node. Holds callsite information, allocation statistics and child nodes.
+         */
+        export interface SamplingHeapProfileNode {
+            /**
+             * Function location.
+             */
+            callFrame: Runtime.CallFrame;
+            /**
+             * Allocations size in bytes for the node excluding children.
+             */
+            selfSize: number;
+            /**
+             * Child nodes.
+             */
+            children: HeapProfiler.SamplingHeapProfileNode[];
+        }
+
+        /**
+         * Profile.
+         */
+        export interface SamplingHeapProfile {
+            head: HeapProfiler.SamplingHeapProfileNode;
+        }
+
+        export interface AddInspectedHeapObjectParameterType {
+            /**
+             * Heap snapshot object id to be accessible by means of $x command line API.
+             */
+            heapObjectId: HeapProfiler.HeapSnapshotObjectId;
+        }
+
+        export interface GetHeapObjectIdParameterType {
+            /**
+             * Identifier of the object to get heap object id for.
+             */
+            objectId: Runtime.RemoteObjectId;
+        }
+
+        export interface GetObjectByHeapObjectIdParameterType {
+            objectId: HeapProfiler.HeapSnapshotObjectId;
+            /**
+             * Symbolic group name that can be used to release multiple objects.
+             */
+            objectGroup?: string;
+        }
+
+        export interface StartSamplingParameterType {
+            /**
+             * Average sample interval in bytes. Poisson distribution is used for the intervals. The
+default value is 32768 bytes.
+             */
+            samplingInterval?: number;
+        }
+
+        export interface StartTrackingHeapObjectsParameterType {
+            trackAllocations?: boolean;
+        }
+
+        export interface StopTrackingHeapObjectsParameterType {
+            /**
+             * If true 'reportHeapSnapshotProgress' events will be generated while snapshot is being taken
+when the tracking is stopped.
+             */
+            reportProgress?: boolean;
+        }
+
+        export interface TakeHeapSnapshotParameterType {
+            /**
+             * If true 'reportHeapSnapshotProgress' events will be generated while snapshot is being taken.
+             */
+            reportProgress?: boolean;
+        }
+
+        export interface GetHeapObjectIdReturnType {
+            /**
+             * Id of the heap snapshot object corresponding to the passed remote object id.
+             */
+            heapSnapshotObjectId: HeapProfiler.HeapSnapshotObjectId;
+        }
+
+        export interface GetObjectByHeapObjectIdReturnType {
+            /**
+             * Evaluation result.
+             */
+            result: Runtime.RemoteObject;
+        }
+
+        export interface GetSamplingProfileReturnType {
+            /**
+             * Return the sampling profile being collected.
+             */
+            profile: HeapProfiler.SamplingHeapProfile;
+        }
+
+        export interface StopSamplingReturnType {
+            /**
+             * Recorded sampling heap profile.
+             */
+            profile: HeapProfiler.SamplingHeapProfile;
+        }
+
+        export interface AddHeapSnapshotChunkEventDataType {
+            chunk: string;
+        }
+
+        export interface HeapStatsUpdateEventDataType {
+            /**
+             * An array of triplets. Each triplet describes a fragment. The first integer is the fragment
+index, the second integer is a total count of objects for the fragment, the third integer is
+a total size of the objects for the fragment.
+             */
+            statsUpdate: number[];
+        }
+
+        export interface LastSeenObjectIdEventDataType {
+            lastSeenObjectId: number;
+            timestamp: number;
+        }
+
+        export interface ReportHeapSnapshotProgressEventDataType {
+            done: number;
+            total: number;
+            finished?: boolean;
+        }
+    }
+
+    export namespace Profiler {
+        /**
+         * Profile node. Holds callsite information, execution statistics and child nodes.
+         */
+        export interface ProfileNode {
+            /**
+             * Unique id of the node.
+             */
+            id: number;
+            /**
+             * Function location.
+             */
+            callFrame: Runtime.CallFrame;
+            /**
+             * Number of samples where this node was on top of the call stack.
+             */
+            hitCount?: number;
+            /**
+             * Child node ids.
+             */
+            children?: number[];
+            /**
+             * The reason of being not optimized. The function may be deoptimized or marked as don't
+optimize.
+             */
+            deoptReason?: string;
+            /**
+             * An array of source position ticks.
+             */
+            positionTicks?: Profiler.PositionTickInfo[];
+        }
+
+        /**
+         * Profile.
+         */
+        export interface Profile {
+            /**
+             * The list of profile nodes. First item is the root node.
+             */
+            nodes: Profiler.ProfileNode[];
+            /**
+             * Profiling start timestamp in microseconds.
+             */
+            startTime: number;
+            /**
+             * Profiling end timestamp in microseconds.
+             */
+            endTime: number;
+            /**
+             * Ids of samples top nodes.
+             */
+            samples?: number[];
+            /**
+             * Time intervals between adjacent samples in microseconds. The first delta is relative to the
+profile startTime.
+             */
+            timeDeltas?: number[];
+        }
+
+        /**
+         * Specifies a number of samples attributed to a certain source position.
+         */
+        export interface PositionTickInfo {
+            /**
+             * Source line number (1-based).
+             */
+            line: number;
+            /**
+             * Number of samples attributed to the source line.
+             */
+            ticks: number;
+        }
+
+        /**
+         * Coverage data for a source range.
+         */
+        export interface CoverageRange {
+            /**
+             * JavaScript script source offset for the range start.
+             */
+            startOffset: number;
+            /**
+             * JavaScript script source offset for the range end.
+             */
+            endOffset: number;
+            /**
+             * Collected execution count of the source range.
+             */
+            count: number;
+        }
+
+        /**
+         * Coverage data for a JavaScript function.
+         */
+        export interface FunctionCoverage {
+            /**
+             * JavaScript function name.
+             */
+            functionName: string;
+            /**
+             * Source ranges inside the function with coverage data.
+             */
+            ranges: Profiler.CoverageRange[];
+            /**
+             * Whether coverage data for this function has block granularity.
+             */
+            isBlockCoverage: boolean;
+        }
+
+        /**
+         * Coverage data for a JavaScript script.
+         */
+        export interface ScriptCoverage {
+            /**
+             * JavaScript script id.
+             */
+            scriptId: Runtime.ScriptId;
+            /**
+             * JavaScript script name or url.
+             */
+            url: string;
+            /**
+             * Functions contained in the script that has coverage data.
+             */
+            functions: Profiler.FunctionCoverage[];
+        }
+
+        /**
+         * Describes a type collected during runtime.
+         * @experimental
+         */
+        export interface TypeObject {
+            /**
+             * Name of a type collected with type profiling.
+             */
+            name: string;
+        }
+
+        /**
+         * Source offset and types for a parameter or return value.
+         * @experimental
+         */
+        export interface TypeProfileEntry {
+            /**
+             * Source offset of the parameter or end of function for return values.
+             */
+            offset: number;
+            /**
+             * The types for this parameter or return value.
+             */
+            types: Profiler.TypeObject[];
+        }
+
+        /**
+         * Type profile data collected during runtime for a JavaScript script.
+         * @experimental
+         */
+        export interface ScriptTypeProfile {
+            /**
+             * JavaScript script id.
+             */
+            scriptId: Runtime.ScriptId;
+            /**
+             * JavaScript script name or url.
+             */
+            url: string;
+            /**
+             * Type profile entries for parameters and return values of the functions in the script.
+             */
+            entries: Profiler.TypeProfileEntry[];
+        }
+
+        export interface SetSamplingIntervalParameterType {
+            /**
+             * New sampling interval in microseconds.
+             */
+            interval: number;
+        }
+
+        export interface StartPreciseCoverageParameterType {
+            /**
+             * Collect accurate call counts beyond simple 'covered' or 'not covered'.
+             */
+            callCount?: boolean;
+            /**
+             * Collect block-based coverage.
+             */
+            detailed?: boolean;
+        }
+
+        export interface GetBestEffortCoverageReturnType {
+            /**
+             * Coverage data for the current isolate.
+             */
+            result: Profiler.ScriptCoverage[];
+        }
+
+        export interface StopReturnType {
+            /**
+             * Recorded profile.
+             */
+            profile: Profiler.Profile;
+        }
+
+        export interface TakePreciseCoverageReturnType {
+            /**
+             * Coverage data for the current isolate.
+             */
+            result: Profiler.ScriptCoverage[];
+        }
+
+        export interface TakeTypeProfileReturnType {
+            /**
+             * Type profile for all scripts since startTypeProfile() was turned on.
+             */
+            result: Profiler.ScriptTypeProfile[];
+        }
+
+        export interface ConsoleProfileFinishedEventDataType {
+            id: string;
+            /**
+             * Location of console.profileEnd().
+             */
+            location: Debugger.Location;
+            profile: Profiler.Profile;
+            /**
+             * Profile title passed as an argument to console.profile().
+             */
+            title?: string;
+        }
+
+        export interface ConsoleProfileStartedEventDataType {
+            id: string;
+            /**
+             * Location of console.profile().
+             */
+            location: Debugger.Location;
+            /**
+             * Profile title passed as an argument to console.profile().
+             */
+            title?: string;
         }
     }
 
@@ -50,7 +1099,8 @@ declare module "inspector" {
         export type RemoteObjectId = string;
 
         /**
-         * Primitive value which cannot be JSON-stringified.
+         * Primitive value which cannot be JSON-stringified. Includes values `-0`, `NaN`, `Infinity`,
+`-Infinity`, and bigint literals.
          */
         export type UnserializableValue = string;
 
@@ -63,11 +1113,11 @@ declare module "inspector" {
              */
             type: string;
             /**
-             * Object subtype hint. Specified for <code>object</code> type values only.
+             * Object subtype hint. Specified for `object` type values only.
              */
             subtype?: string;
             /**
-             * Object class (constructor) name. Specified for <code>object</code> type values only.
+             * Object class (constructor) name. Specified for `object` type values only.
              */
             className?: string;
             /**
@@ -75,7 +1125,8 @@ declare module "inspector" {
              */
             value?: any;
             /**
-             * Primitive value which can not be JSON-stringified does not have <code>value</code>, but gets this property.
+             * Primitive value which can not be JSON-stringified does not have `value`, but gets this
+property.
              */
             unserializableValue?: Runtime.UnserializableValue;
             /**
@@ -87,7 +1138,7 @@ declare module "inspector" {
              */
             objectId?: Runtime.RemoteObjectId;
             /**
-             * Preview containing abbreviated property values. Specified for <code>object</code> type values only.
+             * Preview containing abbreviated property values. Specified for `object` type values only.
              * @experimental
              */
             preview?: Runtime.ObjectPreview;
@@ -118,7 +1169,7 @@ declare module "inspector" {
              */
             type: string;
             /**
-             * Object subtype hint. Specified for <code>object</code> type values only.
+             * Object subtype hint. Specified for `object` type values only.
              */
             subtype?: string;
             /**
@@ -134,7 +1185,7 @@ declare module "inspector" {
              */
             properties: Runtime.PropertyPreview[];
             /**
-             * List of the entries. Specified for <code>map</code> and <code>set</code> subtype values only.
+             * List of the entries. Specified for `map` and `set` subtype values only.
              */
             entries?: Runtime.EntryPreview[];
         }
@@ -160,7 +1211,7 @@ declare module "inspector" {
              */
             valuePreview?: Runtime.ObjectPreview;
             /**
-             * Object subtype hint. Specified for <code>object</code> type values only.
+             * Object subtype hint. Specified for `object` type values only.
              */
             subtype?: string;
         }
@@ -196,19 +1247,23 @@ declare module "inspector" {
              */
             writable?: boolean;
             /**
-             * A function which serves as a getter for the property, or <code>undefined</code> if there is no getter (accessor descriptors only).
+             * A function which serves as a getter for the property, or `undefined` if there is no getter
+(accessor descriptors only).
              */
             get?: Runtime.RemoteObject;
             /**
-             * A function which serves as a setter for the property, or <code>undefined</code> if there is no setter (accessor descriptors only).
+             * A function which serves as a setter for the property, or `undefined` if there is no setter
+(accessor descriptors only).
              */
             set?: Runtime.RemoteObject;
             /**
-             * True if the type of this property descriptor may be changed and if the property may be deleted from the corresponding object.
+             * True if the type of this property descriptor may be changed and if the property may be
+deleted from the corresponding object.
              */
             configurable: boolean;
             /**
-             * True if this property shows up during enumeration of the properties on the corresponding object.
+             * True if this property shows up during enumeration of the properties on the corresponding
+object.
              */
             enumerable: boolean;
             /**
@@ -220,7 +1275,7 @@ declare module "inspector" {
              */
             isOwn?: boolean;
             /**
-             * Property symbol object, if the property is of the <code>symbol</code> type.
+             * Property symbol object, if the property is of the `symbol` type.
              */
             symbol?: Runtime.RemoteObject;
         }
@@ -240,11 +1295,12 @@ declare module "inspector" {
         }
 
         /**
-         * Represents function call argument. Either remote object id <code>objectId</code>, primitive <code>value</code>, unserializable primitive value or neither of (for undefined) them should be specified.
+         * Represents function call argument. Either remote object id `objectId`, primitive `value`,
+unserializable primitive value or neither of (for undefined) them should be specified.
          */
         export interface CallArgument {
             /**
-             * Primitive value.
+             * Primitive value or serializable javascript object.
              */
             value?: any;
             /**
@@ -267,7 +1323,8 @@ declare module "inspector" {
          */
         export interface ExecutionContextDescription {
             /**
-             * Unique id of the execution context. It can be used to specify in which execution context script evaluation should be performed.
+             * Unique id of the execution context. It can be used to specify in which execution context
+script evaluation should be performed.
              */
             id: Runtime.ExecutionContextId;
             /**
@@ -285,7 +1342,8 @@ declare module "inspector" {
         }
 
         /**
-         * Detailed information about exception (or error) that was thrown during script compilation or execution.
+         * Detailed information about exception (or error) that was thrown during script compilation or
+execution.
          */
         export interface ExceptionDetails {
             /**
@@ -362,7 +1420,8 @@ declare module "inspector" {
          */
         export interface StackTrace {
             /**
-             * String label of this stack trace. For async traces this may be a name of the function that initiated the async call.
+             * String label of this stack trace. For async traces this may be a name of the function that
+initiated the async call.
              */
             description?: string;
             /**
@@ -374,51 +1433,26 @@ declare module "inspector" {
              */
             parent?: Runtime.StackTrace;
             /**
-             * Creation frame of the Promise which produced the next synchronous trace when resolved, if available.
+             * Asynchronous JavaScript stack trace that preceded this stack, if available.
              * @experimental
              */
-            promiseCreationFrame?: Runtime.CallFrame;
+            parentId?: Runtime.StackTraceId;
         }
 
-        export interface EvaluateParameterType {
-            /**
-             * Expression to evaluate.
-             */
-            expression: string;
-            /**
-             * Symbolic group name that can be used to release multiple objects.
-             */
-            objectGroup?: string;
-            /**
-             * Determines whether Command Line API should be available during the evaluation.
-             */
-            includeCommandLineAPI?: boolean;
-            /**
-             * In silent mode exceptions thrown during evaluation are not reported and do not pause execution. Overrides <code>setPauseOnException</code> state.
-             */
-            silent?: boolean;
-            /**
-             * Specifies in which execution context to perform evaluation. If the parameter is omitted the evaluation will be performed in the context of the inspected page.
-             */
-            contextId?: Runtime.ExecutionContextId;
-            /**
-             * Whether the result is expected to be a JSON object that should be sent by value.
-             */
-            returnByValue?: boolean;
-            /**
-             * Whether preview should be generated for the result.
-             * @experimental
-             */
-            generatePreview?: boolean;
-            /**
-             * Whether execution should be treated as initiated by user in the UI.
-             * @experimental
-             */
-            userGesture?: boolean;
-            /**
-             * Whether execution should wait for promise to be resolved. If the result of evaluation is not a Promise, it's considered to be an error.
-             */
-            awaitPromise?: boolean;
+        /**
+         * Unique identifier of current debugger.
+         * @experimental
+         */
+        export type UniqueDebuggerId = string;
+
+        /**
+         * If `debuggerId` is set stack trace comes from another debugger and can be resolved there. This
+allows to track cross-debugger calls. See `Runtime.StackTrace` and `Debugger.paused` for usages.
+         * @experimental
+         */
+        export interface StackTraceId {
+            id: string;
+            debuggerId?: Runtime.UniqueDebuggerId;
         }
 
         export interface AwaitPromiseParameterType {
@@ -438,19 +1472,22 @@ declare module "inspector" {
 
         export interface CallFunctionOnParameterType {
             /**
-             * Identifier of the object to call function on.
-             */
-            objectId: Runtime.RemoteObjectId;
-            /**
              * Declaration of the function to call.
              */
             functionDeclaration: string;
             /**
-             * Call arguments. All call arguments must belong to the same JavaScript world as the target object.
+             * Identifier of the object to call function on. Either objectId or executionContextId should
+be specified.
+             */
+            objectId?: Runtime.RemoteObjectId;
+            /**
+             * Call arguments. All call arguments must belong to the same JavaScript world as the target
+object.
              */
             arguments?: Runtime.CallArgument[];
             /**
-             * In silent mode exceptions thrown during evaluation are not reported and do not pause execution. Overrides <code>setPauseOnException</code> state.
+             * In silent mode exceptions thrown during evaluation are not reported and do not pause
+execution. Overrides `setPauseOnException` state.
              */
             silent?: boolean;
             /**
@@ -464,52 +1501,23 @@ declare module "inspector" {
             generatePreview?: boolean;
             /**
              * Whether execution should be treated as initiated by user in the UI.
-             * @experimental
              */
             userGesture?: boolean;
             /**
-             * Whether execution should wait for promise to be resolved. If the result of evaluation is not a Promise, it's considered to be an error.
+             * Whether execution should `await` for resulting value and return once awaited promise is
+resolved.
              */
             awaitPromise?: boolean;
-        }
-
-        export interface GetPropertiesParameterType {
             /**
-             * Identifier of the object to return properties for.
+             * Specifies execution context which global object will be used to call function on. Either
+executionContextId or objectId should be specified.
              */
-            objectId: Runtime.RemoteObjectId;
+            executionContextId?: Runtime.ExecutionContextId;
             /**
-             * If true, returns properties belonging only to the element itself, not to its prototype chain.
+             * Symbolic group name that can be used to release multiple objects. If objectGroup is not
+specified and objectId is, objectGroup will be inherited from object.
              */
-            ownProperties?: boolean;
-            /**
-             * If true, returns accessor properties (with getter/setter) only; internal properties are not returned either.
-             * @experimental
-             */
-            accessorPropertiesOnly?: boolean;
-            /**
-             * Whether preview should be generated for the results.
-             * @experimental
-             */
-            generatePreview?: boolean;
-        }
-
-        export interface ReleaseObjectParameterType {
-            /**
-             * Identifier of the object to release.
-             */
-            objectId: Runtime.RemoteObjectId;
-        }
-
-        export interface ReleaseObjectGroupParameterType {
-            /**
-             * Symbolic object group name.
-             */
-            objectGroup: string;
-        }
-
-        export interface SetCustomObjectFormatterEnabledParameterType {
-            enabled: boolean;
+            objectGroup?: string;
         }
 
         export interface CompileScriptParameterType {
@@ -526,9 +1534,113 @@ declare module "inspector" {
              */
             persistScript: boolean;
             /**
-             * Specifies in which execution context to perform script run. If the parameter is omitted the evaluation will be performed in the context of the inspected page.
+             * Specifies in which execution context to perform script run. If the parameter is omitted the
+evaluation will be performed in the context of the inspected page.
              */
             executionContextId?: Runtime.ExecutionContextId;
+        }
+
+        export interface EvaluateParameterType {
+            /**
+             * Expression to evaluate.
+             */
+            expression: string;
+            /**
+             * Symbolic group name that can be used to release multiple objects.
+             */
+            objectGroup?: string;
+            /**
+             * Determines whether Command Line API should be available during the evaluation.
+             */
+            includeCommandLineAPI?: boolean;
+            /**
+             * In silent mode exceptions thrown during evaluation are not reported and do not pause
+execution. Overrides `setPauseOnException` state.
+             */
+            silent?: boolean;
+            /**
+             * Specifies in which execution context to perform evaluation. If the parameter is omitted the
+evaluation will be performed in the context of the inspected page.
+             */
+            contextId?: Runtime.ExecutionContextId;
+            /**
+             * Whether the result is expected to be a JSON object that should be sent by value.
+             */
+            returnByValue?: boolean;
+            /**
+             * Whether preview should be generated for the result.
+             * @experimental
+             */
+            generatePreview?: boolean;
+            /**
+             * Whether execution should be treated as initiated by user in the UI.
+             */
+            userGesture?: boolean;
+            /**
+             * Whether execution should `await` for resulting value and return once awaited promise is
+resolved.
+             */
+            awaitPromise?: boolean;
+            /**
+             * Whether to throw an exception if side effect cannot be ruled out during evaluation.
+             * @experimental
+             */
+            throwOnSideEffect?: boolean;
+        }
+
+        export interface GetPropertiesParameterType {
+            /**
+             * Identifier of the object to return properties for.
+             */
+            objectId: Runtime.RemoteObjectId;
+            /**
+             * If true, returns properties belonging only to the element itself, not to its prototype
+chain.
+             */
+            ownProperties?: boolean;
+            /**
+             * If true, returns accessor properties (with getter/setter) only; internal properties are not
+returned either.
+             * @experimental
+             */
+            accessorPropertiesOnly?: boolean;
+            /**
+             * Whether preview should be generated for the results.
+             * @experimental
+             */
+            generatePreview?: boolean;
+        }
+
+        export interface GlobalLexicalScopeNamesParameterType {
+            /**
+             * Specifies in which execution context to lookup global scope variables.
+             */
+            executionContextId?: Runtime.ExecutionContextId;
+        }
+
+        export interface QueryObjectsParameterType {
+            /**
+             * Identifier of the prototype to return objects for.
+             */
+            prototypeObjectId: Runtime.RemoteObjectId;
+            /**
+             * Symbolic group name that can be used to release the results.
+             */
+            objectGroup?: string;
+        }
+
+        export interface ReleaseObjectParameterType {
+            /**
+             * Identifier of the object to release.
+             */
+            objectId: Runtime.RemoteObjectId;
+        }
+
+        export interface ReleaseObjectGroupParameterType {
+            /**
+             * Symbolic object group name.
+             */
+            objectGroup: string;
         }
 
         export interface RunScriptParameterType {
@@ -537,7 +1649,8 @@ declare module "inspector" {
              */
             scriptId: Runtime.ScriptId;
             /**
-             * Specifies in which execution context to perform script run. If the parameter is omitted the evaluation will be performed in the context of the inspected page.
+             * Specifies in which execution context to perform script run. If the parameter is omitted the
+evaluation will be performed in the context of the inspected page.
              */
             executionContextId?: Runtime.ExecutionContextId;
             /**
@@ -545,7 +1658,8 @@ declare module "inspector" {
              */
             objectGroup?: string;
             /**
-             * In silent mode exceptions thrown during evaluation are not reported and do not pause execution. Overrides <code>setPauseOnException</code> state.
+             * In silent mode exceptions thrown during evaluation are not reported and do not pause
+execution. Overrides `setPauseOnException` state.
              */
             silent?: boolean;
             /**
@@ -561,20 +1675,14 @@ declare module "inspector" {
              */
             generatePreview?: boolean;
             /**
-             * Whether execution should wait for promise to be resolved. If the result of evaluation is not a Promise, it's considered to be an error.
+             * Whether execution should `await` for resulting value and return once awaited promise is
+resolved.
              */
             awaitPromise?: boolean;
         }
 
-        export interface EvaluateReturnType {
-            /**
-             * Evaluation result.
-             */
-            result: Runtime.RemoteObject;
-            /**
-             * Exception details.
-             */
-            exceptionDetails?: Runtime.ExceptionDetails;
+        export interface SetCustomObjectFormatterEnabledParameterType {
+            enabled: boolean;
         }
 
         export interface AwaitPromiseReturnType {
@@ -599,6 +1707,46 @@ declare module "inspector" {
             exceptionDetails?: Runtime.ExceptionDetails;
         }
 
+        export interface CompileScriptReturnType {
+            /**
+             * Id of the script.
+             */
+            scriptId?: Runtime.ScriptId;
+            /**
+             * Exception details.
+             */
+            exceptionDetails?: Runtime.ExceptionDetails;
+        }
+
+        export interface EvaluateReturnType {
+            /**
+             * Evaluation result.
+             */
+            result: Runtime.RemoteObject;
+            /**
+             * Exception details.
+             */
+            exceptionDetails?: Runtime.ExceptionDetails;
+        }
+
+        export interface GetIsolateIdReturnType {
+            /**
+             * The isolate id.
+             */
+            id: string;
+        }
+
+        export interface GetHeapUsageReturnType {
+            /**
+             * Used heap size in bytes.
+             */
+            usedSize: number;
+            /**
+             * Allocated heap size in bytes.
+             */
+            totalSize: number;
+        }
+
         export interface GetPropertiesReturnType {
             /**
              * Object properties.
@@ -614,15 +1762,15 @@ declare module "inspector" {
             exceptionDetails?: Runtime.ExceptionDetails;
         }
 
-        export interface CompileScriptReturnType {
+        export interface GlobalLexicalScopeNamesReturnType {
+            names: string[];
+        }
+
+        export interface QueryObjectsReturnType {
             /**
-             * Id of the script.
+             * Array with objects.
              */
-            scriptId?: Runtime.ScriptId;
-            /**
-             * Exception details.
-             */
-            exceptionDetails?: Runtime.ExceptionDetails;
+            objects: Runtime.RemoteObject;
         }
 
         export interface RunScriptReturnType {
@@ -634,39 +1782,6 @@ declare module "inspector" {
              * Exception details.
              */
             exceptionDetails?: Runtime.ExceptionDetails;
-        }
-
-        export interface ExecutionContextCreatedEventDataType {
-            /**
-             * A newly created execution context.
-             */
-            context: Runtime.ExecutionContextDescription;
-        }
-
-        export interface ExecutionContextDestroyedEventDataType {
-            /**
-             * Id of the destroyed context
-             */
-            executionContextId: Runtime.ExecutionContextId;
-        }
-
-        export interface ExceptionThrownEventDataType {
-            /**
-             * Timestamp of the exception.
-             */
-            timestamp: Runtime.Timestamp;
-            exceptionDetails: Runtime.ExceptionDetails;
-        }
-
-        export interface ExceptionRevokedEventDataType {
-            /**
-             * Reason describing why exception was revoked.
-             */
-            reason: string;
-            /**
-             * The id of revoked exception, as reported in <code>exceptionUnhandled</code>.
-             */
-            exceptionId: number;
         }
 
         export interface ConsoleAPICalledEventDataType {
@@ -691,10 +1806,45 @@ declare module "inspector" {
              */
             stackTrace?: Runtime.StackTrace;
             /**
-             * Console context descriptor for calls on non-default console context (not console.*): 'anonymous#unique-logger-id' for call on unnamed context, 'name#unique-logger-id' for call on named context.
+             * Console context descriptor for calls on non-default console context (not console.*):
+'anonymous#unique-logger-id' for call on unnamed context, 'name#unique-logger-id' for call
+on named context.
              * @experimental
              */
             context?: string;
+        }
+
+        export interface ExceptionRevokedEventDataType {
+            /**
+             * Reason describing why exception was revoked.
+             */
+            reason: string;
+            /**
+             * The id of revoked exception, as reported in `exceptionThrown`.
+             */
+            exceptionId: number;
+        }
+
+        export interface ExceptionThrownEventDataType {
+            /**
+             * Timestamp of the exception.
+             */
+            timestamp: Runtime.Timestamp;
+            exceptionDetails: Runtime.ExceptionDetails;
+        }
+
+        export interface ExecutionContextCreatedEventDataType {
+            /**
+             * A newly created execution context.
+             */
+            context: Runtime.ExecutionContextDescription;
+        }
+
+        export interface ExecutionContextDestroyedEventDataType {
+            /**
+             * Id of the destroyed context
+             */
+            executionContextId: Runtime.ExecutionContextId;
         }
 
         export interface InspectRequestedEventDataType {
@@ -703,947 +1853,26 @@ declare module "inspector" {
         }
     }
 
-    export namespace Debugger {
+    export namespace Schema {
         /**
-         * Breakpoint identifier.
+         * Description of the protocol domain.
          */
-        export type BreakpointId = string;
-
-        /**
-         * Call frame identifier.
-         */
-        export type CallFrameId = string;
-
-        /**
-         * Location in the source code.
-         */
-        export interface Location {
-            /**
-             * Script identifier as reported in the <code>Debugger.scriptParsed</code>.
-             */
-            scriptId: Runtime.ScriptId;
-            /**
-             * Line number in the script (0-based).
-             */
-            lineNumber: number;
-            /**
-             * Column number in the script (0-based).
-             */
-            columnNumber?: number;
-        }
-
-        /**
-         * Location in the source code.
-         * @experimental
-         */
-        export interface ScriptPosition {
-            lineNumber: number;
-            columnNumber: number;
-        }
-
-        /**
-         * JavaScript call frame. Array of call frames form the call stack.
-         */
-        export interface CallFrame {
-            /**
-             * Call frame identifier. This identifier is only valid while the virtual machine is paused.
-             */
-            callFrameId: Debugger.CallFrameId;
-            /**
-             * Name of the JavaScript function called on this call frame.
-             */
-            functionName: string;
-            /**
-             * Location in the source code.
-             * @experimental
-             */
-            functionLocation?: Debugger.Location;
-            /**
-             * Location in the source code.
-             */
-            location: Debugger.Location;
-            /**
-             * Scope chain for this call frame.
-             */
-            scopeChain: Debugger.Scope[];
-            /**
-             * <code>this</code> object for this call frame.
-             */
-            this: Runtime.RemoteObject;
-            /**
-             * The value being returned, if the function is at return point.
-             */
-            returnValue?: Runtime.RemoteObject;
-        }
-
-        /**
-         * Scope description.
-         */
-        export interface Scope {
-            /**
-             * Scope type.
-             */
-            type: string;
-            /**
-             * Object representing the scope. For <code>global</code> and <code>with</code> scopes it represents the actual object; for the rest of the scopes, it is artificial transient object enumerating scope variables as its properties.
-             */
-            object: Runtime.RemoteObject;
-            name?: string;
-            /**
-             * Location in the source code where scope starts
-             */
-            startLocation?: Debugger.Location;
-            /**
-             * Location in the source code where scope ends
-             */
-            endLocation?: Debugger.Location;
-        }
-
-        /**
-         * Search match for resource.
-         * @experimental
-         */
-        export interface SearchMatch {
-            /**
-             * Line number in resource content.
-             */
-            lineNumber: number;
-            /**
-             * Line with match content.
-             */
-            lineContent: string;
-        }
-
-        /**
-         * @experimental
-         */
-        export interface BreakLocation {
-            /**
-             * Script identifier as reported in the <code>Debugger.scriptParsed</code>.
-             */
-            scriptId: Runtime.ScriptId;
-            /**
-             * Line number in the script (0-based).
-             */
-            lineNumber: number;
-            /**
-             * Column number in the script (0-based).
-             */
-            columnNumber?: number;
-            type?: string;
-        }
-
-        export interface SetBreakpointsActiveParameterType {
-            /**
-             * New value for breakpoints active state.
-             */
-            active: boolean;
-        }
-
-        export interface SetSkipAllPausesParameterType {
-            /**
-             * New value for skip pauses state.
-             */
-            skip: boolean;
-        }
-
-        export interface SetBreakpointByUrlParameterType {
-            /**
-             * Line number to set breakpoint at.
-             */
-            lineNumber: number;
-            /**
-             * URL of the resources to set breakpoint on.
-             */
-            url?: string;
-            /**
-             * Regex pattern for the URLs of the resources to set breakpoints on. Either <code>url</code> or <code>urlRegex</code> must be specified.
-             */
-            urlRegex?: string;
-            /**
-             * Offset in the line to set breakpoint at.
-             */
-            columnNumber?: number;
-            /**
-             * Expression to use as a breakpoint condition. When specified, debugger will only stop on the breakpoint if this expression evaluates to true.
-             */
-            condition?: string;
-        }
-
-        export interface SetBreakpointParameterType {
-            /**
-             * Location to set breakpoint in.
-             */
-            location: Debugger.Location;
-            /**
-             * Expression to use as a breakpoint condition. When specified, debugger will only stop on the breakpoint if this expression evaluates to true.
-             */
-            condition?: string;
-        }
-
-        export interface RemoveBreakpointParameterType {
-            breakpointId: Debugger.BreakpointId;
-        }
-
-        export interface GetPossibleBreakpointsParameterType {
-            /**
-             * Start of range to search possible breakpoint locations in.
-             */
-            start: Debugger.Location;
-            /**
-             * End of range to search possible breakpoint locations in (excluding). When not specified, end of scripts is used as end of range.
-             */
-            end?: Debugger.Location;
-            /**
-             * Only consider locations which are in the same (non-nested) function as start.
-             */
-            restrictToFunction?: boolean;
-        }
-
-        export interface ContinueToLocationParameterType {
-            /**
-             * Location to continue to.
-             */
-            location: Debugger.Location;
-            /**
-             * @experimental
-             */
-            targetCallFrames?: string;
-        }
-
-        export interface SearchInContentParameterType {
-            /**
-             * Id of the script to search in.
-             */
-            scriptId: Runtime.ScriptId;
-            /**
-             * String to search for.
-             */
-            query: string;
-            /**
-             * If true, search is case sensitive.
-             */
-            caseSensitive?: boolean;
-            /**
-             * If true, treats string parameter as regex.
-             */
-            isRegex?: boolean;
-        }
-
-        export interface SetScriptSourceParameterType {
-            /**
-             * Id of the script to edit.
-             */
-            scriptId: Runtime.ScriptId;
-            /**
-             * New content of the script.
-             */
-            scriptSource: string;
-            /**
-             *  If true the change will not actually be applied. Dry run may be used to get result description without actually modifying the code.
-             */
-            dryRun?: boolean;
-        }
-
-        export interface RestartFrameParameterType {
-            /**
-             * Call frame identifier to evaluate on.
-             */
-            callFrameId: Debugger.CallFrameId;
-        }
-
-        export interface GetScriptSourceParameterType {
-            /**
-             * Id of the script to get source for.
-             */
-            scriptId: Runtime.ScriptId;
-        }
-
-        export interface SetPauseOnExceptionsParameterType {
-            /**
-             * Pause on exceptions mode.
-             */
-            state: string;
-        }
-
-        export interface EvaluateOnCallFrameParameterType {
-            /**
-             * Call frame identifier to evaluate on.
-             */
-            callFrameId: Debugger.CallFrameId;
-            /**
-             * Expression to evaluate.
-             */
-            expression: string;
-            /**
-             * String object group name to put result into (allows rapid releasing resulting object handles using <code>releaseObjectGroup</code>).
-             */
-            objectGroup?: string;
-            /**
-             * Specifies whether command line API should be available to the evaluated expression, defaults to false.
-             */
-            includeCommandLineAPI?: boolean;
-            /**
-             * In silent mode exceptions thrown during evaluation are not reported and do not pause execution. Overrides <code>setPauseOnException</code> state.
-             */
-            silent?: boolean;
-            /**
-             * Whether the result is expected to be a JSON object that should be sent by value.
-             */
-            returnByValue?: boolean;
-            /**
-             * Whether preview should be generated for the result.
-             * @experimental
-             */
-            generatePreview?: boolean;
-            /**
-             * Whether to throw an exception if side effect cannot be ruled out during evaluation.
-             * @experimental
-             */
-            throwOnSideEffect?: boolean;
-        }
-
-        export interface SetVariableValueParameterType {
-            /**
-             * 0-based number of scope as was listed in scope chain. Only 'local', 'closure' and 'catch' scope types are allowed. Other scopes could be manipulated manually.
-             */
-            scopeNumber: number;
-            /**
-             * Variable name.
-             */
-            variableName: string;
-            /**
-             * New variable value.
-             */
-            newValue: Runtime.CallArgument;
-            /**
-             * Id of callframe that holds variable.
-             */
-            callFrameId: Debugger.CallFrameId;
-        }
-
-        export interface SetAsyncCallStackDepthParameterType {
-            /**
-             * Maximum depth of async call stacks. Setting to <code>0</code> will effectively disable collecting async call stacks (default).
-             */
-            maxDepth: number;
-        }
-
-        export interface SetBlackboxPatternsParameterType {
-            /**
-             * Array of regexps that will be used to check script url for blackbox state.
-             */
-            patterns: string[];
-        }
-
-        export interface SetBlackboxedRangesParameterType {
-            /**
-             * Id of the script.
-             */
-            scriptId: Runtime.ScriptId;
-            positions: Debugger.ScriptPosition[];
-        }
-
-        export interface SetBreakpointByUrlReturnType {
-            /**
-             * Id of the created breakpoint for further reference.
-             */
-            breakpointId: Debugger.BreakpointId;
-            /**
-             * List of the locations this breakpoint resolved into upon addition.
-             */
-            locations: Debugger.Location[];
-        }
-
-        export interface SetBreakpointReturnType {
-            /**
-             * Id of the created breakpoint for further reference.
-             */
-            breakpointId: Debugger.BreakpointId;
-            /**
-             * Location this breakpoint resolved into.
-             */
-            actualLocation: Debugger.Location;
-        }
-
-        export interface GetPossibleBreakpointsReturnType {
-            /**
-             * List of the possible breakpoint locations.
-             */
-            locations: Debugger.BreakLocation[];
-        }
-
-        export interface SearchInContentReturnType {
-            /**
-             * List of search matches.
-             */
-            result: Debugger.SearchMatch[];
-        }
-
-        export interface SetScriptSourceReturnType {
-            /**
-             * New stack trace in case editing has happened while VM was stopped.
-             */
-            callFrames?: Debugger.CallFrame[];
-            /**
-             * Whether current call stack  was modified after applying the changes.
-             */
-            stackChanged?: boolean;
-            /**
-             * Async stack trace, if any.
-             */
-            asyncStackTrace?: Runtime.StackTrace;
-            /**
-             * Exception details if any.
-             */
-            exceptionDetails?: Runtime.ExceptionDetails;
-        }
-
-        export interface RestartFrameReturnType {
-            /**
-             * New stack trace.
-             */
-            callFrames: Debugger.CallFrame[];
-            /**
-             * Async stack trace, if any.
-             */
-            asyncStackTrace?: Runtime.StackTrace;
-        }
-
-        export interface GetScriptSourceReturnType {
-            /**
-             * Script source.
-             */
-            scriptSource: string;
-        }
-
-        export interface EvaluateOnCallFrameReturnType {
-            /**
-             * Object wrapper for the evaluation result.
-             */
-            result: Runtime.RemoteObject;
-            /**
-             * Exception details.
-             */
-            exceptionDetails?: Runtime.ExceptionDetails;
-        }
-
-        export interface ScriptParsedEventDataType {
-            /**
-             * Identifier of the script parsed.
-             */
-            scriptId: Runtime.ScriptId;
-            /**
-             * URL or name of the script parsed (if any).
-             */
-            url: string;
-            /**
-             * Line offset of the script within the resource with given URL (for script tags).
-             */
-            startLine: number;
-            /**
-             * Column offset of the script within the resource with given URL.
-             */
-            startColumn: number;
-            /**
-             * Last line of the script.
-             */
-            endLine: number;
-            /**
-             * Length of the last line of the script.
-             */
-            endColumn: number;
+        export interface Domain {
             /**
-             * Specifies script creation context.
+             * Domain name.
              */
-            executionContextId: Runtime.ExecutionContextId;
+            name: string;
             /**
-             * Content hash of the script.
+             * Domain version.
              */
-            hash: string;
-            /**
-             * Embedder-specific auxiliary data.
-             */
-            executionContextAuxData?: {};
-            /**
-             * True, if this script is generated as a result of the live edit operation.
-             * @experimental
-             */
-            isLiveEdit?: boolean;
-            /**
-             * URL of source map associated with script (if any).
-             */
-            sourceMapURL?: string;
-            /**
-             * True, if this script has sourceURL.
-             * @experimental
-             */
-            hasSourceURL?: boolean;
-            /**
-             * True, if this script is ES6 module.
-             * @experimental
-             */
-            isModule?: boolean;
-            /**
-             * This script length.
-             * @experimental
-             */
-            length?: number;
-            /**
-             * JavaScript top stack frame of where the script parsed event was triggered if available.
-             * @experimental
-             */
-            stackTrace?: Runtime.StackTrace;
-        }
-
-        export interface ScriptFailedToParseEventDataType {
-            /**
-             * Identifier of the script parsed.
-             */
-            scriptId: Runtime.ScriptId;
-            /**
-             * URL or name of the script parsed (if any).
-             */
-            url: string;
-            /**
-             * Line offset of the script within the resource with given URL (for script tags).
-             */
-            startLine: number;
-            /**
-             * Column offset of the script within the resource with given URL.
-             */
-            startColumn: number;
-            /**
-             * Last line of the script.
-             */
-            endLine: number;
-            /**
-             * Length of the last line of the script.
-             */
-            endColumn: number;
-            /**
-             * Specifies script creation context.
-             */
-            executionContextId: Runtime.ExecutionContextId;
-            /**
-             * Content hash of the script.
-             */
-            hash: string;
-            /**
-             * Embedder-specific auxiliary data.
-             */
-            executionContextAuxData?: {};
-            /**
-             * URL of source map associated with script (if any).
-             */
-            sourceMapURL?: string;
-            /**
-             * True, if this script has sourceURL.
-             * @experimental
-             */
-            hasSourceURL?: boolean;
-            /**
-             * True, if this script is ES6 module.
-             * @experimental
-             */
-            isModule?: boolean;
-            /**
-             * This script length.
-             * @experimental
-             */
-            length?: number;
-            /**
-             * JavaScript top stack frame of where the script parsed event was triggered if available.
-             * @experimental
-             */
-            stackTrace?: Runtime.StackTrace;
-        }
-
-        export interface BreakpointResolvedEventDataType {
-            /**
-             * Breakpoint unique identifier.
-             */
-            breakpointId: Debugger.BreakpointId;
-            /**
-             * Actual breakpoint location.
-             */
-            location: Debugger.Location;
-        }
-
-        export interface PausedEventDataType {
-            /**
-             * Call stack the virtual machine stopped on.
-             */
-            callFrames: Debugger.CallFrame[];
-            /**
-             * Pause reason.
-             */
-            reason: string;
-            /**
-             * Object containing break-specific auxiliary properties.
-             */
-            data?: {};
-            /**
-             * Hit breakpoints IDs
-             */
-            hitBreakpoints?: string[];
-            /**
-             * Async stack trace, if any.
-             */
-            asyncStackTrace?: Runtime.StackTrace;
-        }
-    }
-
-    export namespace Console {
-        /**
-         * Console message.
-         */
-        export interface ConsoleMessage {
-            /**
-             * Message source.
-             */
-            source: string;
-            /**
-             * Message severity.
-             */
-            level: string;
-            /**
-             * Message text.
-             */
-            text: string;
-            /**
-             * URL of the message origin.
-             */
-            url?: string;
-            /**
-             * Line number in the resource that generated this message (1-based).
-             */
-            line?: number;
-            /**
-             * Column number in the resource that generated this message (1-based).
-             */
-            column?: number;
-        }
-
-        export interface MessageAddedEventDataType {
-            /**
-             * Console message that has been added.
-             */
-            message: Console.ConsoleMessage;
-        }
-    }
-
-    export namespace Profiler {
-        /**
-         * Profile node. Holds callsite information, execution statistics and child nodes.
-         */
-        export interface ProfileNode {
-            /**
-             * Unique id of the node.
-             */
-            id: number;
-            /**
-             * Function location.
-             */
-            callFrame: Runtime.CallFrame;
-            /**
-             * Number of samples where this node was on top of the call stack.
-             * @experimental
-             */
-            hitCount?: number;
-            /**
-             * Child node ids.
-             */
-            children?: number[];
-            /**
-             * The reason of being not optimized. The function may be deoptimized or marked as don't optimize.
-             */
-            deoptReason?: string;
-            /**
-             * An array of source position ticks.
-             * @experimental
-             */
-            positionTicks?: Profiler.PositionTickInfo[];
-        }
-
-        /**
-         * Profile.
-         */
-        export interface Profile {
-            /**
-             * The list of profile nodes. First item is the root node.
-             */
-            nodes: Profiler.ProfileNode[];
-            /**
-             * Profiling start timestamp in microseconds.
-             */
-            startTime: number;
-            /**
-             * Profiling end timestamp in microseconds.
-             */
-            endTime: number;
-            /**
-             * Ids of samples top nodes.
-             */
-            samples?: number[];
-            /**
-             * Time intervals between adjacent samples in microseconds. The first delta is relative to the profile startTime.
-             */
-            timeDeltas?: number[];
-        }
-
-        /**
-         * Specifies a number of samples attributed to a certain source position.
-         * @experimental
-         */
-        export interface PositionTickInfo {
-            /**
-             * Source line number (1-based).
-             */
-            line: number;
-            /**
-             * Number of samples attributed to the source line.
-             */
-            ticks: number;
-        }
-
-        /**
-         * Coverage data for a source range.
-         * @experimental
-         */
-        export interface CoverageRange {
-            /**
-             * JavaScript script source offset for the range start.
-             */
-            startOffset: number;
-            /**
-             * JavaScript script source offset for the range end.
-             */
-            endOffset: number;
-            /**
-             * Collected execution count of the source range.
-             */
-            count: number;
-        }
-
-        /**
-         * Coverage data for a JavaScript function.
-         * @experimental
-         */
-        export interface FunctionCoverage {
-            /**
-             * JavaScript function name.
-             */
-            functionName: string;
-            /**
-             * Source ranges inside the function with coverage data.
-             */
-            ranges: Profiler.CoverageRange[];
-            /**
-             * Whether coverage data for this function has block granularity.
-             */
-            isBlockCoverage: boolean;
-        }
-
-        /**
-         * Coverage data for a JavaScript script.
-         * @experimental
-         */
-        export interface ScriptCoverage {
-            /**
-             * JavaScript script id.
-             */
-            scriptId: Runtime.ScriptId;
-            /**
-             * JavaScript script name or url.
-             */
-            url: string;
-            /**
-             * Functions contained in the script that has coverage data.
-             */
-            functions: Profiler.FunctionCoverage[];
-        }
-
-        export interface SetSamplingIntervalParameterType {
-            /**
-             * New sampling interval in microseconds.
-             */
-            interval: number;
-        }
-
-        export interface StartPreciseCoverageParameterType {
-            /**
-             * Collect accurate call counts beyond simple 'covered' or 'not covered'.
-             */
-            callCount?: boolean;
-        }
-
-        export interface StopReturnType {
-            /**
-             * Recorded profile.
-             */
-            profile: Profiler.Profile;
-        }
-
-        export interface TakePreciseCoverageReturnType {
-            /**
-             * Coverage data for the current isolate.
-             */
-            result: Profiler.ScriptCoverage[];
-        }
-
-        export interface GetBestEffortCoverageReturnType {
-            /**
-             * Coverage data for the current isolate.
-             */
-            result: Profiler.ScriptCoverage[];
-        }
-
-        export interface ConsoleProfileStartedEventDataType {
-            id: string;
-            /**
-             * Location of console.profile().
-             */
-            location: Debugger.Location;
-            /**
-             * Profile title passed as an argument to console.profile().
-             */
-            title?: string;
-        }
-
-        export interface ConsoleProfileFinishedEventDataType {
-            id: string;
-            /**
-             * Location of console.profileEnd().
-             */
-            location: Debugger.Location;
-            profile: Profiler.Profile;
-            /**
-             * Profile title passed as an argument to console.profile().
-             */
-            title?: string;
-        }
-    }
-
-    export namespace HeapProfiler {
-        /**
-         * Heap snapshot object id.
-         */
-        export type HeapSnapshotObjectId = string;
-
-        /**
-         * Sampling Heap Profile node. Holds callsite information, allocation statistics and child nodes.
-         */
-        export interface SamplingHeapProfileNode {
-            /**
-             * Function location.
-             */
-            callFrame: Runtime.CallFrame;
-            /**
-             * Allocations size in bytes for the node excluding children.
-             */
-            selfSize: number;
-            /**
-             * Child nodes.
-             */
-            children: HeapProfiler.SamplingHeapProfileNode[];
-        }
-
-        /**
-         * Profile.
-         */
-        export interface SamplingHeapProfile {
-            head: HeapProfiler.SamplingHeapProfileNode;
-        }
-
-        export interface StartTrackingHeapObjectsParameterType {
-            trackAllocations?: boolean;
-        }
-
-        export interface StopTrackingHeapObjectsParameterType {
-            /**
-             * If true 'reportHeapSnapshotProgress' events will be generated while snapshot is being taken when the tracking is stopped.
-             */
-            reportProgress?: boolean;
-        }
-
-        export interface TakeHeapSnapshotParameterType {
-            /**
-             * If true 'reportHeapSnapshotProgress' events will be generated while snapshot is being taken.
-             */
-            reportProgress?: boolean;
-        }
-
-        export interface GetObjectByHeapObjectIdParameterType {
-            objectId: HeapProfiler.HeapSnapshotObjectId;
-            /**
-             * Symbolic group name that can be used to release multiple objects.
-             */
-            objectGroup?: string;
-        }
-
-        export interface AddInspectedHeapObjectParameterType {
-            /**
-             * Heap snapshot object id to be accessible by means of $x command line API.
-             */
-            heapObjectId: HeapProfiler.HeapSnapshotObjectId;
-        }
-
-        export interface GetHeapObjectIdParameterType {
-            /**
-             * Identifier of the object to get heap object id for.
-             */
-            objectId: Runtime.RemoteObjectId;
-        }
-
-        export interface StartSamplingParameterType {
-            /**
-             * Average sample interval in bytes. Poisson distribution is used for the intervals. The default value is 32768 bytes.
-             */
-            samplingInterval?: number;
-        }
-
-        export interface GetObjectByHeapObjectIdReturnType {
-            /**
-             * Evaluation result.
-             */
-            result: Runtime.RemoteObject;
-        }
-
-        export interface GetHeapObjectIdReturnType {
-            /**
-             * Id of the heap snapshot object corresponding to the passed remote object id.
-             */
-            heapSnapshotObjectId: HeapProfiler.HeapSnapshotObjectId;
-        }
-
-        export interface StopSamplingReturnType {
-            /**
-             * Recorded sampling heap profile.
-             */
-            profile: HeapProfiler.SamplingHeapProfile;
-        }
-
-        export interface AddHeapSnapshotChunkEventDataType {
-            chunk: string;
-        }
-
-        export interface ReportHeapSnapshotProgressEventDataType {
-            done: number;
-            total: number;
-            finished?: boolean;
-        }
-
-        export interface LastSeenObjectIdEventDataType {
-            lastSeenObjectId: number;
-            timestamp: number;
+            version: string;
         }
 
-        export interface HeapStatsUpdateEventDataType {
+        export interface GetDomainsReturnType {
             /**
-             * An array of triplets. Each triplet describes a fragment. The first integer is the fragment index, the second integer is a total count of objects for the fragment, the third integer is a total size of the objects for the fragment.
+             * List of supported domains.
              */
-            statsUpdate: number[];
+            domains: Schema.Domain[];
         }
     }
 
@@ -1673,15 +1902,291 @@ declare module "inspector" {
         post(method: string, callback?: (err: Error | null, params?: {}) => void): void;
 
         /**
-         * Returns supported domains.
+         * Does nothing.
          */
-        post(method: "Schema.getDomains", callback?: (err: Error | null, params: Schema.GetDomainsReturnType) => void): void;
-        /**
-         * Evaluates expression on global object.
-         */
-        post(method: "Runtime.evaluate", params?: Runtime.EvaluateParameterType, callback?: (err: Error | null, params: Runtime.EvaluateReturnType) => void): void;
-        post(method: "Runtime.evaluate", callback?: (err: Error | null, params: Runtime.EvaluateReturnType) => void): void;
+        post(method: "Console.clearMessages", callback?: (err: Error | null) => void): void;
 
+        /**
+         * Disables console domain, prevents further console messages from being reported to the client.
+         */
+        post(method: "Console.disable", callback?: (err: Error | null) => void): void;
+
+        /**
+         * Enables console domain, sends the messages collected so far to the client by means of the
+`messageAdded` notification.
+         */
+        post(method: "Console.enable", callback?: (err: Error | null) => void): void;
+        /**
+         * Continues execution until specific location is reached.
+         */
+        post(method: "Debugger.continueToLocation", params?: Debugger.ContinueToLocationParameterType, callback?: (err: Error | null) => void): void;
+        post(method: "Debugger.continueToLocation", callback?: (err: Error | null) => void): void;
+
+        /**
+         * Disables debugger for given page.
+         */
+        post(method: "Debugger.disable", callback?: (err: Error | null) => void): void;
+
+        /**
+         * Enables debugger for the given page. Clients should not assume that the debugging has been
+enabled until the result for this command is received.
+         */
+        post(method: "Debugger.enable", callback?: (err: Error | null, params: Debugger.EnableReturnType) => void): void;
+
+        /**
+         * Evaluates expression on a given call frame.
+         */
+        post(method: "Debugger.evaluateOnCallFrame", params?: Debugger.EvaluateOnCallFrameParameterType, callback?: (err: Error | null, params: Debugger.EvaluateOnCallFrameReturnType) => void): void;
+        post(method: "Debugger.evaluateOnCallFrame", callback?: (err: Error | null, params: Debugger.EvaluateOnCallFrameReturnType) => void): void;
+
+        /**
+         * Returns possible locations for breakpoint. scriptId in start and end range locations should be
+the same.
+         */
+        post(method: "Debugger.getPossibleBreakpoints", params?: Debugger.GetPossibleBreakpointsParameterType, callback?: (err: Error | null, params: Debugger.GetPossibleBreakpointsReturnType) => void): void;
+        post(method: "Debugger.getPossibleBreakpoints", callback?: (err: Error | null, params: Debugger.GetPossibleBreakpointsReturnType) => void): void;
+
+        /**
+         * Returns source for the script with given id.
+         */
+        post(method: "Debugger.getScriptSource", params?: Debugger.GetScriptSourceParameterType, callback?: (err: Error | null, params: Debugger.GetScriptSourceReturnType) => void): void;
+        post(method: "Debugger.getScriptSource", callback?: (err: Error | null, params: Debugger.GetScriptSourceReturnType) => void): void;
+
+        /**
+         * Returns stack trace with given `stackTraceId`.
+         * @experimental
+         */
+        post(method: "Debugger.getStackTrace", params?: Debugger.GetStackTraceParameterType, callback?: (err: Error | null, params: Debugger.GetStackTraceReturnType) => void): void;
+        post(method: "Debugger.getStackTrace", callback?: (err: Error | null, params: Debugger.GetStackTraceReturnType) => void): void;
+
+        /**
+         * Stops on the next JavaScript statement.
+         */
+        post(method: "Debugger.pause", callback?: (err: Error | null) => void): void;
+
+        /**
+         * @experimental
+         */
+        post(method: "Debugger.pauseOnAsyncCall", params?: Debugger.PauseOnAsyncCallParameterType, callback?: (err: Error | null) => void): void;
+        post(method: "Debugger.pauseOnAsyncCall", callback?: (err: Error | null) => void): void;
+
+        /**
+         * Removes JavaScript breakpoint.
+         */
+        post(method: "Debugger.removeBreakpoint", params?: Debugger.RemoveBreakpointParameterType, callback?: (err: Error | null) => void): void;
+        post(method: "Debugger.removeBreakpoint", callback?: (err: Error | null) => void): void;
+
+        /**
+         * Restarts particular call frame from the beginning.
+         */
+        post(method: "Debugger.restartFrame", params?: Debugger.RestartFrameParameterType, callback?: (err: Error | null, params: Debugger.RestartFrameReturnType) => void): void;
+        post(method: "Debugger.restartFrame", callback?: (err: Error | null, params: Debugger.RestartFrameReturnType) => void): void;
+
+        /**
+         * Resumes JavaScript execution.
+         */
+        post(method: "Debugger.resume", callback?: (err: Error | null) => void): void;
+
+        /**
+         * This method is deprecated - use Debugger.stepInto with breakOnAsyncCall and
+Debugger.pauseOnAsyncTask instead. Steps into next scheduled async task if any is scheduled
+before next pause. Returns success when async task is actually scheduled, returns error if no
+task were scheduled or another scheduleStepIntoAsync was called.
+         * @experimental
+         */
+        post(method: "Debugger.scheduleStepIntoAsync", callback?: (err: Error | null) => void): void;
+
+        /**
+         * Searches for given string in script content.
+         */
+        post(method: "Debugger.searchInContent", params?: Debugger.SearchInContentParameterType, callback?: (err: Error | null, params: Debugger.SearchInContentReturnType) => void): void;
+        post(method: "Debugger.searchInContent", callback?: (err: Error | null, params: Debugger.SearchInContentReturnType) => void): void;
+
+        /**
+         * Enables or disables async call stacks tracking.
+         */
+        post(method: "Debugger.setAsyncCallStackDepth", params?: Debugger.SetAsyncCallStackDepthParameterType, callback?: (err: Error | null) => void): void;
+        post(method: "Debugger.setAsyncCallStackDepth", callback?: (err: Error | null) => void): void;
+
+        /**
+         * Replace previous blackbox patterns with passed ones. Forces backend to skip stepping/pausing in
+scripts with url matching one of the patterns. VM will try to leave blackboxed script by
+performing 'step in' several times, finally resorting to 'step out' if unsuccessful.
+         * @experimental
+         */
+        post(method: "Debugger.setBlackboxPatterns", params?: Debugger.SetBlackboxPatternsParameterType, callback?: (err: Error | null) => void): void;
+        post(method: "Debugger.setBlackboxPatterns", callback?: (err: Error | null) => void): void;
+
+        /**
+         * Makes backend skip steps in the script in blackboxed ranges. VM will try leave blacklisted
+scripts by performing 'step in' several times, finally resorting to 'step out' if unsuccessful.
+Positions array contains positions where blackbox state is changed. First interval isn't
+blackboxed. Array should be sorted.
+         * @experimental
+         */
+        post(method: "Debugger.setBlackboxedRanges", params?: Debugger.SetBlackboxedRangesParameterType, callback?: (err: Error | null) => void): void;
+        post(method: "Debugger.setBlackboxedRanges", callback?: (err: Error | null) => void): void;
+
+        /**
+         * Sets JavaScript breakpoint at a given location.
+         */
+        post(method: "Debugger.setBreakpoint", params?: Debugger.SetBreakpointParameterType, callback?: (err: Error | null, params: Debugger.SetBreakpointReturnType) => void): void;
+        post(method: "Debugger.setBreakpoint", callback?: (err: Error | null, params: Debugger.SetBreakpointReturnType) => void): void;
+
+        /**
+         * Sets JavaScript breakpoint at given location specified either by URL or URL regex. Once this
+command is issued, all existing parsed scripts will have breakpoints resolved and returned in
+`locations` property. Further matching script parsing will result in subsequent
+`breakpointResolved` events issued. This logical breakpoint will survive page reloads.
+         */
+        post(method: "Debugger.setBreakpointByUrl", params?: Debugger.SetBreakpointByUrlParameterType, callback?: (err: Error | null, params: Debugger.SetBreakpointByUrlReturnType) => void): void;
+        post(method: "Debugger.setBreakpointByUrl", callback?: (err: Error | null, params: Debugger.SetBreakpointByUrlReturnType) => void): void;
+
+        /**
+         * Activates / deactivates all breakpoints on the page.
+         */
+        post(method: "Debugger.setBreakpointsActive", params?: Debugger.SetBreakpointsActiveParameterType, callback?: (err: Error | null) => void): void;
+        post(method: "Debugger.setBreakpointsActive", callback?: (err: Error | null) => void): void;
+
+        /**
+         * Defines pause on exceptions state. Can be set to stop on all exceptions, uncaught exceptions or
+no exceptions. Initial pause on exceptions state is `none`.
+         */
+        post(method: "Debugger.setPauseOnExceptions", params?: Debugger.SetPauseOnExceptionsParameterType, callback?: (err: Error | null) => void): void;
+        post(method: "Debugger.setPauseOnExceptions", callback?: (err: Error | null) => void): void;
+
+        /**
+         * Changes return value in top frame. Available only at return break position.
+         * @experimental
+         */
+        post(method: "Debugger.setReturnValue", params?: Debugger.SetReturnValueParameterType, callback?: (err: Error | null) => void): void;
+        post(method: "Debugger.setReturnValue", callback?: (err: Error | null) => void): void;
+
+        /**
+         * Edits JavaScript source live.
+         */
+        post(method: "Debugger.setScriptSource", params?: Debugger.SetScriptSourceParameterType, callback?: (err: Error | null, params: Debugger.SetScriptSourceReturnType) => void): void;
+        post(method: "Debugger.setScriptSource", callback?: (err: Error | null, params: Debugger.SetScriptSourceReturnType) => void): void;
+
+        /**
+         * Makes page not interrupt on any pauses (breakpoint, exception, dom exception etc).
+         */
+        post(method: "Debugger.setSkipAllPauses", params?: Debugger.SetSkipAllPausesParameterType, callback?: (err: Error | null) => void): void;
+        post(method: "Debugger.setSkipAllPauses", callback?: (err: Error | null) => void): void;
+
+        /**
+         * Changes value of variable in a callframe. Object-based scopes are not supported and must be
+mutated manually.
+         */
+        post(method: "Debugger.setVariableValue", params?: Debugger.SetVariableValueParameterType, callback?: (err: Error | null) => void): void;
+        post(method: "Debugger.setVariableValue", callback?: (err: Error | null) => void): void;
+
+        /**
+         * Steps into the function call.
+         */
+        post(method: "Debugger.stepInto", params?: Debugger.StepIntoParameterType, callback?: (err: Error | null) => void): void;
+        post(method: "Debugger.stepInto", callback?: (err: Error | null) => void): void;
+
+        /**
+         * Steps out of the function call.
+         */
+        post(method: "Debugger.stepOut", callback?: (err: Error | null) => void): void;
+
+        /**
+         * Steps over the statement.
+         */
+        post(method: "Debugger.stepOver", callback?: (err: Error | null) => void): void;
+        /**
+         * Enables console to refer to the node with given id via $x (see Command Line API for more details
+$x functions).
+         */
+        post(method: "HeapProfiler.addInspectedHeapObject", params?: HeapProfiler.AddInspectedHeapObjectParameterType, callback?: (err: Error | null) => void): void;
+        post(method: "HeapProfiler.addInspectedHeapObject", callback?: (err: Error | null) => void): void;
+
+        post(method: "HeapProfiler.collectGarbage", callback?: (err: Error | null) => void): void;
+
+        post(method: "HeapProfiler.disable", callback?: (err: Error | null) => void): void;
+
+        post(method: "HeapProfiler.enable", callback?: (err: Error | null) => void): void;
+
+        post(method: "HeapProfiler.getHeapObjectId", params?: HeapProfiler.GetHeapObjectIdParameterType, callback?: (err: Error | null, params: HeapProfiler.GetHeapObjectIdReturnType) => void): void;
+        post(method: "HeapProfiler.getHeapObjectId", callback?: (err: Error | null, params: HeapProfiler.GetHeapObjectIdReturnType) => void): void;
+
+        post(method: "HeapProfiler.getObjectByHeapObjectId", params?: HeapProfiler.GetObjectByHeapObjectIdParameterType, callback?: (err: Error | null, params: HeapProfiler.GetObjectByHeapObjectIdReturnType) => void): void;
+        post(method: "HeapProfiler.getObjectByHeapObjectId", callback?: (err: Error | null, params: HeapProfiler.GetObjectByHeapObjectIdReturnType) => void): void;
+
+        post(method: "HeapProfiler.getSamplingProfile", callback?: (err: Error | null, params: HeapProfiler.GetSamplingProfileReturnType) => void): void;
+
+        post(method: "HeapProfiler.startSampling", params?: HeapProfiler.StartSamplingParameterType, callback?: (err: Error | null) => void): void;
+        post(method: "HeapProfiler.startSampling", callback?: (err: Error | null) => void): void;
+
+        post(method: "HeapProfiler.startTrackingHeapObjects", params?: HeapProfiler.StartTrackingHeapObjectsParameterType, callback?: (err: Error | null) => void): void;
+        post(method: "HeapProfiler.startTrackingHeapObjects", callback?: (err: Error | null) => void): void;
+
+        post(method: "HeapProfiler.stopSampling", callback?: (err: Error | null, params: HeapProfiler.StopSamplingReturnType) => void): void;
+
+        post(method: "HeapProfiler.stopTrackingHeapObjects", params?: HeapProfiler.StopTrackingHeapObjectsParameterType, callback?: (err: Error | null) => void): void;
+        post(method: "HeapProfiler.stopTrackingHeapObjects", callback?: (err: Error | null) => void): void;
+
+        post(method: "HeapProfiler.takeHeapSnapshot", params?: HeapProfiler.TakeHeapSnapshotParameterType, callback?: (err: Error | null) => void): void;
+        post(method: "HeapProfiler.takeHeapSnapshot", callback?: (err: Error | null) => void): void;
+        post(method: "Profiler.disable", callback?: (err: Error | null) => void): void;
+
+        post(method: "Profiler.enable", callback?: (err: Error | null) => void): void;
+
+        /**
+         * Collect coverage data for the current isolate. The coverage data may be incomplete due to
+garbage collection.
+         */
+        post(method: "Profiler.getBestEffortCoverage", callback?: (err: Error | null, params: Profiler.GetBestEffortCoverageReturnType) => void): void;
+
+        /**
+         * Changes CPU profiler sampling interval. Must be called before CPU profiles recording started.
+         */
+        post(method: "Profiler.setSamplingInterval", params?: Profiler.SetSamplingIntervalParameterType, callback?: (err: Error | null) => void): void;
+        post(method: "Profiler.setSamplingInterval", callback?: (err: Error | null) => void): void;
+
+        post(method: "Profiler.start", callback?: (err: Error | null) => void): void;
+
+        /**
+         * Enable precise code coverage. Coverage data for JavaScript executed before enabling precise code
+coverage may be incomplete. Enabling prevents running optimized code and resets execution
+counters.
+         */
+        post(method: "Profiler.startPreciseCoverage", params?: Profiler.StartPreciseCoverageParameterType, callback?: (err: Error | null) => void): void;
+        post(method: "Profiler.startPreciseCoverage", callback?: (err: Error | null) => void): void;
+
+        /**
+         * Enable type profile.
+         * @experimental
+         */
+        post(method: "Profiler.startTypeProfile", callback?: (err: Error | null) => void): void;
+
+        post(method: "Profiler.stop", callback?: (err: Error | null, params: Profiler.StopReturnType) => void): void;
+
+        /**
+         * Disable precise code coverage. Disabling releases unnecessary execution count records and allows
+executing optimized code.
+         */
+        post(method: "Profiler.stopPreciseCoverage", callback?: (err: Error | null) => void): void;
+
+        /**
+         * Disable type profile. Disabling releases type profile data collected so far.
+         * @experimental
+         */
+        post(method: "Profiler.stopTypeProfile", callback?: (err: Error | null) => void): void;
+
+        /**
+         * Collect coverage data for the current isolate, and resets execution counters. Precise code
+coverage needs to have started.
+         */
+        post(method: "Profiler.takePreciseCoverage", callback?: (err: Error | null, params: Profiler.TakePreciseCoverageReturnType) => void): void;
+
+        /**
+         * Collect type profile.
+         * @experimental
+         */
+        post(method: "Profiler.takeTypeProfile", callback?: (err: Error | null, params: Profiler.TakeTypeProfileReturnType) => void): void;
         /**
          * Add handler to promise with given promise object id.
          */
@@ -1689,16 +2194,69 @@ declare module "inspector" {
         post(method: "Runtime.awaitPromise", callback?: (err: Error | null, params: Runtime.AwaitPromiseReturnType) => void): void;
 
         /**
-         * Calls function with given declaration on the given object. Object group of the result is inherited from the target object.
+         * Calls function with given declaration on the given object. Object group of the result is
+inherited from the target object.
          */
         post(method: "Runtime.callFunctionOn", params?: Runtime.CallFunctionOnParameterType, callback?: (err: Error | null, params: Runtime.CallFunctionOnReturnType) => void): void;
         post(method: "Runtime.callFunctionOn", callback?: (err: Error | null, params: Runtime.CallFunctionOnReturnType) => void): void;
 
         /**
-         * Returns properties of a given object. Object group of the result is inherited from the target object.
+         * Compiles expression.
+         */
+        post(method: "Runtime.compileScript", params?: Runtime.CompileScriptParameterType, callback?: (err: Error | null, params: Runtime.CompileScriptReturnType) => void): void;
+        post(method: "Runtime.compileScript", callback?: (err: Error | null, params: Runtime.CompileScriptReturnType) => void): void;
+
+        /**
+         * Disables reporting of execution contexts creation.
+         */
+        post(method: "Runtime.disable", callback?: (err: Error | null) => void): void;
+
+        /**
+         * Discards collected exceptions and console API calls.
+         */
+        post(method: "Runtime.discardConsoleEntries", callback?: (err: Error | null) => void): void;
+
+        /**
+         * Enables reporting of execution contexts creation by means of `executionContextCreated` event.
+When the reporting gets enabled the event will be sent immediately for each existing execution
+context.
+         */
+        post(method: "Runtime.enable", callback?: (err: Error | null) => void): void;
+
+        /**
+         * Evaluates expression on global object.
+         */
+        post(method: "Runtime.evaluate", params?: Runtime.EvaluateParameterType, callback?: (err: Error | null, params: Runtime.EvaluateReturnType) => void): void;
+        post(method: "Runtime.evaluate", callback?: (err: Error | null, params: Runtime.EvaluateReturnType) => void): void;
+
+        /**
+         * Returns the isolate id.
+         * @experimental
+         */
+        post(method: "Runtime.getIsolateId", callback?: (err: Error | null, params: Runtime.GetIsolateIdReturnType) => void): void;
+
+        /**
+         * Returns the JavaScript heap usage.
+It is the total usage of the corresponding isolate not scoped to a particular Runtime.
+         * @experimental
+         */
+        post(method: "Runtime.getHeapUsage", callback?: (err: Error | null, params: Runtime.GetHeapUsageReturnType) => void): void;
+
+        /**
+         * Returns properties of a given object. Object group of the result is inherited from the target
+object.
          */
         post(method: "Runtime.getProperties", params?: Runtime.GetPropertiesParameterType, callback?: (err: Error | null, params: Runtime.GetPropertiesReturnType) => void): void;
         post(method: "Runtime.getProperties", callback?: (err: Error | null, params: Runtime.GetPropertiesReturnType) => void): void;
+
+        /**
+         * Returns all let, const and class variables from global scope.
+         */
+        post(method: "Runtime.globalLexicalScopeNames", params?: Runtime.GlobalLexicalScopeNamesParameterType, callback?: (err: Error | null, params: Runtime.GlobalLexicalScopeNamesReturnType) => void): void;
+        post(method: "Runtime.globalLexicalScopeNames", callback?: (err: Error | null, params: Runtime.GlobalLexicalScopeNamesReturnType) => void): void;
+
+        post(method: "Runtime.queryObjects", params?: Runtime.QueryObjectsParameterType, callback?: (err: Error | null, params: Runtime.QueryObjectsReturnType) => void): void;
+        post(method: "Runtime.queryObjects", callback?: (err: Error | null, params: Runtime.QueryObjectsReturnType) => void): void;
 
         /**
          * Releases remote object with given id.
@@ -1718,19 +2276,10 @@ declare module "inspector" {
         post(method: "Runtime.runIfWaitingForDebugger", callback?: (err: Error | null) => void): void;
 
         /**
-         * Enables reporting of execution contexts creation by means of <code>executionContextCreated</code> event. When the reporting gets enabled the event will be sent immediately for each existing execution context.
+         * Runs script with given id in a given context.
          */
-        post(method: "Runtime.enable", callback?: (err: Error | null) => void): void;
-
-        /**
-         * Disables reporting of execution contexts creation.
-         */
-        post(method: "Runtime.disable", callback?: (err: Error | null) => void): void;
-
-        /**
-         * Discards collected exceptions and console API calls.
-         */
-        post(method: "Runtime.discardConsoleEntries", callback?: (err: Error | null) => void): void;
+        post(method: "Runtime.runScript", params?: Runtime.RunScriptParameterType, callback?: (err: Error | null, params: Runtime.RunScriptReturnType) => void): void;
+        post(method: "Runtime.runScript", callback?: (err: Error | null, params: Runtime.RunScriptReturnType) => void): void;
 
         /**
          * @experimental
@@ -1739,245 +2288,15 @@ declare module "inspector" {
         post(method: "Runtime.setCustomObjectFormatterEnabled", callback?: (err: Error | null) => void): void;
 
         /**
-         * Compiles expression.
-         */
-        post(method: "Runtime.compileScript", params?: Runtime.CompileScriptParameterType, callback?: (err: Error | null, params: Runtime.CompileScriptReturnType) => void): void;
-        post(method: "Runtime.compileScript", callback?: (err: Error | null, params: Runtime.CompileScriptReturnType) => void): void;
-
-        /**
-         * Runs script with given id in a given context.
-         */
-        post(method: "Runtime.runScript", params?: Runtime.RunScriptParameterType, callback?: (err: Error | null, params: Runtime.RunScriptReturnType) => void): void;
-        post(method: "Runtime.runScript", callback?: (err: Error | null, params: Runtime.RunScriptReturnType) => void): void;
-        /**
-         * Enables debugger for the given page. Clients should not assume that the debugging has been enabled until the result for this command is received.
-         */
-        post(method: "Debugger.enable", callback?: (err: Error | null) => void): void;
-
-        /**
-         * Disables debugger for given page.
-         */
-        post(method: "Debugger.disable", callback?: (err: Error | null) => void): void;
-
-        /**
-         * Activates / deactivates all breakpoints on the page.
-         */
-        post(method: "Debugger.setBreakpointsActive", params?: Debugger.SetBreakpointsActiveParameterType, callback?: (err: Error | null) => void): void;
-        post(method: "Debugger.setBreakpointsActive", callback?: (err: Error | null) => void): void;
-
-        /**
-         * Makes page not interrupt on any pauses (breakpoint, exception, dom exception etc).
-         */
-        post(method: "Debugger.setSkipAllPauses", params?: Debugger.SetSkipAllPausesParameterType, callback?: (err: Error | null) => void): void;
-        post(method: "Debugger.setSkipAllPauses", callback?: (err: Error | null) => void): void;
-
-        /**
-         * Sets JavaScript breakpoint at given location specified either by URL or URL regex. Once this command is issued, all existing parsed scripts will have breakpoints resolved and returned in <code>locations</code> property. Further matching script parsing will result in subsequent <code>breakpointResolved</code> events issued. This logical breakpoint will survive page reloads.
-         */
-        post(method: "Debugger.setBreakpointByUrl", params?: Debugger.SetBreakpointByUrlParameterType, callback?: (err: Error | null, params: Debugger.SetBreakpointByUrlReturnType) => void): void;
-        post(method: "Debugger.setBreakpointByUrl", callback?: (err: Error | null, params: Debugger.SetBreakpointByUrlReturnType) => void): void;
-
-        /**
-         * Sets JavaScript breakpoint at a given location.
-         */
-        post(method: "Debugger.setBreakpoint", params?: Debugger.SetBreakpointParameterType, callback?: (err: Error | null, params: Debugger.SetBreakpointReturnType) => void): void;
-        post(method: "Debugger.setBreakpoint", callback?: (err: Error | null, params: Debugger.SetBreakpointReturnType) => void): void;
-
-        /**
-         * Removes JavaScript breakpoint.
-         */
-        post(method: "Debugger.removeBreakpoint", params?: Debugger.RemoveBreakpointParameterType, callback?: (err: Error | null) => void): void;
-        post(method: "Debugger.removeBreakpoint", callback?: (err: Error | null) => void): void;
-
-        /**
-         * Returns possible locations for breakpoint. scriptId in start and end range locations should be the same.
+         * Terminate current or next JavaScript execution.
+Will cancel the termination when the outer-most script execution ends.
          * @experimental
          */
-        post(method: "Debugger.getPossibleBreakpoints", params?: Debugger.GetPossibleBreakpointsParameterType, callback?: (err: Error | null, params: Debugger.GetPossibleBreakpointsReturnType) => void): void;
-        post(method: "Debugger.getPossibleBreakpoints", callback?: (err: Error | null, params: Debugger.GetPossibleBreakpointsReturnType) => void): void;
-
+        post(method: "Runtime.terminateExecution", callback?: (err: Error | null) => void): void;
         /**
-         * Continues execution until specific location is reached.
+         * Returns supported domains.
          */
-        post(method: "Debugger.continueToLocation", params?: Debugger.ContinueToLocationParameterType, callback?: (err: Error | null) => void): void;
-        post(method: "Debugger.continueToLocation", callback?: (err: Error | null) => void): void;
-
-        /**
-         * Steps over the statement.
-         */
-        post(method: "Debugger.stepOver", callback?: (err: Error | null) => void): void;
-
-        /**
-         * Steps into the function call.
-         */
-        post(method: "Debugger.stepInto", callback?: (err: Error | null) => void): void;
-
-        /**
-         * Steps out of the function call.
-         */
-        post(method: "Debugger.stepOut", callback?: (err: Error | null) => void): void;
-
-        /**
-         * Stops on the next JavaScript statement.
-         */
-        post(method: "Debugger.pause", callback?: (err: Error | null) => void): void;
-
-        /**
-         * Steps into next scheduled async task if any is scheduled before next pause. Returns success when async task is actually scheduled, returns error if no task were scheduled or another scheduleStepIntoAsync was called.
-         * @experimental
-         */
-        post(method: "Debugger.scheduleStepIntoAsync", callback?: (err: Error | null) => void): void;
-
-        /**
-         * Resumes JavaScript execution.
-         */
-        post(method: "Debugger.resume", callback?: (err: Error | null) => void): void;
-
-        /**
-         * Searches for given string in script content.
-         * @experimental
-         */
-        post(method: "Debugger.searchInContent", params?: Debugger.SearchInContentParameterType, callback?: (err: Error | null, params: Debugger.SearchInContentReturnType) => void): void;
-        post(method: "Debugger.searchInContent", callback?: (err: Error | null, params: Debugger.SearchInContentReturnType) => void): void;
-
-        /**
-         * Edits JavaScript source live.
-         */
-        post(method: "Debugger.setScriptSource", params?: Debugger.SetScriptSourceParameterType, callback?: (err: Error | null, params: Debugger.SetScriptSourceReturnType) => void): void;
-        post(method: "Debugger.setScriptSource", callback?: (err: Error | null, params: Debugger.SetScriptSourceReturnType) => void): void;
-
-        /**
-         * Restarts particular call frame from the beginning.
-         */
-        post(method: "Debugger.restartFrame", params?: Debugger.RestartFrameParameterType, callback?: (err: Error | null, params: Debugger.RestartFrameReturnType) => void): void;
-        post(method: "Debugger.restartFrame", callback?: (err: Error | null, params: Debugger.RestartFrameReturnType) => void): void;
-
-        /**
-         * Returns source for the script with given id.
-         */
-        post(method: "Debugger.getScriptSource", params?: Debugger.GetScriptSourceParameterType, callback?: (err: Error | null, params: Debugger.GetScriptSourceReturnType) => void): void;
-        post(method: "Debugger.getScriptSource", callback?: (err: Error | null, params: Debugger.GetScriptSourceReturnType) => void): void;
-
-        /**
-         * Defines pause on exceptions state. Can be set to stop on all exceptions, uncaught exceptions or no exceptions. Initial pause on exceptions state is <code>none</code>.
-         */
-        post(method: "Debugger.setPauseOnExceptions", params?: Debugger.SetPauseOnExceptionsParameterType, callback?: (err: Error | null) => void): void;
-        post(method: "Debugger.setPauseOnExceptions", callback?: (err: Error | null) => void): void;
-
-        /**
-         * Evaluates expression on a given call frame.
-         */
-        post(method: "Debugger.evaluateOnCallFrame", params?: Debugger.EvaluateOnCallFrameParameterType, callback?: (err: Error | null, params: Debugger.EvaluateOnCallFrameReturnType) => void): void;
-        post(method: "Debugger.evaluateOnCallFrame", callback?: (err: Error | null, params: Debugger.EvaluateOnCallFrameReturnType) => void): void;
-
-        /**
-         * Changes value of variable in a callframe. Object-based scopes are not supported and must be mutated manually.
-         */
-        post(method: "Debugger.setVariableValue", params?: Debugger.SetVariableValueParameterType, callback?: (err: Error | null) => void): void;
-        post(method: "Debugger.setVariableValue", callback?: (err: Error | null) => void): void;
-
-        /**
-         * Enables or disables async call stacks tracking.
-         */
-        post(method: "Debugger.setAsyncCallStackDepth", params?: Debugger.SetAsyncCallStackDepthParameterType, callback?: (err: Error | null) => void): void;
-        post(method: "Debugger.setAsyncCallStackDepth", callback?: (err: Error | null) => void): void;
-
-        /**
-         * Replace previous blackbox patterns with passed ones. Forces backend to skip stepping/pausing in scripts with url matching one of the patterns. VM will try to leave blackboxed script by performing 'step in' several times, finally resorting to 'step out' if unsuccessful.
-         * @experimental
-         */
-        post(method: "Debugger.setBlackboxPatterns", params?: Debugger.SetBlackboxPatternsParameterType, callback?: (err: Error | null) => void): void;
-        post(method: "Debugger.setBlackboxPatterns", callback?: (err: Error | null) => void): void;
-
-        /**
-         * Makes backend skip steps in the script in blackboxed ranges. VM will try leave blacklisted scripts by performing 'step in' several times, finally resorting to 'step out' if unsuccessful. Positions array contains positions where blackbox state is changed. First interval isn't blackboxed. Array should be sorted.
-         * @experimental
-         */
-        post(method: "Debugger.setBlackboxedRanges", params?: Debugger.SetBlackboxedRangesParameterType, callback?: (err: Error | null) => void): void;
-        post(method: "Debugger.setBlackboxedRanges", callback?: (err: Error | null) => void): void;
-        /**
-         * Enables console domain, sends the messages collected so far to the client by means of the <code>messageAdded</code> notification.
-         */
-        post(method: "Console.enable", callback?: (err: Error | null) => void): void;
-
-        /**
-         * Disables console domain, prevents further console messages from being reported to the client.
-         */
-        post(method: "Console.disable", callback?: (err: Error | null) => void): void;
-
-        /**
-         * Does nothing.
-         */
-        post(method: "Console.clearMessages", callback?: (err: Error | null) => void): void;
-        post(method: "Profiler.enable", callback?: (err: Error | null) => void): void;
-
-        post(method: "Profiler.disable", callback?: (err: Error | null) => void): void;
-
-        /**
-         * Changes CPU profiler sampling interval. Must be called before CPU profiles recording started.
-         */
-        post(method: "Profiler.setSamplingInterval", params?: Profiler.SetSamplingIntervalParameterType, callback?: (err: Error | null) => void): void;
-        post(method: "Profiler.setSamplingInterval", callback?: (err: Error | null) => void): void;
-
-        post(method: "Profiler.start", callback?: (err: Error | null) => void): void;
-
-        post(method: "Profiler.stop", callback?: (err: Error | null, params: Profiler.StopReturnType) => void): void;
-
-        /**
-         * Enable precise code coverage. Coverage data for JavaScript executed before enabling precise code coverage may be incomplete. Enabling prevents running optimized code and resets execution counters.
-         * @experimental
-         */
-        post(method: "Profiler.startPreciseCoverage", params?: Profiler.StartPreciseCoverageParameterType, callback?: (err: Error | null) => void): void;
-        post(method: "Profiler.startPreciseCoverage", callback?: (err: Error | null) => void): void;
-
-        /**
-         * Disable precise code coverage. Disabling releases unnecessary execution count records and allows executing optimized code.
-         * @experimental
-         */
-        post(method: "Profiler.stopPreciseCoverage", callback?: (err: Error | null) => void): void;
-
-        /**
-         * Collect coverage data for the current isolate, and resets execution counters. Precise code coverage needs to have started.
-         * @experimental
-         */
-        post(method: "Profiler.takePreciseCoverage", callback?: (err: Error | null, params: Profiler.TakePreciseCoverageReturnType) => void): void;
-
-        /**
-         * Collect coverage data for the current isolate. The coverage data may be incomplete due to garbage collection.
-         * @experimental
-         */
-        post(method: "Profiler.getBestEffortCoverage", callback?: (err: Error | null, params: Profiler.GetBestEffortCoverageReturnType) => void): void;
-        post(method: "HeapProfiler.enable", callback?: (err: Error | null) => void): void;
-
-        post(method: "HeapProfiler.disable", callback?: (err: Error | null) => void): void;
-
-        post(method: "HeapProfiler.startTrackingHeapObjects", params?: HeapProfiler.StartTrackingHeapObjectsParameterType, callback?: (err: Error | null) => void): void;
-        post(method: "HeapProfiler.startTrackingHeapObjects", callback?: (err: Error | null) => void): void;
-
-        post(method: "HeapProfiler.stopTrackingHeapObjects", params?: HeapProfiler.StopTrackingHeapObjectsParameterType, callback?: (err: Error | null) => void): void;
-        post(method: "HeapProfiler.stopTrackingHeapObjects", callback?: (err: Error | null) => void): void;
-
-        post(method: "HeapProfiler.takeHeapSnapshot", params?: HeapProfiler.TakeHeapSnapshotParameterType, callback?: (err: Error | null) => void): void;
-        post(method: "HeapProfiler.takeHeapSnapshot", callback?: (err: Error | null) => void): void;
-
-        post(method: "HeapProfiler.collectGarbage", callback?: (err: Error | null) => void): void;
-
-        post(method: "HeapProfiler.getObjectByHeapObjectId", params?: HeapProfiler.GetObjectByHeapObjectIdParameterType, callback?: (err: Error | null, params: HeapProfiler.GetObjectByHeapObjectIdReturnType) => void): void;
-        post(method: "HeapProfiler.getObjectByHeapObjectId", callback?: (err: Error | null, params: HeapProfiler.GetObjectByHeapObjectIdReturnType) => void): void;
-
-        /**
-         * Enables console to refer to the node with given id via $x (see Command Line API for more details $x functions).
-         */
-        post(method: "HeapProfiler.addInspectedHeapObject", params?: HeapProfiler.AddInspectedHeapObjectParameterType, callback?: (err: Error | null) => void): void;
-        post(method: "HeapProfiler.addInspectedHeapObject", callback?: (err: Error | null) => void): void;
-
-        post(method: "HeapProfiler.getHeapObjectId", params?: HeapProfiler.GetHeapObjectIdParameterType, callback?: (err: Error | null, params: HeapProfiler.GetHeapObjectIdReturnType) => void): void;
-        post(method: "HeapProfiler.getHeapObjectId", callback?: (err: Error | null, params: HeapProfiler.GetHeapObjectIdReturnType) => void): void;
-
-        post(method: "HeapProfiler.startSampling", params?: HeapProfiler.StartSamplingParameterType, callback?: (err: Error | null) => void): void;
-        post(method: "HeapProfiler.startSampling", callback?: (err: Error | null) => void): void;
-
-        post(method: "HeapProfiler.stopSampling", callback?: (err: Error | null, params: HeapProfiler.StopSamplingReturnType) => void): void;
+        post(method: "Schema.getDomains", callback?: (err: Error | null, params: Schema.GetDomainsReturnType) => void): void;
 
         // Events
 
@@ -1989,49 +2308,9 @@ declare module "inspector" {
         addListener(event: "inspectorNotification", listener: (message: InspectorNotification<{}>) => void): this;
 
         /**
-         * Issued when new execution context is created.
+         * Issued when new console message is added.
          */
-        addListener(event: "Runtime.executionContextCreated", listener: (message: InspectorNotification<Runtime.ExecutionContextCreatedEventDataType>) => void): this;
-
-        /**
-         * Issued when execution context is destroyed.
-         */
-        addListener(event: "Runtime.executionContextDestroyed", listener: (message: InspectorNotification<Runtime.ExecutionContextDestroyedEventDataType>) => void): this;
-
-        /**
-         * Issued when all executionContexts were cleared in browser
-         */
-        addListener(event: "Runtime.executionContextsCleared", listener: () => void): this;
-
-        /**
-         * Issued when exception was thrown and unhandled.
-         */
-        addListener(event: "Runtime.exceptionThrown", listener: (message: InspectorNotification<Runtime.ExceptionThrownEventDataType>) => void): this;
-
-        /**
-         * Issued when unhandled exception was revoked.
-         */
-        addListener(event: "Runtime.exceptionRevoked", listener: (message: InspectorNotification<Runtime.ExceptionRevokedEventDataType>) => void): this;
-
-        /**
-         * Issued when console API was called.
-         */
-        addListener(event: "Runtime.consoleAPICalled", listener: (message: InspectorNotification<Runtime.ConsoleAPICalledEventDataType>) => void): this;
-
-        /**
-         * Issued when object should be inspected (for example, as a result of inspect() command line API call).
-         */
-        addListener(event: "Runtime.inspectRequested", listener: (message: InspectorNotification<Runtime.InspectRequestedEventDataType>) => void): this;
-
-        /**
-         * Fired when virtual machine parses script. This event is also fired for all known and uncollected scripts upon enabling debugger.
-         */
-        addListener(event: "Debugger.scriptParsed", listener: (message: InspectorNotification<Debugger.ScriptParsedEventDataType>) => void): this;
-
-        /**
-         * Fired when virtual machine fails to parse the script.
-         */
-        addListener(event: "Debugger.scriptFailedToParse", listener: (message: InspectorNotification<Debugger.ScriptFailedToParseEventDataType>) => void): this;
+        addListener(event: "Console.messageAdded", listener: (message: InspectorNotification<Console.MessageAddedEventDataType>) => void): this;
 
         /**
          * Fired when breakpoint is resolved to an actual script and location.
@@ -2049,52 +2328,97 @@ declare module "inspector" {
         addListener(event: "Debugger.resumed", listener: () => void): this;
 
         /**
-         * Issued when new console message is added.
+         * Fired when virtual machine fails to parse the script.
          */
-        addListener(event: "Console.messageAdded", listener: (message: InspectorNotification<Console.MessageAddedEventDataType>) => void): this;
+        addListener(event: "Debugger.scriptFailedToParse", listener: (message: InspectorNotification<Debugger.ScriptFailedToParseEventDataType>) => void): this;
 
         /**
-         * Sent when new profile recording is started using console.profile() call.
+         * Fired when virtual machine parses script. This event is also fired for all known and uncollected
+scripts upon enabling debugger.
          */
-        addListener(event: "Profiler.consoleProfileStarted", listener: (message: InspectorNotification<Profiler.ConsoleProfileStartedEventDataType>) => void): this;
+        addListener(event: "Debugger.scriptParsed", listener: (message: InspectorNotification<Debugger.ScriptParsedEventDataType>) => void): this;
 
-        addListener(event: "Profiler.consoleProfileFinished", listener: (message: InspectorNotification<Profiler.ConsoleProfileFinishedEventDataType>) => void): this;
         addListener(event: "HeapProfiler.addHeapSnapshotChunk", listener: (message: InspectorNotification<HeapProfiler.AddHeapSnapshotChunkEventDataType>) => void): this;
-        addListener(event: "HeapProfiler.resetProfiles", listener: () => void): this;
-        addListener(event: "HeapProfiler.reportHeapSnapshotProgress", listener: (message: InspectorNotification<HeapProfiler.ReportHeapSnapshotProgressEventDataType>) => void): this;
-
-        /**
-         * If heap objects tracking has been started then backend regularly sends a current value for last seen object id and corresponding timestamp. If the were changes in the heap since last event then one or more heapStatsUpdate events will be sent before a new lastSeenObjectId event.
-         */
-        addListener(event: "HeapProfiler.lastSeenObjectId", listener: (message: InspectorNotification<HeapProfiler.LastSeenObjectIdEventDataType>) => void): this;
 
         /**
          * If heap objects tracking has been started then backend may send update for one or more fragments
          */
         addListener(event: "HeapProfiler.heapStatsUpdate", listener: (message: InspectorNotification<HeapProfiler.HeapStatsUpdateEventDataType>) => void): this;
 
+        /**
+         * If heap objects tracking has been started then backend regularly sends a current value for last
+seen object id and corresponding timestamp. If the were changes in the heap since last event
+then one or more heapStatsUpdate events will be sent before a new lastSeenObjectId event.
+         */
+        addListener(event: "HeapProfiler.lastSeenObjectId", listener: (message: InspectorNotification<HeapProfiler.LastSeenObjectIdEventDataType>) => void): this;
+
+        addListener(event: "HeapProfiler.reportHeapSnapshotProgress", listener: (message: InspectorNotification<HeapProfiler.ReportHeapSnapshotProgressEventDataType>) => void): this;
+        addListener(event: "HeapProfiler.resetProfiles", listener: () => void): this;
+        addListener(event: "Profiler.consoleProfileFinished", listener: (message: InspectorNotification<Profiler.ConsoleProfileFinishedEventDataType>) => void): this;
+
+        /**
+         * Sent when new profile recording is started using console.profile() call.
+         */
+        addListener(event: "Profiler.consoleProfileStarted", listener: (message: InspectorNotification<Profiler.ConsoleProfileStartedEventDataType>) => void): this;
+
+        /**
+         * Issued when console API was called.
+         */
+        addListener(event: "Runtime.consoleAPICalled", listener: (message: InspectorNotification<Runtime.ConsoleAPICalledEventDataType>) => void): this;
+
+        /**
+         * Issued when unhandled exception was revoked.
+         */
+        addListener(event: "Runtime.exceptionRevoked", listener: (message: InspectorNotification<Runtime.ExceptionRevokedEventDataType>) => void): this;
+
+        /**
+         * Issued when exception was thrown and unhandled.
+         */
+        addListener(event: "Runtime.exceptionThrown", listener: (message: InspectorNotification<Runtime.ExceptionThrownEventDataType>) => void): this;
+
+        /**
+         * Issued when new execution context is created.
+         */
+        addListener(event: "Runtime.executionContextCreated", listener: (message: InspectorNotification<Runtime.ExecutionContextCreatedEventDataType>) => void): this;
+
+        /**
+         * Issued when execution context is destroyed.
+         */
+        addListener(event: "Runtime.executionContextDestroyed", listener: (message: InspectorNotification<Runtime.ExecutionContextDestroyedEventDataType>) => void): this;
+
+        /**
+         * Issued when all executionContexts were cleared in browser
+         */
+        addListener(event: "Runtime.executionContextsCleared", listener: () => void): this;
+
+        /**
+         * Issued when object should be inspected (for example, as a result of inspect() command line API
+call).
+         */
+        addListener(event: "Runtime.inspectRequested", listener: (message: InspectorNotification<Runtime.InspectRequestedEventDataType>) => void): this;
+
         emit(event: string | symbol, ...args: any[]): boolean;
         emit(event: "inspectorNotification", message: InspectorNotification<{}>): boolean;
-        emit(event: "Runtime.executionContextCreated", message: InspectorNotification<Runtime.ExecutionContextCreatedEventDataType>): boolean;
-        emit(event: "Runtime.executionContextDestroyed", message: InspectorNotification<Runtime.ExecutionContextDestroyedEventDataType>): boolean;
-        emit(event: "Runtime.executionContextsCleared"): boolean;
-        emit(event: "Runtime.exceptionThrown", message: InspectorNotification<Runtime.ExceptionThrownEventDataType>): boolean;
-        emit(event: "Runtime.exceptionRevoked", message: InspectorNotification<Runtime.ExceptionRevokedEventDataType>): boolean;
-        emit(event: "Runtime.consoleAPICalled", message: InspectorNotification<Runtime.ConsoleAPICalledEventDataType>): boolean;
-        emit(event: "Runtime.inspectRequested", message: InspectorNotification<Runtime.InspectRequestedEventDataType>): boolean;
-        emit(event: "Debugger.scriptParsed", message: InspectorNotification<Debugger.ScriptParsedEventDataType>): boolean;
-        emit(event: "Debugger.scriptFailedToParse", message: InspectorNotification<Debugger.ScriptFailedToParseEventDataType>): boolean;
+        emit(event: "Console.messageAdded", message: InspectorNotification<Console.MessageAddedEventDataType>): boolean;
         emit(event: "Debugger.breakpointResolved", message: InspectorNotification<Debugger.BreakpointResolvedEventDataType>): boolean;
         emit(event: "Debugger.paused", message: InspectorNotification<Debugger.PausedEventDataType>): boolean;
         emit(event: "Debugger.resumed"): boolean;
-        emit(event: "Console.messageAdded", message: InspectorNotification<Console.MessageAddedEventDataType>): boolean;
-        emit(event: "Profiler.consoleProfileStarted", message: InspectorNotification<Profiler.ConsoleProfileStartedEventDataType>): boolean;
-        emit(event: "Profiler.consoleProfileFinished", message: InspectorNotification<Profiler.ConsoleProfileFinishedEventDataType>): boolean;
+        emit(event: "Debugger.scriptFailedToParse", message: InspectorNotification<Debugger.ScriptFailedToParseEventDataType>): boolean;
+        emit(event: "Debugger.scriptParsed", message: InspectorNotification<Debugger.ScriptParsedEventDataType>): boolean;
         emit(event: "HeapProfiler.addHeapSnapshotChunk", message: InspectorNotification<HeapProfiler.AddHeapSnapshotChunkEventDataType>): boolean;
-        emit(event: "HeapProfiler.resetProfiles"): boolean;
-        emit(event: "HeapProfiler.reportHeapSnapshotProgress", message: InspectorNotification<HeapProfiler.ReportHeapSnapshotProgressEventDataType>): boolean;
-        emit(event: "HeapProfiler.lastSeenObjectId", message: InspectorNotification<HeapProfiler.LastSeenObjectIdEventDataType>): boolean;
         emit(event: "HeapProfiler.heapStatsUpdate", message: InspectorNotification<HeapProfiler.HeapStatsUpdateEventDataType>): boolean;
+        emit(event: "HeapProfiler.lastSeenObjectId", message: InspectorNotification<HeapProfiler.LastSeenObjectIdEventDataType>): boolean;
+        emit(event: "HeapProfiler.reportHeapSnapshotProgress", message: InspectorNotification<HeapProfiler.ReportHeapSnapshotProgressEventDataType>): boolean;
+        emit(event: "HeapProfiler.resetProfiles"): boolean;
+        emit(event: "Profiler.consoleProfileFinished", message: InspectorNotification<Profiler.ConsoleProfileFinishedEventDataType>): boolean;
+        emit(event: "Profiler.consoleProfileStarted", message: InspectorNotification<Profiler.ConsoleProfileStartedEventDataType>): boolean;
+        emit(event: "Runtime.consoleAPICalled", message: InspectorNotification<Runtime.ConsoleAPICalledEventDataType>): boolean;
+        emit(event: "Runtime.exceptionRevoked", message: InspectorNotification<Runtime.ExceptionRevokedEventDataType>): boolean;
+        emit(event: "Runtime.exceptionThrown", message: InspectorNotification<Runtime.ExceptionThrownEventDataType>): boolean;
+        emit(event: "Runtime.executionContextCreated", message: InspectorNotification<Runtime.ExecutionContextCreatedEventDataType>): boolean;
+        emit(event: "Runtime.executionContextDestroyed", message: InspectorNotification<Runtime.ExecutionContextDestroyedEventDataType>): boolean;
+        emit(event: "Runtime.executionContextsCleared"): boolean;
+        emit(event: "Runtime.inspectRequested", message: InspectorNotification<Runtime.InspectRequestedEventDataType>): boolean;
 
         on(event: string, listener: (...args: any[]) => void): this;
 
@@ -2104,49 +2428,9 @@ declare module "inspector" {
         on(event: "inspectorNotification", listener: (message: InspectorNotification<{}>) => void): this;
 
         /**
-         * Issued when new execution context is created.
+         * Issued when new console message is added.
          */
-        on(event: "Runtime.executionContextCreated", listener: (message: InspectorNotification<Runtime.ExecutionContextCreatedEventDataType>) => void): this;
-
-        /**
-         * Issued when execution context is destroyed.
-         */
-        on(event: "Runtime.executionContextDestroyed", listener: (message: InspectorNotification<Runtime.ExecutionContextDestroyedEventDataType>) => void): this;
-
-        /**
-         * Issued when all executionContexts were cleared in browser
-         */
-        on(event: "Runtime.executionContextsCleared", listener: () => void): this;
-
-        /**
-         * Issued when exception was thrown and unhandled.
-         */
-        on(event: "Runtime.exceptionThrown", listener: (message: InspectorNotification<Runtime.ExceptionThrownEventDataType>) => void): this;
-
-        /**
-         * Issued when unhandled exception was revoked.
-         */
-        on(event: "Runtime.exceptionRevoked", listener: (message: InspectorNotification<Runtime.ExceptionRevokedEventDataType>) => void): this;
-
-        /**
-         * Issued when console API was called.
-         */
-        on(event: "Runtime.consoleAPICalled", listener: (message: InspectorNotification<Runtime.ConsoleAPICalledEventDataType>) => void): this;
-
-        /**
-         * Issued when object should be inspected (for example, as a result of inspect() command line API call).
-         */
-        on(event: "Runtime.inspectRequested", listener: (message: InspectorNotification<Runtime.InspectRequestedEventDataType>) => void): this;
-
-        /**
-         * Fired when virtual machine parses script. This event is also fired for all known and uncollected scripts upon enabling debugger.
-         */
-        on(event: "Debugger.scriptParsed", listener: (message: InspectorNotification<Debugger.ScriptParsedEventDataType>) => void): this;
-
-        /**
-         * Fired when virtual machine fails to parse the script.
-         */
-        on(event: "Debugger.scriptFailedToParse", listener: (message: InspectorNotification<Debugger.ScriptFailedToParseEventDataType>) => void): this;
+        on(event: "Console.messageAdded", listener: (message: InspectorNotification<Console.MessageAddedEventDataType>) => void): this;
 
         /**
          * Fired when breakpoint is resolved to an actual script and location.
@@ -2164,29 +2448,74 @@ declare module "inspector" {
         on(event: "Debugger.resumed", listener: () => void): this;
 
         /**
-         * Issued when new console message is added.
+         * Fired when virtual machine fails to parse the script.
          */
-        on(event: "Console.messageAdded", listener: (message: InspectorNotification<Console.MessageAddedEventDataType>) => void): this;
+        on(event: "Debugger.scriptFailedToParse", listener: (message: InspectorNotification<Debugger.ScriptFailedToParseEventDataType>) => void): this;
+
+        /**
+         * Fired when virtual machine parses script. This event is also fired for all known and uncollected
+scripts upon enabling debugger.
+         */
+        on(event: "Debugger.scriptParsed", listener: (message: InspectorNotification<Debugger.ScriptParsedEventDataType>) => void): this;
+
+        on(event: "HeapProfiler.addHeapSnapshotChunk", listener: (message: InspectorNotification<HeapProfiler.AddHeapSnapshotChunkEventDataType>) => void): this;
+
+        /**
+         * If heap objects tracking has been started then backend may send update for one or more fragments
+         */
+        on(event: "HeapProfiler.heapStatsUpdate", listener: (message: InspectorNotification<HeapProfiler.HeapStatsUpdateEventDataType>) => void): this;
+
+        /**
+         * If heap objects tracking has been started then backend regularly sends a current value for last
+seen object id and corresponding timestamp. If the were changes in the heap since last event
+then one or more heapStatsUpdate events will be sent before a new lastSeenObjectId event.
+         */
+        on(event: "HeapProfiler.lastSeenObjectId", listener: (message: InspectorNotification<HeapProfiler.LastSeenObjectIdEventDataType>) => void): this;
+
+        on(event: "HeapProfiler.reportHeapSnapshotProgress", listener: (message: InspectorNotification<HeapProfiler.ReportHeapSnapshotProgressEventDataType>) => void): this;
+        on(event: "HeapProfiler.resetProfiles", listener: () => void): this;
+        on(event: "Profiler.consoleProfileFinished", listener: (message: InspectorNotification<Profiler.ConsoleProfileFinishedEventDataType>) => void): this;
 
         /**
          * Sent when new profile recording is started using console.profile() call.
          */
         on(event: "Profiler.consoleProfileStarted", listener: (message: InspectorNotification<Profiler.ConsoleProfileStartedEventDataType>) => void): this;
 
-        on(event: "Profiler.consoleProfileFinished", listener: (message: InspectorNotification<Profiler.ConsoleProfileFinishedEventDataType>) => void): this;
-        on(event: "HeapProfiler.addHeapSnapshotChunk", listener: (message: InspectorNotification<HeapProfiler.AddHeapSnapshotChunkEventDataType>) => void): this;
-        on(event: "HeapProfiler.resetProfiles", listener: () => void): this;
-        on(event: "HeapProfiler.reportHeapSnapshotProgress", listener: (message: InspectorNotification<HeapProfiler.ReportHeapSnapshotProgressEventDataType>) => void): this;
+        /**
+         * Issued when console API was called.
+         */
+        on(event: "Runtime.consoleAPICalled", listener: (message: InspectorNotification<Runtime.ConsoleAPICalledEventDataType>) => void): this;
 
         /**
-         * If heap objects tracking has been started then backend regularly sends a current value for last seen object id and corresponding timestamp. If the were changes in the heap since last event then one or more heapStatsUpdate events will be sent before a new lastSeenObjectId event.
+         * Issued when unhandled exception was revoked.
          */
-        on(event: "HeapProfiler.lastSeenObjectId", listener: (message: InspectorNotification<HeapProfiler.LastSeenObjectIdEventDataType>) => void): this;
+        on(event: "Runtime.exceptionRevoked", listener: (message: InspectorNotification<Runtime.ExceptionRevokedEventDataType>) => void): this;
 
         /**
-         * If heap objects tracking has been started then backend may send update for one or more fragments
+         * Issued when exception was thrown and unhandled.
          */
-        on(event: "HeapProfiler.heapStatsUpdate", listener: (message: InspectorNotification<HeapProfiler.HeapStatsUpdateEventDataType>) => void): this;
+        on(event: "Runtime.exceptionThrown", listener: (message: InspectorNotification<Runtime.ExceptionThrownEventDataType>) => void): this;
+
+        /**
+         * Issued when new execution context is created.
+         */
+        on(event: "Runtime.executionContextCreated", listener: (message: InspectorNotification<Runtime.ExecutionContextCreatedEventDataType>) => void): this;
+
+        /**
+         * Issued when execution context is destroyed.
+         */
+        on(event: "Runtime.executionContextDestroyed", listener: (message: InspectorNotification<Runtime.ExecutionContextDestroyedEventDataType>) => void): this;
+
+        /**
+         * Issued when all executionContexts were cleared in browser
+         */
+        on(event: "Runtime.executionContextsCleared", listener: () => void): this;
+
+        /**
+         * Issued when object should be inspected (for example, as a result of inspect() command line API
+call).
+         */
+        on(event: "Runtime.inspectRequested", listener: (message: InspectorNotification<Runtime.InspectRequestedEventDataType>) => void): this;
 
         once(event: string, listener: (...args: any[]) => void): this;
 
@@ -2196,49 +2525,9 @@ declare module "inspector" {
         once(event: "inspectorNotification", listener: (message: InspectorNotification<{}>) => void): this;
 
         /**
-         * Issued when new execution context is created.
+         * Issued when new console message is added.
          */
-        once(event: "Runtime.executionContextCreated", listener: (message: InspectorNotification<Runtime.ExecutionContextCreatedEventDataType>) => void): this;
-
-        /**
-         * Issued when execution context is destroyed.
-         */
-        once(event: "Runtime.executionContextDestroyed", listener: (message: InspectorNotification<Runtime.ExecutionContextDestroyedEventDataType>) => void): this;
-
-        /**
-         * Issued when all executionContexts were cleared in browser
-         */
-        once(event: "Runtime.executionContextsCleared", listener: () => void): this;
-
-        /**
-         * Issued when exception was thrown and unhandled.
-         */
-        once(event: "Runtime.exceptionThrown", listener: (message: InspectorNotification<Runtime.ExceptionThrownEventDataType>) => void): this;
-
-        /**
-         * Issued when unhandled exception was revoked.
-         */
-        once(event: "Runtime.exceptionRevoked", listener: (message: InspectorNotification<Runtime.ExceptionRevokedEventDataType>) => void): this;
-
-        /**
-         * Issued when console API was called.
-         */
-        once(event: "Runtime.consoleAPICalled", listener: (message: InspectorNotification<Runtime.ConsoleAPICalledEventDataType>) => void): this;
-
-        /**
-         * Issued when object should be inspected (for example, as a result of inspect() command line API call).
-         */
-        once(event: "Runtime.inspectRequested", listener: (message: InspectorNotification<Runtime.InspectRequestedEventDataType>) => void): this;
-
-        /**
-         * Fired when virtual machine parses script. This event is also fired for all known and uncollected scripts upon enabling debugger.
-         */
-        once(event: "Debugger.scriptParsed", listener: (message: InspectorNotification<Debugger.ScriptParsedEventDataType>) => void): this;
-
-        /**
-         * Fired when virtual machine fails to parse the script.
-         */
-        once(event: "Debugger.scriptFailedToParse", listener: (message: InspectorNotification<Debugger.ScriptFailedToParseEventDataType>) => void): this;
+        once(event: "Console.messageAdded", listener: (message: InspectorNotification<Console.MessageAddedEventDataType>) => void): this;
 
         /**
          * Fired when breakpoint is resolved to an actual script and location.
@@ -2256,29 +2545,74 @@ declare module "inspector" {
         once(event: "Debugger.resumed", listener: () => void): this;
 
         /**
-         * Issued when new console message is added.
+         * Fired when virtual machine fails to parse the script.
          */
-        once(event: "Console.messageAdded", listener: (message: InspectorNotification<Console.MessageAddedEventDataType>) => void): this;
+        once(event: "Debugger.scriptFailedToParse", listener: (message: InspectorNotification<Debugger.ScriptFailedToParseEventDataType>) => void): this;
+
+        /**
+         * Fired when virtual machine parses script. This event is also fired for all known and uncollected
+scripts upon enabling debugger.
+         */
+        once(event: "Debugger.scriptParsed", listener: (message: InspectorNotification<Debugger.ScriptParsedEventDataType>) => void): this;
+
+        once(event: "HeapProfiler.addHeapSnapshotChunk", listener: (message: InspectorNotification<HeapProfiler.AddHeapSnapshotChunkEventDataType>) => void): this;
+
+        /**
+         * If heap objects tracking has been started then backend may send update for one or more fragments
+         */
+        once(event: "HeapProfiler.heapStatsUpdate", listener: (message: InspectorNotification<HeapProfiler.HeapStatsUpdateEventDataType>) => void): this;
+
+        /**
+         * If heap objects tracking has been started then backend regularly sends a current value for last
+seen object id and corresponding timestamp. If the were changes in the heap since last event
+then one or more heapStatsUpdate events will be sent before a new lastSeenObjectId event.
+         */
+        once(event: "HeapProfiler.lastSeenObjectId", listener: (message: InspectorNotification<HeapProfiler.LastSeenObjectIdEventDataType>) => void): this;
+
+        once(event: "HeapProfiler.reportHeapSnapshotProgress", listener: (message: InspectorNotification<HeapProfiler.ReportHeapSnapshotProgressEventDataType>) => void): this;
+        once(event: "HeapProfiler.resetProfiles", listener: () => void): this;
+        once(event: "Profiler.consoleProfileFinished", listener: (message: InspectorNotification<Profiler.ConsoleProfileFinishedEventDataType>) => void): this;
 
         /**
          * Sent when new profile recording is started using console.profile() call.
          */
         once(event: "Profiler.consoleProfileStarted", listener: (message: InspectorNotification<Profiler.ConsoleProfileStartedEventDataType>) => void): this;
 
-        once(event: "Profiler.consoleProfileFinished", listener: (message: InspectorNotification<Profiler.ConsoleProfileFinishedEventDataType>) => void): this;
-        once(event: "HeapProfiler.addHeapSnapshotChunk", listener: (message: InspectorNotification<HeapProfiler.AddHeapSnapshotChunkEventDataType>) => void): this;
-        once(event: "HeapProfiler.resetProfiles", listener: () => void): this;
-        once(event: "HeapProfiler.reportHeapSnapshotProgress", listener: (message: InspectorNotification<HeapProfiler.ReportHeapSnapshotProgressEventDataType>) => void): this;
+        /**
+         * Issued when console API was called.
+         */
+        once(event: "Runtime.consoleAPICalled", listener: (message: InspectorNotification<Runtime.ConsoleAPICalledEventDataType>) => void): this;
 
         /**
-         * If heap objects tracking has been started then backend regularly sends a current value for last seen object id and corresponding timestamp. If the were changes in the heap since last event then one or more heapStatsUpdate events will be sent before a new lastSeenObjectId event.
+         * Issued when unhandled exception was revoked.
          */
-        once(event: "HeapProfiler.lastSeenObjectId", listener: (message: InspectorNotification<HeapProfiler.LastSeenObjectIdEventDataType>) => void): this;
+        once(event: "Runtime.exceptionRevoked", listener: (message: InspectorNotification<Runtime.ExceptionRevokedEventDataType>) => void): this;
 
         /**
-         * If heap objects tracking has been started then backend may send update for one or more fragments
+         * Issued when exception was thrown and unhandled.
          */
-        once(event: "HeapProfiler.heapStatsUpdate", listener: (message: InspectorNotification<HeapProfiler.HeapStatsUpdateEventDataType>) => void): this;
+        once(event: "Runtime.exceptionThrown", listener: (message: InspectorNotification<Runtime.ExceptionThrownEventDataType>) => void): this;
+
+        /**
+         * Issued when new execution context is created.
+         */
+        once(event: "Runtime.executionContextCreated", listener: (message: InspectorNotification<Runtime.ExecutionContextCreatedEventDataType>) => void): this;
+
+        /**
+         * Issued when execution context is destroyed.
+         */
+        once(event: "Runtime.executionContextDestroyed", listener: (message: InspectorNotification<Runtime.ExecutionContextDestroyedEventDataType>) => void): this;
+
+        /**
+         * Issued when all executionContexts were cleared in browser
+         */
+        once(event: "Runtime.executionContextsCleared", listener: () => void): this;
+
+        /**
+         * Issued when object should be inspected (for example, as a result of inspect() command line API
+call).
+         */
+        once(event: "Runtime.inspectRequested", listener: (message: InspectorNotification<Runtime.InspectRequestedEventDataType>) => void): this;
 
         prependListener(event: string, listener: (...args: any[]) => void): this;
 
@@ -2288,49 +2622,9 @@ declare module "inspector" {
         prependListener(event: "inspectorNotification", listener: (message: InspectorNotification<{}>) => void): this;
 
         /**
-         * Issued when new execution context is created.
+         * Issued when new console message is added.
          */
-        prependListener(event: "Runtime.executionContextCreated", listener: (message: InspectorNotification<Runtime.ExecutionContextCreatedEventDataType>) => void): this;
-
-        /**
-         * Issued when execution context is destroyed.
-         */
-        prependListener(event: "Runtime.executionContextDestroyed", listener: (message: InspectorNotification<Runtime.ExecutionContextDestroyedEventDataType>) => void): this;
-
-        /**
-         * Issued when all executionContexts were cleared in browser
-         */
-        prependListener(event: "Runtime.executionContextsCleared", listener: () => void): this;
-
-        /**
-         * Issued when exception was thrown and unhandled.
-         */
-        prependListener(event: "Runtime.exceptionThrown", listener: (message: InspectorNotification<Runtime.ExceptionThrownEventDataType>) => void): this;
-
-        /**
-         * Issued when unhandled exception was revoked.
-         */
-        prependListener(event: "Runtime.exceptionRevoked", listener: (message: InspectorNotification<Runtime.ExceptionRevokedEventDataType>) => void): this;
-
-        /**
-         * Issued when console API was called.
-         */
-        prependListener(event: "Runtime.consoleAPICalled", listener: (message: InspectorNotification<Runtime.ConsoleAPICalledEventDataType>) => void): this;
-
-        /**
-         * Issued when object should be inspected (for example, as a result of inspect() command line API call).
-         */
-        prependListener(event: "Runtime.inspectRequested", listener: (message: InspectorNotification<Runtime.InspectRequestedEventDataType>) => void): this;
-
-        /**
-         * Fired when virtual machine parses script. This event is also fired for all known and uncollected scripts upon enabling debugger.
-         */
-        prependListener(event: "Debugger.scriptParsed", listener: (message: InspectorNotification<Debugger.ScriptParsedEventDataType>) => void): this;
-
-        /**
-         * Fired when virtual machine fails to parse the script.
-         */
-        prependListener(event: "Debugger.scriptFailedToParse", listener: (message: InspectorNotification<Debugger.ScriptFailedToParseEventDataType>) => void): this;
+        prependListener(event: "Console.messageAdded", listener: (message: InspectorNotification<Console.MessageAddedEventDataType>) => void): this;
 
         /**
          * Fired when breakpoint is resolved to an actual script and location.
@@ -2348,29 +2642,74 @@ declare module "inspector" {
         prependListener(event: "Debugger.resumed", listener: () => void): this;
 
         /**
-         * Issued when new console message is added.
+         * Fired when virtual machine fails to parse the script.
          */
-        prependListener(event: "Console.messageAdded", listener: (message: InspectorNotification<Console.MessageAddedEventDataType>) => void): this;
+        prependListener(event: "Debugger.scriptFailedToParse", listener: (message: InspectorNotification<Debugger.ScriptFailedToParseEventDataType>) => void): this;
+
+        /**
+         * Fired when virtual machine parses script. This event is also fired for all known and uncollected
+scripts upon enabling debugger.
+         */
+        prependListener(event: "Debugger.scriptParsed", listener: (message: InspectorNotification<Debugger.ScriptParsedEventDataType>) => void): this;
+
+        prependListener(event: "HeapProfiler.addHeapSnapshotChunk", listener: (message: InspectorNotification<HeapProfiler.AddHeapSnapshotChunkEventDataType>) => void): this;
+
+        /**
+         * If heap objects tracking has been started then backend may send update for one or more fragments
+         */
+        prependListener(event: "HeapProfiler.heapStatsUpdate", listener: (message: InspectorNotification<HeapProfiler.HeapStatsUpdateEventDataType>) => void): this;
+
+        /**
+         * If heap objects tracking has been started then backend regularly sends a current value for last
+seen object id and corresponding timestamp. If the were changes in the heap since last event
+then one or more heapStatsUpdate events will be sent before a new lastSeenObjectId event.
+         */
+        prependListener(event: "HeapProfiler.lastSeenObjectId", listener: (message: InspectorNotification<HeapProfiler.LastSeenObjectIdEventDataType>) => void): this;
+
+        prependListener(event: "HeapProfiler.reportHeapSnapshotProgress", listener: (message: InspectorNotification<HeapProfiler.ReportHeapSnapshotProgressEventDataType>) => void): this;
+        prependListener(event: "HeapProfiler.resetProfiles", listener: () => void): this;
+        prependListener(event: "Profiler.consoleProfileFinished", listener: (message: InspectorNotification<Profiler.ConsoleProfileFinishedEventDataType>) => void): this;
 
         /**
          * Sent when new profile recording is started using console.profile() call.
          */
         prependListener(event: "Profiler.consoleProfileStarted", listener: (message: InspectorNotification<Profiler.ConsoleProfileStartedEventDataType>) => void): this;
 
-        prependListener(event: "Profiler.consoleProfileFinished", listener: (message: InspectorNotification<Profiler.ConsoleProfileFinishedEventDataType>) => void): this;
-        prependListener(event: "HeapProfiler.addHeapSnapshotChunk", listener: (message: InspectorNotification<HeapProfiler.AddHeapSnapshotChunkEventDataType>) => void): this;
-        prependListener(event: "HeapProfiler.resetProfiles", listener: () => void): this;
-        prependListener(event: "HeapProfiler.reportHeapSnapshotProgress", listener: (message: InspectorNotification<HeapProfiler.ReportHeapSnapshotProgressEventDataType>) => void): this;
+        /**
+         * Issued when console API was called.
+         */
+        prependListener(event: "Runtime.consoleAPICalled", listener: (message: InspectorNotification<Runtime.ConsoleAPICalledEventDataType>) => void): this;
 
         /**
-         * If heap objects tracking has been started then backend regularly sends a current value for last seen object id and corresponding timestamp. If the were changes in the heap since last event then one or more heapStatsUpdate events will be sent before a new lastSeenObjectId event.
+         * Issued when unhandled exception was revoked.
          */
-        prependListener(event: "HeapProfiler.lastSeenObjectId", listener: (message: InspectorNotification<HeapProfiler.LastSeenObjectIdEventDataType>) => void): this;
+        prependListener(event: "Runtime.exceptionRevoked", listener: (message: InspectorNotification<Runtime.ExceptionRevokedEventDataType>) => void): this;
 
         /**
-         * If heap objects tracking has been started then backend may send update for one or more fragments
+         * Issued when exception was thrown and unhandled.
          */
-        prependListener(event: "HeapProfiler.heapStatsUpdate", listener: (message: InspectorNotification<HeapProfiler.HeapStatsUpdateEventDataType>) => void): this;
+        prependListener(event: "Runtime.exceptionThrown", listener: (message: InspectorNotification<Runtime.ExceptionThrownEventDataType>) => void): this;
+
+        /**
+         * Issued when new execution context is created.
+         */
+        prependListener(event: "Runtime.executionContextCreated", listener: (message: InspectorNotification<Runtime.ExecutionContextCreatedEventDataType>) => void): this;
+
+        /**
+         * Issued when execution context is destroyed.
+         */
+        prependListener(event: "Runtime.executionContextDestroyed", listener: (message: InspectorNotification<Runtime.ExecutionContextDestroyedEventDataType>) => void): this;
+
+        /**
+         * Issued when all executionContexts were cleared in browser
+         */
+        prependListener(event: "Runtime.executionContextsCleared", listener: () => void): this;
+
+        /**
+         * Issued when object should be inspected (for example, as a result of inspect() command line API
+call).
+         */
+        prependListener(event: "Runtime.inspectRequested", listener: (message: InspectorNotification<Runtime.InspectRequestedEventDataType>) => void): this;
 
         prependOnceListener(event: string, listener: (...args: any[]) => void): this;
 
@@ -2380,49 +2719,9 @@ declare module "inspector" {
         prependOnceListener(event: "inspectorNotification", listener: (message: InspectorNotification<{}>) => void): this;
 
         /**
-         * Issued when new execution context is created.
+         * Issued when new console message is added.
          */
-        prependOnceListener(event: "Runtime.executionContextCreated", listener: (message: InspectorNotification<Runtime.ExecutionContextCreatedEventDataType>) => void): this;
-
-        /**
-         * Issued when execution context is destroyed.
-         */
-        prependOnceListener(event: "Runtime.executionContextDestroyed", listener: (message: InspectorNotification<Runtime.ExecutionContextDestroyedEventDataType>) => void): this;
-
-        /**
-         * Issued when all executionContexts were cleared in browser
-         */
-        prependOnceListener(event: "Runtime.executionContextsCleared", listener: () => void): this;
-
-        /**
-         * Issued when exception was thrown and unhandled.
-         */
-        prependOnceListener(event: "Runtime.exceptionThrown", listener: (message: InspectorNotification<Runtime.ExceptionThrownEventDataType>) => void): this;
-
-        /**
-         * Issued when unhandled exception was revoked.
-         */
-        prependOnceListener(event: "Runtime.exceptionRevoked", listener: (message: InspectorNotification<Runtime.ExceptionRevokedEventDataType>) => void): this;
-
-        /**
-         * Issued when console API was called.
-         */
-        prependOnceListener(event: "Runtime.consoleAPICalled", listener: (message: InspectorNotification<Runtime.ConsoleAPICalledEventDataType>) => void): this;
-
-        /**
-         * Issued when object should be inspected (for example, as a result of inspect() command line API call).
-         */
-        prependOnceListener(event: "Runtime.inspectRequested", listener: (message: InspectorNotification<Runtime.InspectRequestedEventDataType>) => void): this;
-
-        /**
-         * Fired when virtual machine parses script. This event is also fired for all known and uncollected scripts upon enabling debugger.
-         */
-        prependOnceListener(event: "Debugger.scriptParsed", listener: (message: InspectorNotification<Debugger.ScriptParsedEventDataType>) => void): this;
-
-        /**
-         * Fired when virtual machine fails to parse the script.
-         */
-        prependOnceListener(event: "Debugger.scriptFailedToParse", listener: (message: InspectorNotification<Debugger.ScriptFailedToParseEventDataType>) => void): this;
+        prependOnceListener(event: "Console.messageAdded", listener: (message: InspectorNotification<Console.MessageAddedEventDataType>) => void): this;
 
         /**
          * Fired when breakpoint is resolved to an actual script and location.
@@ -2440,29 +2739,74 @@ declare module "inspector" {
         prependOnceListener(event: "Debugger.resumed", listener: () => void): this;
 
         /**
-         * Issued when new console message is added.
+         * Fired when virtual machine fails to parse the script.
          */
-        prependOnceListener(event: "Console.messageAdded", listener: (message: InspectorNotification<Console.MessageAddedEventDataType>) => void): this;
+        prependOnceListener(event: "Debugger.scriptFailedToParse", listener: (message: InspectorNotification<Debugger.ScriptFailedToParseEventDataType>) => void): this;
+
+        /**
+         * Fired when virtual machine parses script. This event is also fired for all known and uncollected
+scripts upon enabling debugger.
+         */
+        prependOnceListener(event: "Debugger.scriptParsed", listener: (message: InspectorNotification<Debugger.ScriptParsedEventDataType>) => void): this;
+
+        prependOnceListener(event: "HeapProfiler.addHeapSnapshotChunk", listener: (message: InspectorNotification<HeapProfiler.AddHeapSnapshotChunkEventDataType>) => void): this;
+
+        /**
+         * If heap objects tracking has been started then backend may send update for one or more fragments
+         */
+        prependOnceListener(event: "HeapProfiler.heapStatsUpdate", listener: (message: InspectorNotification<HeapProfiler.HeapStatsUpdateEventDataType>) => void): this;
+
+        /**
+         * If heap objects tracking has been started then backend regularly sends a current value for last
+seen object id and corresponding timestamp. If the were changes in the heap since last event
+then one or more heapStatsUpdate events will be sent before a new lastSeenObjectId event.
+         */
+        prependOnceListener(event: "HeapProfiler.lastSeenObjectId", listener: (message: InspectorNotification<HeapProfiler.LastSeenObjectIdEventDataType>) => void): this;
+
+        prependOnceListener(event: "HeapProfiler.reportHeapSnapshotProgress", listener: (message: InspectorNotification<HeapProfiler.ReportHeapSnapshotProgressEventDataType>) => void): this;
+        prependOnceListener(event: "HeapProfiler.resetProfiles", listener: () => void): this;
+        prependOnceListener(event: "Profiler.consoleProfileFinished", listener: (message: InspectorNotification<Profiler.ConsoleProfileFinishedEventDataType>) => void): this;
 
         /**
          * Sent when new profile recording is started using console.profile() call.
          */
         prependOnceListener(event: "Profiler.consoleProfileStarted", listener: (message: InspectorNotification<Profiler.ConsoleProfileStartedEventDataType>) => void): this;
 
-        prependOnceListener(event: "Profiler.consoleProfileFinished", listener: (message: InspectorNotification<Profiler.ConsoleProfileFinishedEventDataType>) => void): this;
-        prependOnceListener(event: "HeapProfiler.addHeapSnapshotChunk", listener: (message: InspectorNotification<HeapProfiler.AddHeapSnapshotChunkEventDataType>) => void): this;
-        prependOnceListener(event: "HeapProfiler.resetProfiles", listener: () => void): this;
-        prependOnceListener(event: "HeapProfiler.reportHeapSnapshotProgress", listener: (message: InspectorNotification<HeapProfiler.ReportHeapSnapshotProgressEventDataType>) => void): this;
+        /**
+         * Issued when console API was called.
+         */
+        prependOnceListener(event: "Runtime.consoleAPICalled", listener: (message: InspectorNotification<Runtime.ConsoleAPICalledEventDataType>) => void): this;
 
         /**
-         * If heap objects tracking has been started then backend regularly sends a current value for last seen object id and corresponding timestamp. If the were changes in the heap since last event then one or more heapStatsUpdate events will be sent before a new lastSeenObjectId event.
+         * Issued when unhandled exception was revoked.
          */
-        prependOnceListener(event: "HeapProfiler.lastSeenObjectId", listener: (message: InspectorNotification<HeapProfiler.LastSeenObjectIdEventDataType>) => void): this;
+        prependOnceListener(event: "Runtime.exceptionRevoked", listener: (message: InspectorNotification<Runtime.ExceptionRevokedEventDataType>) => void): this;
 
         /**
-         * If heap objects tracking has been started then backend may send update for one or more fragments
+         * Issued when exception was thrown and unhandled.
          */
-        prependOnceListener(event: "HeapProfiler.heapStatsUpdate", listener: (message: InspectorNotification<HeapProfiler.HeapStatsUpdateEventDataType>) => void): this;
+        prependOnceListener(event: "Runtime.exceptionThrown", listener: (message: InspectorNotification<Runtime.ExceptionThrownEventDataType>) => void): this;
+
+        /**
+         * Issued when new execution context is created.
+         */
+        prependOnceListener(event: "Runtime.executionContextCreated", listener: (message: InspectorNotification<Runtime.ExecutionContextCreatedEventDataType>) => void): this;
+
+        /**
+         * Issued when execution context is destroyed.
+         */
+        prependOnceListener(event: "Runtime.executionContextDestroyed", listener: (message: InspectorNotification<Runtime.ExecutionContextDestroyedEventDataType>) => void): this;
+
+        /**
+         * Issued when all executionContexts were cleared in browser
+         */
+        prependOnceListener(event: "Runtime.executionContextsCleared", listener: () => void): this;
+
+        /**
+         * Issued when object should be inspected (for example, as a result of inspect() command line API
+call).
+         */
+        prependOnceListener(event: "Runtime.inspectRequested", listener: (message: InspectorNotification<Runtime.InspectRequestedEventDataType>) => void): this;
     }
 
     // Top Level API

--- a/types/node/v8/inspector.d.ts
+++ b/types/node/v8/inspector.d.ts
@@ -244,7 +244,7 @@ declare module "inspector" {
          */
         export interface CallArgument {
             /**
-             * Primitive value.
+             * Primitive value or serializable javascript object.
              */
             value?: any;
             /**
@@ -416,7 +416,7 @@ declare module "inspector" {
              */
             userGesture?: boolean;
             /**
-             * Whether execution should wait for promise to be resolved. If the result of evaluation is not a Promise, it's considered to be an error.
+             * Whether execution should <code>await</code> for resulting value and return once awaited promise is resolved.
              */
             awaitPromise?: boolean;
         }
@@ -468,7 +468,7 @@ declare module "inspector" {
              */
             userGesture?: boolean;
             /**
-             * Whether execution should wait for promise to be resolved. If the result of evaluation is not a Promise, it's considered to be an error.
+             * Whether execution should <code>await</code> for resulting value and return once awaited promise is resolved.
              */
             awaitPromise?: boolean;
         }
@@ -561,9 +561,16 @@ declare module "inspector" {
              */
             generatePreview?: boolean;
             /**
-             * Whether execution should wait for promise to be resolved. If the result of evaluation is not a Promise, it's considered to be an error.
+             * Whether execution should <code>await</code> for resulting value and return once awaited promise is resolved.
              */
             awaitPromise?: boolean;
+        }
+
+        export interface QueryObjectsParameterType {
+            /**
+             * Identifier of the prototype to return objects for.
+             */
+            prototypeObjectId: Runtime.RemoteObjectId;
         }
 
         export interface EvaluateReturnType {
@@ -634,6 +641,13 @@ declare module "inspector" {
              * Exception details.
              */
             exceptionDetails?: Runtime.ExceptionDetails;
+        }
+
+        export interface QueryObjectsReturnType {
+            /**
+             * Array with objects.
+             */
+            objects: Runtime.RemoteObject;
         }
 
         export interface ExecutionContextCreatedEventDataType {
@@ -1476,6 +1490,10 @@ declare module "inspector" {
              * Collect accurate call counts beyond simple 'covered' or 'not covered'.
              */
             callCount?: boolean;
+            /**
+             * Collect block-based coverage.
+             */
+            detailed?: boolean;
         }
 
         export interface StopReturnType {
@@ -1749,6 +1767,12 @@ declare module "inspector" {
          */
         post(method: "Runtime.runScript", params?: Runtime.RunScriptParameterType, callback?: (err: Error | null, params: Runtime.RunScriptReturnType) => void): void;
         post(method: "Runtime.runScript", callback?: (err: Error | null, params: Runtime.RunScriptReturnType) => void): void;
+
+        /**
+         * @experimental
+         */
+        post(method: "Runtime.queryObjects", params?: Runtime.QueryObjectsParameterType, callback?: (err: Error | null, params: Runtime.QueryObjectsReturnType) => void): void;
+        post(method: "Runtime.queryObjects", callback?: (err: Error | null, params: Runtime.QueryObjectsReturnType) => void): void;
         /**
          * Enables debugger for the given page. Clients should not assume that the debugging has been enabled until the result for this command is received.
          */

--- a/types/node/v9/inspector.d.ts
+++ b/types/node/v9/inspector.d.ts
@@ -244,7 +244,7 @@ declare module "inspector" {
          */
         export interface CallArgument {
             /**
-             * Primitive value.
+             * Primitive value or serializable javascript object.
              */
             value?: any;
             /**
@@ -416,7 +416,7 @@ declare module "inspector" {
              */
             userGesture?: boolean;
             /**
-             * Whether execution should wait for promise to be resolved. If the result of evaluation is not a Promise, it's considered to be an error.
+             * Whether execution should <code>await</code> for resulting value and return once awaited promise is resolved.
              */
             awaitPromise?: boolean;
         }
@@ -468,7 +468,7 @@ declare module "inspector" {
              */
             userGesture?: boolean;
             /**
-             * Whether execution should wait for promise to be resolved. If the result of evaluation is not a Promise, it's considered to be an error.
+             * Whether execution should <code>await</code> for resulting value and return once awaited promise is resolved.
              */
             awaitPromise?: boolean;
         }
@@ -561,9 +561,23 @@ declare module "inspector" {
              */
             generatePreview?: boolean;
             /**
-             * Whether execution should wait for promise to be resolved. If the result of evaluation is not a Promise, it's considered to be an error.
+             * Whether execution should <code>await</code> for resulting value and return once awaited promise is resolved.
              */
             awaitPromise?: boolean;
+        }
+
+        export interface QueryObjectsParameterType {
+            /**
+             * Identifier of the prototype to return objects for.
+             */
+            prototypeObjectId: Runtime.RemoteObjectId;
+        }
+
+        export interface GlobalLexicalScopeNamesParameterType {
+            /**
+             * Specifies in which execution context to lookup global scope variables.
+             */
+            executionContextId?: Runtime.ExecutionContextId;
         }
 
         export interface EvaluateReturnType {
@@ -634,6 +648,17 @@ declare module "inspector" {
              * Exception details.
              */
             exceptionDetails?: Runtime.ExceptionDetails;
+        }
+
+        export interface QueryObjectsReturnType {
+            /**
+             * Array with objects.
+             */
+            objects: Runtime.RemoteObject;
+        }
+
+        export interface GlobalLexicalScopeNamesReturnType {
+            names: string[];
         }
 
         export interface ExecutionContextCreatedEventDataType {
@@ -1476,6 +1501,10 @@ declare module "inspector" {
              * Collect accurate call counts beyond simple 'covered' or 'not covered'.
              */
             callCount?: boolean;
+            /**
+             * Collect block-based coverage.
+             */
+            detailed?: boolean;
         }
 
         export interface StopReturnType {
@@ -1749,6 +1778,19 @@ declare module "inspector" {
          */
         post(method: "Runtime.runScript", params?: Runtime.RunScriptParameterType, callback?: (err: Error | null, params: Runtime.RunScriptReturnType) => void): void;
         post(method: "Runtime.runScript", callback?: (err: Error | null, params: Runtime.RunScriptReturnType) => void): void;
+
+        /**
+         * @experimental
+         */
+        post(method: "Runtime.queryObjects", params?: Runtime.QueryObjectsParameterType, callback?: (err: Error | null, params: Runtime.QueryObjectsReturnType) => void): void;
+        post(method: "Runtime.queryObjects", callback?: (err: Error | null, params: Runtime.QueryObjectsReturnType) => void): void;
+
+        /**
+         * Returns all let, const and class variables from global scope.
+         * @experimental
+         */
+        post(method: "Runtime.globalLexicalScopeNames", params?: Runtime.GlobalLexicalScopeNamesParameterType, callback?: (err: Error | null, params: Runtime.GlobalLexicalScopeNamesReturnType) => void): void;
+        post(method: "Runtime.globalLexicalScopeNames", callback?: (err: Error | null, params: Runtime.GlobalLexicalScopeNamesReturnType) => void): void;
         /**
          * Enables debugger for the given page. Clients should not assume that the debugging has been enabled until the result for this command is received.
          */


### PR DESCRIPTION
This updates Node Inspector types to those of V8 6.2 (for Node 8.11.3 and 9.11.2) and 6.7 (for Node 10.8.0). See the doc links at the bottom for confirmation of V8 versions.

The Node 10 diff is large because the schema had its items re-ordered (possibly alphabetically). The re-order itself shouldn't have any impact on type interfaces.

Generated with [this tool](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/node/scripts/generate-inspector).

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  * https://github.com/nodejs/node/blob/v10.8.0/deps/v8/src/inspector/js_protocol.json
  * https://nodejs.org/en/download/releases/

@eyqs FYI