### PR TITLE
mosca: Add server id property and persistence namespace

### DIFF
--- a/types/mosca/index.d.ts
+++ b/types/mosca/index.d.ts
@@ -1,9 +1,11 @@
 // Type definitions for mosca 2.8
 // Project: https://github.com/mcollina/mosca
 // Definitions by: Joao Gabriel Gouveia <https://github.com/GabrielGouv>
+//                 Jerray Fu <https://github.com/jerray>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 export class Server {
+    id: string;
     opts: any;
     modernOpts: any;
     clients: any;
@@ -82,4 +84,16 @@ export interface Message {
     payload: any;
     qos: number;
     retain: boolean;
+}
+
+export namespace persistence {
+    interface Persistence {
+        wire(server: Server): void;
+    }
+    type FactoryFunc = (options: { [key: string]: any }) => Persistence;
+
+    const Redis: FactoryFunc;
+    const Mongo: FactoryFunc;
+    const LevelUp: FactoryFunc;
+    const Memory: FactoryFunc;
 }


### PR DESCRIPTION
There is an id property in the Server class. It should be a public property.
Persistence should be exported for users who want to store packets in database other than memory.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/mcollina/mosca/blob/master/lib/persistence/index.js>>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
