### PR TITLE
twilio-video: Fix camel case typo and add attribute for Safari track support

### DIFF
--- a/types/twilio-video/index.d.ts
+++ b/types/twilio-video/index.d.ts
@@ -171,7 +171,7 @@ export class Participant extends EventEmitter {
     audioTracks: Map<Track.SID, AudioTrackPublication>;
     dataTracks: Map<Track.SID, DataTrackPublication>;
     identity: Participant.Identity;
-    networkQualityLEvel: NetworkQualityLevel | null;
+    networkQualityLevel: NetworkQualityLevel | null;
     sid: Participant.SID;
     state: string;
     tracks: Map<Track.SID, TrackPublication>;

--- a/types/twilio-video/index.d.ts
+++ b/types/twilio-video/index.d.ts
@@ -39,6 +39,10 @@ export class AudioTrack extends Track {
     kind: 'audio';
     mediaStreamTrack: MediaStreamTrack;
 
+    // Required for Safari if you want to detach without errors
+    // See: https://github.com/twilio/twilio-video.js/issues/294#issuecomment-389708981
+    _attachments?: HTMLMediaElement[];
+
     attach(element?: HTMLMediaElement | string): HTMLMediaElement;
     detach(element?: HTMLMediaElement | string): HTMLMediaElement[];
 }
@@ -432,6 +436,10 @@ export class VideoTrack extends Track {
     dimensions: VideoTrack.Dimensions;
     kind: 'video';
     mediaStreamTrack: MediaStreamTrack;
+
+    // Required for Safari if you want to detach without errors
+    // See: https://github.com/twilio/twilio-video.js/issues/294#issuecomment-389708981
+    _attachments?: HTMLMediaElement[];
 
     attach(element?: HTMLMediaElement | string): HTMLVideoElement;
     detach(element?: HTMLMediaElement | string): HTMLMediaElement[];

--- a/types/twilio-video/twilio-video-tests.ts
+++ b/types/twilio-video/twilio-video-tests.ts
@@ -63,10 +63,14 @@ function trackSubscribed(track: Video.VideoTrack | Video.AudioTrack) {
 
 function trackUnsubscribed(track: Video.VideoTrack | Video.AudioTrack) {
     track.detach().forEach(element => element.remove());
+    // Alternative if Safari crashes when detaching tracks
+    track._attachments!.forEach((detachedElement) => detachedElement.remove());
 }
 
-function insertDomElement(element: any) {
+function insertDomElement(element: HTMLMediaElement) {
     // Do something with the dom element
+    document.createElement('div');
+    element.appendChild(element);
 }
 
 initRoom();


### PR DESCRIPTION
Issue 1: when using a `Participant` object, current implementation will fail as it does not recognize `networkQualityLevel` due to a typo when writing the definition. Sorry about that.

Issue 2: adding `_attachments` as attribute to the `VideoTrack` and `AudioTrack` in order to use the workaround stated in https://github.com/twilio/twilio-video.js/issues/294 .  This is the only way to prevent a crash from this library in Safari 

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://media.twiliocdn.com/sdk/js/video/releases/2.0.0-beta1/docs/Participant.html
