### PR TITLE
Fix for issue #28598 @types/webvr-api breaks on upgrade to TypeScript 3.0.0

### DIFF
--- a/types/webvr-api/index.d.ts
+++ b/types/webvr-api/index.d.ts
@@ -133,8 +133,8 @@ declare var VRDisplay: {
 };
 
 interface VRLayer {
-    leftBounds?: number[] | null;
-    rightBounds?: number[] | null;
+    leftBounds?: number[] | Float32Array | null;
+    rightBounds?: number[] | Float32Array | null;
     source?: HTMLCanvasElement | null;
 }
 


### PR DESCRIPTION
Allow VRLayer left and right bounds to accept types of number[], Float32Array or null.

Please fill in this template.

- [*] Use a meaningful title for the pull request. Include the name of the package modified.
- [*] Test the change in your own code. (Compile and run.)
- [*] Add or edit tests to reflect the change. (Run with `npm test`.)
- [*] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [*] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [*] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [*] Provide a URL to documentation or source code which provides context for the suggested changes: (https://github.com/DefinitelyTyped/DefinitelyTyped/issues/28598)
