### PR TITLE
Add onlyExpandSearchedNodes property

### DIFF
--- a/types/react-sortable-tree/index.d.ts
+++ b/types/react-sortable-tree/index.d.ts
@@ -194,6 +194,7 @@ export interface ReactSortableTreeProps {
     placeholderRenderer?: PlaceholderRenderer;
     theme?: ThemeProps;
     shouldCopyOnOutsideDrop?: boolean | ((data: ShouldCopyData) => boolean);
+    onlyExpandSearchedNodes?: boolean;
 }
 
 declare const SortableTree: React.ComponentClass<ReactSortableTreeProps>;


### PR DESCRIPTION
Add onlyExpandSearchedNodes property to ReactSortableTreeProps

Property can be found here in the [README](https://github.com/frontend-collective/react-sortable-tree#props) aswell as in the [code](https://github.com/frontend-collective/react-sortable-tree/blob/master/src/react-sortable-tree.js#L878)
