### PR TITLE
d3-hexbin, d3-request, d3-time

### DIFF
--- a/types/d3-hexbin/d3-hexbin-tests.ts
+++ b/types/d3-hexbin/d3-hexbin-tests.ts
@@ -8,209 +8,95 @@
 
 import * as d3Hexbin from 'd3-hexbin';
 
+// ----------------------------------------------------------------------------
+// Preparatory Steps
+// ----------------------------------------------------------------------------
+
 interface Point {
-    x0: number;
-    y0: number;
+    x: number;
+    y: number;
 }
 
-{
-    // d3.hexbin() has the expected defaults
-    const b = d3Hexbin.hexbin();
-    const extent = b.extent(); // [[0, 0], [1, 1]]
-    extent.map((x: any, y: any) => { });
-    b.x()([41, 42]); // === 41;
-    b.y()([41, 42]); // === 42;
-    b.radius();      // === 1;
+let num: number;
+let str: string;
+let centers: Array<[number, number]>;
+let extent: [[number, number], [number, number]];
+let size: [number, number];
 
-    // hexbin(points) bins the specified points into hexagonal bins
-    const bins = d3Hexbin.hexbin()([
-        [0, 0], [0, 1], [0, 2],
-        [1, 0], [1, 1], [1, 2],
-        [2, 0], [2, 1], [2, 2]
-    ]);
+let hexbin: d3Hexbin.Hexbin<[number, number]>;
+let hexbinBins: Array<d3Hexbin.HexbinBin<[number, number]>>;
+const data: Array<[number, number]> = [[10, 20], [30, 10]];
 
-    bins.map((bin: any) => {});
-}
+let pointHexbin: d3Hexbin.Hexbin<Point>;
+let pointHexbinBins: Array<d3Hexbin.HexbinBin<Point>>;
+const pointData: Point[] = [{x: 10, y: 20}, {x: 30, y: 10}];
 
-{
-    // hexbin(points) observes the current x- and y-accessors
-    const x = (d: any) => d.x;
-    const y = (d: any) => d.y;
-    const bins = d3Hexbin.hexbin<Point>().x(x).y(y)([
-        {x0: 0, y0: 0}, {x0: 0, y0: 1}, {x0: 0, y0: 2},
-        {x0: 1, y0: 0}, {x0: 1, y0: 1}, {x0: 1, y0: 2},
-        {x0: 2, y0: 0}, {x0: 2, y0: 1}, {x0: 2, y0: 2}
-    ]);
-    bins.map((bin: any) => {});
-}
+let pointAccessor: (d: Point) => number;
 
-{
-    // hexbin(points) observes the current radius
-    const bins = d3Hexbin.hexbin().radius(2)([
-      [0, 0], [0, 1], [0, 2],
-      [1, 0], [1, 1], [1, 2],
-      [2, 0], [2, 1], [2, 2]
-    ]);
-    bins.map((bin: any) => {});
-}
+// ----------------------------------------------------------------------------
+// Hexbin
+// ----------------------------------------------------------------------------
 
-{
-    interface PointX {
-        x: number;
-        [key: number]: number;
-    }
+// Create Hexbin ==============================================================
 
-    // hexbin.x(x) sets the x-coordinate accessor
-    const x = (d: PointX) => d.x;
-    const b = d3Hexbin.hexbin<PointX>().x(x);
-    const bins = b([{x: 1, 1: 2}]);
+// with default data type [number, number] ------------------------------------
 
-    b.x();          // should be x;
-    bins.length;    // should be 1;
-    bins[0].x;      // should be 0.8660254037844386;
-    bins[0].y;      // should be 1.5;
-    bins[0].length; // should be 1;
-}
+hexbin = d3Hexbin.hexbin();
 
-{
-    interface PointY {
-        y: number;
-        [key: number]: number;
-    }
-    // hexbin.y(y) sets the y-coordinate accessor
-    const y = (d: PointY) => d.y;
-    const b = d3Hexbin.hexbin<PointY>().y(y);
-    const bins = b([{0: 1, y: 2}]);
+// with custom data type ------------------------------------------------------
 
-    bins.length;    // should be 1;
-    bins[0].x;      // should be 0.8660254037844386;
-    bins[0].y;      // should be 1.5;
-    bins[0].length; // should be 1;
-}
+pointHexbin = d3Hexbin.hexbin<Point>();
 
-{
-    // hexbin.hexagon() returns the expected path
-    const path: string = d3Hexbin.hexbin().hexagon();
-}
+// Configure Hexbin ===========================================================
 
-{
-    // hexbin.hexagon() observes the current bin radius
-    const path: string = d3Hexbin.hexbin().radius(2).hexagon();
-}
+// x(...) ---------------------------------------------------------------------
 
-{
-    // hexbin.hexagon(radius) observes the specified radius
-    const path: string = d3Hexbin.hexbin().hexagon(2);
-}
+pointHexbin = pointHexbin.x(d => d.x);
 
-{
-    // hexbin.hexagon(radius) uses the current bin radius if radius is undefined
-    let path: string = d3Hexbin.hexbin().hexagon();
-    path = d3Hexbin.hexbin().hexagon(undefined);
-}
+pointAccessor = pointHexbin.x();
 
