### PR TITLE
Adding Writeable and Readable vs WriteStream and ReadStream

### DIFF
--- a/types/inquirer/index.d.ts
+++ b/types/inquirer/index.d.ts
@@ -23,10 +23,10 @@ declare namespace inquirer {
         | ReadonlyArray<Question<T>>
         | Rx.Observable<Question<T>>;
     interface OutputStreamOption {
-        output: NodeJS.WriteStream
+        output: NodeJS.WritableStream
     }
     interface InputStreamOption {
-        input: NodeJS.ReadStream
+        input: NodeJS.ReadableStream
     }
     type StreamOptions = InputStreamOption | OutputStreamOption | (InputStreamOption & OutputStreamOption);
 


### PR DESCRIPTION
On @types/node WriteStream and ReadStream are now WritableStream and ReadableStream.

I imagine this will break for older versions of the node typings where WriteStream and ReadStream are still a thing. Let me know if I need to do something to make this safer for older versions.