### PR TITLE
spark-md5: ArrayBuffer.append takes an ArrayBuffer, not a string

### DIFF
--- a/types/spark-md5/index.d.ts
+++ b/types/spark-md5/index.d.ts
@@ -29,7 +29,7 @@ declare class SparkMD5 {
 declare namespace SparkMD5 {
 	class ArrayBuffer {
 		constructor();
-		append(str: string): ArrayBuffer;
+		append(str: ArrayBufferCopy): ArrayBuffer;
 		end(raw?: boolean): string;
 		reset(): ArrayBuffer;
 		getState(): State;

--- a/types/spark-md5/spark-md5-tests.ts
+++ b/types/spark-md5/spark-md5-tests.ts
@@ -11,8 +11,7 @@ let hexHash = spark.end();
 let rawHash = spark.end(true);
 
 const sparkArr = new SparkMD5.ArrayBuffer();
-sparkArr.append('Hi');
-sparkArr.append(' there');
+sparkArr.append(new ArrayBuffer(8));
 hexHash = sparkArr.end();
 rawHash = sparkArr.end(true);
 


### PR DESCRIPTION
Before TS 3.0, it worked when passing an ArrayBuffer to Spark.ArrayBuffer.append, but it now fails as an ArrayBuffer is no longer a string.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/satazor/js-spark-md5#sparkmd5arraybufferappendarr
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.