### PR TITLE
Update firefox-webext-browser to v63.0b6

### DIFF
--- a/types/firefox-webext-browser/firefox-webext-browser-tests.ts
+++ b/types/firefox-webext-browser/firefox-webext-browser-tests.ts
@@ -6,8 +6,6 @@ browser.runtime.getManifest(); // $ExpectType WebExtensionManifest
 browser.test; // $ExpectError
 browser.manifest; // $ExpectError
 browser._manifest; // $ExpectError
-browser._manifest.WebExtensionLangpackManifest; // $ExpectError
-browser._manifest.NativeManifest; // $ExpectError
 
 // browser.runtime
 const port = browser.runtime.connect();

--- a/types/firefox-webext-browser/index.d.ts
+++ b/types/firefox-webext-browser/index.d.ts
@@ -1,9 +1,9 @@
-// Type definitions for WebExtension Development in FireFox 58.0
+// Type definitions for WebExtension Development in FireFox 63.0
 // Project: https://developer.mozilla.org/en-US/Add-ons/WebExtensions
-// Definitions by: Jacob Bom <https://github.com/bomjacob>
+// Definitions by: Jasmin Bom <https://github.com/jsmnbom>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.9
-// Generated using script at github.com/bomjacob/definitelytyped-firefox-webext-browser
+// Generated using script at github.com/jsmnbom/definitelytyped-firefox-webext-browser
 
 interface WebExtEventBase<TAddListener extends (...args: any[]) => any, TCallback> {
     addListener: TAddListener;
@@ -105,46 +105,14 @@ declare namespace browser._manifest {
 
     type Permission = string | OptionalPermission | _Permission;
 
-    /** Represents a protocol handler definition. */
-    interface ProtocolHandler {
-        /**
-         * A user-readable title string for the protocol handler. This will be displayed to the user in interface
-         * objects as needed.
-         */
-        name: string;
-        /**
-         * The protocol the site wishes to handle, specified as a string. For example, you can register to handle SMS
-         * text message links by registering to handle the "sms" scheme.
-         */
-        protocol: string | _ProtocolHandlerProtocol;
-        /**
-         * The URL of the handler, as a string. This string should include "%s" as a placeholder which will be replaced
-         * with the escaped URL of the document to be handled. This URL might be a true URL, or it could be a phone
-         * number, email address, or so forth.
-         */
-        uriTemplate: ExtensionURL | HttpURL;
-    }
-
     /** Represents a WebExtension manifest.json file */
     interface WebExtensionManifest {
+        experiment_apis?: experiments.ExperimentAPI;
         /** A list of protocol handler definitions. */
         protocol_handlers?: ProtocolHandler[];
         default_locale?: string;
-        manifest_version: number;
         minimum_chrome_version?: string;
         minimum_opera_version?: string;
-        applications?: {
-            gecko?: FirefoxSpecificProperties;
-        };
-        browser_specific_settings?: {
-            gecko?: FirefoxSpecificProperties;
-        };
-        name: string;
-        short_name?: string;
-        description?: string;
-        author?: string;
-        version: string;
-        homepage_url?: string;
         icons?: {
             [key: number]: string;
         };
@@ -171,7 +139,8 @@ declare namespace browser._manifest {
             name?: string;
             url?: string;
         };
-        theme?: ThemeType;
+        hidden?: boolean;
+        theme_experiment?: ThemeExperiment;
         browser_action?: {
             default_title?: string;
             default_icon?: IconPath;
@@ -231,12 +200,16 @@ declare namespace browser._manifest {
             default_icon?: IconPath;
             default_popup?: string;
             browser_style?: boolean;
+            show_matches?: MatchPattern[];
+            hide_matches?: MatchPatternRestricted[];
         };
         sidebar_action?: {
             default_title?: string;
             default_icon?: IconPath;
             browser_style?: boolean;
             default_panel: string;
+            /** Whether or not the sidebar is opened at install. Default is `true`. */
+            open_at_install?: boolean;
         };
         chrome_url_overrides?: {
             newtab?: ExtensionURL;
@@ -245,6 +218,110 @@ declare namespace browser._manifest {
             /** @deprecated Unsupported on Firefox at this time. */
             history?: ExtensionURL;
         };
+        manifest_version: number;
+        applications?: {
+            gecko?: FirefoxSpecificProperties;
+        };
+        browser_specific_settings?: {
+            gecko?: FirefoxSpecificProperties;
+        };
+        name: string;
+        short_name?: string;
+        description?: string;
+        author?: string;
+        version: string;
+        homepage_url?: string;
+    }
+
+    /** Represents a protocol handler definition. */
+    interface ProtocolHandler {
+        /**
+         * A user-readable title string for the protocol handler. This will be displayed to the user in interface
+         * objects as needed.
+         */
+        name: string;
+        /**
+         * The protocol the site wishes to handle, specified as a string. For example, you can register to handle SMS
+         * text message links by registering to handle the "sms" scheme.
+         */
+        protocol: string | _ProtocolHandlerProtocol;
+        /**
+         * The URL of the handler, as a string. This string should include "%s" as a placeholder which will be replaced
+         * with the escaped URL of the document to be handled. This URL might be a true URL, or it could be a phone
+         * number, email address, or so forth.
+         */
+        uriTemplate: ExtensionURL | HttpURL;
+    }
+
+    /** Common properties for all manifest.json files */
+    interface ManifestBase {
+        manifest_version: number;
+        applications?: {
+            gecko?: FirefoxSpecificProperties;
+        };
+        browser_specific_settings?: {
+            gecko?: FirefoxSpecificProperties;
+        };
+        name: string;
+        short_name?: string;
+        description?: string;
+        author?: string;
+        version: string;
+        homepage_url?: string;
+    }
+
+    /** Represents a WebExtension language pack manifest.json file */
+    interface WebExtensionLangpackManifest {
+        homepage_url?: string;
+        langpack_id: string;
+        languages: {
+            [key: string]: {
+                chrome_resources: {
+                    [key: string]: ExtensionURL | {
+                        [key: string]: ExtensionURL;
+                    };
+                };
+                version: string;
+            };
+        };
+        sources?: {
+            [key: string]: {
+                base_path: ExtensionURL;
+                paths?: string[];
+            };
+        };
+        manifest_version: number;
+        applications?: {
+            gecko?: FirefoxSpecificProperties;
+        };
+        browser_specific_settings?: {
+            gecko?: FirefoxSpecificProperties;
+        };
+        name: string;
+        short_name?: string;
+        description?: string;
+        author?: string;
+        version: string;
+    }
+
+    /** Represents a WebExtension dictionary manifest.json file */
+    interface WebExtensionDictionaryManifest {
+        homepage_url?: string;
+        dictionaries: {
+            [key: string]: string;
+        };
+        manifest_version: number;
+        applications?: {
+            gecko?: FirefoxSpecificProperties;
+        };
+        browser_specific_settings?: {
+            gecko?: FirefoxSpecificProperties;
+        };
+        name: string;
+        short_name?: string;
+        description?: string;
+        author?: string;
+        version: string;
     }
 
     interface ThemeIcons {
@@ -275,7 +352,16 @@ declare namespace browser._manifest {
         strict_max_version?: string;
     }
 
-    type MatchPattern = string | _MatchPattern;
+    type MatchPattern = MatchPatternRestricted | MatchPatternUnestricted | _MatchPattern;
+
+    /** Same as MatchPattern above, but excludes<all_urls></all_urls> */
+    type MatchPatternRestricted = string;
+
+    /**
+     * Mostly unrestricted match patterns for privileged add-ons. This should technically be rejected for unprivileged
+     * add-ons, but, reasons. The MatchPattern class will still refuse privileged schemes for those extensions.
+     */
+    type MatchPatternUnestricted = string;
 
     /** Same as MatchPattern above, but includes moz-extension protocol */
     type MatchPatternInternal = string | _MatchPatternInternal;
@@ -291,7 +377,7 @@ declare namespace browser._manifest {
         exclude_globs?: string[];
         /** The list of CSS files to inject */
         css?: ExtensionURL[];
-        /** The list of CSS files to inject */
+        /** The list of JS files to inject */
         js?: ExtensionURL[];
         /**
          * If allFrames is `true`, implies that the JavaScript or CSS should be injected into all frames of current
@@ -324,6 +410,29 @@ declare namespace browser._manifest {
     /** @deprecated Event pages are not currently supported. This will run as a persistent background page. */
     type PersistentBackgroundProperty = boolean;
 
+    /** Represents a native manifest file */
+    type NativeManifest = {
+        name: string;
+        description: string;
+        path: string;
+        type: "pkcs11" | "stdio";
+        allowed_extensions: ExtensionID[];
+    } | {
+        name: ExtensionID;
+        description: string;
+        data: any;
+        type: "storage";
+    };
+
+    type ThemeColor = string | [number, number, number] | [number, number, number, number];
+
+    interface ThemeExperiment {
+        stylesheet?: ExtensionURL;
+        images?: string;
+        colors?: string;
+        properties?: string;
+    }
+
     interface ThemeType {
         images?: {
             additional_backgrounds?: ImageDataOrExtensionURL[];
@@ -331,18 +440,44 @@ declare namespace browser._manifest {
             theme_frame?: ImageDataOrExtensionURL;
         };
         colors?: {
-            accentcolor?: string;
-            frame?: number[];
-            tab_text?: number[];
-            textcolor?: string;
-            toolbar?: string;
-            toolbar_text?: string;
-            bookmark_text?: string;
-            toolbar_field?: string;
-            toolbar_field_text?: string;
-            toolbar_top_separator?: string;
-            toolbar_bottom_separator?: string;
-            toolbar_vertical_separator?: string;
+            tab_selected?: ThemeColor;
+            accentcolor?: ThemeColor;
+            frame?: ThemeColor;
+            frame_inactive?: ThemeColor;
+            textcolor?: ThemeColor;
+            tab_background_text?: ThemeColor;
+            tab_background_separator?: ThemeColor;
+            tab_loading?: ThemeColor;
+            tab_text?: ThemeColor;
+            tab_line?: ThemeColor;
+            toolbar?: ThemeColor;
+            toolbar_text?: ThemeColor;
+            bookmark_text?: ThemeColor;
+            toolbar_field?: ThemeColor;
+            toolbar_field_text?: ThemeColor;
+            toolbar_field_border?: ThemeColor;
+            toolbar_field_separator?: ThemeColor;
+            toolbar_top_separator?: ThemeColor;
+            toolbar_bottom_separator?: ThemeColor;
+            toolbar_vertical_separator?: ThemeColor;
+            icons?: ThemeColor;
+            icons_attention?: ThemeColor;
+            button_background_hover?: ThemeColor;
+            button_background_active?: ThemeColor;
+            popup?: ThemeColor;
+            popup_text?: ThemeColor;
+            popup_border?: ThemeColor;
+            toolbar_field_focus?: ThemeColor;
+            toolbar_field_text_focus?: ThemeColor;
+            toolbar_field_border_focus?: ThemeColor;
+            popup_highlight?: ThemeColor;
+            popup_highlight_text?: ThemeColor;
+            ntp_background?: ThemeColor;
+            ntp_text?: ThemeColor;
+            sidebar?: ThemeColor;
+            sidebar_text?: ThemeColor;
+            sidebar_highlight?: ThemeColor;
+            sidebar_highlight_text?: ThemeColor;
         };
         icons?: {
             back?: ExtensionURL;
@@ -432,11 +567,23 @@ declare namespace browser._manifest {
         };
     }
 
+    /** Contents of manifest.json for a static theme */
+    interface ThemeManifest {
+        theme: ThemeType;
+        default_locale?: string;
+        theme_experiment?: ThemeExperiment;
+        icons?: {
+            [key: number]: string;
+        };
+    }
+
     type KeyName = string;
 
     type _OptionalPermission =
-          "browserSettings"
+        "browserSettings"
         | "cookies"
+        | "downloads"
+        | "downloads.open"
         | "clipboardRead"
         | "clipboardWrite"
         | "geolocation"
@@ -449,13 +596,14 @@ declare namespace browser._manifest {
         | "bookmarks"
         | "find"
         | "history"
+        | "search"
         | "activeTab"
-        | "tabs";
+        | "tabs"
+        | "tabHide";
 
     type _Permission =
-          "contextualIdentities"
-        | "downloads"
-        | "downloads.open"
+        "contextualIdentities"
+        | "dns"
         | "identity"
         | "management"
         | "alarms"
@@ -465,6 +613,7 @@ declare namespace browser._manifest {
         | "privacy"
         | "proxy"
         | "nativeMessaging"
+        | "telemetry"
         | "theme"
         | "browsingData"
         | "devtools"
@@ -474,11 +623,24 @@ declare namespace browser._manifest {
         | "pkcs11"
         | "sessions";
 
+    type _WebExtensionManifestIncognito = "spanning";
+
+    /** Defines the location the browserAction will appear by default. The default location is navbar. */
+    type _WebExtensionManifestBrowserActionDefaultArea =
+        "navbar"
+        | "menupanel"
+        | "tabstrip"
+        | "personaltoolbar";
+
     type _ProtocolHandlerProtocol =
-          "bitcoin"
+        "bitcoin"
+        | "dat"
+        | "dweb"
         | "geo"
         | "gopher"
         | "im"
+        | "ipfs"
+        | "ipns"
         | "irc"
         | "ircs"
         | "magnet"
@@ -489,6 +651,7 @@ declare namespace browser._manifest {
         | "sip"
         | "sms"
         | "smsto"
+        | "ssb"
         | "ssh"
         | "tel"
         | "urn"
@@ -496,21 +659,12 @@ declare namespace browser._manifest {
         | "wtai"
         | "xmpp";
 
-    type _WebExtensionManifestIncognito = "spanning";
-
-    /** Defines the location the browserAction will appear by default. The default location is navbar. */
-    type _WebExtensionManifestBrowserActionDefaultArea =
-          "navbar"
-        | "menupanel"
-        | "tabstrip"
-        | "personaltoolbar";
-
     type _MatchPattern = "<all_urls>";
 
     type _MatchPatternInternal = "<all_urls>";
 
     type _ThemeTypeAdditionalBackgroundsAlignment =
-          "bottom"
+        "bottom"
         | "center"
         | "left"
         | "right"
@@ -526,7 +680,7 @@ declare namespace browser._manifest {
         | "right top";
 
     type _ThemeTypeAdditionalBackgroundsTiling =
-          "no-repeat"
+        "no-repeat"
         | "repeat"
         | "repeat-x"
         | "repeat-y";
@@ -541,12 +695,14 @@ declare namespace browser._manifest {
  */
 declare namespace browser.browserSettings {
     /* browserSettings types */
-
     /** How images should be animated in the browser. */
     type ImageAnimationBehavior =
-          "normal"
+        "normal"
         | "none"
         | "once";
+
+    /** After which mouse event context menus should popup. */
+    type ContextMenuMouseEvent = "mouseup" | "mousedown";
 
     /* browserSettings properties */
     /** Allows or disallows pop-up windows from opening in response to user events. */
@@ -554,6 +710,15 @@ declare namespace browser.browserSettings {
 
     /** Enables or disables the browser cache. */
     const cacheEnabled: types.Setting;
+
+    /** This boolean setting controls whether the selected tab can be closed with a double click. */
+    const closeTabsByDoubleClick: types.Setting;
+
+    /**
+     * Controls after which mouse event context menus popup. This setting's value is of type ContextMenuMouseEvent,
+     * which has possible values of `mouseup` and `mousedown`.
+     */
+    const contextMenuShowEvent: types.Setting;
 
     /** Returns the value of the overridden home page. Read-only. */
     const homepageOverride: types.Setting;
@@ -567,8 +732,30 @@ declare namespace browser.browserSettings {
     /** Returns the value of the overridden new tab page. Read-only. */
     const newTabPageOverride: types.Setting;
 
+    /**
+     * Controls where new tabs are opened. `afterCurrent` will open all new tabs next to the current tab,
+     * `relatedAfterCurrent` will open only related tabs next to the current tab, and `atEnd` will open all tabs at the
+     * end of the tab strip. The default is `relatedAfterCurrent`.
+     */
+    const newTabPosition: types.Setting;
+
+    /** This boolean setting controls whether bookmarks are opened in the current tab or in a new tab. */
+    const openBookmarksInNewTabs: types.Setting;
+
+    /** This boolean setting controls whether search results are opened in the current tab or in a new tab. */
+    const openSearchResultsInNewTabs: types.Setting;
+
+    /** This boolean setting controls whether urlbar results are opened in the current tab or in a new tab. */
+    const openUrlbarResultsInNewTabs: types.Setting;
+
     /** Disables webAPI notifications. */
     const webNotificationsDisabled: types.Setting;
+
+    /** This setting controls whether the user-chosen colors override the page's colors. */
+    const overrideDocumentColors: types.Setting;
+
+    /** This setting controls whether the document's fonts are used. */
+    const useDocumentFonts: types.Setting;
 }
 
 /**
@@ -593,6 +780,51 @@ declare namespace browser.clipboard {
      * @param imageType The type of imageData.
      */
     function setImageData(imageData: ArrayBuffer, imageType: _SetImageData): Promise<void>;
+}
+
+/** Not allowed in: Content scripts, Devtools pages */
+declare namespace browser.contentScripts {
+    /* contentScripts types */
+    type ExtensionFileOrCode = {
+        file: _manifest.ExtensionURL;
+    } | {
+        code: string;
+    };
+
+    /** Details of a content script registered programmatically */
+    interface RegisteredContentScriptOptions {
+        matches: _manifest.MatchPattern[];
+        excludeMatches?: _manifest.MatchPattern[];
+        includeGlobs?: string[];
+        excludeGlobs?: string[];
+        /** The list of CSS files to inject */
+        css?: ExtensionFileOrCode[];
+        /** The list of JS files to inject */
+        js?: ExtensionFileOrCode[];
+        /**
+         * If allFrames is `true`, implies that the JavaScript or CSS should be injected into all frames of current
+         * page. By default, it's `false` and is only injected into the top frame.
+         */
+        allFrames?: boolean;
+        /**
+         * If matchAboutBlank is true, then the code is also injected in about:blank and about:srcdoc frames if your
+         * extension has access to its parent document. Code cannot be inserted in top-level about:-frames. By default
+         * it is `false`.
+         */
+        matchAboutBlank?: boolean;
+        /** The soonest that the JavaScript or CSS will be injected into the tab. Defaults to "document_idle". */
+        runAt?: extensionTypes.RunAt;
+    }
+
+    /** An object that represents a content script registered programmatically */
+    interface RegisteredContentScript {
+        /** Unregister a content script registered programmatically */
+        unregister(): Promise<any>;
+    }
+
+    /* contentScripts functions */
+    /** Register a content script programmatically */
+    function register(contentScriptOptions: RegisteredContentScriptOptions): Promise<RegisteredContentScript>;
 }
 
 /**
@@ -698,6 +930,16 @@ declare namespace browser.contextualIdentities {
  */
 declare namespace browser.cookies {
     /* cookies types */
+    /**
+     * A cookie's 'SameSite' state (https://tools.ietf.org/html/draft-west-first-party-cookies). 'no_restriction'
+     * corresponds to a cookie set without a 'SameSite' attribute, 'lax' to 'SameSite=Lax', and 'strict' to
+     * 'SameSite=Strict'.
+     */
+    type SameSiteStatus =
+        "no_restriction"
+        | "lax"
+        | "strict";
+
     /** Represents information about an HTTP cookie. */
     interface Cookie {
         /** The name of the cookie. */
@@ -718,6 +960,8 @@ declare namespace browser.cookies {
         secure: boolean;
         /** True if the cookie is marked as HttpOnly (i.e. the cookie is inaccessible to client-side scripts). */
         httpOnly: boolean;
+        /** The cookie's same-site status (i.e. whether the cookie is sent with cross-site requests). */
+        sameSite: SameSiteStatus;
         /** True if the cookie is a session cookie, as opposed to a persistent cookie with an expiration date. */
         session: boolean;
         /**
@@ -727,6 +971,8 @@ declare namespace browser.cookies {
         expirationDate?: number;
         /** The ID of the cookie store containing this cookie, as provided in getAllCookieStores(). */
         storeId: string;
+        /** The first-party domain of the cookie. */
+        firstPartyDomain: string;
     }
 
     /**
@@ -751,7 +997,7 @@ declare namespace browser.cookies {
      * "overwrite". Plan your response accordingly.
      */
     type OnChangedCause =
-         "evicted"
+        "evicted"
         | "expired"
         | "explicit"
         | "expired_overwrite"
@@ -778,6 +1024,11 @@ declare namespace browser.cookies {
          * cookie store will be used.
          */
         storeId?: string;
+        /**
+         * The first-party domain which the cookie to retrieve is associated. This attribute is required if First-Party
+         * Isolation is enabled.
+         */
+        firstPartyDomain?: string;
     }): Promise<Cookie>;
 
     /**
@@ -804,6 +1055,12 @@ declare namespace browser.cookies {
          * used.
          */
         storeId?: string;
+        /**
+         * Restricts the retrieved cookies to those whose first-party domains match this one. This attribute is
+         * required if First-Party Isolation is enabled. To not filter by a specific first-party domain, use `null` or
+         * `undefined`.
+         */
+        firstPartyDomain?: string;
     }): Promise<Cookie[]>;
 
     /**
@@ -829,6 +1086,8 @@ declare namespace browser.cookies {
         secure?: boolean;
         /** Whether the cookie should be marked as HttpOnly. Defaults to false. */
         httpOnly?: boolean;
+        /** The cookie's same-site status. */
+        sameSite?: SameSiteStatus;
         /**
          * The expiration date of the cookie as the number of seconds since the UNIX epoch. If omitted, the cookie
          * becomes a session cookie.
@@ -839,6 +1098,10 @@ declare namespace browser.cookies {
          * execution context's cookie store.
          */
         storeId?: string;
+        /**
+         * The first-party domain of the cookie. This attribute is required if First-Party Isolation is enabled.
+         */
+        firstPartyDomain?: string;
     }): Promise<Cookie | undefined>;
 
     /**
@@ -858,6 +1121,11 @@ declare namespace browser.cookies {
          * the current execution context's cookie store.
          */
         storeId?: string;
+        /**
+         * The first-party domain associated with the cookie. This attribute is required if First-Party Isolation is
+         * enabled.
+         */
+        firstPartyDomain?: string;
     }): Promise<{
         /** The URL associated with the cookie that's been removed. */
         url: string;
@@ -865,6 +1133,8 @@ declare namespace browser.cookies {
         name: string;
         /** The ID of the cookie store from which the cookie was removed. */
         storeId: string;
+        /** The first-party domain associated with the cookie that's been removed. */
+        firstPartyDomain: string;
     } | undefined>;
 
     /** Lists all existing cookie stores. */
@@ -888,6 +1158,46 @@ declare namespace browser.cookies {
 }
 
 /**
+ * Asynchronous DNS API
+ *
+ * Permissions: `dns`
+ *
+ * Not allowed in: Content scripts, Devtools pages
+ */
+declare namespace browser.dns {
+    /* dns types */
+    /** An object encapsulating a DNS Record. */
+    interface DNSRecord {
+        /**
+         * The canonical hostname for this record. this value is empty if the record was not fetched with the
+         * 'canonical_name' flag.
+         */
+        canonicalName?: string;
+        /** Record retreived with TRR. */
+        isTRR: string;
+        addresses: string[];
+    }
+
+    type ResolveFlags = _ResolveFlags[];
+
+    type _ResolveFlags =
+        "allow_name_collisions"
+        | "bypass_cache"
+        | "canonical_name"
+        | "disable_ipv4"
+        | "disable_ipv6"
+        | "disable_trr"
+        | "offline"
+        | "priority_low"
+        | "priority_medium"
+        | "speculate";
+
+    /* dns functions */
+    /** Resolves a hostname to a DNS record. */
+    function resolve(hostname: string, flags?: ResolveFlags): Promise<DNSRecord>;
+}
+
+/**
  * Permissions: `downloads`
  *
  * Not allowed in: Content scripts, Devtools pages
@@ -895,12 +1205,12 @@ declare namespace browser.cookies {
 declare namespace browser.downloads {
     /* downloads types */
     type FilenameConflictAction =
-          "uniquify"
+        "uniquify"
         | "overwrite"
         | "prompt";
 
     type InterruptReason =
-          "FILE_FAILED"
+        "FILE_FAILED"
         | "FILE_ACCESS_DENIED"
         | "FILE_NO_SPACE"
         | "FILE_NAME_TOO_LONG"
@@ -940,7 +1250,7 @@ declare namespace browser.downloads {
      * These string constants will never change, however the set of DangerTypes may change.
      */
     type DangerType =
-          "file"
+        "file"
         | "url"
         | "content"
         | "uncommon"
@@ -960,7 +1270,7 @@ declare namespace browser.downloads {
      * These string constants will never change, however the set of States may change.
      */
     type State =
-          "in_progress"
+        "in_progress"
         | "interrupted"
         | "complete";
 
@@ -1085,9 +1395,7 @@ declare namespace browser.downloads {
     }
 
     /** The HTTP method to use if the URL uses the HTTP[S] protocol. */
-    type _DownloadMethod =
-          "GET"
-        | "POST";
+    type _DownloadMethod = "GET" | "POST";
 
     /* downloads functions */
     /**
@@ -1400,6 +1708,45 @@ declare namespace browser.events {
     }
 }
 
+/** Not allowed in: Content scripts, Devtools pages */
+declare namespace browser.experiments {
+    /* experiments types */
+    interface ExperimentAPI {
+        schema: ExperimentURL;
+        parent?: {
+            events?: APIEvents;
+            paths?: APIPaths;
+            script: ExperimentURL;
+            scopes?: APIParentScope[];
+        };
+        child?: {
+            paths: APIPaths;
+            script: ExperimentURL;
+            scopes: APIChildScope[];
+        };
+    }
+
+    type ExperimentURL = string;
+
+    type APIPaths = APIPath[];
+
+    type APIPath = string[];
+
+    type APIEvents = APIEvent[];
+
+    type APIEvent = "startup";
+
+    type APIParentScope =
+        "addon_parent"
+        | "content_parent"
+        | "devtools_parent";
+
+    type APIChildScope =
+        "addon_child"
+        | "content_child"
+        | "devtools_child";
+}
+
 /**
  * The `browser.extension` API has utilities that can be used by any extension page. It includes support for exchanging
  * messages between an extension and its content scripts or between extensions, as described in detail in Message
@@ -1407,10 +1754,9 @@ declare namespace browser.events {
  */
 declare namespace browser.extension {
     /* extension types */
-
     /** The type of extension view. */
     type ViewType =
-          "tab"
+        "tab"
         | "popup"
         | "sidebar";
 
@@ -1507,11 +1853,8 @@ declare namespace browser.extension {
  */
 declare namespace browser.extensionTypes {
     /* extensionTypes types */
-
     /** The format of an image. */
-    type ImageFormat =
-          "jpeg"
-        | "png";
+    type ImageFormat = "jpeg" | "png";
 
     /** Details about the format and quality of an image. */
     interface ImageDetails {
@@ -1527,14 +1870,12 @@ declare namespace browser.extensionTypes {
 
     /** The soonest that the JavaScript or CSS will be injected into the tab. */
     type RunAt =
-          "document_start"
+        "document_start"
         | "document_end"
         | "document_idle";
 
     /** The origin of the CSS to inject, this affects the cascading order (priority) of the stylesheet. */
-    type CSSOrigin =
-          "user"
-        | "author";
+    type CSSOrigin = "user" | "author";
 
     /**
      * Details of the script or CSS to inject. Either the code or the file property must be set, but both may not be
@@ -1679,13 +2020,13 @@ declare namespace browser.identity {
 
     /** Starts an auth flow at the specified URL. */
     function launchWebAuthFlow(details: {
-        url: string;
+        url: _manifest.HttpURL;
         interactive?: boolean;
     }): Promise<string>;
 
     /**
      * Generates a redirect URL to be used in |launchWebAuthFlow|.
-     * @param [ path] The path appended to the end of the generated URL.
+     * @param [path] The path appended to the end of the generated URL.
      */
     function getRedirectURL(path?: string): string;
 
@@ -1706,9 +2047,7 @@ declare namespace browser.identity {
  */
 declare namespace browser.idle {
     /* idle types */
-    type IdleState =
-          "active"
-        | "idle";
+    type IdleState = "active" | "idle";
 
     /* idle functions */
     /**
@@ -1756,14 +2095,10 @@ declare namespace browser.management {
     }
 
     /** A reason the item is disabled. */
-    type ExtensionDisabledReason =
-          "unknown"
-        | "permissions_increase";
+    type ExtensionDisabledReason = "unknown" | "permissions_increase";
 
-    /** The type of this extension. Will always be 'extension'. */
-    type ExtensionType =
-          "extension"
-        | "theme";
+    /** The type of this extension, 'extension' or 'theme'. */
+    type ExtensionType = "extension" | "theme";
 
     /**
      * How the extension was installed. One of
@@ -1773,7 +2108,7 @@ declare namespace browser.management {
      * `other`: The extension was installed by other means.
      */
     type ExtensionInstallType =
-          "development"
+        "development"
         | "normal"
         | "sideload"
         | "other";
@@ -1798,7 +2133,7 @@ declare namespace browser.management {
         enabled: boolean;
         /** A reason the item is disabled. */
         disabledReason?: ExtensionDisabledReason;
-        /** The type of this extension. Will always return 'extension'. */
+        /** The type of this extension, 'extension' or 'theme'. */
         type: ExtensionType;
         /** The URL of the homepage of this extension. */
         homepageUrl?: string;
@@ -1830,6 +2165,16 @@ declare namespace browser.management {
      * @param id The ID from an item of `management.ExtensionInfo`.
      */
     function get(id: _manifest.ExtensionID): Promise<ExtensionInfo | undefined>;
+
+    /** Installs and enables a theme extension from the given url. */
+    function install(options: {
+        /** URL pointing to the XPI file on addons.mozilla.org or similar. */
+        url: _manifest.HttpURL;
+        /** A hash of the XPI file, using sha256 or stronger. */
+        hash?: string;
+    }): Promise<{
+        id: _manifest.ExtensionID;
+    } | undefined>;
 
     /**
      * Returns information about the calling extension. Note: This function can be used without requesting the
@@ -1877,14 +2222,12 @@ declare namespace browser.management {
 declare namespace browser.notifications {
     /* notifications types */
     type TemplateType =
-          "basic"
+        "basic"
         | "image"
         | "list"
         | "progress";
 
-    type PermissionLevel =
-          "granted"
-        | "denied";
+    type PermissionLevel = "granted" | "denied";
 
     interface NotificationItem {
         /** Title of one item of a list notification. */
@@ -2111,10 +2454,9 @@ declare namespace browser.privacy {
  */
 declare namespace browser.privacy.network {
     /* privacy.network types */
-
     /** The IP handling policy of WebRTC. */
     type IPHandlingPolicy =
-          "default"
+        "default"
         | "default_public_and_private_interfaces"
         | "default_public_interface_only"
         | "disable_non_proxied_udp";
@@ -2163,12 +2505,26 @@ declare namespace browser.privacy.services {
  */
 declare namespace browser.privacy.websites {
     /* privacy.websites types */
-
     /** The mode for tracking protection. */
     type TrackingProtectionModeOption =
-          "always"
+        "always"
         | "never"
         | "private_browsing";
+
+    /** The settings for cookies. */
+    interface CookieConfig {
+        /** The type of cookies to allow. */
+        behavior?: _CookieConfigBehavior;
+        /** Whether to create all cookies as nonPersistent (i.e., session) cookies. */
+        nonPersistentCookies?: boolean;
+    }
+
+    /** The type of cookies to allow. */
+    type _CookieConfigBehavior =
+        "allow_all"
+        | "reject_all"
+        | "reject_third_party"
+        | "allow_visited";
 
     /* privacy.websites properties */
     /**
@@ -2221,6 +2577,12 @@ declare namespace browser.privacy.websites {
      * TrackingProtectionModeOption, defaulting to `private_browsing_only`.
      */
     const trackingProtectionMode: types.Setting;
+
+    /**
+     * Allow users to specify the default settings for allowing cookies, as well as whether all cookies should be
+     * created as non-persistent cookies. This setting's value is of type CookieConfig.
+     */
+    const cookieConfig: types.Setting;
 }
 
 /**
@@ -2232,6 +2594,83 @@ declare namespace browser.privacy.websites {
  * Not allowed in: Content scripts, Devtools pages
  */
 declare namespace browser.proxy {
+    /* proxy types */
+    /** An object which describes proxy settings. */
+    interface ProxyConfig {
+        /** The type of proxy to use. */
+        proxyType?: _ProxyConfigProxyType;
+        /** The address of the http proxy, can include a port. */
+        http?: string;
+        /** Use the http proxy server for all protocols. */
+        httpProxyAll?: boolean;
+        /** The address of the ftp proxy, can include a port. */
+        ftp?: string;
+        /** The address of the ssl proxy, can include a port. */
+        ssl?: string;
+        /** The address of the socks proxy, can include a port. */
+        socks?: string;
+        /** The version of the socks proxy. */
+        socksVersion?: number;
+        /** A list of hosts which should not be proxied. */
+        passthrough?: string;
+        /** A URL to use to configure the proxy. */
+        autoConfigUrl?: string;
+        /** Do not prompt for authentication if password is saved. */
+        autoLogin?: boolean;
+        /** Proxy DNS when using SOCKS v5. */
+        proxyDNS?: boolean;
+    }
+
+    /** The type of proxy to use. */
+    type _ProxyConfigProxyType =
+        "none"
+        | "autoDetect"
+        | "system"
+        | "manual"
+        | "autoConfig";
+
+    type _ProxyOnRequestEvent<T = (details: {
+        /**
+         * The ID of the request. Request IDs are unique within a browser session. As a result, they could be used to
+         * relate different events of the same request.
+         */
+        requestId: string;
+        url: string;
+        /** Standard HTTP method. */
+        method: string;
+        /**
+         * The value 0 indicates that the request happens in the main frame; a positive value indicates the ID of a
+         * subframe in which the request happens. If the document of a (sub-)frame is loaded (`type` is `main_frame` or
+         * `sub_frame`), `frameId` indicates the ID of this frame, not the ID of the outer frame. Frame IDs are unique
+         * within a tab.
+         */
+        frameId: number;
+        /** ID of frame that wraps the frame which sent the request. Set to -1 if no parent frame exists. */
+        parentFrameId: number;
+        /** URL of the resource that triggered this request. */
+        originUrl?: string;
+        /** URL of the page into which the requested resource will be loaded. */
+        documentUrl?: string;
+        /** The ID of the tab in which the request takes place. Set to -1 if the request isn't related to a tab. */
+        tabId: number;
+        /** How the requested resource will be used. */
+        type: webRequest.ResourceType;
+        /** The time when this signal is triggered, in milliseconds since the epoch. */
+        timeStamp: number;
+        /**
+         * The server IP address that the request was actually sent to. Note that it may be a literal IPv6 address.
+         */
+        ip?: string;
+        /** Indicates if this response was fetched from disk cache. */
+        fromCache: boolean;
+        /** The HTTP request headers that are going to be sent out with this request. */
+        requestHeaders?: webRequest.HttpHeaders;
+    }) => void> = WebExtEventBase<(callback: T, filter: webRequest.RequestFilter, extraInfoSpec?: Array<"requestHeaders">) => void, T>;
+
+    /* proxy properties */
+    /** Configures proxy settings. This setting's value is an object of type ProxyConfig. */
+    const settings: types.Setting;
+
     /* proxy functions */
     /** Registers the proxy script for the extension. */
     function register(url: string): Promise<void>;
@@ -2246,7 +2685,13 @@ declare namespace browser.proxy {
     function registerProxyScript(url: string): Promise<any>;
 
     /* proxy events */
+    /** Fired when proxy data is needed for a request. */
+    const onRequest: _ProxyOnRequestEvent;
+
     /** Notifies about proxy script errors. */
+    const onError: WebExtEvent<(error: object) => void>;
+
+    /** Please use `proxy.onError`. */
     const onProxyError: WebExtEvent<(error: object) => void>;
 }
 
@@ -2262,10 +2707,10 @@ declare namespace browser.runtime {
     /** An object which allows two way communication with other pages. */
     interface Port {
         name: string;
-        disconnect(): void;
+        disconnect: () => void;
         onDisconnect: events.Event;
         onMessage: events.Event;
-        postMessage(message: object): void;
+        postMessage: (message: object) => void;
         /** This property will **only** be present on ports passed to onConnect/onConnectExternal listeners. */
         sender?: MessageSender;
     }
@@ -2300,7 +2745,7 @@ declare namespace browser.runtime {
 
     /** The operating system the browser is running on. */
     type PlatformOs =
-          "mac"
+        "mac"
         | "win"
         | "android"
         | "cros"
@@ -2309,7 +2754,7 @@ declare namespace browser.runtime {
 
     /** The machine's processor architecture. */
     type PlatformArch =
-          "arm"
+        "arm"
         | "x86-32"
         | "x86-64";
 
@@ -2340,13 +2785,13 @@ declare namespace browser.runtime {
 
     /** Result of the update check. */
     type RequestUpdateCheckStatus =
-          "throttled"
+        "throttled"
         | "no_update"
         | "update_available";
 
     /** The reason that this event is being dispatched. */
     type OnInstalledReason =
-          "install"
+        "install"
         | "update"
         | "browser_update";
 
@@ -2357,7 +2802,7 @@ declare namespace browser.runtime {
      * the enterprise policy.
      */
     type OnRestartRequiredReason =
-          "app_update"
+        "app_update"
         | "os_update"
         | "periodic";
 
@@ -2700,9 +3145,133 @@ declare namespace browser.storage {
 }
 
 /**
- * The theme API allows customizing of visual elements of the browser.
+ * Use the `browser.telemetry` API to send telemetry data to the Mozilla Telemetry service. Restricted to Mozilla
+ * privileged webextensions.
  *
- * Permissions: `theme`
+ * Permissions: `telemetry`, `mozillaAddons`
+ *
+ * Not allowed in: Content scripts, Devtools pages
+ */
+declare namespace browser.telemetry {
+    /* telemetry types */
+    /**
+     * Type of scalar: 'count' for numeric values, 'string' for string values, 'boolean' for boolean values. Maps to
+     * `nsITelemetry.SCALAR_TYPE_*`.
+     */
+    type ScalarType =
+        "count"
+        | "string"
+        | "boolean";
+
+    /** Represents registration data for a Telemetry scalar. */
+    interface ScalarData {
+        kind: ScalarType;
+        /** True if this is a keyed scalar. */
+        keyed?: boolean;
+        /** True if this data should be recorded on release. */
+        record_on_release?: boolean;
+        /**
+         * True if this scalar entry is expired. This allows recording it without error, but it will be discarded.
+         */
+        expired?: boolean;
+    }
+
+    /** Represents registration data for a Telemetry event. */
+    interface EventData {
+        /** List of methods for this event entry. */
+        methods: string[];
+        /** List of objects for this event entry. */
+        objects: string[];
+        /** List of allowed extra keys for this event entry. */
+        extra_keys: string[];
+        /** True if this data should be recorded on release. */
+        record_on_release?: boolean;
+        /**
+         * True if this event entry is expired. This allows recording it without error, but it will be discarded.
+         */
+        expired?: boolean;
+    }
+
+    /* telemetry functions */
+    /**
+     * Submits a custom ping to the Telemetry back-end. See `submitExternalPing` inside TelemetryController.jsm for
+     * more details.
+     * @param type The type of the ping.
+     * @param message The data payload for the ping.
+     * @param options Options object.
+     */
+    function submitPing(type: string, message: any, options: {
+        /** True if the ping should contain the client id. */
+        addClientId?: boolean;
+        /** True if the ping should contain the environment data. */
+        addEnvironment?: boolean;
+        /** Set to override the environment data. */
+        overrideEnvironment?: any;
+        /** If true, send the ping using the PingSender. */
+        usePingSender?: boolean;
+    }): Promise<any>;
+
+    /** Checks if Telemetry is enabled. */
+    function canUpload(): Promise<any>;
+
+    /**
+     * Adds the value to the given scalar.
+     * @param name The scalar name.
+     * @param value The numeric value to add to the scalar. Only unsigned integers supported.
+     */
+    function scalarAdd(name: string, value: number): Promise<any>;
+
+    /**
+     * Sets the named scalar to the given value. Throws if the value type doesn't match the scalar type.
+     * @param name The scalar name
+     * @param value The value to set the scalar to
+     */
+    function scalarSet(name: string, value: string | boolean | number | object): Promise<any>;
+
+    /**
+     * Sets the scalar to the maximum of the current and the passed value
+     * @param name The scalar name.
+     * @param value The numeric value to set the scalar to. Only unsigned integers supported.
+     */
+    function scalarSetMaximum(name: string, value: number): Promise<any>;
+
+    /**
+     * Record an event in Telemetry. Throws when trying to record an unknown event.
+     * @param category The category name.
+     * @param method The method name.
+     * @param object The object name.
+     * @param [value] An optional string value to record.
+     * @param [extra] An optional object of the form (string -> string). It should only contain registered extra keys.
+     */
+    function recordEvent(category: string, method: string, object: string, value?: number, extra?: string): Promise<any>;
+
+    /**
+     * Register new scalars to record them from addons. See nsITelemetry.idl for more details.
+     * @param category The unique category the scalars are registered in.
+     * @param data An object that contains registration data for multiple scalars. Each property name is the scalar
+     *     name, and the corresponding property value is an object of ScalarData type.
+     */
+    function registerScalars(category: string, data: ScalarData): Promise<any>;
+
+    /**
+     * Register new events to record them from addons. See nsITelemetry.idl for more details.
+     * @param category The unique category the events are registered in.
+     * @param data An object that contains registration data for 1+ events. Each property name is the category name,
+     *     and the corresponding property value is an object of EventData type.
+     */
+    function registerEvents(category: string, data: EventData): Promise<any>;
+
+    /**
+     * Enable recording of events in a category. Events default to recording disabled. This allows to toggle recording
+     * for all events in the specified category.
+     * @param category The category name.
+     * @param enabled Whether recording is enabled for events in that category.
+     */
+    function setEventRecordingEnabled(category: string, enabled: boolean): Promise<any>;
+}
+
+/**
+ * The theme API allows customizing of visual elements of the browser.
  *
  * Not allowed in: Content scripts, Devtools pages
  */
@@ -2764,13 +3333,23 @@ declare namespace browser.topSites {
         url: string;
         /** The title of the page. */
         title?: string;
+        /** Data URL for the favicon, if available. */
+        favicon?: string;
     }
 
     /* topSites functions */
     /** Gets a list of top sites. */
     function get(options?: {
-        /** Which providers to get top sites from. Possible values are "places" and "activityStream". */
+        /** @deprecated Please use the other options to tune the results received from topSites. */
         providers?: string[];
+        /** The number of top sites to return, defaults to the value used by Firefox */
+        limit?: number;
+        /** Limit the result to a single top site link per domain */
+        onePerDomain?: boolean;
+        /** Include sites that the user has blocked from appearing on the Firefox new tab. */
+        includeBlocked?: boolean;
+        /** Include sites favicon if available. */
+        includeFavicon?: boolean;
     }): Promise<MostVisitedURL[]>;
 }
 
@@ -2781,7 +3360,6 @@ declare namespace browser.topSites {
  */
 declare namespace browser.types {
     /* types types */
-
     /**
      * The scope of the Setting. One of
      *
@@ -2796,7 +3374,7 @@ declare namespace browser.types {
      * Only `regular` is supported by Firefox at this time.
      */
     type SettingScope =
-          "regular"
+        "regular"
         | "regular_only"
         | "incognito_persistent"
         | "incognito_session_only";
@@ -2810,7 +3388,7 @@ declare namespace browser.types {
      * *   `controlled_by_this_extension`: controlled by this extension
      */
     type LevelOfControl =
-          "not_controllable"
+        "not_controllable"
         | "controlled_by_other_extensions"
         | "controllable_by_this_extension"
         | "controlled_by_this_extension";
@@ -2887,14 +3465,13 @@ declare namespace browser.types {
  */
 declare namespace browser.webNavigation {
     /* webNavigation types */
-
     /**
      * Cause of the navigation. The same transition types as defined in the history API are used. These are the same
      * transition types as defined in the history API except with `"start_page"` in place of `"auto_toplevel"` (for
      * backwards compatibility).
      */
     type TransitionType =
-          "link"
+        "link"
         | "typed"
         | "auto_bookmark"
         | "auto_subframe"
@@ -2907,7 +3484,7 @@ declare namespace browser.webNavigation {
         | "keyword_generated";
 
     type TransitionQualifier =
-          "client_redirect"
+        "client_redirect"
         | "server_redirect"
         | "forward_back"
         | "from_address_bar";
@@ -3221,7 +3798,7 @@ declare namespace browser.webNavigation {
 declare namespace browser.webRequest {
     /* webRequest types */
     type ResourceType =
-          "main_frame"
+        "main_frame"
         | "sub_frame"
         | "stylesheet"
         | "script"
@@ -3240,24 +3817,19 @@ declare namespace browser.webRequest {
         | "csp_report"
         | "imageset"
         | "web_manifest"
+        | "speculative"
         | "other";
 
-    type OnBeforeRequestOptions =
-          "blocking"
-        | "requestBody";
+    type OnBeforeRequestOptions = "blocking" | "requestBody";
 
-    type OnBeforeSendHeadersOptions =
-          "requestHeaders"
-        | "blocking";
+    type OnBeforeSendHeadersOptions = "requestHeaders" | "blocking";
 
     type OnSendHeadersOptions = "requestHeaders";
 
-    type OnHeadersReceivedOptions =
-          "blocking"
-        | "responseHeaders";
+    type OnHeadersReceivedOptions = "blocking" | "responseHeaders";
 
     type OnAuthRequiredOptions =
-          "responseHeaders"
+        "responseHeaders"
         | "blocking"
         | "asyncBlocking";
 
@@ -3310,6 +3882,12 @@ declare namespace browser.webRequest {
          */
         redirectUrl?: string;
         /**
+         * Only used as a response to the onBeforeRequest event. If set, the original request is prevented from being
+         * sent/completed and is instead upgraded to a secure request. If any extension returns `redirectUrl` during
+         * onBeforeRequest, `upgradeToSecure` will have no affect.
+         */
+        upgradeToSecure?: boolean;
+        /**
          * Only used as a response to the onBeforeSendHeaders event. If set, the request is made with these request
          * headers instead.
          */
@@ -3330,6 +3908,75 @@ declare namespace browser.webRequest {
         };
     }
 
+    /** Contains the certificate properties of the request if it is a secure request. */
+    interface CertificateInfo {
+        subject: string;
+        issuer: string;
+        /** Contains start and end timestamps. */
+        validity: {
+            start: number;
+            end: number;
+        };
+        fingerprint: {
+            sha1: string;
+            sha256: string;
+        };
+        serialNumber: string;
+        isBuiltInRoot: boolean;
+        subjectPublicKeyInfoDigest: {
+            sha256: string;
+        };
+        rawDER?: number[];
+    }
+
+    type CertificateTransparencyStatus =
+        "not_applicable"
+        | "policy_compliant"
+        | "policy_not_enough_scts"
+        | "policy_not_diverse_scts";
+
+    type TransportWeaknessReasons = "cipher";
+
+    /** Contains the security properties of the request (ie. SSL/TLS information). */
+    interface SecurityInfo {
+        state: _SecurityInfoState;
+        /** Error message if state is "broken" */
+        errorMessage?: string;
+        /** Protocol version if state is "secure" */
+        protocolVersion?: _SecurityInfoProtocolVersion;
+        /** The cipher suite used in this request if state is "secure". */
+        cipherSuite?: string;
+        /** The key exchange algorithm used in this request if state is "secure". */
+        keaGroupName?: string;
+        /** The signature scheme used in this request if state is "secure". */
+        signatureSchemeName?: string;
+        /**
+         * Certificate data if state is "secure". Will only contain one entry unless `certificateChain` is passed as an
+         * option.
+         */
+        certificates: CertificateInfo[];
+        /** The domain name does not match the certificate domain. */
+        isDomainMismatch?: boolean;
+        isExtendedValidation?: boolean;
+        /**
+         * The certificate is either expired or is not yet valid. See `CertificateInfo.validity` for start and end
+         * dates.
+         */
+        isNotValidAtThisTime?: boolean;
+        isUntrusted?: boolean;
+        /**
+         * Certificate transparency compliance per RFC 6962\. See `https://www.certificate-transparency.org/what-is-ct`
+         * for more information.
+         */
+        certificateTransparencyStatus?: CertificateTransparencyStatus;
+        /** True if host uses Strict Transport Security and state is "secure". */
+        hsts?: boolean;
+        /** True if host uses Public Key Pinning and state is "secure". */
+        hpkp?: string;
+        /** list of reasons that cause the request to be considered weak, if state is "weak" */
+        weaknessReasons?: TransportWeaknessReasons[];
+    }
+
     /** Contains data uploaded in a URL request. */
     interface UploadData {
         /** An ArrayBuffer with a copy of the data. */
@@ -3337,6 +3984,20 @@ declare namespace browser.webRequest {
         /** A string with the file's path and name. */
         file?: string;
     }
+
+    type _SecurityInfoState =
+        "insecure"
+        | "weak"
+        | "broken"
+        | "secure";
+
+    /** Protocol version if state is "secure" */
+    type _SecurityInfoProtocolVersion =
+        "TLSv1"
+        | "TLSv1.1"
+        | "TLSv1.2"
+        | "TLSv1.3"
+        | "unknown";
 
     type _WebRequestOnBeforeRequestEvent<T = (details: {
         /**
@@ -3734,6 +4395,16 @@ declare namespace browser.webRequest {
     /** ... */
     function filterResponseData(requestId: string): object/*StreamFilter*/;
 
+    /**
+     * Retrieves the security information for the request. Returns a promise that will resolve to a SecurityInfo object.
+     */
+    function getSecurityInfo(requestId: string, options?: {
+        /** Include the entire certificate chain. */
+        certificateChain?: boolean;
+        /** Include raw certificate data for processing by the extension. */
+        rawDER?: boolean;
+    }): Promise<SecurityInfo>;
+
     /* webRequest events */
     /**
      * Fired when a request is about to occur.
@@ -3798,7 +4469,6 @@ declare namespace browser.webRequest {
  */
 declare namespace browser.bookmarks {
     /* bookmarks types */
-
     /**
      * Indicates the reason why this node is unmodifiable. The `managed` value indicates that this node was configured
      * by the system administrator or by the custodian of a supervised user. Omitted if the node can be modified by the
@@ -3807,7 +4477,10 @@ declare namespace browser.bookmarks {
     type BookmarkTreeNodeUnmodifiable = "managed";
 
     /** Indicates the type of a BookmarkTreeNode, which can be one of bookmark, folder or separator. */
-    type BookmarkTreeNodeType = "bookmark" | "folder" | "separator";
+    type BookmarkTreeNodeType =
+        "bookmark"
+        | "folder"
+        | "separator";
 
     /**
      * A node (either a bookmark or a folder) in the bookmark tree. Child nodes are ordered within their parent folder.
@@ -3958,19 +4631,6 @@ declare namespace browser.bookmarks {
     const onChildrenReordered: WebExtEvent<(id: string, reorderInfo: {
         childIds: string[];
     }) => void> | undefined;
-
-    /**
-     * Fired when a bookmark import session is begun. Expensive observers should ignore onCreated updates until
-     * onImportEnded is fired. Observers should still handle other notifications immediately.
-     * @deprecated Unsupported on Firefox at this time.
-     */
-    const onImportBegan: WebExtEvent<() => void> | undefined;
-
-    /**
-     * Fired when a bookmark import session is ended.
-     * @deprecated Unsupported on Firefox at this time.
-     */
-    const onImportEnded: WebExtEvent<() => void> | undefined;
 }
 
 /**
@@ -3983,32 +4643,66 @@ declare namespace browser.bookmarks {
  */
 declare namespace browser.browserAction {
     /* browserAction types */
+    /**
+     * Specifies to which tab or window the value should be set, or from which one it should be retrieved. If no tab
+     * nor window is specified, the global value is set or retrieved.
+     */
+    interface Details {
+        /**
+         * When setting a value, it will be specific to the specified tab, and will automatically reset when the tab
+         * navigates. When getting, specifies the tab to get the value from; if there is no tab-specific value, the
+         * window one will be inherited.
+         */
+        tabId?: number;
+        /**
+         * When setting a value, it will be specific to the specified window. When getting, specifies the window to get
+         * the value from; if there is no window-specific value, the global one will be inherited.
+         */
+        windowId?: number;
+    }
+
     type ColorArray = [number, number, number, number];
 
     /** Pixel data for an image. Must be an ImageData object (for example, from a `canvas` element). */
     type ImageDataType = object/*ImageData*/;
 
+    /**
+     * An array of four integers in the range [0,255] that make up the RGBA color of the badge. For example, opaque red
+     * is `[255, 0, 0, 255]`. Can also be a string with a CSS value, with opaque red being `#FF0000` or `#F00`.
+     */
+    type ColorValue = string | ColorArray | null;
+
     /* browserAction functions */
-    /** Sets the title of the browser action. This shows up in the tooltip. */
+    /**
+     * Sets the title of the browser action. This shows up in the tooltip.
+     * @param details Specifies to which tab or window the value should be set, or from which one it should be
+     *     retrieved. If no tab nor window is specified, the global value is set or retrieved.
+     */
     function setTitle(details: {
         /** The string the browser action should display when moused over. */
-        title: string;
-        /** Limits the change to when a particular tab is selected. Automatically resets when the tab is closed. */
+        title: string | null;
+        /**
+         * When setting a value, it will be specific to the specified tab, and will automatically reset when the tab
+         * navigates. When getting, specifies the tab to get the value from; if there is no tab-specific value, the
+         * window one will be inherited.
+         */
         tabId?: number;
+        /**
+         * When setting a value, it will be specific to the specified window. When getting, specifies the window to get
+         * the value from; if there is no window-specific value, the global one will be inherited.
+         */
+        windowId?: number;
     }): Promise<void>;
 
     /** Gets the title of the browser action. */
-    function getTitle(details: {
-        /**
-         * Specify the tab to get the title from. If no tab is specified, the non-tab-specific title is returned.
-         */
-        tabId?: number;
-    }): Promise<string>;
+    function getTitle(details: Details): Promise<string>;
 
     /**
      * Sets the icon for the browser action. The icon can be specified either as the path to an image file or as the
      * pixel data from a canvas element, or as dictionary of either one of those. Either the **path** or the
      * **imageData** property must be specified.
+     * @param details Specifies to which tab or window the value should be set, or from which one it should be
+     *     retrieved. If no tab nor window is specified, the global value is set or retrieved.
      */
     function setIcon(details: {
         /**
@@ -4031,64 +4725,115 @@ declare namespace browser.browserAction {
         path?: string | {
             [key: number]: string;
         };
-        /** Limits the change to when a particular tab is selected. Automatically resets when the tab is closed. */
-        tabId?: number;
-    }): Promise<void>;
-
-    /** Sets the html document to be opened as a popup when the user clicks on the browser action's icon. */
-    function setPopup(details: {
-        /** Limits the change to when a particular tab is selected. Automatically resets when the tab is closed. */
-        tabId?: number;
-        /** The html file to show in a popup. If set to the empty string (''), no popup is shown. */
-        popup: string;
-    }): Promise<void>;
-
-    /** Gets the html document set as the popup for this browser action. */
-    function getPopup(details: {
         /**
-         * Specify the tab to get the popup from. If no tab is specified, the non-tab-specific popup is returned.
+         * When setting a value, it will be specific to the specified tab, and will automatically reset when the tab
+         * navigates. When getting, specifies the tab to get the value from; if there is no tab-specific value, the
+         * window one will be inherited.
          */
         tabId?: number;
-    }): Promise<string>;
-
-    /** Sets the badge text for the browser action. The badge is displayed on top of the icon. */
-    function setBadgeText(details: {
-        /** Any number of characters can be passed, but only about four can fit in the space. */
-        text: string;
-        /** Limits the change to when a particular tab is selected. Automatically resets when the tab is closed. */
-        tabId?: number;
+        /**
+         * When setting a value, it will be specific to the specified window. When getting, specifies the window to get
+         * the value from; if there is no window-specific value, the global one will be inherited.
+         */
+        windowId?: number;
     }): Promise<void>;
 
     /**
-     * Gets the badge text of the browser action. If no tab is specified, the non-tab-specific badge text is returned.
+     * Sets the html document to be opened as a popup when the user clicks on the browser action's icon.
+     * @param details Specifies to which tab or window the value should be set, or from which one it should be
+     *     retrieved. If no tab nor window is specified, the global value is set or retrieved.
      */
-    function getBadgeText(details: {
+    function setPopup(details: {
+        /** The html file to show in a popup. If set to the empty string (''), no popup is shown. */
+        popup: string | null;
         /**
-         * Specify the tab to get the badge text from. If no tab is specified, the non-tab-specific badge text is
-         * returned.
+         * When setting a value, it will be specific to the specified tab, and will automatically reset when the tab
+         * navigates. When getting, specifies the tab to get the value from; if there is no tab-specific value, the
+         * window one will be inherited.
          */
         tabId?: number;
-    }): Promise<string>;
-
-    /** Sets the background color for the badge. */
-    function setBadgeBackgroundColor(details: {
         /**
-         * An array of four integers in the range [0,255] that make up the RGBA color of the badge. For example, opaque
-         * red is `[255, 0, 0, 255]`. Can also be a string with a CSS value, with opaque red being `#FF0000` or `#F00`.
+         * When setting a value, it will be specific to the specified window. When getting, specifies the window to get
+         * the value from; if there is no window-specific value, the global one will be inherited.
          */
-        color: string | ColorArray;
-        /** Limits the change to when a particular tab is selected. Automatically resets when the tab is closed. */
-        tabId?: number;
+        windowId?: number;
     }): Promise<void>;
 
-    /** Gets the background color of the browser action. */
-    function getBadgeBackgroundColor(details: {
+    /** Gets the html document set as the popup for this browser action. */
+    function getPopup(details: Details): Promise<string>;
+
+    /**
+     * Sets the badge text for the browser action. The badge is displayed on top of the icon.
+     * @param details Specifies to which tab or window the value should be set, or from which one it should be
+     *     retrieved. If no tab nor window is specified, the global value is set or retrieved.
+     */
+    function setBadgeText(details: {
+        /** Any number of characters can be passed, but only about four can fit in the space. */
+        text: string | null;
         /**
-         * Specify the tab to get the badge background color from. If no tab is specified, the non-tab-specific badge
-         * background color is returned.
+         * When setting a value, it will be specific to the specified tab, and will automatically reset when the tab
+         * navigates. When getting, specifies the tab to get the value from; if there is no tab-specific value, the
+         * window one will be inherited.
          */
         tabId?: number;
-    }): Promise<ColorArray>;
+        /**
+         * When setting a value, it will be specific to the specified window. When getting, specifies the window to get
+         * the value from; if there is no window-specific value, the global one will be inherited.
+         */
+        windowId?: number;
+    }): Promise<void>;
+
+    /**
+     * Gets the badge text of the browser action. If no tab nor window is specified is specified, the global badge text
+     * is returned.
+     */
+    function getBadgeText(details: Details): Promise<string>;
+
+    /**
+     * Sets the background color for the badge.
+     * @param details Specifies to which tab or window the value should be set, or from which one it should be
+     *     retrieved. If no tab nor window is specified, the global value is set or retrieved.
+     */
+    function setBadgeBackgroundColor(details: {
+        color: ColorValue;
+        /**
+         * When setting a value, it will be specific to the specified tab, and will automatically reset when the tab
+         * navigates. When getting, specifies the tab to get the value from; if there is no tab-specific value, the
+         * window one will be inherited.
+         */
+        tabId?: number;
+        /**
+         * When setting a value, it will be specific to the specified window. When getting, specifies the window to get
+         * the value from; if there is no window-specific value, the global one will be inherited.
+         */
+        windowId?: number;
+    }): Promise<void>;
+
+    /** Gets the background color of the browser action badge. */
+    function getBadgeBackgroundColor(details: Details): Promise<ColorArray>;
+
+    /**
+     * Sets the text color for the badge.
+     * @param details Specifies to which tab or window the value should be set, or from which one it should be
+     *     retrieved. If no tab nor window is specified, the global value is set or retrieved.
+     */
+    function setBadgeTextColor(details: {
+        color: ColorValue;
+        /**
+         * When setting a value, it will be specific to the specified tab, and will automatically reset when the tab
+         * navigates. When getting, specifies the tab to get the value from; if there is no tab-specific value, the
+         * window one will be inherited.
+         */
+        tabId?: number;
+        /**
+         * When setting a value, it will be specific to the specified window. When getting, specifies the window to get
+         * the value from; if there is no window-specific value, the global one will be inherited.
+         */
+        windowId?: number;
+    }): Promise<any>;
+
+    /** Gets the text color of the browser action badge. */
+    function getBadgeTextColor(details: Details): Promise<any>;
 
     /**
      * Enables the browser action for a tab. By default, browser actions are enabled.
@@ -4101,6 +4846,9 @@ declare namespace browser.browserAction {
      * @param [tabId] The id of the tab for which you want to modify the browser action.
      */
     function disable(tabId?: number): Promise<void>;
+
+    /** Checks whether the browser action is enabled. */
+    function isEnabled(details: Details): Promise<any>;
 
     /** Opens the extension popup window in the active window. */
     function openPopup(): Promise<void>;
@@ -4270,6 +5018,24 @@ declare namespace browser.commands {
     }
 
     /* commands functions */
+    /**
+     * Update the details of an already defined command.
+     * @param detail The new description for the command.
+     */
+    function update(detail: {
+        /** The name of the command. */
+        name: string;
+        /** The new description for the command. */
+        description?: string;
+        shortcut?: _manifest.KeyName;
+    }): Promise<void>;
+
+    /**
+     * Reset a command's details to what is specified in the manifest.
+     * @param name The name of the command.
+     */
+    function reset(name: string): Promise<void>;
+
     /** Returns all the registered extension commands for this extension and their shortcut (if active). */
     function getAll(): Promise<Command[] | undefined>;
 
@@ -4279,7 +5045,7 @@ declare namespace browser.commands {
 }
 
 /**
- * Permissions: `devtools`
+ * Manifest keys: `devtools_page`
  *
  * Allowed in: Devtools pages only
  */
@@ -4425,19 +5191,15 @@ declare namespace browser.devtools.network {
     }
 
     /* devtools.network functions */
-    /**
-     * Returns HAR log that contains all known network requests.
-     * @deprecated Unsupported on Firefox at this time.
-     */
+    /** Returns HAR log that contains all known network requests. */
     function getHAR(): Promise<any>;
 
     /* devtools.network events */
     /**
      * Fired when a network request is finished and all request data are available.
      * @param request Description of a network request in the form of a HAR entry. See HAR specification for details.
-     * @deprecated Unsupported on Firefox at this time.
      */
-    const onRequestFinished: WebExtEvent<(request: Request) => void> | undefined;
+    const onRequestFinished: WebExtEvent<(request: Request) => void>;
 
     /**
      * Fired when the inspected window navigates to a new page.
@@ -4575,6 +5337,8 @@ declare namespace browser.devtools.panels {
         onClicked: WebExtEvent<() => void>;
     }
 
+    type _Create = "";
+
     /* devtools.panels properties */
     /** Elements panel. */
     const elements: ElementsPanel;
@@ -4589,10 +5353,11 @@ declare namespace browser.devtools.panels {
     /**
      * Creates an extension panel.
      * @param title Title that is displayed next to the extension icon in the Developer Tools toolbar.
-     * @param iconPath Path of the panel's icon relative to the extension directory.
+     * @param iconPath Path of the panel's icon relative to the extension directory, or an empty string to use the
+     *     default extension icon as the panel icon.
      * @param pagePath Path of the panel's HTML page relative to the extension directory.
      */
-    function create(title: string, iconPath: string, pagePath: string): Promise<ExtensionPanel | undefined>;
+    function create(title: string, iconPath: _manifest.ExtensionURL | _Create, pagePath: _manifest.ExtensionURL): Promise<ExtensionPanel | undefined>;
 
     /**
      * Specifies the function to be called when the user clicks a resource link in the Developer Tools window. To unset
@@ -4695,16 +5460,19 @@ declare namespace browser.find {
 declare namespace browser.geckoProfiler {
     /* geckoProfiler types */
     type ProfilerFeature =
-          "java"
+        "java"
         | "js"
         | "leaf"
         | "mainthreadio"
         | "memory"
         | "privacy"
-        | "restyle"
+        | "responsiveness"
+        | "screenshots"
+        | "seqstyle"
         | "stackwalk"
         | "tasktracer"
-        | "threads";
+        | "threads"
+        | "trackopts";
 
     /* geckoProfiler functions */
     /** Starts the profiler with the specified settings. */
@@ -4768,10 +5536,9 @@ declare namespace browser.geckoProfiler {
  */
 declare namespace browser.history {
     /* history types */
-
     /** The transition type for this visit from its referrer. */
     type TransitionType =
-          "link"
+        "link"
         | "typed"
         | "auto_bookmark"
         | "auto_subframe"
@@ -4902,18 +5669,15 @@ declare namespace browser.history {
  * your context menu additions apply to, such as images, hyperlinks, and pages.
  *
  * Permissions: `contextMenus`
- *
- * Not allowed in: Content scripts, Devtools pages
  */
 declare namespace browser.contextMenus {
     /* contextMenus types */
-
     /**
      * The different contexts a menu can appear in. Specifying 'all' is equivalent to the combination of all other
      * contexts except for 'tab' and 'tools_menu'.
      */
     type ContextType =
-          "all"
+        "all"
         | "page"
         | "frame"
         | "selection"
@@ -4924,13 +5688,14 @@ declare namespace browser.contextMenus {
         | "video"
         | "audio"
         | "launcher"
+        | "bookmark"
         | "browser_action"
         | "page_action"
         | "tab";
 
     /** The type of menu item. */
     type ItemType =
-          "normal"
+        "normal"
         | "checkbox"
         | "radio"
         | "separator";
@@ -4966,12 +5731,19 @@ declare namespace browser.contextMenus {
         wasChecked?: boolean;
         /** A flag indicating the state of a checkbox or radio item after it is clicked. */
         checked?: boolean;
+        /** The id of the bookmark where the context menu was clicked, if it was on a bookmark. */
+        bookmarkId: string;
         /** An array of keyboard modifiers that were held while the menu item was clicked. */
         modifiers: _OnClickDataModifiers[];
+        /**
+         * An identifier of the clicked element, if any. Use menus.getTargetElement in the page to find the
+         * corresponding element.
+         */
+        targetElementId?: number;
     }
 
     type _OnClickDataModifiers =
-          "Shift"
+        "Shift"
         | "Alt"
         | "Command"
         | "Ctrl"
@@ -5017,6 +5789,8 @@ declare namespace browser.contextMenus {
         checked?: boolean;
         /** List of contexts this menu item will appear in. Defaults to ['page'] if not specified. */
         contexts?: ContextType[];
+        /** Whether the item is visible in the menu. */
+        visible?: boolean;
         /**
          * A function that will be called back when the menu item is clicked. Event pages cannot use this; instead,
          * they should register a listener for `contextMenus.onClicked`.
@@ -5024,7 +5798,7 @@ declare namespace browser.contextMenus {
          * @param tab The details of the tab where the click took place. Note: this parameter only present for
          *     extensions.
          */
-        onclick?: (info: menusInternal.OnClickData, tab: tabs.Tab) => void;
+        onclick?: (info: OnClickData, tab: tabs.Tab) => void;
         /** The ID of a parent menu item; this makes the item a child of a previously added item. */
         parentId?: number | string;
         /**
@@ -5056,11 +5830,13 @@ declare namespace browser.contextMenus {
         title?: string;
         checked?: boolean;
         contexts?: ContextType[];
+        /** Whether the item is visible in the menu. */
+        visible?: boolean;
         /**
          * @param tab The details of the tab where the click took place. Note: this parameter only present for
          *     extensions.
          */
-        onclick?: (info: menusInternal.OnClickData, tab: tabs.Tab) => void;
+        onclick?: (info: OnClickData, tab: tabs.Tab) => void;
         /** Note: You cannot change an item to be a child of one of its own descendants. */
         parentId?: number | string;
         documentUrlPatterns?: string[];
@@ -5077,6 +5853,20 @@ declare namespace browser.contextMenus {
     /** Removes all context menu items added by this extension. */
     function removeAll(): Promise<void>;
 
+    /**
+     * Updates the extension items in the shown menu, including changes that have been made since the menu was shown.
+     * Has no effect if the menu is hidden. Rebuilding a shown menu is an expensive operation, only invoke this method
+     * when necessary.
+     */
+    function refresh(): Promise<any>;
+
+    /**
+     * Retrieve the element that was associated with a recent contextmenu event.
+     * @param targetElementId The identifier of the clicked element, available as info.targetElementId in the
+     *     menus.onShown, onClicked or onclick event.
+     */
+    function getTargetElement(targetElementId: number): object/*Element*/ | void;
+
     /* contextMenus events */
     /**
      * Fired when a context menu item is clicked.
@@ -5085,25 +5875,49 @@ declare namespace browser.contextMenus {
      *     parameter will be missing.
      */
     const onClicked: WebExtEvent<(info: OnClickData, tab?: tabs.Tab) => void>;
+
+    /**
+     * Fired when a menu is shown. The extension can add, modify or remove menu items and call menus.refresh() to
+     * update the menu.
+     * @param info Information about the context of the menu action and the created menu items. For more information
+     *     about each property, see OnClickData. The following properties are only set if the extension has host
+     *     permissions for the given context: linkUrl, linkText, srcUrl, pageUrl, frameUrl, selectionText.
+     * @param tab The details of the tab where the menu was opened.
+     */
+    const onShown: WebExtEvent<(info: {
+        /** A list of IDs of the menu items that were shown. */
+        menuIds: number | string[];
+        /** A list of all contexts that apply to the menu. */
+        contexts: ContextType[];
+        editable: boolean;
+        mediaType: string;
+        linkUrl?: string;
+        linkText?: string;
+        srcUrl?: string;
+        pageUrl?: string;
+        frameUrl?: string;
+        selectionText?: string;
+        targetElementId?: number;
+    }, tab: tabs.Tab) => void>;
+
+    /** Fired when a menu is hidden. This event is only fired if onShown has fired before. */
+    const onHidden: WebExtEvent<() => void>;
 }
 
 /**
  * Use the browser.menus API to add items to the browser's menus. You can choose what types of objects your context
  * menu additions apply to, such as images, hyperlinks, and pages.
  *
- * Permissions: `menus`
- *
- * Not allowed in: Content scripts, Devtools pages
+ * Permissions: `menus`, `menus`
  */
 declare namespace browser.menus {
     /* menus types */
-
     /**
      * The different contexts a menu can appear in. Specifying 'all' is equivalent to the combination of all other
      * contexts except for 'tab' and 'tools_menu'.
      */
     type ContextType =
-          "all"
+        "all"
         | "page"
         | "frame"
         | "selection"
@@ -5114,6 +5928,7 @@ declare namespace browser.menus {
         | "video"
         | "audio"
         | "launcher"
+        | "bookmark"
         | "browser_action"
         | "page_action"
         | "tab"
@@ -5121,7 +5936,7 @@ declare namespace browser.menus {
 
     /** The type of menu item. */
     type ItemType =
-          "normal"
+        "normal"
         | "checkbox"
         | "radio"
         | "separator";
@@ -5157,12 +5972,19 @@ declare namespace browser.menus {
         wasChecked?: boolean;
         /** A flag indicating the state of a checkbox or radio item after it is clicked. */
         checked?: boolean;
+        /** The id of the bookmark where the context menu was clicked, if it was on a bookmark. */
+        bookmarkId: string;
         /** An array of keyboard modifiers that were held while the menu item was clicked. */
         modifiers: _OnClickDataModifiers[];
+        /**
+         * An identifier of the clicked element, if any. Use menus.getTargetElement in the page to find the
+         * corresponding element.
+         */
+        targetElementId?: number;
     }
 
     type _OnClickDataModifiers =
-          "Shift"
+        "Shift"
         | "Alt"
         | "Command"
         | "Ctrl"
@@ -5208,6 +6030,8 @@ declare namespace browser.menus {
         checked?: boolean;
         /** List of contexts this menu item will appear in. Defaults to ['page'] if not specified. */
         contexts?: ContextType[];
+        /** Whether the item is visible in the menu. */
+        visible?: boolean;
         /**
          * A function that will be called back when the menu item is clicked. Event pages cannot use this; instead,
          * they should register a listener for `contextMenus.onClicked`.
@@ -5215,7 +6039,7 @@ declare namespace browser.menus {
          * @param tab The details of the tab where the click took place. Note: this parameter only present for
          *     extensions.
          */
-        onclick?: (info: menusInternal.OnClickData, tab: tabs.Tab) => void;
+        onclick?: (info: OnClickData, tab: tabs.Tab) => void;
         /** The ID of a parent menu item; this makes the item a child of a previously added item. */
         parentId?: number | string;
         /**
@@ -5247,11 +6071,13 @@ declare namespace browser.menus {
         title?: string;
         checked?: boolean;
         contexts?: ContextType[];
+        /** Whether the item is visible in the menu. */
+        visible?: boolean;
         /**
          * @param tab The details of the tab where the click took place. Note: this parameter only present for
          *     extensions.
          */
-        onclick?: (info: menusInternal.OnClickData, tab: tabs.Tab) => void;
+        onclick?: (info: OnClickData, tab: tabs.Tab) => void;
         /** Note: You cannot change an item to be a child of one of its own descendants. */
         parentId?: number | string;
         documentUrlPatterns?: string[];
@@ -5268,6 +6094,20 @@ declare namespace browser.menus {
     /** Removes all context menu items added by this extension. */
     function removeAll(): Promise<void>;
 
+    /**
+     * Updates the extension items in the shown menu, including changes that have been made since the menu was shown.
+     * Has no effect if the menu is hidden. Rebuilding a shown menu is an expensive operation, only invoke this method
+     * when necessary.
+     */
+    function refresh(): Promise<any>;
+
+    /**
+     * Retrieve the element that was associated with a recent contextmenu event.
+     * @param targetElementId The identifier of the clicked element, available as info.targetElementId in the
+     *     menus.onShown, onClicked or onclick event.
+     */
+    function getTargetElement(targetElementId: number): object/*Element*/ | void;
+
     /* menus events */
     /**
      * Fired when a context menu item is clicked.
@@ -5276,46 +6116,33 @@ declare namespace browser.menus {
      *     parameter will be missing.
      */
     const onClicked: WebExtEvent<(info: OnClickData, tab?: tabs.Tab) => void>;
-}
 
-/**
- * Use the `browser.contextMenus` API to add items to the browser's context menu. You can choose what types of objects
- * your context menu additions apply to, such as images, hyperlinks, and pages.
- *
- * Not allowed in: Content scripts, Devtools pages
- */
-declare namespace browser.menusInternal {
-    /* menusInternal types */
-    /** Information sent when a context menu item is clicked. */
-    interface OnClickData {
-        /** The ID of the menu item that was clicked. */
-        menuItemId: number | string;
-        /** The parent ID, if any, for the item clicked. */
-        parentMenuItemId?: number | string;
-        /**
-         * One of 'image', 'video', or 'audio' if the context menu was activated on one of these types of elements.
-         */
-        mediaType?: string;
-        /** If the element is a link, the URL it points to. */
-        linkUrl?: string;
-        /** Will be present for elements with a 'src' URL. */
-        srcUrl?: string;
-        /**
-         * The URL of the page where the menu item was clicked. This property is not set if the click occured in a
-         * context where there is no current page, such as in a launcher context menu.
-         */
-        pageUrl?: string;
-        /** The URL of the frame of the element where the context menu was clicked, if it was in a frame. */
-        frameUrl?: string;
-        /** The text for the context selection, if any. */
-        selectionText?: string;
-        /** A flag indicating whether the element is editable (text input, textarea, etc.). */
+    /**
+     * Fired when a menu is shown. The extension can add, modify or remove menu items and call menus.refresh() to
+     * update the menu.
+     * @param info Information about the context of the menu action and the created menu items. For more information
+     *     about each property, see OnClickData. The following properties are only set if the extension has host
+     *     permissions for the given context: linkUrl, linkText, srcUrl, pageUrl, frameUrl, selectionText.
+     * @param tab The details of the tab where the menu was opened.
+     */
+    const onShown: WebExtEvent<(info: {
+        /** A list of IDs of the menu items that were shown. */
+        menuIds: number | string[];
+        /** A list of all contexts that apply to the menu. */
+        contexts: ContextType[];
         editable: boolean;
-        /** A flag indicating the state of a checkbox or radio item before it was clicked. */
-        wasChecked?: boolean;
-        /** A flag indicating the state of a checkbox or radio item after it is clicked. */
-        checked?: boolean;
-    }
+        mediaType: string;
+        linkUrl?: string;
+        linkText?: string;
+        srcUrl?: string;
+        pageUrl?: string;
+        frameUrl?: string;
+        selectionText?: string;
+        targetElementId?: number;
+    }, tab: tabs.Tab) => void>;
+
+    /** Fired when a menu is hidden. This event is only fired if onShown has fired before. */
+    const onHidden: WebExtEvent<() => void>;
 }
 
 /**
@@ -5327,10 +6154,9 @@ declare namespace browser.menusInternal {
  */
 declare namespace browser.omnibox {
     /* omnibox types */
-
     /** The style type. */
     type DescriptionStyleType =
-          "url"
+        "url"
         | "match"
         | "dim";
 
@@ -5340,7 +6166,7 @@ declare namespace browser.omnibox {
      * should take place in a new selected tab.
      */
     type OnInputEnteredDisposition =
-          "currentTab"
+        "currentTab"
         | "newForegroundTab"
         | "newBackgroundTab";
 
@@ -5455,12 +6281,18 @@ declare namespace browser.pageAction {
      */
     function hide(tabId: number): Promise<void>;
 
+    /** Checks whether the page action is shown. */
+    function isShown(details: {
+        /** Specify the tab to get the shownness from. */
+        tabId: number;
+    }): Promise<boolean>;
+
     /** Sets the title of the page action. This is displayed in a tooltip over the page action. */
     function setTitle(details: {
         /** The id of the tab for which you want to modify the page action. */
         tabId: number;
         /** The tooltip string. */
-        title: string;
+        title: string | null;
     }): void;
 
     /** Gets the title of the page action. */
@@ -5504,7 +6336,7 @@ declare namespace browser.pageAction {
         /** The id of the tab for which you want to modify the page action. */
         tabId: number;
         /** The html file to show in a popup. If set to the empty string (''), no popup is shown. */
-        popup: string;
+        popup: string | null;
     }): void;
 
     /** Gets the html document set as the popup for this page action. */
@@ -5551,6 +6383,38 @@ declare namespace browser.pkcs11 {
             isLoggedIn: string;
         };
     }>;
+}
+
+/**
+ * Use browser.search to interact with search engines.
+ *
+ * Permissions: `search`
+ *
+ * Not allowed in: Content scripts, Devtools pages
+ */
+declare namespace browser.search {
+    /* search types */
+    /** An object encapsulating a search engine */
+    interface SearchEngine {
+        name: string;
+        isDefault: boolean;
+        alias?: string;
+        favIconUrl?: string;
+    }
+
+    /* search functions */
+    /** Gets a list of search engines. */
+    function get(): Promise<SearchEngine[]>;
+
+    /** Perform a search. */
+    function search(searchProperties: {
+        /** Terms to search for. */
+        query: string;
+        /** Search engine to use. Uses the default if not specified. */
+        engine?: string;
+        /** The ID of the tab for the search results. If not specified, a new tab is created. */
+        tabId?: number;
+    }): Promise<any>;
 }
 
 /**
@@ -5695,17 +6559,23 @@ declare namespace browser.sidebarAction {
     /** Sets the title of the sidebar action. This shows up in the tooltip. */
     function setTitle(details: {
         /** The string the sidebar action should display when moused over. */
-        title: string;
+        title: string | null;
         /** Sets the sidebar title for the tab specified by tabId. Automatically resets when the tab is closed. */
         tabId?: number;
+        /** Sets the sidebar title for the window specified by windowId. */
+        windowId?: number;
     }): Promise<void>;
 
     /** Gets the title of the sidebar action. */
     function getTitle(details: {
         /**
-         * Specify the tab to get the title from. If no tab is specified, the non-tab-specific title is returned.
+         * Specify the tab to get the title from. If no tab nor window is specified, the global title is returned.
          */
         tabId?: number;
+        /**
+         * Specify the window to get the title from. If no tab nor window is specified, the global title is returned.
+         */
+        windowId?: number;
     }): Promise<string>;
 
     /**
@@ -5734,6 +6604,8 @@ declare namespace browser.sidebarAction {
         path?: string;
         /** Sets the sidebar icon for the tab specified by tabId. Automatically resets when the tab is closed. */
         tabId?: number;
+        /** Sets the sidebar icon for the window specified by windowId. */
+        windowId?: number;
     }): Promise<void>;
 
     /**
@@ -5742,16 +6614,22 @@ declare namespace browser.sidebarAction {
     function setPanel(details: {
         /** Sets the sidebar url for the tab specified by tabId. Automatically resets when the tab is closed. */
         tabId?: number;
+        /** Sets the sidebar url for the window specified by windowId. */
+        windowId?: number;
         /** The url to the html file to show in a sidebar. If set to the empty string (''), no sidebar is shown. */
-        panel: string;
+        panel: string | null;
     }): Promise<void>;
 
     /** Gets the url to the html document set as the panel for this sidebar action. */
     function getPanel(details: {
         /**
-         * Specify the tab to get the sidebar from. If no tab is specified, the non-tab-specific sidebar is returned.
+         * Specify the tab to get the panel from. If no tab nor window is specified, the global panel is returned.
          */
         tabId?: number;
+        /**
+         * Specify the window to get the panel from. If no tab nor window is specified, the global panel is returned.
+         */
+        windowId?: number;
     }): Promise<string>;
 
     /** Opens the extension sidebar in the active window. */
@@ -5759,6 +6637,12 @@ declare namespace browser.sidebarAction {
 
     /** Closes the extension sidebar in the active window if the sidebar belongs to the extension. */
     function close(): Promise<void>;
+
+    /** Checks whether the sidebar action is open. */
+    function isOpen(details: {
+        /** Specify the window to get the openness from. */
+        windowId?: number;
+    }): Promise<boolean>;
 }
 
 /**
@@ -5769,14 +6653,13 @@ declare namespace browser.sidebarAction {
  */
 declare namespace browser.tabs {
     /* tabs types */
-
     /** An event that caused a muted state change. */
     type MutedInfoReason =
         /** A user input action has set/overridden the muted state. */
-          "user"
-/** Tab capture started, forcing a muted state change. */
+        "user"
+        /** Tab capture started, forcing a muted state change. */
         | "capture"
-/** An extension, identified by the extensionId field, set the muted state. */
+        /** An extension, identified by the extensionId field, set the muted state. */
         | "extension";
 
     /** Tab muted state and the reason for the last state change. */
@@ -5793,6 +6676,19 @@ declare namespace browser.tabs {
          * state last changed.
          */
         extensionId?: string;
+    }
+
+    /** Tab sharing state for screen, microphone and camera. */
+    interface SharingState {
+        /**
+         * If the tab is sharing the screen the value will be one of "Screen", "Window", or "Application", or undefined
+         * if not screen sharing.
+         */
+        screen?: string;
+        /** True if the tab is using the camera. */
+        camera: boolean;
+        /** True if the tab is using the microphone. */
+        microphone: boolean;
     }
 
     interface Tab {
@@ -5855,6 +6751,8 @@ declare namespace browser.tabs {
         width?: number;
         /** The height of the tab in pixels. */
         height?: number;
+        /** True if the tab is hidden. */
+        hidden?: boolean;
         /** The session ID used to uniquely identify a Tab obtained from the `sessions` API. */
         sessionId?: string;
         /** The CookieStoreId used for the tab. */
@@ -5863,6 +6761,10 @@ declare namespace browser.tabs {
         isArticle?: boolean;
         /** Whether the document in the tab is being rendered in reader mode. */
         isInReaderMode?: boolean;
+        /** Current tab sharing state for screen, microphone and camera. */
+        sharingState?: SharingState;
+        /** Whether the tab is drawing attention. */
+        attention?: boolean;
     }
 
     /**
@@ -5871,7 +6773,7 @@ declare namespace browser.tabs {
      */
     type ZoomSettingsMode =
         /** Zoom changes are handled automatically by the browser. */
-          "automatic"
+        "automatic"
         /**
          * Overrides the automatic handling of zoom changes. The `onZoomChange` event will still be dispatched, and it
          * is the responsibility of the extension to listen for this event and manually scale the page. This mode does
@@ -5895,7 +6797,7 @@ declare namespace browser.tabs {
          * navigating to other pages in the same origin, they will all be zoomed to the same zoom factor. The
          * `per-origin` scope is only available in the `automatic` mode.
          */
-        | "per-origin"
+        "per-origin"
         /**
          * Zoom changes only take effect in this tab, and zoom changes in other tabs will not affect the zooming of
          * this tab. Also, `per-tab` zoom changes are reset on navigation; navigating a tab will always load pages with
@@ -5921,6 +6823,12 @@ declare namespace browser.tabs {
 
     /** The page settings including: orientation, scale, background, margins, headers, footers. */
     interface PageSettings {
+        /** The page size unit: 0 = inches, 1 = millimeters. Default: 0. */
+        paperSizeUnit?: number;
+        /** The paper width in paper size units. Default: 8.5. */
+        paperWidth?: number;
+        /** The paper height in paper size units. Default: 11.0. */
+        paperHeight?: number;
         /** The page content orientation: 0 = portrait, 1 = landscape. Default: 0. */
         orientation?: number;
         /** The page content scaling factor: 1.0 = 100% = normal size. Default: 1.0. */
@@ -5931,12 +6839,22 @@ declare namespace browser.tabs {
         showBackgroundColors?: boolean;
         /** Whether the page background images should be shown. Default: false. */
         showBackgroundImages?: boolean;
-        /** The page size unit: 0 = inches, 1 = millimeters. Default: 0. */
-        paperSizeUnit?: number;
-        /** The paper width in paper size units. Default: 8.5. */
-        paperWidth?: number;
-        /** The paper height in paper size units. Default: 11.0. */
-        paperHeight?: number;
+        /** The spacing between the left header/footer and the left edge of the paper (inches). Default: 0. */
+        edgeLeft?: number;
+        /** The spacing between the right header/footer and the right edge of the paper (inches). Default: 0. */
+        edgeRight?: number;
+        /** The spacing between the top of the headers and the top edge of the paper (inches). Default: 0 */
+        edgeTop?: number;
+        /** The spacing between the bottom of the footers and the bottom edge of the paper (inches). Default: 0. */
+        edgeBottom?: number;
+        /** The margin between the page content and the left edge of the paper (inches). Default: 0.5. */
+        marginLeft?: number;
+        /** The margin between the page content and the right edge of the paper (inches). Default: 0.5. */
+        marginRight?: number;
+        /** The margin between the page content and the top edge of the paper (inches). Default: 0.5. */
+        marginTop?: number;
+        /** The margin between the page content and the bottom edge of the paper (inches). Default: 0.5. */
+        marginBottom?: number;
         /** The text for the page's left header. Default: '&T'. */
         headerLeft?: string;
         /** The text for the page's center header. Default: ''. */
@@ -5949,28 +6867,87 @@ declare namespace browser.tabs {
         footerCenter?: string;
         /** The text for the page's right footer. Default: '&D'. */
         footerRight?: string;
-        /** The margin between the page content and the left edge of the paper (inches). Default: 0.5. */
-        marginLeft?: number;
-        /** The margin between the page content and the right edge of the paper (inches). Default: 0.5. */
-        marginRight?: number;
-        /** The margin between the page content and the top edge of the paper (inches). Default: 0.5. */
-        marginTop?: number;
-        /** The margin between the page content and the bottom edge of the paper (inches). Default: 0.5. */
-        marginBottom?: number;
     }
 
     /** Whether the tabs have completed loading. */
-    type TabStatus =
-          "loading"
-        | "complete";
+    type TabStatus = "loading" | "complete";
 
     /** The type of window. */
     type WindowType =
-          "normal"
+        "normal"
         | "popup"
         | "panel"
         | "app"
         | "devtools";
+
+    /** Event names supported in onUpdated. */
+    type UpdatePropertyName =
+        "attention"
+        | "audible"
+        | "discarded"
+        | "favIconUrl"
+        | "hidden"
+        | "isarticle"
+        | "isArticle"
+        | "mutedInfo"
+        | "pinned"
+        | "sharingState"
+        | "status"
+        | "title";
+
+    /** An object describing filters to apply to tabs.onUpdated events. */
+    interface UpdateFilter {
+        /**
+         * A list of URLs or URL patterns. Events that cannot match any of the URLs will be filtered out. Filtering
+         * with urls requires the `"tabs"` or `"activeTab"` permission.
+         */
+        urls?: string[];
+        /** A list of property names. Events that do not match any of the names will be filtered out. */
+        properties?: UpdatePropertyName[];
+        tabId?: number;
+        windowId?: number;
+    }
+
+    type _QueryScreen =
+        "Screen"
+        | "Window"
+        | "Application";
+
+    type _TabsOnUpdatedEvent<T = (tabId: number, changeInfo: {
+        /** The tab's new attention state. */
+        attention: boolean;
+        /** The tab's new audible state. */
+        audible?: boolean;
+        /** True while the tab is not loaded with content. */
+        discarded?: boolean;
+        /**
+         * The tab's new favicon URL. This property is only present if the extension's manifest includes the `"tabs"`
+         * permission.
+         */
+        favIconUrl?: string;
+        /** The tab's new hidden state. */
+        hidden?: boolean;
+        /** Whether the document in the tab can be rendered in reader mode. */
+        isArticle?: boolean;
+        /** The tab's new muted state and the reason for the change. */
+        mutedInfo?: MutedInfo;
+        /** The tab's new pinned state. */
+        pinned?: boolean;
+        /** The tab's new sharing state for screen, microphone and camera. */
+        sharingState?: SharingState;
+        /** The status of the tab. Can be either _loading_ or _complete_. */
+        status?: string;
+        /**
+         * The title of the tab if it has changed. This property is only present if the extension's manifest includes
+         * the `"tabs"` permission.
+         */
+        title?: string;
+        /**
+         * The tab's URL if it has changed. This property is only present if the extension's manifest includes the
+         * `"tabs"` permission.
+         */
+        url?: string;
+    }, tab: Tab) => void> = WebExtEventBase<(callback: T, filter?: UpdateFilter) => void, T>;
 
     /* tabs properties */
     /** An ID which represents the absence of a browser tab. */
@@ -6067,6 +7044,10 @@ declare namespace browser.tabs {
         cookieStoreId?: string;
         /** Whether the document in the tab should be opened in reader mode. */
         openInReaderMode?: boolean;
+        /** Whether the tab is marked as 'discarded' when created. */
+        discarded?: boolean;
+        /** The title used for display if the tab is created in discarded mode. */
+        title?: string;
     }): Promise<Tab | undefined>;
 
     /**
@@ -6079,6 +7060,8 @@ declare namespace browser.tabs {
     function query(queryInfo: {
         /** Whether the tabs are active in their windows. */
         active?: boolean;
+        /** Whether the tabs are drawing attention. */
+        attention?: boolean;
         /** Whether the tabs are pinned. */
         pinned?: boolean;
         /** Whether the tabs are audible. */
@@ -6095,6 +7078,8 @@ declare namespace browser.tabs {
         status?: TabStatus;
         /** True while the tabs are not loaded with content. */
         discarded?: boolean;
+        /** True while the tabs are hidden. */
+        hidden?: boolean;
         /** Match page titles against a pattern. */
         title?: string;
         /** Match tabs against one or more URL patterns. Note that fragment identifiers are not matched. */
@@ -6111,12 +7096,15 @@ declare namespace browser.tabs {
          * The ID of the tab that opened this tab. If specified, the opener tab must be in the same window as this tab.
          */
         openerTabId?: number;
+        /** True for any screen sharing, or a string to specify type of screen sharing. */
+        screen?: boolean | _QueryScreen;
+        /** True if the tab is using the camera. */
+        camera?: boolean;
+        /** True if the tab is using the microphone. */
+        microphone?: boolean;
     }): Promise<Tab[]>;
 
-    /**
-     * Highlights the given tabs.
-     * @deprecated Unsupported on Firefox at this time.
-     */
+    /** Highlights the given tabs. */
     function highlight(highlightInfo: {
         /** The window that contains the tabs. */
         windowId?: number;
@@ -6134,10 +7122,7 @@ declare namespace browser.tabs {
          * Whether the tab should be active. Does not affect whether the window is focused (see `windows.update`).
          */
         active?: boolean;
-        /**
-         * Adds or removes the tab from the current selection.
-         * @deprecated Unsupported on Firefox at this time.
-         */
+        /** Adds or removes the tab from the current selection. */
         highlighted?: boolean;
         /**
          * Whether the tab should be selected.
@@ -6166,10 +7151,7 @@ declare namespace browser.tabs {
          * Whether the tab should be active. Does not affect whether the window is focused (see `windows.update`).
          */
         active?: boolean;
-        /**
-         * Adds or removes the tab from the current selection.
-         * @deprecated Unsupported on Firefox at this time.
-         */
+        /** Adds or removes the tab from the current selection. */
         highlighted?: boolean;
         /**
          * Whether the tab should be selected.
@@ -6232,6 +7214,12 @@ declare namespace browser.tabs {
      * @param [tabId] Defaults to the active tab of the current window.
      */
     function toggleReaderMode(tabId?: number): Promise<void>;
+
+    /**
+     * Captures the visible area of a specified tab. You must have <all_urls> permission to use this method.
+     * @param [tabId] The tab to capture. Defaults to the active tab of the current window.
+     */
+    function captureTab(tabId?: number, options?: extensionTypes.ImageDetails): Promise<string>;
 
     /**
      * Captures the visible area of the currently active tab in the specified window. You must have <all_urls>
@@ -6335,6 +7323,19 @@ declare namespace browser.tabs {
      */
     function saveAsPDF(pageSettings: PageSettings): Promise<string | undefined>;
 
+    /**
+     * Shows one or more tabs.
+     * @param tabIds The TAB ID or list of TAB IDs to show.
+     */
+    function show(tabIds: number | number[]): Promise<void>;
+
+    /**
+     * Hides one or more tabs. The `"tabHide"` permission is required to hide tabs. Not all tabs are hidable. Returns
+     * an array of hidden tabs.
+     * @param tabIds The TAB ID or list of TAB IDs to hide.
+     */
+    function hide(tabIds: number | number[]): Promise<number[]>;
+
     /* tabs events */
     /**
      * Fired when a tab is created. Note that the tab's URL may not be set at the time this event fired, but you can
@@ -6348,22 +7349,7 @@ declare namespace browser.tabs {
      * @param changeInfo Lists the changes to the state of the tab that was updated.
      * @param tab Gives the state of the tab that was updated.
      */
-    const onUpdated: WebExtEvent<(tabId: number, changeInfo: {
-        /** The status of the tab. Can be either _loading_ or _complete_. */
-        status: string;
-        /** True while the tab is not loaded with content. */
-        discarded?: boolean;
-        /** The tab's URL if it has changed. */
-        url?: string;
-        /** The tab's new pinned state. */
-        pinned?: boolean;
-        /** The tab's new audible state. */
-        audible?: boolean;
-        /** The tab's new muted state and the reason for the change. */
-        mutedInfo?: MutedInfo;
-        /** The tab's new favicon URL. */
-        favIconUrl?: string;
-    }, tab: Tab) => void>;
+    const onUpdated: _TabsOnUpdatedEvent;
 
     /**
      * Fired when a tab is moved within a window. Only one move event is fired, representing the tab the user directly
@@ -6467,19 +7453,23 @@ declare namespace browser.tabs {
  */
 declare namespace browser.windows {
     /* windows types */
-
     /**
      * The type of browser window this is. Under some circumstances a Window may not be assigned type property, for
      * example when querying closed windows from the `sessions` API.
      */
-    type WindowType = "normal" | "popup" | "panel" | "app" | "devtools";
+    type WindowType =
+        "normal"
+        | "popup"
+        | "panel"
+        | "app"
+        | "devtools";
 
     /**
      * The state of this browser window. Under some circumstances a Window may not be assigned state property, for
      * example when querying closed windows from the `sessions` API.
      */
     type WindowState =
-          "normal"
+        "normal"
         | "minimized"
         | "maximized"
         | "fullscreen"
@@ -6534,7 +7524,26 @@ declare namespace browser.windows {
      * Specifies what type of browser window to create. The 'panel' and 'detached_panel' types create a popup unless
      * the '--enable-panels' flag is set.
      */
-    type CreateType = "normal" | "popup" | "panel" | "detached_panel";
+    type CreateType =
+        "normal"
+        | "popup"
+        | "panel"
+        | "detached_panel";
+
+    /** Specifies whether the `windows.Window` returned should contain a list of the `tabs.Tab` objects. */
+    interface GetInfo {
+        /**
+         * If true, the `windows.Window` returned will have a `tabs` property that contains a list of the `tabs.Tab`
+         * objects. The `Tab` objects only contain the `url`, `title` and `favIconUrl` properties if the extension's
+         * manifest file includes the `"tabs"` permission.
+         */
+        populate?: boolean;
+        /**
+         * `windowTypes` is deprecated and ignored on Firefox.
+         * @deprecated `windowTypes` is deprecated and ignored on Firefox.
+         */
+        windowTypes?: WindowType[];
+    }
 
     /* windows properties */
     /** The windowId value that represents the absence of a browser window. */
@@ -6545,67 +7554,35 @@ declare namespace browser.windows {
 
     /* windows functions */
     /** Gets details about a window. */
-    function get(windowId: number, getInfo?: {
-        /**
-         * If true, the `windows.Window` object will have a `tabs` property that contains a list of the `tabs.Tab`
-         * objects. The `Tab` objects only contain the `url`, `title` and `favIconUrl` properties if the extension's
-         * manifest file includes the `"tabs"` permission.
-         */
-        populate?: boolean;
-        /**
-         * If set, the `windows.Window` returned will be filtered based on its type. If unset the default filter is set
-         * to `['app', 'normal', 'panel', 'popup']`, with `'app'` and `'panel'` window types limited to the extension's
-         * own windows.
-         */
-        windowTypes?: WindowType[];
-    }): Promise<Window>;
+    function get(windowId: number, getInfo?: GetInfo): Promise<Window>;
 
     /** Gets the current window. */
-    function getCurrent(getInfo?: {
-        /**
-         * If true, the `windows.Window` object will have a `tabs` property that contains a list of the `tabs.Tab`
-         * objects. The `Tab` objects only contain the `url`, `title` and `favIconUrl` properties if the extension's
-         * manifest file includes the `"tabs"` permission.
-         */
-        populate?: boolean;
-        /**
-         * If set, the `windows.Window` returned will be filtered based on its type. If unset the default filter is set
-         * to `['app', 'normal', 'panel', 'popup']`, with `'app'` and `'panel'` window types limited to the extension's
-         * own windows.
-         */
-        windowTypes?: WindowType[];
-    }): Promise<Window>;
+    function getCurrent(getInfo?: GetInfo): Promise<Window>;
 
     /** Gets the window that was most recently focused — typically the window 'on top'. */
-    function getLastFocused(getInfo?: {
+    function getLastFocused(getInfo?: GetInfo): Promise<Window>;
+
+    /**
+     * Gets all windows.
+     * @param [getInfo] Specifies properties used to filter the `windows.Window` returned and to determine whether they
+     *     should contain a list of the `tabs.Tab` objects.
+     */
+    function getAll(getInfo?: {
         /**
-         * If true, the `windows.Window` object will have a `tabs` property that contains a list of the `tabs.Tab`
+         * If set, the `windows.Window` returned will be filtered based on its type. If unset the default filter is set
+         * to `['app', 'normal', 'panel', 'popup']`, with `'app'` and `'panel'` window types limited to the extension's
+         * own windows.
+         * @deprecated If set, the `windows.Window` returned will be filtered based on its type. If unset the default
+         *     filter is set to `['app', 'normal', 'panel', 'popup']`, with `'app'` and `'panel'` window types limited
+         *     to the extension's own windows.
+         */
+        windowTypes?: WindowType[];
+        /**
+         * If true, the `windows.Window` returned will have a `tabs` property that contains a list of the `tabs.Tab`
          * objects. The `Tab` objects only contain the `url`, `title` and `favIconUrl` properties if the extension's
          * manifest file includes the `"tabs"` permission.
          */
         populate?: boolean;
-        /**
-         * If set, the `windows.Window` returned will be filtered based on its type. If unset the default filter is set
-         * to `['app', 'normal', 'panel', 'popup']`, with `'app'` and `'panel'` window types limited to the extension's
-         * own windows.
-         */
-        windowTypes?: WindowType[];
-    }): Promise<Window>;
-
-    /** Gets all windows. */
-    function getAll(getInfo?: {
-        /**
-         * If true, each `windows.Window` object will have a `tabs` property that contains a list of the `tabs.Tab`
-         * objects for that window. The `Tab` objects only contain the `url`, `title` and `favIconUrl` properties if
-         * the extension's manifest file includes the `"tabs"` permission.
-         */
-        populate?: boolean;
-        /**
-         * If set, the `windows.Window` returned will be filtered based on its type. If unset the default filter is set
-         * to `['app', 'normal', 'panel', 'popup']`, with `'app'` and `'panel'` window types limited to the extension's
-         * own windows.
-         */
-        windowTypes?: WindowType[];
     }): Promise<Window[]>;
 
     /** Creates (opens) a new browser with any optional sizing, position or default URL provided. */


### PR DESCRIPTION
Updating definitions from firefox version 58.0b3 to 63.0b6.

Note, also update owner name, as my username and name has changed :)
_This means that despite what the bot will probably tell you, I am indeed the owner._

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Chaning an exsisting definition
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
https://gist.github.com/jsmnbom/4cdbe518b9765a2bf1232b660ade51eb
- [x] Increase the version number in the header if appropriate.

These should have been closed earlier as they have been fixed by other contributors in other PRs:
Closes #24937
Closes #23542
Closes #23002
