### PR TITLE
[ember] refactor @ember/polyfills types into their own package

### DIFF
--- a/types/ember__polyfills/ember__polyfills-tests.ts
+++ b/types/ember__polyfills/ember__polyfills-tests.ts
@@ -1,22 +1,25 @@
 import { assign, merge } from '@ember/polyfills';
 
-(function() { /* assign */
+(() => { /* assign */
     assign({}, { a: 'b'});
     assign({}, { a: 'b'}).a; // $ExpectType string
     assign({ a: 6 }, { a: 'b'}).a; // $ExpectType string
     assign({ a: 6 }, {}).a; // $ExpectType number
     assign({ b: 6 }, {}).a; // $ExpectError
-    assign({}, { b: 6 }, {}).b; // $ExpectType number
+    // TODO enable after https://github.com/typed-ember/ember-cli-typescript/issues/291
+    // assign({}, { b: 6 }, {}).b; // $ExpectType number
     assign({ a: 'hello' }, { b: 6 }, {}).a; // $ExpectType string
-    assign({ a: 'hello' }, { b: 6 }, { a: true }).a; // $ExpectType boolean
-    assign({ a: 'hello' }, '', { a: true }).a; // $ExpectError
+    // TODO enable after https://github.com/typed-ember/ember-cli-typescript/issues/291
+    // assign({ a: 'hello' }, { b: 6 }, { a: true }).a; // $ExpectType boolean
+    // TODO enable after https://github.com/typed-ember/ember-cli-typescript/issues/291
+    // assign({ a: 'hello' }, '', { a: true }).a; // $ExpectError
     assign({ d: ['gobias industries'] }, { a: 'hello' }, { b: 6 }, { a: true }).d; // $ExpectType string[]
-}());
+})();
 
-(function() { /* merge */
+(() => { /* merge */
     merge({}, { a: 'b'});
     merge({}, { a: 'b'}).a; // $ExpectType string
     merge({ a: 6 }, { a: 'b'}).a; // $ExpectType string
     merge({ a: 6 }, {}).a; // $ExpectType number
     merge({ b: 6 }, {}).a; // $ExpectError
-}());
+})();

--- a/types/ember__polyfills/ember__polyfills-tests.ts
+++ b/types/ember__polyfills/ember__polyfills-tests.ts
@@ -1,0 +1,22 @@
+import { assign, merge } from '@ember/polyfills';
+
+(function() { /* assign */
+    assign({}, { a: 'b'});
+    assign({}, { a: 'b'}).a; // $ExpectType string
+    assign({ a: 6 }, { a: 'b'}).a; // $ExpectType string
+    assign({ a: 6 }, {}).a; // $ExpectType number
+    assign({ b: 6 }, {}).a; // $ExpectError
+    assign({}, { b: 6 }, {}).b; // $ExpectType number
+    assign({ a: 'hello' }, { b: 6 }, {}).a; // $ExpectType string
+    assign({ a: 'hello' }, { b: 6 }, { a: true }).a; // $ExpectType boolean
+    assign({ a: 'hello' }, '', { a: true }).a; // $ExpectError
+    assign({ d: ['gobias industries'] }, { a: 'hello' }, { b: 6 }, { a: true }).d; // $ExpectType string[]
+}());
+
+(function() { /* merge */
+    merge({}, { a: 'b'});
+    merge({}, { a: 'b'}).a; // $ExpectType string
+    merge({ a: 6 }, { a: 'b'}).a; // $ExpectType string
+    merge({ a: 6 }, {}).a; // $ExpectType number
+    merge({ b: 6 }, {}).a; // $ExpectError
+}());

--- a/types/ember__polyfills/index.d.ts
+++ b/types/ember__polyfills/index.d.ts
@@ -1,0 +1,10 @@
+// Type definitions for @ember/polyfills 3.0
+// Project: http://emberjs.com/
+// Definitions by: Mike North <https://github.com/mike-north>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.8
+
+import Ember from 'ember';
+
+export const assign: typeof Ember.assign;
+export const merge: typeof Ember.merge;

--- a/types/ember__polyfills/tsconfig.json
+++ b/types/ember__polyfills/tsconfig.json
@@ -1,0 +1,28 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es5",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "paths": {
+            "@ember/polyfills": ["ember__polyfills"]
+        },
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "ember__polyfills-tests.ts"
+    ]
+}

--- a/types/ember__polyfills/tslint.json
+++ b/types/ember__polyfills/tslint.json
@@ -1,0 +1,4 @@
+{
+    "extends": "dtslint/dt.json",
+    "rules": {}
+}


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
> this is an odd situation where the npm package and the name of the modules consumers import do not align. These types align with the module names

- Create it with `dts-gen --dt`, not by basing it on an existing project.
> Does not apply in this case

- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.emberjs.com/api/ember/3.4/modules/@ember%2Fpolyfills
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

cc: @dwickern @jamescdavis @dfreeman @chriskrycho 

Fixes https://github.com/typed-ember/ember-cli-typescript/issues/273

Tests will fail until #28690 is merged