### PR TITLE
[react-native] Account for `nativeOnly` props in `requireNativeComponent`

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -8970,11 +8970,13 @@ export interface ComponentInterface<P> {
  * Common types are lined up with the appropriate prop differs with
  * `TypeToDifferMap`.  Non-scalar types not in the map default to `deepDiffer`.
  */
-export function requireNativeComponent<P>(
+export function requireNativeComponent<P, NP = {}>(
     viewName: string,
     componentInterface?: ComponentInterface<P>,
-    extraConfig?: { nativeOnly?: any }
-): React.ComponentClass<PropTypes.InferProps<PropTypes.ValidationMap<P>>>;
+    extraConfig?: { nativeOnly?: NP }
+): React.ComponentClass<
+    Partial<PropTypes.InferProps<PropTypes.ValidationMap<P>>> & { [K in keyof NP]?: any}
+>;
 
 export function findNodeHandle(
     componentOrHandle: null | number | React.Component<any, any> | React.ComponentClass<any>

--- a/types/react-native/test/index.tsx
+++ b/types/react-native/test/index.tsx
@@ -11,6 +11,7 @@ The content of index.io.js could be something like
 For a list of complete Typescript examples: check https://github.com/bgrieder/RNTSExplorer
 */
 
+import * as PropTypes from "prop-types";
 import * as React from "react";
 import {
     Alert,
@@ -75,6 +76,7 @@ import {
     Modal,
     TimePickerAndroid,
     ViewPropTypes,
+    requireNativeComponent,
 } from "react-native";
 
 declare module "react-native" {
@@ -762,3 +764,20 @@ const TimePickerAndroidTest = () => (
         mode: 'spinner'
     })
 )
+
+class BridgedComponentTest extends React.Component {
+    static propTypes = {
+        jsProp: PropTypes.string.isRequired,
+        ...ViewPropTypes,
+    }
+
+    render() {
+        return <NativeBridgedComponent {...this.props} nativeProp="test" />;
+    }
+}
+
+const NativeBridgedComponent = requireNativeComponent("NativeBridgedComponent", BridgedComponentTest, {
+    nativeOnly: {
+        nativeProp: true,
+    }
+});


### PR DESCRIPTION
Adjusted the prop types of the returned native component class so that (a) the `nativeOnly` set of props adds to the prop types and (b) not all the props from the JS component are required (using `Partial`).

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: https://facebook.github.io/react-native/docs/native-components-ios#properties (search for "nativeOnly")
- [x] Increase the version number in the header if appropriate. **N/A**
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. **N/A**