### PR TITLE
[@types/stripe] Fixed StripeWebhookEvent.created to be a number

### DIFF
--- a/types/stripe/index.d.ts
+++ b/types/stripe/index.d.ts
@@ -3627,7 +3627,7 @@ declare namespace Stripe {
             id: string;
             object: string;
             api_version: string;
-            created: Date;
+            created: number;
             data: {
               object: T;
             };


### PR DESCRIPTION
The data received by a webhook endpoint is an almost identical object to the [Event Object](https://stripe.com/docs/api#event_object-created), thus this should be a `number` instead of a `Date`.

![screenshot from 2018-09-17 23-03-55](https://user-images.githubusercontent.com/1110972/45667438-ff5ac180-bacd-11e8-8eca-68801a76fa57.png)
