### PR TITLE
[three] Fix ExtrudeGeometry typo and parameter type

### DIFF
--- a/types/three/three-core.d.ts
+++ b/types/three/three-core.d.ts
@@ -7241,7 +7241,7 @@ export class EdgesGeometry extends BufferGeometry {
     constructor(geometry: BufferGeometry | Geometry, thresholdAngle?: number);
 }
 
-export interface ExtrueGeometryOptions {
+export interface ExtrudeGeometryOptions {
     curveSegments?: number;
     steps?: number;
     depth?: number;
@@ -7259,7 +7259,7 @@ export interface UVGenerator {
 }
 
 export class ExtrudeGeometry extends Geometry {
-    constructor(shape: Shape | Shape[], options?: ExtrueGeometryOptions);
+    constructor(shapes: Shape | Shape[], options?: ExtrudeGeometryOptions);
 
     static WorldUVGenerator: UVGenerator;
 
@@ -7268,7 +7268,7 @@ export class ExtrudeGeometry extends Geometry {
 }
 
 export class ExtrudeBufferGeometry extends BufferGeometry {
-    constructor(shapes?: Shape[], options?: ExtrueGeometryOptions);
+    constructor(shapes: Shape | Shape[], options?: ExtrudeGeometryOptions);
 
     static WorldUVGenerator: UVGenerator;
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/mrdoob/three.js/blob/master/src/geometries/ExtrudeGeometry.js#L76
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
