### PR TITLE
[googlemaps] add missing "fields" + getters/setters to googlemaps places service

### DIFF
--- a/types/googlemaps/googlemaps-tests.ts
+++ b/types/googlemaps/googlemaps-tests.ts
@@ -438,3 +438,16 @@ service.findPlaceFromQuery({
 
     results[0].name; // $ExpectType string
 });
+
+var input = document.getElementById('searchTextField');
+var options: google.maps.places.AutocompleteOptions = {
+  types: ['establishment'],
+  fields: ['formatted_address', 'id'],
+};
+
+let autocomplete = new google.maps.places.Autocomplete(new HTMLInputElement(), options);
+
+autocomplete.getFields();
+autocomplete.setFields();
+autocomplete.setFields(['formatted_phone_number']);
+

--- a/types/googlemaps/index.d.ts
+++ b/types/googlemaps/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Google Maps JavaScript API 3.30
+// Type definitions for Google Maps JavaScript API 3.34
 // Project: https://developers.google.com/maps/
 // Definitions by:  Folia A/S <http://www.folia.dk>,
 //                  Chris Wrench <https://github.com/cgwrench>,

--- a/types/googlemaps/index.d.ts
+++ b/types/googlemaps/index.d.ts
@@ -10,6 +10,7 @@
 //                  Sven Kreiss <https://github.com/svenkreiss>
 //                  Umar Bolatov <https://github.com/bolatovumar>
 //                  Michael Gauthier <https://github.com/gauthierm>
+//                  Derek Sifford <https://github.com/dsifford>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /*
@@ -2477,8 +2478,10 @@ declare namespace google.maps {
         export class Autocomplete extends MVCObject {
             constructor(inputField: HTMLInputElement, opts?: AutocompleteOptions);
             getBounds(): LatLngBounds;
+            getFields(): Array<keyof PlaceResult> | undefined;
             getPlace(): PlaceResult;
             setBounds(bounds: LatLngBounds|LatLngBoundsLiteral): void;
+            setFields(fields?: Array<keyof PlaceResult>): void;
             setComponentRestrictions(restrictions: ComponentRestrictions): void;
             setTypes(types: string[]): void;
         }
@@ -2486,6 +2489,7 @@ declare namespace google.maps {
         export interface AutocompleteOptions  {
             bounds?: LatLngBounds|LatLngBoundsLiteral;
             componentRestrictions?: ComponentRestrictions;
+            fields?: Array<keyof PlaceResult>
             placeIdOnly?: boolean;
             strictBounds?: boolean;
             types?: string[];


### PR DESCRIPTION
**Note:** Tests and lints failed prior to making any changes for me on legacy TS versions. So, not sure what the protocol is for these types of situations.


Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developers.google.com/maps/documentation/javascript/reference/places-widget
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.