### PR TITLE
Interface CleaveOptions at extra options updated

### DIFF
--- a/types/cleave.js/options/index.d.ts
+++ b/types/cleave.js/options/index.d.ts
@@ -51,4 +51,5 @@ export interface CleaveOptions {
     noImmediatePrefix?: boolean;
     rawValueTrimPrefix?: boolean;
     uppercase?: boolean;
+    onValueChanged?(event: any): void;
 }


### PR DESCRIPTION
I updated the interface CleaveOptions at the extra options with the onValueChange, which is a public method at the JavaScript API of cleave.js: https://github.com/nosir/cleave.js/blob/master/doc/options.md#onvaluechanged

Best regards,
Leon
