### PR TITLE
@types/google-apps-script getProperty may return null

### DIFF
--- a/types/google-apps-script/google-apps-script.properties.d.ts
+++ b/types/google-apps-script/google-apps-script.properties.d.ts
@@ -19,7 +19,7 @@ declare namespace GoogleAppsScript {
       deleteProperty(key: string): Properties;
       getKeys(): string[];
       getProperties(): Object;
-      getProperty(key: string): string;
+      getProperty(key: string): string | null;
       setProperties(properties: Object): Properties;
       setProperties(properties: Object, deleteAllOthers: boolean): Properties;
       setProperty(key: string, value: string): Properties;
@@ -56,7 +56,7 @@ declare namespace GoogleAppsScript {
       deleteProperty(key: string): ScriptProperties;
       getKeys(): string[];
       getProperties(): Object;
-      getProperty(key: string): string;
+      getProperty(key: string): string | null;
       setProperties(properties: Object): ScriptProperties;
       setProperties(properties: Object, deleteAllOthers: boolean): ScriptProperties;
       setProperty(key: string, value: string): ScriptProperties;
@@ -73,7 +73,7 @@ declare namespace GoogleAppsScript {
       deleteProperty(key: string): UserProperties;
       getKeys(): string[];
       getProperties(): Object;
-      getProperty(key: string): string;
+      getProperty(key: string): string | null;
       setProperties(properties: Object): UserProperties;
       setProperties(properties: Object, deleteAllOthers: boolean): UserProperties;
       setProperty(key: string, value: string): UserProperties;


### PR DESCRIPTION
This PR is same as #19173.
The PR was once merged, but #27235 reverted it by generated type definition.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [document](https://developers.google.com/apps-script/reference/properties/properties#getProperty(String))
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
