### PR TITLE
smtp-server: callback for `close` doesn't have arguments

### DIFF
--- a/types/smtp-server/index.d.ts
+++ b/types/smtp-server/index.d.ts
@@ -322,6 +322,14 @@ export class SMTPServer extends EventEmitter {
     emit(event: 'close'): boolean;
     emit(event: 'error', err: Error): boolean;
 
+    listenerCount(event: 'close' | 'error'): number;
+
+    listeners(event: 'close'): Array<() => void>;
+    listeners(event: 'error'): Array<(err: Error) => void>;
+
+    off(event: 'close', listener: () => void): this;
+    off(event: 'error', listener: (err: Error) => void): this;
+
     on(event: 'close', listener: () => void): this;
     on(event: 'error', listener: (err: Error) => void): this;
 
@@ -334,6 +342,11 @@ export class SMTPServer extends EventEmitter {
     prependOnceListener(event: 'close', listener: () => void): this;
     prependOnceListener(event: 'error', listener: (err: Error) => void): this;
 
-    listeners(event: 'close'): Array<() => void>;
-    listeners(event: 'error'): Array<(err: Error) => void>;
+    rawListeners(event: 'close'): Array<() => void>;
+    rawListeners(event: 'error'): Array<(err: Error) => void>;
+
+    removeAllListener(event: 'close' | 'error'): this;
+
+    removeListener(event: 'close', listener: () => void): this;
+    removeListener(event: 'error', listener: (err: Error) => void): this;
 }

--- a/types/smtp-server/index.d.ts
+++ b/types/smtp-server/index.d.ts
@@ -153,8 +153,8 @@ export interface SMTPServerOptions extends tls.TlsOptions {
      */
     banner?: string;
     /**
-     * optional maximum allowed message size in bytes,
-     * see details:https://github.com/andris9/smtp-server#using-size-extension
+     * optional maximum allowed message size in bytes
+     * ([see details](https://github.com/andris9/smtp-server#using-size-extension))
      */
     size?: number;
     /**
@@ -176,7 +176,7 @@ export interface SMTPServerOptions extends tls.TlsOptions {
      * use ['AUTH'] as this value.
      * If you want to allow authentication in clear text, set it to ['STARTTLS'].
      */
-    disabledCommands?: string[]; // TODO ('AUTH' | 'STARTTLS' | 'XCLIENT' | 'XFORWARD')[];
+    disabledCommands?: string[]; // TODO: ('AUTH' | 'STARTTLS' | 'XCLIENT' | 'XFORWARD')[];
     /**
      * optional boolean, if set to true then allow using STARTTLS
      * but do not advertise or require it. It only makes sense
@@ -224,17 +224,17 @@ export interface SMTPServerOptions extends tls.TlsOptions {
     maxClients?: number;
     /**
      * boolean, if set to true expects to be behind a proxy that emits a
-     * PROXY header{http://www.haproxy.org/download/1.5/doc/proxy-protocol.txt} (version 1 only)
+     * [PROXY](http://www.haproxy.org/download/1.5/doc/proxy-protocol.txt) header (version 1 only)
      */
     useProxy?: boolean;
     /**
      * boolean, if set to true, enables usage of
-     * XCLIENT{http://www.postfix.org/XCLIENT_README.html} extension to override connection properties.
+     * [XCLIENT](http://www.postfix.org/XCLIENT_README.html) extension to override connection properties.
      * See session.xClient (Map object) for the details provided by the client
      */
     useXClient?: boolean;
     /**
-     * boolean, if set to true, enables usage of XFORWARD{http://www.postfix.org/XFORWARD_README.html} extension.
+     * boolean, if set to true, enables usage of [XFORWARD](http://www.postfix.org/XFORWARD_README.html) extension.
      * See session.xForward (Map object) for the details provided by the client
      */
     useXForward?: boolean;
@@ -248,27 +248,27 @@ export interface SMTPServerOptions extends tls.TlsOptions {
     socketTimeout?: ms;
     /**
      * How many millisceonds to wait before disconnecting pending
-     * connections once server.close() has been called (defaults to 30 seconds)
+     * connections once `server.close()` has been called (defaults to 30 seconds)
      */
     closeTimeout?: ms;
     /**
-     * The callback to handle authentications (see details https://github.com/andris9/smtp-server#handling-authentication)
+     * The callback to handle authentications ([see details](https://github.com/andris9/smtp-server#handling-authentication))
      */
     onAuth?(auth: SMTPServerAuthentication, session: SMTPServerSession, callback: (err: Error | null | undefined, response: SMTPServerAuthenticationResponse) => void): void;
     /**
-     * The callback to handle the client connection. (see details https://github.com/andris9/smtp-server#validating-client-connection)
+     * The callback to handle the client connection. ([see details](https://github.com/andris9/smtp-server#validating-client-connection))
      */
     onConnect?(session: SMTPServerSession, callback: (err?: Error | null) => void): void;
     /**
-     * the callback to validate MAIL FROM commands (see details https://github.com/andris9/smtp-server#validating-sender-addresses)
+     * the callback to validate MAIL FROM commands ([see details](https://github.com/andris9/smtp-server#validating-sender-addresses))
      */
     onMailFrom?(address: SMTPServerAddress, session: SMTPServerSession, callback: (err?: Error | null) => void): void;
     /**
-     * The callback to validate RCPT TO commands (see details https://github.com/andris9/smtp-server#validating-recipient-addresses)
+     * The callback to validate RCPT TO commands ([see details](https://github.com/andris9/smtp-server#validating-recipient-addresses))
      */
     onRcptTo?(address: SMTPServerAddress, session: SMTPServerSession, callback: (err?: Error | null) => void): void;
     /**
-     * the callback to handle incoming messages (see details https://github.com/andris9/smtp-server#processing-incoming-message)
+     * the callback to handle incoming messages ([see details](https://github.com/andris9/smtp-server#processing-incoming-message))
      */
     onData?(stream: Readable, session: SMTPServerSession, callback: (err?: Error | null) => void): void;
     /**

--- a/types/smtp-server/index.d.ts
+++ b/types/smtp-server/index.d.ts
@@ -254,7 +254,7 @@ export interface SMTPServerOptions extends tls.TlsOptions {
     /**
      * The callback to handle authentications ([see details](https://github.com/andris9/smtp-server#handling-authentication))
      */
-    onAuth?(auth: SMTPServerAuthentication, session: SMTPServerSession, callback: (err: Error | null | undefined, response: SMTPServerAuthenticationResponse) => void): void;
+    onAuth?(auth: SMTPServerAuthentication, session: SMTPServerSession, callback: (err: Error | null | undefined, response?: SMTPServerAuthenticationResponse) => void): void;
     /**
      * The callback to handle the client connection. ([see details](https://github.com/andris9/smtp-server#validating-client-connection))
      */
@@ -304,7 +304,7 @@ export class SMTPServer extends EventEmitter {
     updateSecureContext(options: tls.TlsOptions): void;
 
     /** Authentication handler. Override this */
-    onAuth(auth: SMTPServerAuthentication, session: SMTPServerSession, callback: (err: Error | null | undefined, response: SMTPServerAuthenticationResponse) => void): void;
+    onAuth(auth: SMTPServerAuthentication, session: SMTPServerSession, callback: (err: Error | null | undefined, response?: SMTPServerAuthenticationResponse) => void): void;
     /** Override this */
     onClose(session: SMTPServerSession, callback: (err?: Error | null) => void): void;
     /** Override this */

--- a/types/smtp-server/index.d.ts
+++ b/types/smtp-server/index.d.ts
@@ -299,16 +299,21 @@ export class SMTPServer extends EventEmitter {
     listen(handle: any, listeningListener?: () => void): net.Server; // tslint:disable-line unified-signatures
 
     /** Closes the server */
-    close(callback: (err?: Error | null) => void): void;
+    close(callback: () => void): void;
 
     updateSecureContext(options: tls.TlsOptions): void;
 
     /** Authentication handler. Override this */
     onAuth(auth: SMTPServerAuthentication, session: SMTPServerSession, callback: (err: Error | null | undefined, response: SMTPServerAuthenticationResponse) => void): void;
+    /** Override this */
     onClose(session: SMTPServerSession, callback: (err?: Error | null) => void): void;
+    /** Override this */
     onConnect(session: SMTPServerSession, callback: (err?: Error | null) => void): void;
+    /** Override this */
     onData(stream: Readable, session: SMTPServerSession, callback: (err?: Error | null) => void): void;
+    /** Override this */
     onMailFrom(address: SMTPServerAddress, session: SMTPServerSession, callback: (err?: Error | null) => void): void;
+    /** Override this */
     onRcptTo(address: SMTPServerAddress, session: SMTPServerSession, callback: (err?: Error | null) => void): void;
 
     addListener(event: 'close', listener: () => void): this;

--- a/types/smtp-server/smtp-server-tests.ts
+++ b/types/smtp-server/smtp-server-tests.ts
@@ -75,3 +75,7 @@ server.listen(port, () => {
     const address = server.server.address() as AddressInfo;
     console.log(`Listening on [${address.address}]:${address.port}`);
 });
+
+server.close(() => {
+    console.log('Server closed');
+});

--- a/types/smtp-server/smtp-server-tests.ts
+++ b/types/smtp-server/smtp-server-tests.ts
@@ -2,80 +2,159 @@ import { AddressInfo } from 'net';
 import { SMTPServer, SMTPServerAddress, SMTPServerAuthentication, SMTPServerAuthenticationResponse, SMTPServerOptions, SMTPServerSession } from 'smtp-server';
 import { Readable } from 'stream';
 
-const options: SMTPServerOptions = {
-    hideSTARTTLS: true,
-    onConnect,
-    onMailFrom,
-    onRcptTo,
-    onData,
-    onClose,
-};
+function test_with_handlers_as_options() {
+    const options: SMTPServerOptions = {
+        hideSTARTTLS: true,
+        onConnect,
+        onMailFrom,
+        onRcptTo,
+        onData,
+        onClose,
+    };
 
-const port = 2525;
+    const port = 2525;
 
-function onConnect(session: SMTPServerSession, callback: (err?: Error) => void): void {
-    console.log(`[${session.id}] onConnect`);
-    callback();
-}
-
-function onAuth(auth: SMTPServerAuthentication, session: SMTPServerSession, callback: (err: Error | undefined, response?: SMTPServerAuthenticationResponse) => void): void {
-    if (auth.method === 'PLAIN' && auth.username === 'username' && auth.password === 'password') {
-        callback(undefined, { user: auth.username });
-    } else {
-        callback(new Error('Invalid username or password'));
-    }
-}
-
-function onMailFrom(from: SMTPServerAddress, session: SMTPServerSession, callback: (err?: Error) => void): void {
-    console.log(`[${session.id}] onMailFrom ${from.address}`);
-    if (from.address.split('@')[1] === 'spammer.com') {
-        // code 421 disconnects SMTP session immediately
-        callback(Object.assign(new Error('we do not like spam!'), { responseCode: 421 }));
-    } else {
+    function onConnect(session: SMTPServerSession, callback: (err?: Error) => void): void {
+        console.log(`[${session.id}] onConnect`);
         callback();
     }
-}
 
-function onRcptTo(to: SMTPServerAddress, session: SMTPServerSession, callback: (err?: Error) => void): void {
-    console.log(`[${session.id}] onRcptTo ${to.address}`);
-    callback();
-}
+    function onAuth(auth: SMTPServerAuthentication, session: SMTPServerSession, callback: (err: Error | undefined, response?: SMTPServerAuthenticationResponse) => void): void {
+        if (auth.method === 'PLAIN' && auth.username === 'username' && auth.password === 'password') {
+            callback(undefined, { user: auth.username });
+        } else {
+            callback(new Error('Invalid username or password'));
+        }
+    }
 
-function onData(stream: Readable, session: SMTPServerSession, callback: (err?: Error) => void): void {
-    console.log(`[${session.id}] onData started`);
+    function onMailFrom(from: SMTPServerAddress, session: SMTPServerSession, callback: (err?: Error) => void): void {
+        console.log(`[${session.id}] onMailFrom ${from.address}`);
+        if (from.address.split('@')[1] === 'spammer.com') {
+            // code 421 disconnects SMTP session immediately
+            callback(Object.assign(new Error('we do not like spam!'), { responseCode: 421 }));
+        } else {
+            callback();
+        }
+    }
 
-    let messageLength = 0;
-
-    stream.on('data', (chunk: Buffer) => {
-        console.log(`[${session.id}] onData got data chunk ${chunk.length} bytes`);
-        messageLength += chunk.length;
-    });
-
-    stream.once('end', () => {
-        console.log(`[${session.id}] onData finished after reading ${messageLength} bytes`);
+    function onRcptTo(to: SMTPServerAddress, session: SMTPServerSession, callback: (err?: Error) => void): void {
+        console.log(`[${session.id}] onRcptTo ${to.address}`);
         callback();
+    }
+
+    function onData(stream: Readable, session: SMTPServerSession, callback: (err?: Error) => void): void {
+        console.log(`[${session.id}] onData started`);
+
+        let messageLength = 0;
+
+        stream.on('data', (chunk: Buffer) => {
+            console.log(`[${session.id}] onData got data chunk ${chunk.length} bytes`);
+            messageLength += chunk.length;
+        });
+
+        stream.once('end', () => {
+            console.log(`[${session.id}] onData finished after reading ${messageLength} bytes`);
+            callback();
+        });
+    }
+
+    function onClose(session: SMTPServerSession) {
+        console.log(`[${session.id}] onClose`);
+    }
+
+    const server = new SMTPServer(options);
+
+    server.on('error', (err) => {
+        console.log(`Server got error:`, err);
+    });
+
+    server.on('close', () => {
+        console.log('Server closed');
+    });
+
+    server.listen(port, () => {
+        const address = server.server.address() as AddressInfo;
+        console.log(`Listening on [${address.address}]:${address.port}`);
+    });
+
+    server.close(() => {
+        console.log('Server closed');
     });
 }
 
-function onClose(session: SMTPServerSession) {
-    console.log(`[${session.id}] onClose`);
+function test_with_handlers_in_subclass() {
+    class MySMTPServer extends SMTPServer {
+        onConnect(session: SMTPServerSession, callback: (err?: Error) => void): void {
+            console.log(`[${session.id}] onConnect`);
+            callback();
+        }
+
+        onAuth(auth: SMTPServerAuthentication, session: SMTPServerSession, callback: (err: Error | null | undefined, response?: SMTPServerAuthenticationResponse) => void): void {
+            if (auth.method === 'PLAIN' && auth.username === 'username' && auth.password === 'password') {
+                callback(undefined, { user: auth.username });
+            } else {
+                callback(new Error('Invalid username or password'));
+            }
+        }
+
+        onMailFrom(from: SMTPServerAddress, session: SMTPServerSession, callback: (err?: Error) => void): void {
+            console.log(`[${session.id}] onMailFrom ${from.address}`);
+            if (from.address.split('@')[1] === 'spammer.com') {
+                // code 421 disconnects SMTP session immediately
+                callback(Object.assign(new Error('we do not like spam!'), { responseCode: 421 }));
+            } else {
+                callback();
+            }
+        }
+
+        onRcptTo(to: SMTPServerAddress, session: SMTPServerSession, callback: (err?: Error) => void): void {
+            console.log(`[${session.id}] onRcptTo ${to.address}`);
+            callback();
+        }
+
+        onData(stream: Readable, session: SMTPServerSession, callback: (err?: Error) => void): void {
+            console.log(`[${session.id}] onData started`);
+
+            let messageLength = 0;
+
+            stream.on('data', (chunk: Buffer) => {
+                console.log(`[${session.id}] onData got data chunk ${chunk.length} bytes`);
+                messageLength += chunk.length;
+            });
+
+            stream.once('end', () => {
+                console.log(`[${session.id}] onData finished after reading ${messageLength} bytes`);
+                callback();
+            });
+        }
+
+        onClose(session: SMTPServerSession) {
+            console.log(`[${session.id}] onClose`);
+        }
+    }
+
+    const options: SMTPServerOptions = {
+        hideSTARTTLS: true
+    };
+
+    const port = 2525;
+
+    const server = new MySMTPServer(options);
+
+    server.on('error', (err) => {
+        console.log(`Server got error:`, err);
+    });
+
+    server.on('close', () => {
+        console.log('Server closed');
+    });
+
+    server.listen(port, () => {
+        const address = server.server.address() as AddressInfo;
+        console.log(`Listening on [${address.address}]:${address.port}`);
+    });
+
+    server.close(() => {
+        console.log('Server closed');
+    });
 }
-
-const server = new SMTPServer(options);
-
-server.on('error', (err) => {
-    console.log(`Server got error:`, err);
-});
-
-server.on('close', () => {
-    console.log('Server closed');
-});
-
-server.listen(port, () => {
-    const address = server.server.address() as AddressInfo;
-    console.log(`Listening on [${address.address}]:${address.port}`);
-});
-
-server.close(() => {
-    console.log('Server closed');
-});


### PR DESCRIPTION
Callback for `close` method doesn't have arguments.

Some additional tweaks and bugfixes has been added:

* second argument of `onAuth` handler is optional
* more EventEmitter methods
* jsdoc tweaks
* more tests

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
