### PR TITLE
[@types/styled-system] enable transformValue to take a parameter

### DIFF
--- a/types/styled-system/dist/util.d.ts
+++ b/types/styled-system/dist/util.d.ts
@@ -19,7 +19,7 @@ export interface LowLevelStylefunctionArguments {
     cssProperty?: string;
     key?: string;
     getter?: () => any;
-    transformValue?: () => any;
+    transformValue?: (n: string|number) => any;
     scale?: Array<string|number>;
 }
 

--- a/types/styled-system/index.d.ts
+++ b/types/styled-system/index.d.ts
@@ -7,7 +7,6 @@
 //                 Eloy Durán <https://github.com/alloy>
 //                 Matthieu Vachon <https://github.com/maoueh>
 //                 Adam Lavin <https://github.com/lavoaster>
-//                 Nicholas Pappagalo <https://github.com/nicholaai>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 

--- a/types/styled-system/index.d.ts
+++ b/types/styled-system/index.d.ts
@@ -7,6 +7,7 @@
 //                 Eloy Durán <https://github.com/alloy>
 //                 Matthieu Vachon <https://github.com/maoueh>
 //                 Adam Lavin <https://github.com/lavoaster>
+//                 Nicholas Pappagalo <https://github.com/nicholaai>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/jxnblk/styled-system/blob/b2a877b34c8e8f86580656866291a33295d7ee13/docs/api.md#style>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

The `styled` utility function behaves like so 

```js
const fontSize = style({
  // React prop name
  prop: 'fontSize',
  // The corresponding CSS property (defaults to prop argument)
  cssProperty: 'fontSize',
  // key for theme values
  key: 'fontSizes',
  // accessor function for transforming the value
  transformValue: n => n + 'px',
  // add a fallback scale object or array, if theme is not present
  scale: [ 0, 4, 8, 16, 32 ]
})
```

Here, `transformValue` accepts a prop and returns a value. So, you pass in a param, like the number 8, and the function would return the result

```
transformValue: (8) => 8 + 'px'
=> 8px`
```

style utilizes interface LowLevelStylefunctionArguments: 

```js
export interface LowLevelStylefunctionArguments {
    prop: string;
    cssProperty?: string;
    key?: string;
    getter?: () => any;
    transformValue?: () => any;
    scale?: Array<string|number>;
}
```

So, if you try to do the following:

```js
const fontSize = (p: ITest) =>
    p.fontSize
        ? style({
              cssProperty: 'fontSize',
              key: 'fontSizes',
              prop: 'fontSize',
              transformValue: n => n + 'px'
          })
        : { fontSize: `${p.theme.fontSizes[2]}px` };
```

You'll fail to compile with the following error
```
/Users/pathContinued....
(25,17): Argument of type '{ cssProperty: string; key: string; prop: string; transformValue: (n: any) => string; }' is not assignable to parameter of type 'LowLevelStylefunctionArguments'.
  Types of property 'transformValue' are incompatible.
    Type '(n: any) => string' is not assignable to type '() => any'.
```

I've updated the type for `transformValue` like so:

```js
transformValue?: (n: string|number) => any;
```

`string|number` is used as those are the acceptable types for `scale`, which is a fallback if you don't have a theme property set for your `key`

This change allows the app to compile and perform as expected. 

![screen shot 2018-08-11 at 11 46 57 am](https://user-images.githubusercontent.com/8497422/43995189-8d50ea38-9d5e-11e8-8b6c-fc0f0a318e7e.png)



