### PR TITLE
[@types/hammerjs] Corrected interface for Recognizer

### DIFF
--- a/types/hammerjs/index.d.ts
+++ b/types/hammerjs/index.d.ts
@@ -263,19 +263,15 @@ interface Recognizer
 
   canEmit():boolean;
   canRecognizeWith( otherRecognizer:Recognizer ):boolean;
-  dropRecognizeWith( otherRecognizer:Recognizer ):Recognizer;
-  dropRecognizeWith( otherRecognizer:string ):Recognizer;
-  dropRequireFailure( otherRecognizer:Recognizer ):Recognizer;
-  dropRequireFailure( otherRecognizer:string ):Recognizer;
+  dropRecognizeWith( otherRecognizer:Recognizer | Recognizer[] | string):Recognizer;
+  dropRequireFailure( otherRecognizer:Recognizer | Recognizer[] | string):Recognizer;
   emit( input:HammerInput ):void;
   getTouchAction():any[];
   hasRequireFailures():boolean;
   process( inputData:HammerInput ):string;
   recognize( inputData:HammerInput ):void;
-  recognizeWith( otherRecognizer:Recognizer ):Recognizer;
-  recognizeWith( otherRecognizer:string ):Recognizer;
-  requireFailure( otherRecognizer:Recognizer ):Recognizer;
-  requireFailure( otherRecognizer:string ):Recognizer;
+  recognizeWith( otherRecognizer:Recognizer | Recognizer[] | string):Recognizer;
+  requireFailure( otherRecognizer:Recognizer | Recognizer[] | string):Recognizer;
   reset():void;
   set( options?:RecognizerOptions ):Recognizer;
   tryEmit( input:HammerInput ):void;


### PR DESCRIPTION
recognizeWith(), requireFailure(), dropRequireFailure(), dropRecognizeWith():

- Should not be declared twice
- Should accept array of Recognizer, too

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: http://hammerjs.github.io/api/#hammer.manager -> Actually the documentation is not complete but some examples show what types are accepted.
- [X] Increase the version number in the header if appropriate. -> Not needed
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. -> Not needed