### PR TITLE
react-bootstrap: Allow interval prop to be null

### DIFF
--- a/types/react-bootstrap/lib/Carousel.d.ts
+++ b/types/react-bootstrap/lib/Carousel.d.ts
@@ -12,7 +12,7 @@ declare namespace Carousel {
         defaultActiveIndex?: number;
         direction?: string;
         indicators?: boolean;
-        interval?: number;
+        interval?: number | null;
         nextIcon?: React.ReactNode;
         onSelect?: SelectCallback;
         // TODO: Add more specific type


### PR DESCRIPTION
The react-bootstrap docs state that the interval prop on a Carousel can
be null. In this state, a Carousel will not automatically cycle through
its items. Tested locally.

https://react-bootstrap.github.io/components/carousel/#carousels-props-carousel

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.