### PR TITLE
[three] add newly required argument

### DIFF
--- a/types/three/test/math/test_unit_math.ts
+++ b/types/three/test/math/test_unit_math.ts
@@ -765,7 +765,7 @@ declare function equal<T>(a: T, b: T, desc?: string): void;
     test( "setHSL", function () {
         var c = new THREE.Color();
         c.setHSL(0.75, 1.0, 0.25);
-        var hsl = c.getHSL();
+        var hsl = c.getHSL( { h: 0, s: 0, l: 0 } );
 
         ok( hsl.h == 0.75, "hue: " + hsl.h );
         ok( hsl.s == 1.00, "saturation: " + hsl.s );

--- a/types/three/test/math/test_unit_math.ts
+++ b/types/three/test/math/test_unit_math.ts
@@ -755,7 +755,7 @@ declare function equal<T>(a: T, b: T, desc?: string): void;
 
     test( "getHSL", function () {
         var c = new THREE.Color( 0x80ffff );
-        var hsl = c.getHSL();
+        var hsl = c.getHSL( { h: 0, s: 0, l: 0 } );
 
         ok( hsl.h == 0.5, "hue: " + hsl.h );
         ok( hsl.s == 1.0, "saturation: " + hsl.s );

--- a/types/three/three-core.d.ts
+++ b/types/three/three-core.d.ts
@@ -3369,7 +3369,7 @@ export class Color {
      */
     getHexString(): string;
 
-    getHSL(): HSL;
+    getHSL(target: HSL): HSL;
 
     /**
      * Returns the value of this color in CSS context style.


### PR DESCRIPTION
r92 removed the ability to call Color.getHSL() without passing a target object to copy the results to.  The `three` type package currently targets r92 but is missing a definition for this argument.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
    - https://threejs.org/docs/index.html#api/en/math/Color.getHSL
    - https://github.com/mrdoob/three.js/blob/r92/src/math/Color.js#L356
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.