### PR TITLE
adds typings for the 'encoding-down' package

### DIFF
--- a/types/encoding-down/encoding-down-tests.ts
+++ b/types/encoding-down/encoding-down-tests.ts
@@ -1,0 +1,13 @@
+import { AbstractLevelDOWN } from 'abstract-leveldown';
+import EncodingDOWN from 'encoding-down';
+
+const test = (encoding: EncodingDOWN) => {
+    encoding.put("key", "value", (err?: Error) => { });
+    encoding.put(1, "value", { something: true }, (err?: Error) => { });
+
+    encoding.get("key", (err?: Error) => { });
+    encoding.get(1, { something: true }, (err: Error | undefined, value: any) => { });
+};
+
+// $ExpectType void
+test(new EncodingDOWN(new AbstractLevelDOWN("here")));

--- a/types/encoding-down/index.d.ts
+++ b/types/encoding-down/index.d.ts
@@ -1,0 +1,59 @@
+// Type definitions for encoding-down 5.0
+// Project: https://github.com/Level/encoding-down
+// Definitions by: Meirion Hughes <https://github.com/MeirionHughes>
+//                 Daniel Byrne <https://github.com/danwbyrne>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
+
+import {
+  AbstractLevelDOWN,
+  AbstractIteratorOptions,
+  AbstractIterator,
+  AbstractOpenOptions,
+  AbstractGetOptions,
+  ErrorCallback,
+  ErrorValueCallback,
+  AbstractChainedBatch,
+  AbstractBatch,
+  AbstractOptions
+} from 'abstract-leveldown';
+
+import { CodecOptions, CodecEncoder } from 'level-codec';
+
+interface EncodingDown<K = any, V = any> extends AbstractLevelDOWN<K, V> {
+  get(key: K, cb: ErrorValueCallback<V>): void;
+  get(key: K, options: EncodingDown.GetOptions, cb: ErrorValueCallback<V>): void;
+
+  put(key: K, value: V, cb: ErrorCallback): void;
+  put(key: K, value: V, options: EncodingDown.PutOptions, cb: ErrorCallback): void;
+
+  del(key: K, cb: ErrorCallback): void;
+  del(key: K, options: EncodingDown.DelOptions, cb: ErrorCallback): void;
+
+  batch(): EncodingDown.ChainedBatch;
+  batch(array: AbstractBatch[], cb: ErrorCallback): EncodingDown.ChainedBatch;
+  batch(array: AbstractBatch[], options: EncodingDown.BatchOptions, cb: ErrorCallback): EncodingDown.ChainedBatch;
+
+  iterator(options?: EncodingDown.IteratorOptions): AbstractIterator<any, any>;
+}
+
+declare namespace EncodingDown {
+  interface GetOptions extends AbstractGetOptions, CodecOptions {}
+  interface PutOptions extends AbstractOptions, CodecOptions {}
+  interface DelOptions extends AbstractOptions, CodecOptions {}
+  interface BatchOptions extends AbstractOptions, CodecOptions {}
+  interface IteratorOptions extends AbstractIteratorOptions, CodecOptions {}
+  interface ChainedBatch<K = any, V = any> extends AbstractChainedBatch<K, V> {
+    write(cb: any): any;
+    write(options: CodecOptions & AbstractOptions, cb: any): any;
+  }
+  interface Constructor {
+    // tslint:disable-next-line:no-unnecessary-generics
+    <K = any, V = any>(db: AbstractLevelDOWN, options?: CodecOptions): EncodingDown<K, V>;
+    // tslint:disable-next-line:no-unnecessary-generics
+    new <K = any, V = any>(db: AbstractLevelDOWN, options?: CodecOptions): EncodingDown<K, V>;
+  }
+}
+
+declare const EncodingDown: EncodingDown.Constructor;
+export default EncodingDown;

--- a/types/encoding-down/tsconfig.json
+++ b/types/encoding-down/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "encoding-down-tests.ts"
+    ]
+}

--- a/types/encoding-down/tslint.json
+++ b/types/encoding-down/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

in hindsight the pattern I use here is probably the most appropriate way to type out this library, but I'm not sure I'll find the time to make adjustments to the other level packages.
