### PR TITLE
set-cookie-parser: add missing splitCookiesString function

### DIFF
--- a/types/set-cookie-parser/index.d.ts
+++ b/types/set-cookie-parser/index.d.ts
@@ -8,10 +8,12 @@
 declare module "set-cookie-parser" {
     import http = require("http");
 
-    function SetCookieParser(input: string | string[] | http.IncomingMessage): SetCookieParser.Cookie[];
+    function SetCookieParser(input: string | ReadonlyArray<string> | http.IncomingMessage): SetCookieParser.Cookie[];
 
     namespace SetCookieParser {
-        function parse(input: string | string[] | http.IncomingMessage): Cookie[];
+        function parse(input: string | ReadonlyArray<string> | http.IncomingMessage): Cookie[];
+
+        function splitCookiesString(input: string | ReadonlyArray<string> | void): string[];
 
         interface Cookie {
             name: string;

--- a/types/set-cookie-parser/set-cookie-parser-tests.ts
+++ b/types/set-cookie-parser/set-cookie-parser-tests.ts
@@ -65,3 +65,26 @@ var optionalIncludedCookie: setCookie.Cookie = {
     httpOnly: true,
     secure: true
 };
+
+var cookiesString = setCookie.splitCookiesString(null)
+assert.deepStrictEqual(cookiesString, [])
+
+cookiesString = setCookie.splitCookiesString([])
+assert.deepStrictEqual(cookiesString, [])
+
+cookiesString = setCookie.splitCookiesString([
+    'foo=bar; Max-Age=1000; Domain=.example.com; Path=/; Expires=Tue, 01 Jul 2025 10:01:11 GMT; HttpOnly; Secure',
+    'baz=buz; Max-Age=1000; Domain=.example.com; Path=/; Expires=Tue, 01 Jul 2025 10:01:11 GMT; HttpOnly; Secure',
+])
+assert.deepStrictEqual(cookiesString, [
+    'foo=bar; Max-Age=1000; Domain=.example.com; Path=/; Expires=Tue, 01 Jul 2025 10:01:11 GMT; HttpOnly; Secure',
+    'baz=buz; Max-Age=1000; Domain=.example.com; Path=/; Expires=Tue, 01 Jul 2025 10:01:11 GMT; HttpOnly; Secure',
+])
+
+cookiesString = setCookie.splitCookiesString(
+    'foo=bar; Max-Age=1000; Domain=.example.com; Path=/; Expires=Tue, 01 Jul 2025 10:01:11 GMT; HttpOnly; Secure, baz=buz; Max-Age=1000; Domain=.example.com; Path=/; Expires=Tue, 01 Jul 2025 10:01:11 GMT; HttpOnly; Secure',
+)
+assert.deepStrictEqual(cookiesString, [
+    'foo=bar; Max-Age=1000; Domain=.example.com; Path=/; Expires=Tue, 01 Jul 2025 10:01:11 GMT; HttpOnly; Secure',
+    'baz=buz; Max-Age=1000; Domain=.example.com; Path=/; Expires=Tue, 01 Jul 2025 10:01:11 GMT; HttpOnly; Secure',
+])


### PR DESCRIPTION
URL to documentation (usage example): https://github.com/nfriedly/set-cookie-parser#usage-in-react-native
URL to source code: https://github.com/nfriedly/set-cookie-parser/blob/852ba52dcacaf47728c015c7442558f7cff0c785/lib/set-cookie.js#L87

I also changed some `string[]` arguments to `ReadonlyArray<string>`, as per the [common mistake](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes) rules.