### PR TITLE
web3 type definition: fix typo: ssh to shh

### DIFF
--- a/types/web3/index.d.ts
+++ b/types/web3/index.d.ts
@@ -43,7 +43,7 @@ declare class Web3 {
     bzz: Bzz;
     currentProvider: Provider;
     eth: Eth;
-    ssh: Shh;
+    shh: Shh;
     givenProvider: Provider;
     providers: Providers;
     setProvider(provider: Provider): void;


### PR DESCRIPTION
According to the web3 documentation,  (https://web3js.readthedocs.io/en/1.0/web3-shh.html), the module inside the web3 object is named `shh` instead of `ssh`. 
