### PR TITLE
[@types/highcharts] Add click event type to range selector button

### DIFF
--- a/types/highcharts/highstock.d.ts
+++ b/types/highcharts/highstock.d.ts
@@ -2,7 +2,8 @@
 // Project: http://www.highcharts.com/
 
 // Definitions by: David Deutsch <http://github.com/DavidKDeutsch>
-// Definitions by: Dave Baumann <https://github.com/route2Dev>
+//                 Dave Baumann <https://github.com/route2Dev>
+//                 Richard Ison <https://github.com/richardison>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 import * as Highcharts from "highcharts";
@@ -31,11 +32,16 @@ declare namespace Highstock {
         yAxis?: Highcharts.AxisOptions;
     }
 
+    interface RangeSelectButtonEvent {
+        click?(event: Event): void;
+    }
+
     interface RangeSelectorButton {
         type: string; // Defines the timespan, can be one of 'millisecond', 'second', 'minute', 'day', 'week', 'month', 'ytd' (year to date), 'year' and 'all'.
         count?: number;
         text: string;
         dataGrouping?: any; // not sure how this works
+        events?: RangeSelectButtonEvent;
     }
 
     interface RangeSelectorOptions {

--- a/types/highcharts/highstock.d.ts
+++ b/types/highcharts/highstock.d.ts
@@ -32,7 +32,7 @@ declare namespace Highstock {
         yAxis?: Highcharts.AxisOptions;
     }
 
-    interface RangeSelectButtonEvent {
+    interface RangeSelectorButtonEvent {
         click?(event: Event): void;
     }
 
@@ -41,7 +41,7 @@ declare namespace Highstock {
         count?: number;
         text: string;
         dataGrouping?: any; // not sure how this works
-        events?: RangeSelectButtonEvent;
+        events?: RangeSelectorButtonEvent;
     }
 
     interface RangeSelectorOptions {

--- a/types/highcharts/test/highstock.ts
+++ b/types/highcharts/test/highstock.ts
@@ -25,6 +25,14 @@ $(() => {
         rangeSelector: {
             allButtonsEnabled: true,
             selected: 1,
+            buttons: [{
+                type: 'month',
+                count: 1,
+                text: '1m',
+                events: {
+                    click: () => { }
+                }
+            }],
             buttonTheme: { // styles for the buttons
                 fill: 'none',
                 stroke: 'none',


### PR DESCRIPTION
Fixes [Missing events type on RangeSelectorButton](https://github.com/DefinitelyTyped/DefinitelyTyped/issues/28973)

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://api.highcharts.com/highstock/rangeSelector.buttons.events>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

