### PR TITLE
ioredis: support instances with defineCommand

### DIFF
--- a/types/ioredis/index.d.ts
+++ b/types/ioredis/index.d.ts
@@ -23,6 +23,9 @@ interface RedisStatic {
     new(port?: number, host?: string, options?: IORedis.RedisOptions): IORedis.Redis;
     new(host?: string, options?: IORedis.RedisOptions): IORedis.Redis;
     new(options?: IORedis.RedisOptions): IORedis.Redis;
+    new<T>(port?: number, host?: string, options?: IORedis.RedisOptions): IORedis.RedisDefineCommand<T>;
+    new<T>(host?: string, options?: IORedis.RedisOptions): IORedis.RedisDefineCommand<T>;
+    new<T>(options?: IORedis.RedisOptions): IORedis.RedisDefineCommand<T>;
     (port?: number, host?: string, options?: IORedis.RedisOptions): IORedis.Redis;
     (host?: string, options?: IORedis.RedisOptions): IORedis.Redis;
     (options?: IORedis.RedisOptions): IORedis.Redis;
@@ -50,6 +53,8 @@ declare namespace IORedis {
         setArgumentTransformer(name: string, fn: (args: any[]) => any[]): void;
         setReplyTransformer(name: string, fn: (result: any) => any): void;
     }
+
+    type RedisDefineCommand<T> = Redis & T
 
     interface Redis extends NodeJS.EventEmitter, Commander {
         Promise: typeof Promise;

--- a/types/ioredis/index.d.ts
+++ b/types/ioredis/index.d.ts
@@ -54,7 +54,7 @@ declare namespace IORedis {
         setReplyTransformer(name: string, fn: (result: any) => any): void;
     }
 
-    type RedisDefineCommand<T> = Redis & T
+    type RedisDefineCommand<T> = Redis & T;
 
     interface Redis extends NodeJS.EventEmitter, Commander {
         Promise: typeof Promise;

--- a/types/ioredis/ioredis-tests.ts
+++ b/types/ioredis/ioredis-tests.ts
@@ -152,3 +152,24 @@ new Redis.Cluster([{
     host: 'localhost',
     port: 6379
 }]);
+
+interface EchoCommand {
+    echo(key1: string, key2: string, arg1: string, arg2: string): Promise<string[]>;
+    echoBuffer(key1: string, key2: string, arg1: string, arg2: string): Promise<Buffer[]>;
+}
+
+const redisWithEcho = new Redis<EchoCommand>();
+redisWithEcho.defineCommand('echo', {
+    numberOfKeys: 2,
+    lua: 'return {KEYS[1],KEYS[2],ARGV[1],ARGV[2]}'
+});
+
+const echoPromise = redisWithEcho.echo('k1', 'k2', 'a1', 'a2');
+echoPromise.then((result) => {
+    // result === ['k1', 'k2', 'a1', 'a2']
+});
+
+const echoBufferPromise = redisWithEcho.echoBuffer('k1', 'k2', 'a1', 'a2');
+echoBufferPromise.then((result) => {
+    // result === [Buffer.from('k1'), Buffer.from('k2'), Buffer.from('a1'), Buffer.from('a2')]
+});


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/luin/ioredis#lua-scripting
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

This is additional feature of this typings when LUA script is created with `defineCommand` method. Special `new Redis<T>()` syntax can be used and then `redis` object supports additional custom typings for own methods defined with `defineCommand`.

Ie.:

```ts
interface EchoCommand {
    echo(key1: string, key2: string, arg1: string, arg2: string): Promise<string[]>;
}

const redisWithEcho = new Redis<EchoCommand>();
redisWithEcho.defineCommand('echo', {
    numberOfKeys: 2,
    lua: 'return {KEYS[1],KEYS[2],ARGV[1],ARGV[2]}'
});

const echoPromise = redisWithEcho.echo('k1', 'k2', 'a1', 'a2');
echoPromise.then((result) => {
    // result === ['k1', 'k2', 'a1', 'a2']
});
```

Patch is backward compatible: old `new Redis()` without generic still works.
