### PR TITLE
[jss] Correction to JSSPlugin definition

### DIFF
--- a/types/jss/index.d.ts
+++ b/types/jss/index.d.ts
@@ -77,7 +77,7 @@ export interface StyleSheet<RuleName extends string = any> {
 export type GenerateClassName<Name extends string = any> = (rule: Rule, sheet?: StyleSheet<Name>) => string;
 
 export interface JSSPlugin {
-	[key: string]: () => Partial<{
+	[key: string]: Partial<{
 		onCreateRule(name: string, style: Style, options: RuleOptions): Rule;
 		onProcessRule(rule: Rule, sheet: StyleSheet): void;
 		onProcessStyle(style: Style, rule: Rule, sheet: StyleSheet): Style;


### PR DESCRIPTION
JSSPlugin type has to be equivalent to Plugin type in JSS: https://github.com/cssinjs/jss/blob/master/packages/jss/src/types/jss.js#L101
Trying to use a JSS plugin in TypeScript with the current definition causes a compilation error.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] ~~Add or edit tests to reflect the change. (Run with `npm test`.)~~
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/cssinjs/jss/blob/master/packages/jss/src/types/jss.js#L101
- [ ] ~~Increase the version number in the header if appropriate.~~
- [ ] ~~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.~~