### PR TITLE
[got] Allow use of https.RequestOptions

### DIFF
--- a/types/got/got-tests.ts
+++ b/types/got/got-tests.ts
@@ -258,3 +258,5 @@ got('todomvc', {
 got(new url.URL('http://todomvc.com'));
 
 got(url.parse('http://todomvc.com'));
+
+got('https://todomvc.com', { rejectUnauthorized: false });

--- a/types/got/index.d.ts
+++ b/types/got/index.d.ts
@@ -75,7 +75,7 @@ declare const got: got.GotFn &
         CancelError: typeof CancelError;
     };
 
-interface InternalRequestOptions extends http.RequestOptions {
+interface InternalRequestOptions extends https.RequestOptions {
     // Redeclare options with `any` type for allow specify types incompatible with http.RequestOptions.
     timeout?: any;
     agent?: any;
@@ -93,7 +93,7 @@ declare namespace got {
 
     type GotStreamFn = (url: GotUrl, options?: GotOptions<string | null>) => GotEmitter & nodeStream.Duplex;
 
-    type GotUrl = string | http.RequestOptions | Url | URL;
+    type GotUrl = string | https.RequestOptions | Url | URL;
 
     interface GotBodyOptions<E extends string | null> extends GotOptions<E> {
         body?: string | Buffer | nodeStream.Readable;


### PR DESCRIPTION
The current type definitions didn't allow for the use of `https.RequestOptions`.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/sindresorhus/got/blob/cf56247f7a1381155f42065d90322f4e754939a2/test/https.js#L20
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
