### PR TITLE
Redux-form: export some potentially helpful types; rename a type

### DIFF
--- a/types/redux-form/lib/FieldArray.d.ts
+++ b/types/redux-form/lib/FieldArray.d.ts
@@ -1,7 +1,7 @@
 import { Component, ComponentType } from "react";
 import { Validator } from "../index";
 
-interface BaseFieldArrayProps<P = {}> {
+export interface BaseFieldArrayProps<P = {}> {
     name: string;
     component: ComponentType<P>;
     validate?: Validator | Validator[];
@@ -23,14 +23,14 @@ export class FieldArray<P = {}> extends Component<BaseFieldArrayProps<P> & Parti
     getRenderedComponent(): Component<WrappedFieldArrayProps<any> & P>;
 }
 
-interface WrappedFieldArrayProps<FieldValue> {
-    fields: FieldsProps<FieldValue>;
+export interface WrappedFieldArrayProps<FieldValue> {
+    fields: FieldArrayFieldsProps<FieldValue>;
     meta: FieldArrayMetaProps;
 }
 
-type FieldIterate<FieldValue, R = void> = (name: string, index: number, fields: FieldsProps<FieldValue>) => R;
+export type FieldIterate<FieldValue, R = void> = (name: string, index: number, fields: FieldArrayFieldsProps<FieldValue>) => R;
 
-interface FieldsProps<FieldValue> {
+export interface FieldArrayFieldsProps<FieldValue> {
     forEach(callback: FieldIterate<FieldValue>): void;
     get(index: number): FieldValue;
     getAll(): FieldValue[];
@@ -47,7 +47,7 @@ interface FieldsProps<FieldValue> {
     unshift(value: FieldValue): void;
 }
 
-interface FieldArrayMetaProps {
+export interface FieldArrayMetaProps {
     dirty: boolean;
     error?: any;
     form: string;

--- a/types/redux-form/redux-form-tests.tsx
+++ b/types/redux-form/redux-form-tests.tsx
@@ -24,7 +24,8 @@ import {
     FormAction,
     actionTypes,
     submit,
-    SubmissionError
+    SubmissionError,
+    FieldArrayFieldsProps
 } from "redux-form";
 import {
     Field as ImmutableField,


### PR DESCRIPTION
We found we needed to reference these types at places in our code. There shouldn't be any harm in exporting them.

Also, rename `FieldsProps` to `FieldArrayFieldsProps` to be more consistent with the other names in the file and avoid chances of name conflicts. This should be harmless since the interface was not previously exported. The new naming also mirrors [the official library](https://github.com/erikras/redux-form/blob/1bce646543194117b0c656e049e7dec9d9f0af4a/src/propTypes.js#L99)

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/erikras/redux-form/blob/1bce646543194117b0c656e049e7dec9d9f0af4a/src/propTypes.js#L99
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.


