### PR TITLE
doubleclick-gpt: Update to v238 - Add enableLazyLoad & setTagForUnderAgeOfConsent

### DIFF
--- a/types/doubleclick-gpt/doubleclick-gpt-tests.ts
+++ b/types/doubleclick-gpt/doubleclick-gpt-tests.ts
@@ -69,6 +69,10 @@ googletag.pubads().definePassback("/1234567/sports", [468, 60])
         .setTagForChildDirectedTreatment(1)
         .display();
 
+googletag.pubads().definePassback('/1234567/sports', [468, 60])
+        .setTagForUnderAgeOfConsent(1)
+        .display();
+
 googletag.pubads().definePassback("/1234567/sports", [468, 60]).
         setTargeting("color", "red").
         setTargeting("sport", ["rugby", "rowing"]).
@@ -78,6 +82,13 @@ googletag.pubads().definePassback("/1234567/sports", [160, 600]).
     updateTargetingFromMap({"color": "red",
                                                     "interests": ["sports", "music", "movies"]}).
             display();
+
+googletag.pubads().enableLazyLoad();
+googletag.pubads().enableLazyLoad({
+    fetchMarginPercent: 500,
+    renderMarginPercent: 200,
+    mobileScaling: 2.0
+});
 
 // The calls to construct an ad and display contents.
 slot1 = googletag.pubads().display("/1234567/sports", [728, 90], "div-1");
@@ -106,6 +117,13 @@ googletag.pubads().setTagForChildDirectedTreatment(1);
 
 // Clear child-directed setting and return to initial not-set value.
 googletag.pubads().clearTagForChildDirectedTreatment();
+
+// Mark ad requests as coming from users under the age of consent.
+googletag.pubads().setTagForUnderAgeOfConsent(1);
+
+// Clear the tag value that configures whether to mark ad requests as
+// coming from users under the age of consent.
+googletag.pubads().setTagForUnderAgeOfConsent();
 
 googletag.pubads().setTargeting("interests", "sports");
 googletag.pubads().setTargeting("colors", "blue");

--- a/types/doubleclick-gpt/index.d.ts
+++ b/types/doubleclick-gpt/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Google Publisher Tag v199
+// Type definitions for Google Publisher Tag v238
 // Project: https://developers.google.com/doubleclick-gpt/reference
 // Definitions by: John Wright <https://github.com/johngeorgewright>
 //                 Steven Joyce <https://github.com/steven-joyce>
@@ -38,6 +38,12 @@ declare namespace googletag {
 
     export interface ContentService extends Service {
         setContent(slot: Slot, content: String): void;
+    }
+
+    export interface LazyLoadOptionsConfig {
+        fetchMarginPercent?: number,
+        renderMarginPercent?: number,
+        mobileScaling?: number
     }
 
     export interface ResponseInformation {
@@ -101,6 +107,7 @@ declare namespace googletag {
         setClickUrl(url: string): PassbackSlot;
         setForceSafeFrame(forceSafeFrame: boolean): PassbackSlot;
         setTagForChildDirectedTreatment(value: number): PassbackSlot;
+        setTagForUnderAgeOfConsent(value: number): PassbackSlot;
         setTargeting(key: string, value: string | string[]): PassbackSlot;
         updateTargetingFromMap(map: Object): PassbackSlot;
     }
@@ -116,6 +123,7 @@ declare namespace googletag {
         disableInitialLoad(): void;
         display(adUnitPath: string, size: GeneralSize, opt_div?: string | Element, opt_clickUrl?: string): Slot;
         enableAsyncRendering(): boolean;
+        enableLazyLoad(opt_config?: LazyLoadOptionsConfig): void;
         enableSingleRequest(): boolean;
         enableSyncRendering(): boolean;
         enableVideoAds(): void;
@@ -134,6 +142,7 @@ declare namespace googletag {
         setRequestNonPersonalizedAds(nonPersonalizedAds: 0 | 1): PubAdsService;
         setSafeFrameConfig(config: SafeFrameConfig): PubAdsService;
         setTagForChildDirectedTreatment(value: number): PubAdsService;
+        setTagForUnderAgeOfConsent(opt_value?: number): PubAdsService;
         setTargeting(key: string, value: string | string[]): PubAdsService;
         setVideoContent(videoContentId: string, videoCmsId: string): void;
         updateCorrelator(): PubAdsService;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
https://developers.google.com/doubleclick-gpt/versions <- Version 119 -> 238 update, where added functions are: enableLazyLoad & setTagForUnderAgeOfConsent
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.


