### PR TITLE
add type for npm package 'object-keys-mapping'

### DIFF
--- a/types/object-keys-mapping/index.d.ts
+++ b/types/object-keys-mapping/index.d.ts
@@ -1,0 +1,32 @@
+// Type definitions for object-keys-mapping 3.0
+// Project: https://github.com/coderhaoxin/object-keys-mapping#readme
+// Definitions by: newraina <https://github.com/newraina>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.2
+
+export function trim(origin: object, ignore?: (v: any) => boolean): object;
+export function trim(origin: ReadonlyArray<object>, ignore?: (v: any) => boolean): object[];
+
+export function toCamelcase(origin: object): object;
+export function toCamelcase(origin: ReadonlyArray<object>): object[];
+
+export function reverseCamelcase(origin: object): object;
+export function reverseCamelcase(origin: ReadonlyArray<object>): object[];
+
+export interface OperatorOptions {
+    camelcase?: boolean;
+    mapping?: object;
+}
+
+export class Operator {
+    constructor(opts?: { camelcase?: boolean });
+
+    map(origin: object): object;
+    map(origin: ReadonlyArray<object>): object[];
+
+    mapField(path: string): string;
+
+    mapObject(origin: object, path: string): object;
+
+    mapArray(origin: ReadonlyArray<object>): object[];
+}

--- a/types/object-keys-mapping/object-keys-mapping-tests.ts
+++ b/types/object-keys-mapping/object-keys-mapping-tests.ts
@@ -1,0 +1,11 @@
+import { trim, toCamelcase, reverseCamelcase, Operator } from 'object-keys-mapping';
+
+trim({ name: '' });
+
+toCamelcase({ will_be_camelcase: '' });
+
+reverseCamelcase({ willBeUnderlined: '' });
+
+const operator = new Operator({ camelcase: true });
+
+operator.map({});

--- a/types/object-keys-mapping/tsconfig.json
+++ b/types/object-keys-mapping/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "object-keys-mapping-tests.ts"
+    ]
+}

--- a/types/object-keys-mapping/tslint.json
+++ b/types/object-keys-mapping/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
