### PR TITLE
ftpd typings: error and result can both be undefined for readdir, open, stat in FtpFileSystem.

### DIFF
--- a/types/ftpd/index.d.ts
+++ b/types/ftpd/index.d.ts
@@ -130,20 +130,20 @@ export declare class FtpConnection extends events.EventEmitter {
  */
 export interface FtpFileSystem {
     unlink: (path: string, callback?: (err?: NodeJS.ErrnoException) => void) => void;
-    readdir: (path: string, callback?: (err: NodeJS.ErrnoException, files: string[]) => void) => void;
+    readdir: (path: string, callback?: (err?: NodeJS.ErrnoException, files?: string[]) => void) => void;
     mkdir: ((path: string, callback?: (err?: NodeJS.ErrnoException) => void) => void)
     | ((path: string, mode: number, callback?: (err?: NodeJS.ErrnoException) => void) => void)
     | ((path: string, mode: string, callback?: (err?: NodeJS.ErrnoException) => void) => void);
-    open: ((path: string, flags: string, callback?: (err: NodeJS.ErrnoException, fd: number) => any) => void)
-    | ((path: string, flags: string, mode: number, callback?: (err: NodeJS.ErrnoException, fd: number) => any) => void)
-    | ((path: string, flags: string, mode: string, callback?: (err: NodeJS.ErrnoException, fd: number) => any) => void);
+    open: ((path: string, flags: string, callback?: (err?: NodeJS.ErrnoException, fd?: number) => any) => void)
+    | ((path: string, flags: string, mode: number, callback?: (err?: NodeJS.ErrnoException, fd?: number) => any) => void)
+    | ((path: string, flags: string, mode: string, callback?: (err?: NodeJS.ErrnoException, fd?: number) => any) => void);
     close: (fd: number, callback?: (err?: NodeJS.ErrnoException) => void) => void;
     rmdir: (path: string, callback?: (err?: NodeJS.ErrnoException) => void) => void;
     rename: (oldPath: string, newPath: string, callback?: (err?: NodeJS.ErrnoException) => void) => void;
     /**
      * specific object properties: { mode, isDirectory(), size, mtime }
      */
-    stat: (path: string, callback?: (err: NodeJS.ErrnoException, stats: fs.Stats) => any) => void;
+    stat: (path: string, callback?: (err?: NodeJS.ErrnoException, stats?: fs.Stats) => any) => void;
     /**
      * if useReadFile option is not set or is false
      */


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: 

```
import * as fs from "fs";

fs.readdir("./non-existing-dir", (error, files) => {
	// Will print "error: ..."
	console.log("error: ", error);
	// Will print "files: undefined"
	console.log("files: ", files);
});
fs.readdir("./existing-dir", (error, files) => {
	// Will print "error: null"
	console.log("error: ", error);
	// Will print "files: ..."
	console.log("files: ", files);
});
```

- [X] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

