### PR TITLE
Add type definitions for 'resize-img'

### DIFF
--- a/types/resize-img/index.d.ts
+++ b/types/resize-img/index.d.ts
@@ -1,0 +1,19 @@
+// Type definitions for resize-img 1.1
+// Project: https://github.com/kevva/resize-img#readme
+// Definitions by: Yusuke Higuchi <https://github.com/higuri>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types="node" />
+
+export = ResizeImg;
+
+declare function ResizeImg(
+    input: Buffer,
+    options: ResizeImg.ResizeImgOptions): Promise<Buffer>;
+
+declare namespace ResizeImg {
+    interface ResizeImgOptions {
+        width?: number;
+        height?: number;
+    }
+}

--- a/types/resize-img/resize-img-tests.ts
+++ b/types/resize-img/resize-img-tests.ts
@@ -1,0 +1,9 @@
+import * as fs from "fs";
+import resizeImg = require("resize-img");
+
+resizeImg(fs.readFileSync("images/dog.jpg"), {
+    width: 128,
+    height: 128,
+}).then((buf) => {
+    fs.writeFileSync("resized.jpg", buf);
+});

--- a/types/resize-img/tsconfig.json
+++ b/types/resize-img/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "resize-img-tests.ts"
+    ]
+}

--- a/types/resize-img/tslint.json
+++ b/types/resize-img/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:
If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
