### PR TITLE
styled-components fix: Define StyleSheet and change Node to React.ReactNode

### DIFF
--- a/types/styled-components/index.d.ts
+++ b/types/styled-components/index.d.ts
@@ -7,6 +7,7 @@
 // TypeScript Version: 2.8
 
 /// <reference types="node" />
+/// <reference lib="dom" />
 
 import * as React from 'react';
 
@@ -195,7 +196,7 @@ export class StyleSheet {}
 
 interface StyleSheetManagerProps {
     sheet?: StyleSheet;
-    target?: HTMLElement | null;
+    target?: Node;
 }
 
 export class StyleSheetManager extends React.Component<

--- a/types/styled-components/index.d.ts
+++ b/types/styled-components/index.d.ts
@@ -192,8 +192,6 @@ interface StylesheetComponentProps {
     sheet: ServerStyleSheet;
 }
 
-export class StyleSheet {}
-
 interface StyleSheetManagerProps {
     sheet?: StyleSheet;
     target?: Node;

--- a/types/styled-components/index.d.ts
+++ b/types/styled-components/index.d.ts
@@ -190,9 +190,11 @@ interface StylesheetComponentProps {
     sheet: ServerStyleSheet;
 }
 
+export class StyleSheet {}
+
 interface StyleSheetManagerProps {
     sheet?: StyleSheet;
-    target?: Node;
+    target?: React.ReactNode;
 }
 
 export class StyleSheetManager extends React.Component<

--- a/types/styled-components/index.d.ts
+++ b/types/styled-components/index.d.ts
@@ -195,7 +195,7 @@ export class StyleSheet {}
 
 interface StyleSheetManagerProps {
     sheet?: StyleSheet;
-    target?: React.ReactNode;
+    target?: HTMLElement | null;
 }
 
 export class StyleSheetManager extends React.Component<

--- a/types/styled-components/index.d.ts
+++ b/types/styled-components/index.d.ts
@@ -4,7 +4,7 @@
 //                 Ihor Chulinda <https://github.com/Igmat>
 //                 Nico Greenarry <https://github.com/NicoGreenarry>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.8
+// TypeScript Version: 3.0
 
 /// <reference types="node" />
 /// <reference lib="dom" />

--- a/types/styled-components/index.d.ts
+++ b/types/styled-components/index.d.ts
@@ -1,7 +1,8 @@
-// Type definitions for styled-components 3.0
+// Type definitions for styled-components 3.4
 // Project: https://github.com/styled-components/styled-components
 // Definitions by: Igor Oleinikov <https://github.com/Igorbek>
 //                 Ihor Chulinda <https://github.com/Igmat>
+//                 Nico Greenarry <https://github.com/NicoGreenarry>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 


### PR DESCRIPTION
~As referenced [here](https://github.com/styled-components/styled-components/issues/1952), the `StyleSheet` and `Node` types were undefined. This PR defines `StyleSheet`, and replaces `Node` with `React.ReactNode`, following the example found [here](https://github.com/styled-components/styled-components/pull/1954).~
Update: The issue was that we needed a triple-slash directive referencing the "dom" library.

Note: There's a parallel [PR in the `styled-components` repo](https://github.com/styled-components/styled-components/pull/2019), since that repo still maintains typings.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
  - No tests added/changed; tests passed
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint styled-components` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - As referenced [here](https://github.com/styled-components/styled-components/issues/1952), the `StyleSheet` and `Node` types were undefined. This PR defines `StyleSheet`, and replaces `Node` with `React.ReactNode`, following the example found [here](https://github.com/styled-components/styled-components/pull/1954).
- [x] Increase the version number in the header if appropriate.
- ~[ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.~