### PR TITLE
uuid: Revert "added uuid v5 to uuidStatic List (#20634)"

### DIFF
--- a/types/uuid/index.d.ts
+++ b/types/uuid/index.d.ts
@@ -10,12 +10,11 @@
 // because of the existing uuid-js npm types package being at 3.3.28,
 // meaning that `npm install @types/uuid` was installing the typings for uuid-js, not this
 
-import { v1, v4, v5 } from './interfaces';
+import { v1, v4 } from './interfaces';
 
 interface UuidStatic {
     v1: v1;
     v4: v4;
-    v5: v5;
 }
 
 declare const uuid: UuidStatic & v4;


### PR DESCRIPTION
This reverts commit ce9e109a99b10ed1235b53ed990b6088a4e9f531.

AFAICT, the `uuid` module never exported `v5`.  See
https://stackoverflow.com/questions/52048772 .

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.) (Consider [this](https://stackoverflow.com/questions/52048772) a test, even though it wasn't done by me.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.) (N/A: The removed functionality was untested.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/kelektiv/node-uuid/blob/master/index.js (Look, v5 is not exported!)
- [X] Increase the version number in the header if appropriate. (Not applicable?)
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. (Already there)
