### PR TITLE
[Plotly.js] - added typings for histogram plot, and D3 transforms

### DIFF
--- a/types/plotly.js/index.d.ts
+++ b/types/plotly.js/index.d.ts
@@ -602,6 +602,8 @@ export interface PlotMarker {
 	};
 }
 
+export type ScatterMarker = PlotMarker;
+
 export interface ScatterMarkerLine {
 	width: number | number[];
 	color: Color;

--- a/types/plotly.js/index.d.ts
+++ b/types/plotly.js/index.d.ts
@@ -49,9 +49,19 @@ export interface PlotCoordinate {
 	pointNumber: number;
 }
 
-export interface PlotSelectionEvent {
-	points: PlotCoordinate[];
+export interface SelectionDescription {
+	x: number[],
+	y: number[],
 }
+
+export type PlotSelectedData = Partial<PlotScatterDataPoint>;
+
+export interface PlotSelectionEvent {
+	points: PlotSelectedData[];
+	range?: SelectionDescription;
+	lassoPoints?: SelectionDescription;
+}
+
 
 export type PlotRestyleEvent = [
 	any,		// update object -- attribute updated: new value

--- a/types/plotly.js/index.d.ts
+++ b/types/plotly.js/index.d.ts
@@ -423,7 +423,7 @@ export type Color = string | Array<string | undefined | null> | Array<Array<stri
 
 // Bar Scatter
 export interface ScatterData {
-	type: 'bar' | 'pointcloud' | 'scatter' | 'scattergl' | 'scatter3d' |'surface';
+	type: 'bar' | 'histogram' | 'pointcloud' | 'scatter' | 'scattergl' | 'scatter3d' |'surface';
 	x: Datum[] | Datum[][] | TypedArray;
 	y: Datum[] | Datum[][] | TypedArray;
 	z: Datum[] | Datum[][] | Datum[][][] | TypedArray;

--- a/types/plotly.js/index.d.ts
+++ b/types/plotly.js/index.d.ts
@@ -9,6 +9,7 @@
 //                 Drew Diamantoukos <https://github.com/MercifulCode>
 //                 Sooraj Pudiyadath <https://github.com/soorajpudiyadath>
 //                 Jon Freedman <https://github.com/jonfreedman>
+//                 Megan Riel-Mehan <https://github.com/meganrm>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 

--- a/types/plotly.js/index.d.ts
+++ b/types/plotly.js/index.d.ts
@@ -29,7 +29,7 @@ export interface Point {
 
 export interface PlotScatterDataPoint {
 	curveNumber: number;
-	data: ScatterData;
+	data: PlotData;
 	pointIndex: number;
 	pointNumber: number;
 	x: number;
@@ -57,11 +57,10 @@ export interface SelectionDescription {
 export type PlotSelectedData = Partial<PlotScatterDataPoint>;
 
 export interface PlotSelectionEvent {
-	points: PlotSelectedData[];
+	points: PlotScatterDataPoint[];
 	range?: SelectionDescription;
 	lassoPoints?: SelectionDescription;
 }
-
 
 export type PlotRestyleEvent = [
 	any,		// update object -- attribute updated: new value
@@ -151,10 +150,10 @@ export interface PlotlyHTMLElement extends HTMLElement {
 	on(event: 'plotly_sliderend', callback: (event: SliderEndEvent) => void): void;
 	on(event: 'plotly_sliderstart', callback: (event: SliderStartEvent) => void): void;
 	on(event: 'plotly_event', callback: (data: any) => void): void;
-	on(event: 'plotly_beforeplot' , callback: (event: BeforePlotEvent) => boolean): void;
+	on(event: 'plotly_beforeplot', callback: (event: BeforePlotEvent) => boolean): void;
 	on(event: 'plotly_afterexport' | 'plotly_afterplot' | 'plotly_animated' | 'plotly_animationinterrupted' | 'plotly_autosize' |
 		'plotly_beforeexport' | 'plotly_deselect' | 'plotly_doubleclick' | 'plotly_framework' | 'plotly_redraw' |
-		'plotly_transitioning' | 'plotly_transitioninterrupted' , callback: () => void): void;
+		'plotly_transitioning' | 'plotly_transitioninterrupted', callback: () => void): void;
 }
 
 export interface ToImgopts {
@@ -394,32 +393,32 @@ export interface ModeBarButton {
 	/** name / id of the buttons (for tracking) */
 	name: string;
 
-	/**
-	 * text that appears while hovering over the button,
-	 * enter null, false or '' for no hover text
-	 */
+    /**
+     * text that appears while hovering over the button,
+     * enter null, false or '' for no hover text
+     */
 	title: string;
 
-	/**
-	 * svg icon object associated with the button
-	 * can be linked to Plotly.Icons to use the default plotly icons
-	 */
+    /**
+     * svg icon object associated with the button
+     * can be linked to Plotly.Icons to use the default plotly icons
+     */
 	icon: string | Icon;
 
 	/** icon positioning */
 	gravity?: string;
 
-	/**
-	 * click handler associated with the button, a function of
-	 * 'gd' (the main graph object) and
-	 * 'ev' (the event object)
-	 */
+    /**
+     * click handler associated with the button, a function of
+     * 'gd' (the main graph object) and
+     * 'ev' (the event object)
+     */
 	click: ButtonClickEvent;
 
-	/**
-	 * attribute associated with button,
-	 * use this with 'val' to keep track of the state
-	 */
+    /**
+     * attribute associated with button,
+     * use this with 'val' to keep track of the state
+     */
 	attr?: string;
 
 	/** initial 'attr' value, can be a function of gd */
@@ -436,12 +435,13 @@ export type TypedArray = Int8Array | Uint8Array | Int16Array | Uint16Array | Int
 
 export type Dash = 'solid' | 'dot' | 'dash' | 'longdash' | 'dashdot' | 'longdashdot';
 
-export type Data = Partial<ScatterData>;
+export type Data = Partial<PlotData>;
 export type Color = string | Array<string | undefined | null> | Array<Array<string | undefined | null>>;
-
+export type DataTransForm = Partial<Transform>;
+export type ScatterData = PlotData;
 // Bar Scatter
-export interface ScatterData {
-	type: 'bar' | 'histogram' | 'pointcloud' | 'scatter' | 'scattergl' | 'scatter3d' |'surface';
+export interface PlotData {
+	type: 'bar' | 'histogram' | 'pointcloud' | 'scatter' | 'scattergl' | 'scatter3d' | 'surface';
 	x: Datum[] | Datum[][] | TypedArray;
 	y: Datum[] | Datum[][] | TypedArray;
 	z: Datum[] | Datum[][] | Datum[][][] | TypedArray;
@@ -456,7 +456,7 @@ export interface ScatterData {
 	'line.shape': 'linear' | 'spline' | 'hv' | 'vh' | 'hvh' | 'vhv';
 	'line.smoothing': number;
 	'line.simplify': boolean;
-	marker: Partial<ScatterMarker>;
+	marker: Partial<PlotMarker>;
 	'marker.symbol': string | string[]; // Drawing.symbolList
 	'marker.color': Color;
 	'marker.opacity': number | number[];
@@ -472,15 +472,15 @@ export interface ScatterData {
 	mode: 'lines' | 'markers' | 'text' | 'lines+markers' | 'text+markers' | 'text+lines' | 'text+lines+markers' | 'none';
 	hoveron: 'points' | 'fills';
 	hoverinfo: 'all' | 'name' | 'none' | 'skip' | 'text' |
-			'x' | 'x+text' | 'x+name' |
-			'x+y' | 'x+y+text' | 'x+y+name' |
-			'x+y+z' | 'x+y+z+text' | 'x+y+z+name' |
-			'y+x' | 'y+x+text' | 'y+x+name' |
-			'y+z' | 'y+z+text' | 'y+z+name' |
-			'y+x+z' | 'y+x+z+text' | 'y+x+z+name' |
-			'z+x' | 'z+x+text' | 'z+x+name' |
-			'z+y+x' | 'z+y+x+text' | 'z+y+x+name' |
-			'z+x+y' | 'z+x+y+text' | 'z+x+y+name';
+	'x' | 'x+text' | 'x+name' |
+	'x+y' | 'x+y+text' | 'x+y+name' |
+	'x+y+z' | 'x+y+z+text' | 'x+y+z+name' |
+	'y+x' | 'y+x+text' | 'y+x+name' |
+	'y+z' | 'y+z+text' | 'y+z+name' |
+	'y+x+z' | 'y+x+z+text' | 'y+x+z+name' |
+	'z+x' | 'z+x+text' | 'z+x+name' |
+	'z+y+x' | 'z+y+x+text' | 'z+y+x+name' |
+	'z+x+y' | 'z+x+y+text' | 'z+x+y+name';
 	hoverlabel: Partial<Label>;
 	fill: 'none' | 'tozeroy' | 'tozerox' | 'tonexty' | 'tonextx' | 'toself' | 'tonext';
 	fillcolor: string;
@@ -488,7 +488,8 @@ export interface ScatterData {
 	name: string;
 	connectgaps: boolean;
 	visible: boolean | 'legendonly';
-	transforms: Transform[];
+	transforms: DataTransForm[];
+	orientation: 'v' | 'h';
 }
 
 /**
@@ -497,38 +498,38 @@ export interface ScatterData {
  */
 
 export interface TransformStyle {
-    target: number | string | number[] | string[];
-    value: Partial<ScatterData>;
+	target: number | string | number[] | string[];
+	value: Partial<PlotData>;
 }
 
 export interface TransformAggregation {
-    target: string;
-    func?: 'count' | 'sum' | 'avg' | 'median' | 'mode' | 'rms' | 'stddev' | 'min' | 'max' | 'first' | 'last';
+	target: string;
+	func?: 'count' | 'sum' | 'avg' | 'median' | 'mode' | 'rms' | 'stddev' | 'min' | 'max' | 'first' | 'last';
 	funcmode?: 'sample' | 'population';
 	enabled?: boolean;
 }
 
 export interface Transform {
 	type: 'aggregate' | 'filter' | 'groupby' | 'sort';
-	enabled?: boolean;
-	target?: number | string | number[] | string[];
-	operation?: string;
-	aggregations?: TransformAggregation[];
-	preservegaps?: boolean;
-	groups?: string | number[] | string[];
+	enabled: boolean;
+	target: number | string | number[] | string[];
+	operation: string;
+	aggregations: TransformAggregation[];
+	preservegaps: boolean;
+	groups: string | number[] | string[];
 	nameformat: string;
-	styles?: TransformStyle[];
-	value?: any;
-	order?: 'ascending' | 'descending';
+	styles: TransformStyle[];
+	value: any;
+	order: 'ascending' | 'descending';
 }
 /**
  * Any combination of "x", "y", "z", "text", "name" joined with a "+" OR "all" or "none" or "skip".
  * examples: "x", "y", "x+y", "x+y+z", "all"
  * default: "all"
  */
-export interface ScatterMarker {
+export interface PlotMarker {
 	symbol: string | string[]; // Drawing.symbolList
-	color: Color | number[];
+	color: Color | Color[];
 	colorscale: string | string[] | Array<Array<(string | number)>>;
 	cauto: boolean;
 	cmax: number;
@@ -544,6 +545,7 @@ export interface ScatterMarker {
 	sizemode: 'diameter' | 'area';
 	showscale: boolean;
 	line: Partial<ScatterMarkerLine>;
+	width: number;
 	colorbar: {
 		thicknessmode: 'fraction' | 'pixels',
 		thickness: number,
@@ -620,17 +622,17 @@ export interface ScatterLine {
 }
 
 export interface Font {
-	/**
-	 * HTML font family - the typeface that will be applied by the web browser.
-	 * The web browser will only be able to apply a font if it is available on the system
-	 * which it operates. Provide multiple font families, separated by commas, to indicate
-	 * the preference in which to apply fonts if they aren't available on the system.
-	 * The plotly service (at https://plot.ly or on-premise) generates images on a server,
-	 * where only a select number of fonts are installed and supported.
-	 * These include *Arial*, *Balto*, *Courier New*, *Droid Sans*, *Droid Serif*,
-	 * *Droid Sans Mono*, *Gravitas One*, *Old Standard TT*, *Open Sans*, *Overpass*,
-	 * *PT Sans Narrow*, *Raleway*, *Times New Roman*.
-	 */
+    /**
+     * HTML font family - the typeface that will be applied by the web browser.
+     * The web browser will only be able to apply a font if it is available on the system
+     * which it operates. Provide multiple font families, separated by commas, to indicate
+     * the preference in which to apply fonts if they aren't available on the system.
+     * The plotly service (at https://plot.ly or on-premise) generates images on a server,
+     * where only a select number of fonts are installed and supported.
+     * These include *Arial*, *Balto*, *Courier New*, *Droid Sans*, *Droid Serif*,
+     * *Droid Sans Mono*, *Gravitas One*, *Old Standard TT*, *Open Sans*, *Overpass*,
+     * *PT Sans Narrow*, *Raleway*, *Times New Roman*.
+     */
 	family: string;
 	size: number;
 	color: Color;
@@ -705,12 +707,12 @@ export interface Config {
 	/** add mode bar button using config objects (see ./components/modebar/buttons.js for list of arguments) */
 	modeBarButtonsToAdd: ModeBarDefaultButtons[] | ModeBarButton[];
 
-	/**
-	 * fully custom mode bar buttons as nested array, where the outer
-	 * arrays represents button groups, and the inner arrays have
-	 * buttons config objects or names of default buttons
-	 * (see ./components/modebar/buttons.js for more info)
-	 */
+    /**
+     * fully custom mode bar buttons as nested array, where the outer
+     * arrays represents button groups, and the inner arrays have
+     * buttons config objects or names of default buttons
+     * (see ./components/modebar/buttons.js for more info)
+     */
 	modeBarButtons: ModeBarDefaultButtons[][] | ModeBarButton[][] | false;
 
 	/** add the plotly logo on the end of the mode bar */
@@ -719,26 +721,26 @@ export interface Config {
 	/** increase the pixel ratio for Gl plot images */
 	plotGlPixelRatio: number;
 
-	/**
-	 * function to add the background color to a different container
-	 * or 'opaque' to ensure there's white behind it
-	 */
+    /**
+     * function to add the background color to a different container
+     * or 'opaque' to ensure there's white behind it
+     */
 	setBackground: string | 'opaque' | 'transparent';
 
 	/** URL to topojson files used in geo charts */
 	topojsonURL: string;
 
-	/**
-	 * Mapbox access token (required to plot mapbox trace types)
-	 * If using an Mapbox Atlas server, set this option to '',
-	 * so that plotly.js won't attempt to authenticate to the public Mapbox server.
-	 */
+    /**
+     * Mapbox access token (required to plot mapbox trace types)
+     * If using an Mapbox Atlas server, set this option to '',
+     * so that plotly.js won't attempt to authenticate to the public Mapbox server.
+     */
 	mapboxAccessToken: string;
 
-	/**
-	 * Turn all console logging on or off (errors will be thrown)
-	 * This should ONLY be set via Plotly.setPlotConfig
-	 */
+    /**
+     * Turn all console logging on or off (errors will be thrown)
+     * This should ONLY be set via Plotly.setPlotConfig
+     */
 	logging: boolean | 0 | 1 | 2;
 
 	/** Set global transform to be applied to all traces with no specification needed */
@@ -793,46 +795,46 @@ export interface Annotations extends Label {
 	/** Determines whether or not this annotation is visible. */
 	visible: boolean;
 
-	/**
-	 * Sets the text associated with this annotation.
-	 * Plotly uses a subset of HTML tags to do things like
-	 * newline (<br>), bold (<b></b>), italics (<i></i>),
-	 * hyperlinks (<a href='...'></a>). Tags <em>, <sup>, <sub>
-	 * <span> are also supported.
-	 */
+    /**
+     * Sets the text associated with this annotation.
+     * Plotly uses a subset of HTML tags to do things like
+     * newline (<br>), bold (<b></b>), italics (<i></i>),
+     * hyperlinks (<a href='...'></a>). Tags <em>, <sup>, <sub>
+     * <span> are also supported.
+     */
 	text: string;
 
 	/** Sets the angle at which the `text` is drawn with respect to the horizontal. */
 	textangle: string;
 
-	/**
-	 * Sets an explicit width for the text box. null (default) lets the
-	 * text set the box width. Wider text will be clipped.
-	 * There is no automatic wrapping; use <br> to start a new line.
-	 */
+    /**
+     * Sets an explicit width for the text box. null (default) lets the
+     * text set the box width. Wider text will be clipped.
+     * There is no automatic wrapping; use <br> to start a new line.
+     */
 	width: number;
 
-	/**
-	 * Sets an explicit height for the text box. null (default) lets the
-	 * text set the box height. Taller text will be clipped.
-	 */
+    /**
+     * Sets an explicit height for the text box. null (default) lets the
+     * text set the box height. Taller text will be clipped.
+     */
 	height: number;
 
 	/** Sets the opacity of the annotation (text + arrow). */
 	opacity: number;
 
-	/**
-	 * Sets the horizontal alignment of the `text` within the box.
-	 * Has an effect only if `text` spans more two or more lines
-	 * (i.e. `text` contains one or more <br> HTML tags) or if an
-	 * explicit width is set to override the text width.
-	 */
+    /**
+     * Sets the horizontal alignment of the `text` within the box.
+     * Has an effect only if `text` spans more two or more lines
+     * (i.e. `text` contains one or more <br> HTML tags) or if an
+     * explicit width is set to override the text width.
+     */
 	align: 'left' | 'center' | 'right';
 
-	/**
-	 * Sets the vertical alignment of the `text` within the box.
-	 * Has an effect only if an explicit height is set to override the text height.
-	 */
+    /**
+     * Sets the vertical alignment of the `text` within the box.
+     * Has an effect only if an explicit height is set to override the text height.
+     */
 	valign: 'top' | 'middle' | 'bottom';
 
 	/** Sets the padding (in px) between the `text` and the enclosing border. */
@@ -841,11 +843,11 @@ export interface Annotations extends Label {
 	/** Sets the width (in px) of the border enclosing the annotation `text`. */
 	borderwidth: number;
 
-	/**
-	 * Determines whether or not the annotation is drawn with an arrow.
-	 * If *true*, `text` is placed near the arrow's tail.
-	 * If *false*, `text` lines up with the `x` and `y` provided.
-	 */
+    /**
+     * Determines whether or not the annotation is drawn with an arrow.
+     * If *true*, `text` is placed near the arrow's tail.
+     * If *false*, `text` lines up with the `x` and `y` provided.
+     */
 	showarrow: boolean;
 
 	/** Sets the color of the annotation arrow. */
@@ -860,189 +862,189 @@ export interface Annotations extends Label {
 	/** Sets the annotation arrow head position. */
 	arrowside: 'end' | 'start';
 
-	/**
-	 * Sets the size of the end annotation arrow head, relative to `arrowwidth`.
-	 * A value of 1 (default) gives a head about 3x as wide as the line.
-	 */
+    /**
+     * Sets the size of the end annotation arrow head, relative to `arrowwidth`.
+     * A value of 1 (default) gives a head about 3x as wide as the line.
+     */
 	arrowsize: number;
 
-	/**
-	 * Sets the size of the start annotation arrow head, relative to `arrowwidth`.
-	 * A value of 1 (default) gives a head about 3x as wide as the line.
-	 */
+    /**
+     * Sets the size of the start annotation arrow head, relative to `arrowwidth`.
+     * A value of 1 (default) gives a head about 3x as wide as the line.
+     */
 	startarrowsize: number;
 
 	/** Sets the width (in px) of annotation arrow line. */
 	arrowwidth: number;
 
-	/**
-	 * Sets a distance, in pixels, to move the end arrowhead away from the
-	 * position it is pointing at, for example to point at the edge of
-	 * a marker independent of zoom. Note that this shortens the arrow
-	 * from the `ax` / `ay` vector, in contrast to `xshift` / `yshift`
-	 * which moves everything by this amount.
-	 */
+    /**
+     * Sets a distance, in pixels, to move the end arrowhead away from the
+     * position it is pointing at, for example to point at the edge of
+     * a marker independent of zoom. Note that this shortens the arrow
+     * from the `ax` / `ay` vector, in contrast to `xshift` / `yshift`
+     * which moves everything by this amount.
+     */
 	standoff: number;
 
-	/**
-	 * Sets a distance, in pixels, to move the start arrowhead away from the
-	 * position it is pointing at, for example to point at the edge of
-	 * a marker independent of zoom. Note that this shortens the arrow
-	 * from the `ax` / `ay` vector, in contrast to `xshift` / `yshift`
-	 * which moves everything by this amount.
-	 */
+    /**
+     * Sets a distance, in pixels, to move the start arrowhead away from the
+     * position it is pointing at, for example to point at the edge of
+     * a marker independent of zoom. Note that this shortens the arrow
+     * from the `ax` / `ay` vector, in contrast to `xshift` / `yshift`
+     * which moves everything by this amount.
+     */
 	startstandoff: number;
 
-	/**
-	 * Sets the x component of the arrow tail about the arrow head.
-	 * If `axref` is `pixel`, a positive (negative)
-	 * component corresponds to an arrow pointing
-	 * from right to left (left to right).
-	 * If `axref` is an axis, this is an absolute value on that axis,
-	 * like `x`, NOT a relative value.
-	 */
+    /**
+     * Sets the x component of the arrow tail about the arrow head.
+     * If `axref` is `pixel`, a positive (negative)
+     * component corresponds to an arrow pointing
+     * from right to left (left to right).
+     * If `axref` is an axis, this is an absolute value on that axis,
+     * like `x`, NOT a relative value.
+     */
 	ax: number;
 
-	/**
-	 * Sets the y component of the arrow tail about the arrow head.
-	 * If `ayref` is `pixel`, a positive (negative)
-	 * component corresponds to an arrow pointing
-	 * from bottom to top (top to bottom).
-	 * If `ayref` is an axis, this is an absolute value on that axis,
-	 * like `y`, NOT a relative value.
-	 */
+    /**
+     * Sets the y component of the arrow tail about the arrow head.
+     * If `ayref` is `pixel`, a positive (negative)
+     * component corresponds to an arrow pointing
+     * from bottom to top (top to bottom).
+     * If `ayref` is an axis, this is an absolute value on that axis,
+     * like `y`, NOT a relative value.
+     */
 	ay: number;
 
-	/**
-	 * Indicates in what terms the tail of the annotation (ax,ay)
-	 * is specified. If `pixel`, `ax` is a relative offset in pixels
-	 * from `x`. If set to an x axis id (e.g. *x* or *x2*), `ax` is
-	 * specified in the same terms as that axis. This is useful
-	 * for trendline annotations which should continue to indicate
-	 * the correct trend when zoomed.
-	 */
+    /**
+     * Indicates in what terms the tail of the annotation (ax,ay)
+     * is specified. If `pixel`, `ax` is a relative offset in pixels
+     * from `x`. If set to an x axis id (e.g. *x* or *x2*), `ax` is
+     * specified in the same terms as that axis. This is useful
+     * for trendline annotations which should continue to indicate
+     * the correct trend when zoomed.
+     */
 	axref: 'pixel';
 
-	/**
-	 * Indicates in what terms the tail of the annotation (ax,ay)
-	 * is specified. If `pixel`, `ay` is a relative offset in pixels
-	 * from `y`. If set to a y axis id (e.g. *y* or *y2*), `ay` is
-	 * specified in the same terms as that axis. This is useful
-	 * for trendline annotations which should continue to indicate
-	 * the correct trend when zoomed.
-	 */
+    /**
+     * Indicates in what terms the tail of the annotation (ax,ay)
+     * is specified. If `pixel`, `ay` is a relative offset in pixels
+     * from `y`. If set to a y axis id (e.g. *y* or *y2*), `ay` is
+     * specified in the same terms as that axis. This is useful
+     * for trendline annotations which should continue to indicate
+     * the correct trend when zoomed.
+     */
 	ayref: 'pixel';
 
-	/**
-	 * Sets the annotation's x coordinate axis.
-	 * If set to an x axis id (e.g. *x* or *x2*), the `x` position refers to an x coordinate
-	 * If set to *paper*, the `x` position refers to the distance from
-	 * the left side of the plotting area in normalized coordinates
-	 * where 0 (1) corresponds to the left (right) side.
-	 */
+    /**
+     * Sets the annotation's x coordinate axis.
+     * If set to an x axis id (e.g. *x* or *x2*), the `x` position refers to an x coordinate
+     * If set to *paper*, the `x` position refers to the distance from
+     * the left side of the plotting area in normalized coordinates
+     * where 0 (1) corresponds to the left (right) side.
+     */
 	xref: 'paper' | 'x';
 
-	/**
-	 * Sets the annotation's x position.
-	 * If the axis `type` is *log*, then you must take the log of your desired range.
-	 * If the axis `type` is *date*, it should be date strings, like date data,
-	 * though Date objects and unix milliseconds will be accepted and converted to strings.
-	 * If the axis `type` is *category*, it should be numbers, using the scale where each
-	 * category is assigned a serial number from zero in the order it appears.
-	 */
+    /**
+     * Sets the annotation's x position.
+     * If the axis `type` is *log*, then you must take the log of your desired range.
+     * If the axis `type` is *date*, it should be date strings, like date data,
+     * though Date objects and unix milliseconds will be accepted and converted to strings.
+     * If the axis `type` is *category*, it should be numbers, using the scale where each
+     * category is assigned a serial number from zero in the order it appears.
+     */
 	x: number | string;
 
-	/**
-	 * Sets the text box's horizontal position anchor
-	 * This anchor binds the `x` position to the *left*, *center* or *right* of the annotation.
-	 * For example, if `x` is set to 1, `xref` to *paper* and `xanchor` to *right* then the
-	 * right-most portion of the annotation lines up with the right-most edge of the plotting area.
-	 * If *auto*, the anchor is equivalent to *center* for data-referenced annotations or if there
-	 * is an arrow, whereas for paper-referenced with no arrow, the anchor picked corresponds to the closest side.
-	 */
+    /**
+     * Sets the text box's horizontal position anchor
+     * This anchor binds the `x` position to the *left*, *center* or *right* of the annotation.
+     * For example, if `x` is set to 1, `xref` to *paper* and `xanchor` to *right* then the
+     * right-most portion of the annotation lines up with the right-most edge of the plotting area.
+     * If *auto*, the anchor is equivalent to *center* for data-referenced annotations or if there
+     * is an arrow, whereas for paper-referenced with no arrow, the anchor picked corresponds to the closest side.
+     */
 	xanchor: 'auto' | 'left' | 'center' | 'right';
 
-	/**
-	 * Shifts the position of the whole annotation and arrow to the
-	 * right (positive) or left (negative) by this many pixels.
-	 */
+    /**
+     * Shifts the position of the whole annotation and arrow to the
+     * right (positive) or left (negative) by this many pixels.
+     */
 	xshift: number;
 
-	/**
-	 * Sets the annotation's y coordinate axis.
-	 * If set to an y axis id (e.g. *y* or *y2*), the `y` position refers to an y coordinate
-	 * If set to *paper*, the `y` position refers to the distance from
-	 * the bottom of the plotting area in normalized coordinates
-	 * where 0 (1) corresponds to the bottom (top).
-	 */
+    /**
+     * Sets the annotation's y coordinate axis.
+     * If set to an y axis id (e.g. *y* or *y2*), the `y` position refers to an y coordinate
+     * If set to *paper*, the `y` position refers to the distance from
+     * the bottom of the plotting area in normalized coordinates
+     * where 0 (1) corresponds to the bottom (top).
+     */
 	yref: 'paper' | 'y';
 
-	/**
-	 * Sets the annotation's y position.
-	 * If the axis `type` is *log*, then you must take the log of your desired range.
-	 * If the axis `type` is *date*, it should be date strings, like date data,
-	 * though Date objects and unix milliseconds will be accepted and converted to strings.
-	 * If the axis `type` is *category*, it should be numbers, using the scale where each
-	 * category is assigned a serial number from zero in the order it appears.
-	 */
+    /**
+     * Sets the annotation's y position.
+     * If the axis `type` is *log*, then you must take the log of your desired range.
+     * If the axis `type` is *date*, it should be date strings, like date data,
+     * though Date objects and unix milliseconds will be accepted and converted to strings.
+     * If the axis `type` is *category*, it should be numbers, using the scale where each
+     * category is assigned a serial number from zero in the order it appears.
+     */
 	y: number | string;
 
-	/**
-	 * Sets the text box's vertical position anchor
-	 * This anchor binds the `y` position to the *top*, *middle* or *bottom* of the annotation.
-	 * For example, if `y` is set to 1, `yref` to *paper* and `yanchor` to *top* then the
-	 * top-most portion of the annotation lines up with the top-most edge of the plotting area.
-	 * If *auto*, the anchor is equivalent to *middle* for data-referenced annotations or if
-	 * there is an arrow, whereas for paper-referenced with no arrow, the anchor picked
-	 * corresponds to the closest side.
-	 */
+    /**
+     * Sets the text box's vertical position anchor
+     * This anchor binds the `y` position to the *top*, *middle* or *bottom* of the annotation.
+     * For example, if `y` is set to 1, `yref` to *paper* and `yanchor` to *top* then the
+     * top-most portion of the annotation lines up with the top-most edge of the plotting area.
+     * If *auto*, the anchor is equivalent to *middle* for data-referenced annotations or if
+     * there is an arrow, whereas for paper-referenced with no arrow, the anchor picked
+     * corresponds to the closest side.
+     */
 	yanchor: 'auto' | 'top' | 'middle' | 'bottom';
 
-	/**
-	 * Shifts the position of the whole annotation and arrow up
-	 * (positive) or down (negative) by this many pixels.
-	 */
+    /**
+     * Shifts the position of the whole annotation and arrow up
+     * (positive) or down (negative) by this many pixels.
+     */
 	yshift: number;
 
-	/**
-	 * Makes this annotation respond to clicks on the plot.
-	 * If you click a data point that exactly matches the `x` and `y` values of this annotation,
-	 * and it is hidden (visible: false), it will appear. In *onoff* mode, you must click the same
-	 * point again to make it disappear, so if you click multiple points, you can show multiple
-	 * annotations. In *onout* mode, a click anywhere else in the plot (on another data point or not)
-	 * will hide this annotation. If you need to show/hide this annotation in response to different
-	 * `x` or `y` values, you can set `xclick` and/or `yclick`. This is useful for example to label
-	 * the side of a bar. To label markers though, `standoff` is preferred over `xclick` and `yclick`.
-	 */
+    /**
+     * Makes this annotation respond to clicks on the plot.
+     * If you click a data point that exactly matches the `x` and `y` values of this annotation,
+     * and it is hidden (visible: false), it will appear. In *onoff* mode, you must click the same
+     * point again to make it disappear, so if you click multiple points, you can show multiple
+     * annotations. In *onout* mode, a click anywhere else in the plot (on another data point or not)
+     * will hide this annotation. If you need to show/hide this annotation in response to different
+     * `x` or `y` values, you can set `xclick` and/or `yclick`. This is useful for example to label
+     * the side of a bar. To label markers though, `standoff` is preferred over `xclick` and `yclick`.
+     */
 	clicktoshow: false | 'onoff' | 'onout';
 
-	/**
-	 * Toggle this annotation when clicking a data point whose `x` value
-	 * is `xclick` rather than the annotation's `x` value.
-	 */
+    /**
+     * Toggle this annotation when clicking a data point whose `x` value
+     * is `xclick` rather than the annotation's `x` value.
+     */
 	xclick: any;
 
-	/**
-	 * Toggle this annotation when clicking a data point whose `y` value
-	 * is `yclick` rather than the annotation's `y` value.
-	 */
+    /**
+     * Toggle this annotation when clicking a data point whose `y` value
+     * is `yclick` rather than the annotation's `y` value.
+     */
 	yclick: any;
 
-	/**
-	 * Sets text to appear when hovering over this annotation.
-	 * If omitted or blank, no hover label will appear.
-	 */
+    /**
+     * Sets text to appear when hovering over this annotation.
+     * If omitted or blank, no hover label will appear.
+     */
 	hovertext: string;
 
 	hoverlabel: Partial<Label>;
 
-	/**
-	 * Determines whether the annotation text box captures mouse move and click events,
-	 * or allows those events to pass through to data points in the plot that may be
-	 * behind the annotation. By default `captureevents` is *false* unless `hovertext`
-	 * is provided. If you use the event `plotly_clickannotation` without `hovertext`
-	 * you must explicitly enable `captureevents`.
-	 */
+    /**
+     * Determines whether the annotation text box captures mouse move and click events,
+     * or allows those events to pass through to data points in the plot that may be
+     * behind the annotation. By default `captureevents` is *false* unless `hovertext`
+     * is provided. If you use the event `plotly_clickannotation` without `hovertext`
+     * you must explicitly enable `captureevents`.
+     */
 	captureevents: boolean;
 }
 
@@ -1083,221 +1085,221 @@ export interface Domain {
 }
 
 export interface Frame {
-	/**
-	 * An identifier that specifies the group to which the frame belongs,
-	 * used by animate to select a subset of frames.
-	 */
+    /**
+     * An identifier that specifies the group to which the frame belongs,
+     * used by animate to select a subset of frames.
+     */
 	group: string;
-	/**
-	 * A label by which to identify the frame
-	 */
+    /**
+     * A label by which to identify the frame
+     */
 	name: string;
-	/**
-	 * A list of trace indices that identify the respective traces in the
-	 * data attribute
-	 */
+    /**
+     * A list of trace indices that identify the respective traces in the
+     * data attribute
+     */
 	traces: number[];
-	/**
-	 * The name of the frame into which this frame's properties are merged
-	 * before applying. This is used to unify properties and avoid needing
-	 * to specify the same values for the same properties in multiple frames.
-	 */
+    /**
+     * The name of the frame into which this frame's properties are merged
+     * before applying. This is used to unify properties and avoid needing
+     * to specify the same values for the same properties in multiple frames.
+     */
 	baseframe: string;
-	/**
-	 * A list of traces this frame modifies. The format is identical to the
-	 * normal trace definition.
-	 */
+    /**
+     * A list of traces this frame modifies. The format is identical to the
+     * normal trace definition.
+     */
 	data: Data[];
-	/**
-	 * Layout properties which this frame modifies. The format is identical
-	 * to the normal layout definition.
-	 */
+    /**
+     * Layout properties which this frame modifies. The format is identical
+     * to the normal layout definition.
+     */
 	layout: Partial<Layout>;
 }
 
 export interface Transition {
-	/**
-	 * Sets the duration of the slider transition
-	 */
+    /**
+     * Sets the duration of the slider transition
+     */
 	duration: number;
-	/**
-	 * Sets the easing function of the slider transition
-	 */
+    /**
+     * Sets the easing function of the slider transition
+     */
 	easing: 'linear' | 'quad' | 'cubic' | 'sin' | 'exp' | 'circle' | 'elastic' | 'back' | 'bounce' | 'linear-in' |
-		'quad-in' | 'cubic-in' | 'sin-in' | 'exp-in' | 'circle-in' | 'elastic-in' | 'back-in' | 'bounce-in' |
-		'linear-out' | 'quad-out' | 'cubic-out' | 'sin-out' | 'exp-out' | 'circle-out' | 'elastic-out' | 'back-out' |
-		'bounce-out' | 'linear-in-out' | 'quad-in-out' | 'cubic-in-out' | 'sin-in-out' | 'exp-in-out' |
-		'circle-in-out' | 'elastic-in-out' | 'back-in-out' | 'bounce-in-out';
+	'quad-in' | 'cubic-in' | 'sin-in' | 'exp-in' | 'circle-in' | 'elastic-in' | 'back-in' | 'bounce-in' |
+	'linear-out' | 'quad-out' | 'cubic-out' | 'sin-out' | 'exp-out' | 'circle-out' | 'elastic-out' | 'back-out' |
+	'bounce-out' | 'linear-in-out' | 'quad-in-out' | 'cubic-in-out' | 'sin-in-out' | 'exp-in-out' |
+	'circle-in-out' | 'elastic-in-out' | 'back-in-out' | 'bounce-in-out';
 }
 
 export interface SliderStep {
-	/**
-	 * Determines whether or not this step is included in the slider.
-	 */
+    /**
+     * Determines whether or not this step is included in the slider.
+     */
 	visible: boolean;
-	/**
-	 * Sets the Plotly method to be called when the slider value is changed.
-	 * If the `skip` method is used, the API slider will function as normal
-	 * but will perform no API calls and will not bind automatically to state
-	 * updates. This may be used to create a component interface and attach to
-	 * slider events manually via JavaScript.
-	 */
+    /**
+     * Sets the Plotly method to be called when the slider value is changed.
+     * If the `skip` method is used, the API slider will function as normal
+     * but will perform no API calls and will not bind automatically to state
+     * updates. This may be used to create a component interface and attach to
+     * slider events manually via JavaScript.
+     */
 	method: 'animate' | 'relayout' | 'restyle' | 'skip' | 'update';
-	/**
-	 * Sets the arguments values to be passed to the Plotly
-	 * method set in `method` on slide.
-	 */
+    /**
+     * Sets the arguments values to be passed to the Plotly
+     * method set in `method` on slide.
+     */
 	args: any[];
-	/**
-	 * Sets the text label to appear on the slider
-	 */
+    /**
+     * Sets the text label to appear on the slider
+     */
 	label: string;
-	/**
-	 * Sets the value of the slider step, used to refer to the step programatically.
-	 * Defaults to the slider label if not provided.
-	 */
+    /**
+     * Sets the value of the slider step, used to refer to the step programatically.
+     * Defaults to the slider label if not provided.
+     */
 	value: string;
-	/**
-	 * When true, the API method is executed. When false, all other behaviors are the same
-	 * and command execution is skipped. This may be useful when hooking into, for example,
-	 * the `plotly_sliderchange` method and executing the API command manually without losing
-	 * the benefit of the slider automatically binding to the state of the plot through the
-	 * specification of `method` and `args`.
-	 */
+    /**
+     * When true, the API method is executed. When false, all other behaviors are the same
+     * and command execution is skipped. This may be useful when hooking into, for example,
+     * the `plotly_sliderchange` method and executing the API command manually without losing
+     * the benefit of the slider automatically binding to the state of the plot through the
+     * specification of `method` and `args`.
+     */
 	execute: boolean;
 }
 
 export interface Padding {
-	/**
-	 * The amount of padding (in px) along the top of the component.
-	 */
+    /**
+     * The amount of padding (in px) along the top of the component.
+     */
 	t: number;
-	/**
-	 * The amount of padding (in px) on the right side of the component.
-	 */
+    /**
+     * The amount of padding (in px) on the right side of the component.
+     */
 	r: number;
-	/**
-	 * The amount of padding (in px) along the bottom of the component.
-	 */
+    /**
+     * The amount of padding (in px) along the bottom of the component.
+     */
 	b: number;
-	/**
-	 * The amount of padding (in px) on the left side of the component.
-	 */
+    /**
+     * The amount of padding (in px) on the left side of the component.
+     */
 	l: number;
 	editType: 'arraydraw';
 }
 
 export interface Slider {
-	/**
-	 * Determines whether or not the slider is visible.
-	 */
+    /**
+     * Determines whether or not the slider is visible.
+     */
 	visible: boolean;
-	/**
-	 * Determines which button (by index starting from 0) is
-	 * considered active.
-	 */
+    /**
+     * Determines which button (by index starting from 0) is
+     * considered active.
+     */
 	active: number;
 	steps: Array<Partial<SliderStep>>;
-	/**
-	 * Determines whether this slider length
-	 * is set in units of plot *fraction* or in *pixels.
-	 * Use `len` to set the value.
-	 */
+    /**
+     * Determines whether this slider length
+     * is set in units of plot *fraction* or in *pixels.
+     * Use `len` to set the value.
+     */
 	lenmode: 'fraction' | 'pixels';
-	/**
-	 * Sets the length of the slider
-	 * This measure excludes the padding of both ends.
-	 * That is, the slider's length is this length minus the
-	 * padding on both ends.
-	 */
+    /**
+     * Sets the length of the slider
+     * This measure excludes the padding of both ends.
+     * That is, the slider's length is this length minus the
+     * padding on both ends.
+     */
 	len: number;
-	/**
-	 * Sets the x position (in normalized coordinates) of the slider.
-	 */
+    /**
+     * Sets the x position (in normalized coordinates) of the slider.
+     */
 	x: number;
-	/**
-	 * Sets the y position (in normalized coordinates) of the slider.
-	 */
+    /**
+     * Sets the y position (in normalized coordinates) of the slider.
+     */
 	y: number;
-	/**
-	 * Set the padding of the slider component along each side.
-	 */
+    /**
+     * Set the padding of the slider component along each side.
+     */
 	pad: Partial<Padding>;
-	/**
-	 * Sets the slider's horizontal position anchor.
-	 * This anchor binds the `x` position to the *left*, *center*
-	 * or *right* of the range selector.
-	 */
+    /**
+     * Sets the slider's horizontal position anchor.
+     * This anchor binds the `x` position to the *left*, *center*
+     * or *right* of the range selector.
+     */
 	xanchor: 'auto' | 'left' | 'center' | 'right';
-	/**
-	 * Sets the slider's vertical position anchor
-	 * This anchor binds the `y` position to the *top*, *middle*
-	 * or *bottom* of the range selector.
-	 */
+    /**
+     * Sets the slider's vertical position anchor
+     * This anchor binds the `y` position to the *top*, *middle*
+     * or *bottom* of the range selector.
+     */
 	yanchor: 'auto' | 'top' | 'middle' | 'bottom';
 	transition: Transition;
 	currentvalue: {
-		/**
-		 * Shows the currently-selected value above the slider.
-		 */
+        /**
+         * Shows the currently-selected value above the slider.
+         */
 		visible: boolean;
-		/**
-		 * The alignment of the value readout relative to the length of the slider.
-		 */
+        /**
+         * The alignment of the value readout relative to the length of the slider.
+         */
 		xanchor: 'left' | 'center' | 'right';
-		/**
-		 * The amount of space, in pixels, between the current value label
-		 * and the slider.
-		 */
+        /**
+         * The amount of space, in pixels, between the current value label
+         * and the slider.
+         */
 		offset: number;
-		/**
-		 * When currentvalue.visible is true, this sets the prefix of the label.
-		 */
+        /**
+         * When currentvalue.visible is true, this sets the prefix of the label.
+         */
 		prefix: string;
-		/**
-		 * When currentvalue.visible is true, this sets the suffix of the label.
-		 */
+        /**
+         * When currentvalue.visible is true, this sets the suffix of the label.
+         */
 		suffix: string;
-		/**
-		 * Sets the font of the current value label text.
-		 */
+        /**
+         * Sets the font of the current value label text.
+         */
 		font: Partial<Font>;
 	};
-	/**
-	 * Sets the font of the slider step labels.
-	 */
+    /**
+     * Sets the font of the slider step labels.
+     */
 	font: Font;
-	/**
-	 * Sets the background color of the slider grip
-	 * while dragging.
-	 */
+    /**
+     * Sets the background color of the slider grip
+     * while dragging.
+     */
 	activebgcolor: Color;
-	/**
-	 * Sets the background color of the slider.
-	 */
+    /**
+     * Sets the background color of the slider.
+     */
 	bgcolor: Color;
-	/**
-	 * Sets the color of the border enclosing the slider.
-	 */
+    /**
+     * Sets the color of the border enclosing the slider.
+     */
 	bordercolor: Color;
-	/**
-	 * Sets the width (in px) of the border enclosing the slider.
-	 */
+    /**
+     * Sets the width (in px) of the border enclosing the slider.
+     */
 	borderwidth: number;
-	/**
-	 * Sets the length in pixels of step tick marks
-	 */
+    /**
+     * Sets the length in pixels of step tick marks
+     */
 	ticklen: number;
-	/**
-	 * Sets the color of the border enclosing the slider.
-	 */
+    /**
+     * Sets the color of the border enclosing the slider.
+     */
 	tickcolor: Color;
-	/**
-	 * Sets the tick width (in px).
-	 */
+    /**
+     * Sets the tick width (in px).
+     */
 	tickwidth: number;
-	/**
-	 * Sets the length in pixels of minor step tick marks
-	 */
+    /**
+     * Sets the length in pixels of minor step tick marks
+     */
 	minorticklen: number;
 }

--- a/types/plotly.js/index.d.ts
+++ b/types/plotly.js/index.d.ts
@@ -470,8 +470,39 @@ export interface ScatterData {
 	name: string;
 	connectgaps: boolean;
 	visible: boolean | 'legendonly';
+	transforms: Transform[];
 }
 
+/**
+ * These interfaces are based on attribute descriptions in
+ * https://github.com/plotly/plotly.js/tree/9d6144304308fc3007f0facf2535d38ea3e9b26c/src/transforms
+ */
+
+export interface TransformStyle {
+    target: number | string | number[] | string[];
+    value: Partial<ScatterData>;
+}
+
+export interface TransformAggregation {
+    target: string;
+    func?: 'count' | 'sum' | 'avg' | 'median' | 'mode' | 'rms' | 'stddev' | 'min' | 'max' | 'first' | 'last';
+	funcmode?: 'sample' | 'population';
+	enabled?: boolean;
+}
+
+export interface Transform {
+	type: 'aggregate' | 'filter' | 'groupby' | 'sort';
+	enabled?: boolean;
+	target?: number | string | number[] | string[];
+	operation?: string;
+	aggregations?: TransformAggregation[];
+	preservegaps?: boolean;
+	groups?: string | number[] | string[];
+	nameformat: string;
+	styles?: TransformStyle[];
+	value?: any;
+	order?: 'ascending' | 'descending';
+}
 /**
  * Any combination of "x", "y", "z", "text", "name" joined with a "+" OR "all" or "none" or "skip".
  * examples: "x", "y", "x+y", "x+y+z", "all"

--- a/types/plotly.js/index.d.ts
+++ b/types/plotly.js/index.d.ts
@@ -438,7 +438,7 @@ export type Dash = 'solid' | 'dot' | 'dash' | 'longdash' | 'dashdot' | 'longdash
 
 export type Data = Partial<PlotData>;
 export type Color = string | Array<string | undefined | null> | Array<Array<string | undefined | null>>;
-export type DataTransForm = Partial<Transform>;
+export type DataTransform = Partial<Transform>;
 export type ScatterData = PlotData;
 // Bar Scatter
 export interface PlotData {
@@ -489,7 +489,7 @@ export interface PlotData {
 	name: string;
 	connectgaps: boolean;
 	visible: boolean | 'legendonly';
-	transforms: DataTransForm[];
+	transforms: DataTransform[];
 	orientation: 'v' | 'h';
 }
 

--- a/types/plotly.js/index.d.ts
+++ b/types/plotly.js/index.d.ts
@@ -192,6 +192,14 @@ export interface Layout {
 	separators: string;
 	hidesources: boolean;
 	xaxis: Partial<LayoutAxis>;
+	xaxis2: Partial<LayoutAxis>;
+	xaxis3: Partial<LayoutAxis>;
+	xaxis4: Partial<LayoutAxis>;
+	xaxis5: Partial<LayoutAxis>;
+	xaxis6: Partial<LayoutAxis>;
+	xaxis7: Partial<LayoutAxis>;
+	xaxis8: Partial<LayoutAxis>;
+	xaxis9: Partial<LayoutAxis>;
 	yaxis: Partial<LayoutAxis>;
 	yaxis2: Partial<LayoutAxis>;
 	yaxis3: Partial<LayoutAxis>;

--- a/types/plotly.js/index.d.ts
+++ b/types/plotly.js/index.d.ts
@@ -50,8 +50,8 @@ export interface PlotCoordinate {
 }
 
 export interface SelectionDescription {
-	x: number[],
-	y: number[],
+	x: number[];
+	y: number[];
 }
 
 export type PlotSelectedData = Partial<PlotScatterDataPoint>;
@@ -393,32 +393,32 @@ export interface ModeBarButton {
 	/** name / id of the buttons (for tracking) */
 	name: string;
 
-    /**
-     * text that appears while hovering over the button,
-     * enter null, false or '' for no hover text
-     */
+	/**
+	 * text that appears while hovering over the button,
+	 * enter null, false or '' for no hover text
+	 */
 	title: string;
 
-    /**
-     * svg icon object associated with the button
-     * can be linked to Plotly.Icons to use the default plotly icons
-     */
+	/**
+	 * svg icon object associated with the button
+	 * can be linked to Plotly.Icons to use the default plotly icons
+	 */
 	icon: string | Icon;
 
 	/** icon positioning */
 	gravity?: string;
 
-    /**
-     * click handler associated with the button, a function of
-     * 'gd' (the main graph object) and
-     * 'ev' (the event object)
-     */
+	/**
+	 * click handler associated with the button, a function of
+	 * 'gd' (the main graph object) and
+	 * 'ev' (the event object)
+	 */
 	click: ButtonClickEvent;
 
-    /**
-     * attribute associated with button,
-     * use this with 'val' to keep track of the state
-     */
+	/**
+	 * attribute associated with button,
+	 * use this with 'val' to keep track of the state
+	 */
 	attr?: string;
 
 	/** initial 'attr' value, can be a function of gd */
@@ -622,17 +622,17 @@ export interface ScatterLine {
 }
 
 export interface Font {
-    /**
-     * HTML font family - the typeface that will be applied by the web browser.
-     * The web browser will only be able to apply a font if it is available on the system
-     * which it operates. Provide multiple font families, separated by commas, to indicate
-     * the preference in which to apply fonts if they aren't available on the system.
-     * The plotly service (at https://plot.ly or on-premise) generates images on a server,
-     * where only a select number of fonts are installed and supported.
-     * These include *Arial*, *Balto*, *Courier New*, *Droid Sans*, *Droid Serif*,
-     * *Droid Sans Mono*, *Gravitas One*, *Old Standard TT*, *Open Sans*, *Overpass*,
-     * *PT Sans Narrow*, *Raleway*, *Times New Roman*.
-     */
+	/**
+	 * HTML font family - the typeface that will be applied by the web browser.
+	 * The web browser will only be able to apply a font if it is available on the system
+	 * which it operates. Provide multiple font families, separated by commas, to indicate
+	 * the preference in which to apply fonts if they aren't available on the system.
+	 * The plotly service (at https://plot.ly or on-premise) generates images on a server,
+	 * where only a select number of fonts are installed and supported.
+	 * These include *Arial*, *Balto*, *Courier New*, *Droid Sans*, *Droid Serif*,
+	 * *Droid Sans Mono*, *Gravitas One*, *Old Standard TT*, *Open Sans*, *Overpass*,
+	 * *PT Sans Narrow*, *Raleway*, *Times New Roman*.
+	 */
 	family: string;
 	size: number;
 	color: Color;
@@ -707,12 +707,12 @@ export interface Config {
 	/** add mode bar button using config objects (see ./components/modebar/buttons.js for list of arguments) */
 	modeBarButtonsToAdd: ModeBarDefaultButtons[] | ModeBarButton[];
 
-    /**
-     * fully custom mode bar buttons as nested array, where the outer
-     * arrays represents button groups, and the inner arrays have
-     * buttons config objects or names of default buttons
-     * (see ./components/modebar/buttons.js for more info)
-     */
+	/**
+	 * fully custom mode bar buttons as nested array, where the outer
+	 * arrays represents button groups, and the inner arrays have
+	 * buttons config objects or names of default buttons
+	 * (see ./components/modebar/buttons.js for more info)
+	 */
 	modeBarButtons: ModeBarDefaultButtons[][] | ModeBarButton[][] | false;
 
 	/** add the plotly logo on the end of the mode bar */
@@ -721,26 +721,26 @@ export interface Config {
 	/** increase the pixel ratio for Gl plot images */
 	plotGlPixelRatio: number;
 
-    /**
-     * function to add the background color to a different container
-     * or 'opaque' to ensure there's white behind it
-     */
+	/**
+	 * function to add the background color to a different container
+	 * or 'opaque' to ensure there's white behind it
+	 */
 	setBackground: string | 'opaque' | 'transparent';
 
 	/** URL to topojson files used in geo charts */
 	topojsonURL: string;
 
-    /**
-     * Mapbox access token (required to plot mapbox trace types)
-     * If using an Mapbox Atlas server, set this option to '',
-     * so that plotly.js won't attempt to authenticate to the public Mapbox server.
-     */
+	/**
+	 * Mapbox access token (required to plot mapbox trace types)
+	 * If using an Mapbox Atlas server, set this option to '',
+	 * so that plotly.js won't attempt to authenticate to the public Mapbox server.
+	 */
 	mapboxAccessToken: string;
 
-    /**
-     * Turn all console logging on or off (errors will be thrown)
-     * This should ONLY be set via Plotly.setPlotConfig
-     */
+	/**
+	 * Turn all console logging on or off (errors will be thrown)
+	 * This should ONLY be set via Plotly.setPlotConfig
+	 */
 	logging: boolean | 0 | 1 | 2;
 
 	/** Set global transform to be applied to all traces with no specification needed */
@@ -795,46 +795,46 @@ export interface Annotations extends Label {
 	/** Determines whether or not this annotation is visible. */
 	visible: boolean;
 
-    /**
-     * Sets the text associated with this annotation.
-     * Plotly uses a subset of HTML tags to do things like
-     * newline (<br>), bold (<b></b>), italics (<i></i>),
-     * hyperlinks (<a href='...'></a>). Tags <em>, <sup>, <sub>
-     * <span> are also supported.
-     */
+	/**
+	 * Sets the text associated with this annotation.
+	 * Plotly uses a subset of HTML tags to do things like
+	 * newline (<br>), bold (<b></b>), italics (<i></i>),
+	 * hyperlinks (<a href='...'></a>). Tags <em>, <sup>, <sub>
+	 * <span> are also supported.
+	 */
 	text: string;
 
 	/** Sets the angle at which the `text` is drawn with respect to the horizontal. */
 	textangle: string;
 
-    /**
-     * Sets an explicit width for the text box. null (default) lets the
-     * text set the box width. Wider text will be clipped.
-     * There is no automatic wrapping; use <br> to start a new line.
-     */
+	/**
+	 * Sets an explicit width for the text box. null (default) lets the
+	 * text set the box width. Wider text will be clipped.
+	 * There is no automatic wrapping; use <br> to start a new line.
+	 */
 	width: number;
 
-    /**
-     * Sets an explicit height for the text box. null (default) lets the
-     * text set the box height. Taller text will be clipped.
-     */
+	/**
+	 * Sets an explicit height for the text box. null (default) lets the
+	 * text set the box height. Taller text will be clipped.
+	 */
 	height: number;
 
 	/** Sets the opacity of the annotation (text + arrow). */
 	opacity: number;
 
-    /**
-     * Sets the horizontal alignment of the `text` within the box.
-     * Has an effect only if `text` spans more two or more lines
-     * (i.e. `text` contains one or more <br> HTML tags) or if an
-     * explicit width is set to override the text width.
-     */
+	/**
+	 * Sets the horizontal alignment of the `text` within the box.
+	 * Has an effect only if `text` spans more two or more lines
+	 * (i.e. `text` contains one or more <br> HTML tags) or if an
+	 * explicit width is set to override the text width.
+	 */
 	align: 'left' | 'center' | 'right';
 
-    /**
-     * Sets the vertical alignment of the `text` within the box.
-     * Has an effect only if an explicit height is set to override the text height.
-     */
+	/**
+	 * Sets the vertical alignment of the `text` within the box.
+	 * Has an effect only if an explicit height is set to override the text height.
+	 */
 	valign: 'top' | 'middle' | 'bottom';
 
 	/** Sets the padding (in px) between the `text` and the enclosing border. */
@@ -843,11 +843,11 @@ export interface Annotations extends Label {
 	/** Sets the width (in px) of the border enclosing the annotation `text`. */
 	borderwidth: number;
 
-    /**
-     * Determines whether or not the annotation is drawn with an arrow.
-     * If *true*, `text` is placed near the arrow's tail.
-     * If *false*, `text` lines up with the `x` and `y` provided.
-     */
+	/**
+	 * Determines whether or not the annotation is drawn with an arrow.
+	 * If *true*, `text` is placed near the arrow's tail.
+	 * If *false*, `text` lines up with the `x` and `y` provided.
+	 */
 	showarrow: boolean;
 
 	/** Sets the color of the annotation arrow. */
@@ -862,189 +862,189 @@ export interface Annotations extends Label {
 	/** Sets the annotation arrow head position. */
 	arrowside: 'end' | 'start';
 
-    /**
-     * Sets the size of the end annotation arrow head, relative to `arrowwidth`.
-     * A value of 1 (default) gives a head about 3x as wide as the line.
-     */
+	/**
+	 * Sets the size of the end annotation arrow head, relative to `arrowwidth`.
+	 * A value of 1 (default) gives a head about 3x as wide as the line.
+	 */
 	arrowsize: number;
 
-    /**
-     * Sets the size of the start annotation arrow head, relative to `arrowwidth`.
-     * A value of 1 (default) gives a head about 3x as wide as the line.
-     */
+	/**
+	 * Sets the size of the start annotation arrow head, relative to `arrowwidth`.
+	 * A value of 1 (default) gives a head about 3x as wide as the line.
+	 */
 	startarrowsize: number;
 
 	/** Sets the width (in px) of annotation arrow line. */
 	arrowwidth: number;
 
-    /**
-     * Sets a distance, in pixels, to move the end arrowhead away from the
-     * position it is pointing at, for example to point at the edge of
-     * a marker independent of zoom. Note that this shortens the arrow
-     * from the `ax` / `ay` vector, in contrast to `xshift` / `yshift`
-     * which moves everything by this amount.
-     */
+	/**
+	 * Sets a distance, in pixels, to move the end arrowhead away from the
+	 * position it is pointing at, for example to point at the edge of
+	 * a marker independent of zoom. Note that this shortens the arrow
+	 * from the `ax` / `ay` vector, in contrast to `xshift` / `yshift`
+	 * which moves everything by this amount.
+	 */
 	standoff: number;
 
-    /**
-     * Sets a distance, in pixels, to move the start arrowhead away from the
-     * position it is pointing at, for example to point at the edge of
-     * a marker independent of zoom. Note that this shortens the arrow
-     * from the `ax` / `ay` vector, in contrast to `xshift` / `yshift`
-     * which moves everything by this amount.
-     */
+	/**
+	 * Sets a distance, in pixels, to move the start arrowhead away from the
+	 * position it is pointing at, for example to point at the edge of
+	 * a marker independent of zoom. Note that this shortens the arrow
+	 * from the `ax` / `ay` vector, in contrast to `xshift` / `yshift`
+	 * which moves everything by this amount.
+	 */
 	startstandoff: number;
 
-    /**
-     * Sets the x component of the arrow tail about the arrow head.
-     * If `axref` is `pixel`, a positive (negative)
-     * component corresponds to an arrow pointing
-     * from right to left (left to right).
-     * If `axref` is an axis, this is an absolute value on that axis,
-     * like `x`, NOT a relative value.
-     */
+	/**
+	 * Sets the x component of the arrow tail about the arrow head.
+	 * If `axref` is `pixel`, a positive (negative)
+	 * component corresponds to an arrow pointing
+	 * from right to left (left to right).
+	 * If `axref` is an axis, this is an absolute value on that axis,
+	 * like `x`, NOT a relative value.
+	 */
 	ax: number;
 
-    /**
-     * Sets the y component of the arrow tail about the arrow head.
-     * If `ayref` is `pixel`, a positive (negative)
-     * component corresponds to an arrow pointing
-     * from bottom to top (top to bottom).
-     * If `ayref` is an axis, this is an absolute value on that axis,
-     * like `y`, NOT a relative value.
-     */
+	/**
+	 * Sets the y component of the arrow tail about the arrow head.
+	 * If `ayref` is `pixel`, a positive (negative)
+	 * component corresponds to an arrow pointing
+	 * from bottom to top (top to bottom).
+	 * If `ayref` is an axis, this is an absolute value on that axis,
+	 * like `y`, NOT a relative value.
+	 */
 	ay: number;
 
-    /**
-     * Indicates in what terms the tail of the annotation (ax,ay)
-     * is specified. If `pixel`, `ax` is a relative offset in pixels
-     * from `x`. If set to an x axis id (e.g. *x* or *x2*), `ax` is
-     * specified in the same terms as that axis. This is useful
-     * for trendline annotations which should continue to indicate
-     * the correct trend when zoomed.
-     */
+	/**
+	 * Indicates in what terms the tail of the annotation (ax,ay)
+	 * is specified. If `pixel`, `ax` is a relative offset in pixels
+	 * from `x`. If set to an x axis id (e.g. *x* or *x2*), `ax` is
+	 * specified in the same terms as that axis. This is useful
+	 * for trendline annotations which should continue to indicate
+	 * the correct trend when zoomed.
+	 */
 	axref: 'pixel';
 
-    /**
-     * Indicates in what terms the tail of the annotation (ax,ay)
-     * is specified. If `pixel`, `ay` is a relative offset in pixels
-     * from `y`. If set to a y axis id (e.g. *y* or *y2*), `ay` is
-     * specified in the same terms as that axis. This is useful
-     * for trendline annotations which should continue to indicate
-     * the correct trend when zoomed.
-     */
+	/**
+	 * Indicates in what terms the tail of the annotation (ax,ay)
+	 * is specified. If `pixel`, `ay` is a relative offset in pixels
+	 * from `y`. If set to a y axis id (e.g. *y* or *y2*), `ay` is
+	 * specified in the same terms as that axis. This is useful
+	 * for trendline annotations which should continue to indicate
+	 * the correct trend when zoomed.
+	 */
 	ayref: 'pixel';
 
-    /**
-     * Sets the annotation's x coordinate axis.
-     * If set to an x axis id (e.g. *x* or *x2*), the `x` position refers to an x coordinate
-     * If set to *paper*, the `x` position refers to the distance from
-     * the left side of the plotting area in normalized coordinates
-     * where 0 (1) corresponds to the left (right) side.
-     */
+	/**
+	 * Sets the annotation's x coordinate axis.
+	 * If set to an x axis id (e.g. *x* or *x2*), the `x` position refers to an x coordinate
+	 * If set to *paper*, the `x` position refers to the distance from
+	 * the left side of the plotting area in normalized coordinates
+	 * where 0 (1) corresponds to the left (right) side.
+	 */
 	xref: 'paper' | 'x';
 
-    /**
-     * Sets the annotation's x position.
-     * If the axis `type` is *log*, then you must take the log of your desired range.
-     * If the axis `type` is *date*, it should be date strings, like date data,
-     * though Date objects and unix milliseconds will be accepted and converted to strings.
-     * If the axis `type` is *category*, it should be numbers, using the scale where each
-     * category is assigned a serial number from zero in the order it appears.
-     */
+	/**
+	 * Sets the annotation's x position.
+	 * If the axis `type` is *log*, then you must take the log of your desired range.
+	 * If the axis `type` is *date*, it should be date strings, like date data,
+	 * though Date objects and unix milliseconds will be accepted and converted to strings.
+	 * If the axis `type` is *category*, it should be numbers, using the scale where each
+	 * category is assigned a serial number from zero in the order it appears.
+	 */
 	x: number | string;
 
-    /**
-     * Sets the text box's horizontal position anchor
-     * This anchor binds the `x` position to the *left*, *center* or *right* of the annotation.
-     * For example, if `x` is set to 1, `xref` to *paper* and `xanchor` to *right* then the
-     * right-most portion of the annotation lines up with the right-most edge of the plotting area.
-     * If *auto*, the anchor is equivalent to *center* for data-referenced annotations or if there
-     * is an arrow, whereas for paper-referenced with no arrow, the anchor picked corresponds to the closest side.
-     */
+	/**
+	 * Sets the text box's horizontal position anchor
+	 * This anchor binds the `x` position to the *left*, *center* or *right* of the annotation.
+	 * For example, if `x` is set to 1, `xref` to *paper* and `xanchor` to *right* then the
+	 * right-most portion of the annotation lines up with the right-most edge of the plotting area.
+	 * If *auto*, the anchor is equivalent to *center* for data-referenced annotations or if there
+	 * is an arrow, whereas for paper-referenced with no arrow, the anchor picked corresponds to the closest side.
+	 */
 	xanchor: 'auto' | 'left' | 'center' | 'right';
 
-    /**
-     * Shifts the position of the whole annotation and arrow to the
-     * right (positive) or left (negative) by this many pixels.
-     */
+	/**
+	 * Shifts the position of the whole annotation and arrow to the
+	 * right (positive) or left (negative) by this many pixels.
+	 */
 	xshift: number;
 
-    /**
-     * Sets the annotation's y coordinate axis.
-     * If set to an y axis id (e.g. *y* or *y2*), the `y` position refers to an y coordinate
-     * If set to *paper*, the `y` position refers to the distance from
-     * the bottom of the plotting area in normalized coordinates
-     * where 0 (1) corresponds to the bottom (top).
-     */
+	/**
+	 * Sets the annotation's y coordinate axis.
+	 * If set to an y axis id (e.g. *y* or *y2*), the `y` position refers to an y coordinate
+	 * If set to *paper*, the `y` position refers to the distance from
+	 * the bottom of the plotting area in normalized coordinates
+	 * where 0 (1) corresponds to the bottom (top).
+	 */
 	yref: 'paper' | 'y';
 
-    /**
-     * Sets the annotation's y position.
-     * If the axis `type` is *log*, then you must take the log of your desired range.
-     * If the axis `type` is *date*, it should be date strings, like date data,
-     * though Date objects and unix milliseconds will be accepted and converted to strings.
-     * If the axis `type` is *category*, it should be numbers, using the scale where each
-     * category is assigned a serial number from zero in the order it appears.
-     */
+	/**
+	 * Sets the annotation's y position.
+	 * If the axis `type` is *log*, then you must take the log of your desired range.
+	 * If the axis `type` is *date*, it should be date strings, like date data,
+	 * though Date objects and unix milliseconds will be accepted and converted to strings.
+	 * If the axis `type` is *category*, it should be numbers, using the scale where each
+	 * category is assigned a serial number from zero in the order it appears.
+	 */
 	y: number | string;
 
-    /**
-     * Sets the text box's vertical position anchor
-     * This anchor binds the `y` position to the *top*, *middle* or *bottom* of the annotation.
-     * For example, if `y` is set to 1, `yref` to *paper* and `yanchor` to *top* then the
-     * top-most portion of the annotation lines up with the top-most edge of the plotting area.
-     * If *auto*, the anchor is equivalent to *middle* for data-referenced annotations or if
-     * there is an arrow, whereas for paper-referenced with no arrow, the anchor picked
-     * corresponds to the closest side.
-     */
+	/**
+	 * Sets the text box's vertical position anchor
+	 * This anchor binds the `y` position to the *top*, *middle* or *bottom* of the annotation.
+	 * For example, if `y` is set to 1, `yref` to *paper* and `yanchor` to *top* then the
+	 * top-most portion of the annotation lines up with the top-most edge of the plotting area.
+	 * If *auto*, the anchor is equivalent to *middle* for data-referenced annotations or if
+	 * there is an arrow, whereas for paper-referenced with no arrow, the anchor picked
+	 * corresponds to the closest side.
+	 */
 	yanchor: 'auto' | 'top' | 'middle' | 'bottom';
 
-    /**
-     * Shifts the position of the whole annotation and arrow up
-     * (positive) or down (negative) by this many pixels.
-     */
+	/**
+	 * Shifts the position of the whole annotation and arrow up
+	 * (positive) or down (negative) by this many pixels.
+	 */
 	yshift: number;
 
-    /**
-     * Makes this annotation respond to clicks on the plot.
-     * If you click a data point that exactly matches the `x` and `y` values of this annotation,
-     * and it is hidden (visible: false), it will appear. In *onoff* mode, you must click the same
-     * point again to make it disappear, so if you click multiple points, you can show multiple
-     * annotations. In *onout* mode, a click anywhere else in the plot (on another data point or not)
-     * will hide this annotation. If you need to show/hide this annotation in response to different
-     * `x` or `y` values, you can set `xclick` and/or `yclick`. This is useful for example to label
-     * the side of a bar. To label markers though, `standoff` is preferred over `xclick` and `yclick`.
-     */
+	/**
+	 * Makes this annotation respond to clicks on the plot.
+	 * If you click a data point that exactly matches the `x` and `y` values of this annotation,
+	 * and it is hidden (visible: false), it will appear. In *onoff* mode, you must click the same
+	 * point again to make it disappear, so if you click multiple points, you can show multiple
+	 * annotations. In *onout* mode, a click anywhere else in the plot (on another data point or not)
+	 * will hide this annotation. If you need to show/hide this annotation in response to different
+	 * `x` or `y` values, you can set `xclick` and/or `yclick`. This is useful for example to label
+	 * the side of a bar. To label markers though, `standoff` is preferred over `xclick` and `yclick`.
+	 */
 	clicktoshow: false | 'onoff' | 'onout';
 
-    /**
-     * Toggle this annotation when clicking a data point whose `x` value
-     * is `xclick` rather than the annotation's `x` value.
-     */
+	/**
+	 * Toggle this annotation when clicking a data point whose `x` value
+	 * is `xclick` rather than the annotation's `x` value.
+	 */
 	xclick: any;
 
-    /**
-     * Toggle this annotation when clicking a data point whose `y` value
-     * is `yclick` rather than the annotation's `y` value.
-     */
+	/**
+	 * Toggle this annotation when clicking a data point whose `y` value
+	 * is `yclick` rather than the annotation's `y` value.
+	 */
 	yclick: any;
 
-    /**
-     * Sets text to appear when hovering over this annotation.
-     * If omitted or blank, no hover label will appear.
-     */
+	/**
+	 * Sets text to appear when hovering over this annotation.
+	 * If omitted or blank, no hover label will appear.
+	 */
 	hovertext: string;
 
 	hoverlabel: Partial<Label>;
 
-    /**
-     * Determines whether the annotation text box captures mouse move and click events,
-     * or allows those events to pass through to data points in the plot that may be
-     * behind the annotation. By default `captureevents` is *false* unless `hovertext`
-     * is provided. If you use the event `plotly_clickannotation` without `hovertext`
-     * you must explicitly enable `captureevents`.
-     */
+	/**
+	 * Determines whether the annotation text box captures mouse move and click events,
+	 * or allows those events to pass through to data points in the plot that may be
+	 * behind the annotation. By default `captureevents` is *false* unless `hovertext`
+	 * is provided. If you use the event `plotly_clickannotation` without `hovertext`
+	 * you must explicitly enable `captureevents`.
+	 */
 	captureevents: boolean;
 }
 
@@ -1085,46 +1085,46 @@ export interface Domain {
 }
 
 export interface Frame {
-    /**
-     * An identifier that specifies the group to which the frame belongs,
-     * used by animate to select a subset of frames.
-     */
+	/**
+	 * An identifier that specifies the group to which the frame belongs,
+	 * used by animate to select a subset of frames.
+	 */
 	group: string;
-    /**
-     * A label by which to identify the frame
-     */
+	/**
+	 * A label by which to identify the frame
+	 */
 	name: string;
-    /**
-     * A list of trace indices that identify the respective traces in the
-     * data attribute
-     */
+	/**
+	 * A list of trace indices that identify the respective traces in the
+	 * data attribute
+	 */
 	traces: number[];
-    /**
-     * The name of the frame into which this frame's properties are merged
-     * before applying. This is used to unify properties and avoid needing
-     * to specify the same values for the same properties in multiple frames.
-     */
+	/**
+	 * The name of the frame into which this frame's properties are merged
+	 * before applying. This is used to unify properties and avoid needing
+	 * to specify the same values for the same properties in multiple frames.
+	 */
 	baseframe: string;
-    /**
-     * A list of traces this frame modifies. The format is identical to the
-     * normal trace definition.
-     */
+	/**
+	 * A list of traces this frame modifies. The format is identical to the
+	 * normal trace definition.
+	 */
 	data: Data[];
-    /**
-     * Layout properties which this frame modifies. The format is identical
-     * to the normal layout definition.
-     */
+	/**
+	 * Layout properties which this frame modifies. The format is identical
+	 * to the normal layout definition.
+	 */
 	layout: Partial<Layout>;
 }
 
 export interface Transition {
-    /**
-     * Sets the duration of the slider transition
-     */
+	/**
+	 * Sets the duration of the slider transition
+	 */
 	duration: number;
-    /**
-     * Sets the easing function of the slider transition
-     */
+	/**
+	 * Sets the easing function of the slider transition
+	 */
 	easing: 'linear' | 'quad' | 'cubic' | 'sin' | 'exp' | 'circle' | 'elastic' | 'back' | 'bounce' | 'linear-in' |
 	'quad-in' | 'cubic-in' | 'sin-in' | 'exp-in' | 'circle-in' | 'elastic-in' | 'back-in' | 'bounce-in' |
 	'linear-out' | 'quad-out' | 'cubic-out' | 'sin-out' | 'exp-out' | 'circle-out' | 'elastic-out' | 'back-out' |
@@ -1133,173 +1133,173 @@ export interface Transition {
 }
 
 export interface SliderStep {
-    /**
-     * Determines whether or not this step is included in the slider.
-     */
+	/**
+	 * Determines whether or not this step is included in the slider.
+	 */
 	visible: boolean;
-    /**
-     * Sets the Plotly method to be called when the slider value is changed.
-     * If the `skip` method is used, the API slider will function as normal
-     * but will perform no API calls and will not bind automatically to state
-     * updates. This may be used to create a component interface and attach to
-     * slider events manually via JavaScript.
-     */
+	/**
+	 * Sets the Plotly method to be called when the slider value is changed.
+	 * If the `skip` method is used, the API slider will function as normal
+	 * but will perform no API calls and will not bind automatically to state
+	 * updates. This may be used to create a component interface and attach to
+	 * slider events manually via JavaScript.
+	 */
 	method: 'animate' | 'relayout' | 'restyle' | 'skip' | 'update';
-    /**
-     * Sets the arguments values to be passed to the Plotly
-     * method set in `method` on slide.
-     */
+	/**
+	 * Sets the arguments values to be passed to the Plotly
+	 * method set in `method` on slide.
+	 */
 	args: any[];
-    /**
-     * Sets the text label to appear on the slider
-     */
+	/**
+	 * Sets the text label to appear on the slider
+	 */
 	label: string;
-    /**
-     * Sets the value of the slider step, used to refer to the step programatically.
-     * Defaults to the slider label if not provided.
-     */
+	/**
+	 * Sets the value of the slider step, used to refer to the step programatically.
+	 * Defaults to the slider label if not provided.
+	 */
 	value: string;
-    /**
-     * When true, the API method is executed. When false, all other behaviors are the same
-     * and command execution is skipped. This may be useful when hooking into, for example,
-     * the `plotly_sliderchange` method and executing the API command manually without losing
-     * the benefit of the slider automatically binding to the state of the plot through the
-     * specification of `method` and `args`.
-     */
+	/**
+	 * When true, the API method is executed. When false, all other behaviors are the same
+	 * and command execution is skipped. This may be useful when hooking into, for example,
+	 * the `plotly_sliderchange` method and executing the API command manually without losing
+	 * the benefit of the slider automatically binding to the state of the plot through the
+	 * specification of `method` and `args`.
+	 */
 	execute: boolean;
 }
 
 export interface Padding {
-    /**
-     * The amount of padding (in px) along the top of the component.
-     */
+	/**
+	 * The amount of padding (in px) along the top of the component.
+	 */
 	t: number;
-    /**
-     * The amount of padding (in px) on the right side of the component.
-     */
+	/**
+	 * The amount of padding (in px) on the right side of the component.
+	 */
 	r: number;
-    /**
-     * The amount of padding (in px) along the bottom of the component.
-     */
+	/**
+	 * The amount of padding (in px) along the bottom of the component.
+	 */
 	b: number;
-    /**
-     * The amount of padding (in px) on the left side of the component.
-     */
+	/**
+	 * The amount of padding (in px) on the left side of the component.
+	 */
 	l: number;
 	editType: 'arraydraw';
 }
 
 export interface Slider {
-    /**
-     * Determines whether or not the slider is visible.
-     */
+	/**
+	 * Determines whether or not the slider is visible.
+	 */
 	visible: boolean;
-    /**
-     * Determines which button (by index starting from 0) is
-     * considered active.
-     */
+	/**
+	 * Determines which button (by index starting from 0) is
+	 * considered active.
+	 */
 	active: number;
 	steps: Array<Partial<SliderStep>>;
-    /**
-     * Determines whether this slider length
-     * is set in units of plot *fraction* or in *pixels.
-     * Use `len` to set the value.
-     */
+	/**
+	 * Determines whether this slider length
+	 * is set in units of plot *fraction* or in *pixels.
+	 * Use `len` to set the value.
+	 */
 	lenmode: 'fraction' | 'pixels';
-    /**
-     * Sets the length of the slider
-     * This measure excludes the padding of both ends.
-     * That is, the slider's length is this length minus the
-     * padding on both ends.
-     */
+	/**
+	 * Sets the length of the slider
+	 * This measure excludes the padding of both ends.
+	 * That is, the slider's length is this length minus the
+	 * padding on both ends.
+	 */
 	len: number;
-    /**
-     * Sets the x position (in normalized coordinates) of the slider.
-     */
+	/**
+	 * Sets the x position (in normalized coordinates) of the slider.
+	 */
 	x: number;
-    /**
-     * Sets the y position (in normalized coordinates) of the slider.
-     */
+	/**
+	 * Sets the y position (in normalized coordinates) of the slider.
+	 */
 	y: number;
-    /**
-     * Set the padding of the slider component along each side.
-     */
+	/**
+	 * Set the padding of the slider component along each side.
+	 */
 	pad: Partial<Padding>;
-    /**
-     * Sets the slider's horizontal position anchor.
-     * This anchor binds the `x` position to the *left*, *center*
-     * or *right* of the range selector.
-     */
+	/**
+	 * Sets the slider's horizontal position anchor.
+	 * This anchor binds the `x` position to the *left*, *center*
+	 * or *right* of the range selector.
+	 */
 	xanchor: 'auto' | 'left' | 'center' | 'right';
-    /**
-     * Sets the slider's vertical position anchor
-     * This anchor binds the `y` position to the *top*, *middle*
-     * or *bottom* of the range selector.
-     */
+	/**
+	 * Sets the slider's vertical position anchor
+	 * This anchor binds the `y` position to the *top*, *middle*
+	 * or *bottom* of the range selector.
+	 */
 	yanchor: 'auto' | 'top' | 'middle' | 'bottom';
 	transition: Transition;
 	currentvalue: {
-        /**
-         * Shows the currently-selected value above the slider.
-         */
+		/**
+		 * Shows the currently-selected value above the slider.
+		 */
 		visible: boolean;
-        /**
-         * The alignment of the value readout relative to the length of the slider.
-         */
+		/**
+		 * The alignment of the value readout relative to the length of the slider.
+		 */
 		xanchor: 'left' | 'center' | 'right';
-        /**
-         * The amount of space, in pixels, between the current value label
-         * and the slider.
-         */
+		/**
+		 * The amount of space, in pixels, between the current value label
+		 * and the slider.
+		 */
 		offset: number;
-        /**
-         * When currentvalue.visible is true, this sets the prefix of the label.
-         */
+		/**
+		 * When currentvalue.visible is true, this sets the prefix of the label.
+		 */
 		prefix: string;
-        /**
-         * When currentvalue.visible is true, this sets the suffix of the label.
-         */
+		/**
+		 * When currentvalue.visible is true, this sets the suffix of the label.
+		 */
 		suffix: string;
-        /**
-         * Sets the font of the current value label text.
-         */
+		/**
+		 * Sets the font of the current value label text.
+		 */
 		font: Partial<Font>;
 	};
-    /**
-     * Sets the font of the slider step labels.
-     */
+	/**
+	 * Sets the font of the slider step labels.
+	 */
 	font: Font;
-    /**
-     * Sets the background color of the slider grip
-     * while dragging.
-     */
+	/**
+	 * Sets the background color of the slider grip
+	 * while dragging.
+	 */
 	activebgcolor: Color;
-    /**
-     * Sets the background color of the slider.
-     */
+	/**
+	 * Sets the background color of the slider.
+	 */
 	bgcolor: Color;
-    /**
-     * Sets the color of the border enclosing the slider.
-     */
+	/**
+	 * Sets the color of the border enclosing the slider.
+	 */
 	bordercolor: Color;
-    /**
-     * Sets the width (in px) of the border enclosing the slider.
-     */
+	/**
+	 * Sets the width (in px) of the border enclosing the slider.
+	 */
 	borderwidth: number;
-    /**
-     * Sets the length in pixels of step tick marks
-     */
+	/**
+	 * Sets the length in pixels of step tick marks
+	 */
 	ticklen: number;
-    /**
-     * Sets the color of the border enclosing the slider.
-     */
+	/**
+	 * Sets the color of the border enclosing the slider.
+	 */
 	tickcolor: Color;
-    /**
-     * Sets the tick width (in px).
-     */
+	/**
+	 * Sets the tick width (in px).
+	 */
 	tickwidth: number;
-    /**
-     * Sets the length in pixels of minor step tick marks
-     */
+	/**
+	 * Sets the length in pixels of minor step tick marks
+	 */
 	minorticklen: number;
 }

--- a/types/plotly.js/index.d.ts
+++ b/types/plotly.js/index.d.ts
@@ -50,7 +50,7 @@ export interface PlotCoordinate {
 	pointNumber: number;
 }
 
-export interface SelectionDescription {
+export interface SelectionRange {
 	x: number[];
 	y: number[];
 }
@@ -59,8 +59,8 @@ export type PlotSelectedData = Partial<PlotScatterDataPoint>;
 
 export interface PlotSelectionEvent {
 	points: PlotScatterDataPoint[];
-	range?: SelectionDescription;
-	lassoPoints?: SelectionDescription;
+	range?: SelectionRange;
+	lassoPoints?: SelectionRange;
 }
 
 export type PlotRestyleEvent = [

--- a/types/plotly.js/index.d.ts
+++ b/types/plotly.js/index.d.ts
@@ -393,32 +393,32 @@ export interface ModeBarButton {
 	/** name / id of the buttons (for tracking) */
 	name: string;
 
-    /**
-     * text that appears while hovering over the button,
-     * enter null, false or '' for no hover text
-     */
+	/**
+	 * text that appears while hovering over the button,
+	 * enter null, false or '' for no hover text
+	 */
 	title: string;
 
-    /**
-     * svg icon object associated with the button
-     * can be linked to Plotly.Icons to use the default plotly icons
-     */
+	/**
+	 * svg icon object associated with the button
+	 * can be linked to Plotly.Icons to use the default plotly icons
+	 */
 	icon: string | Icon;
 
 	/** icon positioning */
 	gravity?: string;
 
-    /**
-     * click handler associated with the button, a function of
-     * 'gd' (the main graph object) and
-     * 'ev' (the event object)
-     */
+	/**
+	 * click handler associated with the button, a function of
+	 * 'gd' (the main graph object) and
+	 * 'ev' (the event object)
+	 */
 	click: ButtonClickEvent;
 
-    /**
-     * attribute associated with button,
-     * use this with 'val' to keep track of the state
-     */
+	/**
+	 * attribute associated with button,
+	 * use this with 'val' to keep track of the state
+	 */
 	attr?: string;
 
 	/** initial 'attr' value, can be a function of gd */
@@ -622,17 +622,17 @@ export interface ScatterLine {
 }
 
 export interface Font {
-    /**
-     * HTML font family - the typeface that will be applied by the web browser.
-     * The web browser will only be able to apply a font if it is available on the system
-     * which it operates. Provide multiple font families, separated by commas, to indicate
-     * the preference in which to apply fonts if they aren't available on the system.
-     * The plotly service (at https://plot.ly or on-premise) generates images on a server,
-     * where only a select number of fonts are installed and supported.
-     * These include *Arial*, *Balto*, *Courier New*, *Droid Sans*, *Droid Serif*,
-     * *Droid Sans Mono*, *Gravitas One*, *Old Standard TT*, *Open Sans*, *Overpass*,
-     * *PT Sans Narrow*, *Raleway*, *Times New Roman*.
-     */
+	/**
+	 * HTML font family - the typeface that will be applied by the web browser.
+	 * The web browser will only be able to apply a font if it is available on the system
+	 * which it operates. Provide multiple font families, separated by commas, to indicate
+	 * the preference in which to apply fonts if they aren't available on the system.
+	 * The plotly service (at https://plot.ly or on-premise) generates images on a server,
+	 * where only a select number of fonts are installed and supported.
+	 * These include *Arial*, *Balto*, *Courier New*, *Droid Sans*, *Droid Serif*,
+	 * *Droid Sans Mono*, *Gravitas One*, *Old Standard TT*, *Open Sans*, *Overpass*,
+	 * *PT Sans Narrow*, *Raleway*, *Times New Roman*.
+	 */
 	family: string;
 	size: number;
 	color: Color;
@@ -707,12 +707,12 @@ export interface Config {
 	/** add mode bar button using config objects (see ./components/modebar/buttons.js for list of arguments) */
 	modeBarButtonsToAdd: ModeBarDefaultButtons[] | ModeBarButton[];
 
-    /**
-     * fully custom mode bar buttons as nested array, where the outer
-     * arrays represents button groups, and the inner arrays have
-     * buttons config objects or names of default buttons
-     * (see ./components/modebar/buttons.js for more info)
-     */
+	/**
+	 * fully custom mode bar buttons as nested array, where the outer
+	 * arrays represents button groups, and the inner arrays have
+	 * buttons config objects or names of default buttons
+	 * (see ./components/modebar/buttons.js for more info)
+	 */
 	modeBarButtons: ModeBarDefaultButtons[][] | ModeBarButton[][] | false;
 
 	/** add the plotly logo on the end of the mode bar */
@@ -721,26 +721,26 @@ export interface Config {
 	/** increase the pixel ratio for Gl plot images */
 	plotGlPixelRatio: number;
 
-    /**
-     * function to add the background color to a different container
-     * or 'opaque' to ensure there's white behind it
-     */
+	/**
+	 * function to add the background color to a different container
+	 * or 'opaque' to ensure there's white behind it
+	 */
 	setBackground: string | 'opaque' | 'transparent';
 
 	/** URL to topojson files used in geo charts */
 	topojsonURL: string;
 
-    /**
-     * Mapbox access token (required to plot mapbox trace types)
-     * If using an Mapbox Atlas server, set this option to '',
-     * so that plotly.js won't attempt to authenticate to the public Mapbox server.
-     */
+	/**
+	 * Mapbox access token (required to plot mapbox trace types)
+	 * If using an Mapbox Atlas server, set this option to '',
+	 * so that plotly.js won't attempt to authenticate to the public Mapbox server.
+	 */
 	mapboxAccessToken: string;
 
-    /**
-     * Turn all console logging on or off (errors will be thrown)
-     * This should ONLY be set via Plotly.setPlotConfig
-     */
+	/**
+	 * Turn all console logging on or off (errors will be thrown)
+	 * This should ONLY be set via Plotly.setPlotConfig
+	 */
 	logging: boolean | 0 | 1 | 2;
 
 	/** Set global transform to be applied to all traces with no specification needed */
@@ -795,46 +795,46 @@ export interface Annotations extends Label {
 	/** Determines whether or not this annotation is visible. */
 	visible: boolean;
 
-    /**
-     * Sets the text associated with this annotation.
-     * Plotly uses a subset of HTML tags to do things like
-     * newline (<br>), bold (<b></b>), italics (<i></i>),
-     * hyperlinks (<a href='...'></a>). Tags <em>, <sup>, <sub>
-     * <span> are also supported.
-     */
+	/**
+	 * Sets the text associated with this annotation.
+	 * Plotly uses a subset of HTML tags to do things like
+	 * newline (<br>), bold (<b></b>), italics (<i></i>),
+	 * hyperlinks (<a href='...'></a>). Tags <em>, <sup>, <sub>
+	 * <span> are also supported.
+	 */
 	text: string;
 
 	/** Sets the angle at which the `text` is drawn with respect to the horizontal. */
 	textangle: string;
 
-    /**
-     * Sets an explicit width for the text box. null (default) lets the
-     * text set the box width. Wider text will be clipped.
-     * There is no automatic wrapping; use <br> to start a new line.
-     */
+	/**
+	 * Sets an explicit width for the text box. null (default) lets the
+	 * text set the box width. Wider text will be clipped.
+	 * There is no automatic wrapping; use <br> to start a new line.
+	 */
 	width: number;
 
-    /**
-     * Sets an explicit height for the text box. null (default) lets the
-     * text set the box height. Taller text will be clipped.
-     */
+	/**
+	 * Sets an explicit height for the text box. null (default) lets the
+	 * text set the box height. Taller text will be clipped.
+	 */
 	height: number;
 
 	/** Sets the opacity of the annotation (text + arrow). */
 	opacity: number;
 
-    /**
-     * Sets the horizontal alignment of the `text` within the box.
-     * Has an effect only if `text` spans more two or more lines
-     * (i.e. `text` contains one or more <br> HTML tags) or if an
-     * explicit width is set to override the text width.
-     */
+	/**
+	 * Sets the horizontal alignment of the `text` within the box.
+	 * Has an effect only if `text` spans more two or more lines
+	 * (i.e. `text` contains one or more <br> HTML tags) or if an
+	 * explicit width is set to override the text width.
+	 */
 	align: 'left' | 'center' | 'right';
 
-    /**
-     * Sets the vertical alignment of the `text` within the box.
-     * Has an effect only if an explicit height is set to override the text height.
-     */
+	/**
+	 * Sets the vertical alignment of the `text` within the box.
+	 * Has an effect only if an explicit height is set to override the text height.
+	 */
 	valign: 'top' | 'middle' | 'bottom';
 
 	/** Sets the padding (in px) between the `text` and the enclosing border. */
@@ -843,11 +843,11 @@ export interface Annotations extends Label {
 	/** Sets the width (in px) of the border enclosing the annotation `text`. */
 	borderwidth: number;
 
-    /**
-     * Determines whether or not the annotation is drawn with an arrow.
-     * If *true*, `text` is placed near the arrow's tail.
-     * If *false*, `text` lines up with the `x` and `y` provided.
-     */
+	/**
+	 * Determines whether or not the annotation is drawn with an arrow.
+	 * If *true*, `text` is placed near the arrow's tail.
+	 * If *false*, `text` lines up with the `x` and `y` provided.
+	 */
 	showarrow: boolean;
 
 	/** Sets the color of the annotation arrow. */
@@ -862,189 +862,189 @@ export interface Annotations extends Label {
 	/** Sets the annotation arrow head position. */
 	arrowside: 'end' | 'start';
 
-    /**
-     * Sets the size of the end annotation arrow head, relative to `arrowwidth`.
-     * A value of 1 (default) gives a head about 3x as wide as the line.
-     */
+	/**
+	 * Sets the size of the end annotation arrow head, relative to `arrowwidth`.
+	 * A value of 1 (default) gives a head about 3x as wide as the line.
+	 */
 	arrowsize: number;
 
-    /**
-     * Sets the size of the start annotation arrow head, relative to `arrowwidth`.
-     * A value of 1 (default) gives a head about 3x as wide as the line.
-     */
+	/**
+	 * Sets the size of the start annotation arrow head, relative to `arrowwidth`.
+	 * A value of 1 (default) gives a head about 3x as wide as the line.
+	 */
 	startarrowsize: number;
 
 	/** Sets the width (in px) of annotation arrow line. */
 	arrowwidth: number;
 
-    /**
-     * Sets a distance, in pixels, to move the end arrowhead away from the
-     * position it is pointing at, for example to point at the edge of
-     * a marker independent of zoom. Note that this shortens the arrow
-     * from the `ax` / `ay` vector, in contrast to `xshift` / `yshift`
-     * which moves everything by this amount.
-     */
+	/**
+	 * Sets a distance, in pixels, to move the end arrowhead away from the
+	 * position it is pointing at, for example to point at the edge of
+	 * a marker independent of zoom. Note that this shortens the arrow
+	 * from the `ax` / `ay` vector, in contrast to `xshift` / `yshift`
+	 * which moves everything by this amount.
+	 */
 	standoff: number;
 
-    /**
-     * Sets a distance, in pixels, to move the start arrowhead away from the
-     * position it is pointing at, for example to point at the edge of
-     * a marker independent of zoom. Note that this shortens the arrow
-     * from the `ax` / `ay` vector, in contrast to `xshift` / `yshift`
-     * which moves everything by this amount.
-     */
+	/**
+	 * Sets a distance, in pixels, to move the start arrowhead away from the
+	 * position it is pointing at, for example to point at the edge of
+	 * a marker independent of zoom. Note that this shortens the arrow
+	 * from the `ax` / `ay` vector, in contrast to `xshift` / `yshift`
+	 * which moves everything by this amount.
+	 */
 	startstandoff: number;
 
-    /**
-     * Sets the x component of the arrow tail about the arrow head.
-     * If `axref` is `pixel`, a positive (negative)
-     * component corresponds to an arrow pointing
-     * from right to left (left to right).
-     * If `axref` is an axis, this is an absolute value on that axis,
-     * like `x`, NOT a relative value.
-     */
+	/**
+	 * Sets the x component of the arrow tail about the arrow head.
+	 * If `axref` is `pixel`, a positive (negative)
+	 * component corresponds to an arrow pointing
+	 * from right to left (left to right).
+	 * If `axref` is an axis, this is an absolute value on that axis,
+	 * like `x`, NOT a relative value.
+	 */
 	ax: number;
 
-    /**
-     * Sets the y component of the arrow tail about the arrow head.
-     * If `ayref` is `pixel`, a positive (negative)
-     * component corresponds to an arrow pointing
-     * from bottom to top (top to bottom).
-     * If `ayref` is an axis, this is an absolute value on that axis,
-     * like `y`, NOT a relative value.
-     */
+	/**
+	 * Sets the y component of the arrow tail about the arrow head.
+	 * If `ayref` is `pixel`, a positive (negative)
+	 * component corresponds to an arrow pointing
+	 * from bottom to top (top to bottom).
+	 * If `ayref` is an axis, this is an absolute value on that axis,
+	 * like `y`, NOT a relative value.
+	 */
 	ay: number;
 
-    /**
-     * Indicates in what terms the tail of the annotation (ax,ay)
-     * is specified. If `pixel`, `ax` is a relative offset in pixels
-     * from `x`. If set to an x axis id (e.g. *x* or *x2*), `ax` is
-     * specified in the same terms as that axis. This is useful
-     * for trendline annotations which should continue to indicate
-     * the correct trend when zoomed.
-     */
+	/**
+	 * Indicates in what terms the tail of the annotation (ax,ay)
+	 * is specified. If `pixel`, `ax` is a relative offset in pixels
+	 * from `x`. If set to an x axis id (e.g. *x* or *x2*), `ax` is
+	 * specified in the same terms as that axis. This is useful
+	 * for trendline annotations which should continue to indicate
+	 * the correct trend when zoomed.
+	 */
 	axref: 'pixel';
 
-    /**
-     * Indicates in what terms the tail of the annotation (ax,ay)
-     * is specified. If `pixel`, `ay` is a relative offset in pixels
-     * from `y`. If set to a y axis id (e.g. *y* or *y2*), `ay` is
-     * specified in the same terms as that axis. This is useful
-     * for trendline annotations which should continue to indicate
-     * the correct trend when zoomed.
-     */
+	/**
+	 * Indicates in what terms the tail of the annotation (ax,ay)
+	 * is specified. If `pixel`, `ay` is a relative offset in pixels
+	 * from `y`. If set to a y axis id (e.g. *y* or *y2*), `ay` is
+	 * specified in the same terms as that axis. This is useful
+	 * for trendline annotations which should continue to indicate
+	 * the correct trend when zoomed.
+	 */
 	ayref: 'pixel';
 
-    /**
-     * Sets the annotation's x coordinate axis.
-     * If set to an x axis id (e.g. *x* or *x2*), the `x` position refers to an x coordinate
-     * If set to *paper*, the `x` position refers to the distance from
-     * the left side of the plotting area in normalized coordinates
-     * where 0 (1) corresponds to the left (right) side.
-     */
+	/**
+	 * Sets the annotation's x coordinate axis.
+	 * If set to an x axis id (e.g. *x* or *x2*), the `x` position refers to an x coordinate
+	 * If set to *paper*, the `x` position refers to the distance from
+	 * the left side of the plotting area in normalized coordinates
+	 * where 0 (1) corresponds to the left (right) side.
+	 */
 	xref: 'paper' | 'x';
 
-    /**
-     * Sets the annotation's x position.
-     * If the axis `type` is *log*, then you must take the log of your desired range.
-     * If the axis `type` is *date*, it should be date strings, like date data,
-     * though Date objects and unix milliseconds will be accepted and converted to strings.
-     * If the axis `type` is *category*, it should be numbers, using the scale where each
-     * category is assigned a serial number from zero in the order it appears.
-     */
+	/**
+	 * Sets the annotation's x position.
+	 * If the axis `type` is *log*, then you must take the log of your desired range.
+	 * If the axis `type` is *date*, it should be date strings, like date data,
+	 * though Date objects and unix milliseconds will be accepted and converted to strings.
+	 * If the axis `type` is *category*, it should be numbers, using the scale where each
+	 * category is assigned a serial number from zero in the order it appears.
+	 */
 	x: number | string;
 
-    /**
-     * Sets the text box's horizontal position anchor
-     * This anchor binds the `x` position to the *left*, *center* or *right* of the annotation.
-     * For example, if `x` is set to 1, `xref` to *paper* and `xanchor` to *right* then the
-     * right-most portion of the annotation lines up with the right-most edge of the plotting area.
-     * If *auto*, the anchor is equivalent to *center* for data-referenced annotations or if there
-     * is an arrow, whereas for paper-referenced with no arrow, the anchor picked corresponds to the closest side.
-     */
+	/**
+	 * Sets the text box's horizontal position anchor
+	 * This anchor binds the `x` position to the *left*, *center* or *right* of the annotation.
+	 * For example, if `x` is set to 1, `xref` to *paper* and `xanchor` to *right* then the
+	 * right-most portion of the annotation lines up with the right-most edge of the plotting area.
+	 * If *auto*, the anchor is equivalent to *center* for data-referenced annotations or if there
+	 * is an arrow, whereas for paper-referenced with no arrow, the anchor picked corresponds to the closest side.
+	 */
 	xanchor: 'auto' | 'left' | 'center' | 'right';
 
-    /**
-     * Shifts the position of the whole annotation and arrow to the
-     * right (positive) or left (negative) by this many pixels.
-     */
+	/**
+	 * Shifts the position of the whole annotation and arrow to the
+	 * right (positive) or left (negative) by this many pixels.
+	 */
 	xshift: number;
 
-    /**
-     * Sets the annotation's y coordinate axis.
-     * If set to an y axis id (e.g. *y* or *y2*), the `y` position refers to an y coordinate
-     * If set to *paper*, the `y` position refers to the distance from
-     * the bottom of the plotting area in normalized coordinates
-     * where 0 (1) corresponds to the bottom (top).
-     */
+	/**
+	 * Sets the annotation's y coordinate axis.
+	 * If set to an y axis id (e.g. *y* or *y2*), the `y` position refers to an y coordinate
+	 * If set to *paper*, the `y` position refers to the distance from
+	 * the bottom of the plotting area in normalized coordinates
+	 * where 0 (1) corresponds to the bottom (top).
+	 */
 	yref: 'paper' | 'y';
 
-    /**
-     * Sets the annotation's y position.
-     * If the axis `type` is *log*, then you must take the log of your desired range.
-     * If the axis `type` is *date*, it should be date strings, like date data,
-     * though Date objects and unix milliseconds will be accepted and converted to strings.
-     * If the axis `type` is *category*, it should be numbers, using the scale where each
-     * category is assigned a serial number from zero in the order it appears.
-     */
+	/**
+	 * Sets the annotation's y position.
+	 * If the axis `type` is *log*, then you must take the log of your desired range.
+	 * If the axis `type` is *date*, it should be date strings, like date data,
+	 * though Date objects and unix milliseconds will be accepted and converted to strings.
+	 * If the axis `type` is *category*, it should be numbers, using the scale where each
+	 * category is assigned a serial number from zero in the order it appears.
+	 */
 	y: number | string;
 
-    /**
-     * Sets the text box's vertical position anchor
-     * This anchor binds the `y` position to the *top*, *middle* or *bottom* of the annotation.
-     * For example, if `y` is set to 1, `yref` to *paper* and `yanchor` to *top* then the
-     * top-most portion of the annotation lines up with the top-most edge of the plotting area.
-     * If *auto*, the anchor is equivalent to *middle* for data-referenced annotations or if
-     * there is an arrow, whereas for paper-referenced with no arrow, the anchor picked
-     * corresponds to the closest side.
-     */
+	/**
+	 * Sets the text box's vertical position anchor
+	 * This anchor binds the `y` position to the *top*, *middle* or *bottom* of the annotation.
+	 * For example, if `y` is set to 1, `yref` to *paper* and `yanchor` to *top* then the
+	 * top-most portion of the annotation lines up with the top-most edge of the plotting area.
+	 * If *auto*, the anchor is equivalent to *middle* for data-referenced annotations or if
+	 * there is an arrow, whereas for paper-referenced with no arrow, the anchor picked
+	 * corresponds to the closest side.
+	 */
 	yanchor: 'auto' | 'top' | 'middle' | 'bottom';
 
-    /**
-     * Shifts the position of the whole annotation and arrow up
-     * (positive) or down (negative) by this many pixels.
-     */
+	/**
+	 * Shifts the position of the whole annotation and arrow up
+	 * (positive) or down (negative) by this many pixels.
+	 */
 	yshift: number;
 
-    /**
-     * Makes this annotation respond to clicks on the plot.
-     * If you click a data point that exactly matches the `x` and `y` values of this annotation,
-     * and it is hidden (visible: false), it will appear. In *onoff* mode, you must click the same
-     * point again to make it disappear, so if you click multiple points, you can show multiple
-     * annotations. In *onout* mode, a click anywhere else in the plot (on another data point or not)
-     * will hide this annotation. If you need to show/hide this annotation in response to different
-     * `x` or `y` values, you can set `xclick` and/or `yclick`. This is useful for example to label
-     * the side of a bar. To label markers though, `standoff` is preferred over `xclick` and `yclick`.
-     */
+	/**
+	 * Makes this annotation respond to clicks on the plot.
+	 * If you click a data point that exactly matches the `x` and `y` values of this annotation,
+	 * and it is hidden (visible: false), it will appear. In *onoff* mode, you must click the same
+	 * point again to make it disappear, so if you click multiple points, you can show multiple
+	 * annotations. In *onout* mode, a click anywhere else in the plot (on another data point or not)
+	 * will hide this annotation. If you need to show/hide this annotation in response to different
+	 * `x` or `y` values, you can set `xclick` and/or `yclick`. This is useful for example to label
+	 * the side of a bar. To label markers though, `standoff` is preferred over `xclick` and `yclick`.
+	 */
 	clicktoshow: false | 'onoff' | 'onout';
 
-    /**
-     * Toggle this annotation when clicking a data point whose `x` value
-     * is `xclick` rather than the annotation's `x` value.
-     */
+	/**
+	 * Toggle this annotation when clicking a data point whose `x` value
+	 * is `xclick` rather than the annotation's `x` value.
+	 */
 	xclick: any;
 
-    /**
-     * Toggle this annotation when clicking a data point whose `y` value
-     * is `yclick` rather than the annotation's `y` value.
-     */
+	/**
+	 * Toggle this annotation when clicking a data point whose `y` value
+	 * is `yclick` rather than the annotation's `y` value.
+	 */
 	yclick: any;
 
-    /**
-     * Sets text to appear when hovering over this annotation.
-     * If omitted or blank, no hover label will appear.
-     */
+	/**
+	 * Sets text to appear when hovering over this annotation.
+	 * If omitted or blank, no hover label will appear.
+	 */
 	hovertext: string;
 
 	hoverlabel: Partial<Label>;
 
-    /**
-     * Determines whether the annotation text box captures mouse move and click events,
-     * or allows those events to pass through to data points in the plot that may be
-     * behind the annotation. By default `captureevents` is *false* unless `hovertext`
-     * is provided. If you use the event `plotly_clickannotation` without `hovertext`
-     * you must explicitly enable `captureevents`.
-     */
+	/**
+	 * Determines whether the annotation text box captures mouse move and click events,
+	 * or allows those events to pass through to data points in the plot that may be
+	 * behind the annotation. By default `captureevents` is *false* unless `hovertext`
+	 * is provided. If you use the event `plotly_clickannotation` without `hovertext`
+	 * you must explicitly enable `captureevents`.
+	 */
 	captureevents: boolean;
 }
 
@@ -1085,46 +1085,46 @@ export interface Domain {
 }
 
 export interface Frame {
-    /**
-     * An identifier that specifies the group to which the frame belongs,
-     * used by animate to select a subset of frames.
-     */
+	/**
+	 * An identifier that specifies the group to which the frame belongs,
+	 * used by animate to select a subset of frames.
+	 */
 	group: string;
-    /**
-     * A label by which to identify the frame
-     */
+	/**
+	 * A label by which to identify the frame
+	 */
 	name: string;
-    /**
-     * A list of trace indices that identify the respective traces in the
-     * data attribute
-     */
+	/**
+	 * A list of trace indices that identify the respective traces in the
+	 * data attribute
+	 */
 	traces: number[];
-    /**
-     * The name of the frame into which this frame's properties are merged
-     * before applying. This is used to unify properties and avoid needing
-     * to specify the same values for the same properties in multiple frames.
-     */
+	/**
+	 * The name of the frame into which this frame's properties are merged
+	 * before applying. This is used to unify properties and avoid needing
+	 * to specify the same values for the same properties in multiple frames.
+	 */
 	baseframe: string;
-    /**
-     * A list of traces this frame modifies. The format is identical to the
-     * normal trace definition.
-     */
+	/**
+	 * A list of traces this frame modifies. The format is identical to the
+	 * normal trace definition.
+	 */
 	data: Data[];
-    /**
-     * Layout properties which this frame modifies. The format is identical
-     * to the normal layout definition.
-     */
+	/**
+	 * Layout properties which this frame modifies. The format is identical
+	 * to the normal layout definition.
+	 */
 	layout: Partial<Layout>;
 }
 
 export interface Transition {
-    /**
-     * Sets the duration of the slider transition
-     */
+	/**
+	 * Sets the duration of the slider transition
+	 */
 	duration: number;
-    /**
-     * Sets the easing function of the slider transition
-     */
+	/**
+	 * Sets the easing function of the slider transition
+	 */
 	easing: 'linear' | 'quad' | 'cubic' | 'sin' | 'exp' | 'circle' | 'elastic' | 'back' | 'bounce' | 'linear-in' |
 	'quad-in' | 'cubic-in' | 'sin-in' | 'exp-in' | 'circle-in' | 'elastic-in' | 'back-in' | 'bounce-in' |
 	'linear-out' | 'quad-out' | 'cubic-out' | 'sin-out' | 'exp-out' | 'circle-out' | 'elastic-out' | 'back-out' |
@@ -1133,173 +1133,173 @@ export interface Transition {
 }
 
 export interface SliderStep {
-    /**
-     * Determines whether or not this step is included in the slider.
-     */
+	/**
+	 * Determines whether or not this step is included in the slider.
+	 */
 	visible: boolean;
-    /**
-     * Sets the Plotly method to be called when the slider value is changed.
-     * If the `skip` method is used, the API slider will function as normal
-     * but will perform no API calls and will not bind automatically to state
-     * updates. This may be used to create a component interface and attach to
-     * slider events manually via JavaScript.
-     */
+	/**
+	 * Sets the Plotly method to be called when the slider value is changed.
+	 * If the `skip` method is used, the API slider will function as normal
+	 * but will perform no API calls and will not bind automatically to state
+	 * updates. This may be used to create a component interface and attach to
+	 * slider events manually via JavaScript.
+	 */
 	method: 'animate' | 'relayout' | 'restyle' | 'skip' | 'update';
-    /**
-     * Sets the arguments values to be passed to the Plotly
-     * method set in `method` on slide.
-     */
+	/**
+	 * Sets the arguments values to be passed to the Plotly
+	 * method set in `method` on slide.
+	 */
 	args: any[];
-    /**
-     * Sets the text label to appear on the slider
-     */
+	/**
+	 * Sets the text label to appear on the slider
+	 */
 	label: string;
-    /**
-     * Sets the value of the slider step, used to refer to the step programatically.
-     * Defaults to the slider label if not provided.
-     */
+	/**
+	 * Sets the value of the slider step, used to refer to the step programatically.
+	 * Defaults to the slider label if not provided.
+	 */
 	value: string;
-    /**
-     * When true, the API method is executed. When false, all other behaviors are the same
-     * and command execution is skipped. This may be useful when hooking into, for example,
-     * the `plotly_sliderchange` method and executing the API command manually without losing
-     * the benefit of the slider automatically binding to the state of the plot through the
-     * specification of `method` and `args`.
-     */
+	/**
+	 * When true, the API method is executed. When false, all other behaviors are the same
+	 * and command execution is skipped. This may be useful when hooking into, for example,
+	 * the `plotly_sliderchange` method and executing the API command manually without losing
+	 * the benefit of the slider automatically binding to the state of the plot through the
+	 * specification of `method` and `args`.
+	 */
 	execute: boolean;
 }
 
 export interface Padding {
-    /**
-     * The amount of padding (in px) along the top of the component.
-     */
+	/**
+	 * The amount of padding (in px) along the top of the component.
+	 */
 	t: number;
-    /**
-     * The amount of padding (in px) on the right side of the component.
-     */
+	/**
+	 * The amount of padding (in px) on the right side of the component.
+	 */
 	r: number;
-    /**
-     * The amount of padding (in px) along the bottom of the component.
-     */
+	/**
+	 * The amount of padding (in px) along the bottom of the component.
+	 */
 	b: number;
-    /**
-     * The amount of padding (in px) on the left side of the component.
-     */
+	/**
+	 * The amount of padding (in px) on the left side of the component.
+	 */
 	l: number;
 	editType: 'arraydraw';
 }
 
 export interface Slider {
-    /**
-     * Determines whether or not the slider is visible.
-     */
+	/**
+	 * Determines whether or not the slider is visible.
+	 */
 	visible: boolean;
-    /**
-     * Determines which button (by index starting from 0) is
-     * considered active.
-     */
+	/**
+	 * Determines which button (by index starting from 0) is
+	 * considered active.
+	 */
 	active: number;
 	steps: Array<Partial<SliderStep>>;
-    /**
-     * Determines whether this slider length
-     * is set in units of plot *fraction* or in *pixels.
-     * Use `len` to set the value.
-     */
+	/**
+	 * Determines whether this slider length
+	 * is set in units of plot *fraction* or in *pixels.
+	 * Use `len` to set the value.
+	 */
 	lenmode: 'fraction' | 'pixels';
-    /**
-     * Sets the length of the slider
-     * This measure excludes the padding of both ends.
-     * That is, the slider's length is this length minus the
-     * padding on both ends.
-     */
+	/**
+	 * Sets the length of the slider
+	 * This measure excludes the padding of both ends.
+	 * That is, the slider's length is this length minus the
+	 * padding on both ends.
+	 */
 	len: number;
-    /**
-     * Sets the x position (in normalized coordinates) of the slider.
-     */
+	/**
+	 * Sets the x position (in normalized coordinates) of the slider.
+	 */
 	x: number;
-    /**
-     * Sets the y position (in normalized coordinates) of the slider.
-     */
+	/**
+	 * Sets the y position (in normalized coordinates) of the slider.
+	 */
 	y: number;
-    /**
-     * Set the padding of the slider component along each side.
-     */
+	/**
+	 * Set the padding of the slider component along each side.
+	 */
 	pad: Partial<Padding>;
-    /**
-     * Sets the slider's horizontal position anchor.
-     * This anchor binds the `x` position to the *left*, *center*
-     * or *right* of the range selector.
-     */
+	/**
+	 * Sets the slider's horizontal position anchor.
+	 * This anchor binds the `x` position to the *left*, *center*
+	 * or *right* of the range selector.
+	 */
 	xanchor: 'auto' | 'left' | 'center' | 'right';
-    /**
-     * Sets the slider's vertical position anchor
-     * This anchor binds the `y` position to the *top*, *middle*
-     * or *bottom* of the range selector.
-     */
+	/**
+	 * Sets the slider's vertical position anchor
+	 * This anchor binds the `y` position to the *top*, *middle*
+	 * or *bottom* of the range selector.
+	 */
 	yanchor: 'auto' | 'top' | 'middle' | 'bottom';
 	transition: Transition;
 	currentvalue: {
-        /**
-         * Shows the currently-selected value above the slider.
-         */
+		/**
+		 * Shows the currently-selected value above the slider.
+		 */
 		visible: boolean;
-        /**
-         * The alignment of the value readout relative to the length of the slider.
-         */
+		/**
+		 * The alignment of the value readout relative to the length of the slider.
+		 */
 		xanchor: 'left' | 'center' | 'right';
-        /**
-         * The amount of space, in pixels, between the current value label
-         * and the slider.
-         */
+		/**
+		 * The amount of space, in pixels, between the current value label
+		 * and the slider.
+		 */
 		offset: number;
-        /**
-         * When currentvalue.visible is true, this sets the prefix of the label.
-         */
+		/**
+		 * When currentvalue.visible is true, this sets the prefix of the label.
+		 */
 		prefix: string;
-        /**
-         * When currentvalue.visible is true, this sets the suffix of the label.
-         */
+		/**
+		 * When currentvalue.visible is true, this sets the suffix of the label.
+		 */
 		suffix: string;
-        /**
-         * Sets the font of the current value label text.
-         */
+		/**
+		 * Sets the font of the current value label text.
+		 */
 		font: Partial<Font>;
 	};
-    /**
-     * Sets the font of the slider step labels.
-     */
+	/**
+	 * Sets the font of the slider step labels.
+	 */
 	font: Font;
-    /**
-     * Sets the background color of the slider grip
-     * while dragging.
-     */
+	/**
+	 * Sets the background color of the slider grip
+	 * while dragging.
+	 */
 	activebgcolor: Color;
-    /**
-     * Sets the background color of the slider.
-     */
+	/**
+	 * Sets the background color of the slider.
+	 */
 	bgcolor: Color;
-    /**
-     * Sets the color of the border enclosing the slider.
-     */
+	/**
+	 * Sets the color of the border enclosing the slider.
+	 */
 	bordercolor: Color;
-    /**
-     * Sets the width (in px) of the border enclosing the slider.
-     */
+	/**
+	 * Sets the width (in px) of the border enclosing the slider.
+	 */
 	borderwidth: number;
-    /**
-     * Sets the length in pixels of step tick marks
-     */
+	/**
+	 * Sets the length in pixels of step tick marks
+	 */
 	ticklen: number;
-    /**
-     * Sets the color of the border enclosing the slider.
-     */
+	/**
+	 * Sets the color of the border enclosing the slider.
+	 */
 	tickcolor: Color;
-    /**
-     * Sets the tick width (in px).
-     */
+	/**
+	 * Sets the tick width (in px).
+	 */
 	tickwidth: number;
-    /**
-     * Sets the length in pixels of minor step tick marks
-     */
+	/**
+	 * Sets the length in pixels of minor step tick marks
+	 */
 	minorticklen: number;
 }

--- a/types/plotly.js/test/index-tests.ts
+++ b/types/plotly.js/test/index-tests.ts
@@ -9,55 +9,55 @@ const graphDiv = '#test';
 // https://plot.ly/javascript/2d-density-plots/
 
 (() => {
-	const testrows =[
+	const testrows = [
 		{
-			"country": "Afghanistan",
-			"year": 2002,
-			"pop": 8425333,
-			"continent": "Asia",
-			"lifeExp": 28.801,
-			"gdpPercap": 779.4453145
+			country: "Afghanistan",
+			year: 2002,
+			pop: 8425333,
+			continent: "Asia",
+			lifeExp: 28.801,
+			gdpPercap: 779.4453145
 		},
 		{
-			"country": "Argentina",
-			"year": 2002,
-			"pop": 38331121,
-			"continent": "Americas",
-			"lifeExp": 74.34,
-			"gdpPercap": 8797.640716
+			country: "Argentina",
+			year: 2002,
+			pop: 38331121,
+			continent: "Americas",
+			lifeExp: 74.34,
+			gdpPercap: 8797.640716
 		},
 		{
-			"country": "Australia",
-			"year": 2002,
-			"pop": 13177000,
-			"continent": "Oceania",
-			"lifeExp": 71.93,
-			"gdpPercap": 16788.62948
+			country: "Australia",
+			year: 2002,
+			pop: 13177000,
+			continent: "Oceania",
+			lifeExp: 71.93,
+			gdpPercap: 16788.62948
 		},
 		{
-			"country": "Austria",
-			"year": 2002,
-			"pop": 7914969,
-			"continent": "Europe",
-			"lifeExp": 76.04,
-			"gdpPercap": 27042.01868
+			country: "Austria",
+			year: 2002,
+			pop: 7914969,
+			continent: "Europe",
+			lifeExp: 76.04,
+			gdpPercap: 27042.01868
 		},
 		{
-			"country": "Austria",
-			"year": 2001,
-			"pop": 7914969,
-			"continent": "Europe",
-			"lifeExp": 76.04,
-			"gdpPercap": 27042.01868
+			country: "Austria",
+			year: 2001,
+			pop: 7914969,
+			continent: "Europe",
+			lifeExp: 76.04,
+			gdpPercap: 27042.01868
 		},
-	]
+	];
 
 	interface DataRow {
 		[key: string]: string | number;
 	}
 
 	function unpack(rows: DataRow[], key: string) {
-		return rows.map(function (row: DataRow) { return row[key]; });
+		return rows.map((row: DataRow) => row[key]);
 	}
 
 	const trace1 = {

--- a/types/plotly.js/test/index-tests.ts
+++ b/types/plotly.js/test/index-tests.ts
@@ -1,5 +1,5 @@
 import * as Plotly from 'plotly.js';
-import { ScatterData, Layout, PlotlyHTMLElement, newPlot } from 'plotly.js';
+import { ScatterData, Layout, PlotData, PlotlyHTMLElement, newPlot } from 'plotly.js';
 
 const graphDiv = '#test';
 
@@ -16,17 +16,45 @@ const graphDiv = '#test';
 		y: [16, 5, 11, 9],
 		type: 'scatter'
 	} as ScatterData;
-	const data = [trace1, trace2];
+	const trace3 = {
+		yaxis: 'y2',
+		x: [1999, 2000, 2001, 2002],
+		name: 'x density',
+		marker: { color: 'rgb(102,0,0)' },
+		type: 'histogram'
+	} as PlotData;
+	const trace4 = {
+		xaxis: 'x2',
+		y: [16, 5, 11, 9],
+		name: 'y density',
+		marker: { color: 'rgb(102,0,0)' },
+		type: 'histogram'
+	} as PlotData;
+	const data = [trace1, trace2, trace3, trace4];
 	const layout = {
 		title: 'Sales Growth',
 		xaxis: {
 			title: 'Year',
+			domain: [0, 0.85],
 			showgrid: false,
 			zeroline: false
 		},
 		yaxis: {
 			title: 'Percent',
-			showline: false
+			showline: false,
+			domain: [0, 0.85],
+			showgrid: false,
+			zeroline: false
+		},
+		xaxis2: {
+			domain: [0.85, 1],
+			showgrid: false,
+			zeroline: false
+		},
+		yaxis2: {
+			domain: [0.85, 1],
+			showgrid: false,
+			zeroline: false
 		}
 	};
 	Plotly.newPlot(graphDiv, data, layout);

--- a/types/plotly.js/test/index-tests.ts
+++ b/types/plotly.js/test/index-tests.ts
@@ -1,46 +1,128 @@
 import * as Plotly from 'plotly.js';
-import { ScatterData, Layout, PlotData, PlotlyHTMLElement, newPlot } from 'plotly.js';
+import { Layout, PlotData, PlotlyHTMLElement, newPlot } from 'plotly.js';
 
 const graphDiv = '#test';
 
 //////////////////////////////////////////////////////////////////////
 // Plotly.newPlot
+// combination of https://plot.ly/javascript/multiple-transforms/#all-transforms and
+// https://plot.ly/javascript/2d-density-plots/
+
 (() => {
+	const testrows =[
+		{
+			"country": "Afghanistan",
+			"year": 2002,
+			"pop": 8425333,
+			"continent": "Asia",
+			"lifeExp": 28.801,
+			"gdpPercap": 779.4453145
+		},
+		{
+			"country": "Argentina",
+			"year": 2002,
+			"pop": 38331121,
+			"continent": "Americas",
+			"lifeExp": 74.34,
+			"gdpPercap": 8797.640716
+		},
+		{
+			"country": "Australia",
+			"year": 2002,
+			"pop": 13177000,
+			"continent": "Oceania",
+			"lifeExp": 71.93,
+			"gdpPercap": 16788.62948
+		},
+		{
+			"country": "Austria",
+			"year": 2002,
+			"pop": 7914969,
+			"continent": "Europe",
+			"lifeExp": 76.04,
+			"gdpPercap": 27042.01868
+		},
+		{
+			"country": "Austria",
+			"year": 2001,
+			"pop": 7914969,
+			"continent": "Europe",
+			"lifeExp": 76.04,
+			"gdpPercap": 27042.01868
+		},
+	]
+
+	interface DataRow {
+		[key: string]: string | number;
+	}
+
+	function unpack(rows: DataRow[], key: string) {
+		return rows.map(function (row: DataRow) { return row[key]; });
+	}
+
 	const trace1 = {
-		x: [1999, 2000, 2001, 2002],
-		y: [10, 15, 13, 17],
-		type: 'scatter'
-	} as ScatterData;
+		mode: 'markers',
+		x: unpack(testrows, 'lifeExp'),
+		y: unpack(testrows, 'gdpPercap'),
+		text: unpack(testrows, 'continent'),
+		marker: {
+			size: unpack(testrows, 'pop'),
+			sizemode: "area",
+			sizeref: 200000
+		},
+		type: 'scatter',
+		transforms: [
+			{
+				type: 'filter',
+				target: unpack(testrows, 'year'),
+				operation: '=',
+				value: '2002'
+			}, {
+				type: 'groupby',
+				nameformat: `%{group}`,
+				groups: unpack(testrows, 'continent'),
+				styles: [
+					{ target: 'Asia', value: { marker: { color: 'red' } } },
+					{ target: 'Europe', value: { marker: { color: 'blue' } } },
+					{ target: 'Americas', value: { marker: { color: 'orange' } } },
+					{ target: 'Africa', value: { marker: { color: 'green' } } },
+					{ target: 'Oceania', value: { marker: { color: 'purple' } } }
+				]
+			}, {
+				type: 'aggregate',
+				groups: unpack(testrows, 'continent'),
+				aggregations: [
+					{ target: 'x', func: 'avg' },
+					{ target: 'y', func: 'avg' },
+					{ target: 'marker.size', func: 'sum' }
+				]
+			}]
+	} as PlotData;
 	const trace2 = {
-		x: [1999, 2000, 2001, 2002],
-		y: [16, 5, 11, 9],
-		type: 'scatter'
-	} as ScatterData;
-	const trace3 = {
 		yaxis: 'y2',
-		x: [1999, 2000, 2001, 2002],
+		x: unpack(testrows, 'lifeExp'),
 		name: 'x density',
 		marker: { color: 'rgb(102,0,0)' },
 		type: 'histogram'
 	} as PlotData;
-	const trace4 = {
+	const trace3 = {
 		xaxis: 'x2',
-		y: [16, 5, 11, 9],
+		y: unpack(testrows, 'gdpPercap'),
 		name: 'y density',
 		marker: { color: 'rgb(102,0,0)' },
 		type: 'histogram'
 	} as PlotData;
-	const data = [trace1, trace2, trace3, trace4];
+	const data = [trace1, trace2, trace3];
 	const layout = {
-		title: 'Sales Growth',
+		title: 'Gapminder',
 		xaxis: {
-			title: 'Year',
+			title: 'Life Expectancy',
 			domain: [0, 0.85],
 			showgrid: false,
 			zeroline: false
 		},
 		yaxis: {
-			title: 'Percent',
+			title: 'GDP per Cap',
 			showline: false,
 			domain: [0, 0.85],
 			showgrid: false,
@@ -66,7 +148,7 @@ const graphDiv = '#test';
 		x: [1999, 2000, 2001, 2002],
 		y: [10, 9, 8, 7],
 		type: 'scatter'
-	} as ScatterData];
+	} as PlotData];
 	const layout2 = { title: 'Revenue' };
 	Plotly.newPlot(graphDiv, data2, layout2);
 })();


### PR DESCRIPTION
I added `histogram` as a plot type option, and added support for D3 transforms, having more than one x axis, and fixed issues I had with plot selection data. 

I also changed `ScatterData` to `PlotData` since the way this ends up being used (like in react-plotly) the data can be for any type of plot, but I included `ScatterData` as a pointer to `PlotData` to keep it from being a breaking change. Same with `ScatterMarker`.  Let me know if I should just remove these and increase the version number. 

I was unsure what the two test files are for, they seemed pretty similar. Let me know if I should update both, or remove one. 

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: Adds typings for 
[transforms](https://plot.ly/javascript/multiple-transforms/)
[histogram subplots](https://plot.ly/javascript/2d-density-plots/)


- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.