-{
-    // hexbin.centers() returns an array of bin centers
-    const centers = d3Hexbin.hexbin().centers();
-    centers.map((x: any, y: any) => { });
-}
+// y(...) ---------------------------------------------------------------------
 
-{
-    // hexbin.centers() observes the current bin radius
-    const centers = d3Hexbin.hexbin().radius(0.5).centers();
-    centers.map((x: any, y: any) => { });
-}
+pointHexbin = pointHexbin.y(d => d.y);
 
-{
-    // hexbin.centers() observes the current extent
-    const centers = d3Hexbin.hexbin().radius(0.5)
-                            .extent([[-1.1, -1.1], [1.1, 1.1]])
-                            .centers();
-    centers.map((x, y) => { });
-}
+pointAccessor = pointHexbin.x();
 
-{
-    // hexbin.mesh() returns the expected path
-    const path: string = d3Hexbin.hexbin().mesh();
-}
+// hexagon(...) ---------------------------------------------------------------
 
-{
-    // hexbin.mesh() observes the bin radius
-    const path: string = d3Hexbin.hexbin().radius(0.5).mesh();
-}
+str = hexbin.hexagon();
 
-{
-    // hexbin.mesh() observes the extent
-    const path: string = d3Hexbin.hexbin().radius(0.5)
-                         .extent([[-1.1, -1.1], [1.1, 1.1]])
-                         .mesh();
-}
+// centers(...) ---------------------------------------------------------------
 
-{
-    // hexbin.size()
-    let size: [number, number] = [100, 100];
-    d3Hexbin.hexbin().size(size);
-    size = d3Hexbin.hexbin().size();
-}
+centers = hexbin.centers();
 
-{
-    let hb: d3Hexbin.Hexbin<Point>;
-    let bins: Array<d3Hexbin.HexbinBin<Point>>;
+// mesh(...) ------------------------------------------------------------------
 
-    // Create generator =======================================
+str = hexbin.mesh();
 
-    hb = d3Hexbin.hexbin<Point>();
+// radius(...) ----------------------------------------------------------------
 
-    // Configure generator =====================================
+hexbin = hexbin.radius(20);
 
-    // x Accessor ----------------------------------------------
+num = hexbin.radius();
 
-    let x: (d: Point) => number;
-    x = (d: Point) => d.x0;
+// extent(...) ----------------------------------------------------------------
 
-    // test setter
-    hb = hb.x(x);
+hexbin = hexbin.extent([[0, 0], [1, 1]]);
 
-    // test getter
-    x = hb.x();
+extent = hexbin.extent();
 
-    // y Accessor ----------------------------------------------
+// size(...) ------------------------------------------------------------------
 
-    let y: (d: Point) => number;
-    y = (d: Point) => d.y0;
+hexbin = hexbin.size([1, 1]);
 
-    // test setter
-    hb = hb.y(y);
+size = hexbin.size();
 
-    // test getter
-    y = hb.y();
+// Use Hexbin =================================================================
 
-    // Use generator ============================================
+hexbinBins = hexbin(data);
+num = hexbinBins[0].x;
+num = hexbinBins[0].y;
 
-    bins = hb([
-        { x0: 0, y0: 0 }, { x0: 0, y0: 1 }, { x0: 0, y0: 2 },
-        { x0: 1, y0: 0 }, { x0: 1, y0: 1 }, { x0: 1, y0: 2 },
-        { x0: 2, y0: 0 }, { x0: 2, y0: 1 }, { x0: 2, y0: 2 }
-    ]);
-
-    interface RemappedBin {
-        binCoordinates: [number, number];
-        points: Point[];
-    }
-
-    let remappedBins: RemappedBin[];
-
-    remappedBins = bins.map(bin => {
-        const x: number = bin.x; // x-coordinate of bin
-        const y: number = bin.y; // y-coordinate of bin
-        const pointsInBin: Point[] = bin.map(p => {
-            const point: Point = p;
-            return point;
-        });
-        const remapped: RemappedBin = {
-            binCoordinates: [x, y],
-            points: pointsInBin
-        };
-        return remapped;
-    });
-}
+pointHexbinBins = pointHexbin(pointData);
+num = pointHexbinBins[0].x;
+num = pointHexbinBins[0].y;

--- a/types/d3-quadtree/d3-quadtree-tests.ts
+++ b/types/d3-quadtree/d3-quadtree-tests.ts
@@ -157,7 +157,7 @@ testDatum = quadtree.find(20, 30);
 // with radius
 testDatum = quadtree.find(20, 30, 10);
 
