### PR TITLE
[@types/ramda] Adds `Date` to Ord type constraint

### DIFF
--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -22,6 +22,7 @@
 //                 Maciek Blim <https://github.com/blimusiek>
 //                 Marcin Biernat <https://github.com/biern>
 //                 Rayhaneh Banyassady <https://github.com/rayhaneh>
+//                 Ryan McCuaig <https://github.com/rgm>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -30,7 +31,7 @@ declare let R: R.Static;
 declare namespace R {
     type Omit<T, K extends string> = Pick<T, Exclude<keyof T, K>>;
 
-    type Ord = number | string | boolean;
+    type Ord = number | string | boolean | Date;
 
     type Path = ReadonlyArray<(number | string)>;
 

--- a/types/ramda/ramda-tests.ts
+++ b/types/ramda/ramda-tests.ts
@@ -2317,10 +2317,12 @@ class Rectangle {
     const c = {x: 3};
     const d = {x: "a"};
     const e = {x: "z"};
+    const f = {x: new Date(0)};
+    const g = {x: new Date(60 * 1000)};
     R.maxBy(cmp, a, c); // => {x: 3}
     R.maxBy(cmp)(a, c); // => {x: 3}
     R.maxBy(cmp)(a)(b);
-    R.maxBy(cmp)(d)(e);
+    R.maxBy(cmp)(f)(g);
 };
 
 () => {
@@ -2348,10 +2350,13 @@ class Rectangle {
     const c = {x: 3};
     const d = {x: "a"};
     const e = {x: "z"};
+    const f = {x: new Date(0)};
+    const g = {x: new Date(60 * 1000)};
     R.minBy(cmp, a, b); // => {x: 1}
     R.minBy(cmp)(a, b); // => {x: 1}
     R.minBy(cmp)(a)(c);
     R.minBy(cmp, d, e);
+    R.minBy(cmp)(f)(g);
 };
 
 () => {


### PR DESCRIPTION
Review of function implementations like [`maxBy`][1], the [type constraints][2] section of Ramda's wiki, and this [SO answer][3] imply that Javascript's Date object has at least a de-facto `Ord` through
behaving correctly with `<`, `>`, `===`, etc.

This commit extends `Ord` (and therefore all of Ramda's `Ord`-constrained function) to typecheck properly with `Date` values.

[1]:https://github.com/ramda/ramda/blob/d6558dd2b8136af1ffcda4c9b4c54f14f27324f4/source/maxBy.js#L29
[2]:https://github.com/ramda/ramda/wiki/Type-Signatures#type-constraints
[3]:https://stackoverflow.com/a/38620327