### PR TITLE
react-native-google-signin: StatusCodes enum

### DIFF
--- a/types/react-native-google-signin/index.d.ts
+++ b/types/react-native-google-signin/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for react-native-google-signin 0.12
 // Project: https://github.com/devfd/react-native-google-signin
 // Definitions by: Jacob Froman <https://github.com/j-fro>
+//                 Michele Bombardi <https://github.com/bm-software>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -143,4 +144,11 @@ export namespace GoogleSignin {
      * Removes your application from the user's authorized applications
      */
     function revokeAccess(): Promise<void>;
+}
+
+export enum StatusCodes {
+    SIGN_IN_CANCELLED = '12501',
+    IN_PROGRESS = 'ASYNC_OP_IN_PROGRESS',
+    PLAY_SERVICES_NOT_AVAILABLE = 'PLAY_SERVICES_NOT_AVAILABLE',
+    SIGN_IN_REQUIRED = '4',
 }

--- a/types/react-native-google-signin/index.d.ts
+++ b/types/react-native-google-signin/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-native-google-signin 0.12
+// Type definitions for react-native-google-signin 0.13
 // Project: https://github.com/devfd/react-native-google-signin
 // Definitions by: Jacob Froman <https://github.com/j-fro>
 //                 Michele Bombardi <https://github.com/bm-software>


### PR DESCRIPTION
Adding simple enum to mapping `statusCodes` from the original library: [see here](https://github.com/react-native-community/react-native-google-signin/blob/master/src/GoogleSignin.js#L9).


