### PR TITLE
Import MSApp types from TS release-2.7

### DIFF
--- a/types/msapp/index.d.ts
+++ b/types/msapp/index.d.ts
@@ -1,0 +1,66 @@
+// Type definitions for MSApp
+// Definitions by: Kagami Sascha Rosylight <https://github.com/saschanaz>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.8
+
+interface MSApp {
+    clearTemporaryWebDataAsync(): MSAppAsyncOperation;
+    createBlobFromRandomAccessStream(type: string, seeker: any): Blob;
+    createDataPackage(object: any): any;
+    createDataPackageFromSelection(): any;
+    createFileFromStorageFile(storageFile: any): File;
+    createStreamFromInputStream(type: string, inputStream: any): MSStream;
+    execAsyncAtPriority(asynchronousCallback: MSExecAtPriorityFunctionCallback, priority: string, ...args: any[]): void;
+    execAtPriority(synchronousCallback: MSExecAtPriorityFunctionCallback, priority: string, ...args: any[]): any;
+    getCurrentPriority(): string;
+    getHtmlPrintDocumentSourceAsync(htmlDoc: any): Promise<any>;
+    getViewId(view: any): any;
+    isTaskScheduledAtPriorityOrHigher(priority: string): boolean;
+    pageHandlesAllApplicationActivations(enabled: boolean): void;
+    suppressSubdownloadCredentialPrompts(suppress: boolean): void;
+    terminateApp(exceptionObject: any): void;
+    readonly CURRENT: string;
+    readonly HIGH: string;
+    readonly IDLE: string;
+    readonly NORMAL: string;
+}
+declare var MSApp: MSApp;
+
+interface MSAppAsyncOperationEventMap {
+    "complete": Event;
+    "error": Event;
+}
+
+interface MSAppAsyncOperation extends EventTarget {
+    readonly error: DOMError;
+    oncomplete: (this: MSAppAsyncOperation, ev: Event) => any;
+    onerror: (this: MSAppAsyncOperation, ev: Event) => any;
+    readonly readyState: number;
+    readonly result: any;
+    start(): void;
+    readonly COMPLETED: number;
+    readonly ERROR: number;
+    readonly STARTED: number;
+    addEventListener<K extends keyof MSAppAsyncOperationEventMap>(
+        type: K,
+        listener: (this: MSAppAsyncOperation, ev: MSAppAsyncOperationEventMap[K]) => any,
+        options?: boolean | AddEventListenerOptions
+    ): void;
+    addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+    removeEventListener<K extends keyof MSAppAsyncOperationEventMap>(
+        type: K,
+        listener: (this: MSAppAsyncOperation, ev: MSAppAsyncOperationEventMap[K]) => any,
+        options?: boolean | EventListenerOptions
+    ): void;
+    removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
+}
+
+declare var MSAppAsyncOperation: {
+    prototype: MSAppAsyncOperation;
+    new(): MSAppAsyncOperation;
+    readonly COMPLETED: number;
+    readonly ERROR: number;
+    readonly STARTED: number;
+};
+
+type MSExecAtPriorityFunctionCallback = (...args: any[]) => any;

--- a/types/msapp/tsconfig.json
+++ b/types/msapp/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "dom",
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts"
+    ]
+}

--- a/types/msapp/tslint.json
+++ b/types/msapp/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Importing MSApp types from TS 2.7 as [2.8 removed them](https://github.com/Microsoft/TypeScript/wiki/Breaking-Changes#some-ms-specific-types-are-removed-from-libdts).

Some questions:

* The linter requires `major.minor` for the header while the API does not have any version. What should be done?
* MSApp references types from Visual Studio-generated WinRT types, and those references are currently marked as `any`. DefinitelyTyped also have `@types/winrt-uwp` but the autogenerated ones are preferred. Should we still reference `winrt-uwp` and convert those `any` with proper type names?
* The linter wants to convert `MSExecAtPriorityFunctionCallback` as a typedef, but then it causes a name conflict in TS<2.8. How can it be fixed?

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
