### PR TITLE
Fix: missing passReqToCallback property for passport-naver

### DIFF
--- a/types/passport-naver/index.d.ts
+++ b/types/passport-naver/index.d.ts
@@ -1,6 +1,7 @@
-// Type definitions for passport-naver 0.1
+// Type definitions for passport-naver 0.2
 // Project: https://github.com/naver/passport-naver
 // Definitions by: Park9eon <https://github.com/Park9eon>
+//                 ZeroCho <https://github.com/zerocho>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -34,11 +35,16 @@ export interface StrategyOption {
     profileURL?: string;
 }
 
-export type VerifyFunction =
-    (accessToken: string, refreshToken: string, profile: Profile, done: (error: any, user?: any, info?: any) => void) => void;
+export interface StrategyOptionWithRequest extends StrategyOption {
+    passReqToCallback: boolean;
+}
+
+export type VerifyFunction = (accessToken: string, refreshToken: string, profile: Profile, done: (error: any, user?: any, info?: any) => void) => void;
+export type VerifyFunctionWithRequest = (req: express.Request, accessToken: string, refreshToken: string, profile: Profile, done: (error: any, user?: any, info?: any) => void) => void;
 
 export class Strategy extends passport.Strategy {
     constructor(options: StrategyOption, verify: VerifyFunction);
+    constructor(options: StrategyOptionWithRequest, verify: VerifyFunctionWithRequest);
 
     authenticate(req: express.Request, options?: any): void;
     authorizationParams: (options: any) => any;

--- a/types/passport-naver/passport-naver-tests.ts
+++ b/types/passport-naver/passport-naver-tests.ts
@@ -1,10 +1,11 @@
-import {Strategy as NaverStrategy } from 'passport-naver';
+import { Strategy as NaverStrategy } from 'passport-naver';
 
 new NaverStrategy({
         clientID: 'client',
         clientSecret: 'clientSecret',
-        callbackURL: 'callbackUrl'
+        callbackURL: 'callbackUrl',
     },
     (accessToken: string, refreshToken: string, profile: any, done: any) => {
         // signUp or signIn
-    });
+    },
+);


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/jaredhanson/passport-oauth2/blob/a9480960be04ac5312f9eae2a6d06d0e8d0e5dda/lib/strategy.js#L49
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
