### PR TITLE
Add missing unescape method to chrome.cast

### DIFF
--- a/types/chrome/chrome-cast/index.d.ts
+++ b/types/chrome/chrome-cast/index.d.ts
@@ -195,6 +195,14 @@ declare namespace chrome.cast {
         errorCallback: (error: chrome.cast.Error) => void
     ): void
 
+    /**
+     * @param {string} escaped A string to unescape.
+     * @see https://developers.google.com/cast/docs/reference/chrome/chrome.cast#.unescape
+     */
+    export function unescape(
+        escaped: string
+    ): string
+
     export class ApiConfig {
         /**
          * @param {!chrome.cast.SessionRequest} sessionRequest


### PR DESCRIPTION
## Description
Add missing `unescape` method to `chrome.cast`. This method is used to unescape HTML escaped strings, specifically useful to unescape device friendly names.

## PR check list
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.) - **No tests for chromecast**
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Adding an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developers.google.com/cast/docs/reference/chrome/chrome.cast#.unescape
