### PR TITLE
Add tolerance parameter to WebHooks.contructEvent

### DIFF
--- a/types/stripe/index.d.ts
+++ b/types/stripe/index.d.ts
@@ -7192,7 +7192,7 @@ declare namespace Stripe {
         }
 
         class WebHooks {
-            constructEvent<T>(requestBody: any, signature: string | string[], endpointSecret: string): webhooks.StripeWebhookEvent<T>;
+            constructEvent<T>(requestBody: any, signature: string | string[], endpointSecret: string, tolerance: number): webhooks.StripeWebhookEvent<T>;
         }
 
         class EphemeralKeys {

--- a/types/stripe/index.d.ts
+++ b/types/stripe/index.d.ts
@@ -7192,7 +7192,7 @@ declare namespace Stripe {
         }
 
         class WebHooks {
-            constructEvent<T>(requestBody: any, signature: string | string[], endpointSecret: string, tolerance: number): webhooks.StripeWebhookEvent<T>;
+            constructEvent<T>(requestBody: any, signature: string | string[], endpointSecret: string, tolerance?: number): webhooks.StripeWebhookEvent<T>;
         }
 
         class EphemeralKeys {


### PR DESCRIPTION
If changing an existing definition:

 Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/stripe/stripe-node/blob/2e0090559e96f16e9a6f057dadde135f0c731488/lib/Webhooks.js#L9