### PR TITLE
Add typings for react-sound package

### DIFF
--- a/types/react-sound/index.d.ts
+++ b/types/react-sound/index.d.ts
@@ -1,0 +1,34 @@
+// Type definitions for react-sound 1.2
+// Project: https://github.com/leoasis/react-sound
+// Definitions by: Konstantin Lebedev <https://github.com/koss-lebedev>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.8
+
+import * as React from "react";
+
+declare namespace ReactSound {
+    type PlayStatus = 'PLAYING' | 'STOPPED' | 'PAUSED';
+
+    interface ReactSoundProps {
+        url: string;
+        playStatus: PlayStatus;
+        playFromPosition?: number;
+        position?: number;
+        volume?: number;
+        playbackRate?: number;
+        autoLoad?: boolean;
+        loop?: boolean;
+        onError?: () => void;
+        onLoading?: () => void;
+        onLoad?: () => void;
+        onPlaying?: () => void;
+        onPause?: () => void;
+        onResume?: () => void;
+        onStop?: () => void;
+        onFinishedPlaying?: () => void;
+        onBufferChange?: () => void;
+    }
+}
+
+declare const ReactSound: React.ComponentClass<ReactSound.ReactSoundProps>;
+export = ReactSound;

--- a/types/react-sound/react-sound-tests.tsx
+++ b/types/react-sound/react-sound-tests.tsx
@@ -1,0 +1,33 @@
+import ReactSound from "react-sound";
+import * as React from "react";
+
+const ReactSoundRequiredOptions: JSX.Element = (
+    <ReactSound
+        url="http://test.com"
+        playStatus="STOPPED"
+    />
+);
+
+const callbackFn = () => ({});
+
+const ReactSoundAllOptions: JSX.Element = (
+    <ReactSound
+        url="http://test.com/audio.mp3"
+        playStatus="STOPPED"
+        playFromPosition={0}
+        position={0}
+        volume={0}
+        playbackRate={0}
+        autoLoad
+        loop={false}
+        onError={callbackFn}
+        onLoading={callbackFn}
+        onLoad={callbackFn}
+        onPlaying={callbackFn}
+        onPause={callbackFn}
+        onResume={callbackFn}
+        onStop={callbackFn}
+        onFinishedPlaying={callbackFn}
+        onBufferChange={callbackFn}
+    />
+);

--- a/types/react-sound/tsconfig.json
+++ b/types/react-sound/tsconfig.json
@@ -1,0 +1,26 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "jsx": "react",
+        "esModuleInterop": true
+    },
+    "files": [
+        "index.d.ts",
+        "react-sound-tests.tsx"
+    ]
+}

--- a/types/react-sound/tslint.json
+++ b/types/react-sound/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
This PR is to add typings for `react-sound` package (https://github.com/leoasis/react-sound)

The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`

