### PR TITLE
[@types/react] ReactPortal extends ReactElement

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -106,7 +106,7 @@ declare namespace React {
         type: keyof ReactSVG;
     }
 
-    interface ReactPortal {
+    interface ReactPortal extends ReactElement<any> {
         key: Key | null;
         children: ReactNode;
     }


### PR DESCRIPTION
Portals types works normal when used in method `render()` of Class-Component. But, it have breaks when used in Functional-Component:
```tsx
function PortalComponent(props: { root: HTMLElement }) {
    return ReactDOM.createPortal(
        <div/>,
        props.root
    );
}

function MyComponent() {
    const root = document.getElementById('#foo');
    if (!root) {
        return null;
    }

    return (
        // JSX element type 'ReactPortal' is not a constructor function for JSX elements.
        // Property 'render' is missing in type 'ReactPortal'.
        <PortalComponent root={root}/>
    );
}
```

![platform components viewer viewer tsx turbo 2018-08-21 15-49-12](https://user-images.githubusercontent.com/1322855/44402351-26b78080-a55a-11e8-8c91-57348793075f.png)

Actually code is works fine.
Portal should extends from `ReactElement` [similarly `JSX.Element`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/83415ddfbdff33648590070e482357dd74039542/types/react/index.d.ts#L2304).

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://reactjs.org/docs/portals.html
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
