### PR TITLE
[react-redux] Correctly infer prop types from wrapped component

### DIFF
--- a/types/react-redux/index.d.ts
+++ b/types/react-redux/index.d.ts
@@ -62,7 +62,7 @@ type Matching<InjectedProps, DecorationTargetProps> = {
 	[P in keyof DecorationTargetProps]: P extends keyof InjectedProps
 		? InjectedProps[P] extends DecorationTargetProps[P]
 			? DecorationTargetProps[P]
-			: never
+			: InjectedProps[P]
 		: DecorationTargetProps[P];
 };
 
@@ -86,7 +86,7 @@ type Shared<
 // Infers prop type from component C
 type GetProps<C> = C extends ComponentType<infer P> ? P : never;
 
-// Applies LibraryManagedAttributes (proper handling of defaultProps 
+// Applies LibraryManagedAttributes (proper handling of defaultProps
 // and propTypes), as well as defines WrappedComponent.
 type ConnectedComponentClass<C, P> = ComponentClass<JSX.LibraryManagedAttributes<C, P>> & {
 	WrappedComponent: C;

--- a/types/react-redux/index.d.ts
+++ b/types/react-redux/index.d.ts
@@ -53,10 +53,16 @@ interface AdvancedComponentDecorator<TProps, TOwnProps> {
 }
 
 /**
- * a property P will be present if:
+ * A property P will be present if:
  * - it is present in DecorationTargetProps
- * - it is present in InjectedProps[P] and can satisfy DecorationTargetProps[P]
- *   or it is not present in InjectedProps[P]
+ *
+ * Its value will be dependent on the following conditions
+ * - if property P is present in InjectedProps and its definition extends the definition
+ *   in DecorationTargetProps, then its definition will be that of DecorationTargetProps[P]
+ * - if property P is not present in InjectedProps then its definition will be that of
+ *   DecorationTargetProps[P]
+ * - if property P is present in InjectedProps but does not extend the
+ *   DecorationTargetProps[P] definition, its definition will be that of InjectedProps[P]
  */
 type Matching<InjectedProps, DecorationTargetProps> = {
 	[P in keyof DecorationTargetProps]: P extends keyof InjectedProps

--- a/types/react-redux/index.d.ts
+++ b/types/react-redux/index.d.ts
@@ -10,6 +10,7 @@
 //                 Thomas Charlat <https://github.com/kallikrein>
 //                 Valentin Descamps <https://github.com/val1984>
 //                 Johann Rakotoharisoa <https://github.com/jrakotoharisoa>
+//                 Anatoli Papirovski <https://github.com/apapirovski>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -52,6 +53,20 @@ interface AdvancedComponentDecorator<TProps, TOwnProps> {
 }
 
 /**
+ * a property P will be present if:
+ * - it is present in DecorationTargetProps
+ * - it is present in InjectedProps[P] and can satisfy DecorationTargetProps[P]
+ *   or it is not present in InjectedProps[P]
+ */
+type Matching<InjectedProps, DecorationTargetProps> = {
+	[P in keyof DecorationTargetProps]: P extends keyof InjectedProps
+		? InjectedProps[P] extends DecorationTargetProps[P]
+			? DecorationTargetProps[P]
+			: never
+		: DecorationTargetProps[P];
+};
+
+/**
  * a property P will be present if :
  * - it is present in both DecorationTargetProps and InjectedProps
  * - InjectedProps[P] can satisfy DecorationTargetProps[P]
@@ -68,13 +83,22 @@ type Shared<
         [P in Extract<keyof InjectedProps, keyof DecorationTargetProps>]?: InjectedProps[P] extends DecorationTargetProps[P] ? DecorationTargetProps[P] : never;
     };
 
+// Infers prop type from component C
+type GetProps<C> = C extends ComponentType<infer P> ? P : never;
+
+// Applies LibraryManagedAttributes (proper handling of defaultProps 
+// and propTypes), as well as defines WrappedComponent.
+type ConnectedComponentClass<C, P> = ComponentClass<JSX.LibraryManagedAttributes<C, P>> & {
+	WrappedComponent: C;
+}
+
 // Injects props and removes them from the prop requirements.
 // Will not pass through the injected props if they are passed in during
 // render. Also adds new prop requirements from TNeedsProps.
 export interface InferableComponentEnhancerWithProps<TInjectedProps, TNeedsProps> {
-	<P extends Shared<TInjectedProps, P>>(
-		component: ComponentType<P>
-	): ComponentClass<Omit<P, keyof Shared<TInjectedProps, P>> & TNeedsProps> & {WrappedComponent: ComponentType<P>}
+	<C extends ComponentType<Matching<TInjectedProps, GetProps<C>>>>(
+		component: C
+	): ConnectedComponentClass<C, Omit<GetProps<C>, keyof Shared<TInjectedProps, GetProps<C>>> & TNeedsProps>
 }
 
 // Injects props and removes them from the prop requirements.

--- a/types/react-redux/react-redux-tests.tsx
+++ b/types/react-redux/react-redux-tests.tsx
@@ -1154,6 +1154,11 @@ namespace TestFailsMoreSpecificInjectedProps {
   // Since it is possible the injected props could fail to satisfy the decoration props,
   // the following line should fail to compile.
   connect(mapStateToProps, mapDispatchToProps)(Component) // $ExpectError
+
+  // Confirm that this also fails with functional components
+  const FunctionalComponent = (props: MoreSpecificDecorationProps) => null
+  connect(mapStateToProps, mapDispatchToProps)(Component) // $ExpectError
+
 }
 
 namespace TestLibraryManagedAttributes {

--- a/types/react-redux/react-redux-tests.tsx
+++ b/types/react-redux/react-redux-tests.tsx
@@ -1186,5 +1186,5 @@ namespace TestLibraryManagedAttributes {
 	<ConnectedComponent fn={() => {}} />
 
 	const ConnectedComponent2 = connect<MapStateProps, void, OwnProps>(mapStateToProps)(Component);
-	<ConnectedComponent fn={() => {}} />
+	<ConnectedComponent2 fn={() => {}} />
 }

--- a/types/react-redux/react-redux-tests.tsx
+++ b/types/react-redux/react-redux-tests.tsx
@@ -1155,3 +1155,36 @@ namespace TestFailsMoreSpecificInjectedProps {
   // the following line should fail to compile.
   connect(mapStateToProps, mapDispatchToProps)(Component) // $ExpectError
 }
+
+namespace TestLibraryManagedAttributes {
+	interface OwnProps {
+		bar: number,
+		fn: () => void,
+	}
+
+	type MapStateProps = {
+		foo: string,
+	}
+
+	class Component extends React.Component<OwnProps & MapStateProps> {
+		static defaultProps = {
+			bar: 0,
+		}
+
+		render () {
+			return <div />;
+		}
+	}
+
+	function mapStateToProps (state: any): MapStateProps {
+		return {
+			foo: 'foo',
+		};
+	}
+
+	const ConnectedComponent = connect(mapStateToProps)(Component);
+	<ConnectedComponent fn={() => {}} />
+
+	const ConnectedComponent2 = connect<MapStateProps, void, OwnProps>(mapStateToProps)(Component);
+	<ConnectedComponent fn={() => {}} />
+}


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-0.html

---

This makes sure the inferred props include the `defaultProps` and `propTypes` resolutions by using `JSX.LibraryManagedAttributes`. I don't know how people feel about using `JSX.LibraryManagedAttributes` here directly but it feels better than rewriting the same thing from scratch...

This fixes https://github.com/DefinitelyTyped/DefinitelyTyped/issues/27959 