### PR TITLE
Fix MouseEventHandler in  Option.d.ts for React-Select

### DIFF
--- a/types/react-select/lib/components/Option.d.ts
+++ b/types/react-select/lib/components/Option.d.ts
@@ -14,8 +14,8 @@ interface State {
 interface InnerProps {
   id: string;
   key: string;
-  onClick: MouseEventHandler;
-  onMouseOver: MouseEventHandler;
+  onClick: MouseEventHandler<React.MouseEvent<HTMLElement>>;
+  onMouseOver: MouseEventHandler<React.MouseEvent<HTMLElement>>;
   tabIndex: number;
 }
 export type OptionProps<OptionType> = PropsWithStyles &


### PR DESCRIPTION
fixes a typescript error ```Generic type 'MouseEventHandler' requires 1 type argument(s).
(alias) type MouseEventHandler<T> = (event: MouseEvent<T>) => void```

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
