### PR TITLE
Correct Methods of Lazy.js which return non-Sequence values and remove "Object" typings

### DIFF
--- a/types/lazy.js/index.d.ts
+++ b/types/lazy.js/index.d.ts
@@ -114,13 +114,13 @@ declare namespace LazyJS {
     }
   
     interface SequenceBase<T> extends SequenceBaser<T> {
-      first(): any;
+      first(): T;
       first(count: number): Sequence<T>;
-      indexOf(value: any, startIndex?: number): Sequence<T>;
+      indexOf(value: any, startIndex?: number): number;
   
-      last(): any;
+      last(): T;
       last(count: number): Sequence<T>;
-      lastIndexOf(value: any): Sequence<T>;
+      lastIndexOf(value: any): number;
   
       reverse(): Sequence<T>;
     }
@@ -162,7 +162,7 @@ declare namespace LazyJS {
       sort(sortFn?: CompareCallback, descending?: boolean): Sequence<T>;
       sortBy(sortFn: NumberCallback<T>, descending?: boolean): Sequence<T>;
       sortBy(sortFn: string, descending?: boolean): Sequence<T>;
-      sortedIndex(value: T): Sequence<T>;
+      sortedIndex(value: T): number;
       sum(valueFn?: NumberCallback<T>): T;
       takeWhile(predicateFn: TestCallback<T, string | number>): Sequence<T>;
       toArray(): T[];
@@ -184,6 +184,7 @@ declare namespace LazyJS {
     interface ArrayLikeSequence<T> extends Sequence<T> {
       // define()X;
       concat(var_args: T[]): ArrayLikeSequence<T>;
+      first(): T;
       first(count?: number): ArrayLikeSequence<T>;
       get(index: number): T;
       length(): number;
@@ -218,7 +219,7 @@ declare namespace LazyJS {
       //async(): X;
       defaults(defaults: Object): ObjectLikeSequence<T>;
       functions(): Sequence<T>;
-      get(property: string): ObjectLikeSequence<T>;
+      get(property: string): T;
       invert(): ObjectLikeSequence<T>;
       keys(): Sequence<string>;
       merge(others: Object | ObjectLikeSequence<T>, mergeFn?: Function): ObjectLikeSequence<T>;
@@ -252,6 +253,7 @@ declare namespace LazyJS {
       contains(value: string): boolean;
       endsWith(suffix: string): boolean;
       first(): string;
+      first(count: number): StringLikeSequence;
       indexOf(substring: string, startIndex?: number): number;
       last(): string;
       last(count: number): StringLikeSequence;
@@ -270,7 +272,6 @@ declare namespace LazyJS {
       every(predicateFn: TestCallback<string, number>): boolean;
       filter(predicateFn: TestCallback<string, number>): Sequence<string>;
       find(predicateFn: TestCallback<string, number>): string;
-      first(count: number): StringLikeSequence;
       none(valueFn?: TestCallback<string, number>): boolean;
       reject(predicateFn: TestCallback<string, number>): Sequence<string>;
       some(predicateFn?: TestCallback<string, number>): boolean;

--- a/types/lazy.js/index.d.ts
+++ b/types/lazy.js/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for Lazy.js 0.3.2
 // Project: https://github.com/dtao/lazy.js/
-// Definitions by: Bart van der Schoor <https://github.com/Bartvds>
+// Definitions by: Bart van der Schoor <https://github.com/Bartvds>, Mike Doughty <https://github.com/miso440>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare namespace LazyJS {

--- a/types/lazy.js/index.d.ts
+++ b/types/lazy.js/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Lazy.js 0.3.2
+// Type definitions for Lazy.js 0.3.3
 // Project: https://github.com/dtao/lazy.js/
 // Definitions by: Bart van der Schoor <https://github.com/Bartvds>, Mike Doughty <https://github.com/miso440>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -8,8 +8,8 @@ declare namespace LazyJS {
       (value: string): StringLikeSequence;
       <T>(value: T[]): ArrayLikeSequence<T>;
       (value: any[]): ArrayLikeSequence<any>;
-      <T>(value: object): ObjectLikeSequence<T>;
-      (value: object): ObjectLikeSequence<any>;
+      <T>(value: any): ObjectLikeSequence<T>;
+      (value: any): ObjectLikeSequence<any>;
   
       strict(): LazyStatic;
   
@@ -106,7 +106,7 @@ declare namespace LazyJS {
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   
     namespace Sequence {
-      function define(methodName: string[], overrides: object): Function;
+      function define(methodName: string[], overrides: any): Function;
     }
   
     interface Sequence<T> extends SequenceBase<T> {
@@ -139,7 +139,7 @@ declare namespace LazyJS {
       every(predicateFn: TestCallback<T, string | number>): boolean;
       filter(predicateFn: TestCallback<T, string | number>): Sequence<T>;
       find(predicateFn: TestCallback<T, string | number>): T;
-      findWhere(properties: object): T;
+      findWhere(properties: any): T;
       flatten(): Sequence<T>;
       groupBy(keyFn: GetKeyCallback<T>): ObjectLikeSequence<T>;
       initial(count?: number): Sequence<T>;
@@ -166,10 +166,10 @@ declare namespace LazyJS {
       sum(valueFn?: NumberCallback<T>): T;
       takeWhile(predicateFn: TestCallback<T, string | number>): Sequence<T>;
       toArray(): T[];
-      toObject(): object;
+      toObject(): any;
       union(var_args: T[]): Sequence<T>;
       uniq(): Sequence<T>;
-      where(properties: object): Sequence<T>;
+      where(properties: any): Sequence<T>;
       without(...var_args: T[]): Sequence<T>;
       without(var_args: T[]): Sequence<T>;
       zip(var_args: T[]): Sequence<T>;
@@ -178,7 +178,7 @@ declare namespace LazyJS {
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   
     namespace ArrayLikeSequence {
-      function define(methodName: string[], overrides: object): Function;
+      function define(methodName: string[], overrides: any): Function;
     }
   
     interface ArrayLikeSequence<T> extends Sequence<T> {
@@ -210,24 +210,24 @@ declare namespace LazyJS {
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   
     namespace ObjectLikeSequence {
-      function define(methodName: string[], overrides: object): Function;
+      function define(methodName: string[], overrides: any): Function;
     }
   
     interface ObjectLikeSequence<T> extends Sequence<T> {
-      assign(other: object): ObjectLikeSequence<T>;
+      assign(other: any): ObjectLikeSequence<T>;
       // throws error
       //async(): X;
-      defaults(defaults: object): ObjectLikeSequence<T>;
+      defaults(defaults: any): ObjectLikeSequence<T>;
       functions(): Sequence<T>;
       get(property: string): T;
       invert(): ObjectLikeSequence<T>;
       keys(): Sequence<string>;
-      merge(others: object | ObjectLikeSequence<T>, mergeFn?: Function): ObjectLikeSequence<T>;
+      merge(others: any | ObjectLikeSequence<T>, mergeFn?: Function): ObjectLikeSequence<T>;
       omit(properties: string[]): ObjectLikeSequence<T>;
       pairs(): Sequence<T>;
       pick(properties: string[]): ObjectLikeSequence<T>;
       toArray(): T[];
-      toObject(): object;
+      toObject(): any;
       values(): Sequence<T>;
       watch(propertyNames: string | string[]): Sequence<{property: string; value: any;}>;
       
@@ -244,7 +244,7 @@ declare namespace LazyJS {
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   
     namespace StringLikeSequence {
-      function define(methodName: string[], overrides: object): Function;
+      function define(methodName: string[], overrides: any): Function;
     }
   
     interface StringLikeSequence extends SequenceBaser<string> {

--- a/types/lazy.js/index.d.ts
+++ b/types/lazy.js/index.d.ts
@@ -114,11 +114,11 @@ declare namespace LazyJS {
     }
   
     interface SequenceBase<T> extends SequenceBaser<T> {
-      first(): T;
+      first(): any;
       first(count: number): Sequence<T>;
       indexOf(value: any, startIndex?: number): number;
   
-      last(): T;
+      last(): any;
       last(count: number): Sequence<T>;
       lastIndexOf(value: any): number;
   

--- a/types/lazy.js/index.d.ts
+++ b/types/lazy.js/index.d.ts
@@ -8,8 +8,8 @@ declare namespace LazyJS {
       (value: string): StringLikeSequence;
       <T>(value: T[]): ArrayLikeSequence<T>;
       (value: any[]): ArrayLikeSequence<any>;
-      <T>(value: Object): ObjectLikeSequence<T>;
-      (value: Object): ObjectLikeSequence<any>;
+      <T>(value: object): ObjectLikeSequence<T>;
+      (value: object): ObjectLikeSequence<any>;
   
       strict(): LazyStatic;
   
@@ -106,7 +106,7 @@ declare namespace LazyJS {
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   
     namespace Sequence {
-      function define(methodName: string[], overrides: Object): Function;
+      function define(methodName: string[], overrides: object): Function;
     }
   
     interface Sequence<T> extends SequenceBase<T> {
@@ -139,7 +139,7 @@ declare namespace LazyJS {
       every(predicateFn: TestCallback<T, string | number>): boolean;
       filter(predicateFn: TestCallback<T, string | number>): Sequence<T>;
       find(predicateFn: TestCallback<T, string | number>): T;
-      findWhere(properties: Object): T;
+      findWhere(properties: object): T;
       flatten(): Sequence<T>;
       groupBy(keyFn: GetKeyCallback<T>): ObjectLikeSequence<T>;
       initial(count?: number): Sequence<T>;
@@ -166,10 +166,10 @@ declare namespace LazyJS {
       sum(valueFn?: NumberCallback<T>): T;
       takeWhile(predicateFn: TestCallback<T, string | number>): Sequence<T>;
       toArray(): T[];
-      toObject(): Object;
+      toObject(): object;
       union(var_args: T[]): Sequence<T>;
       uniq(): Sequence<T>;
-      where(properties: Object): Sequence<T>;
+      where(properties: object): Sequence<T>;
       without(...var_args: T[]): Sequence<T>;
       without(var_args: T[]): Sequence<T>;
       zip(var_args: T[]): Sequence<T>;
@@ -178,7 +178,7 @@ declare namespace LazyJS {
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   
     namespace ArrayLikeSequence {
-      function define(methodName: string[], overrides: Object): Function;
+      function define(methodName: string[], overrides: object): Function;
     }
   
     interface ArrayLikeSequence<T> extends Sequence<T> {
@@ -210,24 +210,24 @@ declare namespace LazyJS {
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   
     namespace ObjectLikeSequence {
-      function define(methodName: string[], overrides: Object): Function;
+      function define(methodName: string[], overrides: object): Function;
     }
   
     interface ObjectLikeSequence<T> extends Sequence<T> {
-      assign(other: Object): ObjectLikeSequence<T>;
+      assign(other: object): ObjectLikeSequence<T>;
       // throws error
       //async(): X;
-      defaults(defaults: Object): ObjectLikeSequence<T>;
+      defaults(defaults: object): ObjectLikeSequence<T>;
       functions(): Sequence<T>;
       get(property: string): T;
       invert(): ObjectLikeSequence<T>;
       keys(): Sequence<string>;
-      merge(others: Object | ObjectLikeSequence<T>, mergeFn?: Function): ObjectLikeSequence<T>;
+      merge(others: object | ObjectLikeSequence<T>, mergeFn?: Function): ObjectLikeSequence<T>;
       omit(properties: string[]): ObjectLikeSequence<T>;
       pairs(): Sequence<T>;
       pick(properties: string[]): ObjectLikeSequence<T>;
       toArray(): T[];
-      toObject(): Object;
+      toObject(): object;
       values(): Sequence<T>;
       watch(propertyNames: string | string[]): Sequence<{property: string; value: any;}>;
       
@@ -244,7 +244,7 @@ declare namespace LazyJS {
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   
     namespace StringLikeSequence {
-      function define(methodName: string[], overrides: Object): Function;
+      function define(methodName: string[], overrides: object): Function;
     }
   
     interface StringLikeSequence extends SequenceBaser<string> {

--- a/types/lazy.js/lazy.js-tests.ts
+++ b/types/lazy.js/lazy.js-tests.ts
@@ -116,7 +116,7 @@ fooSequence = fooSequence.first(num);
 
 fooSequence = fooSequence.flatten();
 fooObjectSeq = fooSequence.groupBy(fnGetKeyCallback);
-fooSequence = fooSequence.indexOf(x);
+num = fooSequence.indexOf(x);
 fooSequence = fooSequence.initial();
 fooSequence = fooSequence.initial(num);
 fooSequence = fooSequence.intersection(arr);
@@ -128,7 +128,7 @@ str = fooSequence.join(str);
 foo = fooSequence.last();
 fooSequence = fooSequence.last(num);
 
-fooSequence = fooSequence.lastIndexOf(foo);
+num = fooSequence.lastIndexOf(foo);
 barSequence = fooSequence.map(fnMapCallback);
 foo = fooSequence.max();
 foo = fooSequence.max(fnNumberCallback);
@@ -151,7 +151,7 @@ fooSequence = fooSequence.sortBy(str);
 fooSequence = fooSequence.sortBy(str, bool);
 fooSequence = fooSequence.sortBy(fnNumberCallback);
 fooSequence = fooSequence.sortBy(fnNumberCallback, bool);
-fooSequence = fooSequence.sortedIndex(foo);
+num = fooSequence.sortedIndex(foo);
 foo = fooSequence.sum();
 foo = fooSequence.sum(fnNumberCallback);
 fooSequence = fooSequence.takeWhile(fnTestCallback);
@@ -168,7 +168,7 @@ obj = fooSequence.toObject();
 // ArrayLikeSequence
 
 fooArraySeq = fooArraySeq.concat(fooArr);
-fooArraySeq = fooArraySeq.first();
+x = fooArraySeq.first();
 fooArraySeq = fooArraySeq.first(num);
 foo = fooArraySeq.get(num);
 num = fooArraySeq.length();
@@ -185,7 +185,7 @@ fooArraySeq = fooArraySeq.slice(num, num);
 
 fooObjectSeq = fooObjectSeq.defaults(obj);
 fooSequence = fooObjectSeq.functions();
-fooObjectSeq = fooObjectSeq.get(str);
+x = fooObjectSeq.get(str);
 fooObjectSeq = fooObjectSeq.invert();
 strSequence = fooObjectSeq.keys();
 fooObjectSeq = fooObjectSeq.omit(strArr);


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [Lazy.js API Docs](http://danieltao.com/lazy.js/docs/)
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

Notes:

Chose to move from "Object" to "any" rather than to "object" to support compatibility with TypeScript versions earlier than 2.2, per the advice of `npm test "lazy.js"`.