### PR TITLE
jQuery: Type of 'support' as to be JQuerySupport

### DIFF
--- a/types/jquery/index.d.ts
+++ b/types/jquery/index.d.ts
@@ -21,8 +21,9 @@
 //                 John Reilly <https://github.com/johnnyreilly>
 //                 Dick van den Brink <https://github.com/DickvdBrink>
 //                 Thomas Schulz <https://github.com/King2500>
+//                 Marcel Koch <https://github.com/mknet>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 3.0
 
 declare module 'jquery' {
     export = jQuery;

--- a/types/jquery/index.d.ts
+++ b/types/jquery/index.d.ts
@@ -113,7 +113,7 @@ interface JQueryStatic {
      *
      * @deprecated Deprecated since 1.9. See \`{@link https://api.jquery.com/jQuery.support/ }\`.
      */
-    support: JQuery.PlainObject;
+    support: JQuerySupport;
     // Set to HTMLElement to minimize breaks but should probably be Element.
     valHooks: JQuery.PlainObject<JQuery.ValHook<HTMLElement>>;
     // HACK: This is the factory function returned when importing jQuery without a DOM. Declaring it separately breaks using the type parameter on JQueryStatic.

--- a/types/jquery/index.d.ts
+++ b/types/jquery/index.d.ts
@@ -23,7 +23,7 @@
 //                 Thomas Schulz <https://github.com/King2500>
 //                 Marcel Koch <https://github.com/mknet>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.0
+// TypeScript Version: 2.9
 
 declare module 'jquery' {
     export = jQuery;

--- a/types/jquery/jquery-tests.ts
+++ b/types/jquery/jquery-tests.ts
@@ -159,7 +159,7 @@ function JQueryStatic() {
     }
 
     function support() {
-        // $ExpectType PlainObject<any>
+        // $ExpectType JQuerySupport
         $.support;
     }
 

--- a/types/jquery/jquery-tests.ts
+++ b/types/jquery/jquery-tests.ts
@@ -2770,10 +2770,6 @@ function JQuery() {
             // $ExpectType JQuery<HTMLElement>
             $('p').offset({});
 
-            // Weak type test. This may be removed if the TypeScript requirement is increased to 2.4+.
-            // $ExpectError
-            $('p').offset(20);
-
             // $ExpectType JQuery<HTMLElement>
             $('p').offset(function(index, coords) {
                 // $ExpectType HTMLElement

--- a/types/jquery/test/example-tests.ts
+++ b/types/jquery/test/example-tests.ts
@@ -2334,8 +2334,11 @@ function examples() {
     }
 
     function jQuery_contains_0() {
-        $.contains(document.documentElement!, document.body); // true
-        $.contains(document.body, document.documentElement!); // false
+        const elem = document.documentElement;
+        if (elem) {
+            $.contains(elem, document.body); // true
+            $.contains(document.body, elem); // false
+        }
     }
 
     function jQuery_data_0() {


### PR DESCRIPTION
This PR solves this issue issue 

`node_modules/@types/jquery/index.d.ts:116:5 - error TS2717: Subsequent property declarations must have the same type. Property 'support' must be of type 'JQuerySupport', but here has type 'PlainObject<any>'.`

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Increase the version number in the header if appropriate.