### PR TITLE
Update jsforce describe-result.d.ts fixing createable typo

### DIFF
--- a/types/jsforce/describe-result.d.ts
+++ b/types/jsforce/describe-result.d.ts
@@ -70,7 +70,7 @@ export interface Field {
     caseSensitive: boolean;
     compoundFieldName?: maybe<string>;
     controllerName?: maybe<string>;
-    creatable: boolean;
+    createable: boolean;
     custom: boolean;
     defaultValue?: maybe<string | boolean>;
     defaultValueFormula?: maybe<string>;


### PR DESCRIPTION
createable in the Field interface is misspelled see https://developer.salesforce.com/docs/atlas.en-us.api.meta/api/sforce_api_calls_describesobjects_describesobjectresult.htm  It should be createable, not creatable.   The DescribeSObjectResult has createable spelled correctly


- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.salesforce.com/docs/atlas.en-us.api.meta/api/sforce_api_calls_describesobjects_describesobjectresult.htm
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

