### PR TITLE
Reorder function overloads to allow typescript compiler to match variant with function as an argument 

### DIFF
--- a/types/supertest/index.d.ts
+++ b/types/supertest/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for SuperTest v2.0.1
 // Project: https://github.com/visionmedia/supertest
 // Definitions by: Alex Varju <https://github.com/varju>
+//                 Petteri Parkkila <https://github.com/pietu>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
@@ -23,12 +24,12 @@ declare namespace supertest {
       serverAddress(app: any, path: string): string;
       expect(status: number, callback?: CallbackHandler): this;
       expect(status: number, body: any, callback?: CallbackHandler): this;
+      expect(checker: (res: Response) => any): this;
       expect(body: string, callback?: CallbackHandler): this;
       expect(body: RegExp, callback?: CallbackHandler): this;
       expect(body: Object, callback?: CallbackHandler): this;
       expect(field: string, val: string, callback?: CallbackHandler): this;
       expect(field: string, val: RegExp, callback?: CallbackHandler): this;
-      expect(checker: (res: Response) => any): this;
       end(callback?: CallbackHandler): this;
     }
 

--- a/types/supertest/supertest-tests.ts
+++ b/types/supertest/supertest-tests.ts
@@ -59,6 +59,17 @@ function hasPreviousAndNextKeys(res: supertest.Response) {
   if (!('prev' in res.body)) throw new Error("missing prev key");
 }
 
+// functional expect without response type
+(request
+  .get('/') as supertest.Test)
+  .expect(res => {
+    if (!('next' in res.body)) return "missing next key";
+    if (!('prev' in res.body)) throw new Error("missing prev key");
+  })
+  .end((err: any, res: supertest.Response) => {
+    if (err) throw err;
+  });
+
 // object expect
 (request
   .get('/') as supertest.Test)


### PR DESCRIPTION
* `expect` function overload with `(res: Response) => any` as an argument matches to overload with `Object` as an argument and thus the compiler never picks up function variant if it's ordered lower than `Object` variant.
* This allows us to use functions `(res: Response) => any` without need to declare the response type like 
`expect(res => { expect(res.body).toHaveProperty(...) })`
instead of
`expect((res: supertest.Response) => { expect(res.body).toHaveProperty(...) })`

See [TS functions](https://www.typescriptlang.org/docs/handbook/functions.html) last part.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://www.typescriptlang.org/docs/handbook/functions.html>>