### PR TITLE
lodash modularized: allow for import syntax without require()

### DIFF
--- a/types/lodash.add/index.d.ts
+++ b/types/lodash.add/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { add } from "lodash";
-export = add;
+declare namespace _ {
+  type Add = typeof add;
+}
+declare const _add: _.Add;
+export = _add;

--- a/types/lodash.after/index.d.ts
+++ b/types/lodash.after/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { after } from "lodash";
-export = after;
+declare namespace _ {
+  type After = typeof after;
+}
+declare const _after: _.After;
+export = _after;

--- a/types/lodash.ary/index.d.ts
+++ b/types/lodash.ary/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { ary } from "lodash";
-export = ary;
+declare namespace _ {
+  type Ary = typeof ary;
+}
+declare const _ary: _.Ary;
+export = _ary;

--- a/types/lodash.assign/index.d.ts
+++ b/types/lodash.assign/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { assign } from "lodash";
-export = assign;
+declare namespace _ {
+  type Assign = typeof assign;
+}
+declare const _assign: _.Assign;
+export = _assign;

--- a/types/lodash.assignin/index.d.ts
+++ b/types/lodash.assignin/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { assignIn } from "lodash";
-export = assignIn;
+declare namespace _ {
+  type AssignIn = typeof assignIn;
+}
+declare const _assignIn: _.AssignIn;
+export = _assignIn;

--- a/types/lodash.assigninwith/index.d.ts
+++ b/types/lodash.assigninwith/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { assignInWith } from "lodash";
-export = assignInWith;
+declare namespace _ {
+  type AssignInWith = typeof assignInWith;
+}
+declare const _assignInWith: _.AssignInWith;
+export = _assignInWith;

--- a/types/lodash.assignwith/index.d.ts
+++ b/types/lodash.assignwith/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { assignWith } from "lodash";
-export = assignWith;
+declare namespace _ {
+  type AssignWith = typeof assignWith;
+}
+declare const _assignWith: _.AssignWith;
+export = _assignWith;

--- a/types/lodash.at/index.d.ts
+++ b/types/lodash.at/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { at } from "lodash";
-export = at;
+declare namespace _ {
+  type At = typeof at;
+}
+declare const _at: _.At;
+export = _at;

--- a/types/lodash.attempt/index.d.ts
+++ b/types/lodash.attempt/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { attempt } from "lodash";
-export = attempt;
+declare namespace _ {
+  type Attempt = typeof attempt;
+}
+declare const _attempt: _.Attempt;
+export = _attempt;

--- a/types/lodash.before/index.d.ts
+++ b/types/lodash.before/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { before } from "lodash";
-export = before;
+declare namespace _ {
+  type Before = typeof before;
+}
+declare const _before: _.Before;
+export = _before;

--- a/types/lodash.bind/index.d.ts
+++ b/types/lodash.bind/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { bind } from "lodash";
-export = bind;
+declare namespace _ {
+  type Bind = typeof bind;
+}
+declare const _bind: _.Bind;
+export = _bind;

--- a/types/lodash.bindall/index.d.ts
+++ b/types/lodash.bindall/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { bindAll } from "lodash";
-export = bindAll;
+declare namespace _ {
+  type BindAll = typeof bindAll;
+}
+declare const _bindAll: _.BindAll;
+export = _bindAll;

--- a/types/lodash.bindkey/index.d.ts
+++ b/types/lodash.bindkey/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { bindKey } from "lodash";
-export = bindKey;
+declare namespace _ {
+  type BindKey = typeof bindKey;
+}
+declare const _bindKey: _.BindKey;
+export = _bindKey;

--- a/types/lodash.camelcase/index.d.ts
+++ b/types/lodash.camelcase/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { camelCase } from "lodash";
-export = camelCase;
+declare namespace _ {
+  type CamelCase = typeof camelCase;
+}
+declare const _camelCase: _.CamelCase;
+export = _camelCase;

--- a/types/lodash.capitalize/index.d.ts
+++ b/types/lodash.capitalize/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { capitalize } from "lodash";
-export = capitalize;
+declare namespace _ {
+  type Capitalize = typeof capitalize;
+}
+declare const _capitalize: _.Capitalize;
+export = _capitalize;

--- a/types/lodash.castarray/index.d.ts
+++ b/types/lodash.castarray/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { castArray } from "lodash";
-export = castArray;
+declare namespace _ {
+  type CastArray = typeof castArray;
+}
+declare const _castArray: _.CastArray;
+export = _castArray;

--- a/types/lodash.ceil/index.d.ts
+++ b/types/lodash.ceil/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { ceil } from "lodash";
-export = ceil;
+declare namespace _ {
+  type Ceil = typeof ceil;
+}
+declare const _ceil: _.Ceil;
+export = _ceil;

--- a/types/lodash.chunk/index.d.ts
+++ b/types/lodash.chunk/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { chunk } from "lodash";
-export = chunk;
+declare namespace _ {
+  type Chunk = typeof chunk;
+}
+declare const _chunk: _.Chunk;
+export = _chunk;

--- a/types/lodash.clamp/index.d.ts
+++ b/types/lodash.clamp/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { clamp } from "lodash";
-export = clamp;
+declare namespace _ {
+  type Clamp = typeof clamp;
+}
+declare const _clamp: _.Clamp;
+export = _clamp;

--- a/types/lodash.clone/index.d.ts
+++ b/types/lodash.clone/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { clone } from "lodash";
-export = clone;
+declare namespace _ {
+  type Clone = typeof clone;
+}
+declare const _clone: _.Clone;
+export = _clone;

--- a/types/lodash.clonedeep/index.d.ts
+++ b/types/lodash.clonedeep/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { cloneDeep } from "lodash";
-export = cloneDeep;
+declare namespace _ {
+  type CloneDeep = typeof cloneDeep;
+}
+declare const _cloneDeep: _.CloneDeep;
+export = _cloneDeep;

--- a/types/lodash.clonedeepwith/index.d.ts
+++ b/types/lodash.clonedeepwith/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { cloneDeepWith } from "lodash";
-export = cloneDeepWith;
+declare namespace _ {
+  type CloneDeepWith = typeof cloneDeepWith;
+}
+declare const _cloneDeepWith: _.CloneDeepWith;
+export = _cloneDeepWith;

--- a/types/lodash.clonewith/index.d.ts
+++ b/types/lodash.clonewith/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { cloneWith } from "lodash";
-export = cloneWith;
+declare namespace _ {
+  type CloneWith = typeof cloneWith;
+}
+declare const _cloneWith: _.CloneWith;
+export = _cloneWith;

--- a/types/lodash.compact/index.d.ts
+++ b/types/lodash.compact/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { compact } from "lodash";
-export = compact;
+declare namespace _ {
+  type Compact = typeof compact;
+}
+declare const _compact: _.Compact;
+export = _compact;

--- a/types/lodash.concat/index.d.ts
+++ b/types/lodash.concat/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { concat } from "lodash";
-export = concat;
+declare namespace _ {
+  type Concat = typeof concat;
+}
+declare const _concat: _.Concat;
+export = _concat;

--- a/types/lodash.cond/index.d.ts
+++ b/types/lodash.cond/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { cond } from "lodash";
-export = cond;
+declare namespace _ {
+  type Cond = typeof cond;
+}
+declare const _cond: _.Cond;
+export = _cond;

--- a/types/lodash.constant/index.d.ts
+++ b/types/lodash.constant/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { constant } from "lodash";
-export = constant;
+declare namespace _ {
+  type Constant = typeof constant;
+}
+declare const _constant: _.Constant;
+export = _constant;

--- a/types/lodash.countby/index.d.ts
+++ b/types/lodash.countby/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { countBy } from "lodash";
-export = countBy;
+declare namespace _ {
+  type CountBy = typeof countBy;
+}
+declare const _countBy: _.CountBy;
+export = _countBy;

--- a/types/lodash.create/index.d.ts
+++ b/types/lodash.create/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { create } from "lodash";
-export = create;
+declare namespace _ {
+  type Create = typeof create;
+}
+declare const _create: _.Create;
+export = _create;

--- a/types/lodash.curry/index.d.ts
+++ b/types/lodash.curry/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { curry } from "lodash";
-export = curry;
+declare namespace _ {
+  type Curry = typeof curry;
+}
+declare const _curry: _.Curry;
+export = _curry;

--- a/types/lodash.curryright/index.d.ts
+++ b/types/lodash.curryright/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { curryRight } from "lodash";
-export = curryRight;
+declare namespace _ {
+  type CurryRight = typeof curryRight;
+}
+declare const _curryRight: _.CurryRight;
+export = _curryRight;

--- a/types/lodash.debounce/index.d.ts
+++ b/types/lodash.debounce/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { debounce } from "lodash";
-export = debounce;
+declare namespace _ {
+  type Debounce = typeof debounce;
+}
+declare const _debounce: _.Debounce;
+export = _debounce;

--- a/types/lodash.deburr/index.d.ts
+++ b/types/lodash.deburr/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { deburr } from "lodash";
-export = deburr;
+declare namespace _ {
+  type Deburr = typeof deburr;
+}
+declare const _deburr: _.Deburr;
+export = _deburr;

--- a/types/lodash.defaults/index.d.ts
+++ b/types/lodash.defaults/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { defaults } from "lodash";
-export = defaults;
+declare namespace _ {
+  type Defaults = typeof defaults;
+}
+declare const _defaults: _.Defaults;
+export = _defaults;

--- a/types/lodash.defaultsdeep/index.d.ts
+++ b/types/lodash.defaultsdeep/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { defaultsDeep } from "lodash";
-export = defaultsDeep;
+declare namespace _ {
+  type DefaultsDeep = typeof defaultsDeep;
+}
+declare const _defaultsDeep: _.DefaultsDeep;
+export = _defaultsDeep;

--- a/types/lodash.defer/index.d.ts
+++ b/types/lodash.defer/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { defer } from "lodash";
-export = defer;
+declare namespace _ {
+  type Defer = typeof defer;
+}
+declare const _defer: _.Defer;
+export = _defer;

--- a/types/lodash.delay/index.d.ts
+++ b/types/lodash.delay/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { delay } from "lodash";
-export = delay;
+declare namespace _ {
+  type Delay = typeof delay;
+}
+declare const _delay: _.Delay;
+export = _delay;

