### PR TITLE
[page] export a default

### DIFF
--- a/types/page/index.d.ts
+++ b/types/page/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for page v1.5.0
+// Type definitions for page v1.8.6
 // Project: http://visionmedia.github.io/page.js/
 // Definitions by: Alan Norbauer <http://alan.norbauer.com/>
 //                 James Garbutt <https://github.com/43081j>
@@ -285,8 +285,8 @@ declare namespace PageJS {
 }
 
 declare module "page" {
-    var page: PageJS.Static;
-    export = page;
+    const page: PageJS.Static;
+    export default page;
 }
 
 declare var page: PageJS.Static;

--- a/types/page/page-tests.ts
+++ b/types/page/page-tests.ts
@@ -1,6 +1,4 @@
-
-
-import page = require("page");
+import page from 'page';
 
 //***********************************************************************
 // Basic Example


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/visionmedia/page.js/blob/71bb2d8771159985065819fcebd8e6b5c62e3b26/index.js#L16
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

---

### Breaking change

Please review this carefully as im not sure if i can do this change...

Basically, page has exported a `default` for a while in the form of `exports.default`. So in TS we should actually be importing like so:

```ts
import page from 'page';
```

Rather than:

```ts
import * as page from 'page';
```

The latter works but doesn't make much sense against ES modules as you shouldn't be able to invoke a namespace (`page()`). 

However, if we do this change, it means the latter will stop working. I don't think there's a way we can have both (if there is, i'm not aware of it, please suggest). 
