### PR TITLE
Fix when() and when.resolve() when input is a value/promise union type

### DIFF
--- a/types/when/index.d.ts
+++ b/types/when/index.d.ts
@@ -3,13 +3,8 @@
 // Definitions by: Derek Cicerone <https://github.com/derekcicerone>, Wim Looman <https://github.com/Nemo157>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare function When<T>(value: When.Promise<T>): When.Promise<T>;
-declare function When<T>(value: When.Thenable<T>): When.Promise<T>;
-declare function When<T>(value: T): When.Promise<T>;
-
-declare function When<T, U>(value: When.Promise<T>, transform: (val: T) => U): When.Promise<U>;
-declare function When<T, U>(value: When.Thenable<T>, transform: (val: T) => U): When.Promise<U>;
-declare function When<T, U>(value: T, transform: (val: T) => U): When.Promise<U>;
+declare function When<T>(promiseOrValue: T | When.Promise<T> | When.Thenable<T>): When.Promise<T>;
+declare function When<T, U>(promiseOrValue: T | When.Promise<T> | When.Thenable<T>, transform: (val: T) => U): When.Promise<U>;
 
 declare namespace When {
     // Helper interfaces
@@ -236,9 +231,7 @@ declare namespace When {
      *    - fulfilled with promiseOrValue's value after it is fulfilled
      *    - rejected with promiseOrValue's reason after it is rejected
      */
-    function resolve<T>(promise: Promise<T>): Promise<T>;
-    function resolve<T>(foreign: Thenable<T>): Promise<T>;
-    function resolve<T>(value?: T): Promise<T>;
+    function resolve<T>(promiseOrValue: T | Promise<T> | Thenable<T>): Promise<T>;
 
     interface Deferred<T> {
         notify(update: any): void;

--- a/types/when/when-tests.ts
+++ b/types/when/when-tests.ts
@@ -33,6 +33,7 @@ class Data implements IData {
 var promise: when.Promise<number>;
 var promise2: when.Promise<Data>;
 var foreign = new ForeignPromise<number>(1);
+var promiseOrValue = 1 as number | when.Promise<number>;
 var error = new Error("boom!");
 var example: () => void;
 var native: Promise<number>;
@@ -46,12 +47,14 @@ var native: Promise<number>;
 promise = when(1);
 promise = when(when(1));
 promise = when(foreign);
+promise = when(promiseOrValue);
 
 /* when(x, f) */
 
 promise = when(1, val => val + val);
 promise = when(when(1), val => val + val);
 promise = when(foreign, val => val + val);
+promise = when(promiseOrValue, val => val + val);
 
 /* when.try(f, ...args) */
 
@@ -204,6 +207,7 @@ promise = when.promise<number>((resolve, reject) => reject(error));
 promise = when.resolve(1);
 promise = when.resolve(promise);
 promise = when.resolve(foreign);
+promise = when.resolve(promiseOrValue);
 
 /* when.reject(error) */
 


### PR DESCRIPTION
Currently if `when(promiseOrValue)` is called and `promiseOrValue` is a value/promise union type (e.g., `T | when.Promise<T>`), its return value will be `when.Promise<T | when.Promise<T>>`. The actual behaviour is that if `promiseOrValue` is `when.Promise<T>`, it is returned (so the return type will be `when.Promise<T>`), and if `promiseOrValue` is a value, then a promise resolving with that value is returned (so the return type is also `when.Promise<T>`). So, its behaviour is always to return a promise resolving with a value of type `T`, i.e., it should always return `when.Promise<T>`.

This is also true when using `when.resolve(promiseOrValue)`.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/cujojs/when/blob/master/docs/api.md
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.