### PR TITLE
[koa-passport] Update authenticate to support object for options

### DIFF
--- a/types/koa-passport/index.d.ts
+++ b/types/koa-passport/index.d.ts
@@ -43,7 +43,7 @@ declare namespace KoaPassport {
         session(options?: { pauseStream: boolean; }): Middleware;
 
         authenticate(strategy: string | string[], callback?: (...args: any[]) => any): Middleware;
-        authenticate(strategy: string | string[], options: passport.AuthenticateOptions, callback?: (...args: any[]) => any): Middleware;
+        authenticate(strategy: string | string[], options: passport.AuthenticateOptions | object, callback?: (...args: any[]) => any): Middleware;
         authorize(strategy: string | string[], callback?: (...args: any[]) => any): Middleware;
         authorize(strategy: string | string[], options: any, callback?: (...args: any[]) => any): Middleware;
 


### PR DESCRIPTION
- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: **Different strategies require more complex AuthenticationOptions and extending from passport.AuthenticationOptions makes options such as `hd` in** [passport-google-oauth2](https://github.com/jaredhanson/passport-google-oauth2/blob/master/lib/strategy.js#L159) **break**. **Moreover, `hd` is not generic enough to be added to the parent `AuthenticationOptions`. I believe this breaks more cases, `hd` is just a specific attribute I am using in my application.** 
- [X] Increase the version number in the header if appropriate.
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

I apologize if this pull request seems naive, I just do not know another solution for extending the AuthenticationOptions within different strategies as it currently prevents usage of `hd` and `hostedDomain`. These two options work when `koa-passport` is not installed. See the package [here](https://github.com/jaredhanson/passport-google-oauth2).
