### PR TITLE
d3-interpolate: v1.3, JsDoc, strictNullChecks and TS 2.3

### DIFF
--- a/types/d3-array/index.d.ts
+++ b/types/d3-array/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/d3/d3-array
 // Definitions by: Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>, Tom Wanzek <https://github.com/tomwanzek>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
 
 // Last module patch version validated against: 1.2.0
 

--- a/types/d3-axis/index.d.ts
+++ b/types/d3-axis/index.d.ts
@@ -5,6 +5,7 @@
 //                 Boris Yankov <https://github.com/borisyankov>
 //                 denisname <https://github.com/denisname>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
 
 // Last module patch version validated against: 1.0.8
 

--- a/types/d3-brush/index.d.ts
+++ b/types/d3-brush/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/d3/d3-brush/
 // Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
 
 // Last module patch version validated against: 1.0.3
 

--- a/types/d3-chord/index.d.ts
+++ b/types/d3-chord/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/d3/d3-chord/
 // Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
 
 // Last module patch version validated against: 1.0.3
 

--- a/types/d3-interpolate/d3-interpolate-tests.ts
+++ b/types/d3-interpolate/d3-interpolate-tests.ts
@@ -12,8 +12,12 @@ import * as d3Hsv from 'd3-hsv';
 
 // Preparatory steps -------------------------------------------------------------------
 
