### PR TITLE
[react-numeric-input] Improvements and fixes

### DIFF
--- a/types/react-numeric-input/index.d.ts
+++ b/types/react-numeric-input/index.d.ts
@@ -17,11 +17,13 @@ declare namespace NumericInput {
         'min' | 'max' | 'step' | 'onChange' | 'defaultValue' | 'onInvalid' | 'style'
     > {
         addLabelText?: string;
+        componentClass?: string;
         defaultValue?: number | string;
         format?: ((value: number | null) => string);
         max?: BoundsFunctionProp;
         min?: BoundsFunctionProp;
         mobile?: boolean | 'auto' | ((component: NumericInput) => boolean);
+        noStyle?: boolean;
         noValidate?: boolean | string;
         onBlur?: React.FocusEventHandler<HTMLDivElement | HTMLInputElement>;
         onChange?: ((value: number | null, stringValue: string, input: HTMLInputElement) => void);

--- a/types/react-numeric-input/index.d.ts
+++ b/types/react-numeric-input/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for react-numeric-input 2.2
 // Project: https://github.com/vlad-ignatov/react-numeric-input#readme
 // Definitions by: Heather Booker <https://github.com/heatherbooker>
+//                 Aarni Koskela <https://github.com/akx>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -9,38 +10,50 @@ import * as React from 'react';
 export = NumericInput;
 
 declare namespace NumericInput {
-    interface NumericInputProps extends React.Props<NumericInput> {
+    type BoundsFunctionProp = number | ((component: NumericInput) => number | undefined);
+    type Omit<T, K> = Pick<T, Exclude<keyof T, K>>;  // via TS 2.8 manual
+    interface NumericInputProps extends Omit<
+        React.InputHTMLAttributes<HTMLInputElement>,
+        'min' | 'max' | 'step' | 'onChange' | 'defaultValue' | 'onInvalid' | 'style'
+    > {
         addLabelText?: string;
-        className?: string;
         defaultValue?: number | string;
-        disabled?: boolean;
-        format?: ((s: string) => string);
-        max?: number | ((v: number) => number);
-        maxLength?: number;
-        min?: number | ((v: number) => number);
-        mobile?: boolean | 'auto' | ((this: NumericInput) => any); // TODO: fix `any`
-        noValidate?: boolean| string;
+        format?: ((value: number | null) => string);
+        max?: BoundsFunctionProp;
+        min?: BoundsFunctionProp;
+        mobile?: boolean | 'auto' | ((component: NumericInput) => boolean);
+        noValidate?: boolean | string;
         onBlur?: React.FocusEventHandler<HTMLDivElement | HTMLInputElement>;
-        onChange?: ((v: number, s: string, i: JSX.Element) => void);
+        onChange?: ((value: number | null, stringValue: string, input: HTMLInputElement) => void);
         onFocus?: React.FocusEventHandler<HTMLDivElement | HTMLInputElement>;
-        onInput?: ((...args: any[]) => void);
-        onInvalid?: ((err: string, v: number, s: string) => void);
+        onInput?: React.FormEventHandler<HTMLInputElement>;
+        onInvalid?: ((error: string, value: number | null, stringValue: string) => void);
         onKeyDown?: React.KeyboardEventHandler<HTMLDivElement | HTMLInputElement>;
-        onSelect?: ((...args: any[]) => void);
-        onValid?: ((v: number, s: string) => void);
-        parse?: ((s: string) => number | string);
-        pattern?: string;
-        precision?: number | ((this: NumericInput) => void);
-        readOnly?: boolean;
-        required?: boolean;
-        size?: number | string;
+        onSelect?: React.ReactEventHandler<HTMLInputElement>;
+        onValid?: ((value: number | null, stringValue: string) => void);
+        parse?: ((stringValue: string) => number | null);
+        precision?: number | ((component: NumericInput) => number | null | undefined);
         snap?: boolean;
-        step?: number | object; // TODO: should be `number | <some function>`
+        step?: number | ((component: NumericInput, direction: string) => number | undefined);
         strict?: boolean;
-        style?: { [key: string]: { [key: string]: string } } | boolean;
-        type?: string;
+        style?: {[key: string]: React.CSSProperties} | boolean;
         value?: number | string;
+    }
+    // Exposed here for the function prop handlers that get the NumericInput instance as a parameter.
+    // Lifted directly from react-numeric-input@79874ccbe:/src/NumericInput.jsx#L63-L73
+    interface NumericInputState {
+        btnDownActive?: boolean;
+        btnDownHover?: boolean;
+        btnUpActive?: boolean;
+        btnUpHover?: boolean;
+        selectionEnd?: number | null;
+        selectionStart?: number | null;
+        stringValue?: string;
+        value?: number | null;
     }
 }
 
-declare class NumericInput extends React.Component<NumericInput.NumericInputProps> {}
+declare class NumericInput extends React.Component<NumericInput.NumericInputProps, NumericInput.NumericInputState> {
+    static DIRECTION_UP: string;
+    static DIRECTION_DOWN: string;
+}

--- a/types/react-numeric-input/react-numeric-input-tests.tsx
+++ b/types/react-numeric-input/react-numeric-input-tests.tsx
@@ -3,6 +3,16 @@ import NumericInput = require('react-numeric-input');
 
 export class NumericInputTest extends Component {
   render() {
-    return(<NumericInput />);
+    return (
+      <NumericInput
+        min={-10}
+        max={(comp) => (comp.state.value || 1) + 1}
+        format={(x) => `EUR ${x}`}
+        parse={(s) => parseFloat(s.replace(/EUR /, ''))}
+        step={(comp, dir) => (dir === NumericInput.DIRECTION_UP ? 9 : 1)}
+        style={{wrap: {color: 'orange'}}}
+        className="hello"
+      />
+    );
   }
 }


### PR DESCRIPTION
(This is my first time contributing to DefinitelyTyped.)

* No longer inherit from deprecated React.Props
* Derive from `React.InputHTMLAttributes<HTMLInputElement>` to avoid duplication (and to add missing `<input>` props)
* Fix min/max/precision/step props
* Fix the type of the "numeric value" state; it can be `null`
* Clean out `any`s
* Expose the internal state (as used by function props)
* Add new `noStyle` and `componentClass` props added in 2.2.3.

---

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/vlad-ignatov/react-numeric-input/blob/79874ccbe2293873300953f32d91f2d70d32a871/src/NumericInput.jsx
- [x] Increase the version number in the header if appropriate. (Increased 2.2 to 2.2.3.)