--- a/types/lodash.difference/index.d.ts
+++ b/types/lodash.difference/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { difference } from "lodash";
-export = difference;
+declare namespace _ {
+  type Difference = typeof difference;
+}
+declare const _difference: _.Difference;
+export = _difference;

--- a/types/lodash.differenceby/index.d.ts
+++ b/types/lodash.differenceby/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { differenceBy } from "lodash";
-export = differenceBy;
+declare namespace _ {
+  type DifferenceBy = typeof differenceBy;
+}
+declare const _differenceBy: _.DifferenceBy;
+export = _differenceBy;

--- a/types/lodash.differencewith/index.d.ts
+++ b/types/lodash.differencewith/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { differenceWith } from "lodash";
-export = differenceWith;
+declare namespace _ {
+  type DifferenceWith = typeof differenceWith;
+}
+declare const _differenceWith: _.DifferenceWith;
+export = _differenceWith;

--- a/types/lodash.divide/index.d.ts
+++ b/types/lodash.divide/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { divide } from "lodash";
-export = divide;
+declare namespace _ {
+  type Divide = typeof divide;
+}
+declare const _divide: _.Divide;
+export = _divide;

--- a/types/lodash.drop/index.d.ts
+++ b/types/lodash.drop/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { drop } from "lodash";
-export = drop;
+declare namespace _ {
+  type Drop = typeof drop;
+}
+declare const _drop: _.Drop;
+export = _drop;

--- a/types/lodash.dropright/index.d.ts
+++ b/types/lodash.dropright/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { dropRight } from "lodash";
-export = dropRight;
+declare namespace _ {
+  type DropRight = typeof dropRight;
+}
+declare const _dropRight: _.DropRight;
+export = _dropRight;

--- a/types/lodash.droprightwhile/index.d.ts
+++ b/types/lodash.droprightwhile/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { dropRightWhile } from "lodash";
-export = dropRightWhile;
+declare namespace _ {
+  type DropRightWhile = typeof dropRightWhile;
+}
+declare const _dropRightWhile: _.DropRightWhile;
+export = _dropRightWhile;

--- a/types/lodash.dropwhile/index.d.ts
+++ b/types/lodash.dropwhile/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { dropWhile } from "lodash";
-export = dropWhile;
+declare namespace _ {
+  type DropWhile = typeof dropWhile;
+}
+declare const _dropWhile: _.DropWhile;
+export = _dropWhile;

--- a/types/lodash.endswith/index.d.ts
+++ b/types/lodash.endswith/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { endsWith } from "lodash";
-export = endsWith;
+declare namespace _ {
+  type EndsWith = typeof endsWith;
+}
+declare const _endsWith: _.EndsWith;
+export = _endsWith;

--- a/types/lodash.eq/index.d.ts
+++ b/types/lodash.eq/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { eq } from "lodash";
-export = eq;
+declare namespace _ {
+  type Eq = typeof eq;
+}
+declare const _eq: _.Eq;
+export = _eq;

--- a/types/lodash.escape/index.d.ts
+++ b/types/lodash.escape/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { escape } from "lodash";
-export = escape;
+declare namespace _ {
+  type Escape = typeof escape;
+}
+declare const _escape: _.Escape;
+export = _escape;

--- a/types/lodash.escaperegexp/index.d.ts
+++ b/types/lodash.escaperegexp/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { escapeRegExp } from "lodash";
-export = escapeRegExp;
+declare namespace _ {
+  type EscapeRegExp = typeof escapeRegExp;
+}
+declare const _escapeRegExp: _.EscapeRegExp;
+export = _escapeRegExp;

--- a/types/lodash.every/index.d.ts
+++ b/types/lodash.every/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { every } from "lodash";
-export = every;
+declare namespace _ {
+  type Every = typeof every;
+}
+declare const _every: _.Every;
+export = _every;

--- a/types/lodash.fill/index.d.ts
+++ b/types/lodash.fill/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { fill } from "lodash";
-export = fill;
+declare namespace _ {
+  type Fill = typeof fill;
+}
+declare const _fill: _.Fill;
+export = _fill;

--- a/types/lodash.filter/index.d.ts
+++ b/types/lodash.filter/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { filter } from "lodash";
-export = filter;
+declare namespace _ {
+  type Filter = typeof filter;
+}
+declare const _filter: _.Filter;
+export = _filter;

--- a/types/lodash.find/index.d.ts
+++ b/types/lodash.find/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { find } from "lodash";
-export = find;
+declare namespace _ {
+  type Find = typeof find;
+}
+declare const _find: _.Find;
+export = _find;

--- a/types/lodash.findindex/index.d.ts
+++ b/types/lodash.findindex/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { findIndex } from "lodash";
-export = findIndex;
+declare namespace _ {
+  type FindIndex = typeof findIndex;
+}
+declare const _findIndex: _.FindIndex;
+export = _findIndex;

--- a/types/lodash.findkey/index.d.ts
+++ b/types/lodash.findkey/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { findKey } from "lodash";
-export = findKey;
+declare namespace _ {
+  type FindKey = typeof findKey;
+}
+declare const _findKey: _.FindKey;
+export = _findKey;

--- a/types/lodash.findlast/index.d.ts
+++ b/types/lodash.findlast/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { findLast } from "lodash";
-export = findLast;
+declare namespace _ {
+  type FindLast = typeof findLast;
+}
+declare const _findLast: _.FindLast;
+export = _findLast;

--- a/types/lodash.findlastindex/index.d.ts
+++ b/types/lodash.findlastindex/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { findLastIndex } from "lodash";
-export = findLastIndex;
+declare namespace _ {
+  type FindLastIndex = typeof findLastIndex;
+}
+declare const _findLastIndex: _.FindLastIndex;
+export = _findLastIndex;

--- a/types/lodash.findlastkey/index.d.ts
+++ b/types/lodash.findlastkey/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { findLastKey } from "lodash";
-export = findLastKey;
+declare namespace _ {
+  type FindLastKey = typeof findLastKey;
+}
+declare const _findLastKey: _.FindLastKey;
+export = _findLastKey;

--- a/types/lodash.first/index.d.ts
+++ b/types/lodash.first/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { first } from "lodash";
-export = first;
+declare namespace _ {
+  type First = typeof first;
+}
+declare const _first: _.First;
+export = _first;

--- a/types/lodash.flatmap/index.d.ts
+++ b/types/lodash.flatmap/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { flatMap } from "lodash";
-export = flatMap;
+declare namespace _ {
+  type FlatMap = typeof flatMap;
+}
+declare const _flatMap: _.FlatMap;
+export = _flatMap;

--- a/types/lodash.flatmapdeep/index.d.ts
+++ b/types/lodash.flatmapdeep/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { flatMapDeep } from "lodash";
-export = flatMapDeep;
+declare namespace _ {
+  type FlatMapDeep = typeof flatMapDeep;
+}
+declare const _flatMapDeep: _.FlatMapDeep;
+export = _flatMapDeep;

--- a/types/lodash.flatmapdepth/index.d.ts
+++ b/types/lodash.flatmapdepth/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { flatMapDepth } from "lodash";
-export = flatMapDepth;
+declare namespace _ {
+  type FlatMapDepth = typeof flatMapDepth;
+}
+declare const _flatMapDepth: _.FlatMapDepth;
+export = _flatMapDepth;

--- a/types/lodash.flatten/index.d.ts
+++ b/types/lodash.flatten/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { flatten } from "lodash";
-export = flatten;
+declare namespace _ {
+  type Flatten = typeof flatten;
+}
+declare const _flatten: _.Flatten;
+export = _flatten;

--- a/types/lodash.flattendeep/index.d.ts
+++ b/types/lodash.flattendeep/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { flattenDeep } from "lodash";
-export = flattenDeep;
+declare namespace _ {
+  type FlattenDeep = typeof flattenDeep;
+}
+declare const _flattenDeep: _.FlattenDeep;
+export = _flattenDeep;

--- a/types/lodash.flattendepth/index.d.ts
+++ b/types/lodash.flattendepth/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { flattenDepth } from "lodash";
-export = flattenDepth;
+declare namespace _ {
+  type FlattenDepth = typeof flattenDepth;
+}
+declare const _flattenDepth: _.FlattenDepth;
+export = _flattenDepth;

--- a/types/lodash.flip/index.d.ts
+++ b/types/lodash.flip/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { flip } from "lodash";
-export = flip;
+declare namespace _ {
+  type Flip = typeof flip;
+}
+declare const _flip: _.Flip;
+export = _flip;

--- a/types/lodash.floor/index.d.ts
+++ b/types/lodash.floor/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { floor } from "lodash";
-export = floor;
+declare namespace _ {
+  type Floor = typeof floor;
+}
+declare const _floor: _.Floor;
+export = _floor;

--- a/types/lodash.flow/index.d.ts
+++ b/types/lodash.flow/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { flow } from "lodash";
-export = flow;
+declare namespace _ {
+  type Flow = typeof flow;
+}
+declare const _flow: _.Flow;
+export = _flow;

--- a/types/lodash.flowright/index.d.ts
+++ b/types/lodash.flowright/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { flowRight } from "lodash";
-export = flowRight;
+declare namespace _ {
+  type FlowRight = typeof flowRight;
+}
+declare const _flowRight: _.FlowRight;
+export = _flowRight;

--- a/types/lodash.foreach/index.d.ts
+++ b/types/lodash.foreach/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { forEach } from "lodash";
-export = forEach;
+declare namespace _ {
+  type ForEach = typeof forEach;
+}
+declare const _forEach: _.ForEach;
+export = _forEach;

--- a/types/lodash.foreachright/index.d.ts
+++ b/types/lodash.foreachright/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { forEachRight } from "lodash";
-export = forEachRight;
+declare namespace _ {
+  type ForEachRight = typeof forEachRight;
+}
+declare const _forEachRight: _.ForEachRight;
+export = _forEachRight;

--- a/types/lodash.forin/index.d.ts
+++ b/types/lodash.forin/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { forIn } from "lodash";
-export = forIn;
+declare namespace _ {
+  type ForIn = typeof forIn;
+}
+declare const _forIn: _.ForIn;
+export = _forIn;

--- a/types/lodash.forinright/index.d.ts
+++ b/types/lodash.forinright/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { forInRight } from "lodash";
-export = forInRight;
+declare namespace _ {
+  type ForInRight = typeof forInRight;
+}
+declare const _forInRight: _.ForInRight;
+export = _forInRight;

