### PR TITLE
[angular-ui-sortable] Fix test failures caused by TypeScript@next

### DIFF
--- a/types/angular-ui-sortable/angular-ui-sortable-tests.ts
+++ b/types/angular-ui-sortable/angular-ui-sortable-tests.ts
@@ -132,9 +132,8 @@ myApp.controller('sortableController', function ($scope: MySortableControllerSco
   $scope.sortableOptions.tolerance = 'pointer';
   $scope.sortableOptions.zIndex = 9999;
 
-  $scope.sortableOptions['ui-floating'] = undefined;
-  $scope.sortableOptions['ui-floating'] = null;
-  $scope.sortableOptions['ui-floating'] = false;
-  $scope.sortableOptions['ui-floating'] = true;
-  $scope.sortableOptions['ui-floating'] = "auto";
+  const sortableFloatingOption0: ng.ui.UISortableOptions<SortableModelInfo> = { 'ui-floating': undefined };
+  const sortableFloatingOption1: ng.ui.UISortableOptions<SortableModelInfo> = { 'ui-floating': false };
+  const sortableFloatingOption2: ng.ui.UISortableOptions<SortableModelInfo> = { 'ui-floating': true };
+  const sortableFloatingOption3: ng.ui.UISortableOptions<SortableModelInfo> = { 'ui-floating': 'auto' };
 });

--- a/types/angular-ui-sortable/index.d.ts
+++ b/types/angular-ui-sortable/index.d.ts
@@ -12,7 +12,7 @@ declare module 'angular' {
     export namespace ui {
 
         interface UISortableOptions<T> extends SortableOptions<T> {
-            'ui-floating'?: string | boolean;
+            'ui-floating'?: 'auto' | boolean;
         }
 
         interface UISortableProperties<T> {


### PR DESCRIPTION
Resolves: #28887
TBH this feels like a regression in TS 3.1.0-dev.20180915
Docs: https://github.com/angular-ui/ui-sortable#ui-floating

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
