### PR TITLE
nodemailer; for `send()` method `message` is `Readable`

### DIFF
--- a/types/nodemailer/lib/addressparser.d.ts
+++ b/types/nodemailer/lib/addressparser.d.ts
@@ -16,7 +16,6 @@ declare namespace addressparser {
  *
  *     [{name: 'Name', address: 'address@domain'}]
  *
- * @param str Address field
  * @return An array of address objects
  */
 declare function addressparser(address: string): addressparser.Address[];

--- a/types/nodemailer/lib/smtp-connection.d.ts
+++ b/types/nodemailer/lib/smtp-connection.d.ts
@@ -2,7 +2,7 @@
 
 import { EventEmitter } from 'events';
 import * as net from 'net';
-import { Writable } from 'stream';
+import { Readable } from 'stream';
 import * as tls from 'tls';
 
 import * as shared from './shared';
@@ -181,7 +181,7 @@ declare class SMTPConnection extends EventEmitter {
     /** Authenticate user */
     login(auth: SMTPConnection.AuthenticationCredentials | SMTPConnection.AuthenticationOAuth2 | SMTPConnection.Credentials, callback: (err: SMTPConnection.SMTPError | null) => void): void;
     /** Sends a message */
-    send(envelope: SMTPConnection.Envelope, message: string | Buffer | Writable, callback: (err: SMTPConnection.SMTPError | null, info: SMTPConnection.SentMessageInfo) => void): void;
+    send(envelope: SMTPConnection.Envelope, message: string | Buffer | Readable, callback: (err: SMTPConnection.SMTPError | null, info: SMTPConnection.SentMessageInfo) => void): void;
     /** Resets connection state */
     reset(callback: (err: Error | null) => void): void;
 
@@ -190,6 +190,15 @@ declare class SMTPConnection extends EventEmitter {
 
     emit(event: 'connect' | 'end'): boolean;
     emit(event: 'error', error: Error): boolean;
+
+    listenerCount(event: 'connect' | 'end'): number;
+    listenerCount(event: 'error'): number;
+
+    listeners(event: 'connect' | 'end'): Array<() => void>;
+    listeners(event: 'error'): Array<(err: SMTPConnection.SMTPError) => void>;
+
+    off(event: 'connect' | 'end', listener: () => void): this;
+    off(event: 'error', listener: (err: SMTPConnection.SMTPError) => void): this;
 
     on(event: 'connect' | 'end', listener: () => void): this;
     on(event: 'error', listener: (err: SMTPConnection.SMTPError) => void): this;
@@ -203,8 +212,14 @@ declare class SMTPConnection extends EventEmitter {
     prependOnceListener(event: 'connect' | 'end', listener: () => void): this;
     prependOnceListener(event: 'error', listener: (err: SMTPConnection.SMTPError) => void): this;
 
-    listeners(event: 'connect' | 'end'): Array<() => void>;
-    listeners(event: 'error'): Array<(err: SMTPConnection.SMTPError) => void>;
+    rawListeners(event: 'connect' | 'end'): Array<() => void>;
+    rawListeners(event: 'error'): Array<(err: SMTPConnection.SMTPError) => void>;
+
+    removeAllListener(event: 'connect' | 'end'): this;
+    removeAllListener(event: 'error'): this;
+
+    removeListener(event: 'connect' | 'end', listener: () => void): this;
+    removeListener(event: 'error', listener: (err: SMTPConnection.SMTPError) => void): this;
 }
 
 export = SMTPConnection;

--- a/types/nodemailer/lib/smtp-connection.d.ts
+++ b/types/nodemailer/lib/smtp-connection.d.ts
@@ -191,8 +191,7 @@ declare class SMTPConnection extends EventEmitter {
     emit(event: 'connect' | 'end'): boolean;
     emit(event: 'error', error: Error): boolean;
 
-    listenerCount(event: 'connect' | 'end'): number;
-    listenerCount(event: 'error'): number;
+    listenerCount(event: 'connect' | 'end' | 'error'): number;
 
     listeners(event: 'connect' | 'end'): Array<() => void>;
     listeners(event: 'error'): Array<(err: SMTPConnection.SMTPError) => void>;
@@ -215,8 +214,7 @@ declare class SMTPConnection extends EventEmitter {
     rawListeners(event: 'connect' | 'end'): Array<() => void>;
     rawListeners(event: 'error'): Array<(err: SMTPConnection.SMTPError) => void>;
 
-    removeAllListener(event: 'connect' | 'end'): this;
-    removeAllListener(event: 'error'): this;
+    removeAllListener(event: 'connect' | 'end' | 'error'): this;
 
     removeListener(event: 'connect' | 'end', listener: () => void): this;
     removeListener(event: 'error', listener: (err: SMTPConnection.SMTPError) => void): this;


### PR DESCRIPTION
Bugfix for typings: `send()` method accepts `Readable` stream, not `Writable`!

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
