### PR TITLE
[express-winston] Adding support for express-winston v3

### DIFF
--- a/types/express-winston/express-winston-tests.ts
+++ b/types/express-winston/express-winston-tests.ts
@@ -34,9 +34,11 @@ app.use(expressWinston.logger({
   ],
 }));
 
+const logger = winston.createLogger();
+
 // Logger with minimum options (winstonInstance)
 app.use(expressWinston.logger({
-  winstonInstance: winston,
+  winstonInstance: logger,
 }));
 
 // Error Logger with all options
@@ -62,7 +64,7 @@ app.use(expressWinston.errorLogger({
 
 // Error Logger with min options (winstonInstance)
 app.use(expressWinston.errorLogger({
-  winstonInstance: winston,
+  winstonInstance: logger,
 }));
 
 expressWinston.bodyBlacklist.push('potato');

--- a/types/express-winston/index.d.ts
+++ b/types/express-winston/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for express-winston 2.4
+// Type definitions for express-winston 3.0
 // Project: https://github.com/bithavoc/express-winston#readme
 // Definitions by: Alex Brick <https://github.com/bricka>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -44,7 +44,7 @@ export interface LoggerOptionsWithTransports extends BaseLoggerOptions {
 }
 
 export interface LoggerOptionsWithWinstonInstance extends BaseLoggerOptions {
-  winstonInstance: typeof winston;
+  winstonInstance: winston.Logger;
 }
 
 export type LoggerOptions = LoggerOptionsWithTransports | LoggerOptionsWithWinstonInstance;
@@ -66,7 +66,7 @@ export interface ErrorLoggerOptionsWithTransports extends BaseErrorLoggerOptions
 }
 
 export interface ErrorLoggerOptionsWithWinstonInstance extends BaseErrorLoggerOptions {
-  winstonInstance: typeof winston;
+  winstonInstance: winston.Logger;
 }
 
 export type ErrorLoggerOptions = ErrorLoggerOptionsWithTransports | ErrorLoggerOptionsWithWinstonInstance;


### PR DESCRIPTION
The interface to Winston has changed (Winston now has a Logger type).

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/bithavoc/express-winston/blob/master/CHANGELOG.md#300
- [X] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