--- a/types/lodash.forown/index.d.ts
+++ b/types/lodash.forown/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { forOwn } from "lodash";
-export = forOwn;
+declare namespace _ {
+  type ForOwn = typeof forOwn;
+}
+declare const _forOwn: _.ForOwn;
+export = _forOwn;

--- a/types/lodash.forownright/index.d.ts
+++ b/types/lodash.forownright/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { forOwnRight } from "lodash";
-export = forOwnRight;
+declare namespace _ {
+  type ForOwnRight = typeof forOwnRight;
+}
+declare const _forOwnRight: _.ForOwnRight;
+export = _forOwnRight;

--- a/types/lodash.frompairs/index.d.ts
+++ b/types/lodash.frompairs/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { fromPairs } from "lodash";
-export = fromPairs;
+declare namespace _ {
+  type FromPairs = typeof fromPairs;
+}
+declare const _fromPairs: _.FromPairs;
+export = _fromPairs;

--- a/types/lodash.functions/index.d.ts
+++ b/types/lodash.functions/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { functions } from "lodash";
-export = functions;
+declare namespace _ {
+  type Functions = typeof functions;
+}
+declare const _functions: _.Functions;
+export = _functions;

--- a/types/lodash.functionsin/index.d.ts
+++ b/types/lodash.functionsin/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { functionsIn } from "lodash";
-export = functionsIn;
+declare namespace _ {
+  type FunctionsIn = typeof functionsIn;
+}
+declare const _functionsIn: _.FunctionsIn;
+export = _functionsIn;

--- a/types/lodash.get/index.d.ts
+++ b/types/lodash.get/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { get } from "lodash";
-export = get;
+declare namespace _ {
+  type Get = typeof get;
+}
+declare const _get: _.Get;
+export = _get;

--- a/types/lodash.groupby/index.d.ts
+++ b/types/lodash.groupby/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { groupBy } from "lodash";
-export = groupBy;
+declare namespace _ {
+  type GroupBy = typeof groupBy;
+}
+declare const _groupBy: _.GroupBy;
+export = _groupBy;

--- a/types/lodash.gt/index.d.ts
+++ b/types/lodash.gt/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { gt } from "lodash";
-export = gt;
+declare namespace _ {
+  type Gt = typeof gt;
+}
+declare const _gt: _.Gt;
+export = _gt;

--- a/types/lodash.gte/index.d.ts
+++ b/types/lodash.gte/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { gte } from "lodash";
-export = gte;
+declare namespace _ {
+  type Gte = typeof gte;
+}
+declare const _gte: _.Gte;
+export = _gte;

--- a/types/lodash.has/index.d.ts
+++ b/types/lodash.has/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { has } from "lodash";
-export = has;
+declare namespace _ {
+  type Has = typeof has;
+}
+declare const _has: _.Has;
+export = _has;

--- a/types/lodash.hasin/index.d.ts
+++ b/types/lodash.hasin/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { hasIn } from "lodash";
-export = hasIn;
+declare namespace _ {
+  type HasIn = typeof hasIn;
+}
+declare const _hasIn: _.HasIn;
+export = _hasIn;

--- a/types/lodash.head/index.d.ts
+++ b/types/lodash.head/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { head } from "lodash";
-export = head;
+declare namespace _ {
+  type Head = typeof head;
+}
+declare const _head: _.Head;
+export = _head;

--- a/types/lodash.identity/index.d.ts
+++ b/types/lodash.identity/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { identity } from "lodash";
-export = identity;
+declare namespace _ {
+  type Identity = typeof identity;
+}
+declare const _identity: _.Identity;
+export = _identity;

--- a/types/lodash.includes/index.d.ts
+++ b/types/lodash.includes/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { includes } from "lodash";
-export = includes;
+declare namespace _ {
+  type Includes = typeof includes;
+}
+declare const _includes: _.Includes;
+export = _includes;

--- a/types/lodash.indexof/index.d.ts
+++ b/types/lodash.indexof/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { indexOf } from "lodash";
-export = indexOf;
+declare namespace _ {
+  type IndexOf = typeof indexOf;
+}
+declare const _indexOf: _.IndexOf;
+export = _indexOf;

--- a/types/lodash.initial/index.d.ts
+++ b/types/lodash.initial/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { initial } from "lodash";
-export = initial;
+declare namespace _ {
+  type Initial = typeof initial;
+}
+declare const _initial: _.Initial;
+export = _initial;

--- a/types/lodash.inrange/index.d.ts
+++ b/types/lodash.inrange/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { inRange } from "lodash";
-export = inRange;
+declare namespace _ {
+  type InRange = typeof inRange;
+}
+declare const _inRange: _.InRange;
+export = _inRange;

--- a/types/lodash.intersection/index.d.ts
+++ b/types/lodash.intersection/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { intersection } from "lodash";
-export = intersection;
+declare namespace _ {
+  type Intersection = typeof intersection;
+}
+declare const _intersection: _.Intersection;
+export = _intersection;

--- a/types/lodash.intersectionby/index.d.ts
+++ b/types/lodash.intersectionby/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { intersectionBy } from "lodash";
-export = intersectionBy;
+declare namespace _ {
+  type IntersectionBy = typeof intersectionBy;
+}
+declare const _intersectionBy: _.IntersectionBy;
+export = _intersectionBy;

--- a/types/lodash.intersectionwith/index.d.ts
+++ b/types/lodash.intersectionwith/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { intersectionWith } from "lodash";
-export = intersectionWith;
+declare namespace _ {
+  type IntersectionWith = typeof intersectionWith;
+}
+declare const _intersectionWith: _.IntersectionWith;
+export = _intersectionWith;

--- a/types/lodash.invert/index.d.ts
+++ b/types/lodash.invert/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { invert } from "lodash";
-export = invert;
+declare namespace _ {
+  type Invert = typeof invert;
+}
+declare const _invert: _.Invert;
+export = _invert;

--- a/types/lodash.invertby/index.d.ts
+++ b/types/lodash.invertby/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { invertBy } from "lodash";
-export = invertBy;
+declare namespace _ {
+  type InvertBy = typeof invertBy;
+}
+declare const _invertBy: _.InvertBy;
+export = _invertBy;

--- a/types/lodash.invoke/index.d.ts
+++ b/types/lodash.invoke/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { invoke } from "lodash";
-export = invoke;
+declare namespace _ {
+  type Invoke = typeof invoke;
+}
+declare const _invoke: _.Invoke;
+export = _invoke;

--- a/types/lodash.invokemap/index.d.ts
+++ b/types/lodash.invokemap/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { invokeMap } from "lodash";
-export = invokeMap;
+declare namespace _ {
+  type InvokeMap = typeof invokeMap;
+}
+declare const _invokeMap: _.InvokeMap;
+export = _invokeMap;

--- a/types/lodash.isarguments/index.d.ts
+++ b/types/lodash.isarguments/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { isArguments } from "lodash";
-export = isArguments;
+declare namespace _ {
+  type IsArguments = typeof isArguments;
+}
+declare const _isArguments: _.IsArguments;
+export = _isArguments;

--- a/types/lodash.isarray/index.d.ts
+++ b/types/lodash.isarray/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { isArray } from "lodash";
-export = isArray;
+declare namespace _ {
+  type IsArray = typeof isArray;
+}
+declare const _isArray: _.IsArray;
+export = _isArray;

--- a/types/lodash.isarraybuffer/index.d.ts
+++ b/types/lodash.isarraybuffer/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { isArrayBuffer } from "lodash";
-export = isArrayBuffer;
+declare namespace _ {
+  type IsArrayBuffer = typeof isArrayBuffer;
+}
+declare const _isArrayBuffer: _.IsArrayBuffer;
+export = _isArrayBuffer;

--- a/types/lodash.isarraylike/index.d.ts
+++ b/types/lodash.isarraylike/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { isArrayLike } from "lodash";
-export = isArrayLike;
+declare namespace _ {
+  type IsArrayLike = typeof isArrayLike;
+}
+declare const _isArrayLike: _.IsArrayLike;
+export = _isArrayLike;

--- a/types/lodash.isarraylikeobject/index.d.ts
+++ b/types/lodash.isarraylikeobject/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { isArrayLikeObject } from "lodash";
-export = isArrayLikeObject;
+declare namespace _ {
+  type IsArrayLikeObject = typeof isArrayLikeObject;
+}
+declare const _isArrayLikeObject: _.IsArrayLikeObject;
+export = _isArrayLikeObject;

--- a/types/lodash.isboolean/index.d.ts
+++ b/types/lodash.isboolean/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { isBoolean } from "lodash";
-export = isBoolean;
+declare namespace _ {
+  type IsBoolean = typeof isBoolean;
+}
+declare const _isBoolean: _.IsBoolean;
+export = _isBoolean;

--- a/types/lodash.isbuffer/index.d.ts
+++ b/types/lodash.isbuffer/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { isBuffer } from "lodash";
-export = isBuffer;
+declare namespace _ {
+  type IsBuffer = typeof isBuffer;
+}
+declare const _isBuffer: _.IsBuffer;
+export = _isBuffer;

--- a/types/lodash.isdate/index.d.ts
+++ b/types/lodash.isdate/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { isDate } from "lodash";
-export = isDate;
+declare namespace _ {
+  type IsDate = typeof isDate;
+}
+declare const _isDate: _.IsDate;
+export = _isDate;

--- a/types/lodash.iselement/index.d.ts
+++ b/types/lodash.iselement/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { isElement } from "lodash";
-export = isElement;
+declare namespace _ {
+  type IsElement = typeof isElement;
+}
+declare const _isElement: _.IsElement;
+export = _isElement;

--- a/types/lodash.isempty/index.d.ts
+++ b/types/lodash.isempty/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { isEmpty } from "lodash";
-export = isEmpty;
+declare namespace _ {
+  type IsEmpty = typeof isEmpty;
+}
+declare const _isEmpty: _.IsEmpty;
+export = _isEmpty;

--- a/types/lodash.isequal/index.d.ts
+++ b/types/lodash.isequal/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { isEqual } from "lodash";
-export = isEqual;
+declare namespace _ {
+  type IsEqual = typeof isEqual;
+}
+declare const _isEqual: _.IsEqual;
+export = _isEqual;

--- a/types/lodash.isequalwith/index.d.ts
+++ b/types/lodash.isequalwith/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { isEqualWith } from "lodash";
-export = isEqualWith;
+declare namespace _ {
+  type IsEqualWith = typeof isEqualWith;
+}
+declare const _isEqualWith: _.IsEqualWith;
+export = _isEqualWith;

