### PR TITLE
Slickgrid: DataView<T>.mapRowsToIds expects number[], not T[]

### DIFF
--- a/types/slickgrid/index.d.ts
+++ b/types/slickgrid/index.d.ts
@@ -1623,7 +1623,7 @@ declare namespace Slick {
 			public getRowById(id: string): number;
 			public getItemById(id: any): T;
 			public getItemByIdx(idx: number): T;
-			public mapRowsToIds(rowArray: T[]): string[];
+			public mapRowsToIds(rowArray: number[]): string[];
 			public setRefreshHints(hints: RefreshHints): void;
 			public setFilterArgs(args: any): void;
 			public refresh(): void;


### PR DESCRIPTION
Changing an existing definition of DataView<T>.mapRowsToIds

Current definition:
			`public mapRowsToIds(rowArray: T[]): string[];`

Should be:
			`public mapRowsToIds(rowArray: number[]): string[];`


This is clear from the code:
`ids[ids.length] = `**`rows[rowArray[i]]`**`[idProperty];`

Existing definition causes an error when compiling in Typescript 3.0.0 or higher.