### PR TITLE
[@types/ember__utils] refactor types out of @types/ember, more tests

### DIFF
--- a/types/ember__utils/ember__utils-tests.ts
+++ b/types/ember__utils/ember__utils-tests.ts
@@ -1,0 +1,163 @@
+import {
+    compare,
+    isBlank,
+    isEmpty,
+    isEqual,
+    isNone,
+    isPresent,
+    tryInvoke,
+    typeOf
+} from '@ember/utils';
+
+(function() {
+    /** isNone */
+    const maybeUndefined: string | undefined = 'not actually undefined';
+    if (isNone(maybeUndefined)) {
+        return;
+    }
+    const anotherString = maybeUndefined + 'another string';
+    // TODO fix upstream in @types/ember https://github.com/typed-ember/ember-cli-typescript/issues/256
+    // isNone();              // $ExpectType boolean
+    isNone(null);          // $ExpectType boolean
+    isNone(undefined);     // $ExpectType boolean
+    isNone('');            // $ExpectType boolean
+    isNone([]);            // $ExpectType boolean
+    isNone(function() {}); // $ExpectType boolean
+})();
+
+(function() {
+    /** tryInvoke */
+    let d = new Date('03/15/2013');
+
+    // TODO fix enhance in @types/ember https://github.com/typed-ember/ember-cli-typescript/issues/257
+    // tryInvoke(d, 'getTime');              // $ExpectType number
+    // tryInvoke(d, 'setFullYear', [2014]);  // $ExpectType number
+    // tryInvoke(d, 'noSuchMethod', [2014]); // $ExpectType undefined
+    tryInvoke(d, 'getTime');
+    tryInvoke(d, 'setFullYear', [2014]);
+    tryInvoke(d, 'noSuchMethod', [2014]);
+})();
+
+(function() {
+    /** isPresent */
+    // TODO fix upstream in @types/ember https://github.com/typed-ember/ember-cli-typescript/issues/258
+    // isPresent();                // $ExpectType boolean
+    isPresent(null);            // $ExpectType boolean
+    isPresent(undefined);       // $ExpectType boolean
+    isPresent('');              // $ExpectType boolean
+    isPresent('  ');            // $ExpectType boolean
+    isPresent('\n\t');          // $ExpectType boolean
+    isPresent([]);              // $ExpectType boolean
+    isPresent({ length: 0 });   // $ExpectType boolean
+    isPresent(false);           // $ExpectType boolean
+    isPresent(true);            // $ExpectType boolean
+    isPresent('string');        // $ExpectType boolean
+    isPresent(0);               // $ExpectType boolean
+    isPresent(function() {});   // $ExpectType boolean
+    isPresent({});              // $ExpectType boolean
+    isPresent(false);           // $ExpectType boolean
+    isPresent('\n\t Hello');    // $ExpectType boolean
+    isPresent([1, 2, 3]);       // $ExpectType boolean
+})();
+
+(function() {
+    /** typeOf */
+    // TODO: more specific return type in @types/ember https://github.com/typed-ember/ember-cli-typescript/issues/259
+    // typeOf(null);                   // $ExpectType 'null'
+    // typeOf(undefined);              // $ExpectType 'undefined'
+    // typeOf('michael');              // $ExpectType 'string'
+    // // tslint:disable-next-line:no-construct
+    // typeOf(new String('michael'));  // $ExpectType 'string'
+    // typeOf(101);                    // $ExpectType 'number'
+    // // tslint:disable-next-line:no-construct
+    // typeOf(new Number(101));        // $ExpectType 'number'
+    // typeOf(true);                   // $ExpectType 'boolean'
+    // // tslint:disable-next-line:no-construct
+    // typeOf(new Boolean(true));      // $ExpectType 'boolean'
+    // typeOf(() => 4);                // $ExpectType 'function'
+    // typeOf([1, 2, 90]);             // $ExpectType 'array'
+    // typeOf(/abc/);                  // $ExpectType 'regexp'
+    // typeOf(new Date());             // $ExpectType 'date'
+    // typeOf(FileList);               // $ExpectType 'filelist'
+    // // typeOf(EmberObject.extend());   // $ExpectType 'class'
+    // // typeOf(EmberObject.create());   // $ExpectType 'instance'
+    // typeOf(new Error('teamocil'));  // $ExpectType 'error'
+
+    // TODO fix upstream in @types/ember https://github.com/typed-ember/ember-cli-typescript/issues/260
+    // typeOf();
+    typeOf(null);
+    typeOf(undefined);
+    typeOf('michael');
+    // tslint:disable-next-line:no-construct
+    typeOf(new String('michael'));
+    typeOf(101);
+    // tslint:disable-next-line:no-construct
+    typeOf(new Number(101));
+    typeOf(true);
+    // tslint:disable-next-line:no-construct
+    typeOf(new Boolean(true));
+    typeOf(() => 4);
+    typeOf([1, 2, 90]);
+    typeOf(/abc/);
+    typeOf(new Date());
+    typeOf(FileList);
+    typeOf(new Error('teamocil'));
+})();
+
+(function() {
+    /** isEqual */
+    isEqual('foo', 'bar'); // $ExpectType boolean
+    isEqual(14, 37); // $ExpectType boolean
+    isEqual(14, '1'); // $ExpectType boolean
+    isEqual(() => 4, () => 37); // $ExpectType boolean
+    isEqual(14); // $ExpectError
+    isEqual(); // $ExpectError
+})();
+
+(function() {
+    /** compare */
+    compare('foo', 'bar'); // $ExpectType number
+    compare(14, 37); // $ExpectType number
+    compare(class {}, class {}); // $ExpectType number
+    compare([], class {}); // $ExpectType number
+    compare([], undefined); // $ExpectType number
+    compare({}, () => 4); // $ExpectType number
+    compare(14); // $ExpectError
+    compare(); // $ExpectError
+})();
+
+(function() {
+    /** isBlank */
+
+    // TODO fix upstream in @types/ember https://github.com/typed-ember/ember-cli-typescript/issues/254
+    // isBlank(); // $ExpectType boolean
+    isBlank(null); // $ExpectType boolean
+    isBlank(undefined); // $ExpectType boolean
+    isBlank(''); // $ExpectType boolean
+    isBlank([]); // $ExpectType boolean
+    isBlank('\n\t'); // $ExpectType boolean
+    isBlank('  '); // $ExpectType boolean
+    isBlank({}); // $ExpectType boolean
+    isBlank('\n\t Hello'); // $ExpectType boolean
+    isBlank('Hello world'); // $ExpectType boolean
+    isBlank([1, 2, 3]); // $ExpectType boolean
+})();
+
+(function() {
+    /** isEmpty */
+
+    // TODO fix upstream in @types/ember https://github.com/typed-ember/ember-cli-typescript/issues/255
+    // isEmpty(); // $ExpectType boolean
+    isEmpty(null); // $ExpectType boolean
+    isEmpty(undefined); // $ExpectType boolean
+    isEmpty(''); // $ExpectType boolean
+    isEmpty([]); // $ExpectType boolean
+    isEmpty({ size: 0 }); // $ExpectType boolean
+    isEmpty({}); // $ExpectType boolean
+    isEmpty('Adam Hawkins'); // $ExpectType boolean
+    isEmpty([0, 1, 2]); // $ExpectType boolean
+    isEmpty('\n\t'); // $ExpectType boolean
+    isEmpty('  '); // $ExpectType boolean
+    isEmpty({ size: 1 }); // $ExpectType boolean
+    isEmpty({ size: () => 0 }); // $ExpectType boolean
+})();

