### PR TITLE
Export TransitionStatus from react-transition-group

### DIFF
--- a/types/react-transition-group/Transition.d.ts
+++ b/types/react-transition-group/Transition.d.ts
@@ -16,7 +16,7 @@ export interface TransitionActions {
     exit?: boolean;
 }
 
-type TransitionStatus =
+export type TransitionStatus =
     typeof ENTERING |
     typeof ENTERED |
     typeof EXITING |

--- a/types/react-transition-group/react-transition-group-tests.tsx
+++ b/types/react-transition-group/react-transition-group-tests.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import CSSTransition = require("react-transition-group/CSSTransition");
-import Transition, { UNMOUNTED, EXITED, ENTERING, ENTERED, EXITING } from "react-transition-group/Transition";
+import Transition, { UNMOUNTED, EXITED, ENTERING, ENTERED, EXITING, TransitionStatus } from "react-transition-group/Transition";
 import TransitionGroup = require("react-transition-group/TransitionGroup");
 import Components = require("react-transition-group");
 
@@ -24,6 +24,17 @@ const Test: React.StatelessComponent = () => {
 
     function handleEndListener(node: HTMLElement, done: () => void) {
         node.addEventListener("transitionend", done, false);
+    }
+
+    function statusAsArgument(status: TransitionStatus) {
+        switch (status) {
+            case ENTERING:
+            case ENTERED:
+            case EXITING:
+            case EXITED:
+            case UNMOUNTED:
+                return <div>{status}</div>;
+        }
     }
 
     return (
@@ -62,6 +73,10 @@ const Test: React.StatelessComponent = () => {
                              return <div>{status}</div>;
                      }
                 }}
+            </Components.Transition>
+
+            <Components.Transition in timeout={500}>
+                {statusAsArgument}
             </Components.Transition>
 
             <Transition


### PR DESCRIPTION
You can currently not access TransitionStatus which means it's impossible to create functions that accept this type as arguments, for example:

```javascript
const getTransform = (status: TransitionStatus) => {
  switch (status) {
    case ENTERED:
      return {};
    case ENTERING:
      return {};
    default:
      return {};
  }
};

<Transition>
   {(status) => 
     <div style={getTransform(status)} />
   )}
</Transition>
```

This PR simply exports the existing `TransitionStatus` so that we can import it.

Please fill in this template.

- [ x ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ x ] Test the change in your own code. (Compile and run.)
- [ x ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ x ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ x ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ x ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ / ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ / ] Increase the version number in the header if appropriate.
- [ / ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
