### PR TITLE
adds typings for the 'prometheus-gc-stats' package

### DIFF
--- a/types/prometheus-gc-stats/index.d.ts
+++ b/types/prometheus-gc-stats/index.d.ts
@@ -1,0 +1,9 @@
+// Type definitions for prometheus-gc-stats 0.6
+// Project: https://github.com/SimenB/node-prometheus-gc-stats
+// Definitions by: Daniel Byrne <https://github.com/danwbyrne>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+// register is typeof require('prom-client').Registry which has its own .d.ts
+declare function gcStats(register: any): () => void;
+
+export = gcStats;

--- a/types/prometheus-gc-stats/prometheus-gc-stats-tests.ts
+++ b/types/prometheus-gc-stats/prometheus-gc-stats-tests.ts
@@ -1,0 +1,5 @@
+import gcStats = require('prometheus-gc-stats');
+
+const testFunc = gcStats('something');
+// $ExpectType void
+testFunc();

--- a/types/prometheus-gc-stats/tsconfig.json
+++ b/types/prometheus-gc-stats/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "lib": ["es6"],
+    "noImplicitAny": true,
+    "noImplicitThis": true,
+    "strictNullChecks": true,
+    "strictFunctionTypes": true,
+    "baseUrl": "../",
+    "typeRoots": ["../"],
+    "types": [],
+    "noEmit": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "files": [
+		"index.d.ts",
+		"prometheus-gc-stats-tests.ts"
+	]
+}

--- a/types/prometheus-gc-stats/tslint.json
+++ b/types/prometheus-gc-stats/tslint.json
@@ -1,0 +1,3 @@
+{
+  "extends": "dtslint/dt.json"
+}


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.