### PR TITLE
Update index.d.ts: Missing member 'base' in the interface Model

### DIFF
--- a/types/chart.js/index.d.ts
+++ b/types/chart.js/index.d.ts
@@ -159,6 +159,8 @@ interface Model {
     tension: number;
     x: number;
     y: number;
+    base: number;
+    head: number;
 }
 
 declare namespace Chart {


### PR DESCRIPTION
Setting a minimum bar height, with pluginservices and metadata approach.

I need the member 'base' for calculating (barModel.y = barModel.base + minHeight); 
With the modification below, all is working as expected.

Hope this informations as enaught.
Best regards 
Ates Bana

"chart.js":           "2.7.2",
@types/chart.js: "2.7.31"

    interface Model {
        backgroundColor: string;
        borderColor: string;
        borderWidth?: number;
        controlPointNextX: number;
        controlPointNextY: number;
        controlPointPreviousX: number;
        controlPointPreviousY: number;
        hitRadius: number;
        pointStyle: string;
        radius: string;
        skip?: boolean;
        steppedLine?: undefined;
        tension: number;
        x: number;
        y: number;
        base: number;
        head: number;
    }
