### PR TITLE
add dateIcon type

### DIFF
--- a/types/react-widgets/lib/DateTimePicker.d.ts
+++ b/types/react-widgets/lib/DateTimePicker.d.ts
@@ -48,6 +48,10 @@ interface DateTimePickerProps extends ReactWidgetsCommonDropdownProps<DateTimePi
     /*
      * Default value for current date. Useful for suggesting a date when the caldenar opens without keep forcing it once 'value' is set.
      */
+    dateIcon?: any;
+    /*
+     * Specify the element used to render the calendar dropdown icon
+     */
     defaultCurrentDate?: Date;
     /**
      * Change event Handler that is called when the currentDate is changed. The handler is


### PR DESCRIPTION
React Widgets Datepicker - add dateIcon property
https://jquense.github.io/react-widgets/api/DateTimePicker/#dateIcon
https://github.com/jquense/react-widgets/blob/master/packages/react-widgets/src/DateTimePicker.js
