### PR TITLE
Update js-beautify HTML options for 1.8.x

### DIFF
--- a/types/js-beautify/index.d.ts
+++ b/types/js-beautify/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for js_beautify
+// Type definitions for js_beautify 1.8.2
 // Project: https://github.com/beautify-web/js-beautify/
 // Definitions by: Josh Goldberg <https://github.com/JoshuaKGoldberg>, Hans Windhoff <https://github.com/hansrwindhoff>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -26,24 +26,29 @@ interface JsBeautifyOptions {
   end_with_newline?: boolean;
 }
 
+// See https://github.com/beautify-web/js-beautify/blob/v1.8.2/js/src/html/beautifier.js#L268-L330
 interface HTMLBeautifyOptions {
+  indent_inner_html?: boolean;
+  indent_body_inner_html?: boolean;
+  indent_head_inner_html?: boolean;
   indent_size?: number;
   indent_char?: string;
-  indent_with_tabs?: boolean;
-  indent_handlebars?: boolean;
-  eol?: string;
-  end_with_newline?: boolean;
+  wrap_line_length?: number;
   preserve_newlines?: boolean;
   max_preserve_newlines?: number;
-  indent_inner_html?: boolean;
-  brace_style?: 'collapse-preserve-inline'|'collapse'|'expand'|'end-expand'|'none';
-  indent_scripts?: 'keep'|'separate'|'normal';
-  wrap_line_length?: number;
-  wrap_attributes?: 'auto'|'force' ;
+  indent_handlebars?: boolean;
+  wrap_attributes?: 'auto' | 'force' | 'force-expand-multiline' | 'force-aligned' | 'aligned-multiple';
   wrap_attributes_indent_size?: number;
+  end_with_newline?: boolean;
+  extra_liners?: string[];
+  eol?: string;
+  indent_with_tabs?: boolean;
+  disabled?: boolean;
+  inline?: string[];
+  void_elements?: string[];
   unformatted?: string[];
   content_unformatted?: string[];
-  extra_liners?: string|string[];
+  indent_scripts?: 'keep' | 'separate';
 }
 
 interface CSSBeautifyOptions {

--- a/types/js-beautify/index.d.ts
+++ b/types/js-beautify/index.d.ts
@@ -13,7 +13,7 @@ interface JsBeautifyOptions {
   max_preserve_newlines?: number;
   jslint_happy?: boolean;
   space_after_anon_function?: boolean;
-  brace_style?: 'collapse-preserve-inline'|'collapse'|'expand'|'end-expand'|'none';
+  brace_style?: 'collapse-preserve-inline' | 'collapse' | 'expand' | 'end-expand' | 'none';
   keep_array_indentation?: boolean;
   keep_function_indentation?: boolean;
   space_before_conditional?: boolean;
@@ -21,7 +21,7 @@ interface JsBeautifyOptions {
   eval_code?: boolean;
   unescape_strings?: boolean;
   wrap_line_length?: number;
-  wrap_attributes?: 'auto'|'force' ;
+  wrap_attributes?: 'auto' | 'force';
   wrap_attributes_indent_size?: number;
   end_with_newline?: boolean;
 }
@@ -61,21 +61,19 @@ interface CSSBeautifyOptions {
   newline_between_rules?: boolean;
 }
 
-interface jsb{
-  (js_source_text: string, options?: JsBeautifyOptions) : string ;
-  js:(js_source_text: string, options?: JsBeautifyOptions) => string ;
-  js_beautify:(js_source_text: string, options?: JsBeautifyOptions) => string ;
+interface jsb {
+  (js_source_text: string, options?: JsBeautifyOptions): string;
+  js: (js_source_text: string, options?: JsBeautifyOptions) => string;
+  js_beautify: (js_source_text: string, options?: JsBeautifyOptions) => string;
 
-  css:(js_source_text: string, options?: CSSBeautifyOptions) => string ;
-  css_beautify:(js_source_text: string, options?: CSSBeautifyOptions) => string ;
+  css: (js_source_text: string, options?: CSSBeautifyOptions) => string;
+  css_beautify: (js_source_text: string, options?: CSSBeautifyOptions) => string;
 
-  html:(js_source_text: string, options?: HTMLBeautifyOptions) => string ;
-  html_beautify:(js_source_text: string, options?: HTMLBeautifyOptions) => string ;
+  html: (js_source_text: string, options?: HTMLBeautifyOptions) => string;
+  html_beautify: (js_source_text: string, options?: HTMLBeautifyOptions) => string;
 }
 
-declare var js_beautify:jsb;
-declare module "js-beautify"
-{
+declare var js_beautify: jsb;
+declare module "js-beautify" {
     export = js_beautify;
 }
-

--- a/types/js-beautify/js-beautify-tests.ts
+++ b/types/js-beautify/js-beautify-tests.ts
@@ -1,5 +1,3 @@
-
-
 let bCss = js_beautify.css("body{display:none;}");
 bCss = js_beautify.css_beautify("body{display:none;}");
 
@@ -34,4 +32,5 @@ var full: string = js_beautify(
         "wrap_attributes": "auto",
         "wrap_attributes_indent_size": 4,
         "end_with_newline": false
-    });
+    }
+);


### PR DESCRIPTION
js-beautify HTML options have been changed in 1.8.x, see https://github.com/beautify-web/js-beautify/blob/v1.8.2/js/src/html/beautifier.js#L268-L330

Note that I did not change the JS options nor the CSS options.