### PR TITLE
Basic support for typed "this" in Widget Factory

### DIFF
--- a/types/jqueryui/index.d.ts
+++ b/types/jqueryui/index.d.ts
@@ -1071,6 +1071,17 @@ declare namespace JQueryUI {
         show?: any;
     }
 
+    interface WidgetCommonProperties {
+        element: JQuery;
+        defaultElement : string;
+        document: Document;
+        namespace: string;
+        uuid: string;
+        widgetEventPrefix: string;
+        widgetFullName: string;
+        window: Window;
+    }
+
     interface Widget {
         (methodName: string): JQuery;
         (options: WidgetOptions): JQuery;
@@ -1079,8 +1090,8 @@ declare namespace JQueryUI {
         (optionLiteral: string, options: WidgetOptions): any;
         (optionLiteral: string, optionName: string, optionValue: any): JQuery;
 
-        (name: string, prototype: any): JQuery;
-        (name: string, base: Function, prototype: any): JQuery;
+        <T>(name: string, prototype: T & ThisType<T & WidgetCommonProperties>): JQuery;
+        <T>(name: string, base: Function, prototype: T & ThisType<T & WidgetCommonProperties> ): JQuery;
     }
 
     ////////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This change provides very basic support for typed `this` parameter used in functions provided to [Widget Factory](https://learn.jquery.com/jquery-ui/widget-factory/how-to-use-the-widget-factory/).

Now people who use "noImplicitThis" compiler option can have this kind of code checked.

```ts
$.widget('custom.progressbar', {
  // Default options.
  options: {
    value: 0
  },
  _create: function() {
    var progress = this.options.value + '%';
    this.element.addClass('progressbar').text(progress);
  }
});
```

This is not a breaking change for people who don't use "noImplicitThis" option. Those who use this option already had compiler errors and needed to tell this type explicitly, like here

```ts
$.widget('custom.progressbar', {
  options: {
    value: 0
  },
  _create: function(this: { element: JQuery; options: { value: number } }) {
    var progress = this.options.value + '%';
    this.element.addClass('progressbar').text(progress);
  }
});
```
for those people there is also nothing breaking, they can just get rid of this type annotation.

This is small improvement, I had it in my code where we had couple of JQuery UI widgets and I want to switch to Typescript with "strict" compiler switch on. We basically used only `this.element`, no any other properties or methods of base widget (like `_trigger`, `_super`, `_on` etc).

It would be great if this type definitions worked for more use cases with _noImplicitThis_ flag. Now when you turn it on, the tests have many errors. However this would be much bigger change, maybe worth considering to do in the future. So I think this PR is good first step into this direction :)

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.