### PR TITLE
[mongodb] Add 'errmsg' prop to MongoError

### DIFF
--- a/types/mongodb/index.d.ts
+++ b/types/mongodb/index.d.ts
@@ -16,6 +16,7 @@
 //                 Jimmy Shimizu <https://github.com/jishi>
 //                 Dominik Heigl <https://github.com/various89>
 //                 Angela-1 <https://github.com/angela-1>
+//                 Mikael Lirbank <https://github.com/lirbank>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -208,6 +209,7 @@ export class MongoError extends Error {
     constructor(message: string);
     static create(options: Object): MongoError;
     code?: number;
+    errmsg?: string;
 }
 
 /** http://mongodb.github.io/node-mongodb-native/3.1/api/MongoClient.html#.connect */

--- a/types/mongodb/index.d.ts
+++ b/types/mongodb/index.d.ts
@@ -209,17 +209,18 @@ export class MongoError extends Error {
     constructor(message: string);
     static create(options: Object): MongoError;
     code?: number;
-    // While not documented, the 'errmsg' prop is AFAIK the only way to find out
-    // which unique index caused a duplicate key error. When you have multiple
-    // unique indexes on a collection, knowing which index caused a duplicate
-    // key error enables you to send better (more precise) error messages to the
-    // client/user (eg. "Email address must be unique" instead of "Both email
-    // address and username must be unique") - which caters for a better (app)
-    // user experience.
-    // 
-    // Details:
-    // https://github.com/Automattic/mongoose/issues/2129 (issue for mongoose,
-    // but the same applies for the mongodb native driver)
+    /**
+     * While not documented, the 'errmsg' prop is AFAIK the only way to find out
+     * which unique index caused a duplicate key error. When you have multiple
+     * unique indexes on a collection, knowing which index caused a duplicate
+     * key error enables you to send better (more precise) error messages to the
+     * client/user (eg. "Email address must be unique" instead of "Both email
+     * address and username must be unique") - which caters for a better (app)
+     * user experience.
+     * 
+     * Details: https://github.com/Automattic/mongoose/issues/2129 (issue for
+     * mongoose, but the same applies for the native mongodb driver)
+     */
     errmsg?: string;
 }
 

--- a/types/mongodb/index.d.ts
+++ b/types/mongodb/index.d.ts
@@ -220,6 +220,11 @@ export class MongoError extends Error {
      * 
      * Details: https://github.com/Automattic/mongoose/issues/2129 (issue for
      * mongoose, but the same applies for the native mongodb driver)
+     * 
+     * Note that in mongoose (the link above) the prop in question is called
+     * 'message' while in mongodb it is called 'errmsg'. This can be seen in
+     * multiple places in the source code, for example here:
+     * https://github.com/mongodb/node-mongodb-native/blob/a12aa15ac3eaae3ad5c4166ea1423aec4560f155/test/functional/find_tests.js#L1111
      */
     errmsg?: string;
 }

--- a/types/mongodb/index.d.ts
+++ b/types/mongodb/index.d.ts
@@ -209,6 +209,17 @@ export class MongoError extends Error {
     constructor(message: string);
     static create(options: Object): MongoError;
     code?: number;
+    // While not documented, the 'errmsg' prop is AFAIK the only way to find out
+    // which unique index caused a duplicate key error. When you have multiple
+    // unique indexes on a collection, knowing which index caused a duplicate
+    // key error enables you to send better (more precise) error messages to the
+    // client/user (eg. "Email address must be unique" instead of "Both email
+    // address and username must be unique") - which caters for a better (app)
+    // user experience.
+    // 
+    // Details:
+    // https://github.com/Automattic/mongoose/issues/2129 (issue for mongoose,
+    // but the same applies for the mongodb native driver)
     errmsg?: string;
 }
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:

While not documented, the 'errmsg' prop is AFAIK the only way to find out which unique index caused a duplicate key error. When you have multiple unique indexes on a collection, knowing which index caused a duplicate key error enables you to send better (more precise) error messages to the client/user (eg. "Email address must be unique" instead of "Both email address and username must be unique") - which caters for a better (app) user experience.

Details:
https://github.com/Automattic/mongoose/issues/2129 (issue for mongoose, but the same applies for the mongodb native driver)

- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
