### PR TITLE
Fix scoping of chromecast-caf-receiver to be a global const (since the cast sdk is loaded from a script tag)

### DIFF
--- a/types/chromecast-caf-receiver/cast.framework.breaks.d.ts
+++ b/types/chromecast-caf-receiver/cast.framework.breaks.d.ts
@@ -1,15 +1,15 @@
-import { Break, BreakClip } from "./cast.framework.messages";
+import messages from "./cast.framework.messages";
 
-export = cast.framework.breaks;
+export default Breaks;
 
-declare namespace cast.framework.breaks {
+declare namespace Breaks {
     class BreakSeekData {
-        constructor(seekFrom: number, seekTo: number, breaks: Break[]);
+        constructor(seekFrom: number, seekTo: number, breaks: messages.Break[]);
 
         /**
          * List of breaks
          */
-        breaks: Break[];
+        breaks: messages.Break[];
 
         /**
          * Current playback time
@@ -24,12 +24,12 @@ declare namespace cast.framework.breaks {
 
     /** Provide context information for break clip load interceptor. */
     class BreakClipLoadInterceptorContext {
-        constructor(brk: Break);
+        constructor(brk: messages.Break);
 
         /**
          * The container break for the break clip
          */
-        break: Break;
+        break: messages.Break;
     }
 
     /** Interface to manage breaks */
@@ -37,18 +37,18 @@ declare namespace cast.framework.breaks {
         /**
          * Get current media break by id.
          */
-        getBreakById(id: string): Break;
+        getBreakById(id: string): messages.Break;
 
         /**
          * Get current media break clip by id
          */
-        getBreakClipById(id: string): BreakClip;
+        getBreakClipById(id: string): messages.BreakClip;
 
         /** Get current media break clips. */
-        getBreakClips(): BreakClip[];
+        getBreakClips(): messages.BreakClip[];
 
         /** Get current media breaks. */
-        getBreaks(): Break[];
+        getBreaks(): messages.Break[];
 
         /** Returns true if watched breaks should be played. */
         getPlayWatchedBreak(): boolean;

--- a/types/chromecast-caf-receiver/cast.framework.breaks.d.ts
+++ b/types/chromecast-caf-receiver/cast.framework.breaks.d.ts
@@ -62,7 +62,7 @@ declare namespace Breaks {
          */
         setBreakClipLoadInterceptor(
             interceptor: (
-                breakClip: BreakClip,
+                breakClip: messages.BreakClip,
                 breakClipLoaderContext?: BreakClipLoadInterceptorContext
             ) => void
         ): void;

--- a/types/chromecast-caf-receiver/cast.framework.d.ts
+++ b/types/chromecast-caf-receiver/cast.framework.d.ts
@@ -148,8 +148,8 @@ declare namespace Framework {
      * Base implementation of a queue.
      * @see {https://developers.google.com/cast/docs/reference/caf_receiver/cast.framework.QueueBase}
      */
-    interface QueueBase {
-        new(): QueueBase;
+    class QueueBase {
+        constructor();
 
         /**
          * Fetches a window of items using the specified item id as reference; called by the receiver MediaManager when it needs more queue items;
@@ -447,8 +447,8 @@ declare namespace Framework {
     /**
      * Configuration to customize playback behavior.
      */
-    interface PlaybackConfig {
-        new(): PlaybackConfig;
+    class PlaybackConfig {
+        constructor();
 
         /**
          * Duration of buffered media in seconds to start buffering.
@@ -629,10 +629,11 @@ declare namespace Framework {
     }
 
     /** Manages loading of underlying libraries and initializes underlying cast receiver SDK. */
-    interface CastReceiverContext {
+    class CastReceiverContext {
+        constructor(params: any);
+
         /** Returns the CastReceiverContext singleton instance. */
         getInstance(): CastReceiverContext;
-        new(params: any): CastReceiverContext;
 
         /**
          * Sets message listener on custom message channel.

--- a/types/chromecast-caf-receiver/cast.framework.d.ts
+++ b/types/chromecast-caf-receiver/cast.framework.d.ts
@@ -1,5 +1,11 @@
-import { EventType } from "./cast.framework.events";
-import {
+import events from "./cast.framework.events";
+import messages from "./cast.framework.messages";
+import breaks from "./cast.framework.breaks";
+import { EventHandler, RequestHandler, BinaryHandler } from "./index";
+import system from "./cast.framework.system";
+
+/*
+{
     PlayerState,
     PlayStringId,
     ErrorType,
@@ -8,28 +14,22 @@ import {
     MessageType,
     Track,
     TextTrackStyle,
-    QueueItem,
     LoadRequestData,
+    QueueItem,
     QueueData,
     Break,
     LiveSeekableRange,
     MediaInformation,
     ErrorData,
     RequestData
-} from "./cast.framework.messages";
-import { BreakManager } from "./cast.framework.breaks";
-import { EventHandler, RequestHandler, BinaryHandler } from "./index";
-import {
-    EventType as SystemEventType,
-    ApplicationData,
-    Sender,
-    StandbyState,
-    SystemState
-} from "./cast.framework.system";
+}
+*/
 
-export = cast.framework;
+export default Framework;
+
 type HTMLMediaElement = any;
-declare namespace cast.framework {
+
+declare namespace Framework {
     type LoggerLevel =
         | "DEBUG"
         | "VERBOSE"
@@ -49,12 +49,12 @@ declare namespace cast.framework {
         /**
          * Adds text tracks to the list.
          */
-        addTracks(tracks: Track[]): void;
+        addTracks(tracks: messages.Track[]): void;
 
         /**
          * Creates a text track.
          */
-        createTrack(): Track;
+        createTrack(): messages.Track;
 
         /**
          * Gets all active text ids.
@@ -64,27 +64,27 @@ declare namespace cast.framework {
         /**
          * Gets all active text tracks.
          */
-        getActiveTracks(): Track[];
+        getActiveTracks(): messages.Track[];
 
         /**
          * Returns the current text track style.
          */
-        getTextTracksStyle(): TextTrackStyle;
+        getTextTracksStyle(): messages.TextTrackStyle;
 
         /**
          * Gets text track by id.
          */
-        getTrackById(id: number): Track;
+        getTrackById(id: number): messages.Track;
 
         /**
          * Returns all text tracks.
          */
-        getTracks(): Track[];
+        getTracks(): messages.Track[];
 
         /**
          * Gets text tracks by language.
          */
-        getTracksByLanguage(language: string): Track[];
+        getTracksByLanguage(language: string): messages.Track[];
 
         /**
          * Sets text tracks to be active by id.
@@ -99,7 +99,7 @@ declare namespace cast.framework {
         /**
          * Sets text track style.
          */
-        setTextTrackStyle(style: TextTrackStyle): void;
+        setTextTrackStyle(style: messages.TextTrackStyle): void;
     }
 
     /**
@@ -111,7 +111,7 @@ declare namespace cast.framework {
         /**
          * Returns the current queue item.
          */
-        getCurrentItem(): QueueItem;
+        getCurrentItem(): messages.QueueItem;
 
         /**
          * Returns the index of the current queue item.
@@ -121,12 +121,12 @@ declare namespace cast.framework {
         /**
          * Returns the queue items.
          */
-        getItems(): QueueItem[];
+        getItems(): messages.QueueItem[];
 
         /**
          * Inserts items into the queue.
          */
-        insertItems(items: QueueItem[], insertBefore?: number): void;
+        insertItems(items: messages.QueueItem[], insertBefore?: number): void;
 
         /**
          * Removes items from the queue.
@@ -141,7 +141,7 @@ declare namespace cast.framework {
         /**
          * Updates existing queue items by matching itemId.
          */
-        updateItems(items: QueueItem[]): void;
+        updateItems(items: messages.QueueItem[]): void;
     }
 
     /**
@@ -160,7 +160,7 @@ declare namespace cast.framework {
             itemId: number,
             nextCount: number,
             prevCount: number
-        ): QueueItem[] | Promise<QueueItem[]>;
+        ): messages.QueueItem[] | Promise<messages.QueueItem[]>;
 
         /**
          * Initializes the queue with the requestData. This is called when a new LOAD request comes in to the receiver.
@@ -168,13 +168,13 @@ declare namespace cast.framework {
          *  in the load request data.
          */
         initialize(
-            requestData: LoadRequestData
-        ): QueueData | Promise<QueueData>;
+            requestData: messages.LoadRequestData
+        ): messages.QueueData | Promise<messages.QueueData>;
 
         /**
          * Returns next items after the reference item; often the end of the current queue; called by the receiver MediaManager.
          */
-        nextItems(itemId?: number): QueueItem[] | Promise<QueueItem[]>;
+        nextItems(itemId?: number): messages.QueueItem[] | Promise<messages.QueueItem[]>;
 
         /**
          * Sets the current item with the itemId; called by the receiver MediaManager when it changes the current playing item.
@@ -185,7 +185,7 @@ declare namespace cast.framework {
          * A callback for informing the following items have been inserted into the receiver queue in this session.
          *  A cloud based implementation can optionally choose to update its queue based on the new information.
          */
-        onItemsInserted(items: QueueItem[], insertBefore?: number): void;
+        onItemsInserted(items: messages.QueueItem[], insertBefore?: number): void;
 
         /**
          * A callback for informing the following items have been removed from the receiver queue in this session.
@@ -196,12 +196,12 @@ declare namespace cast.framework {
         /**
          * Returns previous items before the reference item; often at the beginning of the queue; called by the receiver MediaManager.
          */
-        prevItems(itemId?: number): QueueItem[] | Promise<QueueItem[]>;
+        prevItems(itemId?: number): messages.QueueItem[] | Promise<messages.QueueItem[]>;
 
         /**
          * Shuffles the queue and returns new queue items. Returns null if the operation is not supported.
          */
-        shuffle(): QueueItem[] | Promise<QueueItem[]>;
+        shuffle(): messages.QueueItem[] | Promise<messages.QueueItem[]>;
     }
 
     /**
@@ -214,7 +214,7 @@ declare namespace cast.framework {
          * Adds an event listener for player event.
          */
         addEventListener: (
-            eventType: EventType | EventType[],
+            eventType: events.EventType | events.EventType[],
             eventListener: EventHandler
         ) => void;
 
@@ -243,12 +243,12 @@ declare namespace cast.framework {
         /**
          * Obtain the breaks (Ads) manager.
          */
-        getBreakManager(): BreakManager;
+        getBreakManager(): breaks.BreakManager;
 
         /**
          * Returns list of breaks.
          */
-        getBreaks(): Break[];
+        getBreaks(): messages.Break[];
 
         /**
          * Gets current time in sec of current media.
@@ -263,12 +263,12 @@ declare namespace cast.framework {
         /**
          * Returns live seekable range with start and end time in seconds. The values are media time based.
          */
-        getLiveSeekableRange(): LiveSeekableRange;
+        getLiveSeekableRange(): messages.LiveSeekableRange;
 
         /**
          * Gets media information of current media.
          */
-        getMediaInformation(): MediaInformation;
+        getMediaInformation(): messages.MediaInformation;
 
         /**
          * Returns playback configuration.
@@ -283,7 +283,7 @@ declare namespace cast.framework {
         /**
          * Gets player state.
          */
-        getPlayerState(): PlayerState;
+        getPlayerState(): messages.PlayerState;
 
         /**
          * Get the preferred playback rate. (Can be used on shutdown event to save latest preferred playback rate to a persistent storage;
@@ -306,7 +306,7 @@ declare namespace cast.framework {
         /**
          * Loads media.
          */
-        load(loadRequest: LoadRequestData): Promise<void>;
+        load(loadRequest: messages.LoadRequestData): Promise<void>;
 
         /**
          * Pauses currently playing media.
@@ -321,7 +321,7 @@ declare namespace cast.framework {
         /**
          * Requests a text string to be played back locally on the receiver device.
          */
-        playString(stringId: PlayStringId, args?: string[]): Promise<ErrorData>;
+        playString(stringId: messages.PlayStringId, args?: string[]): Promise<messages.ErrorData>;
 
         /**
          * Request Google Assistant to refresh the credentials. Only works if the original credentials came from the assistant.
@@ -332,7 +332,7 @@ declare namespace cast.framework {
          * Removes the event listener added for given player event. If event listener is not added; it will be ignored.
          */
         removeEventListener(
-            eventType: EventType | EventType[],
+            eventType: events.EventType | events.EventType[],
             eventListener: EventHandler
         ): void;
 
@@ -347,15 +347,15 @@ declare namespace cast.framework {
         sendError(
             senderId: string,
             requestId: number,
-            type: ErrorType,
-            reason?: ErrorReason,
+            type: messages.ErrorType,
+            reason?: messages.ErrorReason,
             customData?: any
         ): void;
 
         /**
          * Send local media request.
          */
-        sendLocalMediaRequest(request: RequestData): void;
+        sendLocalMediaRequest(request: messages.RequestData): void;
 
         /**
          * Sends a media status message to a specific sender.
@@ -374,7 +374,7 @@ declare namespace cast.framework {
          * it is only needed if they want to make the player go to IDLE in special circumstances and the default idleReason does not reflect their intended
          * behavior.
          */
-        setIdleReason(idleReason: IdleReason): void;
+        setIdleReason(idleReason: messages.IdleReason): void;
 
         /**
          * Sets MediaElement to use. If Promise of MediaElement is set; media begins playback after Promise is resolved.
@@ -385,7 +385,7 @@ declare namespace cast.framework {
          * Sets media information.
          */
         setMediaInformation(
-            mediaInformation: MediaInformation,
+            mediaInformation: messages.MediaInformation,
             opt_broadcast?: boolean
         ): void;
 
@@ -396,7 +396,7 @@ declare namespace cast.framework {
          */
         setMediaPlaybackInfoHandler(
             handler: (
-                loadRequestData: LoadRequestData,
+                loadRequestData: messages.LoadRequestData,
                 playbackConfig: PlaybackConfig
             ) => void
         ): void;
@@ -406,7 +406,7 @@ declare namespace cast.framework {
          * of the media status. By default the media contentId is used as the content url.
          */
         setMediaUrlResolver(
-            resolver: (loadRequestData: LoadRequestData) => void
+            resolver: (loadRequestData: messages.LoadRequestData) => void
         ): void;
 
         /**
@@ -417,8 +417,8 @@ declare namespace cast.framework {
          * the load interceptor will be called for preload messages.
          */
         setMessageInterceptor(
-            type: MessageType,
-            interceptor: (requestData: RequestData) => Promise<any>
+            type: messages.MessageType,
+            interceptor: (requestData: messages.RequestData) => Promise<any>
         ): void;
 
         /**
@@ -447,7 +447,9 @@ declare namespace cast.framework {
     /**
      * Configuration to customize playback behavior.
      */
-    class PlaybackConfig {
+    interface PlaybackConfig {
+        new(): PlaybackConfig;
+
         /**
          * Duration of buffered media in seconds to start buffering.
          */
@@ -627,11 +629,10 @@ declare namespace cast.framework {
     }
 
     /** Manages loading of underlying libraries and initializes underlying cast receiver SDK. */
-    class CastReceiverContext {
+    interface CastReceiverContext {
         /** Returns the CastReceiverContext singleton instance. */
-        static getInstance(): CastReceiverContext;
-
-        constructor(params: any);
+        getInstance(): CastReceiverContext;
+        new(params: any): CastReceiverContext;
 
         /**
          * Sets message listener on custom message channel.
@@ -645,7 +646,7 @@ declare namespace cast.framework {
          * Add listener to cast system events.
          */
         addEventListener(
-            type: SystemEventType | SystemEventType[],
+            type: system.EventType | system.EventType[],
             handler: EventHandler
         ): void;
 
@@ -663,7 +664,7 @@ declare namespace cast.framework {
         /**
          * Provides application information once the system is ready; otherwise it will be null.
          */
-        getApplicationData(): ApplicationData;
+        getApplicationData(): system.ApplicationData;
 
         /**
          * Provides device capabilities information once the system is ready; otherwise it will be null.
@@ -679,22 +680,22 @@ declare namespace cast.framework {
         /**
          * Get a sender by sender id
          */
-        getSender(senderId: string): Sender;
+        getSender(senderId: string): system.Sender;
 
         /**
          * Gets a list of currently-connected senders.
          */
-        getSenders(): Sender[];
+        getSenders(): system.Sender[];
 
         /**
          * Reports if the cast application's HDMI input is in standby.
          */
-        getStandbyState(): StandbyState;
+        getStandbyState(): system.StandbyState;
 
         /**
          * Provides application information about the system state.
          */
-        getSystemState(): SystemState;
+        getSystemState(): system.SystemState;
 
         /**
          * Reports if the cast application is the HDMI active input.
@@ -724,7 +725,7 @@ declare namespace cast.framework {
         /**
          * Remove listener to cast system events.
          */
-        removeEventListener(type: EventType, handler: EventHandler): void;
+        removeEventListener(type: events.EventType, handler: EventHandler): void;
 
         /**
          * Sends a message to a specific sender.
@@ -776,10 +777,10 @@ declare namespace cast.framework {
     class AudioTracksManager {
         constructor(params: any);
         getActiveId(): number;
-        getActiveTrack(): Track;
-        getTrackById(id: number): Track;
-        getTracks(): Track[];
-        getTracksByLanguage(language: string): Track[];
+        getActiveTrack(): messages.Track;
+        getTrackById(id: number): messages.Track;
+        getTracks(): messages.Track[];
+        getTracksByLanguage(language: string): messages.Track[];
         setActiveById(id: number): void;
         setActiveByLanguage(language: string): void;
     }

--- a/types/chromecast-caf-receiver/cast.framework.d.ts
+++ b/types/chromecast-caf-receiver/cast.framework.d.ts
@@ -146,8 +146,11 @@ declare namespace cast.framework {
 
     /**
      * Base implementation of a queue.
+     * @see {https://developers.google.com/cast/docs/reference/caf_receiver/cast.framework.QueueBase}
      */
-    class QueueBase {
+    interface QueueBase {
+        new(): QueueBase;
+
         /**
          * Fetches a window of items using the specified item id as reference; called by the receiver MediaManager when it needs more queue items;
          *  often as a request from senders. If only one of nextCount and prevCount is non-zero; fetchItems should only return items after or before

--- a/types/chromecast-caf-receiver/cast.framework.events.d.ts
+++ b/types/chromecast-caf-receiver/cast.framework.events.d.ts
@@ -1,12 +1,8 @@
-import {
-    RequestData,
-    MediaInformation,
-    Track,
-    MediaStatus
-} from "./cast.framework.messages";
-export = cast.framework.events;
+import messages from "./cast.framework.messages";
 
-declare namespace cast.framework.events {
+export default Events;
+
+declare namespace Events {
     type EventType =
         | "ALL"
         | "ABORT"
@@ -149,14 +145,14 @@ declare namespace cast.framework.events {
     class RequestEvent extends Event {
         constructor(
             type: EventType,
-            requestData?: RequestData,
+            requestData?: messages.RequestData,
             senderId?: string
         );
 
         /**
          * The data that was sent with the request.
          */
-        requestData?: RequestData;
+        requestData?: messages.RequestData;
 
         /**
          * The sender id the request came from.
@@ -179,12 +175,12 @@ declare namespace cast.framework.events {
      * Event data for @see{@link EventType.MEDIA_STATUS} event.
      */
     class MediaStatusEvent extends Event {
-        constructor(type: EventType, mediaStatus?: MediaStatus);
+        constructor(type: EventType, mediaStatus?: messages.MediaStatus);
 
         /**
          * The media status that was sent.
          */
-        mediaStatus?: MediaStatus;
+        mediaStatus?: messages.MediaStatus;
     }
     /**
      * Event data for pause events forwarded from the MediaElement.
@@ -228,23 +224,23 @@ declare namespace cast.framework.events {
      * Event data for all events pertaining to processing a load / preload request. made to the player.
      */
     class LoadEvent extends Event {
-        constructor(type: EventType, media?: MediaInformation);
+        constructor(type: EventType, media?: messages.MediaInformation);
 
         /**
          * Information about the media being loaded.
          */
-        media: MediaInformation;
+        media: messages.MediaInformation;
     }
     /**
      * Event data for @see{@link EventType.INBAND_TRACK_ADDED} event.
      */
     class InbandTrackAddedEvent {
-        constructor(track: Track);
+        constructor(track: messages.Track);
 
         /**
          * Added track.
          */
-        track: Track;
+        track: messages.Track;
     }
 
     /** Event data for @see{@link EventType.ID3} event. */
@@ -333,12 +329,12 @@ declare namespace cast.framework.events {
      * Event data for @see{@link EventType.CACHE_LOADED} event.
      */
     class CacheLoadedEvent extends Event {
-        constructor(media?: MediaInformation);
+        constructor(media?: messages.MediaInformation);
 
         /**
          * Information about the media being cached.
          */
-        media: MediaInformation;
+        media: messages.MediaInformation;
     }
 
     class CacheItemEvent extends Event {

--- a/types/chromecast-caf-receiver/cast.framework.messages.d.ts
+++ b/types/chromecast-caf-receiver/cast.framework.messages.d.ts
@@ -1,7 +1,8 @@
-import { Event, DetailedErrorCode } from "./cast.framework.events";
-export = cast.framework.messages;
+import events from "./cast.framework.events";
 
-declare namespace cast.framework.messages {
+export default Messages;
+
+declare namespace Messages {
     type UserAction =
         | "LIKE"
         | "DISLIKE"
@@ -1369,18 +1370,6 @@ declare namespace cast.framework.messages {
      */
     interface MediaInformation {
         /**
-         * Partial list of break clips that includes current break clip that receiver
-         * is playing or ones that receiver will play shortly after; instead of sending
-         * whole list of clips. This is to avoid overflow of MediaStatus message.
-         */
-        breakClips: BreakClip[];
-
-        /**
-         * List of breaks.
-         */
-        breaks: Break[];
-
-        /**
          * Typically the url of the media.
          */
         contentId: string;
@@ -1415,12 +1404,12 @@ declare namespace cast.framework.messages {
         /**
          * The format of the HLS media segment.
          */
-        hlsSegmentFormat: HlsSegmentFormat;
+        hlsSegmentFormat?: HlsSegmentFormat;
 
         /**
          * The media metadata.
          */
-        metadata: MediaMetadata;
+        metadata?: MediaMetadata;
 
         /**
          * The stream type.
@@ -1430,12 +1419,7 @@ declare namespace cast.framework.messages {
         /**
          * The style of text track.
          */
-        textTrackStyle: TextTrackStyle;
-
-        /**
-         * The media tracks.
-         */
-        tracks: Track[];
+        textTrackStyle?: TextTrackStyle;
     }
 
     /**
@@ -1446,7 +1430,7 @@ declare namespace cast.framework.messages {
          * Array of trackIds that are active. If the array is not provided; the
          * default tracks will be active.
          */
-        activeTrackIds: number[];
+        activeTrackIds?: number[];
 
         /**
          * If the autoplay parameter is specified; the media player will begin
@@ -1488,7 +1472,7 @@ declare namespace cast.framework.messages {
         /**
          * Queue data.
          */
-        queueData: QueueData;
+        queueData?: QueueData;
     }
 
     /**
@@ -1671,13 +1655,13 @@ declare namespace cast.framework.messages {
     }
 
     /** Event data for @see{@link EventType.ERROR} event. */
-    class ErrorEvent extends Event {
-        constructor(detailedErrorCode?: DetailedErrorCode, error?: any);
+    class ErrorEvent extends events.Event {
+        constructor(detailedErrorCode?: events.DetailedErrorCode, error?: any);
 
         /**
          * An error code representing the cause of the error.
          */
-        detailedErrorCode?: DetailedErrorCode;
+        detailedErrorCode?: events.DetailedErrorCode;
 
         /**
          * The error object.

--- a/types/chromecast-caf-receiver/cast.framework.messages.d.ts
+++ b/types/chromecast-caf-receiver/cast.framework.messages.d.ts
@@ -851,8 +851,8 @@ declare namespace cast.framework.messages {
     /**
      * Queue data as part of the LOAD request.
      */
-    class QueueData {
-        constructor(
+    interface QueueData {
+        new(
             id?: string,
             name?: string,
             description?: string,
@@ -860,7 +860,7 @@ declare namespace cast.framework.messages {
             items?: QueueItem[],
             startIndex?: number,
             startTime?: number
-        );
+        ): QueueData;
 
         /**
          * Description of the queue.

--- a/types/chromecast-caf-receiver/cast.framework.messages.d.ts
+++ b/types/chromecast-caf-receiver/cast.framework.messages.d.ts
@@ -852,8 +852,8 @@ declare namespace Messages {
     /**
      * Queue data as part of the LOAD request.
      */
-    interface QueueData {
-        new(
+    class QueueData {
+        constructor(
             id?: string,
             name?: string,
             description?: string,
@@ -861,7 +861,7 @@ declare namespace Messages {
             items?: QueueItem[],
             startIndex?: number,
             startTime?: number
-        ): QueueData;
+        );
 
         /**
          * Description of the queue.

--- a/types/chromecast-caf-receiver/cast.framework.system.d.ts
+++ b/types/chromecast-caf-receiver/cast.framework.system.d.ts
@@ -1,7 +1,8 @@
-import { EventType } from "./cast.framework.events";
-export = cast.framework.system;
+import events from "./cast.framework.events";
 
-declare namespace cast.framework.system {
+export default System;
+
+declare namespace System {
     type EventType =
         // Fired when the system is ready.
         | "READY"

--- a/types/chromecast-caf-receiver/cast.framework.ui.d.ts
+++ b/types/chromecast-caf-receiver/cast.framework.ui.d.ts
@@ -1,10 +1,9 @@
-import { PlayerDataEventType } from "./cast.framework.ui";
-import { MediaMetadata } from "./cast.framework.messages";
+import messages from "./cast.framework.messages";
 import { PlayerDataChangedEventHandler } from "./index";
 
-export = cast.framework.ui;
+export default UI;
 
-declare namespace cast.framework.ui {
+declare namespace UI {
     type ContentType = "video" | "audio" | "image";
 
     type State =
@@ -147,7 +146,7 @@ declare namespace cast.framework.ui {
         /**
          * Media metadata.
          */
-        metadata: MediaMetadata;
+        metadata: messages.MediaMetadata;
 
         /**
          * Next Item subtitle.

--- a/types/chromecast-caf-receiver/chromecast-caf-receiver-tests.ts
+++ b/types/chromecast-caf-receiver/chromecast-caf-receiver-tests.ts
@@ -1,52 +1,27 @@
-import {
-    PlayerData,
-    PlayerDataBinder
-} from "chromecast-caf-receiver/cast.framework.ui";
-import {
-    ReadyEvent,
-    ApplicationData
-} from "chromecast-caf-receiver/cast.framework.system";
-import {
-    RequestEvent,
-    Event,
-    BreaksEvent
-} from "chromecast-caf-receiver/cast.framework.events";
-import {
-    QueueBase,
-    TextTracksManager,
-    QueueManager,
-    PlayerManager
-} from "chromecast-caf-receiver/cast.framework";
-import {
-    BreakSeekData,
-    BreakClipLoadInterceptorContext,
-    BreakManager
-} from "chromecast-caf-receiver/cast.framework.breaks";
-import {
-    Break,
-    BreakClip,
-    LoadRequestData,
-    Track,
-    MediaMetadata
-} from "chromecast-caf-receiver/cast.framework.messages";
+import UI from "chromecast-caf-receiver/cast.framework.ui";
+import System from "chromecast-caf-receiver/cast.framework.system";
+import Events from "chromecast-caf-receiver/cast.framework.events";
+import Framework from "chromecast-caf-receiver/cast.framework";
+import Breaks from "chromecast-caf-receiver/cast.framework.breaks";
+import Messages from "chromecast-caf-receiver/cast.framework.messages";
 
-const breaksEvent = new BreaksEvent('BREAK_STARTED');
+const breaksEvent = new Events.BreaksEvent('BREAK_STARTED');
 breaksEvent.breakId = 'some-break-id';
 breaksEvent.breakClipId = 'some-break-clip-id';
 
-const track = new Track(1, "TEXT");
-const breakClip = new BreakClip("id");
-const adBreak = new Break("id", ["id"], 1);
-const rEvent = new RequestEvent("BITRATE_CHANGED", { requestId: 2 });
-const pManager = new PlayerManager();
+const track = new Messages.Track(1, "TEXT");
+const breakClip = new Messages.BreakClip("id");
+const adBreak = new Messages.Break("id", ["id"], 1);
+const rEvent = new Events.RequestEvent("BITRATE_CHANGED", { requestId: 2 });
+const pManager = new Framework.PlayerManager();
 pManager.addEventListener("STALLED", () => { });
-const ttManager = new TextTracksManager();
-const qManager = new QueueManager();
-const qBase = new QueueBase();
+const ttManager = new Framework.TextTracksManager();
+const qManager = new Framework.QueueManager();
+const qBase = new Framework.QueueBase();
 const items = qBase.fetchItems(1, 3, 4);
-const breakSeekData = new BreakSeekData(0, 100, []);
-const breakClipLoadContext = new BreakClipLoadInterceptorContext(adBreak);
-const breakManager: BreakManager = {
+const breakSeekData = new Breaks.BreakSeekData(0, 100, []);
+const breakClipLoadContext = new Breaks.BreakClipLoadInterceptorContext(adBreak);
+const breakManager: Breaks.BreakManager = {
     getBreakById: () => adBreak,
     getBreakClipById: () => breakClip,
     getBreakClips: () => [breakClip],
@@ -58,24 +33,21 @@ const breakManager: BreakManager = {
     setVastTrackingInterceptor: () => { }
 };
 
-const lrd: LoadRequestData = {
+const lrd: Messages.LoadRequestData = {
     requestId: 1,
     activeTrackIds: [1, 2],
     media: {
-        tracks: [],
         textTrackStyle: {},
         streamType: "BUFFERED",
         metadata: { metadataType: "GENERIC" },
         hlsSegmentFormat: "AAC",
         contentId: "id",
-        contentType: "type",
-        breakClips: [breakClip],
-        breaks: [adBreak]
+        contentType: "type"
     },
     queueData: {}
 };
 
-const appData: ApplicationData = {
+const appData: System.ApplicationData = {
     id: () => "id",
     launchingSenderId: () => "launch-id",
     name: () => "name",
@@ -83,9 +55,9 @@ const appData: ApplicationData = {
     sessionId: () => 1
 };
 
-const readyEvent = new ReadyEvent(appData);
+const readyEvent = new System.ReadyEvent(appData);
 const data = readyEvent.data;
-const pData: PlayerData = {
+const pData: UI.PlayerData = {
     breakPercentagePositions: [1],
     contentType: "video",
     currentBreakClipNumber: 2,
@@ -96,7 +68,7 @@ const pData: PlayerData = {
     isLive: true,
     isPlayingBreak: false,
     isSeeking: true,
-    metadata: new MediaMetadata("GENERIC"),
+    metadata: new Messages.MediaMetadata("GENERIC"),
     nextSubtitle: "sub",
     nextThumbnailUrl: "url",
     nextTitle: "title",
@@ -107,5 +79,5 @@ const pData: PlayerData = {
     title: "title",
     whenSkippable: 321
 };
-const binder = new PlayerDataBinder(pData);
+const binder = new UI.PlayerDataBinder(pData);
 binder.addEventListener("ANY_CHANGE", e => { });

--- a/types/chromecast-caf-receiver/index.d.ts
+++ b/types/chromecast-caf-receiver/index.d.ts
@@ -11,14 +11,153 @@
 /// <reference path="./cast.framework.system.d.ts" />
 /// <reference path="./cast.framework.ui.d.ts" />
 
-import { PlayerDataChangedEvent } from './cast.framework.ui';
-import { NetworkRequestInfo } from './cast.framework';
-import { Event } from './cast.framework.events';
+import framework from './cast.framework';
+import breaks from './cast.framework.breaks';
+import events from './cast.framework.events';
+import messages from './cast.framework.messages';
+import ui from './cast.framework.ui';
 
-export as namespace cast;
-export type EventHandler = (event: Event) => void;
+interface CastReceiverFrameworkSDK {
+    framework: {
+        AudioTracksManager: framework.AudioTracksManager;
+        CastReceiverContext: framework.CastReceiverContext;
+        CastReceiverOptions: framework.CastReceiverOptions;
+        NetworkRequestInfo: framework.NetworkRequestInfo;
+        PlaybackConfig: framework.PlaybackConfig;
+        PlayerManager: framework.PlayerManager;
+        QueueBase: framework.QueueBase;
+        QueueManager: framework.QueueManager;
+        TextTracksManager: framework.TextTracksManager;
+        ContentProtection: framework.ContentProtection;
+        LoggerLevel: framework.LoggerLevel;
+        VERSION: string;
+        breaks: {
+            BreakClipLoadInterceptorContext: breaks.BreakClipLoadInterceptorContext;
+            BreakSeekData: breaks.BreakSeekData;
+            BreakManager: breaks.BreakManager;
+        };
+        events: {
+            BitrateChangedEvent: events.BitrateChangedEvent;
+            BreaksEvent: events.BreaksEvent;
+            BufferingEvent: events.BufferingEvent;
+            CacheItemEvent: events.CacheItemEvent;
+            CacheLoadedEvent: events.CacheLoadedEvent;
+            ClipEndedEvent: events.ClipEndedEvent;
+            EmsgEvent: events.EmsgEvent;
+            ErrorEvent: events.ErrorEvent;
+            Event: events.Event;
+            Id3Event: events.Id3Event;
+            LiveStatusEvent: events.LiveStatusEvent;
+            LoadEvent: events.LoadEvent;
+            MediaElementEvent: events.MediaElementEvent;
+            MediaFinishedEvent: events.MediaFinishedEvent;
+            MediaInformationChangedEvent: events.MediaInformationChangedEvent;
+            MediaPauseEvent: events.MediaPauseEvent;
+            MediaStatusEvent: events.MediaStatusEvent;
+            RequestEvent: events.RequestEvent;
+            SegmentDownloadedEvent: events.SegmentDownloadedEvent;
+            DetailedErrorCode: events.DetailedErrorCode;
+            EndedReason: events.EndedReason;
+            EventType: events.EventType;
+        };
+        messages: {
+            AudiobookChapterMediaMetadata: messages.AudiobookChapterMediaMetadata;
+            AudiobookContainerMetadata: messages.AudiobookContainerMetadata;
+            Break: messages.Break;
+            BreakClip: messages.BreakClip;
+            BreakStatus: messages.BreakStatus;
+            CloudMediaStatus: messages.CloudMediaStatus;
+            ContainerMetadata: messages.ContainerMetadata;
+            CustomCommandRequestData: messages.CustomCommandRequestData;
+            DisplayStatusRequestData: messages.DisplayStatusRequestData;
+            EditAudioTracksRequestData: messages.EditAudioTracksRequestData;
+            EditTracksInfoRequestData: messages.EditTracksInfoRequestData;
+            ErrorData: messages.ErrorData;
+            ExtendedMediaStatus: messages.ExtendedMediaStatus;
+            FetchItemsRequestData: messages.FetchItemsRequestData;
+            FocusStateRequestData: messages.FocusStateRequestData;
+            GenericMediaMetadata: messages.GenericMediaMetadata;
+            GetItemsInfoRequestData: messages.GetItemsInfoRequestData;
+            GetStatusRequestData: messages.GetStatusRequestData;
+            Image: messages.Image;
+            ItemsInfo: messages.ItemsInfo;
+            LiveSeekableRange: messages.LiveSeekableRange;
+            LoadByEntityRequestData: messages.LoadByEntityRequestData;
+            LoadRequestData: messages.LoadRequestData;
+            MediaInformation: messages.MediaInformation;
+            MediaMetadata: messages.MediaMetadata;
+            MediaStatus: messages.MediaStatus;
+            MovieMediaMetadata: messages.MovieMediaMetadata;
+            MusicTrackMediaMetadata: messages.MusicTrackMediaMetadata;
+            PhotoMediaMetadata: messages.PhotoMediaMetadata;
+            PlayStringRequestData: messages.PlayStringRequestData;
+            PrecacheRequestData: messages.PrecacheRequestData;
+            PreloadRequestData: messages.PreloadRequestData;
+            QueueChange: messages.QueueChange;
+            QueueData: messages.QueueData;
+            QueueIds: messages.QueueIds;
+            QueueInsertRequestData: messages.QueueInsertRequestData;
+            QueueItem: messages.QueueItem;
+            QueueLoadRequestData: messages.QueueLoadRequestData;
+            QueueRemoveRequestData: messages.QueueRemoveRequestData;
+            QueueReorderRequestData: messages.QueueReorderRequestData;
+            QueueUpdateRequestData: messages.QueueUpdateRequestData;
+            RefreshCredentialsRequestData: messages.RefreshCredentialsRequestData;
+            RequestData: messages.RequestData;
+            SeekableRange: messages.SeekableRange;
+            SeekRequestData: messages.SeekRequestData;
+            SetCredentialsRequestData: messages.SetCredentialsRequestData;
+            SetPlaybackRateRequestData: messages.SetPlaybackRateRequestData;
+            TextTrackStyle: messages.TextTrackStyle;
+            Track: messages.Track;
+            TvShowMediaMetadata: messages.TvShowMediaMetadata;
+            UserActionRequestData: messages.UserActionRequestData;
+            UserActionState: messages.UserActionState;
+            VastAdsRequest: messages.VastAdsRequest;
+            VideoInformation: messages.VideoInformation;
+            Volume: messages.Volume;
+            VolumeRequestData: messages.VolumeRequestData;
+            CaptionMimeType: messages.CaptionMimeType;
+            Command: messages.Command;
+            ContainerType: messages.ContainerType;
+            ErrorReason: messages.ErrorReason;
+            ErrorType: messages.ErrorType;
+            ExtendedPlayerState: messages.ExtendedPlayerState;
+            FocusState: messages.FocusState;
+            GetStatusOptions: messages.GetStatusOptions;
+            HdrType: messages.HdrType;
+            HlsSegmentFormat: messages.HlsSegmentFormat;
+            HlsVideoSegmentFormat: messages.HlsVideoSegmentFormat;
+            IdleReason: messages.IdleReason;
+            MessageType: messages.MessageType;
+            MetadataType: messages.MetadataType;
+            PlayerState: messages.PlayerState;
+            PlayStringId: messages.PlayStringId;
+            QueueChangeType: messages.QueueChangeType;
+            QueueType: messages.QueueType;
+            RepeatMode: messages.RepeatMode;
+            SeekResumeState: messages.SeekResumeState;
+            StreamingProtocolType: messages.StreamingProtocolType;
+            StreamType: messages.StreamType;
+            TextTrackEdgeType: messages.TextTrackEdgeType;
+            TextTrackFontGenericFamily: messages.TextTrackFontGenericFamily;
+            TextTrackFontStyle: messages.TextTrackFontStyle;
+            TextTrackType: messages.TextTrackType;
+            TextTrackWindowType: messages.TextTrackWindowType;
+            TrackType: messages.TrackType;
+            UserAction: messages.UserAction;
+            UserActionContext: messages.UserActionContext;
+        }
+    };
+}
+
+declare global {
+    const cast: CastReceiverFrameworkSDK;
+}
+
+export type EventHandler = (event: events.Event) => void;
 export type PlayerDataChangedEventHandler = (
-    event: PlayerDataChangedEvent
+    event: ui.PlayerDataChangedEvent
 ) => void;
-export type RequestHandler = (request: NetworkRequestInfo) => void;
+export type RequestHandler = (request: framework.NetworkRequestInfo) => void;
 export type BinaryHandler = (data: Uint8Array) => Uint8Array;

--- a/types/chromecast-caf-receiver/index.d.ts
+++ b/types/chromecast-caf-receiver/index.d.ts
@@ -155,7 +155,7 @@ declare global {
     const cast: CastReceiverFrameworkSDK;
 }
 
-export as namespace CastReceiverFrameworkSDK;
+export as namespace cast;
 
 export type EventHandler = (event: events.Event) => void;
 export type PlayerDataChangedEventHandler = (

--- a/types/chromecast-caf-receiver/index.d.ts
+++ b/types/chromecast-caf-receiver/index.d.ts
@@ -47,11 +47,11 @@ interface CastReceiverFrameworkSDK {
             ErrorEvent: events.ErrorEvent;
             Event: events.Event;
             Id3Event: events.Id3Event;
-            LiveStatusEvent: events.LiveStatusEvent;
+            // LiveStatusEvent: events.LiveStatusEvent;
             LoadEvent: events.LoadEvent;
             MediaElementEvent: events.MediaElementEvent;
             MediaFinishedEvent: events.MediaFinishedEvent;
-            MediaInformationChangedEvent: events.MediaInformationChangedEvent;
+            //  MediaInformationChangedEvent: events.MediaInformationChangedEvent;
             MediaPauseEvent: events.MediaPauseEvent;
             MediaStatusEvent: events.MediaStatusEvent;
             RequestEvent: events.RequestEvent;
@@ -61,13 +61,13 @@ interface CastReceiverFrameworkSDK {
             EventType: events.EventType;
         };
         messages: {
-            AudiobookChapterMediaMetadata: messages.AudiobookChapterMediaMetadata;
-            AudiobookContainerMetadata: messages.AudiobookContainerMetadata;
+            // AudiobookChapterMediaMetadata: messages.AudiobookChapterMediaMetadata;
+            // AudiobookContainerMetadata: messages.AudiobookContainerMetadata;
             Break: messages.Break;
             BreakClip: messages.BreakClip;
             BreakStatus: messages.BreakStatus;
-            CloudMediaStatus: messages.CloudMediaStatus;
-            ContainerMetadata: messages.ContainerMetadata;
+            // CloudMediaStatus: messages.CloudMediaStatus;
+            // ContainerMetadata: messages.ContainerMetadata;
             CustomCommandRequestData: messages.CustomCommandRequestData;
             DisplayStatusRequestData: messages.DisplayStatusRequestData;
             EditAudioTracksRequestData: messages.EditAudioTracksRequestData;
@@ -112,14 +112,14 @@ interface CastReceiverFrameworkSDK {
             Track: messages.Track;
             TvShowMediaMetadata: messages.TvShowMediaMetadata;
             UserActionRequestData: messages.UserActionRequestData;
-            UserActionState: messages.UserActionState;
+            // UserActionState: messages.UserActionState;
             VastAdsRequest: messages.VastAdsRequest;
             VideoInformation: messages.VideoInformation;
             Volume: messages.Volume;
             VolumeRequestData: messages.VolumeRequestData;
-            CaptionMimeType: messages.CaptionMimeType;
+            // CaptionMimeType: messages.CaptionMimeType;
             Command: messages.Command;
-            ContainerType: messages.ContainerType;
+            // ContainerType: messages.ContainerType;
             ErrorReason: messages.ErrorReason;
             ErrorType: messages.ErrorType;
             ExtendedPlayerState: messages.ExtendedPlayerState;
@@ -127,7 +127,7 @@ interface CastReceiverFrameworkSDK {
             GetStatusOptions: messages.GetStatusOptions;
             HdrType: messages.HdrType;
             HlsSegmentFormat: messages.HlsSegmentFormat;
-            HlsVideoSegmentFormat: messages.HlsVideoSegmentFormat;
+            // HlsVideoSegmentFormat: messages.HlsVideoSegmentFormat;
             IdleReason: messages.IdleReason;
             MessageType: messages.MessageType;
             MetadataType: messages.MetadataType;

--- a/types/chromecast-caf-receiver/index.d.ts
+++ b/types/chromecast-caf-receiver/index.d.ts
@@ -17,7 +17,7 @@ import events from './cast.framework.events';
 import messages from './cast.framework.messages';
 import ui from './cast.framework.ui';
 
-interface CastReceiverFrameworkSDK {
+export interface CastReceiverFrameworkSDK {
     framework: {
         AudioTracksManager: framework.AudioTracksManager;
         CastReceiverContext: framework.CastReceiverContext;
@@ -154,8 +154,6 @@ interface CastReceiverFrameworkSDK {
 declare global {
     const cast: CastReceiverFrameworkSDK;
 }
-
-export as namespace cast;
 
 export type EventHandler = (event: events.Event) => void;
 export type PlayerDataChangedEventHandler = (

--- a/types/chromecast-caf-receiver/index.d.ts
+++ b/types/chromecast-caf-receiver/index.d.ts
@@ -155,6 +155,8 @@ declare global {
     const cast: CastReceiverFrameworkSDK;
 }
 
+export as namespace CastReceiverFrameworkSDK;
+
 export type EventHandler = (event: events.Event) => void;
 export type PlayerDataChangedEventHandler = (
     event: ui.PlayerDataChangedEvent

--- a/types/chromecast-caf-receiver/tsconfig.json
+++ b/types/chromecast-caf-receiver/tsconfig.json
@@ -1,6 +1,6 @@
 {
     "compilerOptions": {
-        "module": "commonjs",
+        "module": "none",
         "lib": ["es6"],
         "noImplicitAny": true,
         "noImplicitThis": true,

--- a/types/chromecast-caf-receiver/tsconfig.json
+++ b/types/chromecast-caf-receiver/tsconfig.json
@@ -1,6 +1,6 @@
 {
     "compilerOptions": {
-        "module": "none",
+        "module": "commonjs",
         "lib": ["es6"],
         "noImplicitAny": true,
         "noImplicitThis": true,


### PR DESCRIPTION

- [✔️] Use a meaningful title for the pull request. Include the name of the package modified.
- [✔️] Test the change in your own code. (Compile and run.)
- [ ✔️] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ✔️] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ CAUSES ISSUES] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [✔️ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ✔️] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/28190
- [ -] Increase the version number in the header if appropriate.
- [- ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.


### Common mistakes

> `interface Foo { new(): Foo; }`: This defines a type of objects that are new-able. You probably want `declare class Foo { constructor(); }`.

When I changed QueueBase to be a newable interface instead of being a class tsc correctly lints my JS, but when it's a class it complains that `Type 'QueueBase' is not a constructor function type.`... Not sure what to do about that!?


---

This does some refactoring in the chromecast-caf-receiver folder to make sure it's correctly scoped so that the global cast object (which is imported by a script tag) gets the types from chromecast-caf-receiver.