### PR TITLE
add clipboard-api w3c draft

### DIFF
--- a/types/dom-clipboard-api/dom-clipboard-api-tests.ts
+++ b/types/dom-clipboard-api/dom-clipboard-api-tests.ts
@@ -1,0 +1,16 @@
+const clipboard = navigator.clipboard;
+
+let text: string;
+
+clipboard.writeText('foo');
+clipboard.readText().then((val) => {
+    text = val;
+});
+
+const transfer = new DataTransfer();
+transfer.setData('text/plain', 'foo');
+
+clipboard.write(transfer);
+clipboard.read().then((tf) => {
+    text = tf.getData('text/plain');
+});

--- a/types/dom-clipboard-api/index.d.ts
+++ b/types/dom-clipboard-api/index.d.ts
@@ -1,0 +1,15 @@
+// Type definitions for w3c Clipboard API 1.0
+// Project: https://w3c.github.io/clipboard-apis/
+// Definitions by: James Garbutt <https://github.com/43081j>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+interface Clipboard extends EventTarget {
+  read(): Promise<DataTransfer>;
+  readText(): Promise<string>;
+  write(data: DataTransfer): Promise<void>;
+  writeText(data: string): Promise<void>;
+}
+
+interface Navigator {
+  readonly clipboard: Clipboard;
+}

--- a/types/dom-clipboard-api/tsconfig.json
+++ b/types/dom-clipboard-api/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": false,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "dom-clipboard-api-tests.ts"
+    ]
+}

--- a/types/dom-clipboard-api/tslint.json
+++ b/types/dom-clipboard-api/tslint.json
@@ -1,0 +1,5 @@
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+    }
+}


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

---

Trying to add the clipboard w3c draft as its not ready for the generator yet.