### PR TITLE
fix(stripe): customer.default_source can be null

### DIFF
--- a/types/stripe/index.d.ts
+++ b/types/stripe/index.d.ts
@@ -1322,7 +1322,7 @@ declare namespace Stripe {
             /**
              * ID of the default source attached to this customer. [Expandable]
              */
-            default_source: string | cards.ICard | bitcoinReceivers.IBitcoinReceiver;
+            default_source: string | cards.ICard | bitcoinReceivers.IBitcoinReceiver | null;
 
             /**
              * Whether or not the latest charge for the customer's latest invoice has failed


### PR DESCRIPTION
See https://github.com/DefinitelyTyped/DefinitelyTyped/blob/374598de675780b1312912d43dff88f9fbfcf0d8/types/stripe/index.d.ts#L5973-L5974 where it's even documented in the types that `default_source` can be null.