### PR TITLE
[@types/validator] Add no_symbols as option

### DIFF
--- a/types/validator/index.d.ts
+++ b/types/validator/index.d.ts
@@ -177,7 +177,7 @@ declare namespace ValidatorJS {
     isMultibyte(str: string): boolean;
 
     // check if the string contains only numbers.
-    isNumeric(str: string): boolean;
+    isNumeric(str: string, options?: { no_symbols?: boolean }): boolean;
 
     // check if the string is a valid port number.
     isPort(str: string): boolean;

--- a/types/validator/index.d.ts
+++ b/types/validator/index.d.ts
@@ -177,7 +177,7 @@ declare namespace ValidatorJS {
     isMultibyte(str: string): boolean;
 
     // check if the string contains only numbers.
-    isNumeric(str: string, options?: { no_symbols?: boolean }): boolean;
+    isNumeric(str: string, options?: IsNumericOptions): boolean;
 
     // check if the string is a valid port number.
     isPort(str: string): boolean;
@@ -379,6 +379,13 @@ declare namespace ValidatorJS {
     yahoo_remove_subaddress?: boolean;
     icloud_lowercase?: boolean;
     icloud_remove_subaddress?: boolean;
+  }
+
+  /**
+   * Options for isNumeric
+   */
+  interface IsNumericOptions {
+    no_symbols?: boolean;
   }
 }
 

--- a/types/validator/validator-tests.ts
+++ b/types/validator/validator-tests.ts
@@ -565,7 +565,7 @@ let any: any;
   result = validator.isMultibyte('sample');
 
   result = validator.isNumeric('sample');
-  result = validator.isNumeric('+358', { no_symbols: true })
+  result = validator.isNumeric('+358', { no_symbols: true });
 
   result = validator.isPort('sample');
 

--- a/types/validator/validator-tests.ts
+++ b/types/validator/validator-tests.ts
@@ -565,6 +565,7 @@ let any: any;
   result = validator.isMultibyte('sample');
 
   result = validator.isNumeric('sample');
+  result = validator.isNumeric('+358', { no_symbols: true })
 
   result = validator.isPort('sample');
 


### PR DESCRIPTION
Types for `validator` was missing `options` for function `isNumeric`

Here is picture of documentation for `isNumeric`
![image](https://user-images.githubusercontent.com/12229968/44987597-6b96da80-af90-11e8-8855-3f0de445cd47.png)

Here is also implementation for that function: https://github.com/chriso/validator.js/blob/c192d7c442193d790f5497d92267931d48b2dbc8/src/lib/isNumeric.js