### PR TITLE
Fix dialogflow Credentials interface with snake_case

### DIFF
--- a/types/dialogflow/index.d.ts
+++ b/types/dialogflow/index.d.ts
@@ -760,8 +760,8 @@ export enum MatchMode {
 }
 
 export interface Credentials {
-    clientEmail?: string;
-    privateKey?: string;
+    client_email?: string;
+    private_key?: string;
 }
 
 export interface ClientOptions {


### PR DESCRIPTION
Credentials are snake_case, not camelCase

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/dialogflow/dialogflow-nodejs-client-v2/blob/0cd8ac73905415d320f4b324840b08a40929b928/src/v2/intents_client.js#L68

The interface for Credentials is written in camelCase (`clientEmail` and `privateKey`) but should be in snake_case (`client_email` and `private_key`) as per JSDoc https://github.com/dialogflow/dialogflow-nodejs-client-v2/blob/0cd8ac73905415d320f4b324840b08a40929b928/src/v2/intents_client.js#L68