### PR TITLE
Add HeadingPitchRoll type to Cesium

### DIFF
--- a/types/cesium/index.d.ts
+++ b/types/cesium/index.d.ts
@@ -797,6 +797,22 @@ declare namespace Cesium {
         isLeapSecond: boolean;
     }
 
+    class HeadingPitchRoll {
+        heading: number;
+        pitch: number;
+        roll: number;
+        constructor(heading?: number, pitch?: number, roll?: number);
+        static clone(headingPitchRoll: HeadingPitchRoll, result?: HeadingPitchRoll): HeadingPitchRoll;
+        static equals(left: HeadingPitchRoll | null | undefined, right: HeadingPitchRoll | null | undefined): boolean;
+        static equalsEpsilon(left: HeadingPitchRoll | null | undefined, right: HeadingPitchRoll | null | undefined, relativeEpsilon: number, absoluteEpsilon?: number): boolean;
+        static fromDegrees(heading: number, pitch: number, roll: number, result?: HeadingPitchRoll): HeadingPitchRoll;
+        static fromQuaternion(quaternion: Quaternion, result?: HeadingPitchRoll): HeadingPitchRoll;
+        clone(result?: HeadingPitchRoll): HeadingPitchRoll;
+        equals(right: HeadingPitchRoll | null | undefined): boolean;
+        equalsEpsilon(right: HeadingPitchRoll | null | undefined, relativeEpsilon: number, absoluteEpsilon?: number): boolean;
+        toString(): string;
+    }
+
     class HeightmapTerrainData {
         waterMask: Uint8Array | HTMLImageElement | HTMLCanvasElement;
         constructor(options: {
@@ -959,6 +975,7 @@ declare namespace Cesium {
         static fromArray(array: number[], startingIndex?: number, result?: Matrix3): Matrix3;
         static fromColumnMajorArray(values: number[], result?: Matrix3): Matrix3;
         static fromRowMajorArray(values: number[], result?: Matrix3): Matrix3;
+        static fromHeadingPitchRoll(headingPitchRoll: HeadingPitchRoll, result?: Matrix3): Matrix3;
         static fromQuaternion(quaternion: Quaternion): Matrix3;
         static fromScale(scale: Cartesian3, result?: Matrix3): Matrix3;
         static fromUniformScale(scale: number, result?: Matrix3): Matrix3;
@@ -1236,7 +1253,7 @@ declare namespace Cesium {
         toString(): string;
         static fromAxisAngle(axis: Cartesian3, angle: number, result?: Quaternion): Quaternion;
         static fromRotationMatrix(matrix: Matrix3, result?: Quaternion): Quaternion;
-        static fromHeadingPitchRoll(heading: number, pitch: number, roll: number, result: Quaternion): Quaternion;
+        static fromHeadingPitchRoll(headingPitchRoll: HeadingPitchRoll, result?: Quaternion): Quaternion;
         static pack(value: Quaternion, array: number[], startingIndex?: number): number[];
         static unpack(array: number[], startingIndex?: number, result?: Quaternion): Quaternion;
         static convertPackedArrayForInterpolation(packedArray: number[], startingIndex?: number, lastIndex?: number, result?: number[]): void;
@@ -4880,13 +4897,15 @@ declare namespace Cesium {
         function eastNorthUpToFixedFrame(origin: Cartesian3, ellipsoid?: Ellipsoid, result?: Matrix4): Matrix4;
         function northEastDownToFixedFrame(origin: Cartesian3, ellipsoid?: Ellipsoid, result?: Matrix4): Matrix4;
         function northUpEastToFixedFrame(origin: Cartesian3, ellipsoid?: Ellipsoid, result?: Matrix4): Matrix4;
-        function headingPitchRollToFixedFrame(origin: Cartesian3, heading: number, pitch: number, roll: number, ellipsoid?: Ellipsoid, result?: Matrix4): Matrix4;
-        function headingPitchRollQuaternion(origin: Cartesian3, heading: number, pitch: number, roll: number, ellipsoid?: Ellipsoid, result?: Quaternion): Quaternion;
+        function headingPitchRollToFixedFrame(origin: Cartesian3, headingPitchRoll: HeadingPitchRoll, ellipsoid?: Ellipsoid, fixedFrameTransform?: LocalFrameToFixedFrame, result?: Matrix4): Matrix4;
+        function headingPitchRollQuaternion(origin: Cartesian3, headingPitchRoll: HeadingPitchRoll, ellipsoid?: Ellipsoid, fixedFrameTransform?: LocalFrameToFixedFrame,
+                                            result?: Quaternion): Quaternion;
         function computeTemeToPseudoFixedMatrix(date: JulianDate, result?: Matrix3): Matrix3;
         function preloadIcrfFixed(timeInterval: TimeInterval): Promise<void>;
         function computeIcrfToFixedMatrix(date: JulianDate, result?: Matrix3): Matrix3;
         function computeFixedToIcrfMatrix(date: JulianDate, result?: Matrix3): Matrix3;
         function pointToWindowCoordinates(modelViewProjectionMatrix: Matrix4, viewportTransformation: Matrix4, point: Cartesian3, result?: Cartesian2): Cartesian2;
+        type LocalFrameToFixedFrame = (origin: Cartesian3, ellipsoid?: Ellipsoid, result?: Matrix4) => Matrix4;
     }
 
     namespace TridiagonalSystemSolver {

--- a/types/cesium/test/cesium-global.test.ts
+++ b/types/cesium/test/cesium-global.test.ts
@@ -46,3 +46,7 @@ const entity = new Cesium.Entity({
     })
 });
 viewer.entities.add(entity);
+
+const hpr = new Cesium.HeadingPitchRoll(1.0, 2.2, 3.4);
+const quat: Cesium.Quaternion = Cesium.Quaternion.fromHeadingPitchRoll(hpr);
+const matrix: Cesium.Matrix3 = Cesium.Matrix3.fromHeadingPitchRoll(hpr);

--- a/types/cesium/test/cesium-module.test.ts
+++ b/types/cesium/test/cesium-module.test.ts
@@ -48,3 +48,7 @@ const entity = new Cesium.Entity({
     })
 });
 viewer.entities.add(entity);
+
+const hpr = new Cesium.HeadingPitchRoll(1.0, 2.2, 3.4);
+const quat: Cesium.Quaternion = Cesium.Quaternion.fromHeadingPitchRoll(hpr);
+const matrix: Cesium.Matrix3 = Cesium.Matrix3.fromHeadingPitchRoll(hpr);


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/AnalyticalGraphicsInc/cesium/blob/master/CHANGES.md
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

---

This PR adds the [HeadingPitchRoll](https://cesiumjs.org/Cesium/Build/Documentation/HeadingPitchRoll.html) type to Cesium, which was added in [1.27](https://github.com/AnalyticalGraphicsInc/cesium/blob/master/CHANGES.md#127---2016-11-01). It also adds/updates related methods on [Matrix3](https://cesiumjs.org/Cesium/Build/Documentation/Matrix3.html), [Quaternion](https://cesiumjs.org/Cesium/Build/Documentation/Quaternion.html), and the [Transforms](https://cesiumjs.org/Cesium/Build/Documentation/Transforms.html) namespace.

I didn't update the header version number since all of these changes predate Cesium 1.47 (the version currently declared in index.d.ts).