### PR TITLE
react-virtualized: Table click events, MouseEvent extends SyntheticEvent

### DIFF
--- a/types/react-virtualized/dist/es/Table.d.ts
+++ b/types/react-virtualized/dist/es/Table.d.ts
@@ -189,13 +189,13 @@ export type RowMouseEventHandlerParams = {
         index: number;
     };
     index: number;
-    event: React.SyntheticEvent<React.MouseEvent<any>>;
+    event: React.MouseEvent<any>;
 };
 
 export type HeaderMouseEventHandlerParams = {
     dataKey: string;
     columnData: any;
-    event: React.SyntheticEvent<React.MouseEvent<any>>;
+    event: React.MouseEvent<any>;
 };
 
 // ref: https://github.com/bvaughn/react-virtualized/blob/master/docs/Table.md


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: N/A
- [x] Increase the version number in the header if appropriate. N/A - this is a bug-fix
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`: N/A

---

The SyntheticEvent was passing a MouseEvent as a generic type argument, which is not how it's supposed to be used: MouseEvent extends SyntheticEvent.