### PR TITLE
Update index.d.ts to fix the type of the result of d3.format() so Axis.tickFormat can pass it what it wants to.

### DIFF
--- a/types/d3-format/index.d.ts
+++ b/types/d3-format/index.d.ts
@@ -186,7 +186,8 @@ export function formatDefaultLocale(defaultLocale: FormatLocaleDefinition): Form
  * @param specifier A Specifier string.
  * @throws Error on invalid format specifier.
  */
-export function format(specifier: string): (n: number | { valueOf(): number }) => string;
+export function format(specifier: string):
+    (n: (number | {valueOf: () => number }), index?: number) => string;
 
 /**
  * Returns a new format function for the given string specifier. The returned function


### PR DESCRIPTION
Fix the type of the result of d3.format() so Axis.tickFormat can pass it what it wants to.

Simple enough change, which I have tested in my use case, but I don't have time to follow through with the entire process here.  Here is some background on how I arrived at this change:

The typings for typescript are missing some options for parameter passing that d3 (so generously) allows.  This is probably true in a number of other cases, but I was just tripped by the following:

  (someAxis).tickFormat(d3.format(',.0f'))

This resulted in: error TS2345: Argument of type '(n: number) => string' is not assignable to parameter of type 'null'.

which is fairly obscure.  It turns out that the parameter of type 'null' is the fallback alternative for tickFormat, specified in typings/d3_axis/index.d.ts:

   tickFormat(format: null): this;

since the other alternatives are failing.  But why?  Commenting out that alternative forces the type checker to try the other alternatives, which results in:

error TS2345: Argument of type '(n: number) => string' is not assignable to parameter of type '(domainValue: number | { valueOf(): number; }, index: number) => string'.
  Types of parameters 'n' and 'domainValue' are incompatible.
    Type 'number | { valueOf(): number; }' is not assignable to type 'number'.
      Type '{ valueOf(): number; }' is not assignable to type 'number'.

This is about what the d3.format function returns, which is declared in typings/d3_format/index.d.ts:

export function format(specifier: string): (n: number) => string;

Note that there is no complaint about the second argument that tickFormat wants to pass to d3.format, the index: number, though it seems that it should complain.
