### PR TITLE
update [@types/node-forge] added ed25519 in pki

### DIFF
--- a/types/node-forge/README.md
+++ b/types/node-forge/README.md
@@ -1,0 +1,29 @@
+# DefinitelyTyped for node-forge
+
+## Current node-forge Version
+`v0.7.6`
+## Usage
+
+```bash
+npm install --save-dev @types/node-forge
+npm install --save node-forge
+```
+
+example:
+```ts
+import * as forge from "node-forge";
+
+Buffer.isBuffer(forge.pki.ed25519.generateKeyPair().publicKey) // true
+```
+## License
+BSD-2-Clause
+
+## dependencies
+`@types/node`
+
+## Author
+[Seth Westphal](https://github.com/westy92)
+[Kay Schecker](https://github.com/flynetworks)
+[Aakash Goenka](https://github.com/a-k-g)
+[Rafal2228](https://github.com/rafal2228)
+[Beeno Tung](https://github.com/beenotung)

--- a/types/node-forge/index.d.ts
+++ b/types/node-forge/index.d.ts
@@ -73,6 +73,33 @@ declare module "node-forge" {
             function generateKeyPair(options?: GenerateKeyPairOptions, callback?: (err: Error, keypair: KeyPair) => void): KeyPair;
         }
 
+        namespace ed25519 {
+
+            type NativeBuffer = Buffer | Uint8Array;
+
+            namespace constants {
+                const PUBLIC_KEY_BYTE_LENGTH = 32;
+                const PRIVATE_KEY_BYTE_LENGTH = 64;
+                const SEED_BYTE_LENGTH = 32;
+                const SIGN_BYTE_LENGTH = 64;
+                const HASH_BYTE_LENGTH = 64;
+            }
+
+            function generateKeyPair(options?: { seed?: Buffer | Uint8Array | string }): {
+                publicKey: NativeBuffer;
+                privateKey: NativeBuffer;
+            };
+
+            function publicKeyFromPrivateKey(options: { privateKey: NativeBuffer }): NativeBuffer;
+
+            function sign(options: { privateKey: NativeBuffer }): NativeBuffer;
+
+            function verify(options: {
+                signature: Buffer | Uint8Array | util.ByteBuffer | string,
+                publicKey: NativeBuffer
+            }): boolean;
+        }
+
         interface CertificateFieldOptions {
             name?: string;
             type?: string;

--- a/types/node-forge/index.d.ts
+++ b/types/node-forge/index.d.ts
@@ -7,6 +7,8 @@
 //                 Beeno Tung <https://github.com/beenotung>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
+/// <reference types="node" />
+
 declare module "node-forge" {
     type Byte = string;
     type Bytes = string;

--- a/types/node-forge/index.d.ts
+++ b/types/node-forge/index.d.ts
@@ -6,6 +6,7 @@
 //                 Rafal2228 <https://github.com/rafal2228>
 //                 Beeno Tung <https://github.com/beenotung>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.6
 
 /// <reference types="node" />
 

--- a/types/node-forge/index.d.ts
+++ b/types/node-forge/index.d.ts
@@ -1,9 +1,10 @@
-// Type definitions for node-forge 0.7.5
+// Type definitions for node-forge 0.7.6
 // Project: https://github.com/digitalbazaar/forge
 // Definitions by: Seth Westphal <https://github.com/westy92>
 //                 Kay Schecker <https://github.com/flynetworks>
 //                 Aakash Goenka <https://github.com/a-k-g>
 //                 Rafal2228 <https://github.com/rafal2228>
+//                 Beeno Tung <https://github.com/beenotung>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare module "node-forge" {

--- a/types/urllib/README.md
+++ b/types/urllib/README.md
@@ -1,16 +1,16 @@
 # DefinitelyTyped for Urllib
 
 ## Current Urllib Version
-`v0.7.6`
+`v2.25.4`
 ## Usage
 
 ```bash
-npm install --save-dev @types/node-forge
+npm install --save-dev @types/urllib
 ```
 
 example:
 ```ts
-import * as forge from ".";
+import * as urllib from ".";
 
 urllib.curl('https://example.test.com', {
   method: "GET",

--- a/types/urllib/README.md
+++ b/types/urllib/README.md
@@ -1,16 +1,16 @@
 # DefinitelyTyped for Urllib
 
 ## Current Urllib Version
-`v2.25.4`
+`v0.7.6`
 ## Usage
 
 ```bash
-npm install --save-dev @types/urllib
+npm install --save-dev @types/node-forge
 ```
 
 example:
 ```ts
-import * as urllib from ".";
+import * as forge from ".";
 
 urllib.curl('https://example.test.com', {
   method: "GET",


### PR DESCRIPTION
Updating the current definition, adding type definition of `ed25519` of `pki`.

The original test was broken, so the test is untouch.