### PR TITLE
adds basic typings for the 'bytewise' package

### DIFF
--- a/types/bytewise/bytewise-tests.ts
+++ b/types/bytewise/bytewise-tests.ts
@@ -1,0 +1,10 @@
+import bytewise = require('bytewise');
+
+// $ExpectType Buffer
+bytewise.encode([1, 2, 3]);
+
+// $ExpectType any
+bytewise.decode(bytewise.encode([1, 2 , 3]));
+
+// $ExpectType Buffer
+bytewise.encode(bytewise.sorts.array.bound.lower(['123', -1, 0x123, Buffer.from('test')]));

--- a/types/bytewise/index.d.ts
+++ b/types/bytewise/index.d.ts
@@ -1,0 +1,16 @@
+// Type definitions for bytewise 1.1
+// Project: https://github.com/deanlandolt/bytewise
+// Definitions by: Daniel Byrne <https://github.com/danwbyrne>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.2
+
+/// <reference types= "node" />
+
+interface Bytewise {
+    encode: (value: any) => Buffer;
+    decode: (value: Buffer) => any;
+    [k: string]: any;
+}
+
+declare const bytewise: Bytewise;
+export = bytewise;

--- a/types/bytewise/tsconfig.json
+++ b/types/bytewise/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "bytewise-tests.ts"
+    ]
+}

--- a/types/bytewise/tslint.json
+++ b/types/bytewise/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "dtslint/dt.json"
+}


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

in short this package is kind of a nightmare to type since its main export is another library by the same author, and then that library does the same thing. The `encode`/`decode` functions are the most important and straight forward so I think this is still a useful def.
