### PR TITLE
[ember] refactor @ember/service out into a separate module

### DIFF
--- a/types/ember/index.d.ts
+++ b/types/ember/index.d.ts
@@ -143,7 +143,7 @@ declare module 'ember' {
 
     type ObserverMethod<Target, Sender> =
         | (keyof Target)
-        | ((this: Target, sender: Sender, key: keyof Sender, value: any, rev: number) => void);
+        | ((this: Target, sender: Sender, key: string, value: any, rev: number) => void);
 
     interface RenderOptions {
         into?: string;

--- a/types/ember__service/ember__service-tests.ts
+++ b/types/ember__service/ember__service-tests.ts
@@ -1,0 +1,38 @@
+import Service, { inject } from "@ember/service";
+import EmberObject from "@ember/object";
+
+class FirstSvc extends Service {
+    foo = 'bar';
+    first() { return ''; }
+}
+const SecondSvc = Service.extend({
+    foo: 'bar',
+    second() { return ''; }
+});
+
+class ThirdSvc extends Service.extend({
+    foo: 'bar',
+    third() { return ''; }
+}) { }
+
+declare module '@ember/service' {
+    interface Registry {
+        first: FirstSvc;
+        second: InstanceType<typeof SecondSvc>;
+        third: ThirdSvc;
+    }
+}
+
+const ServiceTriplet = EmberObject.extend({
+    sFirst: inject('first'),
+    sSecond: inject('second'),
+    sThird: inject('third'),
+    unknownService: inject()
+});
+
+const obj = ServiceTriplet.create();
+
+obj.get('sFirst'); // $ExpectType FirstSvc
+obj.get('sSecond').second(); // $ExpectType ""
+obj.get('sThird'); // $ExpectType ThirdSvc
+obj.get('unknownService'); // $ExpectType Service

--- a/types/ember__service/index.d.ts
+++ b/types/ember__service/index.d.ts
@@ -1,0 +1,15 @@
+// Type definitions for @ember/service 3.0
+// Project: http://emberjs.com/
+// Definitions by: Mike North <https://github.com/mike-north>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.8
+
+import Ember from 'ember';
+
+export default class Service extends Ember.Service { }
+export const inject: typeof Ember.inject.service;
+
+// A type registry for Ember `Service`s. Meant to be declaration-merged so
+// string lookups resolve to the correct type.
+// tslint:disable-next-line no-empty-interface strict-export-declare-modifiers
+interface Registry {}

--- a/types/ember__service/tsconfig.json
+++ b/types/ember__service/tsconfig.json
@@ -1,0 +1,28 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es5",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "paths": {
+            "@ember/service": ["ember__service"]
+        },
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "ember__service-tests.ts"
+    ]
+}

--- a/types/ember__service/tslint.json
+++ b/types/ember__service/tslint.json
@@ -1,0 +1,4 @@
+{
+    "extends": "dtslint/dt.json",
+    "rules": {}
+}

--- a/types/ember__utils/ember__utils-tests.ts
+++ b/types/ember__utils/ember__utils-tests.ts
@@ -8,6 +8,7 @@ import {
     tryInvoke,
     typeOf
 } from '@ember/utils';
+import EmberObject from '@ember/object';
 
 (function() {
     /** isNone */
@@ -161,3 +162,10 @@ import {
     isEmpty({ size: 1 }); // $ExpectType boolean
     isEmpty({ size: () => 0 }); // $ExpectType boolean
 })();
+
+class Foo extends EmberObject.extend({
+    abc: true,
+    bar() { return '123'; }
+}) {
+    def: 'hello';
+}


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
> this is an odd situation where the npm package and the name of the modules consumers import do not align. These types align with the module names

- Create it with `dts-gen --dt`, not by basing it on an existing project.
> Does not apply in this case

- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.emberjs.com/api/ember/3.4/modules/@ember%2Fservice
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

cc: @dwickern @jamescdavis @dfreeman @chriskrycho 

Fixes https://github.com/typed-ember/ember-cli-typescript/issues/276