### PR TITLE
[mssql] Add typings for "mssql/msnodesqlv8"

### DIFF
--- a/types/mssql/index.d.ts
+++ b/types/mssql/index.d.ts
@@ -8,6 +8,7 @@
 //                 Peter Keuter <https://github.com/pkeuter>
 //                 David Gasperoni <https://github.com/mcdado>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.1
 
 /// <reference types="node" />
 

--- a/types/mssql/msnodesqlv8.d.ts
+++ b/types/mssql/msnodesqlv8.d.ts
@@ -1,0 +1,2 @@
+// Export the same API as index.d.ts (which implicitly uses the "msnodesqlv8" driver):
+export * from '.';

--- a/types/mssql/mssql-tests.ts
+++ b/types/mssql/mssql-tests.ts
@@ -1,4 +1,5 @@
 import * as sql from 'mssql';
+import * as msnodesqlv8 from 'mssql/msnodesqlv8';
 
 interface Entity {
     value: number;
@@ -202,4 +203,11 @@ function test_classes_extend_eventemitter() {
     request.on('error', () => { });
 
     preparedStatment.on('error', () => { })
+}
+
+async function test_msnodesqlv8() {
+    const connection = new msnodesqlv8.ConnectionPool({ server: "localhost", database: "master", options: { trustedConnection: true } });
+    await connection.connect();
+    const result = await connection.query`SELECT * FROM sys.databases`;
+    await connection.close();
 }

--- a/types/mssql/tsconfig.json
+++ b/types/mssql/tsconfig.json
@@ -18,6 +18,7 @@
     },
     "files": [
         "index.d.ts",
+        "msnodesqlv8.d.ts",
         "mssql-tests.ts"
     ]
 }


### PR DESCRIPTION
`mssql/msnodesqlv8` is a wrapper for "mssql" + implicitly enabled "msnodesqlv8" driver.

See
* [Part of mssql README](https://github.com/tediousjs/node-mssql#microsoft--contributors-node-v8-driver-for-nodejs-for-sql-server) which describes the feature.
* The [concerned module export](https://github.com/tediousjs/node-mssql/blob/7f374a8d73b00b17aa5b5ea5621c4314fc6e2daa/lib/msnodesqlv8.js#L741-L746).
* [Commit which added the feature in mssql](https://github.com/tediousjs/node-mssql/commit/cc1ebe78f00f257e13a06bd8970c04274a27536e#diff-04c6e90faac2675aa89e2176d2eec7d8R286).

Also set TS version to >= 2.1 (to use async/await in the tests; TS 2.1)

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: see above
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
