### PR TITLE
[ember] refactor @ember/component types into their own package

### DIFF
--- a/types/ember/index.d.ts
+++ b/types/ember/index.d.ts
@@ -143,7 +143,7 @@ declare module 'ember' {
 
     type ObserverMethod<Target, Sender> =
         | (keyof Target)
-        | ((this: Target, sender: Sender, key: keyof Sender, value: any, rev: number) => void);
+        | ((this: Target, sender: Sender, key: string, value: any, rev: number) => void);
 
     interface RenderOptions {
         into?: string;

--- a/types/ember__component/checkbox.d.ts
+++ b/types/ember__component/checkbox.d.ts
@@ -1,0 +1,3 @@
+import Ember from 'ember';
+
+export default class Checkbox extends Ember.Checkbox { }

--- a/types/ember__component/helper.d.ts
+++ b/types/ember__component/helper.d.ts
@@ -1,0 +1,17 @@
+import Ember from 'ember';
+
+export default class Helper extends Ember.Helper { }
+/**
+ * In many cases, the ceremony of a full `Helper` class is not required.
+ * The `helper` method create pure-function helpers without instances. For
+ * example:
+ * ```app/helpers/format-currency.js
+ * import { helper } from '@ember/component/helper';
+ * export default helper(function(params, hash) {
+ *   let cents = params[0];
+ *   let currency = hash.currency;
+ *   return `${currency}${cents * 0.01}`;
+ * });
+ * ```
+ */
+export function helper(helperFn: (params: any[], hash?: any) => any): any;

--- a/types/ember__component/index.d.ts
+++ b/types/ember__component/index.d.ts
@@ -1,0 +1,9 @@
+// Type definitions for @ember/component 3.0
+// Project: http://emberjs.com/
+// Definitions by: Mike North <https://github.com/mike-north>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.8
+
+import Ember from 'ember';
+
+export default class Component extends Ember.Component { }

--- a/types/ember__component/test/component.ts
+++ b/types/ember__component/test/component.ts
@@ -1,0 +1,123 @@
+import Component from '@ember/component';
+import Object, { computed, get } from '@ember/object';
+import hbs from 'htmlbars-inline-precompile';
+import { assertType } from "./lib/assert";
+
+Component.extend({
+  layout: hbs`
+        <div>
+          {{yield}}
+        </div>
+    `,
+});
+
+Component.extend({
+  layout: 'my-layout',
+});
+
+const MyComponent = Component.extend();
+assertType<string | string[]>(get(MyComponent, 'positionalParams'));
+
+const component1 = Component.extend({
+  actions: {
+    hello(name: string) {
+      console.log('Hello', name);
+    },
+  },
+});
+
+Component.extend({
+  name: '',
+  hello(name: string) {
+    this.set('name', name);
+  },
+});
+
+Component.extend({
+  tagName: 'em',
+});
+
+Component.extend({
+  classNames: ['my-class', 'my-other-class'],
+});
+
+Component.extend({
+  classNameBindings: ['propertyA', 'propertyB'],
+  propertyA: 'from-a',
+  propertyB: computed(function() {
+    if (!this.get('propertyA')) {
+      return 'from-b';
+    }
+  }),
+});
+
+Component.extend({
+  classNameBindings: ['hovered'],
+  hovered: true,
+});
+
+Component.extend({
+  classNameBindings: ['messages.empty'],
+  messages: Object.create({
+    empty: true,
+  }),
+});
+
+Component.extend({
+  classNameBindings: ['isEnabled:enabled:disabled'],
+  isEnabled: true,
+});
+
+Component.extend({
+  classNameBindings: ['isEnabled::disabled'],
+  isEnabled: true,
+});
+
+Component.extend({
+  tagName: 'a',
+  attributeBindings: ['href'],
+  href: 'http://google.com',
+});
+
+Component.extend({
+  tagName: 'a',
+  attributeBindings: ['url:href'],
+  url: 'http://google.com',
+});
+
+Component.extend({
+  tagName: 'use',
+  attributeBindings: ['xlinkHref:xlink:href'],
+  xlinkHref: '#triangle',
+});
+
+Component.extend({
+  tagName: 'input',
+  attributeBindings: ['disabled'],
+  disabled: false,
+});
+
+Component.extend({
+  tagName: 'input',
+  attributeBindings: ['disabled'],
+  disabled: computed(() => {
+    if ('someLogic') {
+      return true;
+    } else {
+      return false;
+    }
+  }),
+});
+
+Component.extend({
+  tagName: 'form',
+  attributeBindings: ['novalidate'],
+  novalidate: null,
+});
+
+Component.extend({
+  click(event: object) {
+    // will be called when an instance's
+    // rendered element is clicked
+  },
+});

--- a/types/ember__component/test/helper.ts
+++ b/types/ember__component/test/helper.ts
@@ -1,0 +1,25 @@
+import { assertType } from './lib/assert';
+import Helper, { helper } from '@ember/component/helper';
+
+class Timestamp extends Helper {
+    timer?: ReturnType<typeof setInterval>;
+    now = new Date();
+    init() {
+        super.init();
+        this.timer = setInterval(() => {
+            this.set('now', new Date());
+            this.recompute();
+        }, 100);
+    }
+    willDestroy() {
+        clearInterval(this.timer);
+    }
+}
+
+const addHelper = helper(function add([a, b]: number[]) {
+    return a + b;
+});
+
+const dasherizeHelper = helper(function dasherize([str]: string[], { delim = '-'}) {
+    return str.split(/[\s\n\_\.]+/g).join(delim);
+});

--- a/types/ember__component/test/lib/assert.ts
+++ b/types/ember__component/test/lib/assert.ts
@@ -1,0 +1,5 @@
+/** Static assertion that `value` has type `T` */
+// Disable tslint here b/c the generic is used to let us do a type coercion and
+// validate that coercion works for the type value "passed into" the function.
+// tslint:disable-next-line:no-unnecessary-generics
+export declare function assertType<T>(value: T): T;

--- a/types/ember__component/text-area.d.ts
+++ b/types/ember__component/text-area.d.ts
@@ -1,0 +1,3 @@
+import Ember from 'ember';
+
+export default class TextArea extends Ember.TextArea { }

--- a/types/ember__component/text-field.d.ts
+++ b/types/ember__component/text-field.d.ts
@@ -1,0 +1,3 @@
+import Ember from 'ember';
+
+export default class TextField extends Ember.TextField { }

--- a/types/ember__component/tsconfig.json
+++ b/types/ember__component/tsconfig.json
@@ -1,0 +1,35 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es5",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "paths": {
+            "@ember/component": ["ember__component"],
+            "@ember/component/*": ["ember__component/*"]
+        },
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "checkbox.d.ts",
+        "text-area.d.ts",
+        "text-field.d.ts",
+        "helper.d.ts",
+        "test/lib/assert.ts",
+        "test/component.ts",
+        "test/helper.ts"
+    ]
+}

