### PR TITLE
[http-proxy-middleware] Move winston to devDependencies

### DIFF
--- a/types/http-proxy-middleware/package.json
+++ b/types/http-proxy-middleware/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
-    "dependencies": {
+    "devDependencies": {
         "winston": "^3.0.0"
     }
 }


### PR DESCRIPTION
`winston` is used in [`http-proxy-middleware-tests.ts`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/http-proxy-middleware/http-proxy-middleware-tests.ts) but isn't referenced in [`index.d.ts`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/http-proxy-middleware/index.d.ts), so it should be a dev dependency.

This will avoid `winston` (and its dependencies) being brought in when installing `@types/http-proxy-middleware` or another type that has it as a dependency (such as `@types/webpack-dev-server`).