### PR TITLE
[@types/next] Consistent context query types.

### DIFF
--- a/types/next/index.d.ts
+++ b/types/next/index.d.ts
@@ -16,18 +16,18 @@ import * as url from "url";
 
 import { Response as NodeResponse } from "node-fetch";
 
-import { SingletonRouter } from './router';
+import { SingletonRouter, DefaultQuery } from './router';
 
 declare namespace next {
-    /** Map object used in query strings. */
-    type QueryStringMapObject = Record<string, string | string[] | undefined>;
+    // Deprecated
+    type QueryStringMapObject = DefaultQuery;
 
     /**
      * Context object used in methods like `getInitialProps()`
      * https://github.com/zeit/next.js/blob/6.1.1/server/render.js#L77
      * https://github.com/zeit/next.js/blob/6.1.1/readme.md#fetching-data-and-component-lifecycle
      */
-    interface NextContext<Q = QueryStringMapObject> {
+    interface NextContext<Q = DefaultQuery> {
         /** path section of URL */
         pathname: string;
         /** query string section of URL parsed as an object */
@@ -44,8 +44,8 @@ declare namespace next {
         err?: Error;
     }
 
-    type NextSFC<TProps = {}, Q = QueryStringMapObject> = NextStatelessComponent<TProps, Q>;
-    interface NextStatelessComponent<TProps = {}, Q = QueryStringMapObject>
+    type NextSFC<TProps = {}, Q = DefaultQuery> = NextStatelessComponent<TProps, Q>;
+    interface NextStatelessComponent<TProps = {}, Q = DefaultQuery>
         extends React.StatelessComponent<TProps> {
         getInitialProps?: (ctx: NextContext<Q>) => Promise<TProps>;
     }
@@ -142,28 +142,28 @@ declare namespace next {
             req: http.IncomingMessage,
             res: http.ServerResponse,
             pathname: string,
-            query?: QueryStringMapObject,
+            query?: DefaultQuery,
             parsedUrl?: UrlLike
         ): Promise<void>;
         renderToHTML(
             req: http.IncomingMessage,
             res: http.ServerResponse,
             pathname: string,
-            query?: QueryStringMapObject
+            query?: DefaultQuery
         ): Promise<string>;
         renderError(
             err: any,
             req: http.IncomingMessage,
             res: http.ServerResponse,
             pathname: string,
-            query?: QueryStringMapObject
+            query?: DefaultQuery
         ): Promise<void>;
         renderErrorToHTML(
             err: any,
             req: http.IncomingMessage,
             res: http.ServerResponse,
             pathname: string,
-            query?: QueryStringMapObject
+            query?: DefaultQuery
         ): Promise<string>;
         render404(
             req: http.IncomingMessage,

--- a/types/next/router.d.ts
+++ b/types/next/router.d.ts
@@ -26,15 +26,7 @@ export type PopStateCallback = (state: any) => boolean | undefined;
 
 export type RouterCallback = () => void;
 
-export interface DefaultQuery {
-    [key: string]:
-    | boolean
-    | boolean[]
-    | number
-    | number[]
-    | string
-    | string[];
-}
+export type DefaultQuery = Record<string, string | string[] | undefined>;
 
 export interface RouterProps<Q = DefaultQuery> {
     // url property fields

--- a/types/next/test/next-app-tests.tsx
+++ b/types/next/test/next-app-tests.tsx
@@ -1,16 +1,19 @@
 import * as React from "react";
-import App, { Container } from "next/app";
+import App, { Container, AppComponentContext } from "next/app";
+import { NextStatelessComponent } from "next";
 
 interface NextComponentProps {
     example: string;
 }
 
 class TestApp extends App<NextComponentProps> {
-    static async getInitialProps({ Component, router, ctx }: any) {
+    static async getInitialProps({ Component, router, ctx }: AppComponentContext) {
         let pageProps = {};
+        // TODO: fix AppComponentContext to return NextComponentType instead of React.ComponentType
+        const Page = Component as NextStatelessComponent;
 
-        if (Component.getInitialProps) {
-            pageProps = await Component.getInitialProps(ctx);
+        if (Page.getInitialProps) {
+            pageProps = await Page.getInitialProps(ctx);
         }
 
         return { pageProps };

--- a/types/next/test/next-component-tests.tsx
+++ b/types/next/test/next-component-tests.tsx
@@ -5,6 +5,10 @@ interface NextComponentProps {
     example: string;
 }
 
+interface TypedQuery {
+    id?: string;
+}
+
 class ClassNext extends React.Component<NextComponentProps> {
     static async getInitialProps(ctx: NextContext) {
         const { example } = ctx.query;
@@ -15,6 +19,14 @@ class ClassNext extends React.Component<NextComponentProps> {
         return (
             <div>I'm a class component! {this.props.example}</div>
         );
+    }
+}
+
+class ClassNextWithTypedQuery extends React.Component {
+    static async getInitialProps(ctx: NextContext<TypedQuery>) {
+        const { id } = ctx.query;
+        const processQuery = (id?: string) => id;
+        processQuery(id);
     }
 }
 


### PR DESCRIPTION
The two different query types used across this repo cause issues when trying to type `App.getInitialProps` context, since `NextContext.query` is incompatible with `AppComponentContext.ctx.query`.

![screen shot 2018-09-17 at 17 09 46](https://user-images.githubusercontent.com/474603/45636016-78422500-ba9e-11e8-99a5-5b25342c42f6.png)

This normalizes all the usages.

I've marked `QueryStringMapObject` deprecated in the code but it should in fact be removed. I don't know what is the process for this though. There are a lot of inconsistent naming conventions that would require the same.

This PR also surfaces another issue with the `AppComponentContext` that will require to add `NextComponentType` and `NextComponentClass`, akin to React ones. I'll possibly do that on following PRs.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/28047#pullrequestreview-148684223
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.