### PR TITLE
[vis] added order property for TimelineGroup

### DIFF
--- a/types/vis/index.d.ts
+++ b/types/vis/index.d.ts
@@ -10,6 +10,7 @@
 //                 Alex Soh <https://github.com/takato1314>
 //                 Oleksii Kachura <https://github.com/alex-kachura>
 //                 dcop <https://github.com/dcop>
+//                 Avraham Essoudry <https://github.com/avrahamcool>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 import { MomentInput, MomentFormatSpecification, Moment } from 'moment';
@@ -976,6 +977,7 @@ export interface TimelineGroup {
   content: string | HTMLElement;
   id: IdType;
   style?: string;
+  order?: number;
   subgroupOrder?: TimelineOptionsGroupOrderType;
   title?: string;
   visible?: boolean;


### PR DESCRIPTION
currently missing from official docs.
awaiting merge https://github.com/almende/vis/pull/4091

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/almende/vis/pull/4091

