### PR TITLE
[@types/moment-timezone] Fix return type of tz function in Moment interface

### DIFF
--- a/types/moment-timezone/index.d.ts
+++ b/types/moment-timezone/index.d.ts
@@ -58,7 +58,7 @@ declare module "moment" {
 
     interface Moment {
         tz(): string | undefined;
-        tz(timezone: string, keepLocalTime?: boolean): Moment;
+        tz(timezone: string, keepLocalTime?: boolean): moment.Moment;
         zoneAbbr(): string;
         zoneName(): string;
     }


### PR DESCRIPTION
Unless moment.Moment is specified, IDEs think the function's return type is the Moment interface that contains the function.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
