### PR TITLE
[ember] refactor @ember/array types into their own package

### DIFF
--- a/types/ember__array/index.d.ts
+++ b/types/ember__array/index.d.ts
@@ -1,0 +1,13 @@
+// Type definitions for @ember/array 3.0
+// Project: http://emberjs.com/
+// Definitions by: Mike North <https://github.com/mike-north>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.8
+
+import Ember from 'ember';
+
+type EmberArray<T> = Ember.Array<T>;
+export const EmberArray: typeof Ember.Array;
+export default EmberArray;
+export const A: typeof Ember.A;
+export const isArray: typeof Ember.isArray;

--- a/types/ember__array/mutable.d.ts
+++ b/types/ember__array/mutable.d.ts
@@ -1,0 +1,5 @@
+import Ember from 'ember';
+
+type MutableArray<T> = Ember.MutableArray<T>;
+export const MutableArray: typeof Ember.MutableArray;
+export default MutableArray;

--- a/types/ember__array/proxy.d.ts
+++ b/types/ember__array/proxy.d.ts
@@ -1,0 +1,3 @@
+import Ember from 'ember';
+
+export default class ArrayProxy<T> extends Ember.ArrayProxy<T> { }

--- a/types/ember__array/test/array-ext.ts
+++ b/types/ember__array/test/array-ext.ts
@@ -1,0 +1,22 @@
+import { assertType } from './lib/assert';
+import EmberObject from '@ember/object';
+import { ArrayPrototypeExtensions } from '@ember/array/types/prototype-extensions';
+
+declare global {
+    interface Array<T> extends ArrayPrototypeExtensions<T> {}
+}
+
+class Person extends EmberObject {
+    name: string;
+}
+
+const person = Person.create({ name: 'Joe' });
+const array = [person];
+
+assertType<number>(array.get('length'));
+assertType<Person | undefined>(array.get('firstObject'));
+assertType<string[]>(array.mapBy('name'));
+assertType<string[]>(array.map(p => p.get('name')));
+assertType<Person[]>(array.sortBy('name'));
+assertType<Person[]>(array.uniq());
+assertType<Person[]>(array.uniqBy('name'));

--- a/types/ember__array/test/array-proxy.ts
+++ b/types/ember__array/test/array-proxy.ts
@@ -1,0 +1,27 @@
+import { assertType } from './lib/assert';
+import ArrayProxy from '@ember/array/proxy';
+import { A } from '@ember/array';
+
+const pets = ['dog', 'cat', 'fish'];
+const proxy = ArrayProxy.create({ content: A(pets) });
+
+proxy.get('firstObject'); // 'dog'
+proxy.set('content', A(['amoeba', 'paramecium']));
+proxy.get('firstObject'); // 'amoeba'
+
+const overridden = ArrayProxy.create({
+    content: A(pets),
+    objectAtContent(idx: number): string {
+        return this.get('content').objectAt(idx)!.toUpperCase();
+    }
+});
+
+overridden.get('firstObject'); // 'DOG'
+
+class MyNewProxy<T> extends ArrayProxy<T> {
+    isNew = true;
+}
+
+const x = MyNewProxy.create({ content: A([1, 2, 3]) }) as MyNewProxy<number>;
+assertType<number | undefined>(x.get('firstObject'));
+assertType<boolean>(x.isNew);

--- a/types/ember__array/test/array.ts
+++ b/types/ember__array/test/array.ts
@@ -1,0 +1,56 @@
+import { assertType } from './lib/assert';
+import EmberObject from '@ember/object';
+import EmberArray, { A } from '@ember/array';
+import MutableArray from '@ember/array/mutable';
+
+type Person = typeof Person.prototype;
+const Person = EmberObject.extend({
+    name: '',
+    isHappy: false
+});
+
+const people = A([
+    Person.create({ name: 'Yehuda', isHappy: true }),
+    Person.create({ name: 'Majd', isHappy: false }),
+]);
+
+assertType<number>(people.get('length'));
+assertType<Person>(people.get('lastObject'));
+assertType<Person>(people.get('firstObject'));
+assertType<boolean>(people.isAny('isHappy'));
+assertType<boolean>(people.isAny('isHappy', 'false'));
+
+const persons1: Person[] = people.filterBy('isHappy');
+const persons2: MutableArray<Person> = people.filterBy('isHappy');
+const persons3: Person[] = people.rejectBy('isHappy');
+const persons4: MutableArray<Person> = people.rejectBy('isHappy');
+const persons5: Person[] = people.filter((person) => person.get('name') === 'Yehuda');
+const persons6: MutableArray<Person> = people.filter((person) => person.get('name') === 'Yehuda');
+
+assertType<typeof people>(people.get('[]'));
+assertType<Person>(people.get('[]').get('firstObject')); // $ExpectType any
+
+assertType<EmberArray<boolean>>(people.mapBy('isHappy')); // $ExpectType Array<boolean>
+assertType<any[]>(people.mapBy('name.length'));
+
+const last = people.get('lastObject');  // $ExpectType ({ name: string; isHappy: boolean; } & EmberObject & { name: string; isHappy: boolean; }) | undefined
+if (last) {
+    assertType<string>(last.get('name'));
+}
+
+const first = people.get('lastObject');
+if (first) {
+    assertType<boolean>(first.get('isHappy'));
+}
+
+const letters: EmberArray<string> = A(['a', 'b', 'c']);
+const codes: number[] = letters.map((item, index, enumerable) => {
+    assertType<string>(item);
+    assertType<number>(index);
+    return item.charCodeAt(0);
+});
+
+const value = '1,2,3';
+const filters = A(value.split(','));
+filters.push('4');
+filters.sort();

--- a/types/ember__array/test/lib/assert.ts
+++ b/types/ember__array/test/lib/assert.ts
@@ -1,0 +1,5 @@
+/** Static assertion that `value` has type `T` */
+// Disable tslint here b/c the generic is used to let us do a type coercion and
+// validate that coercion works for the type value "passed into" the function.
+// tslint:disable-next-line:no-unnecessary-generics
+export declare function assertType<T>(value: T): T;

--- a/types/ember__array/tsconfig.json
+++ b/types/ember__array/tsconfig.json
@@ -1,0 +1,35 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es5",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "paths": {
+            "@ember/array": ["ember__array"],
+            "@ember/array/*": ["ember__array/*"]
+        },
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "mutable.d.ts",
+        "proxy.d.ts",
+        "types/prototype-extensions.d.ts",
+        "test/lib/assert.ts",
+        "test/array.ts",
+        "test/array-ext.ts",
+        "test/array-proxy.ts"
+    ]
+}

--- a/types/ember__array/tslint.json
+++ b/types/ember__array/tslint.json
@@ -1,0 +1,4 @@
+{
+    "extends": "dtslint/dt.json",
+    "rules": {}
+}

--- a/types/ember__array/types/prototype-extensions.d.ts
+++ b/types/ember__array/types/prototype-extensions.d.ts
@@ -1,0 +1,3 @@
+import Ember from 'ember';
+
+export interface ArrayPrototypeExtensions<T> extends Ember.MutableArray<T>, Ember.Observable, Ember.Copyable {}


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
> this is an odd situation where the npm package and the name of the modules consumers import do not align. These types align with the module names

- Create it with `dts-gen --dt`, not by basing it on an existing project.
> Does not apply in this case

- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.emberjs.com/api/ember/3.4/modules/@ember%2Farray
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

cc: @dwickern @jamescdavis @dfreeman @chriskrycho 

Resolves https://github.com/typed-ember/ember-cli-typescript/issues/262

