### PR TITLE
[react-intl] Add missing children props to formatting components

### DIFF
--- a/types/react-intl/index.d.ts
+++ b/types/react-intl/index.d.ts
@@ -8,6 +8,7 @@
 //                 Brian Houser <https://github.com/bhouser>,
 //                 Krister Kari <https://github.com/kristerkari>
 //                 Martin Raedlinger <https://github.com/formatlos>
+//                 Kanitkorn Sujautra <https://github.com/lukyth>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -94,6 +95,7 @@ declare namespace ReactIntl {
 
         interface Props extends PropsBase {
             value: DateSource;
+            children?: (formattedDate: string) => React.ReactNode;
         }
     }
 
@@ -104,6 +106,7 @@ declare namespace ReactIntl {
 
         interface Props extends PropsBase {
             value: DateSource;
+            children?: (formattedTime: string) => React.ReactNode;
         }
     }
     class FormattedTime extends React.Component<FormattedTime.Props> { }
@@ -125,6 +128,7 @@ declare namespace ReactIntl {
 
         interface Props extends PropsBase {
             value: DateSource;
+            children?: (formattedRelative: string) => React.ReactNode;
         }
     }
 
@@ -154,6 +158,7 @@ declare namespace ReactIntl {
 
         interface Props extends PropsBase {
             value: number;
+            children?: (formattedNumber: string) => React.ReactNode;
         }
     }
     class FormattedNumber extends React.Component<FormattedNumber.Props> { }
@@ -177,6 +182,7 @@ declare namespace ReactIntl {
 
         interface Props extends PropsBase {
             value: number;
+            children?: (formattedPlural: React.ReactNode) => React.ReactNode;
         }
     }
     class FormattedPlural extends React.Component<FormattedPlural.Props> { }

--- a/types/react-intl/react-intl-tests.tsx
+++ b/types/react-intl/react-intl-tests.tsx
@@ -96,6 +96,17 @@ class SomeComponent extends React.Component<SomeComponentProps & InjectedIntlPro
                 updateInterval={123}
                 initialNow={new Date()} />
 
+            <FormattedRelative
+                value={new Date().getTime()}
+                units="hour"
+                style="numeric"
+                format="yyyy-MM-dd"
+                updateInterval={123}
+                initialNow={new Date()}
+            >
+                {formattedRelative => formattedRelative.toUpperCase()}
+            </FormattedRelative>
+
             <FormattedMessage
                 id="test"
                 description="Test"
@@ -233,6 +244,12 @@ class SomeComponent extends React.Component<SomeComponentProps & InjectedIntlPro
                 maximumFractionDigits={3}
                 maximumSignificantDigits={3} />
 
+            <FormattedNumber value={123}>
+                {formattedNum => (
+                    <span className="number">{formattedNum}</span>
+                )}
+            </FormattedNumber>
+
             <FormattedPlural
                 style="cardinal"
                 value={3}
@@ -243,79 +260,128 @@ class SomeComponent extends React.Component<SomeComponentProps & InjectedIntlPro
                 few="haifew"
                 many="haiku" />
 
