### PR TITLE
nodemailer: contentTransferEncoding and contentDisposition values

### DIFF
--- a/types/nodemailer/lib/mailer/index.d.ts
+++ b/types/nodemailer/lib/mailer/index.d.ts
@@ -47,9 +47,9 @@ declare namespace Mail {
         /** optional content type for the attachment, if not set will be derived from the filename property */
         contentType?: string;
         /** optional transfer encoding for the attachment, if not set it will be derived from the contentType property. Example values: quoted-printable, base64. If it is unset then base64 encoding is used for the attachment. If it is set to false then previous default applies (base64 for most, 7bit for text). */
-        contentTransferEncoding?: string;
+        contentTransferEncoding?: '7bit' | 'base64' | 'quoted-printable' | false;
         /** optional content disposition type for the attachment, defaults to ‘attachment’ */
-        contentDisposition?: string;
+        contentDisposition?: 'attachment' | 'inline';
         /** is an object of additional headers */
         headers?: Headers;
         /** an optional value that overrides entire node content in the mime message. If used then all other options set for this node are ignored. */

--- a/types/nodemailer/nodemailer-tests.ts
+++ b/types/nodemailer/nodemailer-tests.ts
@@ -123,7 +123,7 @@ function message_attachments_test() {
         attachments: [
             {   // utf-8 string as an attachment
                 filename: 'text1.txt',
-                content: 'hello world!'
+                content: 'hello world!',
             },
             {   // binary buffer as an attachment
                 filename: 'text2.txt',
@@ -138,12 +138,15 @@ function message_attachments_test() {
             },
             {   // stream as an attachment
                 filename: 'text4.txt',
-                content: fs.createReadStream('file.txt')
+                content: fs.createReadStream('file.txt'),
+                contentTransferEncoding: 'quoted-printable'
             },
             {   // define custom content type for the attachment
                 filename: 'text.bin',
                 content: 'hello world!',
-                contentType: 'text/plain'
+                contentType: 'text/plain',
+                contentTransferEncoding: '7bit',
+                contentDisposition: 'attachment'
             },
             {   // use URL as an attachment
                 filename: 'license.txt',
@@ -152,10 +155,13 @@ function message_attachments_test() {
             {   // encoded string as an attachment
                 filename: 'text1.txt',
                 content: 'aGVsbG8gd29ybGQh',
-                encoding: 'base64'
+                encoding: 'base64',
+                contentTransferEncoding: 'base64'
             },
             {   // data uri as an attachment
-                path: 'data:text/plain;base64,aGVsbG8gd29ybGQ='
+                path: 'data:text/plain;base64,aGVsbG8gd29ybGQ=',
+                contentDisposition: 'inline',
+                contentTransferEncoding: false
             },
             {
                 // use pregenerated MIME node


### PR DESCRIPTION
`contentTransferEncoding` and `contentDisposition` fields can be set only to few valid values.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
