### PR TITLE
[@types/enzyme] Update types for wrapper.ref()

### DIFF
--- a/types/enzyme/index.d.ts
+++ b/types/enzyme/index.d.ts
@@ -456,12 +456,12 @@ export class ReactWrapper<P = {}, S = {}, C = Component> {
     mount(): this;
 
     /**
-     * Returns a wrapper of the node that matches the provided reference name.
+     * Returns the node that matches the provided reference name.
      *
      * NOTE: can only be called on a wrapper instance that is also the root instance.
      */
-    ref(refName: string): ReactWrapper<any, any>;
-    ref<P2, S2>(refName: string): ReactWrapper<P2, S2>;
+    ref(refName: string): Component | HTMLElement;
+    ref<P2, S2>(refName: string): Component | HTMLElement;
 
     /**
      * Detaches the react tree from the DOM. Runs ReactDOM.unmountComponentAtNode() under the hood.


### PR DESCRIPTION
In Enzyme 3.x, wrapper.ref() returns the node itself, not its wrapper. See https://airbnb.io/enzyme/docs/api/ReactWrapper/ref.html

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://airbnb.io/enzyme/docs/api/ReactWrapper/ref.html>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
