### PR TITLE
changes type of `key` from ReadonlyArray<number> to string in `scrypt` package

### DIFF
--- a/types/scrypt-js/index.d.ts
+++ b/types/scrypt-js/index.d.ts
@@ -15,7 +15,7 @@ declare function scrypt(
     callback: (
         error: Error | undefined | null,
         progress: number,
-        key?: ReadonlyArray<number>,
+        key?: string,
     ) => void
 ): void;
 


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/bitcoinjs/wif/blob/master/index.js#L48>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

`key` should have never been a `ReadonlyArray<number>`.