--- a/types/lodash.iserror/index.d.ts
+++ b/types/lodash.iserror/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { isError } from "lodash";
-export = isError;
+declare namespace _ {
+  type IsError = typeof isError;
+}
+declare const _isError: _.IsError;
+export = _isError;

--- a/types/lodash.isfinite/index.d.ts
+++ b/types/lodash.isfinite/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { isFinite } from "lodash";
-export = isFinite;
+declare namespace _ {
+  type IsFinite = typeof isFinite;
+}
+declare const _isFinite: _.IsFinite;
+export = _isFinite;

--- a/types/lodash.isfunction/index.d.ts
+++ b/types/lodash.isfunction/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { isFunction } from "lodash";
-export = isFunction;
+declare namespace _ {
+  type IsFunction = typeof isFunction;
+}
+declare const _isFunction: _.IsFunction;
+export = _isFunction;

--- a/types/lodash.isinteger/index.d.ts
+++ b/types/lodash.isinteger/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { isInteger } from "lodash";
-export = isInteger;
+declare namespace _ {
+  type IsInteger = typeof isInteger;
+}
+declare const _isInteger: _.IsInteger;
+export = _isInteger;

--- a/types/lodash.islength/index.d.ts
+++ b/types/lodash.islength/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { isLength } from "lodash";
-export = isLength;
+declare namespace _ {
+  type IsLength = typeof isLength;
+}
+declare const _isLength: _.IsLength;
+export = _isLength;

--- a/types/lodash.ismap/index.d.ts
+++ b/types/lodash.ismap/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { isMap } from "lodash";
-export = isMap;
+declare namespace _ {
+  type IsMap = typeof isMap;
+}
+declare const _isMap: _.IsMap;
+export = _isMap;

--- a/types/lodash.ismatch/index.d.ts
+++ b/types/lodash.ismatch/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { isMatch } from "lodash";
-export = isMatch;
+declare namespace _ {
+  type IsMatch = typeof isMatch;
+}
+declare const _isMatch: _.IsMatch;
+export = _isMatch;

--- a/types/lodash.ismatchwith/index.d.ts
+++ b/types/lodash.ismatchwith/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { isMatchWith } from "lodash";
-export = isMatchWith;
+declare namespace _ {
+  type IsMatchWith = typeof isMatchWith;
+}
+declare const _isMatchWith: _.IsMatchWith;
+export = _isMatchWith;

--- a/types/lodash.isnan/index.d.ts
+++ b/types/lodash.isnan/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { isNaN } from "lodash";
-export = isNaN;
+declare namespace _ {
+  type IsNaN = typeof isNaN;
+}
+declare const _isNaN: _.IsNaN;
+export = _isNaN;

--- a/types/lodash.isnative/index.d.ts
+++ b/types/lodash.isnative/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { isNative } from "lodash";
-export = isNative;
+declare namespace _ {
+  type IsNative = typeof isNative;
+}
+declare const _isNative: _.IsNative;
+export = _isNative;

--- a/types/lodash.isnil/index.d.ts
+++ b/types/lodash.isnil/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { isNil } from "lodash";
-export = isNil;
+declare namespace _ {
+  type IsNil = typeof isNil;
+}
+declare const _isNil: _.IsNil;
+export = _isNil;

--- a/types/lodash.isnull/index.d.ts
+++ b/types/lodash.isnull/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { isNull } from "lodash";
-export = isNull;
+declare namespace _ {
+  type IsNull = typeof isNull;
+}
+declare const _isNull: _.IsNull;
+export = _isNull;

--- a/types/lodash.isnumber/index.d.ts
+++ b/types/lodash.isnumber/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { isNumber } from "lodash";
-export = isNumber;
+declare namespace _ {
+  type IsNumber = typeof isNumber;
+}
+declare const _isNumber: _.IsNumber;
+export = _isNumber;

--- a/types/lodash.isobject/index.d.ts
+++ b/types/lodash.isobject/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { isObject } from "lodash";
-export = isObject;
+declare namespace _ {
+  type IsObject = typeof isObject;
+}
+declare const _isObject: _.IsObject;
+export = _isObject;

--- a/types/lodash.isobjectlike/index.d.ts
+++ b/types/lodash.isobjectlike/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { isObjectLike } from "lodash";
-export = isObjectLike;
+declare namespace _ {
+  type IsObjectLike = typeof isObjectLike;
+}
+declare const _isObjectLike: _.IsObjectLike;
+export = _isObjectLike;

--- a/types/lodash.isplainobject/index.d.ts
+++ b/types/lodash.isplainobject/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { isPlainObject } from "lodash";
-export = isPlainObject;
+declare namespace _ {
+  type IsPlainObject = typeof isPlainObject;
+}
+declare const _isPlainObject: _.IsPlainObject;
+export = _isPlainObject;

--- a/types/lodash.isregexp/index.d.ts
+++ b/types/lodash.isregexp/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { isRegExp } from "lodash";
-export = isRegExp;
+declare namespace _ {
+  type IsRegExp = typeof isRegExp;
+}
+declare const _isRegExp: _.IsRegExp;
+export = _isRegExp;

--- a/types/lodash.issafeinteger/index.d.ts
+++ b/types/lodash.issafeinteger/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { isSafeInteger } from "lodash";
-export = isSafeInteger;
+declare namespace _ {
+  type IsSafeInteger = typeof isSafeInteger;
+}
+declare const _isSafeInteger: _.IsSafeInteger;
+export = _isSafeInteger;

--- a/types/lodash.isset/index.d.ts
+++ b/types/lodash.isset/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { isSet } from "lodash";
-export = isSet;
+declare namespace _ {
+  type IsSet = typeof isSet;
+}
+declare const _isSet: _.IsSet;
+export = _isSet;

--- a/types/lodash.isstring/index.d.ts
+++ b/types/lodash.isstring/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { isString } from "lodash";
-export = isString;
+declare namespace _ {
+  type IsString = typeof isString;
+}
+declare const _isString: _.IsString;
+export = _isString;

--- a/types/lodash.issymbol/index.d.ts
+++ b/types/lodash.issymbol/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { isSymbol } from "lodash";
-export = isSymbol;
+declare namespace _ {
+  type IsSymbol = typeof isSymbol;
+}
+declare const _isSymbol: _.IsSymbol;
+export = _isSymbol;

--- a/types/lodash.istypedarray/index.d.ts
+++ b/types/lodash.istypedarray/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { isTypedArray } from "lodash";
-export = isTypedArray;
+declare namespace _ {
+  type IsTypedArray = typeof isTypedArray;
+}
+declare const _isTypedArray: _.IsTypedArray;
+export = _isTypedArray;

--- a/types/lodash.isundefined/index.d.ts
+++ b/types/lodash.isundefined/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { isUndefined } from "lodash";
-export = isUndefined;
+declare namespace _ {
+  type IsUndefined = typeof isUndefined;
+}
+declare const _isUndefined: _.IsUndefined;
+export = _isUndefined;

--- a/types/lodash.isweakmap/index.d.ts
+++ b/types/lodash.isweakmap/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { isWeakMap } from "lodash";
-export = isWeakMap;
+declare namespace _ {
+  type IsWeakMap = typeof isWeakMap;
+}
+declare const _isWeakMap: _.IsWeakMap;
+export = _isWeakMap;

--- a/types/lodash.isweakset/index.d.ts
+++ b/types/lodash.isweakset/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { isWeakSet } from "lodash";
-export = isWeakSet;
+declare namespace _ {
+  type IsWeakSet = typeof isWeakSet;
+}
+declare const _isWeakSet: _.IsWeakSet;
+export = _isWeakSet;

--- a/types/lodash.iteratee/index.d.ts
+++ b/types/lodash.iteratee/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { iteratee } from "lodash";
-export = iteratee;
+declare namespace _ {
+  type Iteratee = typeof iteratee;
+}
+declare const _iteratee: _.Iteratee;
+export = _iteratee;

--- a/types/lodash.join/index.d.ts
+++ b/types/lodash.join/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { join } from "lodash";
-export = join;
+declare namespace _ {
+  type Join = typeof join;
+}
+declare const _join: _.Join;
+export = _join;

--- a/types/lodash.kebabcase/index.d.ts
+++ b/types/lodash.kebabcase/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { kebabCase } from "lodash";
-export = kebabCase;
+declare namespace _ {
+  type KebabCase = typeof kebabCase;
+}
+declare const _kebabCase: _.KebabCase;
+export = _kebabCase;

--- a/types/lodash.keyby/index.d.ts
+++ b/types/lodash.keyby/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { keyBy } from "lodash";
-export = keyBy;
+declare namespace _ {
+  type KeyBy = typeof keyBy;
+}
+declare const _keyBy: _.KeyBy;
+export = _keyBy;

--- a/types/lodash.keys/index.d.ts
+++ b/types/lodash.keys/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { keys } from "lodash";
-export = keys;
+declare namespace _ {
+  type Keys = typeof keys;
+}
+declare const _keys: _.Keys;
+export = _keys;

--- a/types/lodash.keysin/index.d.ts
+++ b/types/lodash.keysin/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { keysIn } from "lodash";
-export = keysIn;
+declare namespace _ {
+  type KeysIn = typeof keysIn;
+}
+declare const _keysIn: _.KeysIn;
+export = _keysIn;

--- a/types/lodash.last/index.d.ts
+++ b/types/lodash.last/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { last } from "lodash";
-export = last;
+declare namespace _ {
+  type Last = typeof last;
+}
+declare const _last: _.Last;
+export = _last;

--- a/types/lodash.lastindexof/index.d.ts
+++ b/types/lodash.lastindexof/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { lastIndexOf } from "lodash";
-export = lastIndexOf;
+declare namespace _ {
+  type LastIndexOf = typeof lastIndexOf;
+}
+declare const _lastIndexOf: _.LastIndexOf;
+export = _lastIndexOf;

--- a/types/lodash.lowercase/index.d.ts
+++ b/types/lodash.lowercase/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { lowerCase } from "lodash";
-export = lowerCase;
+declare namespace _ {
+  type LowerCase = typeof lowerCase;
+}
+declare const _lowerCase: _.LowerCase;
+export = _lowerCase;

