### PR TITLE
d3-voronoi: Activate StrictNullChecks

### DIFF
--- a/types/d3-voronoi/d3-voronoi-tests.ts
+++ b/types/d3-voronoi/d3-voronoi-tests.ts
@@ -12,8 +12,8 @@ import * as d3Voronoi from 'd3-voronoi';
 // Preparatory Steps
 // ---------------------------------------------------------------------
 
-let extent: [[number, number], [number, number]];
-let size: [number, number];
+let extent: [[number, number], [number, number]] | null;
+let size: [number, number] | null;
 let coordinates: [number, number];
 
 let num: number;
@@ -38,9 +38,11 @@ let numberAccessor: (d: VoronoiTestDatum) => number;
 
 let edges: Array<d3Voronoi.VoronoiEdge<VoronoiTestDatum>>;
 let edge: d3Voronoi.VoronoiEdge<VoronoiTestDatum>;
-let cells: Array<d3Voronoi.VoronoiCell<VoronoiTestDatum>>;
+let cells: Array<d3Voronoi.VoronoiCell<VoronoiTestDatum> | null>;
 let cell: d3Voronoi.VoronoiCell<VoronoiTestDatum>;
+let cellOrNull: d3Voronoi.VoronoiCell<VoronoiTestDatum> | null;
 let site: d3Voronoi.VoronoiSite<VoronoiTestDatum>;
+let siteOrNull: d3Voronoi.VoronoiSite<VoronoiTestDatum> | null;
 
 let polygons: Array<d3Voronoi.VoronoiPolygon<VoronoiTestDatum>>;
 let polygon: d3Voronoi.VoronoiPolygon<VoronoiTestDatum>;
@@ -57,18 +59,20 @@ let link: d3Voronoi.VoronoiLink<VoronoiTestDatum>;
 
 // VoronoiPoint -------------------------------------------------------
 
-let point: d3Voronoi.VoronoiPoint;
+declare let point: d3Voronoi.VoronoiPoint;
 
 point[0] = 10; // x-coordinate
 point[1] = 10; // y-coordinate
 
 point = [10, 10];
-// point = [10]; // fails, second element for y-coordinate missing
-// point = ['a', 'b']; // fails, wrong element type
+// $ExpectError
+point = [10]; // fails, second element for y-coordinate missing
+// $ExpectError
+point = ['a', 'b']; // fails, wrong element type
 
 // VoronoiPointPair ---------------------------------------------------
 
-let pointPair: d3Voronoi.VoronoiPointPair;
+declare let pointPair: d3Voronoi.VoronoiPointPair;
 
 pointPair[0][0] = 10; // x-coordinate of first point
 pointPair[0][1] = 10; // y-coordinate of first point
@@ -77,10 +81,14 @@ pointPair[1][1] = 10; // y-coordinate of second point
 
 pointPair = [[10, 10], [50, 50]];
 
-// pointPair = [[10, 10]]; // fails, second point coordinates missing
-// pointPair = [[10, 10], [50]]; // fails, one element is not of type [number, number]
-// pointPair = [[10], [50, 50]]; // fails, one element is not of type [number, number]
-// pointPair = [['a', 10], [50, 50]]; // fails, one element is not of type [number, number]
+// $ExpectError
+pointPair = [[10, 10]]; // fails, second point coordinates missing
+// $ExpectError
+pointPair = [[10, 10], [50]]; // fails, one element is not of type [number, number]
+// $ExpectError
+pointPair = [[10], [50, 50]]; // fails, one element is not of type [number, number]
+// $ExpectError
+pointPair = [['a', 10], [50, 50]]; // fails, one element is not of type [number, number]
 
 // VoronoiPolygon -------------------------------------------------------
 
@@ -173,13 +181,14 @@ coordinates = edge[0]; // source point coordinates
 coordinates = edge[1]; // source point coordinates
 
 site = edge.left;
-site = edge.right;
+siteOrNull = edge.right;
 
 // cells() VoronoiCell =================================================
 
 cells = voronoiDiagram.cells;
 
-cell = cells[0];
+cellOrNull = cells[0];
+cell = cells[0]!;
 
 site = cell.site;
 
@@ -237,4 +246,5 @@ nearestSite = voronoiDiagram.find(10, 50);
 nearestSite = voronoiDiagram.find(10, 50, 20);
 
 // wrong data type
-// const wrongSiteDataType: d3Voronoi.VoronoiSite<[number, number]> | null; = voronoiDiagram.find(10, 50); // fails, due to data type mismatch
+// $ExpectError
+const wrongSiteDataType: d3Voronoi.VoronoiSite<[number, number]> | null = voronoiDiagram.find(10, 50); // fails, due to data type mismatch

--- a/types/d3-voronoi/index.d.ts
+++ b/types/d3-voronoi/index.d.ts
@@ -1,6 +1,9 @@
 // Type definitions for D3JS d3-voronoi module 1.1
 // Project: https://github.com/d3/d3-voronoi/
-// Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
+// Definitions by: Tom Wanzek <https://github.com/tomwanzek>
+//                 Alex Ford <https://github.com/gustavderdrache>
+//                 Boris Yankov <https://github.com/borisyankov>
+//                 denisname <https://github.com/denisname>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 

--- a/types/d3-voronoi/index.d.ts
+++ b/types/d3-voronoi/index.d.ts
@@ -2,8 +2,9 @@
 // Project: https://github.com/d3/d3-voronoi/
 // Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
 
-// Last module patch version validated against: 1.1.0
+// Last module patch version validated against: 1.1.4
 
 // --------------------------------------------------------------------------
 // Shared Type Definitions and Interfaces
@@ -61,6 +62,7 @@ export interface VoronoiSite<T> extends VoronoiPoint {
      * The Voronoi Site’s index, corresponding to the associated input point.
      */
     index: number;
+
     /**
      * The input data corresponding to this site.
      */
@@ -78,6 +80,7 @@ export interface VoronoiCell<T> {
      * The Voronoi Site of the cell’s associated input point.
      */
     site: VoronoiSite<T>;
+
     /**
      * An array of indexes into diagram.edges representing the cell’s polygon.
      */
@@ -95,8 +98,9 @@ export interface VoronoiEdge<T> extends VoronoiPointPair {
      * The Voronoi site on the left side of the edge.
      */
     left: VoronoiSite<T>;
+
     /**
-     * The Voronoi site on the right side of the edge. null for a clipped border edge.
+     * The Voronoi site on the right side of the edge; `null` for a clipped border edge.
      */
     right: VoronoiSite<T> | null;
 }
@@ -112,6 +116,7 @@ export interface VoronoiLink<T> {
      * The source node, an element in data.
      */
     source: T;
+
     /**
      * The target node, an element in data.
      */
@@ -137,6 +142,7 @@ export interface VoronoiLayout<T> {
     x(): (d: T) => number;
     /**
      * Set the x-coordinate accessor and return the layout.
+     *
      * @param x An accessor function which takes a data element as input and return a
      * numeric value for the x-coordinate.
      */
@@ -149,6 +155,7 @@ export interface VoronoiLayout<T> {
     y(): (d: T) => number;
     /**
      * Set the y-coordinate accessor and return the layout.
+     *
      * @param y An accessor function which takes a data element as input and return a
      * numeric value for the y-coordinate.
      */
@@ -207,6 +214,7 @@ export interface VoronoiLayout<T> {
      * @param data Array of data points.
      */
     polygons(data: T[]): Array<VoronoiPolygon<T>>;
+
     /**
      * Return the Delaunay triangulation of the specified data array as an array of triangles.
      * Each triangle is a three-element array of elements from data.
@@ -214,6 +222,7 @@ export interface VoronoiLayout<T> {
      * @param data Array of data points.
      */
     triangles(data: T[]): Array<VoronoiTriangle<T>>;
+
     /**
      * Return the Delaunay triangulation of the specified data array as an array of links.
      * Each link has source and target attributes referring to elements in data.
@@ -233,10 +242,12 @@ export interface VoronoiDiagram<T> {
      * Array of Voronoi Edges
      */
     edges: Array<VoronoiEdge<T>>;
+
     /**
      * Array of Voronoi Cells, one per input point; a cell may be null for a coincident point.
      */
     cells: Array<VoronoiCell<T> | null>;
+
     /**
      * Return an array of polygons clipped to the extent, one for each cell in the diagram.
      * Each polygon is represented as an array of points [x, y] where x and y are the point coordinates,
@@ -284,16 +295,11 @@ export interface VoronoiDiagram<T> {
 
 /**
  * Creates a new Voronoi layout with default x- and y- accessors and a null extent.
- *
- * Without specifying a generic the layout is assumed to be based on data represented
- * by a two-dimensional coordinate [number, number] for x- and y-coordinate, respectively.
- */
-export function voronoi(): VoronoiLayout<[number, number]>;
-/**
- * Creates a new Voronoi layout with default x- and y- accessors and a null extent.
  * x- and y-accessors may have to be set to correspond to the data type provided by the
  * generic.
  *
  * The generic refers to the type of the data for the corresponding element.
+ * Without specifying a generic the layout is assumed to be based on data represented
+ * by a two-dimensional coordinate `[number, number]` for x- and y-coordinate, respectively.
  */
-export function voronoi<T>(): VoronoiLayout<T>;
+export function voronoi<T = [number, number]>(): VoronoiLayout<T>;

--- a/types/d3-voronoi/tsconfig.json
+++ b/types/d3-voronoi/tsconfig.json
@@ -6,7 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
-        "strictNullChecks": false,
+        "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",
         "typeRoots": [


### PR DESCRIPTION
Activate strictNullChecks: type definition where already complete, so I just had to update the tests.

For strictFunctionTypes I have nothing to add.

TS 2.3: use default generics for voronoi.

Also, in tests use ExpectError.

Related #23611.

