### PR TITLE
Added missing property in react-redux-toastr

### DIFF
--- a/types/react-redux-toastr/index.d.ts
+++ b/types/react-redux-toastr/index.d.ts
@@ -23,6 +23,7 @@ interface BasicToastrOptions {
     onCloseButtonClick?: () => void;
     onHideComplete?: () => void;
     onShowComplete?: () => void;
+    onToastrClick?: () => void;
     progressBar?: boolean;
     removeOnHover?: boolean;
     showCloseButton?: boolean;


### PR DESCRIPTION
Added onToastrClick property that was missing in BasicToastrOptions

I tested this addition in my own code, it works perfectly.



Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/diegoddox/react-redux-toastr#toastr-methods
