### PR TITLE
[moo] Allow rules to consist of an array of sub-rules

### DIFF
--- a/types/moo/index.d.ts
+++ b/types/moo/index.d.ts
@@ -50,7 +50,7 @@ export interface Rule {
     };
 }
 export interface Rules {
-    [x: string]: RegExp | string | string[] | Rule;
+    [x: string]: RegExp | string | string[] | Rule | Rule[];
 }
 
 export interface Lexer {

--- a/types/moo/moo-tests.ts
+++ b/types/moo/moo-tests.ts
@@ -75,3 +75,13 @@ lexer.next();
 lexer.next();
 lexer.reset('a different line\n', info);
 lexer.next();
+
+// Transform: https://github.com/no-context/moo#transform
+moo.compile({
+    STRING: [
+        { match: /"""[^]*?"""/, lineBreaks: true, value: x => x.slice(3, -3) },
+        { match: /"(?:\\["\\rn]|[^"\\])*?"/, lineBreaks: true, value: x => x.slice(1, -1) },
+        { match: /'(?:\\['\\rn]|[^'\\])*?'/, lineBreaks: true, value: x => x.slice(1, -1) },
+    ],
+    // ...
+});


### PR DESCRIPTION
The current type definitions don't allow an element of Rules to be an array of Rule, however the documentation for moo show that this is allowed.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/no-context/moo#transform
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
