### PR TITLE
[ember] refactor @ember/routing types into their own package

### DIFF
--- a/types/ember/index.d.ts
+++ b/types/ember/index.d.ts
@@ -143,7 +143,7 @@ declare module 'ember' {
 
     type ObserverMethod<Target, Sender> =
         | (keyof Target)
-        | ((this: Target, sender: Sender, key: keyof Sender, value: any, rev: number) => void);
+        | ((this: Target, sender: Sender, key: string, value: any, rev: number) => void);
 
     interface RenderOptions {
         into?: string;

--- a/types/ember__routing/auto-location.d.ts
+++ b/types/ember__routing/auto-location.d.ts
@@ -1,0 +1,3 @@
+import Ember from 'ember';
+
+export default class AutoLocation extends Ember.AutoLocation { }

--- a/types/ember__routing/hash-location.d.ts
+++ b/types/ember__routing/hash-location.d.ts
@@ -1,0 +1,3 @@
+import Ember from 'ember';
+
+export default class HashLocation extends Ember.HashLocation { }

--- a/types/ember__routing/history-location.d.ts
+++ b/types/ember__routing/history-location.d.ts
@@ -1,0 +1,3 @@
+import Ember from 'ember';
+
+export default class HistoryLocation extends Ember.HistoryLocation { }

--- a/types/ember__routing/index.d.ts
+++ b/types/ember__routing/index.d.ts
@@ -1,0 +1,8 @@
+// Type definitions for @ember/controller 3.0
+// Project: http://emberjs.com/
+// Definitions by: Mike North <https://github.com/mike-north>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.8
+
+export { default as Route } from '@ember/routing/route';
+export { default as Router } from '@ember/routing/router';

--- a/types/ember__routing/index.d.ts
+++ b/types/ember__routing/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for @ember/controller 3.0
+// Type definitions for @ember/routing 3.0
 // Project: http://emberjs.com/
 // Definitions by: Mike North <https://github.com/mike-north>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/ember__routing/link-component.d.ts
+++ b/types/ember__routing/link-component.d.ts
@@ -1,0 +1,3 @@
+import Ember from 'ember';
+
+export default class LinkComponent extends Ember.LinkComponent { }

--- a/types/ember__routing/location.d.ts
+++ b/types/ember__routing/location.d.ts
@@ -1,0 +1,4 @@
+import Ember from 'ember';
+
+export const Location: typeof Ember.Location;
+export default Location;

--- a/types/ember__routing/none-location.d.ts
+++ b/types/ember__routing/none-location.d.ts
@@ -1,0 +1,3 @@
+import Ember from 'ember';
+
+export default class NoneLocation extends Ember.NoneLocation { }

--- a/types/ember__routing/route.d.ts
+++ b/types/ember__routing/route.d.ts
@@ -1,0 +1,3 @@
+import Ember from 'ember';
+
+export default class Route extends Ember.Route { }

--- a/types/ember__routing/router-service.d.ts
+++ b/types/ember__routing/router-service.d.ts
@@ -1,0 +1,3 @@
+import { RouterService } from 'ember';
+
+export default class extends RouterService { }

--- a/types/ember__routing/router.d.ts
+++ b/types/ember__routing/router.d.ts
@@ -1,0 +1,3 @@
+import Ember from 'ember';
+
+export default class EmberRouter extends Ember.Router { }

--- a/types/ember__routing/test/lib/assert.ts
+++ b/types/ember__routing/test/lib/assert.ts
@@ -1,0 +1,5 @@
+/** Static assertion that `value` has type `T` */
+// Disable tslint here b/c the generic is used to let us do a type coercion and
+// validate that coercion works for the type value "passed into" the function.
+// tslint:disable-next-line:no-unnecessary-generics
+export declare function assertType<T>(value: T): T;

--- a/types/ember__routing/test/route.ts
+++ b/types/ember__routing/test/route.ts
@@ -1,0 +1,112 @@
+import Route from '@ember/routing/route';
+import Array from '@ember/array';
+import Ember from 'ember'; // currently needed for Transition
+import EmberObject from '@ember/object';
+import Controller from '@ember/controller';
+
+class Post extends EmberObject {}
+
+interface Posts extends Array<Post> {}
+
+Route.extend({
+    beforeModel(transition: Ember.Transition) {
+        this.transitionTo('someOtherRoute');
+    },
+});
+
+Route.extend({
+    afterModel(posts: Posts, transition: Ember.Transition) {
+        if (posts.length === 1) {
+            this.transitionTo('post.show', posts.firstObject);
+        }
+    },
+});
+
+Route.extend({
+    actions: {
+        showModal(evt: { modalName: string }) {
+            this.render(evt.modalName, {
+                outlet: 'modal',
+                into: 'application',
+            });
+        },
+        hideModal(evt: { modalName: string }) {
+            this.disconnectOutlet({
+                outlet: 'modal',
+                parentView: 'application',
+            });
+        },
+    },
+});
+
+Ember.Route.extend({
+    model() {
+        return this.modelFor('post');
+    },
+});
+
+Route.extend({
+    queryParams: {
+        memberQp: { refreshModel: true },
+    },
+});
+
+Route.extend({
+    renderTemplate() {
+        this.render('photos', {
+            into: 'application',
+            outlet: 'anOutletName',
+        });
+    },
+});
+
+Route.extend({
+    renderTemplate(controller: Ember.Controller, model: {}) {
+        this.render('posts', {
+            view: 'someView', // the template to render, referenced by name
+            into: 'application', // the template to render into, referenced by name
+            outlet: 'anOutletName', // the outlet inside `options.into` to render into.
+            controller: 'someControllerName', // the controller to use for this template, referenced by name
+            model, // the model to set on `options.controller`.
+        });
+    },
+});
+
+Route.extend({
+    resetController(controller: Ember.Controller, isExiting: boolean, transition: boolean) {
+        if (isExiting) {
+            //   controller.set('page', 1);
+        }
+    },
+});
+
+class ApplicationController extends Controller {}
+declare module '@ember/controller' {
+    interface Registry {
+        application: ApplicationController;
+    }
+}
+
+Route.extend({
+    setupController(controller: Controller, model: {}) {
+        this._super(controller, model);
+        this.controllerFor('application').set('model', model);
+    },
+});
+
+class RouteUsingClass extends Route.extend({
+    randomProperty: 'the .extend + extends bit type-checks properly',
+}) {
+    beforeModel(this: RouteUsingClass) {
+        return 'beforeModel can return anything, not just promises';
+    }
+    intermediateTransitionWithoutModel() {
+        this.intermediateTransitionTo('some-route');
+    }
+    intermediateTransitionWithModel() {
+        this.intermediateTransitionTo('some.other.route', { });
+    }
+    intermediateTransitionWithMultiModel() {
+        this.intermediateTransitionTo('some.other.route', 1, 2, { });
+    }
+}

--- a/types/ember__routing/test/router.ts
+++ b/types/ember__routing/test/router.ts
@@ -1,0 +1,54 @@
+import Ember from 'ember';
+import { assertType } from './lib/assert';
+
+const AppRouter = Ember.Router.extend({
+});
+
+AppRouter.map(function() {
+    this.route('index', { path: '/' });
+    this.route('about');
+    this.route('favorites', { path: '/favs' });
+    this.route('posts', function() {
+        this.route('index', { path: '/' });
+        this.route('new');
+        this.route('post', { path: '/post/:post_id', resetNamespace: true });
+        this.route('comments', { resetNamespace: true }, function() {
+            this.route('new');
+        });
+    });
+    this.route('photo', { path: '/photo/:id' }, function() {
+        this.route('comment', { path: '/comment/:id' });
+    });
+    this.route('not-found', { path: '/*path' });
+    this.mount('my-engine');
+    this.mount('my-engine', { as: 'some-other-engine', path: '/some-other-engine'});
+});
+
+const RouterServiceConsumer = Ember.Service.extend({
+    router: Ember.inject.service('router'),
+    currentRouteName() {
+        const x: string = Ember.get(this, 'router').currentRouteName;
+    },
+    currentURL() {
+        const x: string = Ember.get(this, 'router').currentURL;
+    },
+    transitionWithoutModel() {
+        Ember.get(this, 'router')
+        .transitionTo('some-route');
+    },
+    transitionWithModel() {
+        const model = Ember.Object.create();
+        Ember.get(this, 'router')
+        .transitionTo('some.other.route', model);
+    },
+    transitionWithMultiModel() {
+        const model = Ember.Object.create();
+        Ember.get(this, 'router')
+        .transitionTo('some.other.route', model, model);
+    },
+    transitionWithModelAndOptions() {
+        const model = Ember.Object.create();
+        Ember.get(this, 'router')
+        .transitionTo('index', model, { queryParams: { search: 'ember' }});
+    }
+});

--- a/types/ember__routing/tsconfig.json
+++ b/types/ember__routing/tsconfig.json
@@ -1,0 +1,40 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es5",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "paths": {
+            "@ember/routing": ["ember__routing"],
+            "@ember/routing/*": ["ember__routing/*"]
+        },
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "auto-location.d.ts",
+        "hash-location.d.ts",
+        "history-location.d.ts",
+        "index.d.ts",
+        "link-component.d.ts",
+        "location.d.ts",
+        "none-location.d.ts",
+        "route.d.ts",
+        "router-service.d.ts",
+        "router.d.ts",
+        "test/lib/assert.ts",
+        "test/route.ts",
+        "test/router.ts"
+    ]
+}

