### PR TITLE
[jsftp] Add types for jsftp

### DIFF
--- a/types/jsftp/index.d.ts
+++ b/types/jsftp/index.d.ts
@@ -1,0 +1,50 @@
+// Type definitions for jsftp 2.1
+// Project: https://github.com/sergi/jsftp
+// Definitions by: Konrad Księski <https://github.com/xyleen>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types="node" />
+
+import { Socket } from 'net';
+import { EventEmitter } from 'events';
+
+export interface JsftpOpts {
+    host?: string;
+    port?: number;
+    user?: string;
+    pass?: string;
+    createSocket?: ({ port, host }: { port: number, host: string }, firstAction: () => {}) => Socket;
+    useList?: boolean;
+}
+
+export type ErrorCallback = (err: Error) => void;
+export type RawCallback = (err: Error, data: { code: number, text: string }) => void;
+export type ListCallback = (err: Error, dirContents: string) => void;
+export type GetCallback = (err: Error, socket: Socket) => void;
+export type LsCallback = (err: Error, res: [{ name: string }]) => void;
+
+export default class Ftp extends EventEmitter {
+    constructor(opts: JsftpOpts);
+
+    ls(filePath: string, callback: LsCallback): void;
+
+    list(filePath: string, callback: ListCallback): void;
+
+    get(remotePath: string, callback: GetCallback): void;
+    get(remotePath: string, localPath: string, callback: ErrorCallback): void;
+
+    put(source: string | Buffer | NodeJS.ReadableStream, remotePath: string, callback: ErrorCallback): void;
+
+    rename(from: string, to: string, callback: ErrorCallback): void;
+
+    // Ftp.raw(command, params, callback)
+    raw(command: string, callback: RawCallback): void;
+    raw(command: string, arg1: any, callback: RawCallback): void;
+    raw(command: string, arg1: any, arg2: any, callback: RawCallback): void;
+    raw(command: string, arg1: any, arg2: any, arg3: any, callback: RawCallback): void;
+    raw(command: string, arg1: any, arg2: any, arg3: any, arg4: any, callback: RawCallback): void;
+
+    keepAlive(timeInMs?: number): void;
+
+    destroy(): void;
+}

--- a/types/jsftp/jsftp-tests.ts
+++ b/types/jsftp/jsftp-tests.ts
@@ -1,0 +1,25 @@
+import Ftp from 'jsftp';
+
+const connectOpts = {
+    host: 'localhost',
+    port: 22222,
+};
+
+const ftp = new Ftp(connectOpts);  // $ExpectType Ftp
+
+ftp.ls('foo', (err) => { });  // $ExpectType void
+
+ftp.list('foo', (err) => { });  // $ExpectType void
+
+ftp.get('foo', (err) => { });  // $ExpectType void
+ftp.get('foo', 'bar', (err) => { });  // $ExpectType void
+
+ftp.put('foo', 'bar', (err) => { });  // $ExpectType void
+
+ftp.rename('foo', 'bar', (err) => { });  // $ExpectType void
+
+ftp.raw('foo', 'param', (err) => { });  // $ExpectType void
+
+ftp.keepAlive();  // $ExpectType void
+
+ftp.destroy();  // $ExpectType void

--- a/types/jsftp/tsconfig.json
+++ b/types/jsftp/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "jsftp-tests.ts"
+    ]
+}

--- a/types/jsftp/tslint.json
+++ b/types/jsftp/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
