### PR TITLE
fix(react): React.createContext parameter is optional

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -262,7 +262,7 @@ declare namespace React {
         Consumer: Consumer<T>;
     }
     function createContext<T>(
-        defaultValue: T,
+        defaultValue?: T,
         calculateChangedBits?: (prev: T, next: T) => number
     ): Context<T>;
 

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -262,7 +262,7 @@ declare namespace React {
         Consumer: Consumer<T>;
     }
     function createContext<T>(
-        defaultValue?: T,
+        defaultValue: T | undefined,
         calculateChangedBits?: (prev: T, next: T) => number
     ): Context<T>;
 

--- a/types/react/test/index.ts
+++ b/types/react/test/index.ts
@@ -221,7 +221,7 @@ const StatelessComponent3: React.SFC<SCProps> =
 const StatelessComponent4: React.SFC = props => null;
 
 // React.createContext
-const context1 = React.createContext<{ foo: string }>();
+const context1 = React.createContext<{ foo: string }>(undefined);
 const context2 = React.createContext<{ foo: string }>({ foo: "text" });
 // $ExpectError
 const context3 = React.createContext<{ foo: string }>({ bar: string });

--- a/types/react/test/index.ts
+++ b/types/react/test/index.ts
@@ -220,6 +220,12 @@ const StatelessComponent3: React.SFC<SCProps> =
 // allows null as props
 const StatelessComponent4: React.SFC = props => null;
 
+// React.createContext
+const context1 = React.createContext<{ foo: string }>();
+const context2 = React.createContext<{ foo: string }>({ foo: "text" });
+// $ExpectError
+const context3 = React.createContext<{ foo: string }>({ bar: string });
+
 // React.createFactory
 const factory: React.CFactory<Props, ModernComponent> =
     React.createFactory(ModernComponent);


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: https://reactjs.org/docs/context.html#reactcreatecontext
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

> Note: passing undefined as a Provider value does not cause Consumers to use defaultValue.