### PR TITLE
corrects the input/output type of `encode` in `WIF` package

### DIFF
--- a/types/wif/index.d.ts
+++ b/types/wif/index.d.ts
@@ -21,7 +21,7 @@ export function encodeRaw(
 ): Buffer;
 
 export function encode(
-    version: number | WIFReturn,
+    version: number,
     privateKey: Buffer,
     compressed: boolean
-): Buffer;
+): string;

--- a/types/wif/wif-tests.ts
+++ b/types/wif/wif-tests.ts
@@ -12,5 +12,5 @@ wif.decode(testString, 0);
 
 // $ExpectType Buffer
 wif.encodeRaw(1, testBuffer, true);
-// $ExpectType Buffer
+// $ExpectType string
 wif.encode(1, testBuffer, true);


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/bitcoinjs/wif/blob/master/index.js#L48>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

got rid of the WIFReturn option since it actually didn't make sense in hindsight, also encode should return a string so I've corrected that.