### PR TITLE
Added ClientSession typings

### DIFF
--- a/types/mongodb/index.d.ts
+++ b/types/mongodb/index.d.ts
@@ -15,6 +15,7 @@
 //                 Geraldine Lemeur <https://github.com/geraldinelemeur>
 //                 Jimmy Shimizu <https://github.com/jishi>
 //                 Angela-1 <https://github.com/angela-1>
+//                 Matthew Duong <https://github.com/thegalah>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -63,9 +64,12 @@ export class MongoClient extends EventEmitter {
 }
 
 declare class ClientSession extends EventEmitter {
+    abortTransaction(): Promise<any>;
+    commitTransaction(): Promise<any>;
     endSession(callback?: MongoCallback<void>): void;
     endSession(options: any, callback?: MongoCallback<void>): void;
     equals(session: ClientSession): boolean;
+    startTransaction(options: object): void;
 }
 
 export interface MongoClientCommonOption {

--- a/types/mongodb/index.d.ts
+++ b/types/mongodb/index.d.ts
@@ -69,7 +69,7 @@ declare class ClientSession extends EventEmitter {
     endSession(callback?: MongoCallback<void>): void;
     endSession(options: any, callback?: MongoCallback<void>): void;
     equals(session: ClientSession): boolean;
-    startTransaction(options: object): void;
+    startTransaction(options?: object): void;
 }
 
 export interface MongoClientCommonOption {


### PR DESCRIPTION
Missing clientsession typings from docs: http://mongodb.github.io/node-mongodb-native/3.1/api/ClientSession.html

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://mongodb.github.io/node-mongodb-native/3.1/api/ClientSession.html
