### PR TITLE
@types/joi add dataUri type definition

### DIFF
--- a/types/joi/index.d.ts
+++ b/types/joi/index.d.ts
@@ -13,6 +13,8 @@
 //                 Rafael Kallis <https://github.com/rafaelkallis>
 //                 Conan Lai <https://github.com/aconanlai>
 //                 Peter Thorson <https://github.com/zaphoyd>
+//                 Will Garcia <https://github.com/thewillg>
+//                 Simon Schick <https://github.com/SimonSchick>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.4
 
@@ -145,6 +147,13 @@ export interface UriOptions {
      * Restrict only relative URIs. Defaults to `false`.
      */
     relativeOnly?: boolean;
+}
+
+export interface DataUriOptions {
+    /**
+     * optional parameter defaulting to true which will require = padding if true or make padding optional if false
+     */
+    paddingRequired?: boolean;
 }
 
 export interface Base64Options {
@@ -629,6 +638,11 @@ export interface StringSchema extends AnySchema {
      * Requires the string value to be a valid RFC 3986 URI.
      */
     uri(options?: UriOptions): this;
+
+    /**
+     * Requires the string value to be a valid data URI string.
+     */
+    dataUri(options?: DataUriOptions): this;
 
     /**
      * Requires the string value to be a valid GUID.

--- a/types/joi/joi-tests.ts
+++ b/types/joi/joi-tests.ts
@@ -120,6 +120,12 @@ base64Opts = { paddingRequired: bool };
 
 // --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- ---
 
+let dataUriOpts: Joi.DataUriOptions = null;
+
+dataUriOpts = { paddingRequired: bool };
+
+// --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- ---
+
 let whenOpts: Joi.WhenOptions = null;
 
 whenOpts = { is: x };
@@ -818,6 +824,8 @@ strSchema = strSchema.normalize();
 strSchema = strSchema.normalize('NFKC');
 strSchema = strSchema.base64();
 strSchema = strSchema.base64(base64Opts);
+strSchema = strSchema.dataUri();
+strSchema = strSchema.dataUri(dataUriOpts);
 
 { // common
     strSchema = strSchema.allow(x);


### PR DESCRIPTION
Joi v13.4.0 introduced string().dataUri()