### PR TITLE
[chrome] Change chrome-cast's class-like interfaces to class definitions.

### DIFF
--- a/types/chrome/chrome-cast/index.d.ts
+++ b/types/chrome/chrome-cast/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for Chrome Cast application development
 // Project: https://developers.google.com/cast/
 // Definitions by: Thomas Stig Jacobsen <https://github.com/eXeDK>
+//                 Stefan Ullinger <https://github.com/stefanullinger>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 ////////////////////
@@ -194,7 +195,7 @@ declare namespace chrome.cast {
         errorCallback: (error: chrome.cast.Error) => void
     ): void
 
-    export interface ApiConfig {
+    export class ApiConfig {
         /**
          * @param {!chrome.cast.SessionRequest} sessionRequest
          * @param {function(!chrome.cast.Session)} sessionListener
@@ -205,13 +206,13 @@ declare namespace chrome.cast {
          * @constructor
          * @see https://developers.google.com/cast/docs/reference/chrome/chrome.cast.ApiConfig
          */
-        new(
+        constructor(
             sessionRequest: chrome.cast.SessionRequest,
             sessionListener: (session: chrome.cast.Session) => void,
             receiverListener: (receiverAvailability: chrome.cast.ReceiverAvailability) => void,
             autoJoinPolicy?: chrome.cast.AutoJoinPolicy,
             defaultActionPolicy?: chrome.cast.DefaultActionPolicy
-        ): ApiConfig;
+        );
 
         sessionRequest: chrome.cast.SessionRequest;
         sessionListener: (session: chrome.cast.Session) => void;
@@ -220,7 +221,7 @@ declare namespace chrome.cast {
         defaultActionPolicy: chrome.cast.DefaultActionPolicy;
     }
 
-    export interface Error {
+    export class Error {
         /**
          * @param {!chrome.cast.ErrorCode} code
          * @param {string=} opt_description
@@ -228,11 +229,11 @@ declare namespace chrome.cast {
          * @constructor
          * @see https://developers.google.com/cast/docs/reference/chrome/chrome.cast.Error
          */
-        new(
+        constructor(
             code: chrome.cast.ErrorCode,
             description?: string,
             details?: Object
-        ): Error;
+        );
 
         code: chrome.cast.ErrorCode;
         description?: string;
@@ -253,22 +254,22 @@ declare namespace chrome.cast {
         width?: number;
     }
 
-    export interface SenderApplication {
+    export class SenderApplication {
         /**
          * @param {!chrome.cast.SenderPlatform} platform
          * @constructor
          * @see https://developers.google.com/cast/docs/reference/chrome/chrome.cast.SenderApplication
          */
-        new(
+        constructor(
             platform: chrome.cast.SenderPlatform
-        ): SenderApplication;
+        );
 
         platform: chrome.cast.SenderPlatform;
         url?: string;
         packageId?: string;
     }
 
-    export interface SessionRequest {
+    export class SessionRequest {
         /**
          * @param {string} appId
          * @param {!Array<chrome.cast.Capability>=} opt_capabilities
@@ -276,11 +277,11 @@ declare namespace chrome.cast {
          * @constructor
          * @see https://developers.google.com/cast/docs/reference/chrome/chrome.cast.SessionRequest
          */
-        new(
+        constructor(
             appId: string,
             capabilities?: Array<chrome.cast.Capability>,
             timeout?: number
-        ): SessionRequest;
+        );
 
         appId: string;
         capabilities: Array<chrome.cast.Capability>;
@@ -288,7 +289,7 @@ declare namespace chrome.cast {
         language?: string;
     }
 
-    export interface Session {
+    export class Session {
         /**
          * @param {string} sessionId
          * @param {string} appId
@@ -298,13 +299,13 @@ declare namespace chrome.cast {
          * @constructor
          * @see https://developers.google.com/cast/docs/reference/chrome/chrome.cast.Session
          */
-        new(
+        constructor(
             sessionId: string,
             appId: string,
             displayName: string,
             appImages: Array<chrome.cast.Image>,
             receiver: chrome.cast.Receiver
-        ): Session;
+        );
 
         sessionId: string;
         appId: string;
@@ -438,7 +439,7 @@ declare namespace chrome.cast {
         ): void
     }
 
-    export interface Receiver {
+    export class Receiver {
         /**
          * @param {string} label
          * @param {string} friendlyName
@@ -447,12 +448,12 @@ declare namespace chrome.cast {
          * @constructor
          * @see https://developers.google.com/cast/docs/reference/chrome/chrome.cast.Receiver
          */
-        new(
+        constructor(
             label: string,
             friendlyName: string,
             capabilities?: Array<chrome.cast.Capability>,
             volume?: chrome.cast.Volume
-        ): Receiver;
+        );
 
         label: string;
         friendlyName: string;
@@ -462,33 +463,33 @@ declare namespace chrome.cast {
         displayStatus: chrome.cast.ReceiverDisplayStatus;
     }
 
-    export interface ReceiverDisplayStatus {
+    export class ReceiverDisplayStatus {
         /**
          * @param {string} statusText
          * @param {!Array<chrome.cast.Image>} appImages
          * @constructor
          * @see https://developers.google.com/cast/docs/reference/chrome/chrome.cast.ReceiverDisplayStatus
          */
-        new(
+        constructor(
             statusText: string,
             appImages: Array<chrome.cast.Image>
-        ): ReceiverDisplayStatus;
+        );
 
         statusText: string;
         appImages: Array<chrome.cast.Image>;
     }
 
-    export interface Volume {
+    export class Volume {
         /**
          * @param {?number=} opt_level
          * @param {?boolean=} opt_muted
          * @constructor
          * @see https://developers.google.com/cast/docs/reference/chrome/chrome.cast.Volume
          */
-        new(
+        constructor(
             level?: number,
             muted?: boolean
-        ): Volume;
+        );
 
         level?: number;
         muted?: boolean;
@@ -574,15 +575,15 @@ declare namespace chrome.cast.media {
         ALL_AND_SHUFFLE = "REPEAT_ALL_AND_SHUFFLE"
     }
 
-    export interface QueueItem {
+    export class QueueItem {
         /**
          * @param {!chrome.cast.media.MediaInfo} mediaInfo
          * @constructor
          * @see https://developers.google.com/cast/docs/reference/chrome/chrome.cast.media.QueueItem
          */
-        new(
+        constructor(
             mediaInfo: chrome.cast.media.MediaInfo
-        ): QueueItem;
+        );
 
         activeTrackIds: Array<Number>;
         autoplay: boolean;
@@ -593,15 +594,15 @@ declare namespace chrome.cast.media {
         startTime: number;
     }
 
-    export interface QueueLoadRequest {
+    export class QueueLoadRequest {
         /**
          * @param {!Array<chrome.cast.media.QueueItem>} items
          * @constructor
          * @see https://developers.google.com/cast/docs/reference/chrome/chrome.cast.media.QueueLoadRequest
          */
-        new(
+        constructor(
             items: Array<chrome.cast.media.QueueItem>
-        ): QueueLoadRequest;
+        );
 
         customData: Object;
         items: Array<chrome.cast.media.QueueItem>;
@@ -609,59 +610,59 @@ declare namespace chrome.cast.media {
         startIndex: number;
     }
 
-    export interface QueueInsertItemsRequest {
+    export class QueueInsertItemsRequest {
         /**
          * @param {!Array<chrome.cast.media.QueueItem>}
          * @constructor
          * @see https://developers.google.com/cast/docs/reference/chrome/chrome.cast.media.QueueInsertItemsRequest
          */
-        new(
+        constructor(
             itemsToInsert: Array<chrome.cast.media.QueueItem>
-        ): QueueInsertItemsRequest;
+        );
 
         customData: Object;
         insertBefore: number;
         items: Array<chrome.cast.media.QueueItem>;
     }
 
-    export interface QueueRemoveItemsRequest {
+    export class QueueRemoveItemsRequest {
         /**
          * @param {!Array<number>}
          * @constructor
          * @see https://developers.google.com/cast/docs/reference/chrome/chrome.cast.media.QueueRemoveItemsRequest
          */
-        new(
+        constructor(
             itemIdsToRemove: Array<number>
-        ): QueueRemoveItemsRequest;
+        );
 
         customData: Object;
         itemIds: Array<number>;
     }
 
-    export interface QueueReorderItemsRequest {
+    export class QueueReorderItemsRequest {
         /**
          * @param {!Array<number>}
          * @constructor
          * @see https://developers.google.com/cast/docs/reference/chrome/chrome.cast.media.QueueReorderItemsRequest
          */
-        new(
+        constructor(
             itemIdsToReorder: Array<number>
-        ): QueueReorderItemsRequest;
+        );
 
         customData: Object;
         insertBefore: number;
         itemIds: Array<number>;
     }
 
-    export interface QueueUpdateItemsRequest {
+    export class QueueUpdateItemsRequest {
         /**
          * @param {!Array<chrome.cast.media.QueueItem>}
          * @constructor
          * @see https://developers.google.com/cast/docs/reference/chrome/chrome.cast.media.QueueUpdateItemsRequest
          */
-        new(
+        constructor(
             itemsToUpdate: Array<chrome.cast.media.QueueItem>
-        ): QueueUpdateItemsRequest;
+        );
 
         customData: Object;
         item: Array<chrome.cast.media.QueueItem>;
@@ -736,67 +737,67 @@ declare namespace chrome.cast.media {
         ITALIC = "ITALIC"
     }
 
-    export interface GetStatusRequest {
+    export class GetStatusRequest {
         /**
          * @constructor
          * @see https://developers.google.com/cast/docs/reference/chrome/chrome.cast.media.GetStatusRequest
          */
-        new(): GetStatusRequest;
+        constructor();
 
         customData: Object;
     }
 
-    export interface PauseRequest {
+    export class PauseRequest {
         /**
          * @constructor
          * @see https://developers.google.com/cast/docs/reference/chrome/chrome.cast.media.PauseRequest
          */
-        new(): PauseRequest;
+        constructor();
 
         customData: Object;
     }
 
-    export interface PlayRequest {
+    export class PlayRequest {
         /**
          * @constructor
          * @see https://developers.google.com/cast/docs/reference/chrome/chrome.cast.media.PlayRequest
          */
-        new(): PlayRequest;
+        constructor();
 
         customData: Object;
     }
 
-    export interface SeekRequest {
+    export class SeekRequest {
         /**
          * @constructor
          * @see https://developers.google.com/cast/docs/reference/chrome/chrome.cast.media.SeekRequest
          */
-        new(): SeekRequest;
+        constructor();
 
         currentTime: number;
         resumeState: chrome.cast.media.ResumeState;
         customData: Object;
     }
 
-    export interface StopRequest {
+    export class StopRequest {
         /**
          * @constructor
          * @see https://developers.google.com/cast/docs/reference/chrome/chrome.cast.media.StopRequest
          */
-        new(): StopRequest;
+        constructor();
 
         customData: Object;
     }
 
-    export interface VolumeRequest {
+    export class VolumeRequest {
         /**
          * @param {!chrome.cast.Volume} volume
          * @constructor
          * @see https://developers.google.com/cast/docs/reference/chrome/chrome.cast.media.VolumeRequest
          */
-        new(
+        constructor(
             volume: chrome.cast.Volume
-        ): VolumeRequest;
+        );
 
         volume: chrome.cast.Volume;
         customData: Object;
@@ -819,17 +820,17 @@ declare namespace chrome.cast.media {
         media: chrome.cast.media.MediaInfo;
     }
 
-    export interface EditTracksInfoRequest {
+    export class EditTracksInfoRequest {
         /**
          * @param {Array<number>=} opt_activeTrackIds
          * @param {chrome.cast.media.TextTrackStyle=} opt_textTrackStyle
          * @constructor
          * @see https://developers.google.com/cast/docs/reference/chrome/chrome.cast.media.EditTracksInfoRequest
          */
-        new(
+        constructor(
             activeTrackIds?: Array<number>,
             textTrackStyle?: chrome.cast.media.TextTrackStyle
-        ): EditTracksInfoRequest;
+        );
 
         activeTrackIds: Array<number>;
         textTrackStyle: chrome.cast.media.TextTrackStyle;
@@ -847,12 +848,12 @@ declare namespace chrome.cast.media {
         type: chrome.cast.media.MetadataType;
     }
 
-    export interface MovieMediaMetadata {
+    export class MovieMediaMetadata {
         /**
          * @constructor
          * @see https://developers.google.com/cast/docs/reference/chrome/chrome.cast.media.MovieMediaMetadata
          */
-        new(): MovieMediaMetadata;
+        constructor();
 
         images: Array<chrome.cast.Image>;
         metadataType: chrome.cast.media.MetadataType;
@@ -866,12 +867,12 @@ declare namespace chrome.cast.media {
         type: chrome.cast.media.MetadataType;
     }
 
-    export interface TvShowMediaMetadata {
+    export class TvShowMediaMetadata {
         /**
          * @constructor
          * @see https://developers.google.com/cast/docs/reference/chrome/chrome.cast.media.TvShowMediaMetadata
          */
-        new(): TvShowMediaMetadata;
+        constructor();
 
         metadataType: chrome.cast.media.MetadataType;
         seriesTitle: string;
@@ -893,12 +894,12 @@ declare namespace chrome.cast.media {
         releaseYear: number;
     }
 
-    export interface MusicTrackMediaMetadata {
+    export class MusicTrackMediaMetadata {
         /**
          * @constructor
          * @see https://developers.google.com/cast/docs/reference/chrome/chrome.cast.media.MusicTrackMediaMetadata
          */
-        new(): MusicTrackMediaMetadata;
+        constructor();
 
         metadataType: chrome.cast.media.MetadataType;
         albumName: string;
@@ -920,12 +921,12 @@ declare namespace chrome.cast.media {
         releaseYear: number;
     }
 
-    export interface PhotoMediaMetadata {
+    export class PhotoMediaMetadata {
         /**
          * @constructor
          * @see https://developers.google.com/cast/docs/reference/chrome/chrome.cast.media.PhotoMediaMetadata
          */
-        new(): PhotoMediaMetadata;
+        constructor();
 
         metadataType: chrome.cast.media.MetadataType;
         title: string;
@@ -964,17 +965,17 @@ declare namespace chrome.cast.media {
         customData: Object;
     }
 
-    export interface Media {
+    export class Media {
         /**
          * @param {string} sessionId
          * @param {number} mediaSessionId
          * @constructor
          * @see https://developers.google.com/cast/docs/reference/chrome/chrome.cast.media.Media
          */
-        new(
+        constructor(
             sessionId: string,
             mediaSessionId: number
-        ): Media;
+        );
 
         activeTrackIds: Array<number>;
         currentItemId: number;
@@ -1210,17 +1211,17 @@ declare namespace chrome.cast.media {
 
     }
 
-    export interface Track {
+    export class Track {
         /**
          * @param {number} trackId
          * @param {!chrome.cast.media.TrackType} trackType
          * @constructor
          * @see https://developers.google.com/cast/docs/reference/chrome/chrome.cast.media.Track
          */
-        new(
+        constructor(
             trackId: number,
             trackType: chrome.cast.media.TrackType
-        ): Track;
+        );
 
         trackId: number;
         trackContentId: string;
@@ -1232,12 +1233,12 @@ declare namespace chrome.cast.media {
         customData: Object;
     }
 
-    export interface TextTrackStyle {
+    export class TextTrackStyle {
         /**
          * @constructor
          * @see https://developers.google.com/cast/docs/reference/chrome/chrome.cast.media.TextTrackStyle
          */
-        new(): TextTrackStyle;
+        constructor();
 
         foregroundColor: string;
         backgroundColor: string;


### PR DESCRIPTION
**TL;DR**: This avoids TS2339 when calling the constructor of these classes, e.g.
`new chrome.cast.SessionRequest(...)`.

**Issue Description:**

I ran into an issue when trying to use the existing chrome-cast type definitions. I wanted to create new instances of `chrome.cast.SessionRequest` and `chrome.cast.ApiConfig`, but the compiler returned with the following errors:

```
TS2339: Property 'SessionRequest' does not exist on type 'typeof cast'.
TS2339: Property 'ApiConfig' does not exist on type 'typeof cast'.
```

I figured out that this is because theses classes are currently defined as class-like interfaces and thus can not be instantiated. My changes are fixing this issue for me.




Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.typescriptlang.org/docs/handbook/declaration-files/templates/module-class-d-ts.html, https://developers.google.com/cast/docs/reference/chrome/
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.