### PR TITLE
[node] Add dns.Resolver declaration

### DIFF
--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -2770,6 +2770,7 @@ declare module "dns" {
 
     export function reverse(ip: string, callback: (err: NodeJS.ErrnoException, hostnames: string[]) => void): void;
     export function setServers(servers: string[]): void;
+    export function getServers(): string[];
 
     // Error codes
     export var NODATA: string;
@@ -2796,6 +2797,25 @@ declare module "dns" {
     export var LOADIPHLPAPI: string;
     export var ADDRGETNETWORKPARAMS: string;
     export var CANCELLED: string;
+
+    export class Resolver {
+        getServers: typeof getServers;
+        setServers: typeof setServers;
+        resolve: typeof resolve;
+        resolve4: typeof resolve4;
+        resolve6: typeof resolve6;
+        resolveAny: typeof resolveAny;
+        resolveCname: typeof resolveCname;
+        resolveMx: typeof resolveMx;
+        resolveNaptr: typeof resolveNaptr;
+        resolveNs: typeof resolveNs;
+        resolvePtr: typeof resolvePtr;
+        resolveSoa: typeof resolveSoa;
+        resolveSrv: typeof resolveSrv;
+        resolveTxt: typeof resolveTxt;
+        reverse: typeof reverse;
+        cancel(): void;
+    }
 }
 
 declare module "net" {

--- a/types/node/node-tests.ts
+++ b/types/node/node-tests.ts
@@ -3388,6 +3388,13 @@ namespace dns_tests {
             const _addresses: string[] | dns.RecordWithTtl[] = addresses;
         });
     }
+    {
+        const resolver = new dns.Resolver();
+        resolver.resolve("nodejs.org", (err, addresses) => {
+            const _addresses: string[] = addresses;
+        });
+        resolver.cancel();
+    }
 }
 
 /*****************************************************************************

--- a/types/node/node-tests.ts
+++ b/types/node/node-tests.ts
@@ -3390,6 +3390,7 @@ namespace dns_tests {
     }
     {
         const resolver = new dns.Resolver();
+        resolver.setServers(["4.4.4.4"]);
         resolver.resolve("nodejs.org", (err, addresses) => {
             const _addresses: string[] = addresses;
         });

--- a/types/node/v8/index.d.ts
+++ b/types/node/v8/index.d.ts
@@ -2646,6 +2646,7 @@ declare module "dns" {
 
     export function reverse(ip: string, callback: (err: NodeJS.ErrnoException, hostnames: string[]) => void): void;
     export function setServers(servers: string[]): void;
+    export function getServers(): string[];
 
     // Error codes
     export var NODATA: string;
@@ -2672,6 +2673,25 @@ declare module "dns" {
     export var LOADIPHLPAPI: string;
     export var ADDRGETNETWORKPARAMS: string;
     export var CANCELLED: string;
+
+    export class Resolver {
+        getServers: typeof getServers;
+        setServers: typeof setServers;
+        resolve: typeof resolve;
+        resolve4: typeof resolve4;
+        resolve6: typeof resolve6;
+        resolveAny: typeof resolveAny;
+        resolveCname: typeof resolveCname;
+        resolveMx: typeof resolveMx;
+        resolveNaptr: typeof resolveNaptr;
+        resolveNs: typeof resolveNs;
+        resolvePtr: typeof resolvePtr;
+        resolveSoa: typeof resolveSoa;
+        resolveSrv: typeof resolveSrv;
+        resolveTxt: typeof resolveTxt;
+        reverse: typeof reverse;
+        cancel(): void;
+    }
 }
 
 declare module "net" {

--- a/types/node/v8/node-tests.ts
+++ b/types/node/v8/node-tests.ts
@@ -3129,6 +3129,7 @@ namespace dns_tests {
     }
     {
         const resolver = new dns.Resolver();
+        resolver.setServers(["4.4.4.4"]);
         resolver.resolve("nodejs.org", (err, addresses) => {
             const _addresses: string[] = addresses;
         });

--- a/types/node/v8/node-tests.ts
+++ b/types/node/v8/node-tests.ts
@@ -3127,6 +3127,13 @@ namespace dns_tests {
             const _addresses: string[] | dns.RecordWithTtl[] = addresses;
         });
     }
+    {
+        const resolver = new dns.Resolver();
+        resolver.resolve("nodejs.org", (err, addresses) => {
+            const _addresses: string[] = addresses;
+        });
+        resolver.cancel();
+    }
 }
 
 /*****************************************************************************

--- a/types/node/v9/index.d.ts
+++ b/types/node/v9/index.d.ts
@@ -2728,6 +2728,7 @@ declare module "dns" {
 
     export function reverse(ip: string, callback: (err: NodeJS.ErrnoException, hostnames: string[]) => void): void;
     export function setServers(servers: string[]): void;
+    export function getServers(): string[];
 
     // Error codes
     export var NODATA: string;
@@ -2754,6 +2755,25 @@ declare module "dns" {
     export var LOADIPHLPAPI: string;
     export var ADDRGETNETWORKPARAMS: string;
     export var CANCELLED: string;
+
+    export class Resolver {
+        getServers: typeof getServers;
+        setServers: typeof setServers;
+        resolve: typeof resolve;
+        resolve4: typeof resolve4;
+        resolve6: typeof resolve6;
+        resolveAny: typeof resolveAny;
+        resolveCname: typeof resolveCname;
+        resolveMx: typeof resolveMx;
+        resolveNaptr: typeof resolveNaptr;
+        resolveNs: typeof resolveNs;
+        resolvePtr: typeof resolvePtr;
+        resolveSoa: typeof resolveSoa;
+        resolveSrv: typeof resolveSrv;
+        resolveTxt: typeof resolveTxt;
+        reverse: typeof reverse;
+        cancel(): void;
+    }
 }
 
 declare module "net" {

--- a/types/node/v9/node-tests.ts
+++ b/types/node/v9/node-tests.ts
@@ -3162,6 +3162,7 @@ namespace dns_tests {
     }
     {
         const resolver = new dns.Resolver();
+        resolver.setServers(["4.4.4.4"]);
         resolver.resolve("nodejs.org", (err, addresses) => {
             const _addresses: string[] = addresses;
         });

--- a/types/node/v9/node-tests.ts
+++ b/types/node/v9/node-tests.ts
@@ -3160,6 +3160,13 @@ namespace dns_tests {
             const _addresses: string[] | dns.RecordWithTtl[] = addresses;
         });
     }
+    {
+        const resolver = new dns.Resolver();
+        resolver.resolve("nodejs.org", (err, addresses) => {
+            const _addresses: string[] = addresses;
+        });
+        resolver.cancel();
+    }
 }
 
 /*****************************************************************************


### PR DESCRIPTION
Add declaration of [`dns.Resolver`](https://nodejs.org/dist/latest-v8.x/docs/api/dns.html#dns_class_dns_resolver) class which is available since Node.js `8.3.0`.

Affected Node.js versions: `v8`, `v9,` `v10`.

***

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
* v8: https://nodejs.org/dist/latest-v8.x/docs/api/dns.html#dns_class_dns_resolver
* v9: https://nodejs.org/docs/latest-v9.x/api/dns.html#dns_class_dns_resolver
* v10: https://nodejs.org/docs/latest/api/dns.html#dns_class_dns_resolver