### PR TITLE
[p-cancelable] Make types compatible with 0.5

### DIFF
--- a/types/p-cancelable/index.d.ts
+++ b/types/p-cancelable/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for p-cancelable 0.3
+// Type definitions for p-cancelable 0.5
 // Project: https://github.com/sindresorhus/p-cancelable#readme
 // Definitions by: BendingBender <https://github.com/BendingBender>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -11,20 +11,22 @@ interface PCancelableConstructor extends PromiseConstructor {
     readonly prototype: PCancelable.PCancelable<any>;
     readonly CancelError: PCancelable.CancelErrorConstructor;
     fn<T, R>(wrapper: (onCancel: (fn?: () => void) => void, input: T) => PromiseLike<R>): (input: T) => PCancelable.PCancelable<R>;
-    new<T>(executor: (onCancel: (fn?: () => void) => void, resolve: (value?: T | PromiseLike<T>) => void, reject: (reason?: any) => void) => void): PCancelable.PCancelable<T>;
+    new<T>(executor: (resolve: (value?: T | PromiseLike<T>) => void, reject: (reason?: any) => void, onCancel: (fn?: () => void) => void) => void): PCancelable.PCancelable<T>;
 }
 
 declare namespace PCancelable {
     interface PCancelable<T> extends Promise<T> {
-        readonly canceled: boolean;
-        cancel(): void;
+        readonly isCanceled: boolean;
+        cancel(reason?: string): void;
+
     }
 
     interface CancelErrorConstructor extends ErrorConstructor {
-        new (): CancelError;
+        new (reason?: string): CancelError;
     }
 
     interface CancelError extends Error {
         readonly name: 'CancelError';
+        readonly isCanceled: boolean;
     }
 }

--- a/types/p-cancelable/index.d.ts
+++ b/types/p-cancelable/index.d.ts
@@ -18,7 +18,6 @@ declare namespace PCancelable {
     interface PCancelable<T> extends Promise<T> {
         readonly isCanceled: boolean;
         cancel(reason?: string): void;
-
     }
 
     interface CancelErrorConstructor extends ErrorConstructor {

--- a/types/p-cancelable/p-cancelable-tests.ts
+++ b/types/p-cancelable/p-cancelable-tests.ts
@@ -3,7 +3,7 @@
 import PCancelableCtor = require('p-cancelable');
 import { EventEmitter } from "events";
 
-const cancelablePromise: PCancelableCtor.PCancelable<{}> = new PCancelableCtor((onCancel, resolve, reject) => {
+const cancelablePromise: PCancelableCtor.PCancelable<{}> = new PCancelableCtor((resolve, reject, onCancel) => {
     class Worker extends EventEmitter {
         close() {
         }
@@ -24,7 +24,7 @@ cancelablePromise
         console.log('Operation finished successfully:', value);
     })
     .catch(reason => {
-        if (cancelablePromise.canceled) {
+        if (cancelablePromise.isCanceled) {
             // Handle the cancelation here
             console.log('Operation was canceled');
             return;
@@ -56,7 +56,7 @@ const fn = PCancelableCtor.fn((onCancel: (fn?: () => void) => void, input: strin
 const promise = fn('input');
 let num: number;
 promise.then(innum => num = innum);
-if (!promise.canceled) {
+if (!promise.isCanceled) {
     promise.cancel();
 }
 


### PR DESCRIPTION
- Append `onCancel` instead of prepending (https://github.com/sindresorhus/p-cancelable/commit/8e3aaec245492f3a38b5d4f74e9861cf3f334616)
- Rename `PCancelable.canceled` to `PCancelable.isCanceled` (https://github.com/sindresorhus/p-cancelable/commit/433d25c8fcf08acd127f0249bc8377379c98363c)
- Add `CancelError.isCanceled` (https://github.com/sindresorhus/p-cancelable/commit/ad14c228a9c53f939ed6de068cfe83b5fa27fe1c)
- Add ability to provide cancel reason (https://github.com/sindresorhus/p-cancelable/commit/a97b12b309f7ab60f8bfa22883b052c17b32a04e)