### PR TITLE
[Sequelize] Add Partial<> to Model#build

### DIFF
--- a/types/sequelize/index.d.ts
+++ b/types/sequelize/index.d.ts
@@ -3986,12 +3986,12 @@ declare namespace sequelize {
         /**
          * Builds a new model instance. Values is an object of key value pairs, must be defined but can be empty.
          */
-        build(record?: TAttributes, options?: BuildOptions): TInstance;
+        build(record?: Partial<TAttributes>, options?: BuildOptions): TInstance;
 
         /**
          * Undocumented bulkBuild
          */
-        bulkBuild(records: TAttributes[], options?: BuildOptions): TInstance[];
+        bulkBuild(records: Partial<TAttributes>[], options?: BuildOptions): TInstance[];
 
         /**
          * Builds a new model instance and calls save on it.


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://docs.sequelizejs.com/manual/tutorial/instances.html#building-a-non-persistent-instance
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

---

It’s not explicitly documented, but `.build()` allow passing models with absent fields. Models don’t get validated until `.save()` is called. I’ve been using this fact to write code like this:

```js
const book = Book.build({
  name: name,
  author: author,
  // Skips a required field `coverColor`
});
book.coverColor = calculateCoverColor(book.id);
await book.save();
```

This PR changes `TAttributes` to `Partial<TAttributes>` to allow this in TypeScript.