### PR TITLE
Change md5 declaration to accepts Array<number>

### DIFF
--- a/types/md5/index.d.ts
+++ b/types/md5/index.d.ts
@@ -11,7 +11,7 @@
  * @param {(string | Buffer)} message - a string or buffer to hash
  * @returns {string} the resultant MD5 hash of the given message
  */
-declare function md5(message: string | Buffer): string;
+declare function md5(message: string | Buffer | Array<number>): string;
 
 declare namespace md5 {}
 


### PR DESCRIPTION
md5 accepts not only `string | Buffer`,
but also `Array<number>` from the beginning:

https://github.com/pvorb/node-md5/blob/master/md5.js#L19

----

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/pvorb/node-md5/blob/master/md5.js#L19
- ~~[ ] Increase the version number in the header if appropriate.~~
- ~~[ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.~~
