### PR TITLE
[@types/split] Specify return type as ThroughStream

### DIFF
--- a/types/split/index.d.ts
+++ b/types/split/index.d.ts
@@ -6,7 +6,6 @@
 /// <reference types="node" />
 /// <reference types="through" />
 
-import { Transform, TransformOptions } from 'stream';
 import { ThroughStream } from 'through';
 
 interface SplitOptions {

--- a/types/split/index.d.ts
+++ b/types/split/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for split v0.3.3
+// Type definitions for split v1.0.1
 // Project: https://github.com/dominictarr/split
 // Definitions by: Marcin Porębski <https://github.com/marcinporebski>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/split/index.d.ts
+++ b/types/split/index.d.ts
@@ -4,13 +4,15 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />
+/// <reference types="through" />
 
-
+import { Transform, TransformOptions } from 'stream';
+import { ThroughStream } from 'through';
 
 interface SplitOptions {
     maxLength: number
 }
 
-declare function split(matcher?: any, mapper?: any, options?: SplitOptions): any;
+declare function split(matcher?: any, mapper?: any, options?: SplitOptions): ThroughStream;
 
 export = split;


### PR DESCRIPTION
Made return type of `split` more specific than `any`.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/dominictarr/split/blob/d69471390bffd2cc66fee9d0cb2e075a58836901/index.js#L53
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