--- a/types/lodash.lowerfirst/index.d.ts
+++ b/types/lodash.lowerfirst/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { lowerFirst } from "lodash";
-export = lowerFirst;
+declare namespace _ {
+  type LowerFirst = typeof lowerFirst;
+}
+declare const _lowerFirst: _.LowerFirst;
+export = _lowerFirst;

--- a/types/lodash.lt/index.d.ts
+++ b/types/lodash.lt/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { lt } from "lodash";
-export = lt;
+declare namespace _ {
+  type Lt = typeof lt;
+}
+declare const _lt: _.Lt;
+export = _lt;

--- a/types/lodash.lte/index.d.ts
+++ b/types/lodash.lte/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { lte } from "lodash";
-export = lte;
+declare namespace _ {
+  type Lte = typeof lte;
+}
+declare const _lte: _.Lte;
+export = _lte;

--- a/types/lodash.mapkeys/index.d.ts
+++ b/types/lodash.mapkeys/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { mapKeys } from "lodash";
-export = mapKeys;
+declare namespace _ {
+  type MapKeys = typeof mapKeys;
+}
+declare const _mapKeys: _.MapKeys;
+export = _mapKeys;

--- a/types/lodash.mapvalues/index.d.ts
+++ b/types/lodash.mapvalues/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { mapValues } from "lodash";
-export = mapValues;
+declare namespace _ {
+  type MapValues = typeof mapValues;
+}
+declare const _mapValues: _.MapValues;
+export = _mapValues;

--- a/types/lodash.matches/index.d.ts
+++ b/types/lodash.matches/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { matches } from "lodash";
-export = matches;
+declare namespace _ {
+  type Matches = typeof matches;
+}
+declare const _matches: _.Matches;
+export = _matches;

--- a/types/lodash.matchesproperty/index.d.ts
+++ b/types/lodash.matchesproperty/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { matchesProperty } from "lodash";
-export = matchesProperty;
+declare namespace _ {
+  type MatchesProperty = typeof matchesProperty;
+}
+declare const _matchesProperty: _.MatchesProperty;
+export = _matchesProperty;

--- a/types/lodash.max/index.d.ts
+++ b/types/lodash.max/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { max } from "lodash";
-export = max;
+declare namespace _ {
+  type Max = typeof max;
+}
+declare const _max: _.Max;
+export = _max;

--- a/types/lodash.maxby/index.d.ts
+++ b/types/lodash.maxby/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { maxBy } from "lodash";
-export = maxBy;
+declare namespace _ {
+  type MaxBy = typeof maxBy;
+}
+declare const _maxBy: _.MaxBy;
+export = _maxBy;

--- a/types/lodash.mean/index.d.ts
+++ b/types/lodash.mean/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { mean } from "lodash";
-export = mean;
+declare namespace _ {
+  type Mean = typeof mean;
+}
+declare const _mean: _.Mean;
+export = _mean;

--- a/types/lodash.meanby/index.d.ts
+++ b/types/lodash.meanby/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { meanBy } from "lodash";
-export = meanBy;
+declare namespace _ {
+  type MeanBy = typeof meanBy;
+}
+declare const _meanBy: _.MeanBy;
+export = _meanBy;

--- a/types/lodash.memoize/index.d.ts
+++ b/types/lodash.memoize/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { memoize } from "lodash";
-export = memoize;
+declare namespace _ {
+  type Memoize = typeof memoize;
+}
+declare const _memoize: _.Memoize;
+export = _memoize;

--- a/types/lodash.merge/index.d.ts
+++ b/types/lodash.merge/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { merge } from "lodash";
-export = merge;
+declare namespace _ {
+  type Merge = typeof merge;
+}
+declare const _merge: _.Merge;
+export = _merge;

--- a/types/lodash.mergewith/index.d.ts
+++ b/types/lodash.mergewith/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { mergeWith } from "lodash";
-export = mergeWith;
+declare namespace _ {
+  type MergeWith = typeof mergeWith;
+}
+declare const _mergeWith: _.MergeWith;
+export = _mergeWith;

--- a/types/lodash.method/index.d.ts
+++ b/types/lodash.method/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { method } from "lodash";
-export = method;
+declare namespace _ {
+  type Method = typeof method;
+}
+declare const _method: _.Method;
+export = _method;

--- a/types/lodash.methodof/index.d.ts
+++ b/types/lodash.methodof/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { methodOf } from "lodash";
-export = methodOf;
+declare namespace _ {
+  type MethodOf = typeof methodOf;
+}
+declare const _methodOf: _.MethodOf;
+export = _methodOf;

--- a/types/lodash.min/index.d.ts
+++ b/types/lodash.min/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { min } from "lodash";
-export = min;
+declare namespace _ {
+  type Min = typeof min;
+}
+declare const _min: _.Min;
+export = _min;

--- a/types/lodash.minby/index.d.ts
+++ b/types/lodash.minby/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { minBy } from "lodash";
-export = minBy;
+declare namespace _ {
+  type MinBy = typeof minBy;
+}
+declare const _minBy: _.MinBy;
+export = _minBy;

--- a/types/lodash.mixin/index.d.ts
+++ b/types/lodash.mixin/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { mixin } from "lodash";
-export = mixin;
+declare namespace _ {
+  type Mixin = typeof mixin;
+}
+declare const _mixin: _.Mixin;
+export = _mixin;

--- a/types/lodash.negate/index.d.ts
+++ b/types/lodash.negate/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { negate } from "lodash";
-export = negate;
+declare namespace _ {
+  type Negate = typeof negate;
+}
+declare const _negate: _.Negate;
+export = _negate;

--- a/types/lodash.noop/index.d.ts
+++ b/types/lodash.noop/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { noop } from "lodash";
-export = noop;
+declare namespace _ {
+  type Noop = typeof noop;
+}
+declare const _noop: _.Noop;
+export = _noop;

--- a/types/lodash.now/index.d.ts
+++ b/types/lodash.now/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { now } from "lodash";
-export = now;
+declare namespace _ {
+  type Now = typeof now;
+}
+declare const _now: _.Now;
+export = _now;

--- a/types/lodash.nth/index.d.ts
+++ b/types/lodash.nth/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { nth } from "lodash";
-export = nth;
+declare namespace _ {
+  type Nth = typeof nth;
+}
+declare const _nth: _.Nth;
+export = _nth;

--- a/types/lodash.ntharg/index.d.ts
+++ b/types/lodash.ntharg/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { nthArg } from "lodash";
-export = nthArg;
+declare namespace _ {
+  type NthArg = typeof nthArg;
+}
+declare const _nthArg: _.NthArg;
+export = _nthArg;

--- a/types/lodash.omit/index.d.ts
+++ b/types/lodash.omit/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { omit } from "lodash";
-export = omit;
+declare namespace _ {
+  type Omit = typeof omit;
+}
+declare const _omit: _.Omit;
+export = _omit;

--- a/types/lodash.omitby/index.d.ts
+++ b/types/lodash.omitby/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { omitBy } from "lodash";
-export = omitBy;
+declare namespace _ {
+  type OmitBy = typeof omitBy;
+}
+declare const _omitBy: _.OmitBy;
+export = _omitBy;

--- a/types/lodash.once/index.d.ts
+++ b/types/lodash.once/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { once } from "lodash";
-export = once;
+declare namespace _ {
+  type Once = typeof once;
+}
+declare const _once: _.Once;
+export = _once;

--- a/types/lodash.orderby/index.d.ts
+++ b/types/lodash.orderby/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { orderBy } from "lodash";
-export = orderBy;
+declare namespace _ {
+  type OrderBy = typeof orderBy;
+}
+declare const _orderBy: _.OrderBy;
+export = _orderBy;

--- a/types/lodash.over/index.d.ts
+++ b/types/lodash.over/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { over } from "lodash";
-export = over;
+declare namespace _ {
+  type Over = typeof over;
+}
+declare const _over: _.Over;
+export = _over;

--- a/types/lodash.overargs/index.d.ts
+++ b/types/lodash.overargs/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { overArgs } from "lodash";
-export = overArgs;
+declare namespace _ {
+  type OverArgs = typeof overArgs;
+}
+declare const _overArgs: _.OverArgs;
+export = _overArgs;

--- a/types/lodash.overevery/index.d.ts
+++ b/types/lodash.overevery/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { overEvery } from "lodash";
-export = overEvery;
+declare namespace _ {
+  type OverEvery = typeof overEvery;
+}
+declare const _overEvery: _.OverEvery;
+export = _overEvery;

--- a/types/lodash.oversome/index.d.ts
+++ b/types/lodash.oversome/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { overSome } from "lodash";
-export = overSome;
+declare namespace _ {
+  type OverSome = typeof overSome;
+}
+declare const _overSome: _.OverSome;
+export = _overSome;

--- a/types/lodash.pad/index.d.ts
+++ b/types/lodash.pad/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { pad } from "lodash";
-export = pad;
+declare namespace _ {
+  type Pad = typeof pad;
+}
+declare const _pad: _.Pad;
+export = _pad;

--- a/types/lodash.padend/index.d.ts
+++ b/types/lodash.padend/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { padEnd } from "lodash";
-export = padEnd;
+declare namespace _ {
+  type PadEnd = typeof padEnd;
+}
+declare const _padEnd: _.PadEnd;
+export = _padEnd;

--- a/types/lodash.padstart/index.d.ts
+++ b/types/lodash.padstart/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { padStart } from "lodash";
-export = padStart;
+declare namespace _ {
+  type PadStart = typeof padStart;
+}
+declare const _padStart: _.PadStart;
+export = _padStart;

--- a/types/lodash.parseint/index.d.ts
+++ b/types/lodash.parseint/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { parseInt } from "lodash";
-export = parseInt;
+declare namespace _ {
+  type ParseInt = typeof parseInt;
+}
+declare const _parseInt: _.ParseInt;
+export = _parseInt;

--- a/types/lodash.partial/index.d.ts
+++ b/types/lodash.partial/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { partial } from "lodash";
-export = partial;
+declare namespace _ {
+  type Partial = typeof partial;
+}
+declare const _partial: _.Partial;
+export = _partial;

--- a/types/lodash.partialright/index.d.ts
+++ b/types/lodash.partialright/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { partialRight } from "lodash";
-export = partialRight;
+declare namespace _ {
+  type PartialRight = typeof partialRight;
+}
+declare const _partialRight: _.PartialRight;
+export = _partialRight;

