### PR TITLE
[react-intl] More accurate injectIntl types

### DIFF
--- a/types/react-intl/index.d.ts
+++ b/types/react-intl/index.d.ts
@@ -28,10 +28,8 @@ declare namespace ReactIntl {
         withRef?: boolean;
     }
 
-    type ComponentConstructor<P> = React.ComponentClass<P> | React.StatelessComponent<P>;
-
-    function injectIntl<P>(component: ComponentConstructor<P & InjectedIntlProps>, options?: InjectIntlConfig):
-        React.ComponentClass<P> & { WrappedComponent: ComponentConstructor<P & InjectedIntlProps> };
+    function injectIntl<P extends InjectedIntlProps>(component: React.ComponentType<P>, options?: InjectIntlConfig):
+        React.ComponentClass<Pick<P, Exclude<keyof P, keyof InjectedIntlProps>>> & { WrappedComponent: React.ComponentType<P> };
 
     function addLocaleData(data: Locale[] | Locale): void;
 

--- a/types/react-intl/react-intl-tests.tsx
+++ b/types/react-intl/react-intl-tests.tsx
@@ -32,7 +32,7 @@ interface SomeComponentProps {
     className: string;
 }
 
-const SomeFunctionalComponentWithIntl: React.ComponentClass<SomeComponentProps> = injectIntl<SomeComponentProps>(({
+const SomeFunctionalComponentWithIntl: React.ComponentClass<SomeComponentProps> = injectIntl<SomeComponentProps & InjectedIntlProps>(({
     intl: {
         formatDate,
         formatHTMLMessage,


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Use Exclude to be able to correctly exclude intl prop from more complex type definitions that use nested Pick and the like. Also correctly type check the passed in component and do not accept ones that don't have `intl` in their props definition.
