### PR TITLE
Use StyleProp for style properties

### DIFF
--- a/types/react-native-sortable-list/index.d.ts
+++ b/types/react-native-sortable-list/index.d.ts
@@ -5,7 +5,7 @@
 // TypeScript Version: 2.8
 
 import * as React from 'react';
-import { ViewStyle } from 'react-native';
+import { StyleProp, ViewStyle } from 'react-native';
 
 type DataKey = string | number;
 
@@ -44,17 +44,17 @@ interface SortableListProps {
     /**
      * style of HOC
      */
-    style?: ViewStyle
+    style?: StyleProp<ViewStyle>
 
     /**
      * these styles will be applied to the inner scroll view content container
      */
-    contentContainerStyle?: ViewStyle
+    contentContainerStyle?: StyleProp<ViewStyle>
 
     /**
      * these styles will be applied to the inner scroll view content container, excluding the header and footer
      */
-    innerContainerStyle?: ViewStyle
+    innerContainerStyle?: StyleProp<ViewStyle>
 
     /**
      * when true, the SortableList's children are arranged horizontally in a row instead of vertically in a column.

--- a/types/react-native-swiper/index.d.ts
+++ b/types/react-native-swiper/index.d.ts
@@ -9,6 +9,7 @@
 import * as React from 'react';
 import {
   ViewStyle,
+  StyleProp,
   NativeSyntheticEvent,
   NativeScrollEvent,
 } from 'react-native';
@@ -31,7 +32,7 @@ export interface SwiperState {
 export interface SwiperProperties extends React.Props<Swiper> {
   horizontal?: boolean;
 
-  style?: ViewStyle;
+  style?: StyleProp<ViewStyle>;
 
   pagingEnabled?: boolean;
 
@@ -71,9 +72,9 @@ export interface SwiperProperties extends React.Props<Swiper> {
 
   renderPagination?(index: number, total: number, thisObject: Swiper): JSX.Element;
 
-  dotStyle?: ViewStyle;
+  dotStyle?: StyleProp<ViewStyle>;
 
-  activeDotStyle?: ViewStyle;
+  activeDotStyle?: StyleProp<ViewStyle>;
 
   activeDot?: JSX.Element;
 
@@ -87,9 +88,9 @@ export interface SwiperProperties extends React.Props<Swiper> {
 
   width?: number;
 
-  paginationStyle?: ViewStyle;
+  paginationStyle?: StyleProp<ViewStyle>;
 
-  buttonWrapperStyle?: ViewStyle;
+  buttonWrapperStyle?: StyleProp<ViewStyle>;
 
   nextButton?: JSX.Element;
 


### PR DESCRIPTION
Use StyleProp for style properties in react-native-swiper and react-native-sortable-list. This correctly handles properties created by `StyleSheet.create`.