### PR TITLE
[cookie-session] Add missing sameSite option type. name should be optional.

### DIFF
--- a/types/cookie-session/index.d.ts
+++ b/types/cookie-session/index.d.ts
@@ -15,7 +15,7 @@ declare namespace CookieSessionInterfaces {
         /**
          * The name of the cookie to set, defaults to session.
          */
-        name: string;
+        name?: string;
 
         /**
          * The list of keys to use to sign & verify cookie values. Set cookies are always signed with keys[0], while the other keys are valid for verification, allowing for key rotation.
@@ -46,6 +46,11 @@ declare namespace CookieSessionInterfaces {
          * a string indicating the domain of the cookie (no default).
          */
         domain?: string;
+
+        /**
+         * a boolean or string indicating whether the cookie is a "same site" cookie (false by default). This can be set to 'strict', 'lax', or true (which maps to 'strict').
+         */
+        sameSite?: "strict" | "lax" | boolean;
 
         /**
          * a boolean indicating whether the cookie is only to be sent over HTTPS (false by default for HTTP, true by default for HTTPS).


### PR DESCRIPTION
Fixes incorrect error throwing when not supplying a name value, and when attempting to pass the sameSite option.

* `name` value is optional; defaults to `session` if not provided.
* `sameSite` option missing in definitions. Option allows either a boolean; or `'lax'` & `'strict'` strings.

Docs for above:
https://github.com/expressjs/cookie-session#name
https://github.com/expressjs/cookie-session#cookie-options

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/expressjs/cookie-session/releases/tag/2.0.0-beta.1
- [ ] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
