### PR TITLE
[@types/algoliasearch] add missing types for facet_stats in algolia s…

### DIFF
--- a/types/algoliasearch/index.d.ts
+++ b/types/algoliasearch/index.d.ts
@@ -1776,6 +1776,14 @@ declare namespace algoliasearch {
     facets?: {
       [facetName: string]: { [facetValue: string]: number };
     };
+    facets_stats?: {
+      [facetName: string]: {
+        avg: number,
+        max: number,
+        min: number,
+        sum: number,
+      };
+    };
   }
 
   interface MultiResponse {

--- a/types/algoliasearch/lite/index.d.ts
+++ b/types/algoliasearch/lite/index.d.ts
@@ -4,6 +4,7 @@
 //                 Haroen Viaene <https://github.com/haroenv>
 //                 Aurélien Hervé <https://github.com/aherve>
 //                 Samuel Vaillant <https://github.com/samouss>
+//                 Claas Brüggemann <https://github.com/ClaasBrueggemann>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
@@ -569,6 +570,14 @@ declare namespace algoliasearch {
     params: string;
     facets?: {
       [facetName: string]: { [facetValue: string]: number };
+    };
+    facets_stats?: {
+      [facetName: string]: {
+        avg: number,
+        max: number,
+        min: number,
+        sum: number,
+      };
     };
   }
 


### PR DESCRIPTION
As you can see in the Algolia documentation, if the response contains values for numeric facets, it will also include facet_stats, describing min, max, avg and sum of a facet. This Pr is adding the missing facet_stats typings on the Response.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] https://www.algolia.com/doc/api-reference/api-methods/search/#response
