### PR TITLE
[ember-mocha] Update typings for ember-mocha 0.14

### DIFF
--- a/types/ember-mocha/ember-mocha-tests.ts
+++ b/types/ember-mocha/ember-mocha-tests.ts
@@ -1,7 +1,8 @@
 import {
     describeComponent, describeModel, describeModule,
     setResolver, setupAcceptanceTest, setupComponentTest,
-    setupModelTest, setupTest
+    setupModelTest, setupTest, setupRenderingTest,
+    setupApplicationTest
 } from 'ember-mocha';
 import { describe, it, beforeEach, afterEach, before, after } from 'mocha';
 import chai = require('chai');
@@ -96,8 +97,6 @@ describeModule('component:x-foo', 'TestModule callbacks', function() {
 });
 
 describe('setupTest', function() {
-    setupTest();
-
     setupTest('service:ajax');
 
     setupTest('service:ajax', {
@@ -193,3 +192,62 @@ it('can calculate the result', function(assert) {
 it.skip('disabled test');
 
 it.skip('disabled test', function() { });
+
+// New testing APIs of ember-mocha 0.14
+
+describe('setupTest', function() {
+    setupTest();
+
+    setupTest({ resolver: Ember.DefaultResolver.create() });
+
+    const hooks = setupTest();
+    hooks.beforeEach(function() {
+        this.owner.lookup('service:foo');
+    });
+    hooks.afterEach(function() {
+        this.owner.factoryFor('service:foo');
+    });
+
+    setupRenderingTest();
+
+    setupRenderingTest({ resolver: Ember.DefaultResolver.create() });
+
+    const hooks2 = setupRenderingTest();
+    hooks2.beforeEach(function() {
+        this.owner.lookup('service:foo');
+    });
+
+    hooks2.afterEach(function() {
+        this.owner.factoryFor('service:foo');
+    });
+
+    setupApplicationTest();
+
+    setupApplicationTest({ resolver: Ember.DefaultResolver.create() });
+
+    const hooks3 = setupApplicationTest();
+    hooks3.beforeEach(function() {
+        this.owner.lookup('service:foo');
+    });
+
+    hooks3.afterEach(function() {
+        this.owner.factoryFor('service:foo');
+    });
+
+    it('test', function() {
+    });
+});
+
+describe('rendering test', function() {
+    setupRenderingTest();
+
+    it('renders', async function() {
+        // setup the outer context
+        this.set('value', 'cat');
+
+        // render the component
+        await this.render(hbs`{{ x-foo value=value}}`);
+
+        chai.expect(this.element.querySelector('div>.value').textContent.trim()).to.equal('cat', 'The component shows the correct value');
+    });
+});

--- a/types/ember-mocha/index.d.ts
+++ b/types/ember-mocha/index.d.ts
@@ -1,6 +1,7 @@
-// Type definitions for ember-mocha 0.12
+// Type definitions for ember-mocha 0.14
 // Project: https://github.com/emberjs/ember-mocha#readme
 // Definitions by: Derek Wickern <https://github.com/dwickern>
+//                 Simon Ihmig <https://github.com/simonihmig>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.4
 
@@ -36,6 +37,17 @@ declare module 'ember-mocha' {
         (callbacks: ModuleCallbacks): void;
     }
 
+    interface TestHooks {
+        beforeEach: mochaBeforeEach;
+        afterEach: mochaAfterEach;
+    }
+
+    interface SetupOptions {
+        resolver: Ember.Resolver;
+    }
+
+    type NewSetupTest = (options?: SetupOptions) => TestHooks;
+
     /** @deprecated Use setupTest instead */
     export const describeModule: ContextDefinition;
 
@@ -45,10 +57,13 @@ declare module 'ember-mocha' {
     /** @deprecated Use setupModelTest instead */
     export const describeModel: ContextDefinition;
 
-    export const setupTest: SetupTest;
+    export const setupTest: NewSetupTest & SetupTest;
     export const setupAcceptanceTest: SetupTest;
     export const setupComponentTest: SetupTest;
     export const setupModelTest: SetupTest;
+
+    export const setupRenderingTest: NewSetupTest;
+    export const setupApplicationTest: NewSetupTest;
 
     export const it: typeof mochaIt;
 


### PR DESCRIPTION
This adds the types for the new RFC232/RFC268 based APIs in ember-mocha 0.14

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: adds typings for these changes: https://github.com/emberjs/ember-mocha/pull/190, https://github.com/emberjs/ember-mocha/pull/199
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
