### PR TITLE
[recompose] Fix invalid types when chaining HOC

### DIFF
--- a/types/recompose/index.d.ts
+++ b/types/recompose/index.d.ts
@@ -19,8 +19,8 @@ declare module 'recompose' {
     type predicate<T> = mapper<T, boolean>;
     type predicateDiff<T> = (current: T, next: T) => boolean
 
-    // Diff / Omit taken from https://github.com/Microsoft/TypeScript/issues/12215#issuecomment-311923766
-    type Omit<T, K extends keyof T> = Pick<T, ({ [P in keyof T]: P } & { [P in K]: never } & { [x: string]: never, [x: number]: never })[keyof T]>;
+    // Diff / Omit taken from https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-8.html
+    type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>
 
     interface Observer<T>{
         next(props: T): void;


### PR DESCRIPTION
- This fixes cases of invalid types when chaining HOCs
- The solution is to use the recommended `Omit` type definition as stated here https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-8.html
- Issue and solution as described here https://github.com/Microsoft/TypeScript/issues/25041

#### Checklist
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
