### PR TITLE
[ember] relax Ember.set while we figure out CP unwrapping again

### DIFF
--- a/types/ember/index.d.ts
+++ b/types/ember/index.d.ts
@@ -1708,14 +1708,18 @@ declare module 'ember' {
             /**
              * Sets the provided key or path to the value.
              */
-            set<K extends keyof this>(key: K, value: UnwrapComputedPropertySetter<this[K]>): UnwrapComputedPropertySetter<this[K]>;
+            set<K extends keyof this>(key: K, value: this[K]): this[K];
+            set<T>(key: keyof this, value: T): T;
             /**
              * Sets a list of properties at once. These properties are set inside
              * a single `beginPropertyChanges` and `endPropertyChanges` batch, so
              * observers will be buffered.
              */
             setProperties<K extends keyof this>(
-                hash: Pick<UnwrapComputedPropertySetters<this>, K>
+                hash: Pick<this, K>
+            ): Pick< UnwrapComputedPropertySetters<this>, K>;
+            setProperties<K extends keyof this>(
+                hash: {[KK in K]: any}
             ): Pick< UnwrapComputedPropertySetters<this>, K>;
             /**
              * Convenience method to call `propertyWillChange` and `propertyDidChange` in

--- a/types/ember/test/object.ts
+++ b/types/ember/test/object.ts
@@ -25,3 +25,27 @@ class MyObject31 extends Ember.Object {
         super(properties);
     }
 }
+
+class Foo extends Ember.Object.extend({
+    a: Ember.computed({
+        get() { return ''; },
+        set(key: string, newVal: string) { return ''; }
+    })
+}) {
+    b = 5;
+    baz() {
+        let y = this.b; // $ExpectType number
+        let z = this.a; // $ExpectType ComputedProperty<string, string>
+        this.b = 10;
+        this.get('b').toFixed(4); // $ExpectType string
+        this.set('a', 'abc').split(','); // $ExpectType string[]
+        this.set('b', 10).toFixed(4); // $ExpectType string
+
+        this.setProperties({ b: 11 });
+        // this.setProperties({ b: '11' }); // $ExpectError
+        this.setProperties({
+            a: 'def',
+            b: 11
+        });
+    }
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.emberjs.com/api/ember/3.4/classes/Observable
- * Increase the version number in the header if appropriate.
- * If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

--- 

There's a fairly glaring and critical bug having to do with the changes to regain compatibility with TS 3.1. This relaxes the types while we figure out a more permanent solution
Details here: https://github.com/typed-ember/ember-cli-typescript/issues/286
