### PR TITLE
[relay-runtime] Fix wrong types, export ROOT_ID

### DIFF
--- a/types/relay-runtime/index.d.ts
+++ b/types/relay-runtime/index.d.ts
@@ -61,6 +61,11 @@ export interface OperationDefaults {
 }
 
 // ~~~~~~~~~~~~~~~~~~~~~
+// Constants
+// ~~~~~~~~~~~~~~~~~~~~~
+export const ROOT_ID: string;
+
+// ~~~~~~~~~~~~~~~~~~~~~
 // RelayQL
 // ~~~~~~~~~~~~~~~~~~~~~
 export type RelayQL = (strings: string[], ...substitutions: any[]) => RelayConcreteNode;
@@ -189,7 +194,7 @@ export interface RecordProxy {
 export interface RecordSourceProxy {
     create(dataID: DataID, typeName: string): RecordProxy;
     delete(dataID: DataID): void;
-    get(dataID: DataID): Array<RecordProxy | null> | null;
+    get(dataID: DataID): RecordProxy | null;
     getRoot(): RecordProxy;
 }
 
@@ -1010,7 +1015,7 @@ export type Observable<T> = RelayObservable<T>;
 // commitLocalUpdate
 // ~~~~~~~~~~~~~~~~~~~~~
 // exposed through RelayModern, not Runtime directly
-export type commitLocalUpdate = (environment: Environment, updater: StoreUpdater) => void;
+export function commitLocalUpdate(environment: Environment, updater: StoreUpdater): void;
 
 // ~~~~~~~~~~~~~~~~~~~~~
 // commitRelayModernMutation

--- a/types/relay-runtime/relay-runtime-tests.tsx
+++ b/types/relay-runtime/relay-runtime-tests.tsx
@@ -6,6 +6,8 @@ import {
     ConnectionHandler,
     ViewerHandler,
     RecordSourceInspector,
+    commitLocalUpdate,
+    ROOT_ID,
 } from "relay-runtime";
 
 const source = new RecordSource();
@@ -60,3 +62,12 @@ function handlerProvider(handle: any) {
 // ~~~~~~~~~~~~~~~~~~~~~
 
 const inspector = new RecordSourceInspector(source);
+
+// ~~~~~~~~~~~~~~~~~~~~~
+// commitLocalUpdate
+// ~~~~~~~~~~~~~~~~~~~~~
+
+commitLocalUpdate(environment, store => {
+  const root = store.get(ROOT_ID)!;
+  root.setValue("foo", "localKey");
+});


### PR DESCRIPTION
These are the type changes and fixes we use for our next version of [talk](https://github.com/coralproject/talk/tree/next/)
  - export `ROOT_ID`, see https://github.com/facebook/relay/pull/2504#issuecomment-412233610
  - `RecordSourceProxy` does not return an array see https://github.com/facebook/relay/blob/master/packages/relay-runtime/store/RelayStoreTypes.js#L196
  - `commitLocalUpdate` wrongly exported as a type only. 

### Checklist
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes
- [x] Increase the version number in the header if appropriate.
