### PR TITLE
feat(better-scroll): add typings

### DIFF
--- a/notNeededPackages.json
+++ b/notNeededPackages.json
@@ -157,12 +157,6 @@
             "asOfVersion": "2.0.0"
         },
         {
-            "libraryName": "better-scroll",
-            "typingsPackageName": "better-scroll",
-            "sourceRepoURL": "https://github.com/ustbhuangyi/better-scroll",
-            "asOfVersion": "1.5.0"
-        },
-        {
             "libraryName": "BigInteger.js",
             "typingsPackageName": "big-integer",
             "sourceRepoURL": "https://github.com/peterolson/BigInteger.js",

--- a/types/better-scroll/better-scroll-tests.ts
+++ b/types/better-scroll/better-scroll-tests.ts
@@ -1,0 +1,68 @@
+import BScroll from 'better-scroll';
+
+const BScroll1 = new BScroll('#wrapper');
+const BScroll2 = new BScroll('#wrapper', { scrollX: false, scrollY: false });
+const BScroll3 = new BScroll('#wrapper', {
+    snap: true,
+    wheel: false,
+    scrollbar: false,
+    pullDownRefresh: false,
+});
+const BScroll4 = new BScroll('#wrapper', {
+    wheel: {
+        selectedIndex: 0,
+    },
+});
+const BScroll6 = new BScroll('#wrapper', {
+    snap: {
+        loop: false,
+        el: document.querySelector('div-test') as Element,
+        threshold: 0.1,
+        stepX: 100,
+        stepY: 100,
+        listenFlick: true,
+    },
+});
+const BScroll7 = new BScroll('#wrapper', {
+    scrollbar: {
+        fade: true,
+    },
+});
+
+const BScroll8 = new BScroll('#wrapper', {
+    pullDownRefresh: {
+        threshold: 50,
+        stop: 20,
+    },
+});
+
+BScroll1.refresh();
+BScroll1.scrollTo(0, 100);
+BScroll1.scrollTo(0, 100, 200);
+
+BScroll1.scrollToElement('selectedElement');
+BScroll1.scrollToElement('selectedElement', 250);
+
+BScroll1.scrollToElement(document.getElementById('selectedElement') as HTMLElement);
+BScroll1.scrollToElement(document.getElementById('selectedElement') as HTMLElement, 250);
+
+BScroll2.on('scrollStart', () => { console.log('scroll started'); });
+
+const BScroll9 = new BScroll(document.getElementById('wrapper') as HTMLElement);
+const BScroll10 = new BScroll(document.getElementById('wrapper') as HTMLElement, { freeScroll: true });
+const BScroll11 = new BScroll(document.getElementById('wrapper') as HTMLElement, {
+    preventDefaultException: {
+        tagName: /^(INPUT|TEXTAREA|BUTTON|SELECT)$/,
+    },
+});
+const BScroll12 = new BScroll(document.getElementById('wrapper') as HTMLElement, {
+    preventDefaultException: {
+        className: /(^|\s)test(\s|$)/,
+    },
+});
+
+const BScroll13 = new BScroll(document.getElementById('wrapper') as HTMLElement, {
+    swipeBounceTime: 1000,
+});
+
+const BScroll14 = new BScroll('#wrapper', { disableMouse: true, disableTouch: false });

--- a/types/better-scroll/index.d.ts
+++ b/types/better-scroll/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for better-scroll 1.12
 // Project: https://github.com/ustbhuangyi/better-scroll
-// Definitions by: My Self <https://github.com/me>
+// Definitions by: cloudstone <https://github.com/stoneChen>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 // TypeScript Version: 2.2

--- a/types/better-scroll/index.d.ts
+++ b/types/better-scroll/index.d.ts
@@ -1,0 +1,238 @@
+// Type definitions for better-scroll 1.12
+// Project: https://github.com/ustbhuangyi/better-scroll
+// Definitions by: My Self <https://github.com/me>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+// TypeScript Version: 2.2
+export interface WheelOption {
+    selectedIndex: number;
+    rotate: number;
+    adjustTime: number;
+    wheelWrapperClass: string;
+    wheelItemClass: string;
+}
+
+export interface PageOption {
+    x: number;
+    y: number;
+    pageX: number;
+    pageY: number;
+}
+
+export interface SlideOption {
+    loop: boolean;
+    el: Element;
+    threshold: number;
+    stepX: number;
+    stepY: number;
+    speed: number;
+    listenFlick: boolean;
+}
+
+export interface ScrollBarOption {
+    fade: boolean;
+}
+
+export interface PullDownOption {
+    threshold: number;
+    stop: number;
+}
+
+export interface PullUpOption {
+    threshold: number;
+}
+
+export interface BounceObjectOption {
+    top?: boolean;
+    bottom?: boolean;
+    left?: boolean;
+    right?: boolean;
+}
+
+export interface EaseOption {
+    swipe?: {
+        style: string;
+        fn: (t: number) => number;
+    };
+    swipeBounce?: {
+        style: string;
+        fn: (t: number) => number;
+    };
+    bounce?: {
+        style: string;
+        fn: (t: number) => number;
+    };
+}
+
+export interface BsOption {
+    startX: number;
+    startY: number;
+    scrollX: boolean;
+    scrollY: boolean;
+    freeScroll: boolean;
+    directionLockThreshold: number;
+    eventPassthrough: string | boolean;
+    click: boolean;
+    tap: boolean;
+    bounce: boolean | BounceObjectOption;
+    bounceTime: number;
+    momentum: boolean;
+    momentumLimitTime: number;
+    momentumLimitDistance: number;
+    swipeTime: number;
+    swipeBounceTime: number;
+    deceleration: number;
+    flickLimitTime: number;
+    flickLimitDistance: number;
+    resizePolling: number;
+    probeType: number;
+    preventDefault: boolean;
+    preventDefaultException: object;
+    HWCompositing: boolean;
+    useTransition: boolean;
+    useTransform: boolean;
+    bindToWrapper: boolean;
+    disableMouse: boolean;
+    disableTouch: boolean;
+    observeDOM: boolean;
+    autoBlur: boolean;
+    stopPropagation: boolean;
+    /**
+     * for picker
+     * wheel: {
+     *   selectedIndex: 0,
+     *   rotate: 25,
+     *   adjustTime: 400
+     * }
+     */
+    wheel: Partial<WheelOption> | boolean;
+    /**
+     * for slide
+     * snap: {
+     *   loop: boolean,
+     *   el: domEl,
+     *   threshold: 0.1,
+     *   stepX: 100,
+     *   stepY: 100,
+     *   listenFlick: true
+     * }
+     */
+    snap: Partial<SlideOption> | boolean;
+    /**
+     * for scrollbar
+     * scrollbar: {
+     *   fade: true
+     * }
+     */
+    scrollbar: Partial<ScrollBarOption> | boolean;
+    /**
+     * for pull down and refresh
+     * pullDownRefresh: {
+     *   threshold: 50,
+     *   stop: 20
+     * }
+     */
+    pullDownRefresh: Partial<PullDownOption> | boolean;
+    /**
+     * for pull up and load
+     * pullUpLoad: {
+     *   threshold: 50
+     * }
+     */
+    pullUpLoad: Partial<PullUpOption> | boolean;
+}
+
+export interface Position {
+    x: number;
+    y: number;
+}
+
+export default class BScroll {
+    constructor(element: Element | string, options?: Partial<BsOption>);
+
+    x: number;
+    y: number;
+    maxScrollX: number;
+    maxScrollY: number;
+    movingDirectionX: number;
+    movingDirectionY: number;
+    directionX: number;
+    directionY: number;
+    enabled: boolean;
+    isInTransition: boolean;
+    isAnimating: boolean;
+    options: BsOption;
+
+    refresh(): void;
+
+    enable(): void;
+
+    disable(): void;
+
+    scrollBy(x: number, y: number, time?: number, easing?: object): void;
+
+    scrollTo(x: number, y: number, time?: number, easing?: object): void;
+
+    scrollToElement(el: HTMLElement | string, time?: number, offsetX?: number | boolean, offsetY?: number | boolean, easing?: object): void;
+
+    stop(): void;
+
+    destroy(): void;
+
+    goToPage(x: number, y: number, time?: number, easing?: object): void;
+
+    next(time?: number, easing?: object): void;
+
+    prev(time?: number, easing?: object): void;
+
+    getCurrentPage(): PageOption;
+
+    wheelTo(index: number): void;
+
+    getSelectedIndex(): number;
+
+    finishPullDown(): void;
+
+    finishPullUp(): void;
+
+    on(
+        type:
+            'beforeScrollStart' |
+            'scrollStart' |
+            'scrollCancel' |
+            'beforeScrollStart' |
+            'flick' |
+            'refresh' |
+            'destroy' |
+            'pullingDown' |
+            'pullingUp',
+        fn: () => any
+    ): void;
+
+    on(
+        type:
+            'scroll' |
+            'scrollEnd' |
+            'touchEnd',
+        fn: (pos: Position) => any
+    ): void;
+
+    off(
+        type:
+            'beforeScrollStart' |
+            'scrollStart' |
+            'scroll' |
+            'scrollCancel' |
+            'beforeScrollStart' |
+            'scrollEnd' |
+            'touchEnd' |
+            'flick' |
+            'refresh' |
+            'destroy' |
+            'pullingDown' |
+            'pullingUp',
+        fn: (...args: any[]) => void
+    ): void;
+
+    trigger(type: string): void;
+}

--- a/types/better-scroll/tsconfig.json
+++ b/types/better-scroll/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "better-scroll-tests.ts"
+    ]
+}

--- a/types/better-scroll/tslint.json
+++ b/types/better-scroll/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
The package(written in js) now has its own definition file(it had ever have `@types/better-scroll`), but it is maintained all by other ts users. It is not convenient for the author to merge this type of PR frequently.

I had reach an agreement with the  author. He prefer to moving the definition into `@types`, and maintained by ts users.

Once the new `@types/better-scroll` has been published, I will make another PR to the original package removing the definition in the package itself(and also docs).

Thanks.