### PR TITLE
[passport] allow successReturnToOrRedirect as boolean

### DIFF
--- a/types/passport/index.d.ts
+++ b/types/passport/index.d.ts
@@ -44,7 +44,7 @@ declare namespace passport {
         successFlash?: string | boolean;
         successMessage?: boolean | string;
         successRedirect?: string;
-        successReturnToOrRedirect?: string;
+        successReturnToOrRedirect?: boolean | string;
         pauseStream?: boolean;
         userProperty?: string;
         passReqToCallback?: boolean;


### PR DESCRIPTION
The type for `AuthenticateOptions['successReturnToOrRedirect']` should include boolean. If you check the implementation, it is checked for truthiness, and then the `url` value is either taken from this option, or overridden by a value in the session. That means a boolean `true` is the easiest way to indicate that the url should be taken from the session.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/jaredhanson/passport/blob/2327a36e7c005ccc7134ad157b2f258b57aa0912/lib/middleware/authenticate.js#L252-L257
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
