### PR TITLE
[graphql-resolve-batch] Batch resolvers receive ResolveInfo

### DIFF
--- a/types/graphql-resolve-batch/graphql-resolve-batch-tests.ts
+++ b/types/graphql-resolve-batch/graphql-resolve-batch-tests.ts
@@ -95,13 +95,15 @@ const withSourceAndArgsAndContextTyped = createBatchResolver<
     SomeTestResult,
     SomeTestArgs,
     SomeTestContext
->(async (sources, args, context) => {
+>(async (sources, args, context, info) => {
     // $ExpectType ReadonlyArray<SomeTestSource>
     const verifySources = sources;
     // $ExpectType string
     const verifyArgs = args.someArg;
     // $ExpectType string
     const verifyContext = context.someContextProp;
+    // $ExpectType GraphQLResolveInfo
+    const verifyInfo = info;
 
     const result = await asyncBatchFunction(sources);
     return result;

--- a/types/graphql-resolve-batch/index.d.ts
+++ b/types/graphql-resolve-batch/index.d.ts
@@ -4,6 +4,8 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
+import { GraphQLResolveInfo } from 'graphql';
+
 /**
  * Creates a GraphQL.js field resolver that batches together multiple resolves
  * together that share the *exact* same GraphQL field selection.
@@ -45,5 +47,6 @@ export type ResolverFunction<TSource, TArgs, TContext, TReturn> = (
 export type BatchResolveFunction<TSource, TArgs, TContext, TReturn> = (
     sources: ReadonlyArray<TSource>,
     args: TArgs,
-    context: TContext
+    context: TContext,
+    info: GraphQLResolveInfo
 ) => TReturn[] | Promise<TReturn[]>;


### PR DESCRIPTION
Like [regular resolvers](https://www.apollographql.com/docs/graphql-tools/resolvers#Resolver-function-signature), `graphql-resolve-batch` provides [a fourth `info` argument](https://github.com/calebmer/graphql-resolve-batch/blob/30eb41a13640405c0f16f031b9c6b4c17a0bc39c/src/batch.js#L101-L105) to batch resolvers that captures information about the current state of the query.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/calebmer/graphql-resolve-batch/blob/30eb41a13640405c0f16f031b9c6b4c17a0bc39c/src/batch.js#L101-L105