### PR TITLE
[web3] Add underscore and bn.js type dependencies for web3

### DIFF
--- a/types/web3/package.json
+++ b/types/web3/package.json
@@ -1,0 +1,7 @@
+{
+  "private": true,
+  "dependencies": {
+    "@types/bn.js": "^4.11.1",
+    "@types/underscore": "^1.8.9"
+  }
+}


### PR DESCRIPTION
This PR adds a package.json for the `bn.js` and `underscore` dependencies within the `web3` package. Unchecked boxes in the below PR template are because they are not applicable.

This PR was necessary for my application to build successfully with `tsc`. I was receiving these errors:

```
../node_modules/@types/web3/eth/contract.d.ts:4:28 - error TS7016: Could not find a declaration file for module 'bn.js'. '/home/mike/work/consensys/node_modules/bn.js/lib/bn.js' implicitly has an 'any' type.
  If the 'bn.js' package actually exposes this module, consider sending a pull request to amend 'https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/bn.js`

4 import BigNumber = require("bn.js")
```


- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.