### PR TITLE
[q] correct then() for typescript@next

### DIFF
--- a/types/q/index.d.ts
+++ b/types/q/index.d.ts
@@ -60,7 +60,7 @@ declare namespace Q {
 		/**
 		 * The then method from the Promises/A+ specification, with an additional progress handler.
 		 */
-		then<U>(onFulfill?: ((value: T) => IWhenable<U>) | null, onReject?: ((error: any) => IWhenable<U>) | null, onProgress?: ((progress: any) => any) | null): Promise<U>;
+		then<U, V = never>(onFulfill?: ((value: T) => IWhenable<U>) | null, onReject?: ((error: any) => IWhenable<V>) | null, onProgress?: ((progress: any) => any) | null): Promise<U>;
 
 		/**
 		 * Like a finally clause, allows you to observe either the fulfillment or rejection of a promise, but to do so


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/Microsoft/TypeScript/blob/v3.1-rc/lib/lib.es5.d.ts#L1323
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

typescript@next complains that `Promise<number>` is not assignable to `IWhenable<number>`:
```
ERROR: 5:7     expect  TypeScript@next compile error:
Type 'Promise<number>' is not assignable to type 'IWhenable<number>'.
  Type 'Promise<number>' is not assignable to type 'PromiseLike<number>'.
    Types of property 'then' are incompatible.
      Type '<U>(onFulfill?: ((value: number) => IWhenable<U>) | null | undefined, onReject?: ((error: any) => IWhenable<U>) | null | undefined, onProgress?: ((progress: any) => any) | null | undefined) => Promise<...>' is not assignable to type '<TResult1 = number, TResult2 = never>(onfulfilled?: ((value: number) => TResult1 | PromiseLike<TResult1>) | null | undefined, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | null | undefined) => PromiseLike<...>'.
        Types of parameters 'onReject' and 'onrejected' are incompatible.
          Type 'TResult2 | PromiseLike<TResult2>' is not assignable to type 'TResult1 | PromiseLike<TResult1>'.
            Type 'TResult2' is not assignable to type 'TResult1 | PromiseLike<TResult1>'.
              Type 'TResult2' is not assignable to type 'PromiseLike<TResult1>'.
```

Fixed this by adapting `then` similar as in lib.es5.d.ts.

This mismatch causes followup fails in e.g. sequelize as you can see in #28708
