### PR TITLE
adds typings for the 'grpc-error' package

### DIFF
--- a/types/grpc-error/grpc-error-tests.ts
+++ b/types/grpc-error/grpc-error-tests.ts
@@ -1,0 +1,7 @@
+import GRPCError = require('grpc-error');
+
+const error1 = new GRPCError('test');
+const error2 = new GRPCError({status_code: 'invalid'});
+const error3 = new GRPCError('test', 12);
+const error4 = new GRPCError('test', {status_code: 'invalid'});
+const error5 = new GRPCError('test', 12, {status_code: 'invalid'});

--- a/types/grpc-error/index.d.ts
+++ b/types/grpc-error/index.d.ts
@@ -1,0 +1,16 @@
+// Type definitions for grpc-error 1.0
+// Project: https://github.com/bojand/grpc-error
+// Definitions by: Daniel Byrne <https://github.com/danwbyrne>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.2
+
+declare class GRPCError extends Error {
+  constructor(value: string | object);
+  constructor(message: string, value: number | object);
+  constructor(message: string, code: number, metadata: object);
+
+  code: number;
+  metadata: object;
+}
+
+export = GRPCError;

--- a/types/grpc-error/tsconfig.json
+++ b/types/grpc-error/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "lib": ["es6"],
+    "noImplicitAny": true,
+    "noImplicitThis": true,
+    "strictNullChecks": true,
+    "strictFunctionTypes": true,
+    "baseUrl": "../",
+    "typeRoots": ["../"],
+    "types": [],
+    "noEmit": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "files": [
+		"index.d.ts",
+		"grpc-error-tests.ts"
+	]
+}

--- a/types/grpc-error/tslint.json
+++ b/types/grpc-error/tslint.json
@@ -1,0 +1,3 @@
+{
+  "extends": "dtslint/dt.json"
+}


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.