### PR TITLE
[sharp] Fix #28100: make the first argument omitable

### DIFF
--- a/types/sharp/index.d.ts
+++ b/types/sharp/index.d.ts
@@ -15,6 +15,7 @@ import { Duplex } from "stream";
  * @throws {Error} Invalid parameters
  * @returns A sharp instance that can be used to chain operations
  */
+declare function sharp(options?: sharp.SharpOptions): sharp.SharpInstance;
 declare function sharp(input?: string | Buffer, options?: sharp.SharpOptions): sharp.SharpInstance;
 declare namespace sharp {
     const gravity: GravityEnum;

--- a/types/sharp/sharp-tests.ts
+++ b/types/sharp/sharp-tests.ts
@@ -47,6 +47,17 @@ sharp('input.jpg')
         // containing a scaled and cropped version of input.jpg
     });
 
+sharp({
+    create: {
+        width: 300,
+        height: 200,
+        channels: 4,
+        background: { r: 255, g: 0, b: 0, alpha: 128 }
+    }
+})
+.png()
+.toBuffer();
+
 let transformer = sharp()
     .resize(300)
     .on('info', (info: sharp.OutputInfo) => {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <http://sharp.dimens.io/en/stable/api-constructor/#examples> (and this also fixes issue #28100)
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
