### PR TITLE
Fix slate-plain-serializer's default export

### DIFF
--- a/types/slate-plain-serializer/index.d.ts
+++ b/types/slate-plain-serializer/index.d.ts
@@ -1,6 +1,7 @@
-// Type definitions for slate-plain-serializer 0.5
+// Type definitions for slate-plain-serializer 0.6
 // Project: https://github.com/ianstormtaylor/slate
 // Definitions by: Brandon Shelton <https://github.com/YangusKhan>
+//                 Martin Kiefel <https://github.com/mkiefel>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.6
 import { BlockProperties, MarkProperties, Value } from 'slate';
@@ -11,5 +12,9 @@ export interface DeserializeOptions {
     defaultMarks?: MarkProperties[] | Set<MarkProperties>;
 }
 
-export function deserialize(string: string, options?: DeserializeOptions): Value;
-export function serialize(value: Value): string;
+declare namespace Plain {
+  function deserialize(string: string, options?: DeserializeOptions): Value;
+  function serialize(value: Value): string;
+}
+
+export default Plain;

--- a/types/slate-plain-serializer/slate-plain-serializer-tests.ts
+++ b/types/slate-plain-serializer/slate-plain-serializer-tests.ts
@@ -1,4 +1,4 @@
-import * as Plain from "slate-plain-serializer";
+import Plain from "slate-plain-serializer";
 import { Value } from "slate";
 
 const val = Value.create();


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [source](https://github.com/ianstormtaylor/slate/blob/ba9b79112e2024640cfbdfedd70c9795a059a102/packages/slate-plain-serializer/src/index.js#L91) and the import example in [documentation](https://github.com/ianstormtaylor/slate/blob/master/docs/reference/slate-plain-serializer/index.md#slate-plain-serializer)
- [x] Increase the version number in the header if appropriate.