--- a/types/ember__routing/tslint.json
+++ b/types/ember__routing/tslint.json
@@ -1,0 +1,4 @@
+{
+    "extends": "dtslint/dt.json",
+    "rules": {}
+}

--- a/types/ember__utils/ember__utils-tests.ts
+++ b/types/ember__utils/ember__utils-tests.ts
@@ -8,6 +8,7 @@ import {
     tryInvoke,
     typeOf
 } from '@ember/utils';
+import EmberObject from '@ember/object';
 
 (function() {
     /** isNone */
@@ -161,3 +162,10 @@ import {
     isEmpty({ size: 1 }); // $ExpectType boolean
     isEmpty({ size: () => 0 }); // $ExpectType boolean
 })();
+
+class Foo extends EmberObject.extend({
+    abc: true,
+    bar() { return '123'; }
+}) {
+    def: 'hello';
+}


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
> this is an odd situation where the npm package and the name of the modules consumers import do not align. These types align with the module names

- Create it with `dts-gen --dt`, not by basing it on an existing project.
> Does not apply in this case

- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.emberjs.com/api/ember/3.4/modules/@ember%2Frouting
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

cc: @dwickern @jamescdavis @dfreeman @chriskrycho 

Fixes https://github.com/typed-ember/ember-cli-typescript/issues/274