### PR TITLE
[ember] refactor @ember/application types into their own package

### DIFF
--- a/types/ember-resolver/ember-resolver-tests.ts
+++ b/types/ember-resolver/ember-resolver-tests.ts
@@ -1,5 +1,5 @@
-import Application from '@ember/application';
 import EmberResolver from 'ember-resolver';
+import { Ember } from 'ember';
 
 const MyResolver = EmberResolver.extend({
     pluralizedTypes: {
@@ -7,6 +7,6 @@ const MyResolver = EmberResolver.extend({
     }
 });
 
-const App = Application.extend({
+const App = Ember.Application.extend({
     Resolver: MyResolver
 });

--- a/types/ember-resolver/index.d.ts
+++ b/types/ember-resolver/index.d.ts
@@ -5,11 +5,9 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
-/// <reference types="ember" />
-
-import Resolver from '@ember/application/resolver';
+import Ember from 'ember';
 
 /**
  * An Ember `Resolver` implementation used by ember-cli.
  */
-export default class EmberResolver extends Resolver {}
+export default class EmberResolver extends Ember.Resolver {}

--- a/types/ember-resolver/v4/ember-resolver-tests.ts
+++ b/types/ember-resolver/v4/ember-resolver-tests.ts
@@ -1,4 +1,4 @@
-import Application from '@ember/application';
+import Ember from 'ember';
 import EmberResolver from 'ember-resolver';
 
 const MyResolver = EmberResolver.extend({
@@ -7,6 +7,6 @@ const MyResolver = EmberResolver.extend({
     }
 });
 
-const App = Application.extend({
+const App = Ember.Application.extend({
     Resolver: MyResolver
 });

--- a/types/ember-resolver/v4/index.d.ts
+++ b/types/ember-resolver/v4/index.d.ts
@@ -5,11 +5,9 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.4
 
-/// <reference types="ember" />
-
-import Resolver from '@ember/application/resolver';
+import Ember from 'ember';
 
 /**
  * An Ember `Resolver` implementation used by ember-cli.
  */
-export default class EmberResolver extends Resolver {}
+export default class EmberResolver extends Ember.Resolver {}

--- a/types/ember/index.d.ts
+++ b/types/ember/index.d.ts
@@ -143,7 +143,7 @@ declare module 'ember' {
 
     type ObserverMethod<Target, Sender> =
         | (keyof Target)
-        | ((this: Target, sender: Sender, key: keyof Sender, value: any, rev: number) => void);
+        | ((this: Target, sender: Sender, key: string, value: any, rev: number) => void);
 
     interface RenderOptions {
         into?: string;

--- a/types/ember__application/deprecations.d.ts
+++ b/types/ember__application/deprecations.d.ts
@@ -1,0 +1,4 @@
+import Ember from 'ember';
+
+export const deprecate: typeof Ember.deprecate;
+export const deprecateFunc: typeof Ember.deprecateFunc;

--- a/types/ember__application/globals-resolver.d.ts
+++ b/types/ember__application/globals-resolver.d.ts
@@ -1,0 +1,3 @@
+import Ember from 'ember';
+
+export default class GlobalsResolver extends Ember.DefaultResolver { }

--- a/types/ember__application/index.d.ts
+++ b/types/ember__application/index.d.ts
@@ -1,0 +1,13 @@
+// Type definitions for @ember/application 3.0
+// Project: http://emberjs.com/
+// Definitions by: Mike North <https://github.com/mike-north>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.8
+
+import Ember from 'ember';
+
+export default class Application extends Ember.Application { }
+export const getOwner: typeof Ember.getOwner;
+export const onLoad: typeof Ember.onLoad;
+export const runLoadHooks: typeof Ember.runLoadHooks;
+export const setOwner: typeof Ember.setOwner;

--- a/types/ember__application/instance.d.ts
+++ b/types/ember__application/instance.d.ts
@@ -1,0 +1,3 @@
+import Ember from 'ember';
+
+export default class ApplicationInstance extends Ember.ApplicationInstance { }

--- a/types/ember__application/resolver.d.ts
+++ b/types/ember__application/resolver.d.ts
@@ -1,0 +1,3 @@
+import Ember from 'ember';
+
+export default class Resolver extends Ember.Resolver { }

--- a/types/ember__application/test/application-instance.ts
+++ b/types/ember__application/test/application-instance.ts
@@ -1,0 +1,29 @@
+import ApplicationInstance from '@ember/application/instance';
+import hbs from 'htmlbars-inline-precompile';
+
+const appInstance = ApplicationInstance.create();
+appInstance.register('some:injection', class Foo {});
+
+appInstance.register('some:injection', class Foo {}, {
+  singleton: true,
+});
+
+appInstance.register('some:injection', class Foo {}, {
+  instantiate: false,
+});
+
+appInstance.register('templates:foo/bar', hbs`<h1>Hello World</h1>`);
+
+appInstance.register('some:injection', class Foo {}, {
+    singleton: false,
+    instantiate: true,
+});
+
+appInstance.factoryFor('router:main');
+appInstance.lookup('route:basic');
+
+appInstance.boot();
+
+(async () => {
+  await appInstance.boot();
+})();

--- a/types/ember__application/test/application.ts
+++ b/types/ember__application/test/application.ts
@@ -1,0 +1,41 @@
+import Application from "@ember/application";
+import EmberObject from "@ember/object";
+
+const BaseApp = Application.extend({
+    modulePrefix: 'my-app'
+});
+
+BaseApp.initializer({
+    name: 'my-initializer',
+    initialize(app) {
+        app.register('foo:bar', EmberObject.extend({ foo: 'bar' }));
+    }
+});
+
+BaseApp.instanceInitializer({
+    name: 'my-instance-initializer',
+    initialize(app) {
+        app.lookup('foo:bar').get('foo');
+    }
+});
+
+const App1 = BaseApp.create({
+    rootElement: '#app-one',
+    customEvents: {
+        paste: 'paste'
+    }
+});
+
+const App2 = BaseApp.create({
+    rootElement: '#app-two',
+    customEvents: {
+        mouseenter: null,
+        mouseleave: null
+    }
+});
+
+const App3 = BaseApp.create();
+
+const App3Instance1 = App3.buildInstance(); // $ExpectType ApplicationInstance
+
+const App3Instance2 = App3.buildInstance({ foo: 'bar' }); // $ExpectType ApplicationInstance

--- a/types/ember__application/test/deprecations.ts
+++ b/types/ember__application/test/deprecations.ts
@@ -1,0 +1,14 @@
+import { deprecate, deprecateFunc } from '@ember/application/deprecations';
+
+deprecate('this is no longer advised', false, {
+    id: 'no-longer-advised',
+    until: 'v4.0'
+});
+deprecate('this is no longer advised', false);
+
+deprecateFunc('this is no longer advised', () => {});
+deprecateFunc(
+    'this is no longer advised',
+    { id: 'no-longer-do-this', until: 'v4.0' },
+    () => {}
+);

--- a/types/ember__application/test/globals-resolver.ts
+++ b/types/ember__application/test/globals-resolver.ts
@@ -1,0 +1,6 @@
+import GlobalsResolver from "@ember/application/globals-resolver";
+
+const gr = GlobalsResolver.create();
+
+gr.resolve('App.IndexController');
+gr.resolve(); // $ExpectError

--- a/types/ember__application/test/resolver.ts
+++ b/types/ember__application/test/resolver.ts
@@ -1,0 +1,3 @@
+import Resolver from "@ember/application/resolver";
+
+const res = Resolver.create();

--- a/types/ember__application/tsconfig.json
+++ b/types/ember__application/tsconfig.json
@@ -1,0 +1,37 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es5",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "paths": {
+            "@ember/application": ["ember__application"],
+            "@ember/application/*": ["ember__application/*"]
+        },
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "deprecations.d.ts",
+        "globals-resolver.d.ts",
+        "index.d.ts",
+        "instance.d.ts",
+        "resolver.d.ts",
+        "test/application.ts",
+        "test/deprecations.ts",
+        "test/resolver.ts",
+        "test/globals-resolver.ts",
+        "test/application-instance.ts"
+    ]
+}

--- a/types/ember__application/tslint.json
+++ b/types/ember__application/tslint.json
@@ -1,0 +1,4 @@
+{
+    "extends": "dtslint/dt.json",
+    "rules": {}
+}

--- a/types/ember__utils/ember__utils-tests.ts
+++ b/types/ember__utils/ember__utils-tests.ts
@@ -8,6 +8,7 @@ import {
     tryInvoke,
     typeOf
 } from '@ember/utils';
+import EmberObject from '@ember/object';
 
 (function() {
     /** isNone */
@@ -161,3 +162,10 @@ import {
     isEmpty({ size: 1 }); // $ExpectType boolean
     isEmpty({ size: () => 0 }); // $ExpectType boolean
 })();
+
+class Foo extends EmberObject.extend({
+    abc: true,
+    bar() { return '123'; }
+}) {
+    def: 'hello';
+}


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
> this is an odd situation where the npm package and the name of the modules consumers import do not align. These types align with the module names

- Create it with `dts-gen --dt`, not by basing it on an existing project.
> Does not apply in this case

- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.emberjs.com/api/ember/3.4/modules/@ember%2Fapplication
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

cc: @dwickern @jamescdavis @dfreeman @chriskrycho 

Fixes https://github.com/typed-ember/ember-cli-typescript/issues/263