### PR TITLE
[jasminewd2] Add `DoneFn` to supporting functions

### DIFF
--- a/types/jasminewd2/index.d.ts
+++ b/types/jasminewd2/index.d.ts
@@ -1,18 +1,19 @@
 // Type definitions for jasminewd2 2.0
 // Project: https://github.com/angular/jasminewd
 // Definitions by: Sammy Jelin <https://github.com/sjelin>
+//                 George Kalpakas <https://github.com/gkalpak>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.1
 
 /// <reference types="jasmine" />
 
-declare function it(expectation: string, assertion?: () => Promise<void>, timeout?: number): void;
-declare function fit(expectation: string, assertion?: () => Promise<void>, timeout?: number): void;
-declare function xit(expectation: string, assertion?: () => Promise<void>, timeout?: number): void;
-declare function beforeEach(action: () => Promise<void>, timeout?: number): void;
-declare function afterEach(action: () => Promise<void>, timeout?: number): void;
-declare function beforeAll(action: () => Promise<void>, timeout?: number): void;
-declare function afterAll(action: () => Promise<void>, timeout?: number): void;
+declare function it(expectation: string, assertion?: (done: DoneFn) => Promise<void>, timeout?: number): void;
+declare function fit(expectation: string, assertion?: (done: DoneFn) => Promise<void>, timeout?: number): void;
+declare function xit(expectation: string, assertion?: (done: DoneFn) => Promise<void>, timeout?: number): void;
+declare function beforeEach(action: (done: DoneFn) => Promise<void>, timeout?: number): void;
+declare function afterEach(action: (done: DoneFn) => Promise<void>, timeout?: number): void;
+declare function beforeAll(action: (done: DoneFn) => Promise<void>, timeout?: number): void;
+declare function afterAll(action: (done: DoneFn) => Promise<void>, timeout?: number): void;
 
 declare namespace jasmine {
   interface Matchers<T> {

--- a/types/jasminewd2/jasminewd2-tests.ts
+++ b/types/jasminewd2/jasminewd2-tests.ts
@@ -1,6 +1,4 @@
-let promise = new Promise<void>((resolve, reject) => {
-  resolve();
-});
+const promise = Promise.resolve();
 
 describe('jasminewd', () => {
   describe('global it, fit, xit, before and after', () => {
@@ -30,6 +28,34 @@ describe('jasminewd', () => {
 
     afterAll(() => {
       return promise;
+    });
+
+    it('should be able to use DoneFn', done => {
+      promise.then(done, done.fail);
+    });
+
+    fit('should be able to use DoneFn', done => {
+      promise.then(done, done.fail);
+    });
+
+    xit('should be able to use DoneFn', done => {
+      promise.then(done, done.fail);
+    });
+
+    beforeEach(done => {
+      promise.then(done, done.fail);
+    });
+
+    afterEach(done => {
+      promise.then(done, done.fail);
+    });
+
+    beforeAll(done => {
+      promise.then(done, done.fail);
+    });
+
+    afterAll(done => {
+      promise.then(done, done.fail);
     });
   });
 


### PR DESCRIPTION
`jasminewd2` [supports][1] Jasmine's passing a `DoneFn` callback to global `it`/`fit`/`xit`/`beforeAll`/`beforeEach`/`afterAll`/`afterEach`
functions, but the types did not reflect that.

(Related: Workaround in [angular/angular][2].)

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/angular/jasminewd/blob/236b0d211ef7b8510629dcbc7d2a18afaabd2f10/index.js#L102-L118
- [ ] ~~Increase the version number in the header if appropriate.~~
- [ ] ~~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.~~

[1]: https://github.com/angular/jasminewd/blob/236b0d211ef7b8510629dcbc7d2a18afaabd2f10/index.js#L102-L118
[2]: https://github.com/angular/angular/blob/8f81dba367912d5c905dcd90893475e563bc2eea/tools/types-ext/jasminewd2.d.ts