### PR TITLE
Added definitions for node-redis-pubsub

### DIFF
--- a/types/node-redis-pubsub/index.d.ts
+++ b/types/node-redis-pubsub/index.d.ts
@@ -1,0 +1,28 @@
+// Type definitions for node-redis-pubsub 3.0.0
+// Project: https://github.com/louischatriot/node-redis-pubsub#readme
+// Definitions by: Rene Keijzer <https://github.com/renekeijzer>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+
+
+
+
+import *  as redis from 'redis';
+
+declare function NRP(options:object) : NRP.NodeRedisPubSub;
+declare namespace NRP {
+    function initClient(options:object) : NRP.NodeRedisPubSub;
+
+    class NodeRedisPubSub {
+        constructor(options : object);
+        getRedisClient(any:void): redis.RedisClient;
+        on(channel:string, handler:Function, callback?:Function):Function;
+        subscribe(channel:string, handler:Function, callback?:Function):Function;
+        emit(channel:string, message:string) : any;
+        publish(channel:string, message:string) : any;
+        quit(any:void):void;
+        end(any:void):void;
+    }
+}
+
+export = NRP;

--- a/types/node-redis-pubsub/index.d.ts
+++ b/types/node-redis-pubsub/index.d.ts
@@ -4,7 +4,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
-import * as redis from 'redis';
+import * as redis from "redis";
 
 declare function NRP(options: object): NRP.NodeRedisPubSub;
 declare namespace NRP {
@@ -12,8 +12,16 @@ declare namespace NRP {
     class NodeRedisPubSub {
         constructor(options: object);
         getRedisClient(): redis.RedisClient;
-        on(channel: string, handler: () => void, callback?: () => void): () => void;
-        subscribe(channel: string, handler: () => void, callback?: () => void): () => void;
+        on(
+            channel: string,
+            handler: (data: string, channel: string) => void,
+            callback?: () => void
+        ): () => void;
+        subscribe(
+            channel: string,
+            handler: (data: string, channel: string) => void,
+            callback?: () => void
+        ): () => void;
         emit(channel: string, message: string): void;
         publish(channel: string, message: string): void;
         quit(): void;

--- a/types/node-redis-pubsub/index.d.ts
+++ b/types/node-redis-pubsub/index.d.ts
@@ -1,27 +1,23 @@
-// Type definitions for node-redis-pubsub 3.0.0
+// Type definitions for node-redis-pubsub 3.0
 // Project: https://github.com/louischatriot/node-redis-pubsub#readme
 // Definitions by: Rene Keijzer <https://github.com/renekeijzer>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.2
 
+import * as redis from 'redis';
 
-
-
-
-import *  as redis from 'redis';
-
-declare function NRP(options:object) : NRP.NodeRedisPubSub;
+declare function NRP(options: object): NRP.NodeRedisPubSub;
 declare namespace NRP {
-    function initClient(options:object) : NRP.NodeRedisPubSub;
-
+    function initClient(options: object): NodeRedisPubSub;
     class NodeRedisPubSub {
-        constructor(options : object);
-        getRedisClient(any:void): redis.RedisClient;
-        on(channel:string, handler:Function, callback?:Function):Function;
-        subscribe(channel:string, handler:Function, callback?:Function):Function;
-        emit(channel:string, message:string) : any;
-        publish(channel:string, message:string) : any;
-        quit(any:void):void;
-        end(any:void):void;
+        constructor(options: object);
+        getRedisClient(): redis.RedisClient;
+        on(channel: string, handler: () => void, callback?: () => void): () => void;
+        subscribe(channel: string, handler: () => void, callback?: () => void): () => void;
+        emit(channel: string, message: string): void;
+        publish(channel: string, message: string): void;
+        quit(): void;
+        end(): void;
     }
 }
 

--- a/types/node-redis-pubsub/node-redis-pubsub-tests.ts
+++ b/types/node-redis-pubsub/node-redis-pubsub-tests.ts
@@ -1,0 +1,19 @@
+import * as NRP from "node-redis-pubsub";
+import { RedisClient } from "redis";
+
+const options = {
+    port: 6379
+};
+const nrp: NRP.NodeRedisPubSub = NRP(options);
+
+nrp.on("message:*", (data, channel) => {});
+
+nrp.subscribe("message:*", (data, channel) => {});
+
+const redis: RedisClient = nrp.getRedisClient();
+
+nrp.emit("message:test", "hello world");
+nrp.publish("message:test2", "hello world2");
+
+nrp.quit();
+nrp.end();

--- a/types/node-redis-pubsub/node-redis-pubsub-tests.ts
+++ b/types/node-redis-pubsub/node-redis-pubsub-tests.ts
@@ -1,4 +1,4 @@
-import * as NRP from "node-redis-pubsub";
+import NRP = require("node-redis-pubsub");
 import { RedisClient } from "redis";
 
 const options = {

--- a/types/node-redis-pubsub/package.json
+++ b/types/node-redis-pubsub/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "node-redis-pubsub",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@types/redis": "^2.8.6"
+  }
+}

--- a/types/node-redis-pubsub/package.json
+++ b/types/node-redis-pubsub/package.json
@@ -1,12 +1,5 @@
 {
-  "name": "node-redis-pubsub",
-  "version": "1.0.0",
-  "description": "",
-  "main": "index.js",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
-  "author": "",
+  "private":true,
   "license": "ISC",
   "dependencies": {
     "@types/redis": "^2.8.6"

--- a/types/node-redis-pubsub/package.json
+++ b/types/node-redis-pubsub/package.json
@@ -1,6 +1,5 @@
 {
   "private":true,
-  "license": "MIT",
   "dependencies": {
     "@types/redis": "^2.8.6"
   }

--- a/types/node-redis-pubsub/package.json
+++ b/types/node-redis-pubsub/package.json
@@ -1,6 +1,0 @@
-{
-  "private":true,
-  "dependencies": {
-    "@types/redis": "^2.8.6"
-  }
-}

--- a/types/node-redis-pubsub/package.json
+++ b/types/node-redis-pubsub/package.json
@@ -1,6 +1,6 @@
 {
   "private":true,
-  "license": "ISC",
+  "license": "MIT",
   "dependencies": {
     "@types/redis": "^2.8.6"
   }

--- a/types/node-redis-pubsub/tsconfig.json
+++ b/types/node-redis-pubsub/tsconfig.json
@@ -1,5 +1,5 @@
 {
-"compilerOptions": {
+    "compilerOptions": {
         "module": "commonjs",
         "lib": [
             "es6"
@@ -17,6 +17,7 @@
         "forceConsistentCasingInFileNames": true
     },
     "files": [
-        "index.d.ts"
+        "index.d.ts",
+        "node-redis-pubsub-tests.ts"
     ]
 }

--- a/types/node-redis-pubsub/tsconfig.json
+++ b/types/node-redis-pubsub/tsconfig.json
@@ -1,0 +1,22 @@
+{
+"compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts"
+    ]
+}

--- a/types/node-redis-pubsub/tslint.json
+++ b/types/node-redis-pubsub/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.) => worked on my pubsub demo @ tsc 3.0.3
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [X] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [X] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [X] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [X] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
