### PR TITLE
nodemailer: callback for `connect` has `err` argument

### DIFF
--- a/types/nodemailer/lib/smtp-connection.d.ts
+++ b/types/nodemailer/lib/smtp-connection.d.ts
@@ -173,17 +173,17 @@ declare class SMTPConnection extends EventEmitter {
     constructor(options?: SMTPConnection.Options);
 
     /** Creates a connection to a SMTP server and sets up connection listener */
-    connect(callback: () => void): void;
+    connect(callback: (err?: SMTPConnection.SMTPError) => void): void;
     /** Sends QUIT */
     quit(): void;
     /** Closes the connection to the server */
     close(): void;
     /** Authenticate user */
-    login(auth: SMTPConnection.AuthenticationCredentials | SMTPConnection.AuthenticationOAuth2 | SMTPConnection.Credentials, callback: (err: SMTPConnection.SMTPError | null) => void): void;
+    login(auth: SMTPConnection.AuthenticationCredentials | SMTPConnection.AuthenticationOAuth2 | SMTPConnection.Credentials, callback: (err?: SMTPConnection.SMTPError) => void): void;
     /** Sends a message */
     send(envelope: SMTPConnection.Envelope, message: string | Buffer | Readable, callback: (err: SMTPConnection.SMTPError | null, info: SMTPConnection.SentMessageInfo) => void): void;
     /** Resets connection state */
-    reset(callback: (err: Error | null) => void): void;
+    reset(callback: (err?: SMTPConnection.SMTPError) => void): void;
 
     addListener(event: 'connect' | 'end', listener: () => void): this;
     addListener(event: 'error', listener: (err: SMTPConnection.SMTPError) => void): this;

--- a/types/nodemailer/nodemailer-tests.ts
+++ b/types/nodemailer/nodemailer-tests.ts
@@ -1059,7 +1059,8 @@ function dkim_specific_header_key_test() {
 
 function smtp_connection_test() {
     const connection = new SMTPConnection();
-    connection.connect(() => {
+    connection.connect((err) => {
+        if (err) throw err;
         connection.login({ user: 'user', pass: 'pass' }, (err) => {
             if (err) throw err;
             connection.send({ from: 'a@example.com', to: 'b@example.net' }, 'message', (err, info) => {


### PR DESCRIPTION
`connect` method has an `err` as an optional first argument.

More callbacks definition was fixed: if it is just a first and only argument then is optional (`undefined` rather than `null)

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
