### PR TITLE
@types/google-map-react - optional elementType and featureType of a MapTypeStyle

### DIFF
--- a/types/google-map-react/google-map-react-tests.tsx
+++ b/types/google-map-react/google-map-react-tests.tsx
@@ -21,6 +21,9 @@ const options: MapOptions = {
         {
             elementType: "labels.text.stroke",
             stylers: [ {color: "#242f3e"} ]
+        },
+        {
+            stylers: [ {color: "#fcfffd"} ]
         }
     ],
 };

--- a/types/google-map-react/google-map-react-tests.tsx
+++ b/types/google-map-react/google-map-react-tests.tsx
@@ -13,6 +13,14 @@ const options: MapOptions = {
             featureType: "administrative",
             elementType: "all",
             stylers: [ {saturation: "-100"} ]
+        },
+        {
+            featureType: "administrative.neighborhood",
+            stylers: [ {visibility: "off" } ]
+        },
+        {
+            elementType: "labels.text.stroke",
+            stylers: [ {color: "#242f3e"} ]
         }
     ],
 };

--- a/types/google-map-react/index.d.ts
+++ b/types/google-map-react/index.d.ts
@@ -1,7 +1,6 @@
 // Type definitions for google-map-react 0.23
 // Project: https://github.com/istarkov/google-map-react
 // Definitions by: Honza Brecka <https://github.com/honzabrecka>
-// Definitions by: Andres Rosero <https://github.com/drebits>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 

--- a/types/google-map-react/index.d.ts
+++ b/types/google-map-react/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for google-map-react 0.23
 // Project: https://github.com/istarkov/google-map-react
 // Definitions by: Honza Brecka <https://github.com/honzabrecka>
+// Definitions by: Andres Rosero <https://github.com/drebits>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -9,8 +10,8 @@ import * as React from 'react';
 export type BootstrapURLKeys = ({ key: string; } | { client: string; v: string; }) & { language?: string };
 
 export interface MapTypeStyle {
-  elementType: string;
-  featureType: string;
+  elementType?: string;
+  featureType?: string;
   stylers: any[];
 }
 


### PR DESCRIPTION
Hi, I just made a couple of changes to make optional the elementType and the featureType. This is because according to the documentation these parameters are optional, and also because for instance, in my team, the designers use tools like [this](https://mapstyle.withgoogle.com/), which do not always generate these parameters.
Thanks.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://developers.google.com/maps/documentation/javascript/style-reference>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
