### PR TITLE
Add boolean option to underlayColor type in react-aria-types

### DIFF
--- a/types/react-aria-modal/index.d.ts
+++ b/types/react-aria-modal/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for react-aria-modal 2.12
 // Project: https://github.com/davidtheclark/react-aria-modal#readme
 // Definitions by: forabi <https://github.com/forabi>
+//                 Sasha <https://github.com/SashaBajzek>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -140,7 +141,7 @@ export interface AriaModalProps {
      *
      * Default: rgba(0,0,0,0.5)
      */
-    underlayColor?: string;
+    underlayColor?: string | boolean;
 
     /**
      * If `true`, the modal's contents will be vertically (as well as horizontally) centered.


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <<See line 59 of react-aria-modal demo 5, the underlayColor is a boolean: 
 https://github.com/davidtheclark/react-aria-modal/blob/master/demo/js/demo-five.js>>
- [X] Increase the version number in the header if appropriate.
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.