### PR TITLE
Replace JSX.Element with React.ComponentType in `withInfo` options from @storybook/addon-info

### DIFF
--- a/types/storybook__addon-info/index.d.ts
+++ b/types/storybook__addon-info/index.d.ts
@@ -19,8 +19,8 @@ export interface Options {
   header?: boolean;
   inline?: boolean;
   source?: boolean;
-  propTables?: JSX.Element[] | false;
-  propTablesExclude?: JSX.Element[];
+  propTables?: React.ComponentType[] | false;
+  propTablesExclude?: React.ComponentType[];
   styles?: object;
   marksyConf?: object;
   maxPropsIntoLine?: number;


### PR DESCRIPTION
Is meant to be `React.ComponentType` (see https://github.com/storybooks/storybook/tree/master/addons/info).
`JSX.Element` is the type of an instance of a component (e.g. `<MyComponent />`), while `React.ComponentType` is the type of the component class itself (e.g. `MyComponent`).

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/storybooks/storybook/tree/master/addons/info>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
