### PR TITLE
node: fix for Cipher and Decipher in CCM/GCM mode

### DIFF
--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -5893,10 +5893,10 @@ declare module "crypto" {
     export type CipherCCMTypes = 'aes-128-ccm' | 'aes-192-ccm' | 'aes-256-ccm';
     export type CipherGCMTypes = 'aes-128-gcm' | 'aes-192-gcm' | 'aes-256-gcm';
     export interface CipherCCMOptions extends stream.TransformOptions {
-        authTagLength: number;
+        authTagLength: 4 | 6 | 8 | 10 | 12 | 14 | 16;
     }
     export interface CipherGCMOptions extends stream.TransformOptions {
-        authTagLength?: number;
+        authTagLength?: 4 | 8 | 12 | 13 | 14 | 15 | 16;
     }
     /** @deprecated since v10.0.0 use createCipheriv() */
     export function createCipher(algorithm: string, password: string | Buffer | NodeJS.TypedArray | DataView, options?: stream.TransformOptions): Cipher;
@@ -5904,7 +5904,7 @@ declare module "crypto" {
     export function createCipher(algorithm: CipherGCMTypes, password: string | Buffer | NodeJS.TypedArray | DataView, options: CipherGCMOptions): CipherGCM;
 
     export function createCipheriv(algorithm: string, key: string | Buffer | NodeJS.TypedArray | DataView, iv: string | Buffer | NodeJS.TypedArray | DataView, options?: stream.TransformOptions): Cipher;
-    export function createCipheriv(algorithm: CipherGCMTypes, key: string | Buffer | NodeJS.TypedArray | DataView, iv: string | Buffer | NodeJS.TypedArray | DataView, options: CipherCCMOptions): CipherCCM;
+    export function createCipheriv(algorithm: CipherCCMTypes, key: string | Buffer | NodeJS.TypedArray | DataView, iv: string | Buffer | NodeJS.TypedArray | DataView, options: CipherCCMOptions): CipherCCM;
     export function createCipheriv(algorithm: CipherGCMTypes, key: string | Buffer | NodeJS.TypedArray | DataView, iv: string | Buffer | NodeJS.TypedArray | DataView, options: CipherGCMOptions): CipherGCM;
 
     export interface Cipher extends NodeJS.ReadWriteStream {
@@ -5921,11 +5921,11 @@ declare module "crypto" {
         // setAAD(buffer: Buffer): this; // docs only say buffer
     }
     export interface CipherCCM extends Cipher {
-        setAAD(buffer: Buffer, options: { plainTextLength: number }): this;
+        setAAD(buffer: Buffer, options: { plaintextLength: number }): this;
         getAuthTag(): Buffer;
     }
     export interface CipherGCM extends Cipher {
-        setAAD(buffer: Buffer, options?: { plainTextLength: number }): this;
+        setAAD(buffer: Buffer, options?: { plaintextLength: number }): this;
         getAuthTag(): Buffer;
     }
     /** @deprecated since v10.0.0 use createCipheriv() */
@@ -5950,12 +5950,12 @@ declare module "crypto" {
         // setAAD(buffer: Buffer | NodeJS.TypedArray | DataView): this;
     }
     export interface DecipherCCM extends Decipher {
-        setAuthTag(buffer: Buffer | NodeJS.TypedArray | DataView, options: { plainTextLength: number }): this;
-        setAAD(buffer: Buffer | NodeJS.TypedArray | DataView): this;
+        setAAD(buffer: Buffer | NodeJS.TypedArray | DataView, options: { plaintextLength: number }): this;
+        setAuthTag(buffer: Buffer | NodeJS.TypedArray | DataView): this;
     }
     export interface DecipherGCM extends Decipher {
-        setAuthTag(buffer: Buffer | NodeJS.TypedArray | DataView, options?: { plainTextLength: number }): this;
-        setAAD(buffer: Buffer | NodeJS.TypedArray | DataView): this;
+        setAAD(buffer: Buffer | NodeJS.TypedArray | DataView, options?: { plaintextLength: number }): this;
+        setAuthTag(buffer: Buffer | NodeJS.TypedArray | DataView): this;
     }
 
     export function createSign(algorithm: string, options?: stream.WritableOptions): Signer;

--- a/types/node/node-tests.ts
+++ b/types/node/node-tests.ts
@@ -1225,6 +1225,125 @@ namespace crypto_tests {
     }
 
     {
+        // crypto_cipher_decipher_iv_string_test
+        let key: Buffer = new Buffer([1, 2, 3, 4, 5, 6, 7, 8, 9, 1, 2, 3, 4, 5, 6, 7]);
+        let clearText: string = "This is the clear text.";
+        let iv: Buffer = crypto.randomBytes(16);
+        let cipher: crypto.Cipher = crypto.createCipheriv("aes-128-ecb", key, iv);
+        let cipherText: string = cipher.update(clearText, "utf8", "hex");
+        cipherText += cipher.final("hex");
+
+        let decipher: crypto.Decipher = crypto.createDecipheriv("aes-128-ecb", key, iv);
+        let clearText2: string = decipher.update(cipherText, "hex", "utf8");
+        clearText2 += decipher.final("utf8");
+
+        assert.equal(clearText2, clearText);
+    }
+
+    {
+        // crypto_cipher_decipher_iv_buffer_test
+        let key: Buffer = new Buffer([1, 2, 3, 4, 5, 6, 7, 8, 9, 1, 2, 3, 4, 5, 6, 7]);
+        let clearText: Buffer = new Buffer([1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4]);
+        let iv: Buffer = crypto.randomBytes(16);
+        let cipher: crypto.Cipher = crypto.createCipheriv("aes-128-ecb", key, iv);
+        let cipherBuffers: Buffer[] = [];
+        cipherBuffers.push(cipher.update(clearText));
+        cipherBuffers.push(cipher.final());
+
+        let cipherText: Buffer = Buffer.concat(cipherBuffers);
+
+        let decipher: crypto.Decipher = crypto.createDecipheriv("aes-128-ecb", key, iv);
+        let decipherBuffers: Buffer[] = [];
+        decipherBuffers.push(decipher.update(cipherText));
+        decipherBuffers.push(decipher.final());
+
+        let clearText2: Buffer = Buffer.concat(decipherBuffers);
+
+        assert.deepEqual(clearText2, clearText);
+    }
+
+    {
+        // crypto_cipher_decipher_iv_dataview_test
+        let key: Buffer = new Buffer([1, 2, 3, 4, 5, 6, 7, 8, 9, 1, 2, 3, 4, 5, 6, 7]);
+        let clearText: DataView = new DataView(
+            new Buffer([1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4]).buffer);
+        let iv: Buffer = crypto.randomBytes(16);
+        let cipher: crypto.Cipher = crypto.createCipheriv("aes-128-ecb", key, iv);
+        let cipherBuffers: Buffer[] = [];
+        cipherBuffers.push(cipher.update(clearText));
+        cipherBuffers.push(cipher.final());
+
+        let cipherText: DataView = new DataView(Buffer.concat(cipherBuffers).buffer);
+
+        let decipher: crypto.Decipher = crypto.createDecipheriv("aes-128-ecb", key, iv);
+        let decipherBuffers: Buffer[] = [];
+        decipherBuffers.push(decipher.update(cipherText));
+        decipherBuffers.push(decipher.final());
+
+        let clearText2: Buffer = Buffer.concat(decipherBuffers);
+
+        assert.deepEqual(clearText2, clearText);
+    }
+
+    {
+        // crypto_cipher_decipher_iv_ccm_string_test
+        let key: Buffer = new Buffer([1, 2, 3, 4, 5, 6, 7, 8, 9, 1, 2, 3, 4, 5, 6, 7]);
+        let clearText: string = "This is the clear text.";
+        let iv: Buffer = crypto.randomBytes(16);
+        let aad: Buffer = Buffer.from("0123456789", "hex");
+        let cipher: crypto.CipherCCM = crypto.createCipheriv("aes-128-ccm", key, iv, {
+            authTagLength: 16
+        });
+        cipher.setAAD(aad, {
+            plaintextLength: Buffer.byteLength(clearText)
+        });
+        let cipherText: string = cipher.update(clearText, "utf8", "hex");
+        cipherText += cipher.final("hex");
+        let tag: Buffer = cipher.getAuthTag();
+
+        let decipher: crypto.DecipherCCM = crypto.createDecipheriv("aes-128-ccm", key, iv, {
+            authTagLength: 16
+        });
+        decipher.setAuthTag(tag);
+        decipher.setAAD(aad, {
+            plaintextLength: Buffer.byteLength(cipherText, "hex")
+        });
+        let clearText2: string = decipher.update(cipherText, "hex", "utf8");
+        clearText2 += decipher.final("utf8");
+
+        assert.equal(clearText2, clearText);
+    }
+
+    {
+        // crypto_cipher_decipher_iv_gcm_string_test
+        let key: Buffer = new Buffer([1, 2, 3, 4, 5, 6, 7, 8, 9, 1, 2, 3, 4, 5, 6, 7]);
+        let clearText: string = "This is the clear text.";
+        let iv: Buffer = crypto.randomBytes(16);
+        let aad: Buffer = Buffer.from("0123456789", "hex");
+        let cipher: crypto.CipherGCM = crypto.createCipheriv("aes-128-gcm", key, iv, {
+            authTagLength: 16
+        });
+        cipher.setAAD(aad, {
+            plaintextLength: Buffer.byteLength(clearText)
+        });
+        let cipherText: string = cipher.update(clearText, "utf8", "hex");
+        cipherText += cipher.final("hex");
+        let tag: Buffer = cipher.getAuthTag();
+
+        let decipher: crypto.DecipherGCM = crypto.createDecipheriv("aes-128-gcm", key, iv, {
+            authTagLength: 16
+        });
+        decipher.setAuthTag(tag);
+        decipher.setAAD(aad, {
+            plaintextLength: Buffer.byteLength(cipherText, "hex")
+        });
+        let clearText2: string = decipher.update(cipherText, "hex", "utf8");
+        clearText2 += decipher.final("utf8");
+
+        assert.equal(clearText2, clearText);
+    }
+
+    {
         // crypto_timingsafeequal_buffer_test
         let buffer1: Buffer = new Buffer([1, 2, 3, 4, 5]);
         let buffer2: Buffer = new Buffer([1, 2, 3, 4, 5]);


### PR DESCRIPTION
- `createCipheriv` in CCM mode had the wrong type for the `algorithm` argument
- The option `plaintextLength` was misspelled as `plainTextLength`
- In the interfaces `DecipherCCM` and `DecipherGCM`, the options argument was mistakenly put on `setAuthTag` function and not the `setAAD` function
- The interface `CipherCCMOptions` specifies the valid value for `authTagLength` as the union type `4 | 6 | 8 | 10 | 12 | 14 | 16`. See [note about authentication tag length here](https://nodejs.org/api/crypto.html#crypto_ccm_mode)
- The interface `CipherGCMOptions` specifies the valid value for `authTagLength` as the union type `4 | 8 | 12 | 13 | 14 | 15 | 16`. See [src here](https://github.com/nodejs/node/blob/884b23daf723db60ebe939e6dde492fa5f9230eb/src/node_crypto.cc#L2774-L2776)
- Added tests for `createCipheriv` and `createDecipheriv` (copied from the ones that use the now deprecated `createCipher`)
- Added tests for `createCipheriv` and `createDecipheriv` in CCM and GCM mode

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/api/crypto.html#crypto_ccm_mode
