### PR TITLE
ioredis: support Buffers as keys

### DIFF
--- a/types/ioredis/index.d.ts
+++ b/types/ioredis/index.d.ts
@@ -45,6 +45,8 @@ declare class Commander {
 }
 
 declare namespace IORedis {
+    type KeyType = string | Buffer
+
     interface Command {
         setArgumentTransformer(name: string, fn: (args: any[]) => any[]): void;
         setReplyTransformer(name: string, fn: (result: any) => any): void;
@@ -59,257 +61,257 @@ declare namespace IORedis {
 
         send_command(command: string, ...args: any[]): any;
 
-        bitcount(key: string, callback: (err: Error, res: number) => void): void;
-        bitcount(key: string, start: number, end: number, callback: (err: Error, res: number) => void): void;
-        bitcount(key: string): Promise<number>;
-        bitcount(key: string, start: number, end: number): Promise<number>;
+        bitcount(key: KeyType, callback: (err: Error, res: number) => void): void;
+        bitcount(key: KeyType, start: number, end: number, callback: (err: Error, res: number) => void): void;
+        bitcount(key: KeyType): Promise<number>;
+        bitcount(key: KeyType, start: number, end: number): Promise<number>;
 
-        get(key: string, callback: (err: Error, res: string) => void): void;
-        get(key: string): Promise<string>;
+        get(key: KeyType, callback: (err: Error, res: string) => void): void;
+        get(key: KeyType): Promise<string>;
 
-        getBuffer(key: string, callback: (err: Error, res: Buffer) => void): void;
-        getBuffer(key: string): Promise<Buffer>;
+        getBuffer(key: KeyType, callback: (err: Error, res: Buffer) => void): void;
+        getBuffer(key: KeyType): Promise<Buffer>;
 
-        set(key: string, value: any, expiryMode?: string | any[], time?: number | string, setMode?: number | string): Promise<string>;
+        set(key: KeyType, value: any, expiryMode?: string | any[], time?: number | string, setMode?: number | string): Promise<string>;
 
-        set(key: string, value: any, callback: (err: Error, res: string) => void): void;
-        set(key: string, value: any, setMode: string | any[], callback: (err: Error, res: string) => void): void;
-        set(key: string, value: any, expiryMode: string, time: number | string, callback: (err: Error, res: string) => void): void;
-        set(key: string, value: any, expiryMode: string, time: number | string, setMode: number | string, callback: (err: Error, res: string) => void): void;
+        set(key: KeyType, value: any, callback: (err: Error, res: string) => void): void;
+        set(key: KeyType, value: any, setMode: string | any[], callback: (err: Error, res: string) => void): void;
+        set(key: KeyType, value: any, expiryMode: string, time: number | string, callback: (err: Error, res: string) => void): void;
+        set(key: KeyType, value: any, expiryMode: string, time: number | string, setMode: number | string, callback: (err: Error, res: string) => void): void;
 
-        setBuffer(key: string, value: any, expiryMode?: string | any[], time?: number | string, setMode?: number | string): Promise<Buffer>;
+        setBuffer(key: KeyType, value: any, expiryMode?: string | any[], time?: number | string, setMode?: number | string): Promise<Buffer>;
 
-        setBuffer(key: string, value: any, callback: (err: Error, res: Buffer) => void): void;
-        setBuffer(key: string, value: any, setMode: string, callback: (err: Error, res: Buffer) => void): void;
-        setBuffer(key: string, value: any, expiryMode: string, time: number, callback: (err: Error, res: Buffer) => void): void;
-        setBuffer(key: string, value: any, expiryMode: string, time: number | string, setMode: number | string, callback: (err: Error, res: Buffer) => void): void;
+        setBuffer(key: KeyType, value: any, callback: (err: Error, res: Buffer) => void): void;
+        setBuffer(key: KeyType, value: any, setMode: string, callback: (err: Error, res: Buffer) => void): void;
+        setBuffer(key: KeyType, value: any, expiryMode: string, time: number, callback: (err: Error, res: Buffer) => void): void;
+        setBuffer(key: KeyType, value: any, expiryMode: string, time: number | string, setMode: number | string, callback: (err: Error, res: Buffer) => void): void;
 
-        setnx(key: string, value: any, callback: (err: Error, res: any) => void): void;
-        setnx(key: string, value: any): Promise<any>;
+        setnx(key: KeyType, value: any, callback: (err: Error, res: any) => void): void;
+        setnx(key: KeyType, value: any): Promise<any>;
 
-        setex(key: string, seconds: number, value: any, callback: (err: Error, res: any) => void): void;
-        setex(key: string, seconds: number, value: any): Promise<any>;
+        setex(key: KeyType, seconds: number, value: any, callback: (err: Error, res: any) => void): void;
+        setex(key: KeyType, seconds: number, value: any): Promise<any>;
 
-        psetex(key: string, milliseconds: number, value: any, callback: (err: Error, res: any) => void): void;
-        psetex(key: string, milliseconds: number, value: any): Promise<any>;
+        psetex(key: KeyType, milliseconds: number, value: any, callback: (err: Error, res: any) => void): void;
+        psetex(key: KeyType, milliseconds: number, value: any): Promise<any>;
 
-        append(key: string, value: any, callback: (err: Error, res: number) => void): void;
-        append(key: string, value: any): Promise<number>;
+        append(key: KeyType, value: any, callback: (err: Error, res: number) => void): void;
+        append(key: KeyType, value: any): Promise<number>;
 
-        strlen(key: string, callback: (err: Error, res: number) => void): void;
-        strlen(key: string): Promise<number>;
+        strlen(key: KeyType, callback: (err: Error, res: number) => void): void;
+        strlen(key: KeyType): Promise<number>;
 
-        del(...keys: string[]): any;
+        del(...keys: KeyType[]): any;
 
-        exists(...keys: string[]): any;
+        exists(...keys: KeyType[]): any;
 
-        setbit(key: string, offset: number, value: any, callback: (err: Error, res: number) => void): void;
-        setbit(key: string, offset: number, value: any): Promise<number>;
+        setbit(key: KeyType, offset: number, value: any, callback: (err: Error, res: number) => void): void;
+        setbit(key: KeyType, offset: number, value: any): Promise<number>;
 
-        getbit(key: string, offset: number, callback: (err: Error, res: number) => void): void;
-        getbit(key: string, offset: number): Promise<number>;
+        getbit(key: KeyType, offset: number, callback: (err: Error, res: number) => void): void;
+        getbit(key: KeyType, offset: number): Promise<number>;
 
-        setrange(key: string, offset: number, value: any, callback: (err: Error, res: number) => void): void;
-        setrange(key: string, offset: number, value: any): Promise<number>;
+        setrange(key: KeyType, offset: number, value: any, callback: (err: Error, res: number) => void): void;
+        setrange(key: KeyType, offset: number, value: any): Promise<number>;
 
-        getrange(key: string, start: number, end: number, callback: (err: Error, res: string) => void): void;
-        getrange(key: string, start: number, end: number): Promise<string>;
+        getrange(key: KeyType, start: number, end: number, callback: (err: Error, res: string) => void): void;
+        getrange(key: KeyType, start: number, end: number): Promise<string>;
 
-        substr(key: string, start: number, end: number, callback: (err: Error, res: string) => void): void;
-        substr(key: string, start: number, end: number): Promise<string>;
+        substr(key: KeyType, start: number, end: number, callback: (err: Error, res: string) => void): void;
+        substr(key: KeyType, start: number, end: number): Promise<string>;
 
-        incr(key: string, callback: (err: Error, res: number) => void): void;
-        incr(key: string): Promise<number>;
+        incr(key: KeyType, callback: (err: Error, res: number) => void): void;
+        incr(key: KeyType): Promise<number>;
 
-        decr(key: string, callback: (err: Error, res: number) => void): void;
-        decr(key: string): Promise<number>;
+        decr(key: KeyType, callback: (err: Error, res: number) => void): void;
+        decr(key: KeyType): Promise<number>;
 
-        mget(...keys: string[]): any;
+        mget(...keys: KeyType[]): any;
 
-        rpush(key: string, ...values: any[]): any;
+        rpush(key: KeyType, ...values: any[]): any;
 
-        lpush(key: string, ...values: any[]): any;
+        lpush(key: KeyType, ...values: any[]): any;
 
-        rpushx(key: string, value: any, callback: (err: Error, res: number) => void): void;
-        rpushx(key: string, value: any): Promise<number>;
+        rpushx(key: KeyType, value: any, callback: (err: Error, res: number) => void): void;
+        rpushx(key: KeyType, value: any): Promise<number>;
 
-        lpushx(key: string, value: any, callback: (err: Error, res: number) => void): void;
-        lpushx(key: string, value: any): Promise<number>;
+        lpushx(key: KeyType, value: any, callback: (err: Error, res: number) => void): void;
+        lpushx(key: KeyType, value: any): Promise<number>;
 
-        linsert(key: string, direction: "BEFORE" | "AFTER", pivot: string, value: any, callback: (err: Error, res: number) => void): void;
-        linsert(key: string, direction: "BEFORE" | "AFTER", pivot: string, value: any): Promise<number>;
+        linsert(key: KeyType, direction: "BEFORE" | "AFTER", pivot: string, value: any, callback: (err: Error, res: number) => void): void;
+        linsert(key: KeyType, direction: "BEFORE" | "AFTER", pivot: string, value: any): Promise<number>;
 
-        rpop(key: string, callback: (err: Error, res: string) => void): void;
-        rpop(key: string): Promise<string>;
+        rpop(key: KeyType, callback: (err: Error, res: string) => void): void;
+        rpop(key: KeyType): Promise<string>;
 
-        lpop(key: string, callback: (err: Error, res: string) => void): void;
-        lpop(key: string): Promise<string>;
+        lpop(key: KeyType, callback: (err: Error, res: string) => void): void;
+        lpop(key: KeyType): Promise<string>;
 
-        brpop(...keys: string[]): any;
+        brpop(...keys: KeyType[]): any;
 
-        blpop(...keys: string[]): any;
+        blpop(...keys: KeyType[]): any;
 
         brpoplpush(source: string, destination: string, timeout: number, callback: (err: Error, res: any) => void): void;
         brpoplpush(source: string, destination: string, timeout: number): Promise<any>;
 
-        llen(key: string, callback: (err: Error, res: number) => void): void;
-        llen(key: string): Promise<number>;
+        llen(key: KeyType, callback: (err: Error, res: number) => void): void;
+        llen(key: KeyType): Promise<number>;
 
-        lindex(key: string, index: number, callback: (err: Error, res: string) => void): void;
-        lindex(key: string, index: number): Promise<string>;
+        lindex(key: KeyType, index: number, callback: (err: Error, res: string) => void): void;
+        lindex(key: KeyType, index: number): Promise<string>;
 
-        lset(key: string, index: number, value: any, callback: (err: Error, res: any) => void): void;
-        lset(key: string, index: number, value: any): Promise<any>;
+        lset(key: KeyType, index: number, value: any, callback: (err: Error, res: any) => void): void;
+        lset(key: KeyType, index: number, value: any): Promise<any>;
 
-        lrange(key: string, start: number, stop: number, callback: (err: Error, res: any) => void): void;
-        lrange(key: string, start: number, stop: number): Promise<any>;
+        lrange(key: KeyType, start: number, stop: number, callback: (err: Error, res: any) => void): void;
+        lrange(key: KeyType, start: number, stop: number): Promise<any>;
 
-        ltrim(key: string, start: number, stop: number, callback: (err: Error, res: any) => void): void;
-        ltrim(key: string, start: number, stop: number): Promise<any>;
+        ltrim(key: KeyType, start: number, stop: number, callback: (err: Error, res: any) => void): void;
+        ltrim(key: KeyType, start: number, stop: number): Promise<any>;
 
-        lrem(key: string, count: number, value: any, callback: (err: Error, res: number) => void): void;
-        lrem(key: string, count: number, value: any): Promise<number>;
+        lrem(key: KeyType, count: number, value: any, callback: (err: Error, res: number) => void): void;
+        lrem(key: KeyType, count: number, value: any): Promise<number>;
 
         rpoplpush(source: string, destination: string, callback: (err: Error, res: string) => void): void;
         rpoplpush(source: string, destination: string): Promise<string>;
 
-        sadd(key: string, ...members: any[]): any;
+        sadd(key: KeyType, ...members: any[]): any;
 
-        srem(key: string, ...members: any[]): any;
+        srem(key: KeyType, ...members: any[]): any;
 
         smove(source: string, destination: string, member: string, callback: (err: Error, res: string) => void): void;
         smove(source: string, destination: string, member: string): Promise<string>;
 
-        sismember(key: string, member: string, callback: (err: Error, res: 1 | 0) => void): void;
-        sismember(key: string, member: string): Promise<1 | 0>;
+        sismember(key: KeyType, member: string, callback: (err: Error, res: 1 | 0) => void): void;
+        sismember(key: KeyType, member: string): Promise<1 | 0>;
 
-        scard(key: string, callback: (err: Error, res: number) => void): void;
-        scard(key: string): Promise<number>;
+        scard(key: KeyType, callback: (err: Error, res: number) => void): void;
+        scard(key: KeyType): Promise<number>;
 
-        spop(key: string, callback: (err: Error, res: any) => void): void;
-        spop(key: string, count: number, callback: (err: Error, res: any) => void): void;
-        spop(key: string, count?: number): Promise<any>;
+        spop(key: KeyType, callback: (err: Error, res: any) => void): void;
+        spop(key: KeyType, count: number, callback: (err: Error, res: any) => void): void;
+        spop(key: KeyType, count?: number): Promise<any>;
 
-        srandmember(key: string, callback: (err: Error, res: any) => void): void;
-        srandmember(key: string, count: number, callback: (err: Error, res: any) => void): void;
-        srandmember(key: string, count?: number): Promise<any>;
+        srandmember(key: KeyType, callback: (err: Error, res: any) => void): void;
+        srandmember(key: KeyType, count: number, callback: (err: Error, res: any) => void): void;
+        srandmember(key: KeyType, count?: number): Promise<any>;
 
-        sinter(...keys: string[]): any;
+        sinter(...keys: KeyType[]): any;
 
-        sinterstore(destination: string, ...keys: string[]): any;
+        sinterstore(destination: string, ...keys: KeyType[]): any;
 
-        sunion(...keys: string[]): any;
+        sunion(...keys: KeyType[]): any;
 
-        sunionstore(destination: string, ...keys: string[]): any;
+        sunionstore(destination: string, ...keys: KeyType[]): any;
 
-        sdiff(...keys: string[]): any;
+        sdiff(...keys: KeyType[]): any;
 
-        sdiffstore(destination: string, ...keys: string[]): any;
+        sdiffstore(destination: string, ...keys: KeyType[]): any;
 
-        smembers(key: string, callback: (err: Error, res: any) => void): void;
-        smembers(key: string): Promise<any>;
+        smembers(key: KeyType, callback: (err: Error, res: any) => void): void;
+        smembers(key: KeyType): Promise<any>;
 
-        zadd(key: string, ...args: string[]): any;
+        zadd(key: KeyType, ...args: string[]): any;
 
-        zincrby(key: string, increment: number, member: string, callback: (err: Error, res: any) => void): void;
-        zincrby(key: string, increment: number, member: string): Promise<any>;
+        zincrby(key: KeyType, increment: number, member: string, callback: (err: Error, res: any) => void): void;
+        zincrby(key: KeyType, increment: number, member: string): Promise<any>;
 
-        zrem(key: string, ...members: any[]): any;
+        zrem(key: KeyType, ...members: any[]): any;
 
-        zremrangebyscore(key: string, min: number | string, max: number | string, callback: (err: Error, res: any) => void): void;
-        zremrangebyscore(key: string, min: number | string, max: number | string): Promise<any>;
+        zremrangebyscore(key: KeyType, min: number | string, max: number | string, callback: (err: Error, res: any) => void): void;
+        zremrangebyscore(key: KeyType, min: number | string, max: number | string): Promise<any>;
 
-        zremrangebyrank(key: string, start: number, stop: number, callback: (err: Error, res: any) => void): void;
-        zremrangebyrank(key: string, start: number, stop: number): Promise<any>;
+        zremrangebyrank(key: KeyType, start: number, stop: number, callback: (err: Error, res: any) => void): void;
+        zremrangebyrank(key: KeyType, start: number, stop: number): Promise<any>;
 
-        zunionstore(destination: string, numkeys: number, key: string, ...args: string[]): any;
+        zunionstore(destination: string, numkeys: number, key: KeyType, ...args: string[]): any;
 
-        zinterstore(destination: string, numkeys: number, key: string, ...args: string[]): any;
+        zinterstore(destination: string, numkeys: number, key: KeyType, ...args: string[]): any;
 
-        zrange(key: string, start: number, stop: number, callback: (err: Error, res: any) => void): void;
-        zrange(key: string, start: number, stop: number, withScores: "WITHSCORES", callback: (err: Error, res: any) => void): void;
-        zrange(key: string, start: number, stop: number, withScores?: "WITHSCORES"): Promise<any>;
+        zrange(key: KeyType, start: number, stop: number, callback: (err: Error, res: any) => void): void;
+        zrange(key: KeyType, start: number, stop: number, withScores: "WITHSCORES", callback: (err: Error, res: any) => void): void;
+        zrange(key: KeyType, start: number, stop: number, withScores?: "WITHSCORES"): Promise<any>;
 
-        zrevrange(key: string, start: number, stop: number, callback: (err: Error, res: any) => void): void;
-        zrevrange(key: string, start: number, stop: number, withScores: "WITHSCORES", callback: (err: Error, res: any) => void): void;
-        zrevrange(key: string, start: number, stop: number, withScores?: "WITHSCORES"): Promise<any>;
+        zrevrange(key: KeyType, start: number, stop: number, callback: (err: Error, res: any) => void): void;
+        zrevrange(key: KeyType, start: number, stop: number, withScores: "WITHSCORES", callback: (err: Error, res: any) => void): void;
+        zrevrange(key: KeyType, start: number, stop: number, withScores?: "WITHSCORES"): Promise<any>;
 
-        zrangebyscore(key: string, min: number | string, max: number | string, ...args: string[]): any;
+        zrangebyscore(key: KeyType, min: number | string, max: number | string, ...args: string[]): any;
 
-        zrevrangebyscore(key: string, max: number | string, min: number | string, ...args: string[]): any;
+        zrevrangebyscore(key: KeyType, max: number | string, min: number | string, ...args: string[]): any;
 
-        zcount(key: string, min: number | string, max: number | string, callback: (err: Error, res: number) => void): void;
-        zcount(key: string, min: number | string, max: number | string): Promise<number>;
+        zcount(key: KeyType, min: number | string, max: number | string, callback: (err: Error, res: number) => void): void;
+        zcount(key: KeyType, min: number | string, max: number | string): Promise<number>;
 
-        zcard(key: string, callback: (err: Error, res: number) => void): void;
-        zcard(key: string): Promise<number>;
+        zcard(key: KeyType, callback: (err: Error, res: number) => void): void;
+        zcard(key: KeyType): Promise<number>;
 
-        zscore(key: string, member: string, callback: (err: Error, res: string) => void): void;
-        zscore(key: string, member: string): Promise<string>;
+        zscore(key: KeyType, member: string, callback: (err: Error, res: string) => void): void;
+        zscore(key: KeyType, member: string): Promise<string>;
 
-        zrank(key: string, member: string, callback: (err: Error, res: number) => void): void;
-        zrank(key: string, member: string): Promise<number>;
+        zrank(key: KeyType, member: string, callback: (err: Error, res: number) => void): void;
+        zrank(key: KeyType, member: string): Promise<number>;
 
-        zrevrank(key: string, member: string, callback: (err: Error, res: number) => void): void;
-        zrevrank(key: string, member: string): Promise<number>;
+        zrevrank(key: KeyType, member: string, callback: (err: Error, res: number) => void): void;
+        zrevrank(key: KeyType, member: string): Promise<number>;
 
-        hset(key: string, field: string, value: any, callback: (err: Error, res: 0 | 1) => void): void;
-        hset(key: string, field: string, value: any): Promise<0 | 1>;
-        hsetBuffer(key: string, field: string, value: any, callback: (err: Error, res: 0 | 1) => void): void;
-        hsetBuffer(key: string, field: string, value: any): Promise<Buffer>;
+        hset(key: KeyType, field: string, value: any, callback: (err: Error, res: 0 | 1) => void): void;
+        hset(key: KeyType, field: string, value: any): Promise<0 | 1>;
+        hsetBuffer(key: KeyType, field: string, value: any, callback: (err: Error, res: 0 | 1) => void): void;
+        hsetBuffer(key: KeyType, field: string, value: any): Promise<Buffer>;
 
-        hsetnx(key: string, field: string, value: any, callback: (err: Error, res: 0 | 1) => void): void;
-        hsetnx(key: string, field: string, value: any): Promise<0 | 1>;
+        hsetnx(key: KeyType, field: string, value: any, callback: (err: Error, res: 0 | 1) => void): void;
+        hsetnx(key: KeyType, field: string, value: any): Promise<0 | 1>;
 
-        hget(key: string, field: string, callback: (err: Error, res: string) => void): void;
-        hget(key: string, field: string): Promise<string>;
-        hgetBuffer(key: string, field: string, callback: (err: Error, res: Buffer) => void): void;
-        hgetBuffer(key: string, field: string): Promise<Buffer>;
+        hget(key: KeyType, field: string, callback: (err: Error, res: string) => void): void;
+        hget(key: KeyType, field: string): Promise<string>;
+        hgetBuffer(key: KeyType, field: string, callback: (err: Error, res: Buffer) => void): void;
+        hgetBuffer(key: KeyType, field: string): Promise<Buffer>;
 
-        hmset(key: string, field: string, value: any, ...args: string[]): Promise<0 | 1>;
-        hmset(key: string, data: any, callback: (err: Error, res: 0 | 1) => void): void;
-        hmset(key: string, data: any): Promise<0 | 1>;
+        hmset(key: KeyType, field: string, value: any, ...args: string[]): Promise<0 | 1>;
+        hmset(key: KeyType, data: any, callback: (err: Error, res: 0 | 1) => void): void;
+        hmset(key: KeyType, data: any): Promise<0 | 1>;
 
-        hmget(key: string, ...fields: string[]): any;
+        hmget(key: KeyType, ...fields: string[]): any;
 
-        hincrby(key: string, field: string, increment: number, callback: (err: Error, res: number) => void): void;
-        hincrby(key: string, field: string, increment: number): Promise<number>;
+        hincrby(key: KeyType, field: string, increment: number, callback: (err: Error, res: number) => void): void;
+        hincrby(key: KeyType, field: string, increment: number): Promise<number>;
 
-        hincrbyfloat(key: string, field: string, increment: number, callback: (err: Error, res: number) => void): void;
-        hincrbyfloat(key: string, field: string, increment: number): Promise<number>;
+        hincrbyfloat(key: KeyType, field: string, increment: number, callback: (err: Error, res: number) => void): void;
+        hincrbyfloat(key: KeyType, field: string, increment: number): Promise<number>;
 
-        hdel(key: string, ...fields: string[]): any;
+        hdel(key: KeyType, ...fields: string[]): any;
 
-        hlen(key: string, callback: (err: Error, res: number) => void): void;
-        hlen(key: string): Promise<number>;
+        hlen(key: KeyType, callback: (err: Error, res: number) => void): void;
+        hlen(key: KeyType): Promise<number>;
 
-        hkeys(key: string, callback: (err: Error, res: any) => void): void;
-        hkeys(key: string): Promise<any>;
+        hkeys(key: KeyType, callback: (err: Error, res: any) => void): void;
+        hkeys(key: KeyType): Promise<any>;
 
-        hvals(key: string, callback: (err: Error, res: any) => void): void;
-        hvals(key: string): Promise<any>;
+        hvals(key: KeyType, callback: (err: Error, res: any) => void): void;
+        hvals(key: KeyType): Promise<any>;
 
-        hgetall(key: string, callback: (err: Error, res: any) => void): void;
-        hgetall(key: string): Promise<any>;
+        hgetall(key: KeyType, callback: (err: Error, res: any) => void): void;
+        hgetall(key: KeyType): Promise<any>;
 
-        hexists(key: string, field: string, callback: (err: Error, res: 0 | 1) => void): void;
-        hexists(key: string, field: string): Promise<0 | 1>;
+        hexists(key: KeyType, field: string, callback: (err: Error, res: 0 | 1) => void): void;
+        hexists(key: KeyType, field: string): Promise<0 | 1>;
 
-        incrby(key: string, increment: number, callback: (err: Error, res: number) => void): void;
-        incrby(key: string, increment: number): Promise<number>;
+        incrby(key: KeyType, increment: number, callback: (err: Error, res: number) => void): void;
+        incrby(key: KeyType, increment: number): Promise<number>;
 
-        incrbyfloat(key: string, increment: number, callback: (err: Error, res: number) => void): void;
-        incrbyfloat(key: string, increment: number): Promise<number>;
+        incrbyfloat(key: KeyType, increment: number, callback: (err: Error, res: number) => void): void;
+        incrbyfloat(key: KeyType, increment: number): Promise<number>;
 
-        decrby(key: string, decrement: number, callback: (err: Error, res: number) => void): void;
-        decrby(key: string, decrement: number): Promise<number>;
+        decrby(key: KeyType, decrement: number, callback: (err: Error, res: number) => void): void;
+        decrby(key: KeyType, decrement: number): Promise<number>;
 
-        getset(key: string, value: any, callback: (err: Error, res: string) => void): void;
-        getset(key: string, value: any): Promise<string>;
+        getset(key: KeyType, value: any, callback: (err: Error, res: string) => void): void;
+        getset(key: KeyType, value: any): Promise<string>;
 
-        mset(key: string, value: any, ...args: string[]): any;
+        mset(key: KeyType, value: any, ...args: string[]): any;
 
-        msetnx(key: string, value: any, ...args: string[]): any;
+        msetnx(key: KeyType, value: any, ...args: string[]): any;
 
         randomkey(callback: (err: Error, res: string) => void): void;
         randomkey(): Promise<string>;
@@ -317,26 +319,26 @@ declare namespace IORedis {
         select(index: number, callback: (err: Error, res: string) => void): void;
         select(index: number): Promise<string>;
 
-        move(key: string, db: string, callback: (err: Error, res: 0 | 1) => void): void;
-        move(key: string, db: string): Promise<0 | 1>;
+        move(key: KeyType, db: string, callback: (err: Error, res: 0 | 1) => void): void;
+        move(key: KeyType, db: string): Promise<0 | 1>;
 
-        rename(key: string, newkey: string, callback: (err: Error, res: string) => void): void;
-        rename(key: string, newkey: string): Promise<string>;
+        rename(key: KeyType, newkey: KeyType, callback: (err: Error, res: string) => void): void;
+        rename(key: KeyType, newkey: KeyType): Promise<string>;
 
-        renamenx(key: string, newkey: string, callback: (err: Error, res: 0 | 1) => void): void;
-        renamenx(key: string, newkey: string): Promise<0 | 1>;
+        renamenx(key: KeyType, newkey: KeyType, callback: (err: Error, res: 0 | 1) => void): void;
+        renamenx(key: KeyType, newkey: KeyType): Promise<0 | 1>;
 
-        expire(key: string, seconds: number, callback: (err: Error, res: 0 | 1) => void): void;
-        expire(key: string, seconds: number): Promise<0 | 1>;
+        expire(key: KeyType, seconds: number, callback: (err: Error, res: 0 | 1) => void): void;
+        expire(key: KeyType, seconds: number): Promise<0 | 1>;
 
-        pexpire(key: string, milliseconds: number, callback: (err: Error, res: 0 | 1) => void): void;
-        pexpire(key: string, milliseconds: number): Promise<0 | 1>;
+        pexpire(key: KeyType, milliseconds: number, callback: (err: Error, res: 0 | 1) => void): void;
+        pexpire(key: KeyType, milliseconds: number): Promise<0 | 1>;
 
-        expireat(key: string, timestamp: number, callback: (err: Error, res: 0 | 1) => void): void;
-        expireat(key: string, timestamp: number): Promise<0 | 1>;
+        expireat(key: KeyType, timestamp: number, callback: (err: Error, res: 0 | 1) => void): void;
+        expireat(key: KeyType, timestamp: number): Promise<0 | 1>;
 
-        pexpireat(key: string, millisecondsTimestamp: number, callback: (err: Error, res: 0 | 1) => void): void;
-        pexpireat(key: string, millisecondsTimestamp: number): Promise<0 | 1>;
+        pexpireat(key: KeyType, millisecondsTimestamp: number, callback: (err: Error, res: 0 | 1) => void): void;
+        pexpireat(key: KeyType, millisecondsTimestamp: number): Promise<0 | 1>;
 
         keys(pattern: string, callback: (err: Error, res: string[]) => void): void;
         keys(pattern: string): Promise<string[]>;
@@ -369,8 +371,8 @@ declare namespace IORedis {
         lastsave(callback: (err: Error, res: number) => void): void;
         lastsave(): Promise<number>;
 
-        type(key: string, callback: (err: Error, res: string) => void): void;
-        type(key: string): Promise<string>;
+        type(key: KeyType, callback: (err: Error, res: string) => void): void;
+        type(key: KeyType): Promise<string>;
 
         multi(commands?: string[][], options?: MultiOptions): Pipeline;
         multi(options: { pipeline: false }): Promise<string>;
@@ -390,7 +392,7 @@ declare namespace IORedis {
         flushall(callback: (err: Error, res: string) => void): void;
         flushall(): Promise<string>;
 
-        sort(key: string, ...args: string[]): any;
+        sort(key: KeyType, ...args: string[]): any;
 
         info(callback: (err: Error, res: any) => void): void;
         info(section: string, callback: (err: Error, res: any) => void): void;
@@ -402,11 +404,11 @@ declare namespace IORedis {
         monitor(callback: (err: Error, res: NodeJS.EventEmitter) => void): void;
         monitor(): Promise<NodeJS.EventEmitter>;
 
-        ttl(key: string, callback: (err: Error, res: number) => void): void;
-        ttl(key: string): Promise<number>;
+        ttl(key: KeyType, callback: (err: Error, res: number) => void): void;
+        ttl(key: KeyType): Promise<number>;
 
-        persist(key: string, callback: (err: Error, res: 0 | 1) => void): void;
-        persist(key: string): Promise<0 | 1>;
+        persist(key: KeyType, callback: (err: Error, res: 0 | 1) => void): void;
+        persist(key: KeyType): Promise<0 | 1>;
 
         slaveof(host: string, port: number, callback: (err: Error, res: string) => void): void;
         slaveof(host: string, port: number): Promise<string>;
@@ -426,7 +428,7 @@ declare namespace IORedis {
         publish(channel: string, message: string, callback: (err: Error, res: number) => void): void;
         publish(channel: string, message: string): Promise<number>;
 
-        watch(...keys: string[]): any;
+        watch(...keys: KeyType[]): any;
 
         unwatch(callback: (err: Error, res: string) => void): void;
         unwatch(): Promise<string>;
@@ -437,8 +439,8 @@ declare namespace IORedis {
 
         migrate(...args: any[]): any;
 
-        dump(key: string, callback: (err: Error, res: string) => void): void;
-        dump(key: string): Promise<string>;
+        dump(key: KeyType, callback: (err: Error, res: string) => void): void;
+        dump(key: KeyType): Promise<string>;
 
         object(subcommand: string, ...args: any[]): any;
 
@@ -455,24 +457,24 @@ declare namespace IORedis {
 
         scan(cursor: number, ...args: any[]): any;
 
-        sscan(key: string, cursor: number, ...args: any[]): any;
+        sscan(key: KeyType, cursor: number, ...args: any[]): any;
 
-        hscan(key: string, cursor: number, ...args: any[]): any;
+        hscan(key: KeyType, cursor: number, ...args: any[]): any;
 
-        zscan(key: string, cursor: number, ...args: any[]): any;
+        zscan(key: KeyType, cursor: number, ...args: any[]): any;
 
-        pfmerge(destkey: string, ...sourcekeys: string[]): any;
+        pfmerge(destkey: KeyType, ...sourcekeys: KeyType[]): any;
 
-        pfadd(key: string, ...elements: string[]): any;
+        pfadd(key: KeyType, ...elements: string[]): any;
 
-        pfcount(...keys: string[]): any;
+        pfcount(...keys: KeyType[]): any;
 
         pipeline(commands?: string[][]): Pipeline;
 
         scanStream(options?: ScanStreamOption): NodeJS.EventEmitter;
-        sscanStream(key: string, options?: ScanStreamOption): NodeJS.EventEmitter;
-        hscanStream(key: string, options?: ScanStreamOption): NodeJS.EventEmitter;
-        zscanStream(key: string, options?: ScanStreamOption): NodeJS.EventEmitter;
+        sscanStream(key: KeyType, options?: ScanStreamOption): NodeJS.EventEmitter;
+        hscanStream(key: KeyType, options?: ScanStreamOption): NodeJS.EventEmitter;
+        zscanStream(key: KeyType, options?: ScanStreamOption): NodeJS.EventEmitter;
     }
 
     interface Pipeline {
@@ -483,208 +485,208 @@ declare namespace IORedis {
         _result: any[];
         _transactions: number;
         _shaToScript: {};
-        bitcount(key: string, callback?: (err: Error, res: number) => void): Pipeline;
-        bitcount(key: string, start: number, end: number, callback?: (err: Error, res: number) => void): Pipeline;
+        bitcount(key: KeyType, callback?: (err: Error, res: number) => void): Pipeline;
+        bitcount(key: KeyType, start: number, end: number, callback?: (err: Error, res: number) => void): Pipeline;
 
-        get(key: string, callback?: (err: Error, res: string) => void): Pipeline;
-        getBuffer(key: string, callback?: (err: Error, res: Buffer) => void): Pipeline;
+        get(key: KeyType, callback?: (err: Error, res: string) => void): Pipeline;
+        getBuffer(key: KeyType, callback?: (err: Error, res: Buffer) => void): Pipeline;
 
-        set(key: string, value: any, callback?: (err: Error, res: string) => void): Pipeline;
-        set(key: string, value: any, setMode: string, callback?: (err: Error, res: string) => void): Pipeline;
-        set(key: string, value: any, expiryMode: string, time: number, callback?: (err: Error, res: string) => void): Pipeline;
-        set(key: string, value: any, expiryMode: string, time: number, setMode: string, callback?: (err: Error, res: string) => void): Pipeline;
+        set(key: KeyType, value: any, callback?: (err: Error, res: string) => void): Pipeline;
+        set(key: KeyType, value: any, setMode: string, callback?: (err: Error, res: string) => void): Pipeline;
+        set(key: KeyType, value: any, expiryMode: string, time: number, callback?: (err: Error, res: string) => void): Pipeline;
+        set(key: KeyType, value: any, expiryMode: string, time: number, setMode: string, callback?: (err: Error, res: string) => void): Pipeline;
 
-        setBuffer(key: string, value: any, callback?: (err: Error, res: Buffer) => void): Pipeline;
-        setBuffer(key: string, value: any, setMode: string, callback?: (err: Error, res: Buffer) => void): Pipeline;
-        setBuffer(key: string, value: any, expiryMode: string, time: number, callback?: (err: Error, res: Buffer) => void): Pipeline;
-        setBuffer(key: string, value: any, expiryMode: string, time: number, setMode: string, callback?: (err: Error, res: Buffer) => void): Pipeline;
+        setBuffer(key: KeyType, value: any, callback?: (err: Error, res: Buffer) => void): Pipeline;
+        setBuffer(key: KeyType, value: any, setMode: string, callback?: (err: Error, res: Buffer) => void): Pipeline;
+        setBuffer(key: KeyType, value: any, expiryMode: string, time: number, callback?: (err: Error, res: Buffer) => void): Pipeline;
+        setBuffer(key: KeyType, value: any, expiryMode: string, time: number, setMode: string, callback?: (err: Error, res: Buffer) => void): Pipeline;
 
-        setnx(key: string, value: any, callback?: (err: Error, res: any) => void): Pipeline;
+        setnx(key: KeyType, value: any, callback?: (err: Error, res: any) => void): Pipeline;
 
-        setex(key: string, seconds: number, value: any, callback?: (err: Error, res: any) => void): Pipeline;
+        setex(key: KeyType, seconds: number, value: any, callback?: (err: Error, res: any) => void): Pipeline;
 
-        psetex(key: string, milliseconds: number, value: any, callback?: (err: Error, res: any) => void): Pipeline;
+        psetex(key: KeyType, milliseconds: number, value: any, callback?: (err: Error, res: any) => void): Pipeline;
 
-        append(key: string, value: any, callback?: (err: Error, res: number) => void): Pipeline;
+        append(key: KeyType, value: any, callback?: (err: Error, res: number) => void): Pipeline;
 
-        strlen(key: string, callback?: (err: Error, res: number) => void): Pipeline;
+        strlen(key: KeyType, callback?: (err: Error, res: number) => void): Pipeline;
 
-        del(...keys: string[]): Pipeline;
+        del(...keys: KeyType[]): Pipeline;
 
-        exists(...keys: string[]): Pipeline;
+        exists(...keys: KeyType[]): Pipeline;
 
-        setbit(key: string, offset: number, value: any, callback?: (err: Error, res: number) => void): Pipeline;
+        setbit(key: KeyType, offset: number, value: any, callback?: (err: Error, res: number) => void): Pipeline;
 
-        getbit(key: string, offset: number, callback?: (err: Error, res: number) => void): Pipeline;
+        getbit(key: KeyType, offset: number, callback?: (err: Error, res: number) => void): Pipeline;
 
-        setrange(key: string, offset: number, value: any, callback?: (err: Error, res: number) => void): Pipeline;
+        setrange(key: KeyType, offset: number, value: any, callback?: (err: Error, res: number) => void): Pipeline;
 
-        getrange(key: string, start: number, end: number, callback?: (err: Error, res: string) => void): Pipeline;
+        getrange(key: KeyType, start: number, end: number, callback?: (err: Error, res: string) => void): Pipeline;
 
-        substr(key: string, start: number, end: number, callback?: (err: Error, res: string) => void): Pipeline;
+        substr(key: KeyType, start: number, end: number, callback?: (err: Error, res: string) => void): Pipeline;
 
-        incr(key: string, callback?: (err: Error, res: number) => void): Pipeline;
+        incr(key: KeyType, callback?: (err: Error, res: number) => void): Pipeline;
 
-        decr(key: string, callback?: (err: Error, res: number) => void): Pipeline;
+        decr(key: KeyType, callback?: (err: Error, res: number) => void): Pipeline;
 
-        mget(...keys: string[]): Pipeline;
+        mget(...keys: KeyType[]): Pipeline;
 
-        rpush(key: string, ...values: any[]): Pipeline;
+        rpush(key: KeyType, ...values: any[]): Pipeline;
 
-        lpush(key: string, ...values: any[]): Pipeline;
+        lpush(key: KeyType, ...values: any[]): Pipeline;
 
-        rpushx(key: string, value: any, callback?: (err: Error, res: number) => void): Pipeline;
+        rpushx(key: KeyType, value: any, callback?: (err: Error, res: number) => void): Pipeline;
 
-        lpushx(key: string, value: any, callback?: (err: Error, res: number) => void): Pipeline;
+        lpushx(key: KeyType, value: any, callback?: (err: Error, res: number) => void): Pipeline;
 
-        linsert(key: string, direction: "BEFORE" | "AFTER", pivot: string, value: any, callback?: (err: Error, res: number) => void): Pipeline;
+        linsert(key: KeyType, direction: "BEFORE" | "AFTER", pivot: string, value: any, callback?: (err: Error, res: number) => void): Pipeline;
 
-        rpop(key: string, callback?: (err: Error, res: string) => void): Pipeline;
+        rpop(key: KeyType, callback?: (err: Error, res: string) => void): Pipeline;
 
-        lpop(key: string, callback?: (err: Error, res: string) => void): Pipeline;
+        lpop(key: KeyType, callback?: (err: Error, res: string) => void): Pipeline;
 
-        brpop(...keys: string[]): Pipeline;
+        brpop(...keys: KeyType[]): Pipeline;
 
-        blpop(...keys: string[]): Pipeline;
+        blpop(...keys: KeyType[]): Pipeline;
 
         brpoplpush(source: string, destination: string, timeout: number, callback?: (err: Error, res: any) => void): Pipeline;
 
-        llen(key: string, callback?: (err: Error, res: number) => void): Pipeline;
+        llen(key: KeyType, callback?: (err: Error, res: number) => void): Pipeline;
 
-        lindex(key: string, index: number, callback?: (err: Error, res: string) => void): Pipeline;
+        lindex(key: KeyType, index: number, callback?: (err: Error, res: string) => void): Pipeline;
 
-        lset(key: string, index: number, value: any, callback?: (err: Error, res: any) => void): Pipeline;
+        lset(key: KeyType, index: number, value: any, callback?: (err: Error, res: any) => void): Pipeline;
 
-        lrange(key: string, start: number, stop: number, callback?: (err: Error, res: any) => void): Pipeline;
+        lrange(key: KeyType, start: number, stop: number, callback?: (err: Error, res: any) => void): Pipeline;
 
-        ltrim(key: string, start: number, stop: number, callback?: (err: Error, res: any) => void): Pipeline;
+        ltrim(key: KeyType, start: number, stop: number, callback?: (err: Error, res: any) => void): Pipeline;
 
-        lrem(key: string, count: number, value: any, callback?: (err: Error, res: number) => void): Pipeline;
+        lrem(key: KeyType, count: number, value: any, callback?: (err: Error, res: number) => void): Pipeline;
 
         rpoplpush(source: string, destination: string, callback?: (err: Error, res: string) => void): Pipeline;
 
-        sadd(key: string, ...members: any[]): Pipeline;
+        sadd(key: KeyType, ...members: any[]): Pipeline;
 
-        srem(key: string, ...members: any[]): Pipeline;
+        srem(key: KeyType, ...members: any[]): Pipeline;
 
         smove(source: string, destination: string, member: string, callback?: (err: Error, res: string) => void): Pipeline;
 
-        sismember(key: string, member: string, callback?: (err: Error, res: 1 | 0) => void): Pipeline;
+        sismember(key: KeyType, member: string, callback?: (err: Error, res: 1 | 0) => void): Pipeline;
 
-        scard(key: string, callback?: (err: Error, res: number) => void): Pipeline;
+        scard(key: KeyType, callback?: (err: Error, res: number) => void): Pipeline;
 
-        spop(key: string, callback?: (err: Error, res: any) => void): Pipeline;
-        spop(key: string, count: number, callback?: (err: Error, res: any) => void): Pipeline;
+        spop(key: KeyType, callback?: (err: Error, res: any) => void): Pipeline;
+        spop(key: KeyType, count: number, callback?: (err: Error, res: any) => void): Pipeline;
 
-        srandmember(key: string, callback?: (err: Error, res: any) => void): Pipeline;
-        srandmember(key: string, count: number, callback?: (err: Error, res: any) => void): Pipeline;
+        srandmember(key: KeyType, callback?: (err: Error, res: any) => void): Pipeline;
+        srandmember(key: KeyType, count: number, callback?: (err: Error, res: any) => void): Pipeline;
 
-        sinter(...keys: string[]): Pipeline;
+        sinter(...keys: KeyType[]): Pipeline;
 
-        sinterstore(destination: string, ...keys: string[]): Pipeline;
+        sinterstore(destination: string, ...keys: KeyType[]): Pipeline;
 
-        sunion(...keys: string[]): Pipeline;
+        sunion(...keys: KeyType[]): Pipeline;
 
-        sunionstore(destination: string, ...keys: string[]): Pipeline;
+        sunionstore(destination: string, ...keys: KeyType[]): Pipeline;
 
-        sdiff(...keys: string[]): Pipeline;
+        sdiff(...keys: KeyType[]): Pipeline;
 
-        sdiffstore(destination: string, ...keys: string[]): Pipeline;
+        sdiffstore(destination: string, ...keys: KeyType[]): Pipeline;
 
-        smembers(key: string, callback?: (err: Error, res: any) => void): Pipeline;
+        smembers(key: KeyType, callback?: (err: Error, res: any) => void): Pipeline;
 
-        zadd(key: string, ...args: string[]): Pipeline;
+        zadd(key: KeyType, ...args: string[]): Pipeline;
 
-        zincrby(key: string, increment: number, member: string, callback?: (err: Error, res: any) => void): Pipeline;
+        zincrby(key: KeyType, increment: number, member: string, callback?: (err: Error, res: any) => void): Pipeline;
 
-        zrem(key: string, ...members: any[]): Pipeline;
+        zrem(key: KeyType, ...members: any[]): Pipeline;
 
-        zremrangebyscore(key: string, min: number | string, max: number | string, callback?: (err: Error, res: any) => void): Pipeline;
+        zremrangebyscore(key: KeyType, min: number | string, max: number | string, callback?: (err: Error, res: any) => void): Pipeline;
 
-        zremrangebyrank(key: string, start: number, stop: number, callback?: (err: Error, res: any) => void): Pipeline;
+        zremrangebyrank(key: KeyType, start: number, stop: number, callback?: (err: Error, res: any) => void): Pipeline;
 
-        zunionstore(destination: string, numkeys: number, key: string, ...args: string[]): Pipeline;
+        zunionstore(destination: string, numkeys: number, key: KeyType, ...args: string[]): Pipeline;
 
-        zinterstore(destination: string, numkeys: number, key: string, ...args: string[]): Pipeline;
+        zinterstore(destination: string, numkeys: number, key: KeyType, ...args: string[]): Pipeline;
 
-        zrange(key: string, start: number, stop: number, callback?: (err: Error, res: any) => void): Pipeline;
-        zrange(key: string, start: number, stop: number, withScores: "WITHSCORES", callback?: (err: Error, res: any) => void): Pipeline;
+        zrange(key: KeyType, start: number, stop: number, callback?: (err: Error, res: any) => void): Pipeline;
+        zrange(key: KeyType, start: number, stop: number, withScores: "WITHSCORES", callback?: (err: Error, res: any) => void): Pipeline;
 
-        zrevrange(key: string, start: number, stop: number, callback?: (err: Error, res: any) => void): Pipeline;
-        zrevrange(key: string, start: number, stop: number, withScores: "WITHSCORES", callback?: (err: Error, res: any) => void): Pipeline;
+        zrevrange(key: KeyType, start: number, stop: number, callback?: (err: Error, res: any) => void): Pipeline;
+        zrevrange(key: KeyType, start: number, stop: number, withScores: "WITHSCORES", callback?: (err: Error, res: any) => void): Pipeline;
 
-        zrangebyscore(key: string, min: number | string, max: number | string, ...args: string[]): Pipeline;
+        zrangebyscore(key: KeyType, min: number | string, max: number | string, ...args: string[]): Pipeline;
 
-        zrevrangebyscore(key: string, max: number | string, min: number | string, ...args: string[]): Pipeline;
+        zrevrangebyscore(key: KeyType, max: number | string, min: number | string, ...args: string[]): Pipeline;
 
-        zcount(key: string, min: number | string, max: number | string, callback?: (err: Error, res: number) => void): Pipeline;
+        zcount(key: KeyType, min: number | string, max: number | string, callback?: (err: Error, res: number) => void): Pipeline;
 
-        zcard(key: string, callback?: (err: Error, res: number) => void): Pipeline;
+        zcard(key: KeyType, callback?: (err: Error, res: number) => void): Pipeline;
 
-        zscore(key: string, member: string, callback?: (err: Error, res: number) => void): Pipeline;
+        zscore(key: KeyType, member: string, callback?: (err: Error, res: number) => void): Pipeline;
 
-        zrank(key: string, member: string, callback?: (err: Error, res: number) => void): Pipeline;
+        zrank(key: KeyType, member: string, callback?: (err: Error, res: number) => void): Pipeline;
 
-        zrevrank(key: string, member: string, callback?: (err: Error, res: number) => void): Pipeline;
+        zrevrank(key: KeyType, member: string, callback?: (err: Error, res: number) => void): Pipeline;
 
-        hset(key: string, field: string, value: any, callback?: (err: Error, res: 0 | 1) => void): Pipeline;
-        hsetBuffer(key: string, field: string, value: any, callback?: (err: Error, res: Buffer) => void): Pipeline;
+        hset(key: KeyType, field: string, value: any, callback?: (err: Error, res: 0 | 1) => void): Pipeline;
+        hsetBuffer(key: KeyType, field: string, value: any, callback?: (err: Error, res: Buffer) => void): Pipeline;
 
-        hsetnx(key: string, field: string, value: any, callback?: (err: Error, res: 0 | 1) => void): Pipeline;
+        hsetnx(key: KeyType, field: string, value: any, callback?: (err: Error, res: 0 | 1) => void): Pipeline;
 
-        hget(key: string, field: string, callback?: (err: Error, res: string) => void): Pipeline;
-        hgetBuffer(key: string, field: string, callback?: (err: Error, res: Buffer) => void): Pipeline;
+        hget(key: KeyType, field: string, callback?: (err: Error, res: string) => void): Pipeline;
+        hgetBuffer(key: KeyType, field: string, callback?: (err: Error, res: Buffer) => void): Pipeline;
 
-        hmset(key: string, field: string, value: any, ...args: string[]): Pipeline;
-        hmset(key: string, data: any, callback?: (err: Error, res: 0 | 1) => void): Pipeline;
+        hmset(key: KeyType, field: string, value: any, ...args: string[]): Pipeline;
+        hmset(key: KeyType, data: any, callback?: (err: Error, res: 0 | 1) => void): Pipeline;
 
-        hmget(key: string, ...fields: string[]): Pipeline;
+        hmget(key: KeyType, ...fields: string[]): Pipeline;
 
-        hincrby(key: string, field: string, increment: number, callback?: (err: Error, res: number) => void): Pipeline;
+        hincrby(key: KeyType, field: string, increment: number, callback?: (err: Error, res: number) => void): Pipeline;
 
-        hincrbyfloat(key: string, field: string, increment: number, callback?: (err: Error, res: number) => void): Pipeline;
+        hincrbyfloat(key: KeyType, field: string, increment: number, callback?: (err: Error, res: number) => void): Pipeline;
 
-        hdel(key: string, ...fields: string[]): Pipeline;
+        hdel(key: KeyType, ...fields: string[]): Pipeline;
 
-        hlen(key: string, callback?: (err: Error, res: number) => void): Pipeline;
+        hlen(key: KeyType, callback?: (err: Error, res: number) => void): Pipeline;
 
-        hkeys(key: string, callback?: (err: Error, res: any) => void): Pipeline;
+        hkeys(key: KeyType, callback?: (err: Error, res: any) => void): Pipeline;
 
-        hvals(key: string, callback?: (err: Error, res: any) => void): Pipeline;
+        hvals(key: KeyType, callback?: (err: Error, res: any) => void): Pipeline;
 
-        hgetall(key: string, callback?: (err: Error, res: any) => void): Pipeline;
+        hgetall(key: KeyType, callback?: (err: Error, res: any) => void): Pipeline;
 
-        hexists(key: string, field: string, callback?: (err: Error, res: 0 | 1) => void): Pipeline;
+        hexists(key: KeyType, field: string, callback?: (err: Error, res: 0 | 1) => void): Pipeline;
 
-        incrby(key: string, increment: number, callback?: (err: Error, res: number) => void): Pipeline;
+        incrby(key: KeyType, increment: number, callback?: (err: Error, res: number) => void): Pipeline;
 
-        incrbyfloat(key: string, increment: number, callback?: (err: Error, res: number) => void): Pipeline;
+        incrbyfloat(key: KeyType, increment: number, callback?: (err: Error, res: number) => void): Pipeline;
 
-        decrby(key: string, decrement: number, callback?: (err: Error, res: number) => void): Pipeline;
+        decrby(key: KeyType, decrement: number, callback?: (err: Error, res: number) => void): Pipeline;
 
-        getset(key: string, value: any, callback?: (err: Error, res: string) => void): Pipeline;
+        getset(key: KeyType, value: any, callback?: (err: Error, res: string) => void): Pipeline;
 
-        mset(key: string, value: any, ...args: string[]): Pipeline;
+        mset(key: KeyType, value: any, ...args: string[]): Pipeline;
 
-        msetnx(key: string, value: any, ...args: string[]): Pipeline;
+        msetnx(key: KeyType, value: any, ...args: string[]): Pipeline;
 
         randomkey(callback?: (err: Error, res: string) => void): Pipeline;
 
         select(index: number, callback?: (err: Error, res: string) => void): Pipeline;
 
-        move(key: string, db: string, callback?: (err: Error, res: 0 | 1) => void): Pipeline;
+        move(key: KeyType, db: string, callback?: (err: Error, res: 0 | 1) => void): Pipeline;
 
-        rename(key: string, newkey: string, callback?: (err: Error, res: string) => void): Pipeline;
+        rename(key: KeyType, newkey: KeyType, callback?: (err: Error, res: string) => void): Pipeline;
 
-        renamenx(key: string, newkey: string, callback?: (err: Error, res: 0 | 1) => void): Pipeline;
+        renamenx(key: KeyType, newkey: KeyType, callback?: (err: Error, res: 0 | 1) => void): Pipeline;
 
-        expire(key: string, seconds: number, callback?: (err: Error, res: 0 | 1) => void): Pipeline;
+        expire(key: KeyType, seconds: number, callback?: (err: Error, res: 0 | 1) => void): Pipeline;
 
-        pexpire(key: string, milliseconds: number, callback?: (err: Error, res: 0 | 1) => void): Pipeline;
+        pexpire(key: KeyType, milliseconds: number, callback?: (err: Error, res: 0 | 1) => void): Pipeline;
 
-        expireat(key: string, timestamp: number, callback?: (err: Error, res: 0 | 1) => void): Pipeline;
+        expireat(key: KeyType, timestamp: number, callback?: (err: Error, res: 0 | 1) => void): Pipeline;
 
-        pexpireat(key: string, millisecondsTimestamp: number, callback?: (err: Error, res: 0 | 1) => void): Pipeline;
+        pexpireat(key: KeyType, millisecondsTimestamp: number, callback?: (err: Error, res: 0 | 1) => void): Pipeline;
 
         keys(pattern: string, callback?: (err: Error, res: string[]) => void): Pipeline;
 
@@ -707,7 +709,7 @@ declare namespace IORedis {
 
         lastsave(callback?: (err: Error, res: number) => void): Pipeline;
 
-        type(key: string, callback?: (err: Error, res: string) => void): Pipeline;
+        type(key: KeyType, callback?: (err: Error, res: string) => void): Pipeline;
 
         multi(callback?: (err: Error, res: string) => void): Pipeline;
 
@@ -721,7 +723,7 @@ declare namespace IORedis {
 
         flushall(callback?: (err: Error, res: string) => void): Pipeline;
 
-        sort(key: string, ...args: string[]): Pipeline;
+        sort(key: KeyType, ...args: string[]): Pipeline;
 
         info(callback?: (err: Error, res: any) => void): Pipeline;
         info(section: string, callback?: (err: Error, res: any) => void): Pipeline;
@@ -730,9 +732,9 @@ declare namespace IORedis {
 
         monitor(callback?: (err: Error, res: NodeJS.EventEmitter) => void): Pipeline;
 
-        ttl(key: string, callback?: (err: Error, res: number) => void): Pipeline;
+        ttl(key: KeyType, callback?: (err: Error, res: number) => void): Pipeline;
 
-        persist(key: string, callback?: (err: Error, res: 0 | 1) => void): Pipeline;
+        persist(key: KeyType, callback?: (err: Error, res: 0 | 1) => void): Pipeline;
 
         slaveof(host: string, port: number, callback?: (err: Error, res: string) => void): Pipeline;
 
@@ -750,7 +752,7 @@ declare namespace IORedis {
 
         publish(channel: string, message: string, callback?: (err: Error, res: number) => void): Pipeline;
 
-        watch(...keys: string[]): Pipeline;
+        watch(...keys: KeyType[]): Pipeline;
 
         unwatch(callback?: (err: Error, res: string) => void): Pipeline;
 
@@ -760,7 +762,7 @@ declare namespace IORedis {
 
         migrate(...args: any[]): Pipeline;
 
-        dump(key: string, callback?: (err: Error, res: string) => void): Pipeline;
+        dump(key: KeyType, callback?: (err: Error, res: string) => void): Pipeline;
 
         object(subcommand: string, ...args: any[]): Pipeline;
 
@@ -776,17 +778,17 @@ declare namespace IORedis {
 
         scan(cursor: number, ...args: any[]): Pipeline;
 
-        sscan(key: string, cursor: number, ...args: any[]): Pipeline;
+        sscan(key: KeyType, cursor: number, ...args: any[]): Pipeline;
 
-        hscan(key: string, cursor: number, ...args: any[]): Pipeline;
+        hscan(key: KeyType, cursor: number, ...args: any[]): Pipeline;
 
-        zscan(key: string, cursor: number, ...args: any[]): Pipeline;
+        zscan(key: KeyType, cursor: number, ...args: any[]): Pipeline;
 
-        pfmerge(destkey: string, ...sourcekeys: string[]): Pipeline;
+        pfmerge(destkey: KeyType, ...sourcekeys: KeyType[]): Pipeline;
 
-        pfadd(key: string, ...elements: string[]): Pipeline;
+        pfadd(key: KeyType, ...elements: string[]): Pipeline;
 
-        pfcount(...keys: string[]): Pipeline;
+        pfcount(...keys: KeyType[]): Pipeline;
     }
 
     interface NodeConfiguration {

--- a/types/ioredis/index.d.ts
+++ b/types/ioredis/index.d.ts
@@ -45,7 +45,7 @@ declare class Commander {
 }
 
 declare namespace IORedis {
-    type KeyType = string | Buffer
+    type KeyType = string | Buffer;
 
     interface Command {
         setArgumentTransformer(name: string, fn: (args: any[]) => any[]): void;

--- a/types/ioredis/ioredis-tests.ts
+++ b/types/ioredis/ioredis-tests.ts
@@ -31,6 +31,10 @@ redis.set('key', '100', 'EX', 10, 'NX', (err, data) => {});
 redis.set('key', '100', ['EX', 10, 'NX'], (err, data) => {});
 redis.setBuffer('key', '100', 'NX', 'EX', 10, (err, data) => {});
 
+// Should support usage of Buffer
+redis.set(Buffer.from('key'), '100');
+redis.setBuffer(Buffer.from('key'), '100', 'NX', 'EX', 10);
+
 new Redis();       // Connect to 127.0.0.1:6379
 new Redis(6380);   // 127.0.0.1:6380
 new Redis(6379, '192.168.1.1');       // 192.168.1.1:6379


### PR DESCRIPTION
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [buffer support test](https://github.com/luin/ioredis/blob/master/test/functional/send_command.js#L39)
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
