### PR TITLE
Fixing angular ICacheObject::get return type

### DIFF
--- a/types/angular/index.d.ts
+++ b/types/angular/index.d.ts
@@ -1316,7 +1316,7 @@ declare namespace angular {
          *
          * @param key the key of the data to be retrieved
          */
-        get<T>(key: string): T;
+        get<T>(key: string): T | undefined;
 
         /**
          * Removes an entry from the Cache object.


### PR DESCRIPTION
get can return undefined if the key isn't in the cache.

See the example:
https://docs.angularjs.org/api/ng/type/$cacheFactory.Cache
```
  superCache.remove('another key');
  expect(superCache.get('another key')).toBeUndefined();
```

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.angularjs.org/api/ng/type/$cacheFactory.Cache