### PR TITLE
mistaken type restriction fix in `env-paths`

### DIFF
--- a/types/env-paths/env-paths-tests.ts
+++ b/types/env-paths/env-paths-tests.ts
@@ -6,3 +6,5 @@ envPaths('./');
 envPaths('./', {suffix: 'test'});
 // $ExpectType Paths
 envPaths('./', {suffix: false});
+// $ExpectType Paths
+envPaths('./', {suffix: true});

--- a/types/env-paths/index.d.ts
+++ b/types/env-paths/index.d.ts
@@ -5,7 +5,7 @@
 
 export = envPaths;
 
-declare function envPaths(name: string, opts?: { suffix: string | false }): envPaths.Paths;
+declare function envPaths(name: string, opts?: { suffix: string | boolean }): envPaths.Paths;
 
 declare namespace envPaths {
   interface Paths {


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

I don't know why I decided people could only use `false` before. I think I had a misunderstanding about how the `Object.assign` method was working here: https://github.com/sindresorhus/env-paths/blob/e61ddbde6c89222f1b7a1f8b941a2d8ff2d60527/index.js#L53
