### PR TITLE
[compute-quantile]: Add types for the «compute-quantile» package

### DIFF
--- a/types/compute-quantile/compute-quantile-tests.ts
+++ b/types/compute-quantile/compute-quantile-tests.ts
@@ -1,0 +1,13 @@
+import quantile = require('compute-quantile');
+
+// $ExpectType number
+quantile([1, 2, 3], 0.5);
+
+// $ExpectType number
+quantile([1, 2, 3], 0.5, undefined);
+
+// $ExpectType number
+quantile([1, 2, 3], 0.5, {});
+
+// $ExpectType number
+quantile([1, 2, 3], 0.5, { sorted: true });

--- a/types/compute-quantile/index.d.ts
+++ b/types/compute-quantile/index.d.ts
@@ -1,0 +1,23 @@
+// Type definitions for compute-quantile 1.0
+// Project: https://github.com/compute-io/quantile
+// Definitions by: mrmlnc <https://github.com/mrmlnc>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/**
+ * Computes a quantile for a numeric array.
+ */
+declare function quantile(array: ArrayLike<number>, quantile: number, options?: quantile.Options): number;
+
+declare namespace quantile {
+    interface Options {
+        /**
+         * If the input `array` is already sorted in `__ascending__` order, you can set the `sorted` option to `true`.
+         *
+         * @default
+         * false
+         */
+        sorted?: boolean;
+    }
+}
+
+export = quantile;

--- a/types/compute-quantile/tsconfig.json
+++ b/types/compute-quantile/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "compute-quantile-tests.ts"
+    ]
+}

--- a/types/compute-quantile/tslint.json
+++ b/types/compute-quantile/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.