### PR TITLE
@types/payment Add formatCardNumber in the types

### DIFF
--- a/types/payment/index.d.ts
+++ b/types/payment/index.d.ts
@@ -12,6 +12,10 @@ interface Fns {
      */
     validateCardNumber(cardNumber: string): boolean;
     /**
+     * Formats a card number
+     */
+    formatCardNumber(cardNumber: string): string;
+    /**
      * Validates a card expiry:
      * * Validates numbers
      * * Validates in the future


### PR DESCRIPTION
I wanna use the `formatCardNumber` function standalone but it is not defined in the types yet, so there we go.