-            <FormattedDate
-                value={new Date()}
-                format="short"
-                localeMatcher="best fit"
-                formatMatcher="basic"
-                timeZone="EDT"
-                hour12={false}
-                weekday="short"
-                era="short"
-                year="2-digit"
-                month="2-digit"
-                day="2-digit"
-                hour="2-digit"
-                minute="2-digit"
-                second="2-digit"
-                timeZoneName="short" />
-
-            <FormattedDate
-                value={Date.now()}
-                format="short"
-                localeMatcher="best fit"
-                formatMatcher="basic"
-                timeZone="EDT"
-                hour12={false}
-                weekday="short"
-                era="short"
-                year="2-digit"
-                month="2-digit"
-                day="2-digit"
-                hour="2-digit"
-                minute="2-digit"
-                second="2-digit"
-                timeZoneName="short" />
-
-            <FormattedTime
-                value={new Date()}
-                format="short"
-                localeMatcher="best fit"
-                formatMatcher="basic"
-                timeZone="EDT"
-                hour12={false}
-                weekday="short"
-                era="short"
-                year="2-digit"
-                month="2-digit"
-                day="2-digit"
-                hour="2-digit"
-                minute="2-digit"
-                second="2-digit"
-                timeZoneName="short" />
-
-            <FormattedTime
-                value={Date.now()}
-                format="short"
-                localeMatcher="best fit"
-                formatMatcher="basic"
-                timeZone="EDT"
-                hour12={false}
-                weekday="short"
-                era="short"
-                year="2-digit"
-                month="2-digit"
-                day="2-digit"
-                hour="2-digit"
-                minute="2-digit"
-                second="2-digit"
-                timeZoneName="short" />
-
-            <FormattedNumber value={123}>
-                {(formattedNum: string) => (
-                    <span className="number">{formattedNum}</span>
+            <FormattedPlural
+                style="cardinal"
+                value={3}
+                other="hai?"
+                zero="no hai"
+                one="hai"
+                two="hai2"
+                few="haifew"
+                many="haiku"
+            >
+                {formattedPlural => (
+                    <span className="number">{formattedPlural}</span>
                 )}
-            </FormattedNumber>
+            </FormattedPlural>
+
+            <FormattedDate
+                value={new Date()}
+                format="short"
+                localeMatcher="best fit"
+                formatMatcher="basic"
+                timeZone="EDT"
+                hour12={false}
+                weekday="short"
+                era="short"
+                year="2-digit"
+                month="2-digit"
+                day="2-digit"
+                hour="2-digit"
+                minute="2-digit"
+                second="2-digit"
+                timeZoneName="short" />
+
+            <FormattedDate
+                value={Date.now()}
+                format="short"
+                localeMatcher="best fit"
+                formatMatcher="basic"
+                timeZone="EDT"
+                hour12={false}
+                weekday="short"
+                era="short"
+                year="2-digit"
+                month="2-digit"
+                day="2-digit"
+                hour="2-digit"
+                minute="2-digit"
+                second="2-digit"
+                timeZoneName="short" />
+
+            <FormattedDate
+                value={Date.now()}
+                format="short"
+                localeMatcher="best fit"
+                formatMatcher="basic"
+                timeZone="EDT"
+                hour12={false}
+                weekday="short"
+                era="short"
+                year="2-digit"
+                month="2-digit"
+                day="2-digit"
+                hour="2-digit"
+                minute="2-digit"
+                second="2-digit"
+                timeZoneName="short"
+            >
+                {formattedDate => formattedDate.toUpperCase()}
+            </FormattedDate>
+
+            <FormattedTime
+                value={new Date()}
+                format="short"
+                localeMatcher="best fit"
+                formatMatcher="basic"
+                timeZone="EDT"
+                hour12={false}
+                weekday="short"
+                era="short"
+                year="2-digit"
+                month="2-digit"
+                day="2-digit"
+                hour="2-digit"
+                minute="2-digit"
+                second="2-digit"
+                timeZoneName="short" />
+
+            <FormattedTime
+                value={Date.now()}
+                format="short"
+                localeMatcher="best fit"
+                formatMatcher="basic"
+                timeZone="EDT"
+                hour12={false}
+                weekday="short"
+                era="short"
+                year="2-digit"
+                month="2-digit"
+                day="2-digit"
+                hour="2-digit"
+                minute="2-digit"
+                second="2-digit"
+                timeZoneName="short" />
+
+            <FormattedTime
+                value={Date.now()}
+                format="short"
+                localeMatcher="best fit"
+                formatMatcher="basic"
+                timeZone="EDT"
+                hour12={false}
+                weekday="short"
+                era="short"
+                year="2-digit"
+                month="2-digit"
+                day="2-digit"
+                hour="2-digit"
+                minute="2-digit"
+                second="2-digit"
+                timeZoneName="short"
+            >
+                {formattedTime => formattedTime.toUpperCase()}
+            </FormattedTime>
         </div>;
     }
 }


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - https://github.com/yahoo/react-intl/wiki/Components#date-formatting-components
  - https://github.com/yahoo/react-intl/wiki/Components#number-formatting-components
  - https://github.com/yahoo/react-intl/blob/master/src/components/number.js#L42
  - https://github.com/yahoo/react-intl/blob/master/src/components/plural.js#L54
  - https://github.com/yahoo/react-intl/blob/master/src/components/relative.js#L166
  - https://github.com/yahoo/react-intl/blob/master/src/components/time.js#L42
  - https://github.com/yahoo/react-intl/blob/master/src/components/date.js#L42
- [ ] ~~Increase the version number in the header if appropriate.~~
- [ ] ~~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.~~

Formatting components are supporting render function as a child but the `children` prop is missing in the type definition.

I'm not sure if this PR should bump a patch version or not, and how to do it if it should 😅.