### PR TITLE
sinon: Allow stubbed instance with private constructors

### DIFF
--- a/types/sinon/index.d.ts
+++ b/types/sinon/index.d.ts
@@ -1409,9 +1409,7 @@ declare namespace Sinon {
      *
      * @template TType Type being stubbed.
      */
-    interface StubbableType<TType> {
-        new(...args: any[]): TType;
-    }
+    type StubbableType<TType> = Function & { prototype: TType };
 
     /**
      * An instance of a stubbed object type with functions replaced by stubs.

--- a/types/sinon/sinon-tests.ts
+++ b/types/sinon/sinon-tests.ts
@@ -67,14 +67,26 @@ function testSandbox() {
     sb.replaceSetter(replaceMe, 'setter', (v) => { });
 
     const cls = class {
-        foo() {}
+        foo() { }
         bar: number;
+    };
+    const PrivateFoo = class {
+        private constructor() { }
+        foo() { }
+        bar: number;
+        static create() {
+            return new PrivateFoo();
+        }
     };
 
     const stubInstance = sb.createStubInstance(cls);
+    const privateFooStubbedInstance = sb.createStubInstance(PrivateFoo);
     stubInstance.foo.calledWith('foo');
+    privateFooStubbedInstance.foo.calledWith('foo');
     const clsFoo: sinon.SinonStub = stubInstance.foo;
+    const privateFooFoo: sinon.SinonStub = privateFooStubbedInstance.foo;
     const clsBar: number = stubInstance.bar;
+    const privateFooBar: number = privateFooStubbedInstance.bar;
 }
 
 function testFakeServer() {
@@ -106,7 +118,7 @@ function testXHR() {
 
     sinon.FakeXMLHttpRequest.useFilters = true;
     sinon.FakeXMLHttpRequest.addFilter((method, url, async, user, pass) => true);
-    sinon.FakeXMLHttpRequest.onCreate = (xhr) => {};
+    sinon.FakeXMLHttpRequest.onCreate = (xhr) => { };
     sinon.FakeXMLHttpRequest.restore();
 }
 
@@ -117,7 +129,7 @@ function testClock() {
     let now = 0;
     now = clock.now;
 
-    const fn = () => {};
+    const fn = () => { };
 
     clock.setTimeout(fn, 0);
     clock.setTimeout(fn, 0, 'a', 'b');
@@ -173,7 +185,7 @@ function testExpectation() {
 
 function testMatch() {
     const obj = {};
-    const fn = () => {};
+    const fn = () => { };
 
     sinon.match(5).test(5);
     sinon.match('str').test('foo');
@@ -216,7 +228,7 @@ function testMatch() {
 }
 
 function testFake() {
-    const fn = () => {};
+    const fn = () => { };
     let fake = sinon.fake();
 
     fake = sinon.fake(() => true);
@@ -277,9 +289,9 @@ function testAssert() {
 }
 
 function testSpy() {
-    const fn = () => {};
+    const fn = () => { };
     const obj = class {
-        foo() {}
+        foo() { }
     };
     const instance = new obj();
 
@@ -369,14 +381,14 @@ function testSpy() {
 
 function testStub() {
     const obj = class {
-        foo() {}
+        foo() { }
     };
     const instance = new obj();
 
     let stub = sinon.stub();
     stub = sinon.stub(instance, 'foo');
 
-	const spy: sinon.SinonSpy = stub;
+    const spy: sinon.SinonSpy = stub;
 
     sinon.stub(instance);
 
@@ -408,9 +420,9 @@ function testStub() {
     stub.callsArgOnAsync(1, instance);
     stub.callsArgWithAsync(1, 'a', 2);
     stub.callsArgOnWithAsync(1, instance, 'a', 2);
-    stub.callsFake(() => {});
+    stub.callsFake(() => { });
     stub.get(() => true);
-    stub.set((v) => {});
+    stub.set((v) => { });
     stub.onCall(1).returns(true);
     stub.onFirstCall().resolves('foo');
     stub.onSecondCall().resolves('foo');


### PR DESCRIPTION
Allow `createStubInstance` to create instances of classes with a private constructor. The way I understand it is that the intersection type `Function & { prototype: TType }` can be used for a class. If you disagree, please enlighten me.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://sinonjs.org/releases/v6.1.5/utils/#sinoncreatestubinstanceconstructor
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
