### PR TITLE
CKEditor: Basic strict null checks

### DIFF
--- a/types/ckeditor/index.d.ts
+++ b/types/ckeditor/index.d.ts
@@ -8,7 +8,7 @@
 // See https://github.com/DefinitelyTyped/DefinitelyTyped/issues/1827 for more informations.
 
 interface Window {
-    CKEDITOR_BASEPATH: string;
+    CKEDITOR_BASEPATH?: string;
 }
 
 declare namespace CKEDITOR {
@@ -2530,7 +2530,7 @@ declare namespace CKEDITOR {
                 accessKeyUp(dialog: dialog, key: string): void;
                 disable(): void;
                 enable(): void;
-                focus(): ui.dialog.uiElement;
+                focus(): ui.dialog.uiElement | undefined;
                 getDialog(): dialog;
                 getElement(): dom.element;
                 getInputElement(): dom.element;
@@ -2541,7 +2541,7 @@ declare namespace CKEDITOR {
                 isVisible(): boolean;
                 registerEvents(definition: CKEDITOR.dialog.definition.uiElement): ui.dialog.uiElement;
                 selectParentTab(): ui.dialog.uiElement;
-                setValue(value: any, noChangeEvent: boolean): ui.dialog.uiElement;
+                setValue(value: any, noChangeEvent: boolean): ui.dialog.uiElement | undefined;
             }
 
             class vbox extends hbox {


### PR DESCRIPTION
This is a small pull request. It adds some _strict null checks_ declarations. 
Although far from complete, at least the definitions can be used by those who have already activated _strictNullChecks_ in in their code.

For now, the type definition produces the following errors.

<pre>Property 'focus' in type 'textInput' is not assignable to the same property in base type 'labeledElement'.
   Type '() => undefined' is not assignable to type '() => uiElement'.
     Type 'undefined' is not assignable to type 'uiElement'</pre>
and
<pre>
Property 'setValue' in type 'checkbox' is not assignable to the same property in base type 'uiElement'.
   Type '(checked: boolean, noChangeEvent: boolean) => undefined' is not assignable to type '(value: any, noChangeEvent: boolean) => uiElement'.
     Type 'undefined' is not assignable to type 'uiElement'.</pre>

With this PR, there are no more errors.
