### PR TITLE
@types/react-dates incorrect disabled type for DateRangePickerShape

### DIFF
--- a/types/react-dates/index.d.ts
+++ b/types/react-dates/index.d.ts
@@ -49,7 +49,7 @@ declare namespace ReactDates {
         // input related props
         startDatePlaceholderText?: string,
         endDatePlaceholderText?: string,
-        disabled?: boolean,
+        disabled?: DisabledShape,
         required?: boolean,
         readOnly?: boolean,
         screenReaderInputMessage?: string,


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://gist.github.com/aldis-ameriks/8bf7069fe025cca156fba9626d9833a4 see line 39. The disabled prop should take disabled, "startDate", "endDate" to disable all, only start date or only end date inputs respectively. Current version only accepts a boolean value which disables both inputs.
- [-] Increase the version number in the header if appropriate.
- [-] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

