### PR TITLE
[react-beautiful-dnd] Add ignoreContainerClipping to DroppableProps

### DIFF
--- a/types/react-beautiful-dnd/index.d.ts
+++ b/types/react-beautiful-dnd/index.d.ts
@@ -73,6 +73,7 @@ export interface DroppableStateSnapshot {
 export interface DroppableProps {
     droppableId: DroppableId;
     type?: TypeId;
+    ignoreContainerClipping?: boolean;
     isDropDisabled?: boolean;
     direction?: 'vertical' | 'horizontal';
     children(provided: DroppableProvided, snapshot: DroppableStateSnapshot): React.ReactElement<any>;

--- a/types/react-beautiful-dnd/react-beautiful-dnd-tests.tsx
+++ b/types/react-beautiful-dnd/react-beautiful-dnd-tests.tsx
@@ -73,7 +73,7 @@ class App extends React.Component<{}, AppState> {
   render() {
     return (
       <DragDropContext onDragStart={this.onDragStart} onDragUpdate={this.onDragUpdate} onDragEnd={this.onDragEnd}>
-        <Droppable droppableId="droppable">
+        <Droppable droppableId="droppable" ignoreContainerClipping={false}>
           {(provided, snapshot) => (
             <div ref={provided.innerRef} style={getListStyle(snapshot.isDraggingOver)} {...provided.droppableProps}>
               {this.state.items.map((item, index) => (


### PR DESCRIPTION
* This prop was added in https://github.com/atlassian/react-beautiful-dnd/pull/148
  but was never updated here.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

**Note** This failed, but not due to my changes.

```
Error: /Users/willduffy/src/DefinitelyTyped/types/react-beautiful-dnd/index.d.ts:16:42
ERROR: 16:42  expect  TypeScript@next compile error:
Property 'zIndex' does not exist on type 'CSSProperties'.
```

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/atlassian/react-beautiful-dnd/pull/148
- [ ] Increase the version number in the header if appropriate. 

**Note** The header states version 7.1, but `ignoreContainerClipping` was added in version 2.5 so I don't feel my change merits updating the version. It's on version 9 now but I'm not familiar with the changelog between 7.1 and 9.0.1 so I do not want to update this myself!

https://github.com/atlassian/react-beautiful-dnd/releases/tag/v2.5.0

- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

