### PR TITLE
[webpack] improve input/outputFileSystem types

### DIFF
--- a/types/memory-fs/index.d.ts
+++ b/types/memory-fs/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/webpack/memory-fs
 // Definitions by: e-cloud <https://github.com/e-cloud>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
 
 /// <reference types="node" />
 
@@ -38,7 +39,7 @@ declare class MemoryFileSystem {
 
     unlinkSync(_path: string): void;
 
-    readlinkSync(_path: string): void;
+    readlinkSync(_path: string): string;
 
     writeFileSync(_path: string, content: string | Buffer, encoding?: string): void;
 
@@ -51,11 +52,11 @@ declare class MemoryFileSystem {
 
     createWriteStream(path: string, options?: any): any;
 
-    exists(path: string, callback: (isExist: boolean) => any): any;
+    exists(path: string, callback: (isExist: boolean) => void): void;
 
-    writeFile(path: string, content: string | Buffer, callback: (err?: Error) => any): any;
+    writeFile(path: string, content: string | Buffer, callback: (err: Error | undefined) => void): void;
 
-    writeFile(path: string, content: string | Buffer, encoding: string, callback: (err?: Error) => any): any;
+    writeFile(path: string, content: string | Buffer, encoding: string, callback: (err: Error | undefined) => void): void;
 
     join(path: string, request: string): string;
 
@@ -63,21 +64,23 @@ declare class MemoryFileSystem {
 
     normalize(path: string): string;
 
-    stat(path: string, callback: (err?: Error, result?: any) => any): void;
+    stat(path: string, callback: (err: Error | null, result?: any) => void): void;
 
-    readdir(path: string, callback: (err?: Error, result?: any) => any): void;
+    readdir(path: string, callback: (err: Error | null, result?: any) => void): void;
 
-    mkdirp(path: string, callback: (err?: Error, result?: any) => any): void;
+    mkdirp(path: string, callback: (err: Error | null, result?: any) => void): void;
 
-    rmdir(path: string, callback: (err?: Error, result?: any) => any): void;
+    rmdir(path: string, callback: (err: Error | null, result?: any) => void): void;
 
-    unlink(path: string, callback: (err?: Error, result?: any) => any): void;
+    unlink(path: string, callback: (err: Error | null, result?: any) => void): void;
 
-    readlink(path: string, callback: (err?: Error, result?: any) => any): void;
+    readlink(path: string, callback: (err: Error | null, result?: any) => void): void;
 
-    mkdir(path: string, optArg: {}, callback: (err?: Error, result?: any) => any): void;
+    mkdir(path: string, callback: (err: Error | null) => void): void;
+    mkdir(path: string, optArg: {}, callback: (err: Error | null, result?: any) => void): void;
 
-    readFile(path: string, optArg: {}, callback: (err?: Error, result?: any) => any): void;
+    readFile(path: string, callback: (err: Error | null, result?: any) => void): void;
+    readFile(path: string, optArg: {}, callback: (err: Error | null, result?: any) => void): void;
 }
 
 export = MemoryFileSystem;

--- a/types/memory-fs/test/webpack.ts
+++ b/types/memory-fs/test/webpack.ts
@@ -1,0 +1,7 @@
+import MemoryFileSystem = require('memory-fs')
+import webpack = require('webpack')
+
+// integration with webpack
+const compiler = webpack()
+compiler.inputFileSystem = new MemoryFileSystem()
+compiler.outputFileSystem = new MemoryFileSystem()

--- a/types/memory-fs/tsconfig.json
+++ b/types/memory-fs/tsconfig.json
@@ -22,6 +22,7 @@
         "lib/normalize.d.ts",
         "test/index.ts",
         "test/join.ts",
-        "test/normalize.ts"
+        "test/normalize.ts",
+        "test/webpack.ts"
     ]
 }

--- a/types/webpack/index.d.ts
+++ b/types/webpack/index.d.ts
@@ -1036,23 +1036,22 @@ declare namespace webpack {
     }
 
     interface InputFileSystem {
-        purge(): void;
-        readFile(path: string, callback: (err: Error, contents: Buffer) => void): void;
+        purge?(): void;
+        readFile(path: string, callback: (err: Error | undefined | null, contents: Buffer) => void): void;
         readFileSync(path: string): Buffer;
-        readlink(path: string, callback: (err: Error, linkString: string) => void): void;
+        readlink(path: string, callback: (err: Error | undefined | null, linkString: string) => void): void;
         readlinkSync(path: string): string;
-        stat(path: string, callback: (err: Error, stats: any) => void): void;
+        stat(path: string, callback: (err: Error | undefined | null, stats: any) => void): void;
         statSync(path: string): any;
     }
 
     interface OutputFileSystem {
         join(...paths: string[]): string;
-        mkdir(path: string, callback: (err: Error) => void): void;
-        mkdirp(path: string, callback: (err: Error) => void): void;
-        purge(): void;
-        rmdir(path: string, callback: (err: Error) => void): void;
-        unlink(path: string, callback: (err: Error) => void): void;
-        writeFile(path: string, data: any, callback: (err: Error) => void): void;
+        mkdir(path: string, callback: (err: Error | undefined | null) => void): void;
+        mkdirp(path: string, callback: (err: Error | undefined | null) => void): void;
+        rmdir(path: string, callback: (err: Error | undefined | null) => void): void;
+        unlink(path: string, callback: (err: Error | undefined | null) => void): void;
+        writeFile(path: string, data: any, callback: (err: Error | undefined | null) => void): void;
     }
 
     interface SortableSet<T> extends Set<T> {


### PR DESCRIPTION
Looking `webpack`'s code-base:
- `purge() ` should be optional, and is only used on `inputFileSystem`.
- Error can be `undefined` or `null`. `memory-fs` passes null and works.

Also for memory-fs:
- adjusted types based on current implementation
- `null` for no-Error in most async methods, except for `writeFile`, where `undefined` is used.
- added an integration test with `webpack`'s `input/outputFileSystem`

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
https://github.com/webpack/webpack/blob/v4.19.1/test/Compiler.test.js#L182
https://github.com/webpack/webpack/search?q=purge&unscoped_q=purge
https://github.com/webpack/memory-fs/blob/v0.4.1/lib/MemoryFileSystem.js
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.