### PR TITLE
Adds generic Query parameter to next.js's router

### DIFF
--- a/types/next/app.d.ts
+++ b/types/next/app.d.ts
@@ -1,19 +1,19 @@
 import * as React from "react";
 import { NextContext } from ".";
-import { RouterProps } from "./router";
+import { RouterProps, DefaultQuery } from "./router";
 
-export interface AppComponentProps {
+export interface AppComponentProps<Q = DefaultQuery> {
     Component: React.ComponentType<any>;
-    router: RouterProps;
+    router: RouterProps<Q>;
     pageProps: any;
 }
 
-export interface AppComponentContext {
+export interface AppComponentContext<Q = DefaultQuery> {
     Component: React.ComponentType<any>;
-    router: RouterProps;
-    ctx: NextContext;
+    router: RouterProps<Q>;
+    ctx: NextContext<Q>;
 }
 
-export class Container extends React.Component {}
+export class Container extends React.Component { }
 
-export default class App<TProps = {}> extends React.Component<TProps & AppComponentProps> {}
+export default class App<TProps = {}, Q = DefaultQuery> extends React.Component<TProps & AppComponentProps<Q>> { }

--- a/types/next/index.d.ts
+++ b/types/next/index.d.ts
@@ -24,11 +24,11 @@ declare namespace next {
      * Context object used in methods like `getInitialProps()`
      * <<https://github.com/zeit/next.js/issues/1651>>
      */
-    interface NextContext {
+    interface NextContext<Q = QueryStringMapObject> {
         /** path section of URL */
         pathname: string;
         /** query string section of URL parsed as an object */
-        query: QueryStringMapObject;
+        query: Q;
         /** String of the actual path (including the query) shows in the browser */
         asPath: string;
         /** HTTP request object (server only) */

--- a/types/next/index.d.ts
+++ b/types/next/index.d.ts
@@ -43,10 +43,10 @@ declare namespace next {
         isServer?: boolean;
     }
 
-    type NextSFC<TProps = {}> = NextStatelessComponent<TProps>;
-    interface NextStatelessComponent<TProps = {}>
+    type NextSFC<TProps = {}, Q = QueryStringMapObject> = NextStatelessComponent<TProps, Q>;
+    interface NextStatelessComponent<TProps = {}, Q = QueryStringMapObject>
         extends React.StatelessComponent<TProps> {
-        getInitialProps?: (ctx: NextContext) => Promise<TProps>;
+        getInitialProps?: (ctx: NextContext<Q>) => Promise<TProps>;
     }
 
     type UrlLike = url.UrlObject | url.Url;

--- a/types/next/router.d.ts
+++ b/types/next/router.d.ts
@@ -90,8 +90,12 @@ export interface WithRouterProps<Q = DefaultQuery> {
     router: SingletonRouter<Q>;
 }
 
-export function withRouter<T extends {}>(
-    Component: React.ComponentType<T & WithRouterProps>,
+// Manually disabling the no-unnecessary-generics rule so users can
+// retain type inference if they warp their component in withRouter
+// without defining props explicitly
+export function withRouter<T extends {}, Q = DefaultQuery>(
+    // tslint:disable-next-line:no-unnecessary-generics
+    Component: React.ComponentType<T & WithRouterProps<Q>>,
 ): React.ComponentType<T>;
 
 declare const Router: SingletonRouter;

--- a/types/next/router.d.ts
+++ b/types/next/router.d.ts
@@ -26,20 +26,22 @@ export type PopStateCallback = (state: any) => boolean | undefined;
 
 export type RouterCallback = () => void;
 
-export interface RouterProps {
+interface DefaultQuery {
+    [key: string]:
+    | boolean
+    | boolean[]
+    | number
+    | number[]
+    | string
+    | string[];
+}
+
+export interface RouterProps<Q = DefaultQuery> {
     // url property fields
     readonly pathname: string;
     readonly route: string;
     readonly asPath?: string;
-    readonly query?: {
-        [key: string]:
-            | boolean
-            | boolean[]
-            | number
-            | number[]
-            | string
-            | string[];
-    };
+    readonly query?: Q;
 
     // property fields
     readonly components: {
@@ -78,14 +80,14 @@ export interface RouterProps {
     };
 }
 
-export interface SingletonRouter extends RouterProps {
-    router: RouterProps | null;
+export interface SingletonRouter<Q = DefaultQuery> extends RouterProps<Q> {
+    router: RouterProps<Q> | null;
     readyCallbacks: RouterCallback[];
     ready(cb: RouterCallback): void;
 }
 
-export interface WithRouterProps {
-    router: SingletonRouter;
+export interface WithRouterProps<Q = DefaultQuery> {
+    router: SingletonRouter<Q>;
 }
 
 export function withRouter<T extends {}>(

--- a/types/next/router.d.ts
+++ b/types/next/router.d.ts
@@ -26,7 +26,7 @@ export type PopStateCallback = (state: any) => boolean | undefined;
 
 export type RouterCallback = () => void;
 
-interface DefaultQuery {
+export interface DefaultQuery {
     [key: string]:
     | boolean
     | boolean[]

--- a/types/next/test/next-router-tests.tsx
+++ b/types/next/test/next-router-tests.tsx
@@ -96,3 +96,13 @@ class TestComponent extends React.Component<TestComponentProps & WithRouterProps
 }
 
 withRouter(TestComponent);
+
+interface TestSFCQuery {
+    test?: string;
+}
+
+interface TestSFCProps extends WithRouterProps<TestSFCQuery> { }
+
+const TestSFC: React.SFC<TestSFCProps> = ({ router }) => {
+    return <div>{router.query && router.query.test}</div>;
+};


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [ ] ~Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>~
- [ ] Increase the version number in the header if appropriate.
^ *Not sure if this is located* 
- [ ] ~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.~

I was looking for a simple solution to get static typings for the `query` object passed down from the router. With next using the query object instead of route params, it seems to make sense to give some option to type it, if for nothing else than documentation :D

Proposed useage would be like this:

```tsx
import { withRouter, WithRouterProps } from 'next/router'

interface Query {
  blogId?: string
}

// The new generic type is optional, defaulting to the existing behavior
interface Props extends WithRouterProps<Query> {}

const Blog: React.SFC<Props> = ({ router }) => {
  // Here router.query autocompletes to blogId
  return <div>Blog {router.query && router.query.blogId}</div>
}

export default withRouter(Blog)
```

Thoughts? I didn't find a clean way to type the query object and thought this may be useful for others too. 

One small snag, I wasn't able to add the generic to `withRouter` without the linter yelling at me for single use generics. If you like the idea, I will play more to get `withRouter` typed similarly.

Perhaps another place to add this would be the `NextContext` object as well as the query is passed to `getInitialProps`.