### PR TITLE
Added PDFMake type definition for 'pdfmake' export

### DIFF
--- a/types/pdfmake/index.d.ts
+++ b/types/pdfmake/index.d.ts
@@ -2,6 +2,7 @@
 // Project: http://pdfmake.org
 // Definitions by: Milen Stefanov <https://github.com/m1llen1um>
 //                 Rajab Shakirov <https://github.com/radziksh>
+//                 Felix Christl  <https://github.com/fchristl>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare module 'pdfmake/build/vfs_fonts' {
@@ -9,6 +10,22 @@ declare module 'pdfmake/build/vfs_fonts' {
         vfs: any;
         [name: string]: any;
     };
+}
+
+declare module 'pdfmake' {
+    import {TDocumentDefinitions} from 'pdfmake/build/pdfmake';
+    import PDFDocument = PDFKit.PDFDocument;
+    type FontDescriptors = {
+        [key: string]: {
+            [key: string]: string;
+        };
+    }
+
+    class PdfPrinter {
+        constructor(fontDescriptors: FontDescriptors);
+        createPdfKitDocument(docDefinition: TDocumentDefinitions, options?: any): PDFDocument;
+    }
+    export = PdfPrinter;
 }
 
 declare module 'pdfmake/build/pdfmake' {

--- a/types/pdfmake/package.json
+++ b/types/pdfmake/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "@types/pdfkit": "^0.7.36"
+  }
+}

--- a/types/pdfmake/package.json
+++ b/types/pdfmake/package.json
@@ -1,5 +1,0 @@
-{
-  "dependencies": {
-    "@types/pdfkit": "^0.7.36"
-  }
-}


### PR DESCRIPTION
- Added PDFMake type definition for 'pdfmake' export
- Added package.json for PDFMake to include a dependency on pdfkit (for
  PDFDocument type)

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/bpampuch/pdfmake/blob/master/src/printer.js
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.