### PR TITLE
Fix typo in Dialogflow QueryResult

### DIFF
--- a/types/dialogflow/index.d.ts
+++ b/types/dialogflow/index.d.ts
@@ -550,7 +550,7 @@ export interface DetectIntentResponse {
 
 export interface QueryResult {
     queryText: string;
-    laugnageCode: string;
+    languageCode: string;
     speechRecognitionConfidence: number;
     action: string;
     parameters: any;


### PR DESCRIPTION
In dialogflow's interface 'QueryResult' languageCode was misspelled incorrectly as "laugnageCode".

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://dialogflow.com/docs/reference/api-v2/rest/Shared.Types/QueryResult

As per [documentation](https://dialogflow.com/docs/reference/api-v2/rest/Shared.Types/QueryResult) the correct key is "languageCode".