### PR TITLE
[ember] refactor @ember/engine types into their own package

### DIFF
--- a/types/ember/index.d.ts
+++ b/types/ember/index.d.ts
@@ -143,7 +143,7 @@ declare module 'ember' {
 
     type ObserverMethod<Target, Sender> =
         | (keyof Target)
-        | ((this: Target, sender: Sender, key: keyof Sender, value: any, rev: number) => void);
+        | ((this: Target, sender: Sender, key: string, value: any, rev: number) => void);
 
     interface RenderOptions {
         into?: string;

--- a/types/ember__engine/index.d.ts
+++ b/types/ember__engine/index.d.ts
@@ -1,0 +1,10 @@
+// Type definitions for @ember/engine 3.0
+// Project: http://emberjs.com/
+// Definitions by: Mike North <https://github.com/mike-north>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.8
+
+import Ember from 'ember';
+
+export default class Engine extends Ember.Engine { }
+export const getEngineParent: typeof Ember.getEngineParent;

--- a/types/ember__engine/instance.d.ts
+++ b/types/ember__engine/instance.d.ts
@@ -1,0 +1,3 @@
+import Ember from 'ember';
+
+export default class EngineInstance extends Ember.EngineInstance { }

--- a/types/ember__engine/test/engine-instance.ts
+++ b/types/ember__engine/test/engine-instance.ts
@@ -1,0 +1,26 @@
+import EngineInstance from '@ember/engine/instance';
+
+const engineInstance = EngineInstance.create();
+engineInstance.register('some:injection', class Foo {});
+
+engineInstance.register('some:injection', class Foo {}, {
+  singleton: true,
+});
+
+engineInstance.register('some:injection', class Foo {}, {
+  instantiate: false,
+});
+
+engineInstance.register('some:injection', class Foo {}, {
+    singleton: false,
+    instantiate: true,
+});
+
+engineInstance.factoryFor('router:main');
+engineInstance.lookup('route:basic');
+
+engineInstance.boot();
+
+(async () => {
+  await engineInstance.boot();
+})();

--- a/types/ember__engine/test/engine.ts
+++ b/types/ember__engine/test/engine.ts
@@ -1,0 +1,41 @@
+import Engine from "@ember/engine";
+import EmberObject from "@ember/object";
+
+const BaseEngine = Engine.extend({
+    modulePrefix: 'my-engine'
+});
+
+BaseEngine.initializer({
+    name: 'my-initializer',
+    initialize(engine) {
+        engine.register('foo:bar', EmberObject.extend({ foo: 'bar' }));
+    }
+});
+
+BaseEngine.instanceInitializer({
+    name: 'my-instance-initializer',
+    initialize(engine) {
+        engine.lookup('foo:bar').get('foo');
+    }
+});
+
+const Engine1 = BaseEngine.create({
+    rootElement: '#engine-one',
+    customEvents: {
+        paste: 'paste'
+    }
+});
+
+const Engine2 = BaseEngine.create({
+    rootElement: '#engine-two',
+    customEvents: {
+        mouseenter: null,
+        mouseleave: null
+    }
+});
+
+const Engine3 = BaseEngine.create();
+
+const Engine3Instance1 = Engine3.buildInstance();
+
+const Engine3Instance2 = Engine3.buildInstance({ foo: 'bar' });

--- a/types/ember__engine/tsconfig.json
+++ b/types/ember__engine/tsconfig.json
@@ -1,0 +1,31 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es5",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "paths": {
+            "@ember/engine": ["ember__engine"],
+            "@ember/engine/*": ["ember__engine/*"]
+        },
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "instance.d.ts",
+        "test/engine.ts",
+        "test/engine-instance.ts"
+    ]
+}

--- a/types/ember__engine/tslint.json
+++ b/types/ember__engine/tslint.json
@@ -1,0 +1,4 @@
+{
+    "extends": "dtslint/dt.json",
+    "rules": {}
+}

--- a/types/ember__utils/ember__utils-tests.ts
+++ b/types/ember__utils/ember__utils-tests.ts
@@ -8,6 +8,7 @@ import {
     tryInvoke,
     typeOf
 } from '@ember/utils';
+import EmberObject from '@ember/object';
 
 (function() {
     /** isNone */
@@ -161,3 +162,10 @@ import {
     isEmpty({ size: 1 }); // $ExpectType boolean
     isEmpty({ size: () => 0 }); // $ExpectType boolean
 })();
+
+class Foo extends EmberObject.extend({
+    abc: true,
+    bar() { return '123'; }
+}) {
+    def: 'hello';
+}


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
> this is an odd situation where the npm package and the name of the modules consumers import do not align. These types align with the module names

- Create it with `dts-gen --dt`, not by basing it on an existing project.
> Does not apply in this case

- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.emberjs.com/api/ember/3.4/modules/@ember%2Fengine
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

cc: @dwickern @jamescdavis @dfreeman @chriskrycho 

Fixes https://github.com/typed-ember/ember-cli-typescript/issues/267