### PR TITLE
[CodeMirror] Add some missing definitions

### DIFF
--- a/types/codemirror/index.d.ts
+++ b/types/codemirror/index.d.ts
@@ -17,8 +17,16 @@ declare namespace CodeMirror {
     export var Pos: CodeMirror.PositionConstructor;
     export var Pass: {toString(): "CodeMirror.PASS"};
 
+    /** Find the column position at a given string index using a given tabsize. */
     function countColumn(line: string, index: number | null, tabSize: number): number;
     function fromTextArea(host: HTMLTextAreaElement, options?: EditorConfiguration): CodeMirror.EditorFromTextArea;
+
+    /** Compare two positions, return 0 if they are the same, a negative number when a is less, and a positive number otherwise. */
+    function cmpPos(a: Position, b: Position): number;
+
+    /** Utility function that computes an end position from a change (an object with from, to, and text properties, as passed to various event handlers).
+    The returned position will be the end of the changed range, after the change is applied. */
+    function changeEnd(change: EditorChange): Position;
 
     /** It contains a string that indicates the version of the library. This is a triple of integers "major.minor.patch", 
     where patch is zero for releases, and something else (usually one) for dev snapshots. */
@@ -51,6 +59,14 @@ declare namespace CodeMirror {
     CodeMirror.registerHelper("hint", "foo", myFoo), the value CodeMirror.hint.foo will point to myFoo. */
     function registerHelper(namespace: string, name: string, helper: any): void;
 
+    /** Given a state object, returns a {state, mode} object with the inner mode and its state for the current position. */
+    function innerMode(mode: Mode<any>, state: any): { state: any, mode: Mode<any> };
+
+    /** Sometimes, it is useful to add or override mode object properties from external code.
+    The CodeMirror.extendMode function can be used to add properties to mode objects produced for a specific mode.
+    Its first argument is the name of the mode, its second an object that specifies the properties that should be added.
+    This is mostly useful to add utilities that can later be looked up through getMode. */
+    function extendMode(name: string, properties: Mode<any>): void;
 
     function on(element: any, eventName: string, handler: Function): void;
     function off(element: any, eventName: string, handler: Function): void;
@@ -324,6 +340,9 @@ declare namespace CodeMirror {
         you should probably follow up by calling this method to ensure CodeMirror is still looking as intended. */
         refresh(): void;
 
+        /** Gets the inner mode at a given position. This will return the same as getMode for simple modes, but will return an inner mode for nesting modes (such as htmlmixed). */
+        getModeAt(pos: Position): any;
+
         /** Retrieves information about the token the current mode found before the given position (a {line, ch} object). */
         getTokenAt(pos: CodeMirror.Position, precise?: boolean): Token;
 
@@ -555,8 +574,10 @@ declare namespace CodeMirror {
         /** Return true if any text is selected. */
         somethingSelected(): boolean;
 
-        /** Set the cursor position.You can either pass a single { line , ch } object , or the line and the character as two separate parameters. */
-        setCursor(pos: CodeMirror.Position): void;
+        /** Set the cursor position. You can either pass a single {line, ch} object, or the line and the character as two separate parameters.
+        Will replace all selections with a single, empty selection at the given position.
+        The supported options are the same as for setSelection */
+        setCursor(pos: CodeMirror.Position | number, ch?: number, options?: { bias?: number, origin?: string, scroll?: boolean }): void;
 
         /** Set a single selection range. anchor and head should be {line, ch} objects. head defaults to anchor when not given. */
         setSelection(anchor: CodeMirror.Position, head: CodeMirror.Position, options?: { bias?: number, origin?: string, scroll?: boolean }): void;
@@ -709,9 +730,9 @@ declare namespace CodeMirror {
         /** Array of strings representing the text that replaced the changed range (split by line). */
         text: string[];
         /**  Text that used to be between from and to, which is overwritten by this change. */
-        removed: string[];
+        removed?: string[];
         /**  String representing the origin of the change event and wether it can be merged with history */
-        origin: string;
+        origin?: string;
     }
 
     interface EditorChangeLinkedList extends CodeMirror.EditorChange {
@@ -1083,7 +1104,7 @@ declare namespace CodeMirror {
          * This function should read one token from the stream it is given as an argument, optionally update its state,
          * and return a style string, or null for tokens that do not have to be styled. Multiple styles can be returned, separated by spaces.
          */
-        token(stream: StringStream, state: T): string | null;
+        token?: (stream: StringStream, state: T) => string | null;
 
         /**
          * A function that produces a state object to be used at the start of a document.


### PR DESCRIPTION
- CodeMirror.changeEnd
- CodeMirror.cmpPos
- CodeMirror.extendMode
- CodeMirror.innerMode
- cm.getModeAt
- doc.setCursor(line, ch)

Fixes https://github.com/DefinitelyTyped/DefinitelyTyped/issues/28324

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://codemirror.net/doc/manual.html
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

