### PR TITLE
[sequelize] Adding missing `DefineOptions`.`schemaDelimiter` property

### DIFF
--- a/types/sequelize/index.d.ts
+++ b/types/sequelize/index.d.ts
@@ -5233,8 +5233,17 @@ declare namespace sequelize {
          * `this.constructor.prototype.find.apply(this, arguments)`
          */
         classMethods?: Object;
-
+        
+        /**
+         * Change the database schema. PG only feature, but also works with other dialects.
+         */
         schema?: string;
+        
+        
+        /**
+         * Change the database schema delimiter. Defaults to "." on PG but for other dialects can be also changed to "_".
+         */
+        schemaDelimiter?: string;
 
         /**
          * You can also change the database engine, e.g. to MyISAM. InnoDB is the default.


### PR DESCRIPTION
Added missing property `schemaDelimiter` to `DefineOptions` type.
Also added comments on schema and schemaDelimiter properties.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/sequelize/sequelize/blob/b37985d550e8aeb2bc518f3bd5dcb09c95a142d8/lib/model.js#L887
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.