### PR TITLE
Add AWS Lambda CloudFront Event origin fields.

### DIFF
--- a/types/aws-lambda/index.d.ts
+++ b/types/aws-lambda/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for AWS Lambda 8.11
+// Type definitions for AWS Lambda 8.10
 // Project: http://docs.aws.amazon.com/lambda
 // Definitions by: James Darbyshire <https://github.com/darbio/aws-lambda-typescript>
 //                 Michael Skarum <https://github.com/skarum>
@@ -562,6 +562,9 @@ export interface CodePipelineEvent {
 /**
  * CloudFront events
  * http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/lambda-event-structure.html
+ * Bear in mind that the "example" event structure in the page above includes
+ * both an S3 and a Custom origin, which is not strictly allowed. Only one
+ * of these per event may be present.
  */
 export interface CloudFrontHeaders {
     [name: string]: Array<{
@@ -570,10 +573,9 @@ export interface CloudFrontHeaders {
     }>;
 }
 
-export interface CloudFrontOrigin {
-    custom?: CloudFrontCustomOrigin;
-    s3?: CloudFrontS3Origin;
-}
+export type CloudFrontOrigin =
+    | { s3: CloudFrontS3Origin, custom?: never }
+    | { custom: CloudFrontCustomOrigin, s3?: never };
 
 export interface CloudFrontCustomOrigin {
     customHeaders: CloudFrontHeaders;

--- a/types/aws-lambda/index.d.ts
+++ b/types/aws-lambda/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for AWS Lambda 8.10
+// Type definitions for AWS Lambda 8.11
 // Project: http://docs.aws.amazon.com/lambda
 // Definitions by: James Darbyshire <https://github.com/darbio/aws-lambda-typescript>
 //                 Michael Skarum <https://github.com/skarum>
@@ -21,6 +21,7 @@
 //                 Jeremy Nagel <https://github.com/jeznag>
 //                 Louis Larry <https://github.com/louislarry>
 //                 Daniel Papukchiev <https://github.com/dpapukchiev>
+//                 Oliver Hookins <https://github.com/ohookins>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -569,6 +570,30 @@ export interface CloudFrontHeaders {
     }>;
 }
 
+export interface CloudFrontOrigin {
+    custom?: CloudFrontCustomOrigin;
+    s3?: CloudFrontS3Origin;
+}
+
+export interface CloudFrontCustomOrigin {
+    customHeaders: CloudFrontHeaders;
+    domainName: string;
+    keepaliveTimeout: number;
+    path: string;
+    port: number;
+    protocol: 'http' | 'https';
+    readTimeout: number;
+    sslProtocols: string[];
+}
+
+export interface CloudFrontS3Origin {
+    authMethod: 'origin-access-identity' | 'none';
+    customHeaders: CloudFrontHeaders;
+    domainName: string;
+    path: string;
+    region: string;
+}
+
 export interface CloudFrontResponse {
     status: string;
     statusDescription: string;
@@ -581,6 +606,7 @@ export interface CloudFrontRequest {
     uri: string;
     querystring: string;
     headers: CloudFrontHeaders;
+    origin?: CloudFrontOrigin;
 }
 
 export interface CloudFrontEvent {


### PR DESCRIPTION
This is my first foray into TypeScript so please let me know if anything needs to be changed. The existing tests already contained the whole schema but there were a number of missing interfaces from the definition. It's perhaps too permissive (several optional fields) since the `CloudFrontRequestEvent` is used in both a request event and response event, but in the response event the `origin` field is not present. To fix would require a bit of refactoring and more duplication.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/lambda-event-structure.html
- [x] Increase the version number in the header if appropriate.
- ~[] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.~