--- a/types/ember__utils/index.d.ts
+++ b/types/ember__utils/index.d.ts
@@ -1,0 +1,16 @@
+// Type definitions for @ember/utils 3.0
+// Project: http://emberjs.com/
+// Definitions by: Mike North <https://github.com/mike-north>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.8
+
+import Ember from 'ember';
+
+export const compare: typeof Ember.compare;
+export const isBlank: typeof Ember.isBlank;
+export const isEmpty: typeof Ember.isEmpty;
+export const isEqual: typeof Ember.isEqual;
+export const isNone: typeof Ember.isNone;
+export const isPresent: typeof Ember.isPresent;
+export const tryInvoke: typeof Ember.tryInvoke;
+export const typeOf: typeof Ember.typeOf;

--- a/types/ember__utils/tsconfig.json
+++ b/types/ember__utils/tsconfig.json
@@ -9,7 +9,7 @@
         "noImplicitAny": true,
         "noImplicitThis": true,
         "strictNullChecks": true,
-        "strictFunctionTypes": false,
+        "strictFunctionTypes": true,
         "baseUrl": "../",
         "typeRoots": [
             "../"

--- a/types/ember__utils/tsconfig.json
+++ b/types/ember__utils/tsconfig.json
@@ -1,0 +1,28 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es5",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": false,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "paths": {
+            "@ember/utils": ["ember__utils"]
+        },
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "ember__utils-tests.ts"
+    ]
+}

--- a/types/ember__utils/tslint.json
+++ b/types/ember__utils/tslint.json
@@ -1,0 +1,30 @@
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        // Heavy use of Function type in this older package.
+        "ban-types": false,
+        "jsdoc-format": false,
+        "no-misused-new": false,
+
+        // these are disabled because of rfc176 module exports
+        "strict-export-declare-modifiers": false,
+        "no-single-declare-module": false,
+        "no-declare-current-package": false,
+        "no-self-import": false,
+
+        // We use interfaces in a number of places to express things (including
+        // mixins in particular, but also including extending a global
+        // interface) which TS currently can't express correctly.
+        "no-empty-interface": false,
+
+        "no-duplicate-imports": false,
+        "no-unnecessary-qualifier": false,
+        "prefer-const": false,
+        "no-void-expression": false,
+        "only-arrow-functions": false,
+        "no-submodule-imports": false,
+
+        // false positives
+        "unified-signatures": false
+    }
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
> this is an odd situation where the npm package and the name of the modules consumers import do not align. These types align with the module names
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
> Again, an a
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.emberjs.com/api/ember/3.4/modules/@ember%2Futils
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

cc: @dwickern @jamescdavis @dfreeman @chriskrycho 

Fixes https://github.com/typed-ember/ember-cli-typescript/issues/261