### PR TITLE
feat: update puppeteer definition

### DIFF
--- a/types/puppeteer/index.d.ts
+++ b/types/puppeteer/index.d.ts
@@ -592,6 +592,14 @@ export interface ScreenshotOptions {
   encoding?: "base64" | "binary";
 }
 
+export interface BinaryScreenShotOptions extends ScreenshotOptions {
+    encoding?: "binary";
+}
+
+export interface Base64ScreenShotOptions extends ScreenshotOptions {
+    encoding: "base64";
+}
+
 /** Options for `addStyleTag` */
 export interface StyleTagOptions {
   /** Url of the <link> tag. */
@@ -747,7 +755,9 @@ export interface ElementHandle<E extends Element = Element> extends JSHandle, Ev
    * If the element is detached from DOM, the method throws an error.
    * @param options Same options as in page.screenshot.
    */
-  screenshot(options?: ScreenshotOptions): Promise<Buffer>;
+  screenshot(options?: Base64ScreenShotOptions): Promise<string>;
+  screenshot(options?: BinaryScreenShotOptions): Promise<Buffer>;
+  screenshot(options?: ScreenshotOptions): Promise<string | Buffer>;
   /**
    * This method scrolls element into view if needed, and then uses touchscreen.tap to tap in the center of the element.
    * If the element is detached from DOM, the method throws an error.
@@ -1346,6 +1356,8 @@ export interface Page extends EventEmitter, FrameBase {
    * Captures a screenshot of the page.
    * @param options The screenshot options.
    */
+  screenshot(options?: Base64ScreenShotOptions): Promise<string>;
+  screenshot(options?: BinaryScreenShotOptions): Promise<Buffer>;
   screenshot(options?: ScreenshotOptions): Promise<string | Buffer>;
 
   /**

--- a/types/puppeteer/puppeteer-tests.ts
+++ b/types/puppeteer/puppeteer-tests.ts
@@ -403,8 +403,12 @@ puppeteer.launch().then(async browser => {
   const browser = await puppeteer.launch();
   const page = await browser.newPage();
   await page.goto("https://example.com");
-  const base64string: string = (await page.screenshot({ encoding: "base64" })) as string;
-  const buffer: Buffer = (await page.screenshot({ encoding: "binary" })) as Buffer;
+  const base64string: string = await page.screenshot({ encoding: "base64" });
+  const buffer: Buffer = await page.screenshot({ encoding: "binary" });
+  const screenshotOptions: puppeteer.ScreenshotOptions = {
+    fullPage: true,
+  };
+  const stringOrBuffer: string | Buffer = await page.screenshot(screenshotOptions);
 
   browser.close();
 })();


### PR DESCRIPTION
Overloaded the screenshot methods to define the return type based on what kind of encoding is used.
Edited the test and made sure normal ScreenshotOptions worked as normal still, the two new extended interfaces can be used for objects to pass in also but did not add test for that directly, should be handled right with the current test cases.

If there is a better way to be able to achieve this sort of overloading behavior please let me know.
The overloaded methods are ordered as the base64 first as it is the most defined, if encoding is not included it is returned as a Buffer, an object that is passed to screenshot that typescript knows to not include an encoding typescript will understand it as a Buffer return. The normal ScreenshotOptions overload is last as it is the least defined not knowing what the return type will be.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/28617#issuecomment-419109507
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

