### PR TITLE
Add definitions for fabric Object.borderDashArray & Text.charSpacing

### DIFF
--- a/types/fabric/fabric-impl.d.ts
+++ b/types/fabric/fabric-impl.d.ts
@@ -2048,7 +2048,12 @@ interface IObjectOptions {
 	 */
 	borderColor?: string;
 
-	/**
+    /**
+     * Array specifying dash pattern of an object's border (hasBorder must be true)
+     */
+    borderDashArray?: number[];
+
+    /**
 	 * Color of controlling corners of an object (when it's active)
 	 */
 	cornerColor?: string;
@@ -3114,6 +3119,10 @@ interface ITextOptions extends IObjectOptions {
 	 * Line height
 	 */
 	lineHeight?: number;
+    /**
+     * Character spacing
+     */
+    charSpacing?: number;
 	/**
 	 * When defined, an object is rendered via stroke and this property specifies its color.
 	 * <b>Backwards incompatibility note?:</b> This property was named "strokeStyle" until v1.1.6
@@ -3254,6 +3263,15 @@ export class Text extends Object {
 	 * @param lineHeight Line height
 	 */
 	setLineHeight(lineHeight: number): Text;
+    /**
+     * Retrieves object's charSpacing
+     */
+    getCharSpacing(): number;
+    /**
+     * Sets object's charSpacing
+     * @param charSpacing Character spacing
+     */
+    setCharSpacing(charSpacing: number): Text;
 	/**
 	 * Retrieves object's textAlign
 	 */


### PR DESCRIPTION
Simply adding missing definitions for a couple of props.