### PR TITLE
[React] add experimental attribute allow for iframes

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -1441,6 +1441,7 @@ declare namespace React {
     }
 
     interface IframeHTMLAttributes<T> extends HTMLAttributes<T> {
+        allow?: string;
         allowFullScreen?: boolean;
         allowTransparency?: boolean;
         frameBorder?: number | string;


### PR DESCRIPTION
This is a very simple change to add the allow prop to iframes. an example of a use case for this would be to have an iframe that has allow="camera".

If changing an existing definition:
- [ x ] Provide a URL to documentation or source code which provides context for the suggested changes: <https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#Browser_compatibility>
- [ - ] Increase the version number in the header if appropriate.
- [ - ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
