### PR TITLE
[@types/aws-lambda] CognitoUserPoolTriggerEvent.response.challengeMetadata wrong casing

### DIFF
--- a/types/aws-lambda/aws-lambda-tests.ts
+++ b/types/aws-lambda/aws-lambda-tests.ts
@@ -413,7 +413,7 @@ boolOrUndefined = cognitoUserPoolEvent.response.issueTokens;
 boolOrUndefined = cognitoUserPoolEvent.response.failAuthentication;
 str = cognitoUserPoolEvent.response.publicChallengeParameters!["captchaUrl"];
 str = cognitoUserPoolEvent.response.privateChallengeParameters!["answer"];
-strOrUndefined = cognitoUserPoolEvent.response.challengeMetaData;
+strOrUndefined = cognitoUserPoolEvent.response.challengeMetadata;
 boolOrUndefined = cognitoUserPoolEvent.response.answerCorrect;
 
 // CloudFormation Custom Resource

--- a/types/aws-lambda/index.d.ts
+++ b/types/aws-lambda/index.d.ts
@@ -266,7 +266,7 @@ export interface CognitoUserPoolTriggerEvent {
         failAuthentication?: boolean;
         publicChallengeParameters?: { [key: string]: string };
         privateChallengeParameters?: { [key: string]: string };
-        challengeMetaData?: string;
+        challengeMetadata?: string;
         answerCorrect?: boolean;
     };
 }


### PR DESCRIPTION
response.challengeMetadata has a lower case d.
request.challengeMetaData does have an upper case D.

This is not a bug in documentation. This is how the API actually implements it.

See for documentation:
https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-lambda-create-auth-challenge.html#cognito-user-pools-lambda-trigger-syntax-create-auth-challenge-response


Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-lambda-create-auth-challenge.html#cognito-user-pools-lambda-trigger-syntax-create-auth-challenge-response
- [N/A] Increase the version number in the header if appropriate.
- [N/A] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
