### PR TITLE
[@types/when] Allow when() and when.resolve() without arguments

### DIFF
--- a/types/when/index.d.ts
+++ b/types/when/index.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: Derek Cicerone <https://github.com/derekcicerone>, Wim Looman <https://github.com/Nemo157>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
+declare function When(): When.Promise<void>;
 declare function When<T>(promiseOrValue: T | When.Promise<T> | When.Thenable<T>): When.Promise<T>;
 declare function When<T, U>(promiseOrValue: T | When.Promise<T> | When.Thenable<T>, transform: (val: T) => U): When.Promise<U>;
 
@@ -231,6 +232,7 @@ declare namespace When {
      *    - fulfilled with promiseOrValue's value after it is fulfilled
      *    - rejected with promiseOrValue's reason after it is rejected
      */
+    function resolve(): Promise<void>;
     function resolve<T>(promiseOrValue: T | Promise<T> | Thenable<T>): Promise<T>;
 
     interface Deferred<T> {

--- a/types/when/when-tests.ts
+++ b/types/when/when-tests.ts
@@ -32,6 +32,7 @@ class Data implements IData {
 
 var promise: when.Promise<number>;
 var promise2: when.Promise<Data>;
+var emptyPromise: when.Promise<void>;
 var foreign = new ForeignPromise<number>(1);
 var promiseOrValue = 1 as number | when.Promise<number>;
 var error = new Error("boom!");
@@ -41,6 +42,10 @@ var native: Promise<number>;
 /* * * * * * *
  *   Core    *
  * * * * * * */
+
+/* when() */
+
+emptyPromise = when();
 
 /* when(x) */
 
@@ -201,6 +206,10 @@ when.unfold(function (x) {
 
 promise = when.promise<number>(resolve => resolve(5));
 promise = when.promise<number>((resolve, reject) => reject(error));
+
+/* when.resolve() */
+
+emptyPromise = when.resolve();
 
 /* when.resolve(x) */
 


### PR DESCRIPTION
I accidentally made `when.resolve`'s parameter required in #28487. This pull request restores it to optional, and adds tests for the parameter-less case.

Additionally, `when` without arguments past the first is just an alias for `when.resolve`, so it also allows a parameter-less case.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
    - https://github.com/cujojs/when/blob/master/docs/api.md
    - https://github.com/DefinitelyTyped/DefinitelyTyped/blob/8d87c67236a73febd08e7afa94cdcc02ae76d38b/types/when/index.d.ts#L241
    - https://github.com/cujojs/when/blob/3.7.8/when.js#L82-L86 (for current when)
    - https://github.com/cujojs/when/blob/2.4.1/when.js#L52-L56 (for when 2.4)
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
