### PR TITLE
Added type definitions for koa-redis-cache

### DIFF
--- a/types/koa-redis-cache/index.d.ts
+++ b/types/koa-redis-cache/index.d.ts
@@ -1,0 +1,93 @@
+// Type definitions for koa-redis-cache 3.0.1
+// Project: https://github.com/coderhaoxin/koa-redis-cache
+// Definitions by: Dima Mukhin <https://github.com/dimamukhin>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import * as Koa from "koa";
+import * as Redis from "redis";
+
+type onErrorCallback = (error: Error) => void;
+
+type getPrefixCallback = (ctx: Koa.Context) => String;
+
+declare namespace cache {
+    interface CacheOptions {
+        /**
+         * redis key prefix, default is koa-redis-cache:
+         * If a function is supplied, its signature should be function(ctx) {} and it should return a string to use as the redis key prefix
+         */
+        prefix?: String | getPrefixCallback;
+
+        /**
+         * redis expire time (second), default is 30 * 60 (30 min)
+         */
+        expire?: Number;
+
+        /**
+         * if the passParam exists in the query string, skip the cache
+         */
+        passParam?: String;
+
+        /**
+         * max length of body size (in bytes) to cache.
+         * if the size of the body exceeds maxLength, the body will not be cached.
+         * default is: Infinity
+         */
+        maxLength?: Number;
+
+        /**
+         * the routes to cache, default is ['(.*)'].
+         * can be set to an array of routes (String), or an array of RouteOptions
+         */
+        routes?: Array<RouteOptions> | Array<String>;
+
+        /**
+         * the routes to exclude, default is [].
+         * example: ['/api/(.*)', '/view/:id']
+         */
+        exclude?: Array<String>;
+
+        /**
+         * callback function for error, default is function() {}
+         */
+        onerror?: onErrorCallback;
+
+        /**
+         * redis options
+         */
+        redis?: RedisOptions;
+    }
+
+    interface RouteOptions {
+        /**
+         * the route to cache, example: '/api/(.*)'
+         */
+        route: String;
+
+        /**
+         * expiration time in seconds for cached responses for the route
+         */
+        expire?: Number;
+    }
+
+    interface RedisOptions {
+        /**
+         * host name of the redis server, default: 'localhost'
+         */
+        host?: String,
+
+        /**
+         * port number of the redis server, default: 6379
+         */
+        port?: Number,
+
+        /**
+         * node_redis options
+         */
+        options?: Redis.ClientOpts
+    }
+}
+
+declare function cache(opts?: cache.CacheOptions): Koa.Middleware;
+
+export = cache;

--- a/types/koa-redis-cache/index.d.ts
+++ b/types/koa-redis-cache/index.d.ts
@@ -1,14 +1,15 @@
-// Type definitions for koa-redis-cache 3.0.1
+// Type definitions for koa-redis-cache 3.0
 // Project: https://github.com/coderhaoxin/koa-redis-cache
 // Definitions by: Dima Mukhin <https://github.com/dimamukhin>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
 
 import * as Koa from "koa";
 import * as Redis from "redis";
 
 type onErrorCallback = (error: Error) => void;
 
-type getPrefixCallback = (ctx: Koa.Context) => String;
+type getPrefixCallback = (ctx: Koa.Context) => string;
 
 declare namespace cache {
     interface CacheOptions {
@@ -16,36 +17,36 @@ declare namespace cache {
          * redis key prefix, default is koa-redis-cache:
          * If a function is supplied, its signature should be function(ctx) {} and it should return a string to use as the redis key prefix
          */
-        prefix?: String | getPrefixCallback;
+        prefix?: string | getPrefixCallback;
 
         /**
          * redis expire time (second), default is 30 * 60 (30 min)
          */
-        expire?: Number;
+        expire?: number;
 
         /**
          * if the passParam exists in the query string, skip the cache
          */
-        passParam?: String;
+        passParam?: string;
 
         /**
          * max length of body size (in bytes) to cache.
          * if the size of the body exceeds maxLength, the body will not be cached.
          * default is: Infinity
          */
-        maxLength?: Number;
+        maxLength?: number;
 
         /**
          * the routes to cache, default is ['(.*)'].
-         * can be set to an array of routes (String), or an array of RouteOptions
+         * can be set to an array of routes (string), or an array of RouteOptions
          */
-        routes?: Array<RouteOptions> | Array<String>;
+        routes?: RouteOptions[] | string[];
 
         /**
          * the routes to exclude, default is [].
          * example: ['/api/(.*)', '/view/:id']
          */
-        exclude?: Array<String>;
+        exclude?: string[];
 
         /**
          * callback function for error, default is function() {}
@@ -62,29 +63,29 @@ declare namespace cache {
         /**
          * the route to cache, example: '/api/(.*)'
          */
-        route: String;
+        route: string;
 
         /**
          * expiration time in seconds for cached responses for the route
          */
-        expire?: Number;
+        expire?: number;
     }
 
     interface RedisOptions {
         /**
          * host name of the redis server, default: 'localhost'
          */
-        host?: String,
+        host?: string;
 
         /**
          * port number of the redis server, default: 6379
          */
-        port?: Number,
+        port?: number;
 
         /**
          * node_redis options
          */
-        options?: Redis.ClientOpts
+        options?: Redis.ClientOpts;
     }
 }
 

--- a/types/koa-redis-cache/koa-redis-cache-tests.ts
+++ b/types/koa-redis-cache/koa-redis-cache-tests.ts
@@ -1,0 +1,34 @@
+import * as Koa from "koa";
+import * as cache from 'koa-redis-cache';
+
+const app = new Koa();
+
+const routeOptions: Array<cache.RouteOptions> = [
+    {
+        route: '/api/test',
+        expire: 60
+    },
+    {
+        route: '/api/users'
+    }
+];
+
+const redisOptions: cache.RedisOptions = {
+    port: 6379,
+    host: 'localhost'
+};
+
+const options: cache.CacheOptions = {
+    prefix: (ctx: Koa.Context) => 'koa-redis-cache:',
+    expire: 30 * 30,
+    passParam: 'skip',
+    maxLength: 1024,
+    routes: routeOptions,
+    exclude: ['/api/(.*)', '/view/:id'],
+    onerror: (error: Error) => console.log(error),
+    redis: redisOptions
+};
+
+app.use(cache(options));
+
+app.listen(80);

--- a/types/koa-redis-cache/koa-redis-cache-tests.ts
+++ b/types/koa-redis-cache/koa-redis-cache-tests.ts
@@ -3,7 +3,7 @@ import * as cache from 'koa-redis-cache';
 
 const app = new Koa();
 
-const routeOptions: Array<cache.RouteOptions> = [
+const routeOptions: cache.RouteOptions[] = [
     {
         route: '/api/test',
         expire: 60

--- a/types/koa-redis-cache/tsconfig.json
+++ b/types/koa-redis-cache/tsconfig.json
@@ -7,6 +7,7 @@
         "noImplicitAny": true,
         "noImplicitThis": true,
         "strictNullChecks": true,
+        "strictFunctionTypes": true,
         "baseUrl": "../",
         "typeRoots": [
             "../"

--- a/types/koa-redis-cache/tsconfig.json
+++ b/types/koa-redis-cache/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "koa-redis-cache-tests.ts"
+    ]
+}

--- a/types/koa-redis-cache/tslint.json
+++ b/types/koa-redis-cache/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project. (note: I had to look into existing projects to fix problems with `dts-gen --dt`)
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
