### PR TITLE
[create-subscription] Fix tests for ts@next

### DIFF
--- a/types/create-subscription/create-subscription-tests.tsx
+++ b/types/create-subscription/create-subscription-tests.tsx
@@ -105,15 +105,7 @@ declare const wrongPromise: Promise<number>;
 </PromiseSubscription>;
 
 // $ExpectError
-const MismatchSubscription = createSubscription({
-    getCurrentValue: (a: number) => null,
-    subscribe: (a: string, callback) => (() => undefined)
-});
+const MismatchSubscription = createSubscription({ getCurrentValue: (a: number) => null, subscribe: (a: string, callback) => (() => undefined) });
 
 // $ExpectError
-const NoUnsubscribe = createSubscription({
-    getCurrentValue: (a: number) => a,
-    subscribe: (a: number, callback) => {
-        // oops, should've returned a callback here
-    }
-});
+const NoUnsubscribe = createSubscription({ getCurrentValue: (a: number) => a, subscribe: (a: number, callback) => { /* oops, should've returned a callback here */ }});


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Fix tests for typescript@next which reports errors on a differnt line. As tests are executed also with older typescript versions the only solution is to move everything on one line.

No change in exported type definitions.

Refs: #28708
