### PR TITLE
plot.ly: Type axis names properly.

### DIFF
--- a/types/plotly.js/index.d.ts
+++ b/types/plotly.js/index.d.ts
@@ -318,17 +318,21 @@ export interface Axis {
 export type Calendar = 'gregorian' | 'chinese' | 'coptic' | 'discworld' | 'ethiopian' | 'hebrew' | 'islamic' | 'julian' | 'mayan' |
 	'nanakshahi' | 'nepali' | 'persian' | 'jalali' | 'taiwan' | 'thai' | 'ummalqura';
 
+export type AxisName =
+	| 'x' | 'x2' | 'x3' | 'x4' | 'x5' | 'x6' | 'x7' | 'x8' | 'x9'
+	| 'y' | 'y2' | 'y3' | 'y4' | 'y5' | 'y6' | 'y7' | 'y8' | 'y9';
+
 export interface LayoutAxis extends Axis {
 	fixedrange: boolean;
-	scaleanchor: '/^x([2-9]|[1-9][0-9]+)?$/' | '/^y([2-9]|[1-9][0-9]+)?$/';
+	scaleanchor: AxisName;
 	scaleratio: number;
 	constrain: 'range' | 'domain';
 	constraintoward: 'left' | 'center' | 'right' | 'top' | 'middle' | 'bottom';
 	spikedash: string;
 	spikemode: string;
-	anchor: 'free' | '/^x([2-9]|[1-9][0-9]+)?$/' | '/^y([2-9]|[1-9][0-9]+)?$/';
+	anchor: 'free' | AxisName;
 	side: 'top' | 'bottom' | 'left' | 'right';
-	overlaying: 'free' | '/^x([2-9]|[1-9][0-9]+)?$/' | '/^y([2-9]|[1-9][0-9]+)?$/';
+	overlaying: 'free' | AxisName;
 	layer: 'above traces' | 'below traces';
 	domain: number[];
 	position: number;


### PR DESCRIPTION
The typings describe a regex as a string literal, meaning that it only accepted the literal string `'/^x([2-9]|[1-9][0-9]+)?$/'` (or the Y equivalent) rather than the strings that that regex describes. Plotly appears to support arbitrarily many axes but following the example from `Layout` I've enumerated string values up to and including 9 under the assumption that that covers all actual use-cases.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://plot.ly/javascript/reference/#layout-xaxis-overlaying 
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.