### PR TITLE
Add @mapbox/polyline package

### DIFF
--- a/types/mapbox__polyline/index.d.ts
+++ b/types/mapbox__polyline/index.d.ts
@@ -1,0 +1,15 @@
+// Type definitions for mapbox__polyline 1.0
+// Project: https://github.com/mapbox/polyline
+// Definitions by: Arseniy Maximov <https://github.com/Kern0>
+//                 Marko Klopets <https://github.com/mklopets>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
+
+/// <reference types="geojson" />
+
+export function decode(string: string, precision?: number): number[][];
+export function encode(coordinates: number[][], precision?: number): string;
+export function fromGeoJSON(geojson: GeoJSON.LineString | GeoJSON.Feature<GeoJSON.LineString>, precision?: number): string;
+export function toGeoJSON(string: string, precision?: number): GeoJSON.LineString;
+
+export as namespace polyline;

--- a/types/mapbox__polyline/mapbox__polyline-tests.ts
+++ b/types/mapbox__polyline/mapbox__polyline-tests.ts
@@ -1,0 +1,25 @@
+const decodedString: number[][] = polyline.decode('_p~iF~ps|U_ulLnnqC_mqNvxq`@');
+const decodedStringWithPrecision: number[][] = polyline.decode('_p~iF~ps|U_ulLnnqC_mqNvxq`@', 2);
+
+const encoded: string = polyline.encode([[38.5, -120.2], [40.7, -120.95], [43.252, -126.453]]);
+const encodedWithPrecision: string = polyline.encode([[38.5, -120.2], [40.7, -120.95], [43.252, -126.453]], 2);
+
+const fromGeoJSON: string = polyline.fromGeoJSON({
+    type: 'Feature',
+    geometry: {
+        type: 'LineString',
+        coordinates: [[-120.2, 38.5], [-120.95, 40.7], [-126.453, 43.252]]
+    },
+    properties: {}
+});
+const fromGeoJSONWithPrecision: string = polyline.fromGeoJSON({
+    type: 'Feature',
+    geometry: {
+        type: 'LineString',
+        coordinates: [[-120.2, 38.5], [-120.95, 40.7], [-126.453, 43.252]]
+    },
+    properties: {}
+}, 3);
+
+const toGeoJSON: GeoJSON.LineString = polyline.toGeoJSON('_p~iF~ps|U_ulLnnqC_mqNvxq`@');
+const toGeoJSONWithPrecision: GeoJSON.LineString = polyline.toGeoJSON('_p~iF~ps|U_ulLnnqC_mqNvxq`@', 6);

--- a/types/mapbox__polyline/tsconfig.json
+++ b/types/mapbox__polyline/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "mapbox__polyline-tests.ts"
+    ]
+}

--- a/types/mapbox__polyline/tslint.json
+++ b/types/mapbox__polyline/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
There's already @types/polyline, but that refers to an old version of the package – it lives at the same repo, but is now named incorrectly (it was turned into a scoped @mapbox package) and also is missing one of the functions in its declarations.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.