### PR TITLE
[pikaday] Add missing second parameter for setMoment

### DIFF
--- a/types/pikaday/index.d.ts
+++ b/types/pikaday/index.d.ts
@@ -54,7 +54,7 @@ declare class Pikaday {
     /**
      * Set the current selection with a Moment.js object (see setDate).
      */
-    setMoment(moment: any): void;
+    setMoment(moment: any, preventOnSelect?: boolean): void;
 
     /**
      * Change the current view to see a specific date.

--- a/types/pikaday/pikaday-tests.ts
+++ b/types/pikaday/pikaday-tests.ts
@@ -32,6 +32,7 @@ new Pikaday({field: $('#datepicker')[0]});
     picker.setDate('2015-01-01');
     picker.getMoment();
     picker.setMoment(moment('14th February 2014', 'DDo MMMM YYYY'));
+    picker.setMoment(moment('14th February 2014', 'DDo MMMM YYYY'), true);
     picker.gotoDate(new Date(2014, 1));
     picker.gotoToday();
     picker.gotoMonth(2);


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/dbushell/Pikaday/blob/master/pikaday.js#L769

Fix for issue https://github.com/DefinitelyTyped/DefinitelyTyped/issues/19425

@MidnightDesign @wake42
