### PR TITLE
[@types/webpack-dev-server] Fix stats to webpack.Options.Stats

### DIFF
--- a/types/webpack-dev-server/index.d.ts
+++ b/types/webpack-dev-server/index.d.ts
@@ -158,7 +158,7 @@ declare namespace WebpackDevServer {
          * This option lets you precisely control what bundle information gets displayed.
          * This can be a nice middle ground if you want some bundle information, but not all of it.
          */
-        stats?: string | webpack.Stats;
+        stats?: string | webpack.Options.Stats;
         /** This option lets the browser open with your local IP. */
         useLocalIp?: boolean;
         /** Tell the server to watch the files served by the devServer.contentBase option. File changes will trigger a full page reload. */


### PR DESCRIPTION
This commit adds more stats options available to `webpack-dev-server`. The webpack site [0] states that all `webpack.Options.Stats` are supported on `webpack-dev-server`:
"For webpack-dev-server, this property needs to be in the devServer object."

[0]: https://webpack.js.org/configuration/stats/

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://webpack.js.org/configuration/stats/
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.