### PR TITLE
[webpack-dev-server] Updated stats interface to match webpack interface

### DIFF
--- a/types/webpack-dev-server/index.d.ts
+++ b/types/webpack-dev-server/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for webpack-dev-server 3.1.5
+// Type definitions for webpack-dev-server 3.1
 // Project: https://github.com/webpack/webpack-dev-server
 // Definitions by: maestroh <https://github.com/maestroh>
 //                 Dave Parslow <https://github.com/daveparslow>

--- a/types/webpack-dev-server/index.d.ts
+++ b/types/webpack-dev-server/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for webpack-dev-server 2.9
+// Type definitions for webpack-dev-server 3.1.5
 // Project: https://github.com/webpack/webpack-dev-server
 // Definitions by: maestroh <https://github.com/maestroh>
 //                 Dave Parslow <https://github.com/daveparslow>
@@ -158,7 +158,7 @@ declare namespace WebpackDevServer {
          * This option lets you precisely control what bundle information gets displayed.
          * This can be a nice middle ground if you want some bundle information, but not all of it.
          */
-        stats?: string | webpack.Stats;
+        stats?: string | webpack.Options.Stats;
         /** This option lets the browser open with your local IP. */
         useLocalIp?: boolean;
         /** Tell the server to watch the files served by the devServer.contentBase option. File changes will trigger a full page reload. */


### PR DESCRIPTION
Stumbled upon this while trying to modify some stats output on dev-server. Typescript started to complain about type mismatch.
I would also think about removing `string` from this definition cause of this:
https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/webpack/index.d.ts#L1228
https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/webpack/index.d.ts#L1138

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/webpack/index.d.ts#L106
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.