### PR TITLE
[grasp] Fix tests for ts@next

### DIFF
--- a/types/grasp/grasp-tests.ts
+++ b/types/grasp/grasp-tests.ts
@@ -17,10 +17,7 @@ grasp({
 });
 
 // $ExpectError
-grasp({
-    args: [],
-    textFormat: { cyan: "cyan" }
-});
+grasp({ args: [], textFormat: { cyan: "cyan" } });
 
 // $ExpectType string
 grasp.VERSION;


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Fix tests for typescript@next which reports errors on a differnt line. As tests are executed also with older typescript versions the only solution is to move everything on one line.

No change in exported type definitions.

Refs: #28708
