### PR TITLE
fix(yargs): type 'string' is not assignable to type '"string"'

### DIFF
--- a/types/yargs/index.d.ts
+++ b/types/yargs/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for yargs 11.1
+// Type definitions for yargs 11.2
 // Project: https://github.com/chevex/yargs
 // Definitions by: Martin Poelstra <https://github.com/poelstra>
 //                 Mizunashi Mana <https://github.com/mizunashi-mana>
@@ -282,7 +282,7 @@ declare namespace yargs {
         requiresArg?: boolean;
         skipValidation?: boolean;
         string?: boolean;
-        type?: "array" | "count" | PositionalOptionsType;
+        type?: string;
     }
 
     interface PositionalOptions {


### PR DESCRIPTION
Reasoning for change. There is logic built into the interface Options where the property of types must be either the value of "string", "number" , etc. However, the type of the input is just a string. Having the logic built in makes it unusable.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [X] Increase the version number in the header if appropriate.
