### PR TITLE
[ember] refactor @ember/string types into their own package

### DIFF
--- a/types/ember__string/ember__string-tests.ts
+++ b/types/ember__string/ember__string-tests.ts
@@ -1,0 +1,33 @@
+import { dasherize, camelize, capitalize, classify, decamelize, htmlSafe, loc, underscore, w } from '@ember/string';
+
+dasherize(); // $ExpectError
+dasherize('blue man group'); // $ExpectType string
+dasherize('', ''); // $ExpectError
+
+camelize(); // $ExpectError
+camelize('blue man group'); // $ExpectType string
+camelize('', ''); // $ExpectError
+
+decamelize(); // $ExpectError
+decamelize('blue man group'); // $ExpectType string
+decamelize('', ''); // $ExpectError
+
+underscore(); // $ExpectError
+underscore('blue man group'); // $ExpectType string
+underscore('', ''); // $ExpectError
+
+w(); // $ExpectError
+w('blue man group'); // $ExpectType string[]
+w('', ''); // $ExpectError
+
+classify(); // $ExpectError
+classify('blue man group'); // $ExpectType string
+classify('', ''); // $ExpectError
+
+capitalize(); // $ExpectError
+capitalize('blue man group'); // $ExpectType string
+capitalize('', ''); // $ExpectError
+
+loc(); // $ExpectError
+loc("_Hello World");  // $ExpectType string
+loc("_Hello %@ %@", ["John", "Smith"]);  // $ExpectType string

--- a/types/ember__string/index.d.ts
+++ b/types/ember__string/index.d.ts
@@ -1,0 +1,18 @@
+// Type definitions for @ember/string 3.0
+// Project: http://emberjs.com/
+// Definitions by: Mike North <https://github.com/mike-north>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.8
+
+import Ember from 'ember';
+
+export const camelize: typeof Ember.String.camelize;
+export const capitalize: typeof Ember.String.capitalize;
+export const classify: typeof Ember.String.classify;
+export const dasherize: typeof Ember.String.dasherize;
+export const decamelize: typeof Ember.String.decamelize;
+export const htmlSafe: typeof Ember.String.htmlSafe;
+export const isHTMLSafe: typeof Ember.String.isHTMLSafe;
+export const loc: typeof Ember.String.loc;
+export const underscore: typeof Ember.String.underscore;
+export const w: typeof Ember.String.w;

--- a/types/ember__string/tsconfig.json
+++ b/types/ember__string/tsconfig.json
@@ -1,0 +1,28 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es5",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "paths": {
+            "@ember/string": ["ember__string"]
+        },
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "ember__string-tests.ts"
+    ]
+}

--- a/types/ember__string/tslint.json
+++ b/types/ember__string/tslint.json
@@ -1,0 +1,30 @@
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        // Heavy use of Function type in this older package.
+        "ban-types": false,
+        "jsdoc-format": false,
+        "no-misused-new": false,
+
+        // these are disabled because of rfc176 module exports
+        "strict-export-declare-modifiers": false,
+        "no-single-declare-module": false,
+        "no-declare-current-package": false,
+        "no-self-import": false,
+
+        // We use interfaces in a number of places to express things (including
+        // mixins in particular, but also including extending a global
+        // interface) which TS currently can't express correctly.
+        "no-empty-interface": false,
+
+        "no-duplicate-imports": false,
+        "no-unnecessary-qualifier": false,
+        "prefer-const": false,
+        "no-void-expression": false,
+        "only-arrow-functions": false,
+        "no-submodule-imports": false,
+
+        // false positives
+        "unified-signatures": false
+    }
+}

--- a/types/ember__string/tslint.json
+++ b/types/ember__string/tslint.json
@@ -1,30 +1,4 @@
 {
     "extends": "dtslint/dt.json",
-    "rules": {
-        // Heavy use of Function type in this older package.
-        "ban-types": false,
-        "jsdoc-format": false,
-        "no-misused-new": false,
-
-        // these are disabled because of rfc176 module exports
-        "strict-export-declare-modifiers": false,
-        "no-single-declare-module": false,
-        "no-declare-current-package": false,
-        "no-self-import": false,
-
-        // We use interfaces in a number of places to express things (including
-        // mixins in particular, but also including extending a global
-        // interface) which TS currently can't express correctly.
-        "no-empty-interface": false,
-
-        "no-duplicate-imports": false,
-        "no-unnecessary-qualifier": false,
-        "prefer-const": false,
-        "no-void-expression": false,
-        "only-arrow-functions": false,
-        "no-submodule-imports": false,
-
-        // false positives
-        "unified-signatures": false
-    }
+    "rules": {}
 }


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
> this is an odd situation where the npm package and the name of the modules consumers import do not align. These types align with the module names

- Create it with `dts-gen --dt`, not by basing it on an existing project.
> Does not apply in this case

- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.emberjs.com/api/ember/3.4/modules/@ember%2Fstring
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

cc: @dwickern @jamescdavis @dfreeman @chriskrycho 

Fixes https://github.com/typed-ember/ember-cli-typescript/issues/277