### PR TITLE
@types/knex WithWrapped interface to allow QueryBuilder argument

### DIFF
--- a/types/knex/index.d.ts
+++ b/types/knex/index.d.ts
@@ -262,6 +262,7 @@ declare namespace Knex {
     }
 
     interface WithWrapped {
+        (alias: string, queryBuilder: QueryBuilder): QueryBuilder;
         (alias: string, callback: (queryBuilder: QueryBuilder) => any): QueryBuilder;
     }
 

--- a/types/knex/knex-tests.ts
+++ b/types/knex/knex-tests.ts
@@ -589,6 +589,9 @@ knex.with('new_books', 'select * from books where published_date >= :year', { ye
 knex.with('new_books', 'select * from books where published_date >= ?', [2016])
   .select('*').from('new_books');
 
+knex.with('new_books', knex.select('*').from('books').where("published_date", ">=", 2016))
+  .select('*').from('new_books');
+
 knex.withRaw('recent_books', 'select * from books where published_date >= :year', { year: 2013 })
   .select('*').from('recent_books');
 
@@ -598,6 +601,9 @@ knex.withRaw('recent_books', knex.raw('select * from books where published_date 
 knex.withWrapped("antique_books", function (qb) {
   qb.select('*').from('books').where('published_date', '<', 1899);
 }).select('*').from('antique_books');
+
+knex.withWrapped('new_books', knex.select('*').from('books').where("published_date", ">=", 2016))
+  .select('*').from('new_books');
 
 var someExternalMethod: Function;
 


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://knexjs.org/#Builder-with>>

I have tested that the `.with` method allows putting in a QueryBuilder object, and even checked the source code to see if this is intended behaviour. Unfortunately the documentation does not show this type of usage.