### PR TITLE
[jsforce] Change SalesforceId from class extending string to type alias

### DIFF
--- a/types/jsforce/salesforce-id.d.ts
+++ b/types/jsforce/salesforce-id.d.ts
@@ -1,2 +1,1 @@
-export class SalesforceId extends String {
-}
+export type SalesforceId = string


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: http://jsforce.github.io/jsforce/doc/SObject.html#record
- [X] Increase the version number in the header if appropriate.
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

An empty class (SalesforceId) extending String is used extensively in the type definitions. This is incorrect according to the [jsforce code](https://github.com/jsforce/jsforce/search?q=%22String.prototype%22&unscoped_q=%22String.prototype%22) (they never create a class extending a String prototype).
The class definition has been changed to a type alias for the primitive string
