### PR TITLE
Fix jszip default export

### DIFF
--- a/types/jszip/index.d.ts
+++ b/types/jszip/index.d.ts
@@ -256,4 +256,4 @@ interface JSZip {
 
 declare var JSZip: JSZip;
 
-export = JSZip;
+export default = JSZip;

--- a/types/jszip/index.d.ts
+++ b/types/jszip/index.d.ts
@@ -256,4 +256,4 @@ interface JSZip {
 
 declare var JSZip: JSZip;
 
-export default = JSZip;
+export default JSZip;


### PR DESCRIPTION
I'm not versed in TypeScript so this might be the wrong fix, let me know.

**Before:**

```
/foo/bar.ts:2:8 - error TS1192: Module '"/foo/node_modules/@types/jszip/index"' has no default export.

2 import JSZip from 'jszip';
```

**After:**

No error