### PR TITLE
feathersjs__feathers: Add missing members and docs to HookContext

### DIFF
--- a/types/feathersjs__feathers/feathersjs__feathers-tests.ts
+++ b/types/feathersjs__feathers/feathersjs__feathers-tests.ts
@@ -1,4 +1,4 @@
-import feathers, { Application } from '@feathersjs/feathers';
+import feathers, { Application, HookContext } from '@feathersjs/feathers';
 
 interface User {
     id: number;
@@ -13,4 +13,13 @@ const app = feathers() as Application<Services>;
 
 app.service('users').get(0).then(u => {
     const user: User = u;
+});
+
+app.service('users').hooks({
+    before: {
+        all: (context: HookContext) => {
+            context.statusCode = 200;
+            context.dispatch = { test: 'true' };
+        }
+    }
 });

--- a/types/feathersjs__feathers/index.d.ts
+++ b/types/feathersjs__feathers/index.d.ts
@@ -57,7 +57,7 @@ export interface HookContext<T = any> {
      * A read only property that contains the Feathers application object. This can be used to
      * retrieve other services (via context.app.service('name')) or configuration values.
      */
-    app?: Application;
+    readonly app: Application;
     /**
      * A writeable property containing the data of a create, update and patch service
      * method call.
@@ -78,17 +78,17 @@ export interface HookContext<T = any> {
      * A read only property with the name of the service method (one of find, get,
      * create, update, patch, remove).
      */
-    method?: string;
+    readonly method: string;
     /**
      * A writeable property that contains the service method parameters (including
      * params.query).
      */
-    params?: Params;
+    params: Params;
     /**
      * A read only property and contains the service name (or path) without leading or
      * trailing slashes.
      */
-    path?: string;
+    readonly path: string;
     /**
      * A writeable property containing the result of the successful service method call.
      * It is only available in after hooks.
@@ -102,7 +102,7 @@ export interface HookContext<T = any> {
     /**
      * A read only property and contains the service this hook currently runs on.
      */
-    service: Service<T>;
+    readonly service: Service<T>;
     /**
      * A writeable, optional property and contains a "safe" version of the data that
      * should be sent to any client. If context.dispatch has not been set context.result
@@ -117,7 +117,7 @@ export interface HookContext<T = any> {
     /**
      * A read only property with the hook type (one of before, after or error).
      */
-    type: "before" | "after" | "error";
+    readonly type: "before" | "after" | "error";
 }
 
 export interface HookMap {

--- a/types/feathersjs__feathers/index.d.ts
+++ b/types/feathersjs__feathers/index.d.ts
@@ -1,6 +1,8 @@
 // Type definitions for @feathersjs/feathers 3.0
 // Project: http://feathersjs.com/
-// Definitions by: Jan Lohage <https://github.com/j2L4e>, Abraao Alves <https://github.com/AbraaoAlves>
+// Definitions by:  Jan Lohage <https://github.com/j2L4e>
+//                  Abraao Alves <https://github.com/AbraaoAlves>
+//                  Tim Mensch <https://github.com/TimMensch>
 // Definitions: https://github.com/feathersjs-ecosystem/feathers-typescript
 
 // TypeScript Version: 2.3
@@ -51,16 +53,71 @@ export type Hook = (hook: HookContext) => (Promise<HookContext | SkipSymbol | vo
 export type SkipSymbol = symbol | '__feathersSkipHooks';
 
 export interface HookContext<T = any> {
+    /**
+     * A read only property that contains the Feathers application object. This can be used to
+     * retrieve other services (via context.app.service('name')) or configuration values.
+     */
     app?: Application;
+    /**
+     * A writeable property containing the data of a create, update and patch service
+     * method call.
+     */
     data?: T;
+    /**
+     * A writeable property with the error object that was thrown in a failed method call.
+     * It is only available in error hooks.
+     */
     error?: any;
+    /**
+     * A writeable property and the id for a get, remove, update and patch service
+     * method call. For remove, update and patch context.id can also be null when
+     * modifying multiple entries. In all other cases it will be undefined.
+     */
     id?: string | number;
+    /**
+     * A read only property with the name of the service method (one of find, get,
+     * create, update, patch, remove).
+     */
     method?: string;
+    /**
+     * A writeable property that contains the service method parameters (including
+     * params.query).
+     */
     params?: Params;
+    /**
+     * A read only property and contains the service name (or path) without leading or
+     * trailing slashes.
+     */
     path?: string;
+    /**
+     * A writeable property containing the result of the successful service method call.
+     * It is only available in after hooks.
+     *
+     * `context.result` can also be set in
+     *
+     *  - A before hook to skip the actual service method (database) call
+     *  - An error hook to swallow the error and return a result instead
+     */
     result?: T;
+    /**
+     * A read only property and contains the service this hook currently runs on.
+     */
     service: Service<T>;
-    type: 'before' | 'after' | 'error';
+    /**
+     * A writeable, optional property and contains a "safe" version of the data that
+     * should be sent to any client. If context.dispatch has not been set context.result
+     * will be sent to the client instead.
+     */
+    dispatch?: T;
+    /**
+     * A writeable, optional property that allows to override the standard HTTP status
+     * code that should be returned.
+     */
+    statusCode?: number;
+    /**
+     * A read only property with the hook type (one of before, after or error).
+     */
+    type: "before" | "after" | "error";
 }
 
 export interface HookMap {

--- a/types/feathersjs__feathers/tslint.json
+++ b/types/feathersjs__feathers/tslint.json
@@ -1,3 +1,6 @@
 {
-    "extends": "dtslint/dt.json"
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "file-name-casing": false
+    }
 }


### PR DESCRIPTION
The HookContext object in FeathersJS wasn't fully specified: There were two elements missing, `dispatch` and `statusCode`. 

While I was there I added docs to the interface, and a simple test case that verifies that the types are correct.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.feathersjs.com/api/hooks.html#hook-context
- [X] Increase the version number in the header if appropriate. (none)
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. (Already there, though I updated it so that it didn't throw a spurious warning).
