### PR TITLE
[sequelize] Improve type safety when using define

### DIFF
--- a/types/sequelize/index.d.ts
+++ b/types/sequelize/index.d.ts
@@ -4673,6 +4673,20 @@ declare namespace sequelize {
     }
 
     /**
+     * Interface for Attributes provided for a column
+     *
+     * @see Sequelize.define
+     */
+    type DefineModelAttributes<T> = {
+
+        /**
+         * The description of a database column for model
+         */
+        [P in keyof T]: string | DataTypeAbstract | DefineAttributeColumnOptions;
+
+    }
+
+    /**
      * Interface for query options
      *
      * @see Options
@@ -5976,7 +5990,7 @@ declare namespace sequelize {
          * @param options    These options are merged with the default define options provided to the Sequelize
          *                   constructor
          */
-        define<TInstance, TAttributes>(modelName: string, attributes: DefineAttributes,
+        define<TInstance, TAttributes>(modelName: string, attributes: DefineModelAttributes<TAttributes>,
             options?: DefineOptions<TInstance>): Model<TInstance, TAttributes>;
 
         /**

--- a/types/sequelize/sequelize-tests.ts
+++ b/types/sequelize/sequelize-tests.ts
@@ -1299,7 +1299,7 @@ var testModel = s.define( 'User', {
     theDate : Sequelize.DATE,
     aBool : Sequelize.BOOLEAN
 } );
-var testModel = s.define( 'FrozenUser', {}, { freezeTableName : true } );
+const testFrozenModel = s.define( 'FrozenUser', {}, { freezeTableName : true } );
 s.define( 'UserWithClassAndInstanceMethods', {}, {
     classMethods : { doSmth : function() { return 1; } },
     instanceMethods : { makeItSo : function() { return 2; } }
@@ -1544,7 +1544,11 @@ interface ChairAttributes {
 }
 interface ChairInstance extends Sequelize.Instance<ChairAttributes> {}
 
-const Chair = s.define<ChairInstance, ChairAttributes>('chair', {});
+const Chair = s.define<ChairInstance, ChairAttributes>('chair', {
+    id: Sequelize.NUMBER,
+    color: Sequelize.STRING,
+    legs: Sequelize.NUMBER
+});
 
 Chair.findAll({
     where: {
@@ -1733,7 +1737,7 @@ s.define('DefineOptionsIndexesTest', {
     email: {
         allowNull: false,
         type: Sequelize.STRING(255),
-        set: function (val) {
+        set: function (val: any) {
             if (typeof val === "string") {
                 val = val.toLowerCase();
             } else {

--- a/types/sequelize/sequelize-tests.ts
+++ b/types/sequelize/sequelize-tests.ts
@@ -34,11 +34,16 @@ s.transaction().then( ( a ) => t = a );
 interface GUserAttributes {
     id? : number;
     username? : string;
+    email: string;
 }
 
 interface GUserInstance extends Sequelize.Instance<GUserAttributes> {}
-var GUser = s.define<GUserInstance, GUserAttributes>( 'user', { id: Sequelize.INTEGER, username : Sequelize.STRING });
-GUser.create({ id : 1, username : 'one' }).then( ( guser ) => guser.save() );
+const GUser = s.define<GUserInstance, GUserAttributes>('user', {
+    id: Sequelize.INTEGER,
+    username: Sequelize.STRING,
+    email: Sequelize.STRING
+});
+GUser.create({ id : 1, username : 'one', email: 'one@lol.com' }).then((guser) => guser.save());
 
 var schema : Sequelize.DefineAttributes = {
     key : { type : Sequelize.STRING, primaryKey : true },


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

## Backstory for this change

Concider the following code:
```typescript
interface GUserAttributes {
    id? : number;
    username? : string;
    email: string;
}

interface GUserInstance extends Sequelize.Instance<GUserAttributes> {}
const GUser = s.define<GUserInstance, GUserAttributes>('user', {
    id: Sequelize.INTEGER,
    username: Sequelize.STRING
});
```

Before this PR there wasn't any error although `email` field is required and it is not defined inside `define`

But with this PR exactly the same code gives you an error
```
[ts]
Argument of type '{ id: DataTypeInteger; username: DataTypeString; }' is not assignable to parameter of type 'DefineModelAttributes<GUserAttributes>'.
  Property 'email' is missing in type '{ id: DataTypeInteger; username: DataTypeString; }'.
```

![image](https://user-images.githubusercontent.com/12229968/44466969-533acd80-a62a-11e8-8e8c-6cba35b1d71d.png)

So you as a developer are more safe and can fix the error like so:
![image](https://user-images.githubusercontent.com/12229968/44467048-9301b500-a62a-11e8-8477-c6bd24c5959b.png)


What do you guys think? :)