-// visit() --------------------------------------------------------------------
+// visit() -------------------------------------------------------------------
 
 quadtree = quadtree.visit((node, x0, y0, x1, y1) => {
     let bound: number;
@@ -199,7 +199,7 @@ quadtree = quadtree.visit((node, x0, y0, x1, y1) => {
     return 10; // fails wrong return type
 });
 
-// visitAfter() ---------------------------------------------------------------
+// visitAfter() --------------------------------------------------------------
 
 quadtree = quadtree.visitAfter((node, x0, y0, x1, y1) => {
     let bound: number;
@@ -218,7 +218,7 @@ quadtree = quadtree.visitAfter((node, x0, y0, x1, y1) => {
     }
 });
 
-// Test  QuadtreeLeaf =========================================================
+// Test QuadtreeLeaf =========================================================
 
 declare const leaf: d3Quadtree.QuadtreeLeaf<TestDatum>;
 let nextLeaf: d3Quadtree.QuadtreeLeaf<TestDatum> | undefined;
@@ -227,7 +227,7 @@ testDatum = leaf.data;
 
 nextLeaf = leaf.next ? leaf.next : undefined;
 
-// Test  QuadtreeInternalNode =================================================
+// Test QuadtreeInternalNode =================================================
 
 declare const internalNode: d3Quadtree.QuadtreeInternalNode<TestDatum>;
 let quadNode: d3Quadtree.QuadtreeInternalNode<TestDatum> | d3Quadtree.QuadtreeLeaf<TestDatum> | undefined;

--- a/types/d3-request/d3-request-tests.ts
+++ b/types/d3-request/d3-request-tests.ts
@@ -350,7 +350,7 @@ let csvRequest: d3Request.DsvRequest = d3Request.csv(url);
 
 // url and callback for response handling
 const csvRequestWithCallback: d3Request.DsvRequest = d3Request.csv(url, function(error, data) {
-    const that: d3Request.Request = this;
+    const that: d3Request.DsvRequest = this;
     const err: any = error;
     const d: DSVParsedArray<DSVRowString> = data;
     console.log(d);
@@ -369,7 +369,7 @@ const csvRequestWithRowWithCallback: d3Request.DsvRequest = d3Request.csv<Respon
         return mappedRow;
     },
     function(error, data) {
-        const that: d3Request.Request = this;
+        const that: d3Request.DsvRequest = this;
         const err: any = error;
         const d: DSVParsedArray<ResponseDatumGET> = data;
         console.log(data);
@@ -384,7 +384,7 @@ const tsvRequest: d3Request.DsvRequest = d3Request.tsv(url);
 
 // url and callback for response handling
 const tsvRequestWithCallback: d3Request.DsvRequest = d3Request.tsv(url, function(error, data) {
-    const that: d3Request.Request = this;
+    const that: d3Request.DsvRequest = this;
     const err: any = error;
     const d: DSVParsedArray<DSVRowString> = data;
     console.log(d);
@@ -403,7 +403,7 @@ const tsvRequestWithRowWithCallback: d3Request.DsvRequest = d3Request.tsv<Respon
         return mappedRow;
     },
     function(error, data) {
-        const that: d3Request.Request = this;
+        const that: d3Request.DsvRequest = this;
         const err: any = error;
         const d: DSVParsedArray<ResponseDatumGET> = data;
         console.log(data);

--- a/types/d3-request/tsconfig.json
+++ b/types/d3-request/tsconfig.json
@@ -8,7 +8,7 @@
         "noImplicitAny": true,
         "noImplicitThis": true,
         "strictNullChecks": true,
-        "strictFunctionTypes": false,
+        "strictFunctionTypes": true,
         "baseUrl": "../",
         "typeRoots": [
             "../"

--- a/types/d3-time/index.d.ts
+++ b/types/d3-time/index.d.ts
@@ -1,6 +1,9 @@
 // Type definitions for D3JS d3-time module 1.0
 // Project: https://github.com/d3/d3-time/
-// Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
+// Definitions by: Tom Wanzek <https://github.com/tomwanzek>
+//                 Alex Ford <https://github.com/gustavderdrache>
+//                 Boris Yankov <https://github.com/borisyankov>
+//                 denisname <https://github.com/denisname>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 // Last module patch version validated against: 1.0.7
@@ -134,7 +137,7 @@ export interface CountableTimeInterval extends TimeInterval {
      * because its purpose is to return the zero-based number of the specified end date relative to the specified start date.
      *
      * @param start A start date object.
-     * @param start An end date object.
+     * @param end An end date object.
      */
     count(start: Date, end: Date): number;
     /**

--- a/types/d3-timer/index.d.ts
+++ b/types/d3-timer/index.d.ts
@@ -1,6 +1,9 @@
 // Type definitions for d3JS d3-timer module 1.0
 // Project: https://github.com/d3/d3-timer/
-// Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
+// Definitions by: Tom Wanzek <https://github.com/tomwanzek>
+//                 Alex Ford <https://github.com/gustavderdrache>
+//                 Boris Yankov <https://github.com/borisyankov>
+//                 denisname <https://github.com/denisname>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 // Last module patch version validated against: 1.0.7


### PR DESCRIPTION
Rewrite `d3-hexbin` tests. The actual tests are written like functional tests and not like definitions tests. Also they differ completely from what is done in all other d3 modules.

Activate strictFunctionTypes in `d3-request`. Only had to change the tests. Related #28580.

Fix typo in `d3-time`. Thanks to @psimyn in #28666.

Add me as author to d3-time. Forgot to do it in #25973.