### PR TITLE
[passport-oauth2] Allows callbackURL option to be omitted in constructor of OAuth2Strategy

### DIFF
--- a/types/passport-oauth2/index.d.ts
+++ b/types/passport-oauth2/index.d.ts
@@ -45,7 +45,7 @@ declare namespace OAuth2Strategy {
         tokenURL: string;
         clientID: string;
         clientSecret: string;
-        callbackURL: string;
+        callbackURL?: string;
     }
     interface StrategyOptions extends _StrategyOptionsBase {
         passReqToCallback?: false;

--- a/types/passport-oauth2/passport-oauth2-tests.ts
+++ b/types/passport-oauth2/passport-oauth2-tests.ts
@@ -33,7 +33,6 @@ function verifyFunction4(_req: Request, _accessToken: string, _refreshToken: str
 
 const strategyOptions2: StrategyOptionsWithRequest = {
     authorizationURL: 'http://www.example.com/auth',
-    callbackURL: 'http://www.example.com/callback',
     clientID: 'dummy',
     clientSecret: 'secret',
     tokenURL: 'http://www.example.com/token',


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/jaredhanson/passport-oauth2/blob/master/lib/strategy.js (all uses of callbackURL are checked for truthiness)
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