--- a/types/lodash.partition/index.d.ts
+++ b/types/lodash.partition/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { partition } from "lodash";
-export = partition;
+declare namespace _ {
+  type Partition = typeof partition;
+}
+declare const _partition: _.Partition;
+export = _partition;

--- a/types/lodash.pick/index.d.ts
+++ b/types/lodash.pick/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { pick } from "lodash";
-export = pick;
+declare namespace _ {
+  type Pick = typeof pick;
+}
+declare const _pick: _.Pick;
+export = _pick;

--- a/types/lodash.pickby/index.d.ts
+++ b/types/lodash.pickby/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { pickBy } from "lodash";
-export = pickBy;
+declare namespace _ {
+  type PickBy = typeof pickBy;
+}
+declare const _pickBy: _.PickBy;
+export = _pickBy;

--- a/types/lodash.property/index.d.ts
+++ b/types/lodash.property/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { property } from "lodash";
-export = property;
+declare namespace _ {
+  type Property = typeof property;
+}
+declare const _property: _.Property;
+export = _property;

--- a/types/lodash.propertyof/index.d.ts
+++ b/types/lodash.propertyof/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { propertyOf } from "lodash";
-export = propertyOf;
+declare namespace _ {
+  type PropertyOf = typeof propertyOf;
+}
+declare const _propertyOf: _.PropertyOf;
+export = _propertyOf;

--- a/types/lodash.pull/index.d.ts
+++ b/types/lodash.pull/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { pull } from "lodash";
-export = pull;
+declare namespace _ {
+  type Pull = typeof pull;
+}
+declare const _pull: _.Pull;
+export = _pull;

--- a/types/lodash.pullall/index.d.ts
+++ b/types/lodash.pullall/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { pullAll } from "lodash";
-export = pullAll;
+declare namespace _ {
+  type PullAll = typeof pullAll;
+}
+declare const _pullAll: _.PullAll;
+export = _pullAll;

--- a/types/lodash.pullallby/index.d.ts
+++ b/types/lodash.pullallby/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { pullAllBy } from "lodash";
-export = pullAllBy;
+declare namespace _ {
+  type PullAllBy = typeof pullAllBy;
+}
+declare const _pullAllBy: _.PullAllBy;
+export = _pullAllBy;

--- a/types/lodash.pullallwith/index.d.ts
+++ b/types/lodash.pullallwith/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { pullAllWith } from "lodash";
-export = pullAllWith;
+declare namespace _ {
+  type PullAllWith = typeof pullAllWith;
+}
+declare const _pullAllWith: _.PullAllWith;
+export = _pullAllWith;

--- a/types/lodash.pullat/index.d.ts
+++ b/types/lodash.pullat/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { pullAt } from "lodash";
-export = pullAt;
+declare namespace _ {
+  type PullAt = typeof pullAt;
+}
+declare const _pullAt: _.PullAt;
+export = _pullAt;

--- a/types/lodash.random/index.d.ts
+++ b/types/lodash.random/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { random } from "lodash";
-export = random;
+declare namespace _ {
+  type Random = typeof random;
+}
+declare const _random: _.Random;
+export = _random;

--- a/types/lodash.range/index.d.ts
+++ b/types/lodash.range/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { range } from "lodash";
-export = range;
+declare namespace _ {
+  type Range = typeof range;
+}
+declare const _range: _.Range;
+export = _range;

--- a/types/lodash.rangeright/index.d.ts
+++ b/types/lodash.rangeright/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { rangeRight } from "lodash";
-export = rangeRight;
+declare namespace _ {
+  type RangeRight = typeof rangeRight;
+}
+declare const _rangeRight: _.RangeRight;
+export = _rangeRight;

--- a/types/lodash.rearg/index.d.ts
+++ b/types/lodash.rearg/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { rearg } from "lodash";
-export = rearg;
+declare namespace _ {
+  type Rearg = typeof rearg;
+}
+declare const _rearg: _.Rearg;
+export = _rearg;

--- a/types/lodash.reduce/index.d.ts
+++ b/types/lodash.reduce/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { reduce } from "lodash";
-export = reduce;
+declare namespace _ {
+  type Reduce = typeof reduce;
+}
+declare const _reduce: _.Reduce;
+export = _reduce;

--- a/types/lodash.reduceright/index.d.ts
+++ b/types/lodash.reduceright/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { reduceRight } from "lodash";
-export = reduceRight;
+declare namespace _ {
+  type ReduceRight = typeof reduceRight;
+}
+declare const _reduceRight: _.ReduceRight;
+export = _reduceRight;

--- a/types/lodash.reject/index.d.ts
+++ b/types/lodash.reject/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { reject } from "lodash";
-export = reject;
+declare namespace _ {
+  type Reject = typeof reject;
+}
+declare const _reject: _.Reject;
+export = _reject;

--- a/types/lodash.remove/index.d.ts
+++ b/types/lodash.remove/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { remove } from "lodash";
-export = remove;
+declare namespace _ {
+  type Remove = typeof remove;
+}
+declare const _remove: _.Remove;
+export = _remove;

--- a/types/lodash.repeat/index.d.ts
+++ b/types/lodash.repeat/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { repeat } from "lodash";
-export = repeat;
+declare namespace _ {
+  type Repeat = typeof repeat;
+}
+declare const _repeat: _.Repeat;
+export = _repeat;

--- a/types/lodash.replace/index.d.ts
+++ b/types/lodash.replace/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { replace } from "lodash";
-export = replace;
+declare namespace _ {
+  type Replace = typeof replace;
+}
+declare const _replace: _.Replace;
+export = _replace;

--- a/types/lodash.rest/index.d.ts
+++ b/types/lodash.rest/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { rest } from "lodash";
-export = rest;
+declare namespace _ {
+  type Rest = typeof rest;
+}
+declare const _rest: _.Rest;
+export = _rest;

--- a/types/lodash.result/index.d.ts
+++ b/types/lodash.result/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { result } from "lodash";
-export = result;
+declare namespace _ {
+  type Result = typeof result;
+}
+declare const _result: _.Result;
+export = _result;

--- a/types/lodash.reverse/index.d.ts
+++ b/types/lodash.reverse/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { reverse } from "lodash";
-export = reverse;
+declare namespace _ {
+  type Reverse = typeof reverse;
+}
+declare const _reverse: _.Reverse;
+export = _reverse;

--- a/types/lodash.round/index.d.ts
+++ b/types/lodash.round/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { round } from "lodash";
-export = round;
+declare namespace _ {
+  type Round = typeof round;
+}
+declare const _round: _.Round;
+export = _round;

--- a/types/lodash.sample/index.d.ts
+++ b/types/lodash.sample/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { sample } from "lodash";
-export = sample;
+declare namespace _ {
+  type Sample = typeof sample;
+}
+declare const _sample: _.Sample;
+export = _sample;

--- a/types/lodash.samplesize/index.d.ts
+++ b/types/lodash.samplesize/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { sampleSize } from "lodash";
-export = sampleSize;
+declare namespace _ {
+  type SampleSize = typeof sampleSize;
+}
+declare const _sampleSize: _.SampleSize;
+export = _sampleSize;

--- a/types/lodash.set/index.d.ts
+++ b/types/lodash.set/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { set } from "lodash";
-export = set;
+declare namespace _ {
+  type Set = typeof set;
+}
+declare const _set: _.Set;
+export = _set;

--- a/types/lodash.setwith/index.d.ts
+++ b/types/lodash.setwith/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { setWith } from "lodash";
-export = setWith;
+declare namespace _ {
+  type SetWith = typeof setWith;
+}
+declare const _setWith: _.SetWith;
+export = _setWith;

--- a/types/lodash.shuffle/index.d.ts
+++ b/types/lodash.shuffle/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { shuffle } from "lodash";
-export = shuffle;
+declare namespace _ {
+  type Shuffle = typeof shuffle;
+}
+declare const _shuffle: _.Shuffle;
+export = _shuffle;

--- a/types/lodash.size/index.d.ts
+++ b/types/lodash.size/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { size } from "lodash";
-export = size;
+declare namespace _ {
+  type Size = typeof size;
+}
+declare const _size: _.Size;
+export = _size;

--- a/types/lodash.slice/index.d.ts
+++ b/types/lodash.slice/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { slice } from "lodash";
-export = slice;
+declare namespace _ {
+  type Slice = typeof slice;
+}
+declare const _slice: _.Slice;
+export = _slice;

--- a/types/lodash.snakecase/index.d.ts
+++ b/types/lodash.snakecase/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { snakeCase } from "lodash";
-export = snakeCase;
+declare namespace _ {
+  type SnakeCase = typeof snakeCase;
+}
+declare const _snakeCase: _.SnakeCase;
+export = _snakeCase;

--- a/types/lodash.some/index.d.ts
+++ b/types/lodash.some/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { some } from "lodash";
-export = some;
+declare namespace _ {
+  type Some = typeof some;
+}
+declare const _some: _.Some;
+export = _some;

--- a/types/lodash.sortby/index.d.ts
+++ b/types/lodash.sortby/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { sortBy } from "lodash";
-export = sortBy;
+declare namespace _ {
+  type SortBy = typeof sortBy;
+}
+declare const _sortBy: _.SortBy;
+export = _sortBy;

--- a/types/lodash.sortedindex/index.d.ts
+++ b/types/lodash.sortedindex/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { sortedIndex } from "lodash";
-export = sortedIndex;
+declare namespace _ {
+  type SortedIndex = typeof sortedIndex;
+}
+declare const _sortedIndex: _.SortedIndex;
+export = _sortedIndex;

--- a/types/lodash.sortedindexby/index.d.ts
+++ b/types/lodash.sortedindexby/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { sortedIndexBy } from "lodash";
-export = sortedIndexBy;
+declare namespace _ {
+  type SortedIndexBy = typeof sortedIndexBy;
+}
+declare const _sortedIndexBy: _.SortedIndexBy;
+export = _sortedIndexBy;

--- a/types/lodash.sortedindexof/index.d.ts
+++ b/types/lodash.sortedindexof/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { sortedIndexOf } from "lodash";
-export = sortedIndexOf;
+declare namespace _ {
+  type SortedIndexOf = typeof sortedIndexOf;
+}
+declare const _sortedIndexOf: _.SortedIndexOf;
+export = _sortedIndexOf;

