### PR TITLE
changes the type of next to be a `Promise<any>` in `koa-convert`

### DIFF
--- a/types/koa-convert/index.d.ts
+++ b/types/koa-convert/index.d.ts
@@ -7,7 +7,7 @@
 import { Context, Middleware } from "koa";
 
 declare function convert(
-    mw: (context: Context, next: () => void) => Generator
+    mw: (context: Context, next: () => Promise<any>) => Generator
 ): Middleware;
 
 export = convert;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

The 'Koa.Middleware' format is `(ctx: Context, next: () => Promise<any>)` so I've updated the accepted type here to match up.