### PR TITLE
@types/ember: fix incorrect argument type of Application.register

### DIFF
--- a/types/ember/index.d.ts
+++ b/types/ember/index.d.ts
@@ -332,7 +332,11 @@ declare module 'ember' {
              * `inject`) or for service lookup. Each factory is registered with
              * a full name including two parts: `type:name`.
              */
-            register(fullName: string, factory: any, options?: { singleton?: boolean, instantiate?: boolean }): any;
+            register(
+                fullName: string,
+                factory: any,
+                options?: { singleton?: boolean, instantiate?: boolean }
+            ): any;
             /**
              * Unregister a factory.
              */
@@ -428,10 +432,12 @@ declare module 'ember' {
             injectTestHelpers(): void;
             /**
             registers a factory for later injection
-            @param fullName type:name (e.g., 'model:user')
-            @param factory (e.g., App.Person)
             **/
-            register(fullName: string, factory: object, options?: {}): void;
+            register(
+                fullName: string,
+                factory: any,
+                options?: { singleton?: boolean, instantiate?: boolean }
+            ): void;
             /**
             This removes all helpers that have been registered, and resets and functions
             that were overridden by the helpers.
@@ -1816,8 +1822,8 @@ declare module 'ember' {
         class Registry {
             register(
                 fullName: string,
-                factory: EmberClassConstructor<any>,
-                options?: { singleton?: boolean }
+                factory: any,
+                options?: { singleton?: boolean, instantiate?: boolean }
             ): void;
         }
         class Resolver extends Ember.Object {}

--- a/types/ember/index.d.ts
+++ b/types/ember/index.d.ts
@@ -431,7 +431,7 @@ declare module 'ember' {
             @param fullName type:name (e.g., 'model:user')
             @param factory (e.g., App.Person)
             **/
-            register(fullName: string, factory: Function, options?: {}): void;
+            register(fullName: string, factory: object, options?: {}): void;
             /**
             This removes all helpers that have been registered, and resets and functions
             that were overridden by the helpers.


### PR DESCRIPTION
Please fill in this template.

- [ ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.

---

According https://guides.emberjs.com/release/applications/dependency-injection/#toc_registering-already-instantiated-objects:

> When registering an already instantiated object instead of a class, use the instantiate: false option to avoid attempts to re-instantiate it during lookups.

so an `object` should be more appropriate than `Function` type for the `factory` argument in `Application.register`, this PR will address this issue.