--- a/types/ember__component/tslint.json
+++ b/types/ember__component/tslint.json
@@ -1,0 +1,4 @@
+{
+    "extends": "dtslint/dt.json",
+    "rules": {}
+}

--- a/types/ember__utils/ember__utils-tests.ts
+++ b/types/ember__utils/ember__utils-tests.ts
@@ -8,6 +8,7 @@ import {
     tryInvoke,
     typeOf
 } from '@ember/utils';
+import EmberObject from '@ember/object';
 
 (function() {
     /** isNone */
@@ -161,3 +162,10 @@ import {
     isEmpty({ size: 1 }); // $ExpectType boolean
     isEmpty({ size: () => 0 }); // $ExpectType boolean
 })();
+
+class Foo extends EmberObject.extend({
+    abc: true,
+    bar() { return '123'; }
+}) {
+    def: 'hello';
+}


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
> this is an odd situation where the npm package and the name of the modules consumers import do not align. These types align with the module names

- Create it with `dts-gen --dt`, not by basing it on an existing project.
> Does not apply in this case

- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.emberjs.com/api/ember/3.4/modules/@ember%2Fcomponent
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

cc: @dwickern @jamescdavis @dfreeman @chriskrycho 

Fixes https://github.com/typed-ember/ember-cli-typescript/issues/264