--- a/types/lodash.sortedlastindex/index.d.ts
+++ b/types/lodash.sortedlastindex/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { sortedLastIndex } from "lodash";
-export = sortedLastIndex;
+declare namespace _ {
+  type SortedLastIndex = typeof sortedLastIndex;
+}
+declare const _sortedLastIndex: _.SortedLastIndex;
+export = _sortedLastIndex;

--- a/types/lodash.sortedlastindexby/index.d.ts
+++ b/types/lodash.sortedlastindexby/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { sortedLastIndexBy } from "lodash";
-export = sortedLastIndexBy;
+declare namespace _ {
+  type SortedLastIndexBy = typeof sortedLastIndexBy;
+}
+declare const _sortedLastIndexBy: _.SortedLastIndexBy;
+export = _sortedLastIndexBy;

--- a/types/lodash.sortedlastindexof/index.d.ts
+++ b/types/lodash.sortedlastindexof/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { sortedLastIndexOf } from "lodash";
-export = sortedLastIndexOf;
+declare namespace _ {
+  type SortedLastIndexOf = typeof sortedLastIndexOf;
+}
+declare const _sortedLastIndexOf: _.SortedLastIndexOf;
+export = _sortedLastIndexOf;

--- a/types/lodash.sorteduniq/index.d.ts
+++ b/types/lodash.sorteduniq/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { sortedUniq } from "lodash";
-export = sortedUniq;
+declare namespace _ {
+  type SortedUniq = typeof sortedUniq;
+}
+declare const _sortedUniq: _.SortedUniq;
+export = _sortedUniq;

--- a/types/lodash.sorteduniqby/index.d.ts
+++ b/types/lodash.sorteduniqby/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { sortedUniqBy } from "lodash";
-export = sortedUniqBy;
+declare namespace _ {
+  type SortedUniqBy = typeof sortedUniqBy;
+}
+declare const _sortedUniqBy: _.SortedUniqBy;
+export = _sortedUniqBy;

--- a/types/lodash.split/index.d.ts
+++ b/types/lodash.split/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { split } from "lodash";
-export = split;
+declare namespace _ {
+  type Split = typeof split;
+}
+declare const _split: _.Split;
+export = _split;

--- a/types/lodash.spread/index.d.ts
+++ b/types/lodash.spread/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { spread } from "lodash";
-export = spread;
+declare namespace _ {
+  type Spread = typeof spread;
+}
+declare const _spread: _.Spread;
+export = _spread;

--- a/types/lodash.startcase/index.d.ts
+++ b/types/lodash.startcase/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { startCase } from "lodash";
-export = startCase;
+declare namespace _ {
+  type StartCase = typeof startCase;
+}
+declare const _startCase: _.StartCase;
+export = _startCase;

--- a/types/lodash.startswith/index.d.ts
+++ b/types/lodash.startswith/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { startsWith } from "lodash";
-export = startsWith;
+declare namespace _ {
+  type StartsWith = typeof startsWith;
+}
+declare const _startsWith: _.StartsWith;
+export = _startsWith;

--- a/types/lodash.subtract/index.d.ts
+++ b/types/lodash.subtract/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { subtract } from "lodash";
-export = subtract;
+declare namespace _ {
+  type Subtract = typeof subtract;
+}
+declare const _subtract: _.Subtract;
+export = _subtract;

--- a/types/lodash.sum/index.d.ts
+++ b/types/lodash.sum/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { sum } from "lodash";
-export = sum;
+declare namespace _ {
+  type Sum = typeof sum;
+}
+declare const _sum: _.Sum;
+export = _sum;

--- a/types/lodash.sumby/index.d.ts
+++ b/types/lodash.sumby/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { sumBy } from "lodash";
-export = sumBy;
+declare namespace _ {
+  type SumBy = typeof sumBy;
+}
+declare const _sumBy: _.SumBy;
+export = _sumBy;

--- a/types/lodash.tail/index.d.ts
+++ b/types/lodash.tail/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { tail } from "lodash";
-export = tail;
+declare namespace _ {
+  type Tail = typeof tail;
+}
+declare const _tail: _.Tail;
+export = _tail;

--- a/types/lodash.take/index.d.ts
+++ b/types/lodash.take/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { take } from "lodash";
-export = take;
+declare namespace _ {
+  type Take = typeof take;
+}
+declare const _take: _.Take;
+export = _take;

--- a/types/lodash.takeright/index.d.ts
+++ b/types/lodash.takeright/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { takeRight } from "lodash";
-export = takeRight;
+declare namespace _ {
+  type TakeRight = typeof takeRight;
+}
+declare const _takeRight: _.TakeRight;
+export = _takeRight;

--- a/types/lodash.takerightwhile/index.d.ts
+++ b/types/lodash.takerightwhile/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { takeRightWhile } from "lodash";
-export = takeRightWhile;
+declare namespace _ {
+  type TakeRightWhile = typeof takeRightWhile;
+}
+declare const _takeRightWhile: _.TakeRightWhile;
+export = _takeRightWhile;

--- a/types/lodash.takewhile/index.d.ts
+++ b/types/lodash.takewhile/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { takeWhile } from "lodash";
-export = takeWhile;
+declare namespace _ {
+  type TakeWhile = typeof takeWhile;
+}
+declare const _takeWhile: _.TakeWhile;
+export = _takeWhile;

--- a/types/lodash.template/index.d.ts
+++ b/types/lodash.template/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { template } from "lodash";
-export = template;
+declare namespace _ {
+  type Template = typeof template;
+}
+declare const _template: _.Template;
+export = _template;

--- a/types/lodash.throttle/index.d.ts
+++ b/types/lodash.throttle/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { throttle } from "lodash";
-export = throttle;
+declare namespace _ {
+  type Throttle = typeof throttle;
+}
+declare const _throttle: _.Throttle;
+export = _throttle;

--- a/types/lodash.times/index.d.ts
+++ b/types/lodash.times/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { times } from "lodash";
-export = times;
+declare namespace _ {
+  type Times = typeof times;
+}
+declare const _times: _.Times;
+export = _times;

--- a/types/lodash.toarray/index.d.ts
+++ b/types/lodash.toarray/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { toArray } from "lodash";
-export = toArray;
+declare namespace _ {
+  type ToArray = typeof toArray;
+}
+declare const _toArray: _.ToArray;
+export = _toArray;

--- a/types/lodash.tofinite/index.d.ts
+++ b/types/lodash.tofinite/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { toFinite } from "lodash";
-export = toFinite;
+declare namespace _ {
+  type ToFinite = typeof toFinite;
+}
+declare const _toFinite: _.ToFinite;
+export = _toFinite;

--- a/types/lodash.tointeger/index.d.ts
+++ b/types/lodash.tointeger/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { toInteger } from "lodash";
-export = toInteger;
+declare namespace _ {
+  type ToInteger = typeof toInteger;
+}
+declare const _toInteger: _.ToInteger;
+export = _toInteger;

--- a/types/lodash.tolength/index.d.ts
+++ b/types/lodash.tolength/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { toLength } from "lodash";
-export = toLength;
+declare namespace _ {
+  type ToLength = typeof toLength;
+}
+declare const _toLength: _.ToLength;
+export = _toLength;

--- a/types/lodash.tolower/index.d.ts
+++ b/types/lodash.tolower/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { toLower } from "lodash";
-export = toLower;
+declare namespace _ {
+  type ToLower = typeof toLower;
+}
+declare const _toLower: _.ToLower;
+export = _toLower;

--- a/types/lodash.tonumber/index.d.ts
+++ b/types/lodash.tonumber/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { toNumber } from "lodash";
-export = toNumber;
+declare namespace _ {
+  type ToNumber = typeof toNumber;
+}
+declare const _toNumber: _.ToNumber;
+export = _toNumber;

--- a/types/lodash.topairs/index.d.ts
+++ b/types/lodash.topairs/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { toPairs } from "lodash";
-export = toPairs;
+declare namespace _ {
+  type ToPairs = typeof toPairs;
+}
+declare const _toPairs: _.ToPairs;
+export = _toPairs;

--- a/types/lodash.topairsin/index.d.ts
+++ b/types/lodash.topairsin/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { toPairsIn } from "lodash";
-export = toPairsIn;
+declare namespace _ {
+  type ToPairsIn = typeof toPairsIn;
+}
+declare const _toPairsIn: _.ToPairsIn;
+export = _toPairsIn;

--- a/types/lodash.topath/index.d.ts
+++ b/types/lodash.topath/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { toPath } from "lodash";
-export = toPath;
+declare namespace _ {
+  type ToPath = typeof toPath;
+}
+declare const _toPath: _.ToPath;
+export = _toPath;

--- a/types/lodash.toplainobject/index.d.ts
+++ b/types/lodash.toplainobject/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { toPlainObject } from "lodash";
-export = toPlainObject;
+declare namespace _ {
+  type ToPlainObject = typeof toPlainObject;
+}
+declare const _toPlainObject: _.ToPlainObject;
+export = _toPlainObject;

--- a/types/lodash.tosafeinteger/index.d.ts
+++ b/types/lodash.tosafeinteger/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { toSafeInteger } from "lodash";
-export = toSafeInteger;
+declare namespace _ {
+  type ToSafeInteger = typeof toSafeInteger;
+}
+declare const _toSafeInteger: _.ToSafeInteger;
+export = _toSafeInteger;

--- a/types/lodash.tostring/index.d.ts
+++ b/types/lodash.tostring/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { toString } from "lodash";
-export = toString;
+declare namespace _ {
+  type ToString = typeof toString;
+}
+declare const _toString: _.ToString;
+export = _toString;

--- a/types/lodash.toupper/index.d.ts
+++ b/types/lodash.toupper/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { toUpper } from "lodash";
-export = toUpper;
+declare namespace _ {
+  type ToUpper = typeof toUpper;
+}
+declare const _toUpper: _.ToUpper;
+export = _toUpper;

--- a/types/lodash.transform/index.d.ts
+++ b/types/lodash.transform/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { transform } from "lodash";
-export = transform;
+declare namespace _ {
+  type Transform = typeof transform;
+}
+declare const _transform: _.Transform;
+export = _transform;

--- a/types/lodash.trim/index.d.ts
+++ b/types/lodash.trim/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { trim } from "lodash";
-export = trim;
+declare namespace _ {
+  type Trim = typeof trim;
+}
+declare const _trim: _.Trim;
+export = _trim;

