### PR TITLE
[HOLD] [dd-trace] Update for v0.6.0

### DIFF
--- a/types/dd-trace/dd-trace-tests.ts
+++ b/types/dd-trace/dd-trace-tests.ts
@@ -1,35 +1,52 @@
-import * as tracer from 'dd-trace';
-import SpanContext = require('dd-trace/src/opentracing/span_context');
+import * as tracer from "dd-trace";
+import SpanContext = require("dd-trace/src/opentracing/span_context");
 
 tracer.init({
-    service: 'MyLovelyService',
-    hostname: 'localhost',
+    service: "MyLovelyService",
+    hostname: "localhost",
     port: 8126,
     logger: {
-        debug: msg => { },
-        error: err => { }
-    }
+        debug: msg => {},
+        error: err => {},
+    },
+});
+
+tracer.use("express", {
+    service: "incoming-request",
+    headers: ["User-Agent"],
+    validateStatus: code => code !== 418,
+});
+
+tracer.use("graphql", {
+    depth: 1,
+    // Can’t use spread operator here due to https://github.com/Microsoft/TypeScript/issues/10727
+    // tslint:disable-next-line:prefer-object-spread
+    variables: variables => Object.assign({}, variables, { password: "REDACTED" }),
+});
+
+tracer.use("http", {
+    splitByDomain: true,
 });
 
 tracer
-    .trace('web.request', {
-        service: 'my_service',
+    .trace("web.request", {
+        service: "my_service",
         childOf: new SpanContext({ traceId: 1337, spanId: 42 }), // Childof must be an instance of this type. See: https://github.com/DataDog/dd-trace-js/blob/master/src/opentracing/tracer.js#L99
         tags: {
-            env: 'dev'
-        }
+            env: "dev",
+        },
     })
     .then(span => {
-        span.setTag('my_tag', 'my_value');
+        span.setTag("my_tag", "my_value");
         span.finish();
     });
 
 const parentScope = tracer.scopeManager().active();
-const span = tracer.startSpan('memcached', {
+const span = tracer.startSpan("memcached", {
     childOf: parentScope && parentScope.span(),
     tags: {
-        'service.name': 'my-memcached',
-        'resource.name': 'get',
-        'span.type': 'memcached',
+        "service.name": "my-memcached",
+        "resource.name": "get",
+        "span.type": "memcached",
     },
 });

--- a/types/dd-trace/index.d.ts
+++ b/types/dd-trace/index.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: Colin Bradley <https://github.com/ColinBradley>
 //                 Eloy Durán <https://github.com/alloy>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.1
 
 // Prettified with:
 // $ prettier --parser typescript --tab-width 4 --semi --trailing-comma es5 --write --print-width 120 types/dd-trace/{,*}/*.ts*


### PR DESCRIPTION
* Adds typings for the plugins, including those added in v0.6.0: https://github.com/DataDog/dd-trace-js/blob/v0.6.0/docs/API.md
* Ran prettier to make formatting consistent