### PR TITLE
[puppeteer] add option defaultViewport to launchOptions interface to adhere to official docs

### DIFF
--- a/types/puppeteer/index.d.ts
+++ b/types/puppeteer/index.d.ts
@@ -1648,6 +1648,35 @@ export interface LaunchOptions {
    */
   slowMo?: number;
   /**
+   * Sets a consistent viewport for each page. Defaults to an 800x600 viewport. null disables the default viewport.
+   */
+  defaultViewport?: {
+    /**
+     * page width in pixels.
+     */
+    width?: number;
+    /**
+     * page height in pixels.
+     */
+    height?: number;
+    /**
+     * Specify device scale factor (can be thought of as dpr). Defaults to 1.
+     */
+    deviceScaleFactor?: number;
+    /**
+     * Whether the meta viewport tag is taken into account. Defaults to false.
+     */
+    isMobile?: boolean;
+    /**
+     * Specifies if viewport supports touch events. Defaults to false.
+     */
+    hasTouch?: boolean;
+    /**
+     * Specifies if viewport is in landscape mode. Defaults to false.
+     */
+    isLandscape?: boolean;
+  };
+  /**
    * Additional arguments to pass to the Chromium instance. List of Chromium
    * flags can be found here.
    */

--- a/types/puppeteer/puppeteer-tests.ts
+++ b/types/puppeteer/puppeteer-tests.ts
@@ -167,6 +167,7 @@ puppeteer.launch().then(async browser => {
       '--no-sandbox',
       '--disable-setuid-sandbox',
     ],
+    defaultViewport: { width: 800, height: 600 },
     handleSIGINT: true,
     handleSIGHUP: true,
     handleSIGTERM: true,


### PR DESCRIPTION
add option defaultViewport to launchOptions interface to adhere to official docs

Please fill in this template.

- [✓] Use a meaningful title for the pull request. Include the name of the package modified.
- [✓] Test the change in your own code. (Compile and run.)
- [✓] Add or edit tests to reflect the change. (Run with `npm test`.)
- [✓] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [✓] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [✓] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [✓] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md\#puppeteerlaunchoptions
- [N/A] Increase the version number in the header if appropriate.
- [N/A] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.