### PR TITLE
@types/nested-error-stacks Added typings for nested-error-stacks

### DIFF
--- a/types/nested-error-stacks/index.d.ts
+++ b/types/nested-error-stacks/index.d.ts
@@ -3,6 +3,8 @@
 // Definitions by: Wouter van Heeswijk <https://github.com/woutervh->
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-export default class NestedError extends Error {
+declare class NestedError extends Error {
     constructor(message?: any, nested?: Error);
 }
+
+export = NestedError;

--- a/types/nested-error-stacks/index.d.ts
+++ b/types/nested-error-stacks/index.d.ts
@@ -1,0 +1,10 @@
+// Type definitions for nested-error-stacks 2.1.0
+// Project: https://github.com/mdlavin/nested-error-stacks
+// Definitions by: Wouter van Heeswijk <https://github.com/woutervh->
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare module 'nested-error-stacks' {
+    export default class NestedError extends Error {
+        constructor(message?: any, nested?: Error);
+    }
+}

--- a/types/nested-error-stacks/index.d.ts
+++ b/types/nested-error-stacks/index.d.ts
@@ -1,10 +1,8 @@
-// Type definitions for nested-error-stacks 2.1.0
+// Type definitions for nested-error-stacks 2.1
 // Project: https://github.com/mdlavin/nested-error-stacks
 // Definitions by: Wouter van Heeswijk <https://github.com/woutervh->
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare module 'nested-error-stacks' {
-    export default class NestedError extends Error {
-        constructor(message?: any, nested?: Error);
-    }
+export default class NestedError extends Error {
+    constructor(message?: any, nested?: Error);
 }

--- a/types/nested-error-stacks/nested-error-stacks-tests.ts
+++ b/types/nested-error-stacks/nested-error-stacks-tests.ts
@@ -1,0 +1,7 @@
+import NestedErrorStacks from 'nested-error-stacks';
+
+const error = new NestedErrorStacks('Top level error', new Error('Nested error'));
+console.log(error);
+console.log(error.message);
+console.log(error.name);
+console.log(error.stack);

--- a/types/nested-error-stacks/nested-error-stacks-tests.ts
+++ b/types/nested-error-stacks/nested-error-stacks-tests.ts
@@ -1,7 +1,6 @@
 import NestedErrorStacks from 'nested-error-stacks';
 
 const error = new NestedErrorStacks('Top level error', new Error('Nested error'));
-console.log(error);
-console.log(error.message);
-console.log(error.name);
-console.log(error.stack);
+const message = error.message;
+const name = error.name;
+const stack = error.stack;

--- a/types/nested-error-stacks/nested-error-stacks-tests.ts
+++ b/types/nested-error-stacks/nested-error-stacks-tests.ts
@@ -1,4 +1,4 @@
-import NestedErrorStacks from 'nested-error-stacks';
+import NestedErrorStacks = require('nested-error-stacks');
 
 const error = new NestedErrorStacks('Top level error', new Error('Nested error'));
 const message = error.message;

--- a/types/nested-error-stacks/tsconfig.json
+++ b/types/nested-error-stacks/tsconfig.json
@@ -12,7 +12,7 @@
         "typeRoots": [
             "../"
         ],
-        "types": ["node"],
+        "types": [],
         "noEmit": true,
         "forceConsistentCasingInFileNames": true
     },

--- a/types/nested-error-stacks/tsconfig.json
+++ b/types/nested-error-stacks/tsconfig.json
@@ -6,7 +6,8 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
-        "strict": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
         "baseUrl": "../",
         "typeRoots": [
             "../"

--- a/types/nested-error-stacks/tsconfig.json
+++ b/types/nested-error-stacks/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strict": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": ["node"],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "nested-error-stacks-tests.ts"
+    ]
+}

--- a/types/nested-error-stacks/tslint.json
+++ b/types/nested-error-stacks/tslint.json
@@ -1,0 +1,3 @@
+{
+	"extends": "dtslint/dt.json"
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
