### PR TITLE
Add new types for Google Maps Places autocomplete session support

### DIFF
--- a/types/googlemaps/googlemaps-tests.ts
+++ b/types/googlemaps/googlemaps-tests.ts
@@ -418,7 +418,8 @@ let service = new google.maps.places.PlacesService(new HTMLDivElement());
 
 service.getDetails({
     placeId: '-a1',
-    fields: ['name']
+    fields: ['name'],
+    sessionToken: new google.maps.places.AutocompleteSessionToken()
 }, (result, status) => {
     if (status === google.maps.places.PlacesServiceStatus.NOT_FOUND) {
         return;

--- a/types/googlemaps/index.d.ts
+++ b/types/googlemaps/index.d.ts
@@ -1,14 +1,15 @@
 // Type definitions for Google Maps JavaScript API 3.30
 // Project: https://developers.google.com/maps/
-// Definitions by:  Folia A/S <http://www.folia.dk>, 
-//                  Chris Wrench <https://github.com/cgwrench>, 
-//                  Kiarash Ghiaseddin <https://github.com/Silver-Connection/DefinitelyTyped>,  
-//                  Grant Hutchins <https://github.com/nertzy>, 
-//                  Denis Atyasov <https://github.com/xaolas>, 
-//                  Michael McMullin <https://github.com/mrmcnerd>, 
-//                  Martin Costello <https://github.com/martincostello>, 
+// Definitions by:  Folia A/S <http://www.folia.dk>,
+//                  Chris Wrench <https://github.com/cgwrench>,
+//                  Kiarash Ghiaseddin <https://github.com/Silver-Connection/DefinitelyTyped>,
+//                  Grant Hutchins <https://github.com/nertzy>,
+//                  Denis Atyasov <https://github.com/xaolas>,
+//                  Michael McMullin <https://github.com/mrmcnerd>,
+//                  Martin Costello <https://github.com/martincostello>,
 //                  Sven Kreiss <https://github.com/svenkreiss>
 //                  Umar Bolatov <https://github.com/bolatovumar>
+//                  Michael Gauthier <https://github.com/gauthierm>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /*
@@ -2542,6 +2543,10 @@ declare namespace google.maps {
             getQueryPredictions(request: QueryAutocompletionRequest, callback: (result: QueryAutocompletePrediction[], status: PlacesServiceStatus) => void): void;
         }
 
+        export class AutocompleteSessionToken {
+            constructor();
+        }
+
         export interface AutocompletionRequest {
             bounds?: LatLngBounds|LatLngBoundsLiteral;
             componentRestrictions?: ComponentRestrictions;
@@ -2549,6 +2554,7 @@ declare namespace google.maps {
             location?: LatLng;
             offset?: number;
             radius?: number;
+            sessionToken?: AutocompleteSessionToken;
             types?: string[];
         }
 
@@ -2566,6 +2572,7 @@ declare namespace google.maps {
         export interface PlaceDetailsRequest  {
             placeId: string;
             fields?: string[];
+            sessionToken?: AutocompleteSessionToken;
         }
 
         export interface PlaceGeometry {


### PR DESCRIPTION
Support added by Google in version 3.33.

See:

 - https://developers.google.com/maps/documentation/javascript/releases
 - https://developers.google.com/maps/documentation/javascript/places-autocomplete#session_tokens
 - https://developers.google.com/maps/documentation/javascript/reference/places-autocomplete-service#AutocompleteSessionToken
 - https://developers.google.com/maps/documentation/javascript/reference/places-service#PlaceDetailsRequest
 - https://developers.google.com/maps/documentation/javascript/reference/places-autocomplete-service#AutocompletionRequest

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes
- [ ] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.