### PR TITLE
Add PromiseLike-compatible type for then

### DIFF
--- a/types/q/index.d.ts
+++ b/types/q/index.d.ts
@@ -61,7 +61,7 @@ declare namespace Q {
 		 * The then method from the Promises/A+ specification, with an additional progress handler.
 		 */
 		then<U>(onFulfill?: ((value: T) => IWhenable<U>) | null, onReject?: ((error: any) => IWhenable<U>) | null, onProgress?: ((progress: any) => any) | null): Promise<U>;
-
+		then<U = T, V = never>(onFulfill?: ((value: T) => IWhenable<U>) | null, onReject?: ((error: any) => IWhenable<V>) | null, onProgress?: ((progress: any) => any) | null): Promise<U | V>;
 		/**
 		 * Like a finally clause, allows you to observe either the fulfillment or rejection of a promise, but to do so
 		 * without modifying the final value. This is useful for collecting resources regardless of whether a job succeeded,

--- a/types/q/q-tests.ts
+++ b/types/q/q-tests.ts
@@ -245,6 +245,9 @@ Q.try(() => {
 })
 	.catch((error) => console.error("Couldn't sync to the cloud", error));
 
+// ensure Q.Promise is compatible with PromiseLike
+const p7: PromiseLike<void> = Q.Promise<void>((resolve) => resolve());
+
 // thenReject, returning a Promise of the same type as the Promise it is called on
 function thenRejectSameType(arg: any): Q.Promise<number> {
 	if (!arg) {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/Microsoft/TypeScript/pull/14095/files#diff-dbd7748aef21cd49b7878047278b29f1
- [ ] ~~Increase the version number in the header if appropriate.~~
- [ ] ~~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.~~

Currently, `Q.Promise` is not compatible with `PromiseLike` from the lib, since the version from the lib can return different types from `onFulfill` and `onReject`. This is causing issues in other packages which expect them to be compatible. Here, I've just added the more general type as an overload so any consumers of the package can still hit the older version.