### PR TITLE
[react-native] Add types for devtools modules

### DIFF
--- a/types/react-native/Devtools.d.ts
+++ b/types/react-native/Devtools.d.ts
@@ -1,0 +1,22 @@
+declare module 'react-native/Libraries/Core/Devtools/parseErrorStack' {
+    export type StackFrame = {
+        file: string;
+        methodName: string;
+        lineNumber: number;
+        column: number | null;
+    };
+
+    export interface ExtendedError extends Error {
+        framesToPop?: number;
+    }
+
+    export default function parseErrorStack(error: ExtendedError): StackFrame[];
+}
+
+declare module 'react-native/Libraries/Core/Devtools/symbolicateStackTrace' {
+    import { StackFrame } from 'react-native/Libraries/Core/Devtools/parseErrorStack';
+
+    export default function symbolicateStackTrace(
+        stack: ReadonlyArray<StackFrame>
+    ): Promise<StackFrame[]>;
+}

--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -30,6 +30,7 @@
 /// <reference path="globals.d.ts" />
 /// <reference path="legacy-properties.d.ts" />
 /// <reference path="BatchedBridge.d.ts" />
+/// <reference path="Devtools.d.ts" />
 
 import * as React from 'react';
 


### PR DESCRIPTION
Adds type declarations for `parseErrorStack` and `symbolicateStackTrace`, which are used to process caught errors.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
https://github.com/facebook/react-native/blob/1151c096dab17e5d9a6ac05b61aacecd4305f3db/Libraries/Core/Devtools/symbolicateStackTrace.js and 
https://github.com/facebook/react-native/blob/36199d3dda9eedb45628fc49483e98764d67847a/Libraries/Core/Devtools/parseErrorStack.js
- [x] Increase the version number in the header if appropriate. **N/A**
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. **N/A**