### PR TITLE
[ember] refactor @ember/test types into their own package

### DIFF
--- a/types/ember__test/adapter.d.ts
+++ b/types/ember__test/adapter.d.ts
@@ -1,0 +1,2 @@
+import Ember from 'ember';
+export default class TestAdapter extends Ember.Test.Adapter { }

--- a/types/ember__test/ember__test-tests.ts
+++ b/types/ember__test/ember__test-tests.ts
@@ -1,0 +1,39 @@
+import { registerWaiter, registerHelper, registerAsyncHelper } from '@ember/test';
+import TestAdapter from '@ember/test/adapter';
+
+const pending = 0;
+registerWaiter(() => pending !== 0);
+
+declare const MyDb: {
+    hasPendingTransactions(): boolean;
+};
+
+registerWaiter(MyDb, MyDb.hasPendingTransactions);
+registerWaiter(); // $ExpectError
+
+registerHelper('boot', app => {
+    app.advanceReadiness(); // $ExpectType void
+    app.deferReadiness(); // $ExpectType void
+    app.register('foo', class {}); // $ExpectType void
+    app.register('foo'); // $ExpectError
+    app.register(); // $ExpectError
+});
+
+registerAsyncHelper('boot', app => {
+    app.advanceReadiness();
+    app.deferReadiness();
+    app.register('foo', class {});
+});
+
+registerAsyncHelper('waitForPromise', (app, promise) => {
+    app.advanceReadiness();
+    app.deferReadiness();
+    app.register('foo', class {});
+    return new Promise(() => {
+        const adapter = new TestAdapter();
+        adapter.asyncStart();
+        return promise.then(() => {
+            adapter.asyncEnd();
+        });
+    });
+});

--- a/types/ember__test/index.d.ts
+++ b/types/ember__test/index.d.ts
@@ -1,0 +1,12 @@
+// Type definitions for @ember/test 3.0
+// Project: http://emberjs.com/
+// Definitions by: Mike North <https://github.com/mike-north>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.8
+
+import Ember from 'ember';
+export const registerAsyncHelper: typeof Ember.Test.registerAsyncHelper;
+export const registerHelper: typeof Ember.Test.registerHelper;
+export const registerWaiter: typeof Ember.Test.registerWaiter;
+export const unregisterHelper: typeof Ember.Test.unregisterHelper;
+export const unregisterWaiter: typeof Ember.Test.unregisterWaiter;

--- a/types/ember__test/tsconfig.json
+++ b/types/ember__test/tsconfig.json
@@ -1,0 +1,30 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es5",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "paths": {
+            "@ember/test": ["ember__test"],
+            "@ember/test/*": ["ember__test/*"]
+        },
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "adapter.d.ts",
+        "ember__test-tests.ts"
+    ]
+}

--- a/types/ember__test/tslint.json
+++ b/types/ember__test/tslint.json
@@ -1,0 +1,4 @@
+{
+    "extends": "dtslint/dt.json",
+    "rules": { }
+}


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
> this is an odd situation where the npm package and the name of the modules consumers import do not align. These types align with the module names

- Create it with `dts-gen --dt`, not by basing it on an existing project.
> Does not apply in this case

- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.emberjs.com/api/ember/3.4/modules/@ember%2Ftest
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

cc: @dwickern @jamescdavis @dfreeman @chriskrycho 

https://github.com/typed-ember/ember-cli-typescript/issues/278

