### PR TITLE
Revert incompatible changes from #27796

### DIFF
--- a/types/webcomponents.js/index.d.ts
+++ b/types/webcomponents.js/index.d.ts
@@ -36,7 +36,7 @@ export interface Polyfill {
 declare global {
     // This contains duplicates of some types in lib.dom.d.ts in order to support typescript 2.0
     interface ElementDefinitionOptions {
-        extends?: string;
+        extends: string;
     }
 
     interface ShadowRoot extends DocumentFragment {


### PR DESCRIPTION
`lib.dom.d.ts` defines `extends` as mandatory since TypeScript version 2.9: https://github.com/Microsoft/TypeScript/blob/fe387cc7f0739256337771e62398a565fbcf82c1/lib/lib.dom.d.ts#L5160

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/Microsoft/TypeScript/blob/fe387cc7f0739256337771e62398a565fbcf82c1/lib/lib.dom.d.ts#L5160>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.