### PR TITLE
updates some definitions of `bn.js`

### DIFF
--- a/types/bn.js/bn.js-tests.ts
+++ b/types/bn.js/bn.js-tests.ts
@@ -5,3 +5,6 @@ let bn = new BN(42);
 bn = bn.add(bn);
 bn.isZero();
 bn.byteLength;
+
+bn.toArrayLike(Buffer, 'le', 2);
+const test = new BN(1, 'le');

--- a/types/bn.js/index.d.ts
+++ b/types/bn.js/index.d.ts
@@ -48,6 +48,10 @@ declare class BN {
         base?: number,
         endian?: Endianness
     );
+    constructor(
+        number: number | string | number[] | Buffer | BN,
+        endian?: Endianness
+    )
 
     /**
      * @description  create a reduction context
@@ -63,6 +67,16 @@ declare class BN {
      * @description returns true if the supplied object is a BN.js instance
      */
     static isBN(b: any): b is BN;
+
+    /**
+     * @description returns the maximum of 2 BN instances.
+     */
+    static max(left: BN, right: BN): BN;
+
+    /**
+     * @description returns the minimum of 2 BN instances.
+     */
+    static min(left: BN, right: BN): BN;
 
     /**
      * @description  Convert number to red
@@ -98,10 +112,16 @@ declare class BN {
      * @description convert to an instance of `type`, which must behave like an Array
      */
     toArrayLike(
-        ArrayType: Buffer | any[],
+        ArrayType: typeof Buffer,
         endian?: Endianness,
         length?: number
-    ): Buffer | any[];
+    ): Buffer;
+
+    toArrayLike(
+        ArrayType: any[],
+        endian?: Endianness,
+        length?: number
+    ): any[];
 
     /**
      * @description  convert to Node.js Buffer (if available). For compatibility with browserify and similar tools, use this instead: a.toArrayLike(Buffer, endian, length)


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/indutny/bn.js/blob/e69c617b3297b99aca429f30842e27979ef9beb5/lib/bn.js#L66>>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

I change a few things around that were breaking on our end from these new types, also added the static min/max functions that were left out (linked above).

We were getting some errors on our constructors due to the optional arguments not playing around, so I've just added overloads for it *as well as* splitting the `toArrayLike` function so that it has a clearer output type (and the input of ArrayType needed to be `typeof Buffer`). I'm attaching pictures of the errors we were getting previously.

![Constructor Error](https://user-images.githubusercontent.com/9561608/45122974-46ce6e80-b11a-11e8-908c-97cc06e4191c.PNG)

![To Array Like](https://user-images.githubusercontent.com/9561608/45122984-4fbf4000-b11a-11e8-9ba7-6a5ea45a5c11.PNG)

