### PR TITLE
StripeJS Typings fix (Typings were not imported correctly)

### DIFF
--- a/types/stripejs/element.d.ts
+++ b/types/stripejs/element.d.ts
@@ -33,7 +33,7 @@ export interface ElementFactory {
     create(
         type: ElementType,
         options: CardElementOptions | IBANElementOptions | IdealBankOptions | PaymentButtonOptions
-    ): Element;
+    ): StripeElement;
 }
 
 export interface ElementCreatorOptions {
@@ -107,7 +107,7 @@ export interface FontConfigElement {
 }
 
 // --- ELEMENT --- //
-export interface Element {
+export interface StripeElement {
     /**
      * Mount the element to the DOM
      * @see https://stripe.com/docs/stripe-js/reference#element-mount

--- a/types/stripejs/index.d.ts
+++ b/types/stripejs/index.d.ts
@@ -4,7 +4,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.1
 
-import { Element, ElementCreatorOptions, ElementFactory } from './element';
+import { StripeElement, ElementCreatorOptions, ElementFactory } from './element';
 import { StripePaymentOptions, StripePaymentRequest } from './payment';
 import { BankTokenData, PiiTokenData, TokenData, IBANTokenData, TokenResult } from './token';
 import { SourceData, SourceResult } from './source';
@@ -60,7 +60,7 @@ export interface StripeJS {
      *
      * @return an object containing the generated token or an error
      */
-    createToken(element: Element, data?: TokenData | IBANTokenData): Promise<TokenResult>;
+    createToken(element: StripeElement, data?: TokenData | IBANTokenData): Promise<TokenResult>;
     createToken(type: 'bank_account', data: BankTokenData): Promise<TokenResult>;
     createToken(type: 'pii', data: PiiTokenData): Promise<TokenResult>;
 
@@ -75,7 +75,7 @@ export interface StripeJS {
      *
      * @return an object containing the generated Source or an error
      */
-    createSource(element: Element, data: SourceData): Promise<SourceResult>;
+    createSource(element: StripeElement, data: SourceData): Promise<SourceResult>;
     createSource(data: SourceData): Promise<SourceResult>;
 
     /**

--- a/types/stripejs/index.d.ts
+++ b/types/stripejs/index.d.ts
@@ -4,7 +4,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.1
 
-import { ElementCreatorOptions, ElementFactory } from './element';
+import { Element, ElementCreatorOptions, ElementFactory } from './element';
 import { StripePaymentOptions, StripePaymentRequest } from './payment';
 import { BankTokenData, PiiTokenData, TokenData, IBANTokenData, TokenResult } from './token';
 import { SourceData, SourceResult } from './source';

--- a/types/stripejs/stripejs-tests.ts
+++ b/types/stripejs/stripejs-tests.ts
@@ -1,4 +1,5 @@
 import { StripeJS } from "stripejs";
+import { StripeElement } from "stripejs/element";
 import { CanMakePaymentResult, StripePaymentResponse } from "stripejs/payment";
 import { BankTokenData, IBANTokenData, TokenData, TokenResult } from "stripejs/token";
 import { SourceData, SourceResult } from "stripejs/source";
@@ -52,7 +53,7 @@ describe('StripeJS', () => {
     });
 
     it('Should be possible to create a token', () => {
-        const element: Element = {} as any;
+        const element: StripeElement = {} as any;
         const data: TokenData = {
             name: '',
             currency: 'eur',
@@ -83,7 +84,7 @@ describe('StripeJS', () => {
     });
 
     it('Should be possible to create a source object', () => {
-        const element: Element = {} as any;
+        const element: StripeElement = {} as any;
         const data: SourceData = {
             type: 'alipay',
             flow: 'none',


### PR DESCRIPTION
+ Element was not included so the native Element was used instead. This caused a warning when trying to use the StripeJS functions with the StripeJS Element object

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: (Forgot to import the correct typing so no docs changed)
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.