-interface Interpolator<T> {
-    (t: number): T;
+type Interpolator<T> = (t: number) => T;
+
+interface Xyz {
+    x: number;
+    y: number;
+    z: number;
 }
 
 class NumCoercible {
@@ -39,13 +43,17 @@ class StringCoercible {
     }
 }
 
+let iNull: Interpolator<null>;
+let iBoolean: Interpolator<boolean>;
 let iNum: Interpolator<number>;
 let iString: Interpolator<string>;
 let iDate: Interpolator<Date>;
 let iArrayNum: Interpolator<number[]>;
 let iArrayStr: Interpolator<string[]>;
 let iArrayMixed: Interpolator<[Date, string]>;
+let iMix: Interpolator<Date | string>;
 let iKeyVal: Interpolator<{ [key: string]: any }>;
+let iXyz: Interpolator<Xyz>;
 let iRGBColorObj: Interpolator<d3Color.RGBColor>;
 let iZoom: d3Interpolate.ZoomInterpolator;
 
@@ -54,12 +62,20 @@ let str: string;
 let arrNum: number[];
 let arrStr: string[];
 let objKeyVal: { [key: string]: any };
+let xyz: Xyz;
 let objRGBColor: d3Color.RGBColor;
 let zoom: [number, number, number];
 
 // test interpolate(a, b) signature ----------------------------------------------------
 
-iNum = d3Interpolate.interpolate('1', 5);
+// $ExpectError
+iNum = d3Interpolate.interpolate('1', 5); // fails, https://github.com/Microsoft/TypeScript/issues/4002#issuecomment-124201510
+
+// null and boolean interpolator
+iNull = d3Interpolate.interpolate(null, null);
+iNull = d3Interpolate.interpolate(10, null);
+iBoolean = d3Interpolate.interpolate(false, true);
+iBoolean = d3Interpolate.interpolate("10", true);
 
 // color interpolator returning a color string
 iString = d3Interpolate.interpolate('seagreen', d3Color.rgb(100, 100, 100));
@@ -87,32 +103,34 @@ iNum = d3Interpolate.interpolate(new NumCoercible(2), new NumCoercible(20));
 // Key Value
 
 iKeyVal = d3Interpolate.interpolate({ x: 0, y: 1 }, { x: 1, y: 10, z: 100 });
+iXyz = d3Interpolate.interpolate({ x: 0, y: 1 }, { x: 1, y: 10, z: 100 });
+iXyz = d3Interpolate.interpolate<Xyz>({ x: 0, y: 1 }, { x: 1, y: 10, z: 100 });
 
 d3Interpolate.interpolate<NumCoercible>(new NumCoercible(1), new NumCoercible(5));
 d3Interpolate.interpolate<NumCoercible>({ a: 1 }, new NumCoercible(5));
 
-// test interpolateNumber(a, b) signature ----------------------------------------------------
+// test interpolateNumber(a, b) signature ----------------------------------------------
 
 iNum = d3Interpolate.interpolateNumber(0, 100);
 iNum = d3Interpolate.interpolateNumber(new NumCoercible(0), new NumCoercible(100));
 num = iNum(0.5);
 
-// test interpolateNumber(a, b) signature ----------------------------------------------------
+// test interpolateNumber(a, b) signature ----------------------------------------------
 
 iNum = d3Interpolate.interpolateRound(0, 100);
 iNum = d3Interpolate.interpolateRound(new NumCoercible(0), new NumCoercible(100));
 num = iNum(0.5);
 
-// test interpolateString(a, b) signature ----------------------------------------------------
+// test interpolateString(a, b) signature ----------------------------------------------
 
 iString = d3Interpolate.interpolateString('-1', '2');
 str = iString(0.5);
 
-// test interpolateDate(a, b) signature ----------------------------------------------------
+// test interpolateDate(a, b) signature ------------------------------------------------
 
 iDate = d3Interpolate.interpolateDate(new Date(2016, 6, 1), new Date(2016, 6, 31));
 
-// test interpolateArray(a, b) signature ----------------------------------------------------
+// test interpolateArray(a, b) signature -----------------------------------------------
 
 iArrayNum = d3Interpolate.interpolateArray<number[]>([1, 2], [4, 8]); // explicit typing
 arrNum = iArrayNum(0.5);
@@ -129,39 +147,49 @@ arrStr = iArrayStr(0.5);
 // two element array with first element date and second element string
 iArrayMixed = d3Interpolate.interpolateArray<[Date, string]>([new Date(2016, 6, 1), 'b: 1'], [new Date(2016, 6, 31), 'b: 8']);
 
-// test interpolateObject(a, b) signature ----------------------------------------------------
+// test interpolateObject(a, b) signature ----------------------------------------------
 
 iKeyVal = d3Interpolate.interpolateObject({ x: 0, y: 1 }, { x: 1, y: 10, z: 100 });
 objKeyVal = iKeyVal(0.5);
 
+iXyz = d3Interpolate.interpolateObject({ x: 0, y: 1 }, { x: 1, y: 10, z: 100 });
+iXyz = d3Interpolate.interpolateObject<Xyz>({ x: 0, y: 1 }, { x: 1, y: 10, z: 100 });
+xyz = iXyz(0.5);
+
 iRGBColorObj = d3Interpolate.interpolateObject<d3Color.RGBColor>(d3Color.rgb('steelblue'), d3Color.rgb('seagreen'));
 objRGBColor = iRGBColorObj(0.5);
 
-// test interpolateTransformCss(a, b) signature ----------------------------------------------------
+// test interpolateTransformCss(a, b) signature ----------------------------------------
 
 iString = d3Interpolate.interpolateTransformCss('rotate(0deg)', 'rotate(60deg)');
 str = iString(0.5);
 
-// test interpolateTransformSvg(a, b) signature ----------------------------------------------------
+// test interpolateTransformSvg(a, b) signature ----------------------------------------
 
 iString = d3Interpolate.interpolateTransformSvg('rotate(0)', 'rotate(60)');
 str = iString(0.5);
 
-// test interpolateZoom(a, b) signature ----------------------------------------------------
+// test interpolateZoom(a, b) signature ------------------------------------------------
 
 iZoom = d3Interpolate.interpolateZoom([50, 50, 300], [100, 100, 500]);
 zoom = iZoom(0.5);
 
+num = iZoom.duration;
 console.log('Recommended transition duration = %d', iZoom.duration);
 
-// test quantize(interpolator, n) signature ------------------------------------------------
+// test interpolateDiscrete(a, b) signature --------------------------------------------
+
+iNum = d3Interpolate.interpolateDiscrete([1, 2, 3]);
+iMix = d3Interpolate.interpolateDiscrete([new Date(2016, 6, 1), 'b: 2']);
+
+// test quantize(interpolator, n) signature --------------------------------------------
 
 arrNum = d3Interpolate.quantize(d3Interpolate.interpolateRound(-1, 2), 4); // inferred template parameter type
 arrStr = d3Interpolate.quantize<string>(d3Interpolate.interpolateString('-1', '2'), 4); // explicit template parameter typing
+// $ExpectError
+arrStr = d3Interpolate.quantize<string>(d3Interpolate.interpolateRound(-1, 2), 4); // fails, due to explicit typing v argument type mismatch
 
-// arrStr = d3Interpolate.quantize<string>(d3Interpolate.interpolateRound(-1, 2), 4); // test fails, due to explicit typing v argument type mismatch
-
-// test interpolateRgb(a, b) signatures ----------------------------------------------------------------
+// test interpolateRgb(a, b) signatures ------------------------------------------------
 
 // without gamma correction
 iString = d3Interpolate.interpolateRgb('seagreen', 'steelblue');
@@ -172,13 +200,13 @@ str = iString(0.5);
 // with gamma correction
 iString = d3Interpolate.interpolateRgb.gamma(2.2)('purple', 'orange');
 
-// test interpolateRgbBasis(color) and  interpolateRgbBasisClosed(color) signatures -------------------------
+// test interpolateRgbBasis(color) and  interpolateRgbBasisClosed(color) signatures ----
 
 iString = d3Interpolate.interpolateRgbBasis(['seagreen', d3Color.rgb('steelblue'), 'rgb(100, 100, 100)']);
 iString = d3Interpolate.interpolateRgbBasis(['seagreen', d3Hsv.hsv('steelblue'), 'rgb(100, 100, 100)']);
 iString = d3Interpolate.interpolateRgbBasisClosed(['seagreen', d3Hsv.hsv('steelblue'), 'rgb(100, 100, 100)']);
 
-// test interpolateHsl(a, b) and interpolateHslLong(a, b)----------------------------------------------------------------
+// test interpolateHsl(a, b) and interpolateHslLong(a, b)-------------------------------
 
 iString = d3Interpolate.interpolateHsl('seagreen', 'steelblue');
 iString = d3Interpolate.interpolateHsl(d3Color.rgb('seagreen'), d3Color.hcl('steelblue'));
@@ -188,13 +216,13 @@ iString = d3Interpolate.interpolateHslLong('seagreen', 'steelblue');
 iString = d3Interpolate.interpolateHslLong(d3Color.rgb('seagreen'), d3Color.hcl('steelblue'));
 iString = d3Interpolate.interpolateHslLong(d3Color.rgb('seagreen'), d3Hsv.hsv('steelblue'));
 
-// test interpolateLab(a, b) --------------------------------------------------------------------------------------------
+// test interpolateLab(a, b) -----------------------------------------------------------
 
 iString = d3Interpolate.interpolateLab('seagreen', 'steelblue');
 iString = d3Interpolate.interpolateLab(d3Color.rgb('seagreen'), d3Color.hcl('steelblue'));
 iString = d3Interpolate.interpolateLab(d3Color.rgb('seagreen'), d3Hsv.hsv('steelblue'));
 
-// test interpolateHcl(a, b) and interpolateHclLong(a, b) ----------------------------------------------------------------
+// test interpolateHcl(a, b) and interpolateHclLong(a, b) ------------------------------
 
 iString = d3Interpolate.interpolateHcl('seagreen', 'steelblue');
 iString = d3Interpolate.interpolateHcl(d3Color.rgb('seagreen'), d3Color.hcl('steelblue'));
@@ -204,7 +232,7 @@ iString = d3Interpolate.interpolateHclLong('seagreen', 'steelblue');
 iString = d3Interpolate.interpolateHclLong(d3Color.rgb('seagreen'), d3Color.hcl('steelblue'));
 iString = d3Interpolate.interpolateHclLong(d3Color.rgb('seagreen'), d3Hsv.hsv('steelblue'));
 
-// test interpolateCubehelix(a, b) and interpolateCubehelixLong(a, b) ---------------------------------------------------
+// test interpolateCubehelix(a, b) and interpolateCubehelixLong(a, b) ------------------
 
 // without gamma correction
 iString = d3Interpolate.interpolateCubehelix('seagreen', 'steelblue');
@@ -224,21 +252,29 @@ str = iString(0.5);
 // with gamma correction
 iString = d3Interpolate.interpolateCubehelixLong.gamma(2.2)('purple', 'orange');
 
-// test interpolateBasis(splineNodes) and interpolateBasisClosed(splineNodes: number[]) ----------------------------
+// test interpolateBasis(splineNodes) and interpolateBasisClosed(splineNodes) ----------
 
 iNum = d3Interpolate.interpolateBasis([1, 50, 30, 10]);
 
 iNum = d3Interpolate.interpolateBasisClosed([1, 50, 30, 10]);
 
+// test interpolateHue -----------------------------------------------------------------
+
+iNum = d3Interpolate.interpolateHue(30, 90);
+
+// test piecewise ----------------------------------------------------------------------
+
+iZoom = d3Interpolate.piecewise(d3Interpolate.interpolateZoom, [[50, 50, 300], [100, 100, 500]]);
+
 iString = d3Interpolate.piecewise(d3Interpolate.interpolateRgb.gamma(2.2), ['red', 'green', 'blue']);
 iString = d3Interpolate.piecewise(d3Interpolate.interpolateCubehelix, ['red', 'green', 'blue']);
-iZoom = d3Interpolate.piecewise(d3Interpolate.interpolateZoom, [[50, 50, 300], [100, 100, 500]]);
 iNum = d3Interpolate.piecewise(d3Interpolate.interpolateNumber, [1, 2, 3]);
 iNum = d3Interpolate.piecewise(d3Interpolate.interpolateRound, [1.1, 2.2, 3.3]);
-iString = d3Interpolate.piecewise(d3Interpolate.interpolateString, ['a', 'b', 'c']);
+iString = d3Interpolate.piecewise(d3Interpolate.interpolateString, ['2px', '3px', '5px']);
 iDate = d3Interpolate.piecewise(d3Interpolate.interpolateDate, [new Date(2018, 5, 1), new Date(2018, 5, 2), new Date(2018, 5, 3)]);
-iArrayNum = d3Interpolate.piecewise<number[]>(d3Interpolate.interpolateArray, [1, 2, 4, 8]);
-iArrayStr = d3Interpolate.piecewise<string[]>(d3Interpolate.interpolateArray, ['a', 'b', 'c', 'd']);
-iArrayMixed = d3Interpolate.piecewise<[Date, string]>(d3Interpolate.interpolateArray, [new Date(2016, 6, 1), 'b: 1']);
 iString = d3Interpolate.piecewise(d3Interpolate.interpolateTransformCss, ['rotate(0deg)', 'rotate(60deg)']);
 iString = d3Interpolate.piecewise(d3Interpolate.interpolateTransformSvg, ['rotate(0)', 'rotate(60)']);
+
+iArrayNum = d3Interpolate.piecewise<number[]>(d3Interpolate.interpolateArray, [[1, 2], [4, 8]]);
+iArrayStr = d3Interpolate.piecewise<string[]>(d3Interpolate.interpolateArray, [['2px', '1em'], ['3px', '1.2em']]);
+iArrayMixed = d3Interpolate.piecewise<[Date, string]>(d3Interpolate.interpolateArray, [[new Date(2016, 6, 1), 'b: 1']]);

--- a/types/d3-interpolate/index.d.ts
+++ b/types/d3-interpolate/index.d.ts
@@ -1,97 +1,314 @@
-// Type definitions for D3JS d3-interpolate module 1.2
+// Type definitions for D3JS d3-interpolate module 1.3
 // Project: https://github.com/d3/d3-interpolate/
-// Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
+// Definitions by: Tom Wanzek <https://github.com/tomwanzek>
+//                 Alex Ford <https://github.com/gustavderdrache>
+//                 Boris Yankov <https://github.com/borisyankov>
+//                 denisname <https://github.com/denisname>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
 
-// Last module patch version validated against: 1.2.0
+// Last module patch version validated against: 1.3.2
 
 import { ColorCommonInstance } from 'd3-color';
 
-// --------------------------------------------------------------------------
+// ---------------------------------------------------------------------------
 // Shared Type Definitions and Interfaces
-// --------------------------------------------------------------------------
+// ---------------------------------------------------------------------------
 
 export interface ZoomInterpolator extends Function {
     (t: number): ZoomView;
     /**
-     * Recommended duration of zoom transition in ms
+     * Recommended duration of zoom transition in milliseconds.
      */
     duration: number;
 }
 
 export interface ColorGammaInterpolationFactory extends Function {
     (a: string | ColorCommonInstance, b: string | ColorCommonInstance): ((t: number) => string);
+    /**
+     * Returns a new interpolator factory of the same type using the specified *gamma*.
+     * For example, to interpolate from purple to orange with a gamma of 2.2 in RGB space: `d3.interpolateRgb.gamma(2.2)("purple", "orange")`.
+     * See Eric Brasseur’s article, [Gamma error in picture scaling](https://web.archive.org/web/20160112115812/http://www.4p8.com/eric.brasseur/gamma.html), for more on gamma correction.
+     */
     gamma(g: number): ColorGammaInterpolationFactory;
 }
 
 /**
  * Type zoomView is used to represent a numeric array with three elements.
  * In order of appearance the elements correspond to:
- * - cx: x-coordinate of the center of the viewport
- * - cy: y-coordinate of the center of the viewport
+ * - cx: *x*-coordinate of the center of the viewport
+ * - cy: *y*-coordinate of the center of the viewport
  * - width: size of the viewport
  */
 export type ZoomView = [number, number, number];
 
-// --------------------------------------------------------------------------
+// ---------------------------------------------------------------------------
 // Interpolation Function Factories
-// --------------------------------------------------------------------------
+// ---------------------------------------------------------------------------
 
+/**
+ * Returns an `null` constant interpolator.
+ */
 export function interpolate(a: any, b: null): ((t: number) => null);
-export function interpolate(a: number | { valueOf(): number }, b: number): ((t: number) => number);
-export function interpolate(a: any, b: ColorCommonInstance): ((t: number) => string);
-export function interpolate(a: Date, b: Date): ((t: number) => Date);
-export function interpolate(a: string | { toString(): string }, b: string): ((t: number) => string);
-export function interpolate<U extends any[]>(a: any[], b: U): ((t: number) => U);
-export function interpolate(a: number | { valueOf(): number }, b: { valueOf(): number }): ((t: number) => number);
-export function interpolate<U extends any>(a: any, b: U): ((t: number) => U); // TODO: extends 'any' should become 'object' with TS 2.2+ definitions
-export function interpolate(a: any, b: { [key: string]: any }): ((t: number) => { [key: string]: any });
 
+/**
+ * Returns an boolean constant interpolator of value `b`.
+ */
+export function interpolate(a: any, b: boolean): ((t: number) => boolean);
+
+/**
+ * Returns a `interpolateNumber` interpolator.
+ */
+export function interpolate(a: number | { valueOf(): number }, b: number): ((t: number) => number);
+
+/**
+ * Returns a `interpolateRgb` interpolator.
+ */
+export function interpolate(a: string | ColorCommonInstance, b: ColorCommonInstance): ((t: number) => string);
+
+/**
+ * Returns a `interpolateDate` interpolator.
+ */
+export function interpolate(a: Date, b: Date): ((t: number) => Date);
+
+/**
+ * Returns a `interpolateString` interpolator. If `b` is a string coercible to a color use use `interpolateRgb`.
+ */
+export function interpolate(a: string | { toString(): string }, b: string): ((t: number) => string);
+
+/**
+ * Returns a `interpolateArray` interpolator.
+ */
+export function interpolate<U extends any[]>(a: any[], b: U): ((t: number) => U);
+
+/**
+ * Returns a `interpolateNumber` interpolator.
+ */
+export function interpolate(a: number | { valueOf(): number }, b: { valueOf(): number }): ((t: number) => number);
+
+/**
+ * Returns a `interpolateObject` interpolator.
+ */
+export function interpolate<U extends object>(a: any, b: U): ((t: number) => U);
+
+/**
+ * Returns an interpolator between the two numbers `a` and `b`.
+ * The returned interpolator is equivalent to: `(t) => a * (1 - t) + b * t`.
+ */
 export function interpolateNumber(a: number | { valueOf(): number }, b: number | { valueOf(): number }): ((t: number) => number);
 
+/**
+ * Returns an interpolator between the two numbers `a` and `b`; the interpolator is similar to `interpolateNumber`,
+ * except it will round the resulting value to the nearest integer.
+ */
 export function interpolateRound(a: number | { valueOf(): number }, b: number | { valueOf(): number }): ((t: number) => number);
 
+/**
+ * Returns an interpolator between the two strings `a` and `b`.
+ * The string interpolator finds numbers embedded in `a` and `b`, where each number is of the form understood by JavaScript.
+ * A few examples of numbers that will be detected within a string: `-1`, `42`, `3.14159`, and `6.0221413e+23`.
+ *
+ * For each number embedded in `b`, the interpolator will attempt to find a corresponding number in `a`.
+ * If a corresponding number is found, a numeric interpolator is created using `interpolateNumber`.
+ * The remaining parts of the string `b` are used as a template.
+ *
+ * For example, if `a` is `"300 12px sans-serif"`, and `b` is `"500 36px Comic-Sans"`, two embedded numbers are found.
+ * The remaining static parts (of string `b`) are a space between the two numbers (`" "`), and the suffix (`"px Comic-Sans"`).
+ * The result of the interpolator at `t` = 0.5 is `"400 24px Comic-Sans"`.
+ */
 export function interpolateString(a: string | { toString(): string }, b: string | { toString(): string }): ((t: number) => string);
 
+/**
+ * Returns an interpolator between the two dates `a` and `b`.
+ *
+ * Note: *no defensive copy* of the returned date is created; the same Date instance is returned for every evaluation of the interpolator.
+ * No copy is made for performance reasons; interpolators are often part of the inner loop of animated transitions.
+ */
 export function interpolateDate(a: Date, b: Date): ((t: number) => Date);
 
 export type ArrayInterpolator<A extends any[]> = ((t: number) => A);
 
+/**
+ * Returns an interpolator between the two arrays `a` and `b`. Internally, an array template is created that is the same length in `b`.
+ * For each element in `b`, if there exists a corresponding element in `a`, a generic interpolator is created for the two elements using `interpolate`.
+ * If there is no such element, the static value from `b` is used in the template.
+ * Then, for the given parameter `t`, the template’s embedded interpolators are evaluated. The updated array template is then returned.
+ *
+ * For example, if `a` is the array `[0, 1]` and `b` is the array `[1, 10, 100]`, then the result of the interpolator for `t = 0.5` is the array `[0.5, 5.5, 100]`.
+ *
+ * Note: *no defensive copy* of the template array is created; modifications of the returned array may adversely affect subsequent evaluation of the interpolator.
+ * No copy is made for performance reasons; interpolators are often part of the inner loop of animated transitions.
+ */
 export function interpolateArray<A extends any[]>(a: any[], b: A): ArrayInterpolator<A>;
 
-export function interpolateObject<U extends any>(a: any, b: U): ((t: number) => U);  // TODO: extends 'any' should become 'object' with TS 2.2+ definitions
-export function interpolateObject(a: { [key: string]: any }, b: { [key: string]: any }): ((t: number) => { [key: string]: any });
+/**
+ * Returns an interpolator between the two objects `a` and `b`. Internally, an object template is created that has the same properties as `b`.
+ * For each property in `b`, if there exists a corresponding property in `a`, a generic interpolator is created for the two elements using `interpolate`.
+ * If there is no such property, the static value from `b` is used in the template.
+ * Then, for the given parameter `t`, the template's embedded interpolators are evaluated and the updated object template is then returned.
+ *
+ * For example, if `a` is the object `{x: 0, y: 1}` and `b` is the object `{x: 1, y: 10, z: 100}`, the result of the interpolator for `t = 0.5` is the object `{x: 0.5, y: 5.5, z: 100}`.
+ *
+ * Note: *no defensive copy* of the template object is created; modifications of the returned object may adversely affect subsequent evaluation of the interpolator.
+ * No copy is made for performance reasons; interpolators are often part of the inner loop of animated transitions.
+ */
+export function interpolateObject<U extends object>(a: any, b: U): ((t: number) => U);
 
+/**
+ * Returns an interpolator between the two 2D CSS transforms represented by `a` and `b`.
+ * Each transform is decomposed to a standard representation of translate, rotate, *x*-skew and scale; these component transformations are then interpolated.
+ * This behavior is standardized by CSS: see [matrix decomposition for animation](http://www.w3.org/TR/css3-2d-transforms/#matrix-decomposition).
+ */
 export function interpolateTransformCss(a: string, b: string): ((t: number) => string);
+
+/**
+ * Returns an interpolator between the two 2D SVG transforms represented by `a` and `b`.
+ * Each transform is decomposed to a standard representation of translate, rotate, *x*-skew and scale; these component transformations are then interpolated.
+ * This behavior is standardized by CSS: see [matrix decomposition for animation](http://www.w3.org/TR/css3-2d-transforms/#matrix-decomposition).
+ */
 export function interpolateTransformSvg(a: string, b: string): ((t: number) => string);
 
 /**
- * Create Interpolator for zoom views
+ * Returns an interpolator between the two views `a` and `b` of a two-dimensional plane,
+ * based on [“Smooth and efficient zooming and panning”](http://www.win.tue.nl/~vanwijk/zoompan.pdf).
+ * Each view is defined as an array of three numbers: *cx*, *cy* and *width*.
+ * The first two coordinates *cx*, *cy* represent the center of the viewport; the last coordinate *width* represents the size of the viewport.
+ *
+ * The returned interpolator exposes a *duration* property which encodes the recommended transition duration in milliseconds.
+ * This duration is based on the path length of the curved trajectory through *x,y* space.
+ * If you want to a slower or faster transition, multiply this by an arbitrary scale factor (*V* as described in the original paper).
  */
 export function interpolateZoom(a: ZoomView, b: ZoomView): ZoomInterpolator;
 
+/**
+ * Returns a discrete interpolator for the given array of values. The returned interpolator maps `t` in `[0, 1 / n)` to values[0],
+ * `t` in `[1 / n, 2 / n)` to `values[1]`, and so on, where `n = values.length`. In effect, this is a lightweight quantize scale with a fixed domain of [0, 1].
+ */
+export function interpolateDiscrete<T>(values: T[]): ((t: number) => T);
+
+// Sampling ------------------------------------------------------------------
+
+/**
+ * Returns `n` uniformly-spaced samples from the specified `interpolator`, where `n` is an integer greater than one.
+ * The first sample is always at `t = 0`, and the last sample is always at `t = 1`.
+ * This can be useful in generating a fixed number of samples from a given interpolator,
+ * such as to derive the range of a [quantize scale](https://github.com/d3/d3-scale#quantize-scales) from a [continuous interpolator](https://github.com/d3/d3-scale#interpolateWarm).
+ *
+ * Caution: this method will not work with interpolators that do not return defensive copies of their output,
+ * such as `d3.interpolateArray`, `d3.interpolateDate` and `d3.interpolateObject`. For those interpolators, you must wrap the interpolator and create a copy for each returned value.
+ */
 export function quantize<T>(interpolator: ((t: number) => T), n: number): T[];
 
-// Color interpolation related
+// Color Spaces
 
+/**
+ * Returns an RGB color space interpolator between the two colors `a` and `b` with a configurable gamma. If the gamma is not specified, it defaults to 1.0.
+ * The colors `a` and `b` need not be in RGB; they will be converted to RGB using [`d3.rgb`](https://github.com/d3/d3-color#rgb). The return value of the interpolator is an RGB string.
+ */
 export const interpolateRgb: ColorGammaInterpolationFactory;
 
+/**
+ * Returns a uniform nonrational B-spline interpolator through the specified array of *colors*, which are converted to RGB color space.
+ * Implicit control points are generated such that the interpolator returns `colors[0]` at `t = 0` and `colors[colors.length - 1]` at `t = 1`.
+ * Opacity interpolation is not currently supported. See also `d3.interpolateBasis`, and see [d3-scale-chromatic](https://github.com/d3/d3-scale-chromatic) for examples.
+ */
 export function interpolateRgbBasis(colors: Array<string | ColorCommonInstance>): ((t: number) => string);
+
+/**
+ * Returns a uniform nonrational B-spline interpolator through the specified array of colors, which are converted to RGB color space.
+ * The control points are implicitly repeated such that the resulting spline has cyclical C² continuity when repeated around `t` in [0,1];
+ * this is useful, for example, to create cyclical color scales. Opacity interpolation is not currently supported.
+ * See also `d3.interpolateBasisClosed, and see [d3-scale-chromatic](https://github.com/d3/d3-scale-chromatic) for examples.
+ */
 export function interpolateRgbBasisClosed(colors: Array<string | ColorCommonInstance>): ((t: number) => string);
 
+/**
+ * Returns an HSL color space interpolator between the two colors *a* and *b*. The colors *a* and *b* need not be in HSL;
+ * they will be converted to HSL using `d3.hsl`. If either color’s hue or saturation is NaN, the opposing color’s channel value is used.
+ * The shortest path between hues is used. The return value of the interpolator is an RGB string.
+ */
 export function interpolateHsl(a: string | ColorCommonInstance, b: string | ColorCommonInstance): ((t: number) => string);
+
+/**
+ * Like `interpolateHsl`, but does not use the shortest path between hues.
+ */
 export function interpolateHslLong(a: string | ColorCommonInstance, b: string | ColorCommonInstance): ((t: number) => string);
+
+/**
+ * Returns a Lab color space interpolator between the two colors *a* and *b*. The colors *a* and *b* need not be in Lab;
+ * they will be converted to Lab using `d3.lab`. The return value of the interpolator is an RGB string.
+ */
 export function interpolateLab(a: string | ColorCommonInstance, b: string | ColorCommonInstance): ((t: number) => string);
+
+/**
+ * Returns an HCL color space interpolator between the two colors `a` and `b`. The colors `a` and `b` need not be in HCL;
+ * they will be converted to HCL using `d3.hcl`. If either color’s hue or chroma is NaN, the opposing color’s channel value is used.
+ * The shortest path between hues is used. The return value of the interpolator is an RGB string.
+ */
 export function interpolateHcl(a: string | ColorCommonInstance, b: string | ColorCommonInstance): ((t: number) => string);
+
+/**
+ * Like `interpolateHcl`, but does not use the shortest path between hues.
+ */
 export function interpolateHclLong(a: string | ColorCommonInstance, b: string | ColorCommonInstance): ((t: number) => string);
+
+/**
+ * Returns a Cubehelix color space interpolator between the two colors `a` and `b` using a configurable `gamma`.
+ * If the gamma is not specified, it defaults to 1.0. The colors `a` and `b` need not be in Cubehelix;
+ * they will be converted to Cubehelix using [`d3.cubehelix`](https://github.com/d3/d3-color#cubehelix).
+ * If either color’s hue or saturation is NaN, the opposing color’s channel value is used. The shortest path between hues is used. The return value of the interpolator is an RGB string.
+ */
 export const interpolateCubehelix: ColorGammaInterpolationFactory;
+
+/**
+ * Like `interpolateCubehelix`, but does not use the shortest path between hues.
+ */
 export const interpolateCubehelixLong: ColorGammaInterpolationFactory;
 
-// Spline related
+/**
+ * Returns an interpolator between the two hue angles `a` and `b`. If either hue is NaN, the opposing value is used.
+ * The shortest path between hues is used. The return value of the interpolator is a number in `[0, 360)`.
+ */
+export function interpolateHue(a: number, b: number): ((t: number) => number);
 
+// Splines -------------------------------------------------------------------
+
+/**
+ * Returns a uniform nonrational B-spline interpolator through the specified array of `values`, which must be numbers.
+ * Implicit control points are generated such that the interpolator returns `values[0]` at `t` = 0 and `values[values.length - 1]` at `t` = 1.
+ * See also [`d3.curveBasis`](https://github.com/d3/d3-shape#curveBasis).
+ */
 export function interpolateBasis(splineNodes: number[]): ((t: number) => number);
+
+/**
+ * Returns a uniform nonrational B-spline interpolator through the specified array of `values`, which must be numbers.
+ * The control points are implicitly repeated such that the resulting one-dimensional spline has cyclical C² continuity when repeated around `t` in [0,1].
+ * See also [`d3.curveBasisClosed`](https://github.com/d3/d3-shape#curveBasisClosed).
+ */
 export function interpolateBasisClosed(splineNodes: number[]): ((t: number) => number);
 
+// Piecewise -----------------------------------------------------------------
+
+/**
+ * Returns a piecewise zoom interpolator, composing zoom interpolators for each adjacent pair of zoom view.
+ * The returned interpolator maps `t` in `[0, 1 / (n - 1)]` to `interpolate(values[0], values[1])`, `t` in `[1 / (n - 1), 2 / (n - 1)]` to `interpolate(values[1], values[2])`,
+ * and so on, where `n = values.length`. In effect, this is a lightweight linear scale.
+ * For example, to blend through three different zoom views: `d3.piecewise(d3.interpolateZoom, [[0, 0, 1], [0, 0, 10], [0, 0, 15]])`.
+ */
 export function piecewise(interpolate: (a: ZoomView, b: ZoomView) => ZoomInterpolator, values: ZoomView[]): ZoomInterpolator;
-export function piecewise<A extends any[]>(interpolate: (a: any[], b: A) => ArrayInterpolator<A>, values: A): ArrayInterpolator<A>;
+
+/**
+ * Returns a piecewise array interpolator, composing array interpolators for each adjacent pair of arrays.
+ * The returned interpolator maps `t` in `[0, 1 / (n - 1)]` to `interpolate(values[0], values[1])`, `t` in `[1 / (n - 1), 2 / (n - 1)]` to `interpolate(values[1], values[2])`,
+ * and so on, where `n = values.length`. In effect, this is a lightweight linear scale.
+ * For example, to blend through three different arrays: `d3.piecewise(d3.interpolateArray, [[0, 0, 1], [0, 0, 10], [0, 0, 15]])`.
+ */
+export function piecewise<A extends any[]>(interpolate: (a: any[], b: A) => ArrayInterpolator<A>, values: A[]): ArrayInterpolator<A>;
+
+/**
+ * Returns a piecewise interpolator, composing interpolators for each adjacent pair of values.
+ * The returned interpolator maps `t` in `[0, 1 / (n - 1)]` to `interpolate(values[0], values[1])`, `t` in `[1 / (n - 1), 2 / (n - 1)]` to `interpolate(values[1], values[2])`,
+ * and so on, where `n = values.length`. In effect, this is a lightweight linear scale.
+ * For example, to blend through red, green and blue: `d3.piecewise(d3.interpolateRgb.gamma(2.2), ["red", "green", "blue"])`.
+ */
 export function piecewise<TData, Interpolator>(interpolate: (a: TData, b: TData) => Interpolator, values: TData[]): (t: number) => any;

--- a/types/d3-interpolate/tsconfig.json
+++ b/types/d3-interpolate/tsconfig.json
@@ -7,7 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
-        "strictNullChecks": false,
+        "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/d3-interpolate/tslint.json
+++ b/types/d3-interpolate/tslint.json
@@ -2,7 +2,6 @@
     "extends": "dtslint/dt.json",
     "rules": {
         "unified-signatures": false,
-        "callable-types": false,
         "no-unnecessary-generics": false
     }
 }

