### PR TITLE
Create Type Definitions for google-translate-api

### DIFF
--- a/types/google-translate-api/google-translate-api-tests.ts
+++ b/types/google-translate-api/google-translate-api-tests.ts
@@ -1,3 +1,3 @@
-import translate = require('google-translate-api')
+import translate = require('google-translate-api');
 
-translate('hello', { from: 'en', to: 'zh-tw' }) // $ExpectType Promise<TranslateResult>
+translate('hello', { from: 'en', to: 'zh-tw' }); // $ExpectType Promise<TranslateResult>

--- a/types/google-translate-api/google-translate-api-tests.ts
+++ b/types/google-translate-api/google-translate-api-tests.ts
@@ -1,0 +1,3 @@
+import translate = require('google-translate-api')
+
+translate('hello', { from: 'en', to: 'zh-tw' }) // $ExpectType Promise<TranslateResult>

--- a/types/google-translate-api/index.d.ts
+++ b/types/google-translate-api/index.d.ts
@@ -4,24 +4,24 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 interface TranslateOption {
-	from?: string
-	to?: string
-	raw?: boolean
+	from?: string;
+	to?: string;
+	raw?: boolean;
 }
 interface TranslateResult {
-	text: string
+	text: string;
 	from: {
 		language: {
-			didYouMean: boolean
-			iso: string
+			didYouMean: boolean;
+			iso: string;
 		}
 		text: {
-			autoCorrected: boolean
-			value: string
-			didYouMean: boolean
+			autoCorrected: boolean;
+			value: string;
+			didYouMean: boolean;
 		}
-	}
-	raw: string
+	};
+	raw: string;
 }
-declare function translate(text: string, options?: TranslateOption): Promise<TranslateResult>
-export = translate
+declare function translate(text: string, options?: TranslateOption): Promise<TranslateResult>;
+export = translate;

--- a/types/google-translate-api/index.d.ts
+++ b/types/google-translate-api/index.d.ts
@@ -1,0 +1,27 @@
+// Type definitions for google-translate-api 2.3
+// Project: https://github.com/matheuss/google-translate-api#readme
+// Definitions by: maple3142 <https://github.com/maple3142>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+interface TranslateOption {
+	from?: string
+	to?: string
+	raw?: boolean
+}
+interface TranslateResult {
+	text: string
+	from: {
+		language: {
+			didYouMean: boolean
+			iso: string
+		}
+		text: {
+			autoCorrected: boolean
+			value: string
+			didYouMean: boolean
+		}
+	}
+	raw: string
+}
+declare function translate(text: string, options?: TranslateOption): Promise<TranslateResult>
+export = translate

--- a/types/google-translate-api/tsconfig.json
+++ b/types/google-translate-api/tsconfig.json
@@ -1,0 +1,16 @@
+{
+	"compilerOptions": {
+		"module": "commonjs",
+		"lib": ["es6"],
+		"noImplicitAny": true,
+		"noImplicitThis": true,
+		"strictNullChecks": true,
+		"baseUrl": "../",
+		"typeRoots": ["../"],
+		"types": [],
+		"noEmit": true,
+		"forceConsistentCasingInFileNames": true,
+		"strictFunctionTypes": true
+	},
+	"files": ["index.d.ts", "google-translate-api-tests.ts"]
+}

--- a/types/google-translate-api/tslint.json
+++ b/types/google-translate-api/tslint.json
@@ -1,0 +1,6 @@
+{
+	"extends": "dtslint/dt.json",
+	"rules": {
+		"semicolon": false
+	}
+}

--- a/types/google-translate-api/tslint.json
+++ b/types/google-translate-api/tslint.json
@@ -1,6 +1,6 @@
 {
 	"extends": "dtslint/dt.json",
 	"rules": {
-		"semicolon": false
+		"semicolon": true
 	}
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
