### PR TITLE
Fixing callback type in send method for ws

### DIFF
--- a/types/ws/index.d.ts
+++ b/types/ws/index.d.ts
@@ -44,8 +44,8 @@ declare class WebSocket extends events.EventEmitter {
     close(code?: number, data?: string): void;
     ping(data?: any, mask?: boolean, cb?: (err: Error) => void): void;
     pong(data?: any, mask?: boolean, cb?: (err: Error) => void): void;
-    send(data: any, cb?: (err: Error) => void): void;
-    send(data: any, options: { mask?: boolean; binary?: boolean; compress?: boolean; fin?: boolean }, cb?: (err: Error) => void): void;
+    send(data: any, cb?: (err?: Error) => void): void;
+    send(data: any, options: { mask?: boolean; binary?: boolean; compress?: boolean; fin?: boolean }, cb?: (err?: Error) => void): void;
     terminate(): void;
 
     // HTML5 WebSocket events

--- a/types/ws/ws-tests.ts
+++ b/types/ws/ws-tests.ts
@@ -22,6 +22,8 @@ import * as https from 'https';
     wss.on('connection', (ws, req) => {
         ws.on('message', (message) => console.log('received: %s', message));
         ws.send('something');
+        ws.send('something', (error?: Error) => {});
+        ws.send('something', {}, (error?: Error) => {});
     });
 
     wss.on('upgrade', (res) => {


### PR DESCRIPTION
According to https://github.com/websockets/ws#error-handling-best-practices, the error in the send callback is undefined when there is no error. I constated this behavior when developping too.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/websockets/ws#error-handling-best-practices
- [X] Increase the version number in the header if appropriate.
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
