### PR TITLE
[@types/youtube] Exposing typing for hidden `host` property in PlayerOptions

### DIFF
--- a/types/youtube/index.d.ts
+++ b/types/youtube/index.d.ts
@@ -4,6 +4,7 @@
 //                 Ian Obermiller <http://ianobermiller.com>,
 //                 Josh Goldberg <https://github.com/JoshuaKGoldberg>
 //                 Eliot Fallon <https://github.com/eliotfallon213>
+//                 Terry Mun <https://github.com/terrymun>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.1
 
@@ -394,6 +395,11 @@ declare namespace YT
 		 * Handlers for events fired by the player.
 		 */
 		events?: Events;
+
+		/**
+		 * Points host to correct origin for CORS
+		 */
+		host?: string;
 	}
 
 	/**

--- a/types/youtube/youtube-tests.ts
+++ b/types/youtube/youtube-tests.ts
@@ -10,6 +10,7 @@ const players: YT.Player[] = [
         videoId: "videoId",
         playerVars: {},
         events: {},
+        host: 'https://www.youtube.com',
     }),
     new YT.Player("id", {
         playerVars: {


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

***

Changing/updating a pre-existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/kaorun343/vue-youtube-embed/issues/29#issuecomment-335100319. The `host` key is not officially documented, but fixes issues with `postMessage` errors in the console due to CORS
- [x] ~Increase the version number in the header if appropriate.~ (no version number originally specified, but tested with latest version released on May 18, 2018).
- [x] ~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.~ File already exists
