### PR TITLE
Allow specific mangle options to be passed to gulp-uglify, fix incorrectly narrow type in uglify-js

### DIFF
--- a/types/gulp-filter/index.d.ts
+++ b/types/gulp-filter/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/sindresorhus/gulp-filter
 // Definitions by: Tanguy Krotoff <https://github.com/tkrotoff>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.2
 
 /// <reference types="node" />
 

--- a/types/gulp-filter/tsconfig.json
+++ b/types/gulp-filter/tsconfig.json
@@ -14,10 +14,7 @@
         ],
         "types": [],
         "noEmit": true,
-        "forceConsistentCasingInFileNames": true,
-        "paths": {
-            "uglify-js": ["uglify-js/v2"]
-        }
+        "forceConsistentCasingInFileNames": true
     },
     "files": [
         "index.d.ts",

--- a/types/gulp-rev-replace/index.d.ts
+++ b/types/gulp-rev-replace/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/jamesknelson/gulp-rev-replace
 // Definitions by: Tanguy Krotoff <https://github.com/tkrotoff>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.2
 
 /// <reference types="node" />
 

--- a/types/gulp-rev-replace/tsconfig.json
+++ b/types/gulp-rev-replace/tsconfig.json
@@ -14,12 +14,7 @@
         ],
         "types": [],
         "noEmit": true,
-        "forceConsistentCasingInFileNames": true,
-        "paths": {
-            "uglify-js": [
-                "uglify-js/v2"
-            ]
-        }
+        "forceConsistentCasingInFileNames": true
     },
     "files": [
         "index.d.ts",

--- a/types/gulp-uglify/index.d.ts
+++ b/types/gulp-uglify/index.d.ts
@@ -13,17 +13,17 @@ declare namespace GulpUglify {
         /**
          * Pass false to skip mangling names.
          */
-        mangle?: boolean;
+        mangle?: UglifyJS.MangleOptions | boolean;
 
         /**
          * Pass if you wish to specify additional output options. The defaults are optimized for best compression.
          */
-        output?: UglifyJS.BeautifierOptions;
+        output?: UglifyJS.OutputOptions;
 
         /**
          * Pass an object to specify custom compressor options. Pass false to skip compression completely.
          */
-        compress?: UglifyJS.CompressorOptions | boolean;
+        compress?: UglifyJS.CompressOptions | boolean;
     }
 }
 

--- a/types/gulp-uglify/index.d.ts
+++ b/types/gulp-uglify/index.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: Christopher Haws <https://github.com/ChristopherHaws>
 //                 Leonard Thieu <https://github.com/leonard-thieu>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.2
 
 /// <reference types="node"/>
 

--- a/types/gulp-uglify/tsconfig.json
+++ b/types/gulp-uglify/tsconfig.json
@@ -14,12 +14,7 @@
         ],
         "types": [],
         "noEmit": true,
-        "forceConsistentCasingInFileNames": true,
-        "paths": {
-            "uglify-js": [
-                "uglify-js/v2"
-            ]
-        }
+        "forceConsistentCasingInFileNames": true
     },
     "files": [
         "index.d.ts",

--- a/types/gulp-useref/index.d.ts
+++ b/types/gulp-useref/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/jonkemp/gulp-useref
 // Definitions by: Tanguy Krotoff <https://github.com/tkrotoff>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.2
 
 /// <reference types="node" />
 

--- a/types/gulp-useref/tsconfig.json
+++ b/types/gulp-useref/tsconfig.json
@@ -14,10 +14,7 @@
         ],
         "types": [],
         "noEmit": true,
-        "forceConsistentCasingInFileNames": true,
-        "paths": {
-            "uglify-js": ["uglify-js/v2"]
-        }
+        "forceConsistentCasingInFileNames": true
     },
     "files": [
         "index.d.ts",

--- a/types/uglify-js/index.d.ts
+++ b/types/uglify-js/index.d.ts
@@ -165,7 +165,7 @@ export interface OutputOptions {
     indent_start?: boolean;
     inline_script?: boolean;
     keep_quoted_props?: boolean;
-    max_line_len?: boolean;
+    max_line_len?: boolean | number;
     preamble?: string;
     preserve_line?: boolean;
     quote_keys?: boolean;

--- a/types/uglify-js/v2/index.d.ts
+++ b/types/uglify-js/v2/index.d.ts
@@ -159,7 +159,7 @@ declare namespace UglifyJS {
         /**
          * Maximum line length (for non-beautified output)
          */
-        max_line_len?: number;
+        max_line_len?: boolean | number;
 
         /**
          * Output IE-safe code?


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: uglify-js accepts a number for max_line_len: https://github.com/mishoo/UglifyJS2/blob/b5ce1997112007d772e23bb04e09ed425bff608a/test/compress/max_line_len.js#L24, 
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
