### PR TITLE
[ember] relax types around Ember.set & setProperties

### DIFF
--- a/types/ember/index.d.ts
+++ b/types/ember/index.d.ts
@@ -3233,6 +3233,11 @@ declare module 'ember' {
             key: K,
             value: UnwrapComputedPropertySetter<T[K]>
         ): UnwrapComputedPropertyGetter<T[K]>;
+        function set<T, K extends keyof T>(
+            obj: T,
+            key: K,
+            value: T[K]
+        ): T[K];
         /**
          * Error-tolerant form of `Ember.set`. Will not blow up if any part of the
          * chain is `undefined`, `null`, or destroyed.
@@ -3247,6 +3252,11 @@ declare module 'ember' {
             obj: T,
             hash: Pick<UnwrapComputedPropertySetters<T>, K>
         ): Pick<UnwrapComputedPropertyGetters<T>, K>;
+        // TODO: in TS2.9 - Pick<UnwrapComputedPropertySetters<T> | T, K>
+        function setProperties<T, K extends keyof T>(
+            obj: T,
+            hash: Pick<T, K>
+        ): Pick<T, K>;
         /**
          * Detects when a specific package of Ember (e.g. 'Ember.Application')
          * has fully loaded and is available for extension.

--- a/types/ember/test/object.ts
+++ b/types/ember/test/object.ts
@@ -49,3 +49,20 @@ class Foo extends Ember.Object.extend({
         });
     }
 }
+
+export class Foo2 extends Ember.Object {
+  name!: string;
+
+  changeName(name: string) {
+    let a: string = this.set('name', name);
+    let b: number = this.set('name', name); // $ExpectError
+    let x: string = Ember.set(this, 'name', name);
+    let y: number = Ember.set(this, 'name', name); // $ExpectError
+    this.setProperties({
+        name
+    });
+    Ember.setProperties(this, {
+        name
+    });
+  }
+}


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.emberjs.com/api/ember/3.4/functions/@ember%2Fobject/set
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

---
- Fixes https://github.com/typed-ember/ember-cli-typescript/issues/308
- Workaround due to breaking change https://github.com/Microsoft/TypeScript/issues/26120
- Would much much cleaner w/ a fix for https://github.com/Microsoft/TypeScript/issues/27014
