### PR TITLE
react-native-vector-icons: support font awesome5

### DIFF
--- a/types/react-native-vector-icons/FontAwesome5.d.ts
+++ b/types/react-native-vector-icons/FontAwesome5.d.ts
@@ -1,0 +1,43 @@
+import { Component } from "../../../../../Library/Caches/typescript/2.9/node_modules/@types/react";
+import { Icon, IconProps, ImageSource } from "./Icon";
+
+export const FA5Style: {
+    regular: 0;
+    light: 1;
+    solid: 2;
+    brand: 3;
+};
+
+type ValueOf<T> = T[keyof T];
+
+// borrowed from
+// https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-8.html
+type Omit<T, K> = Pick<T, Exclude<keyof T, K>>;
+
+export type FontAwesome5IconVariants = keyof Omit<typeof FA5Style, "regular">;
+
+// borrowed from https://stackoverflow.com/a/49725198/1105281
+type RequireOnlyOne<T, Keys extends keyof T = keyof T> = Omit<T, Keys> &
+    {
+        [K in Keys]-?: Required<Pick<T, K>> &
+            Partial<Record<Exclude<Keys, K>, undefined>>
+    }[Keys];
+
+export type FontAwesome5IconProps = RequireOnlyOne<
+    { [K in FontAwesome5IconVariants]?: boolean } & IconProps,
+    FontAwesome5IconVariants
+>;
+
+export default class FontAwesome5Icon extends Component<
+    FontAwesome5IconProps,
+    any
+> {
+    static getImageSource(
+        name: string,
+        size?: number,
+        color?: string,
+        fa5Style?: ValueOf<typeof FA5Style>
+    ): Promise<ImageSource>;
+    static loadFont(file?: string): Promise<void>;
+    static hasIcon(name: string): boolean;
+}

--- a/types/react-native-vector-icons/FontAwesome5.d.ts
+++ b/types/react-native-vector-icons/FontAwesome5.d.ts
@@ -16,14 +16,14 @@ type Omit<T, K> = Pick<T, Exclude<keyof T, K>>;
 
 export type FontAwesome5IconVariants = keyof Omit<typeof FA5Style, "regular">;
 
-// borrowed from https://stackoverflow.com/a/49725198/1105281
-type RequireOnlyOne<T, Keys extends keyof T = keyof T> = Omit<T, Keys> &
+// modified from https://stackoverflow.com/a/49725198/1105281
+type AllowOnlyOne<T, Keys extends keyof T = keyof T> = Omit<T, Keys> &
     {
-        [K in Keys]-?: Required<Pick<T, K>> &
+        [K in Keys]-?: Partial<Pick<T, K>> &
             Partial<Record<Exclude<Keys, K>, undefined>>
     }[Keys];
 
-export type FontAwesome5IconProps = RequireOnlyOne<
+export type FontAwesome5IconProps = AllowOnlyOne<
     { [K in FontAwesome5IconVariants]?: boolean } & IconProps,
     FontAwesome5IconVariants
 >;

--- a/types/react-native-vector-icons/FontAwesome5.d.ts
+++ b/types/react-native-vector-icons/FontAwesome5.d.ts
@@ -8,16 +8,16 @@ export const FA5Style: {
     brand: 3;
 };
 
-type ValueOf<T> = T[keyof T];
+export type ValueOf<T> = T[keyof T];
 
 // borrowed from
 // https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-8.html
-type Omit<T, K> = Pick<T, Exclude<keyof T, K>>;
+export type Omit<T, K> = Pick<T, Exclude<keyof T, K>>;
 
 export type FontAwesome5IconVariants = keyof Omit<typeof FA5Style, "regular">;
 
 // modified from https://stackoverflow.com/a/49725198/1105281
-type AllowOnlyOne<T, Keys extends keyof T = keyof T> = Omit<T, Keys> &
+export type AllowOnlyOne<T, Keys extends keyof T = keyof T> = Omit<T, Keys> &
     {
         [K in Keys]-?: Partial<Pick<T, K>> &
             Partial<Record<Exclude<Keys, K>, undefined>>

--- a/types/react-native-vector-icons/FontAwesome5.d.ts
+++ b/types/react-native-vector-icons/FontAwesome5.d.ts
@@ -1,4 +1,4 @@
-import { Component } from "../../../../../Library/Caches/typescript/2.9/node_modules/@types/react";
+import { Component } from "react";
 import { Icon, IconProps, ImageSource } from "./Icon";
 
 export const FA5Style: {

--- a/types/react-native-vector-icons/FontAwesome5Pro.d.ts
+++ b/types/react-native-vector-icons/FontAwesome5Pro.d.ts
@@ -1,0 +1,6 @@
+import { Component } from "react";
+import FontAwesome5Icon, { FontAwesome5IconProps } from "./FontAwesome5";
+
+export type FontAwesome5ProIconProps = FontAwesome5IconProps;
+export { FA5Style } from "./FontAwesome5";
+export default FontAwesome5Icon;

--- a/types/react-native-vector-icons/react-native-vector-icons-tests.tsx
+++ b/types/react-native-vector-icons/react-native-vector-icons-tests.tsx
@@ -29,6 +29,7 @@ class Example extends React.Component {
       <View>
         {/* Normal Icon */}
         <MaterialIcon size={30} color="red" name="exit" />
+        <FontAwesome5Icon size={10} name="handshake" />
         <FontAwesome5Icon size={10} name="handshake" solid />
         <FontAwesome5ProIcon size={10} name="parachute-box" light />
 

--- a/types/react-native-vector-icons/react-native-vector-icons-tests.tsx
+++ b/types/react-native-vector-icons/react-native-vector-icons-tests.tsx
@@ -3,6 +3,8 @@ import { View, Text, TabBarIOS } from 'react-native';
 import { createIconSet } from 'react-native-vector-icons';
 import MaterialIcon from 'react-native-vector-icons/MaterialIcons';
 import FontAwesomeIcon from 'react-native-vector-icons/FontAwesome';
+import FontAwesome5Icon from 'react-native-vector-icons/FontAwesome5';
+import FontAwesome5ProIcon from 'react-native-vector-icons/FontAwesome5Pro';
 import Ionicon from 'react-native-vector-icons/Ionicons';
 
 const glyphMap = {
@@ -27,6 +29,8 @@ class Example extends React.Component {
       <View>
         {/* Normal Icon */}
         <MaterialIcon size={30} color="red" name="exit" />
+        <FontAwesome5Icon size={10} name="handshake" solid />
+        <FontAwesome5ProIcon size={10} name="parachute-box" light />
 
         {/* Icon button  */}
         <FontAwesomeIcon.Button

--- a/types/react-native-vector-icons/tsconfig.json
+++ b/types/react-native-vector-icons/tsconfig.json
@@ -25,6 +25,8 @@
         "EvilIcons.d.ts",
         "Feather.d.ts",
         "FontAwesome.d.ts",
+        "FontAwesome5.d.ts",
+        "FontAwesome5Pro.d.ts",
         "Foundation.d.ts",
         "Ionicons.d.ts",
         "MaterialCommunityIcons.d.ts",


### PR DESCRIPTION
This does not add support for the tab bar and button usages, because I'm not 100% sure how to express those.

- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/oblador/react-native-vector-icons/blob/master/FONTAWESOME5.md
- N/A ~~Increase the version number in the header if appropriate.~~
- N/A ~~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.~~