--- a/types/lodash.trimend/index.d.ts
+++ b/types/lodash.trimend/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { trimEnd } from "lodash";
-export = trimEnd;
+declare namespace _ {
+  type TrimEnd = typeof trimEnd;
+}
+declare const _trimEnd: _.TrimEnd;
+export = _trimEnd;

--- a/types/lodash.trimstart/index.d.ts
+++ b/types/lodash.trimstart/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { trimStart } from "lodash";
-export = trimStart;
+declare namespace _ {
+  type TrimStart = typeof trimStart;
+}
+declare const _trimStart: _.TrimStart;
+export = _trimStart;

--- a/types/lodash.truncate/index.d.ts
+++ b/types/lodash.truncate/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { truncate } from "lodash";
-export = truncate;
+declare namespace _ {
+  type Truncate = typeof truncate;
+}
+declare const _truncate: _.Truncate;
+export = _truncate;

--- a/types/lodash.unary/index.d.ts
+++ b/types/lodash.unary/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { unary } from "lodash";
-export = unary;
+declare namespace _ {
+  type Unary = typeof unary;
+}
+declare const _unary: _.Unary;
+export = _unary;

--- a/types/lodash.unescape/index.d.ts
+++ b/types/lodash.unescape/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { unescape } from "lodash";
-export = unescape;
+declare namespace _ {
+  type Unescape = typeof unescape;
+}
+declare const _unescape: _.Unescape;
+export = _unescape;

--- a/types/lodash.union/index.d.ts
+++ b/types/lodash.union/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { union } from "lodash";
-export = union;
+declare namespace _ {
+  type Union = typeof union;
+}
+declare const _union: _.Union;
+export = _union;

--- a/types/lodash.unionby/index.d.ts
+++ b/types/lodash.unionby/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { unionBy } from "lodash";
-export = unionBy;
+declare namespace _ {
+  type UnionBy = typeof unionBy;
+}
+declare const _unionBy: _.UnionBy;
+export = _unionBy;

--- a/types/lodash.unionwith/index.d.ts
+++ b/types/lodash.unionwith/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { unionWith } from "lodash";
-export = unionWith;
+declare namespace _ {
+  type UnionWith = typeof unionWith;
+}
+declare const _unionWith: _.UnionWith;
+export = _unionWith;

--- a/types/lodash.uniq/index.d.ts
+++ b/types/lodash.uniq/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { uniq } from "lodash";
-export = uniq;
+declare namespace _ {
+  type Uniq = typeof uniq;
+}
+declare const _uniq: _.Uniq;
+export = _uniq;

--- a/types/lodash.uniqby/index.d.ts
+++ b/types/lodash.uniqby/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { uniqBy } from "lodash";
-export = uniqBy;
+declare namespace _ {
+  type UniqBy = typeof uniqBy;
+}
+declare const _uniqBy: _.UniqBy;
+export = _uniqBy;

--- a/types/lodash.uniqueid/index.d.ts
+++ b/types/lodash.uniqueid/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { uniqueId } from "lodash";
-export = uniqueId;
+declare namespace _ {
+  type UniqueId = typeof uniqueId;
+}
+declare const _uniqueId: _.UniqueId;
+export = _uniqueId;

--- a/types/lodash.uniqwith/index.d.ts
+++ b/types/lodash.uniqwith/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { uniqWith } from "lodash";
-export = uniqWith;
+declare namespace _ {
+  type UniqWith = typeof uniqWith;
+}
+declare const _uniqWith: _.UniqWith;
+export = _uniqWith;

--- a/types/lodash.unset/index.d.ts
+++ b/types/lodash.unset/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { unset } from "lodash";
-export = unset;
+declare namespace _ {
+  type Unset = typeof unset;
+}
+declare const _unset: _.Unset;
+export = _unset;

--- a/types/lodash.unzip/index.d.ts
+++ b/types/lodash.unzip/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { unzip } from "lodash";
-export = unzip;
+declare namespace _ {
+  type Unzip = typeof unzip;
+}
+declare const _unzip: _.Unzip;
+export = _unzip;

--- a/types/lodash.unzipwith/index.d.ts
+++ b/types/lodash.unzipwith/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { unzipWith } from "lodash";
-export = unzipWith;
+declare namespace _ {
+  type UnzipWith = typeof unzipWith;
+}
+declare const _unzipWith: _.UnzipWith;
+export = _unzipWith;

--- a/types/lodash.update/index.d.ts
+++ b/types/lodash.update/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { update } from "lodash";
-export = update;
+declare namespace _ {
+  type Update = typeof update;
+}
+declare const _update: _.Update;
+export = _update;

--- a/types/lodash.updatewith/index.d.ts
+++ b/types/lodash.updatewith/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { updateWith } from "lodash";
-export = updateWith;
+declare namespace _ {
+  type UpdateWith = typeof updateWith;
+}
+declare const _updateWith: _.UpdateWith;
+export = _updateWith;

--- a/types/lodash.uppercase/index.d.ts
+++ b/types/lodash.uppercase/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { upperCase } from "lodash";
-export = upperCase;
+declare namespace _ {
+  type UpperCase = typeof upperCase;
+}
+declare const _upperCase: _.UpperCase;
+export = _upperCase;

--- a/types/lodash.upperfirst/index.d.ts
+++ b/types/lodash.upperfirst/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { upperFirst } from "lodash";
-export = upperFirst;
+declare namespace _ {
+  type UpperFirst = typeof upperFirst;
+}
+declare const _upperFirst: _.UpperFirst;
+export = _upperFirst;

--- a/types/lodash.values/index.d.ts
+++ b/types/lodash.values/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { values } from "lodash";
-export = values;
+declare namespace _ {
+  type Values = typeof values;
+}
+declare const _values: _.Values;
+export = _values;

--- a/types/lodash.valuesin/index.d.ts
+++ b/types/lodash.valuesin/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { valuesIn } from "lodash";
-export = valuesIn;
+declare namespace _ {
+  type ValuesIn = typeof valuesIn;
+}
+declare const _valuesIn: _.ValuesIn;
+export = _valuesIn;

--- a/types/lodash.without/index.d.ts
+++ b/types/lodash.without/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { without } from "lodash";
-export = without;
+declare namespace _ {
+  type Without = typeof without;
+}
+declare const _without: _.Without;
+export = _without;

--- a/types/lodash.words/index.d.ts
+++ b/types/lodash.words/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { words } from "lodash";
-export = words;
+declare namespace _ {
+  type Words = typeof words;
+}
+declare const _words: _.Words;
+export = _words;

--- a/types/lodash.wrap/index.d.ts
+++ b/types/lodash.wrap/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { wrap } from "lodash";
-export = wrap;
+declare namespace _ {
+  type Wrap = typeof wrap;
+}
+declare const _wrap: _.Wrap;
+export = _wrap;

--- a/types/lodash.xor/index.d.ts
+++ b/types/lodash.xor/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { xor } from "lodash";
-export = xor;
+declare namespace _ {
+  type Xor = typeof xor;
+}
+declare const _xor: _.Xor;
+export = _xor;

--- a/types/lodash.xorby/index.d.ts
+++ b/types/lodash.xorby/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { xorBy } from "lodash";
-export = xorBy;
+declare namespace _ {
+  type XorBy = typeof xorBy;
+}
+declare const _xorBy: _.XorBy;
+export = _xorBy;

--- a/types/lodash.xorwith/index.d.ts
+++ b/types/lodash.xorwith/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { xorWith } from "lodash";
-export = xorWith;
+declare namespace _ {
+  type XorWith = typeof xorWith;
+}
+declare const _xorWith: _.XorWith;
+export = _xorWith;

--- a/types/lodash.zip/index.d.ts
+++ b/types/lodash.zip/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { zip } from "lodash";
-export = zip;
+declare namespace _ {
+  type Zip = typeof zip;
+}
+declare const _zip: _.Zip;
+export = _zip;

--- a/types/lodash.zipobject/index.d.ts
+++ b/types/lodash.zipobject/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { zipObject } from "lodash";
-export = zipObject;
+declare namespace _ {
+  type ZipObject = typeof zipObject;
+}
+declare const _zipObject: _.ZipObject;
+export = _zipObject;

--- a/types/lodash.zipobjectdeep/index.d.ts
+++ b/types/lodash.zipobjectdeep/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { zipObjectDeep } from "lodash";
-export = zipObjectDeep;
+declare namespace _ {
+  type ZipObjectDeep = typeof zipObjectDeep;
+}
+declare const _zipObjectDeep: _.ZipObjectDeep;
+export = _zipObjectDeep;

--- a/types/lodash.zipwith/index.d.ts
+++ b/types/lodash.zipwith/index.d.ts
@@ -7,4 +7,8 @@
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { zipWith } from "lodash";
-export = zipWith;
+declare namespace _ {
+  type ZipWith = typeof zipWith;
+}
+declare const _zipWith: _.ZipWith;
+export = _zipWith;

--- a/types/lodash/scripts/generate-modules.ts
+++ b/types/lodash/scripts/generate-modules.ts
@@ -50,6 +50,11 @@ async function globalDefinitionText(moduleName: string): Promise<string> {
     const npmInfo = JSON.parse(await loadString(url));
     const fullVersion = npmInfo["dist-tags"].latest;
     const majorMinor = fullVersion.split(".").slice(0, 2).join(".");
+    const pascalCaseModuleName = moduleName.substr(0, 1).toUpperCase() + moduleName.substr(1);
+
+    if (pascalCaseModuleName == moduleName) {
+        throw new Error(`Can not pascal case module name. Is moduleName "${moduleName}" valid?`)
+    }
 
     return `
 // Type definitions for ${fullName} ${majorMinor}
@@ -61,7 +66,11 @@ async function globalDefinitionText(moduleName: string): Promise<string> {
 // Generated from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/scripts/generate-modules.ts
 
 import { ${moduleName} } from "lodash";
-export = ${moduleName};
+declare namespace _ {
+  type ${pascalCaseModuleName} = typeof ${moduleName};
+}
+declare const _${moduleName}: _.${pascalCaseModuleName};
+export = _${moduleName};
 `.trim() + "\n";
 }
 


### PR DESCRIPTION
The proposed changes would allow for importing modularized lodash functions like this:

    import * as flowRight from 'lodash.flowright';

_This approach is currently documented in the [README](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/readme.md#different-ways-people-might-use-lodash) yet does not work_

currently only the following syntax is supported (which after the change will still work)

    import flowRight = require('lodash.flowright');


Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/21085#issuecomment-362910453
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.