### PR TITLE
[credit-card-type] Upgrade to v7 (no hyphen in "mastercard")

### DIFF
--- a/types/credit-card-type/index.d.ts
+++ b/types/credit-card-type/index.d.ts
@@ -1,31 +1,39 @@
-// Type definitions for Credit Card Type v5.0.0
+// Type definitions for Credit Card Type v7.0.0
 // Project: https://github.com/braintree/credit-card-type
 // Definitions by: Karol Janyst <https://github.com/LKay>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.9
 
 declare namespace creditCardType {
-
-    type CardBrand = "american-express" | "diners-club" | "discover" | "jcb" | "maestro" | "master-card" | "unionpay" | "visa"
+    type CardBrand =
+        | "american-express"
+        | "diners-club"
+        | "discover"
+        | "jcb"
+        | "maestro"
+        | "mastercard"
+        | "unionpay"
+        | "visa";
 
     interface CreditCardTypeInfo {
-        niceType?: string
-        type?: CardBrand
-        prefixPattern?: RegExp
-        exactPattern?: RegExp
-        gaps?: Array<number>
-        lengths?: Array<number>
+        niceType?: string;
+        type?: CardBrand;
+        prefixPattern?: RegExp;
+        exactPattern?: RegExp;
+        gaps?: Array<number>;
+        lengths?: Array<number>;
         code?: {
-            name?: string
-            size?: number
-        }
+            name?: string;
+            size?: number;
+        };
     }
 
     interface CreditCardType {
-        (number: string): Array<CreditCardTypeInfo>
-        getTypeInfo (type: string): CreditCardTypeInfo
-        types: { [type: string]: string }
+        (number: string): Array<CreditCardTypeInfo>;
+        getTypeInfo(type: string): CreditCardTypeInfo;
+        types: { [type: string]: string };
     }
 }
 
-declare const creditCardType: creditCardType.CreditCardType
-export = creditCardType
+declare const creditCardType: creditCardType.CreditCardType;
+export = creditCardType;


### PR DESCRIPTION
Prior to v7 of `credit-card-type`, the library used used `"master-card"`. Now it uses `"mastercard"` (no hyphen)

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
Source code:
https://github.com/braintree/credit-card-type/blob/master/index.js#L7
Changelog:
https://github.com/braintree/credit-card-type/blob/master/CHANGELOG.md#700
- [x] Increase the version number in the header if appropriate.