### PR TITLE
browserify: work around TypeScript issue 14107

### DIFF
--- a/types/browserify/browserify-tests.ts
+++ b/types/browserify/browserify-tests.ts
@@ -60,3 +60,6 @@ Object.keys(insertGlobals.vars).forEach((x) => {
 var b = browserify('./browser/main.js', {
   insertGlobalVars: insertGlobalVars
 });
+
+declare const file: string | string[];
+b.add(file);

--- a/types/browserify/index.d.ts
+++ b/types/browserify/index.d.ts
@@ -1,6 +1,9 @@
 // Type definitions for Browserify 12.0
 // Project: http://browserify.org/
-// Definitions by: Andrew Gaspar <https://github.com/AndrewGaspar>, John Vilk <https://github.com/jvilk>, Leonard Thieu <https://github.com/leonard-thieu>
+// Definitions by: Andrew Gaspar <https://github.com/AndrewGaspar>
+//                 John Vilk <https://github.com/jvilk>
+//                 Leonard Thieu <https://github.com/leonard-thieu>
+//                 Linus Unnebäck <https://github.com/LinusU>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />
@@ -102,8 +105,7 @@ interface BrowserifyObject extends NodeJS.EventEmitter {
    * Add an entry file from file that will be executed when the bundle loads.
    * If file is an array, each item in file will be added as an entry file.
    */
-  add(file: InputFile[], opts?: FileOptions): BrowserifyObject;
-  add(file: InputFile, opts?: FileOptions): BrowserifyObject;
+  add(file: InputFile | InputFile[], opts?: FileOptions): BrowserifyObject;
   /**
    * Make file available from outside the bundle with require(file).
    * The file param is anything that can be resolved by require.resolve().


### PR DESCRIPTION
Changes the overloaded function to a single function that accepts a union. This works around Microsoft/TypeScript#14107.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: **n/a**
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