--- a/types/d3-scale/index.d.ts
+++ b/types/d3-scale/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/d3/d3-scale/
 // Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
 
 // Last module patch version validated against: 2.0.0
 

--- a/types/d3-scale/v1/index.d.ts
+++ b/types/d3-scale/v1/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/d3/d3-scale/
 // Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
 
 // Last module patch version validated against: 1.0.7
 

--- a/types/d3-selection-multi/index.d.ts
+++ b/types/d3-selection-multi/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/d3/d3-selection-multi/
 // Definitions by: Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
 
 // Last module patch version validated against: 1.0.0
 

--- a/types/d3-transition/index.d.ts
+++ b/types/d3-transition/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/d3/d3-transition/
 // Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
 
 // Last module patch version validated against: 1.1
 

--- a/types/d3-zoom/index.d.ts
+++ b/types/d3-zoom/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/d3/d3-zoom/
 // Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
 
 // Last module patch version validated against: 1.7.0
 


### PR DESCRIPTION
Update definition to 1.3: add `interpolateDiscrete` and `interpolateHue`.
Add JsDoc.
Activate strictNullChecks. Code and tests were already good...
TS 2.3: use `object` in `interpolate` and `interpolateObject`.
Correction in `piecewise`, `values` is an array.
Use `$ExpectError`.
Linting: remove callable-types.
For strictFunctionTypes, I have nothing to add.

Related #23611.