### PR TITLE
Fix puppeteer.Page.browser method declaration

### DIFF
--- a/types/puppeteer/index.d.ts
+++ b/types/puppeteer/index.d.ts
@@ -1223,7 +1223,7 @@ export interface Page extends EventEmitter, FrameBase {
   bringToFront(): Promise<void>;
 
   /** Get the browser the page belongs to. */
-  browser(): Promise<Browser>;
+  browser(): Browser;
 
   /** Closes the current page. */
   close(options?: PageCloseOptions): Promise<void>;


### PR DESCRIPTION
It returns plain Browser: https://pptr.dev/#?product=Puppeteer&version=v1.6.2&show=api-pagebrowser
