### PR TITLE
Recompose: `shallowEqual`: use generics to fix inference

### DIFF
--- a/types/recompose/index.d.ts
+++ b/types/recompose/index.d.ts
@@ -309,8 +309,8 @@ declare module 'recompose' {
     ): string;
 
     // shallowEqual: https://github.com/acdlite/recompose/blob/master/docs/API.md#shallowEqual
-    export function shallowEqual(
-        a: Object, b: Object
+    export function shallowEqual<A, B>(
+        a: A, b: B
     ): boolean;
 
     // isClassComponent: https://github.com/acdlite/recompose/blob/master/docs/API.md#isClassComponent

--- a/types/recompose/recompose-tests.tsx
+++ b/types/recompose/recompose-tests.tsx
@@ -412,3 +412,11 @@ function testLifecycle() {
         }
     })(component)
 }
+
+function testShallowEqual() {
+    const a = { prop: 1 }
+    const b = { prop: 1 }
+    // Generics are not needed inside this function, however they should flow through for outside
+    // inference.
+    shallowEqual(a, b)
+}


### PR DESCRIPTION
Without specifying generics, the generics are lost during inference, e.g.:

``` ts
    props$.pipe(
        distinctUntilChanged(shallowEqual),
        // Property 'prop' does not exist on type 'Object'.
        map(props => props.prop),
    )
```

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.