### PR TITLE
changes 'toposort' typing to not use 'default'

### DIFF
--- a/types/toposort/index.d.ts
+++ b/types/toposort/index.d.ts
@@ -3,4 +3,4 @@
 // Definitions by: Daniel Byrne <https://github.com/danwbyrne>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-export default function toposort(graph: ReadonlyArray<[string, string]>): ReadonlyArray<string>;
+export function toposort(graph: ReadonlyArray<[string, string]>): ReadonlyArray<string>;

--- a/types/toposort/toposort-tests.ts
+++ b/types/toposort/toposort-tests.ts
@@ -1,18 +1,9 @@
-import toposort from 'toposort';
+import { toposort } from 'toposort';
 
 const testGraph: ReadonlyArray<[string, string]> = [
-  [
-    'string1',
-    'string2',
-  ],
-  [
-    'string2',
-    'string3',
-  ],
-  [
-    'string3',
-    'string1',
-  ],
+    ["string1", "string2"],
+    ["string2", "string3"],
+    ["string3", "string1"]
 ];
 
 // $ExpectType ReadonlyArray<string>


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

As @armanio123 pointed out to me here: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/28433#discussion_r213150518, if the library doesn't use `export default` than neither should the typings. This fixes that.