### PR TITLE
[webpack-dev-server] add tests for Stats, only allow specific strings

### DIFF
--- a/types/webpack-dev-server/index.d.ts
+++ b/types/webpack-dev-server/index.d.ts
@@ -158,7 +158,7 @@ declare namespace WebpackDevServer {
          * This option lets you precisely control what bundle information gets displayed.
          * This can be a nice middle ground if you want some bundle information, but not all of it.
          */
-        stats?: string | webpack.Options.Stats;
+        stats?: webpack.Options.Stats;
         /** This option lets the browser open with your local IP. */
         useLocalIp?: boolean;
         /** Tell the server to watch the files served by the devServer.contentBase option. File changes will trigger a full page reload. */

--- a/types/webpack-dev-server/webpack-dev-server-tests.ts
+++ b/types/webpack-dev-server/webpack-dev-server-tests.ts
@@ -58,6 +58,11 @@ const config: WebpackDevServer.Configuration = {
     staticOptions: {
     },
 
+    stats: {
+        assets: false,
+        warningsFilter: /1/,
+    },
+
     // webpack-dev-middleware options
     quiet: false,
     noInfo: false,
@@ -70,6 +75,13 @@ const config: WebpackDevServer.Configuration = {
     // It's a required option.
     publicPath: "/assets/",
     headers: { "X-Custom-Header": "yes" }
+};
+
+const c2: WebpackDevServer.Configuration = {
+    stats: false,
+};
+const c3: WebpackDevServer.Configuration = {
+    stats: "verbose",
 };
 
 // API example


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://webpack.js.org/configuration/stats/#stats
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.


Ref #28362 