### PR TITLE
twilio-video 2.0.0-beta1 types fix

### DIFF
--- a/types/twilio-video/index.d.ts
+++ b/types/twilio-video/index.d.ts
@@ -475,7 +475,8 @@ export interface ConnectOptions {
     video?: boolean | CreateLocalTrackOptions;
 }
 export interface CreateLocalTrackOptions {
-    logLevel: LogLevel | LogLevels;
+    // In API reference logLevel is not optional, but in the Twilio examples it is
+    logLevel?: LogLevel | LogLevels;
     name?: string;
     workaroundWebKitBug180748?: boolean;
 }

--- a/types/twilio-video/index.d.ts
+++ b/types/twilio-video/index.d.ts
@@ -94,7 +94,7 @@ export class LocalParticipant extends Participant {
     tracks: Map<Track.SID, LocalTrackPublication>;
     videoTracks: Map<Track.SID, LocalVideoTrackPublication>;
 
-    publishTrack(localTrack: LocalTrack): Promise<LocalTrackPublication>;
+    publishTrack(track: LocalTrack): Promise<LocalTrackPublication>;
     publishTrack(
         mediaStreamTrack: MediaStreamTrack, options?: LocalTrackOptions,
     ): Promise<LocalTrackPublication>;
@@ -102,6 +102,8 @@ export class LocalParticipant extends Participant {
         tracks: LocalTrack[] | MediaStreamTrack[],
     ): Promise<LocalTrackPublication[]>;
     setParameters(encodingParameters?: EncodingParameters | null): LocalParticipant;
+    unpublishTrack(track: LocalTrack): LocalTrackPublication;
+    unpublishTracks(tracks: LocalTrack): LocalTrackPublication[];
 }
 export class LocalTrackPublication extends TrackPublication {
     isTrackEnabled: boolean;
@@ -475,7 +477,7 @@ export interface ConnectOptions {
 export interface CreateLocalTrackOptions {
     logLevel: LogLevel | LogLevels;
     name?: string;
-    workaroundWebKitBug180748?: boolean; // Lol
+    workaroundWebKitBug180748?: boolean;
 }
 export interface CreateLocalTracksOptions {
     audio?: boolean | CreateLocalTrackOptions;

--- a/types/twilio-video/index.d.ts
+++ b/types/twilio-video/index.d.ts
@@ -474,7 +474,7 @@ export interface ConnectOptions {
     tracks?: LocalTrack[] | MediaStreamTrack[];
     video?: boolean | CreateLocalTrackOptions;
 }
-export interface CreateLocalTrackOptions {
+export interface CreateLocalTrackOptions extends MediaTrackConstraints {
     // In API reference logLevel is not optional, but in the Twilio examples it is
     logLevel?: LogLevel | LogLevels;
     name?: string;


### PR DESCRIPTION
After developing a bit more the production application with the new types, and had the need of using manual local tracks, I discovered a few fixes to be made:

- Two missing functions in `LocalParticipant`: `unpublishTrack` and `unpublishTracks`. See [LocalParticipant documentation](https://media.twiliocdn.com/sdk/js/video/releases/2.0.0-beta1/docs/LocalParticipant.html).
- When creating a single track using `createLocalVideoTrack` or `createLocalAudioTrack`, the documentation defines a non optional `logLevel`, but the examples don't specify it and the code works without it. See [Examples](https://media.twiliocdn.com/sdk/js/video/releases/2.0.0-beta1/docs/global.html#createLocalVideoTrack__anchor). Therefore, `logLevel` is optional in `CreateLocalTrackOptions` as well (and documented in the code).
- `CreateLocalTrackOptions` should extend `MediaTrackConstraints`. Currently, it will complain when writing our own video and audio constraints. [CreateLocalTrackOptions](https://media.twiliocdn.com/sdk/js/video/releases/2.0.0-beta1/docs/global.html#CreateLocalTrackOptions)

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://media.twiliocdn.com/sdk/js/video/releases/2.0.0-beta1/docs
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
