### PR TITLE
@types/google-map-react: Add the missing 'onDrag' event to Props

### DIFF
--- a/types/google-map-react/index.d.ts
+++ b/types/google-map-react/index.d.ts
@@ -131,6 +131,7 @@ export interface Props {
   onChildClick?(hoverKey: any, childProps: any): void;
   onChildMouseEnter?(hoverKey: any, childProps: any): void;
   onChildMouseLeave?(hoverKey: any, childProps: any): void;
+  onDrag?(args: any): void;
   onZoomAnimationStart?(args: any): void;
   onZoomAnimationEnd?(args: any): void;
   onMapTypeIdChange?(args: any): void;


### PR DESCRIPTION
I have tested this and it works.

Here is the onDrag event from source code:
1. https://github.com/google-map-react/google-map-react/blob/28506dd42787dca81c0a6b137d072b70b9b9ab1e/src/google_map.js#L119

2. https://github.com/google-map-react/google-map-react/blob/28506dd42787dca81c0a6b137d072b70b9b9ab1e/src/google_map.js#L794