### PR TITLE
Fix default export usage in my definition for react-global-configuration

### DIFF
--- a/types/react-global-configuration/index.d.ts
+++ b/types/react-global-configuration/index.d.ts
@@ -9,11 +9,7 @@ export interface Options {
     assign: boolean;
 }
 
-declare namespace ReactGlobalConfiguration {
-    function set(newConfiguration: any, newOptions?: Options): void;
-    function get(key?: string): any;
-    function get<Value = any>(key: string, fallbackValue: Value): Value;
-    function serialize(): string;
-}
-
-export default ReactGlobalConfiguration;
+export function set(newConfiguration: any, newOptions?: Options): void;
+export function get(key?: string): any;
+export function get<Value = any>(key: string, fallbackValue: Value): Value;
+export function serialize(): string;

--- a/types/react-global-configuration/tsconfig.json
+++ b/types/react-global-configuration/tsconfig.json
@@ -14,7 +14,8 @@
         ],
         "types": [],
         "noEmit": true,
-        "forceConsistentCasingInFileNames": true
+        "forceConsistentCasingInFileNames": true,
+        "allowSyntheticDefaultImports": true
     },
     "files": [
         "index.d.ts",


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: **`react-global-configuration` is not changed. this is fixing mistake of my definition.**
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
