### PR TITLE
[@types/minio] replace secure with useSSL option

### DIFF
--- a/types/minio/index.d.ts
+++ b/types/minio/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for minio 6.0
+// Type definitions for minio 7.0
 // Project: https://github.com/minio/minio-js#readme
 // Definitions by: Barin Britva <https://github.com/barinbritva>
 //                 Lubomir Kaplan <https://github.com/castorw>
@@ -20,7 +20,7 @@ export interface ClientOptions {
     endPoint: string;
     accessKey: string;
     secretKey: string;
-    secure?: boolean;
+    useSSL?: boolean;
     port?: number;
     region?: Region;
     transport?: any;

--- a/types/minio/minio-tests.ts
+++ b/types/minio/minio-tests.ts
@@ -4,7 +4,7 @@ import Minio = require('minio');
 const minio = new Minio.Client({
     endPoint: 'localhost',
     port: 9000,
-    secure: false,
+    useSSL: false,
     accessKey: 'iV7RAFOtxF',
     secretKey: 'Go1hhOkXnl',
 });


### PR DESCRIPTION
In the newer version of minio, secure option is replaced with useSSL
https://github.com/minio/minio-js#initialize-minio-client

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
 https://github.com/minio/minio-js#initialize-minio-client
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.


