### PR TITLE
[react-albus] Add function-as-children to Step

### DIFF
--- a/types/react-albus/index.d.ts
+++ b/types/react-albus/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for react-albus 2.0
 // Project: https://github.com/americanexpress/react-albus#readme
 // Definitions by: Sindre Seppola <https://github.com/sseppola>
+//                 Conrad Reuter <https://github.com/conradreuter>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -34,5 +35,7 @@ export const Steps: React.ComponentType<{
 
 export const Step: React.ComponentType<{
     id: string;
-    render: (wizard: WizardContext) => React.ReactNode;
-}>;
+} & (
+    | { render?: (wizard: WizardContext) => React.ReactNode; }
+    | { children: (wizard: WizardContext) => React.ReactNode; }
+)>;

--- a/types/react-albus/react-albus-tests.tsx
+++ b/types/react-albus/react-albus-tests.tsx
@@ -37,15 +37,20 @@ const Example = () => (
                         </div>
                     )}
                 />
-                <Step
-                    id="dumbledore"
-                    render={({ previous }) => (
+                <Step id="dumbledore">
+                    {({ previous, next }) => (
                         <div>
                             <h1>Dumbledore</h1>
                             <button onClick={previous}>Previous</button>
+                            <button onClick={next}>Next</button>
                         </div>
                     )}
-                />
+                </Step>
+                <Step id="harry">
+                    <div>
+                        <h1>Harry</h1>
+                    </div>
+                </Step>
             </Steps>
         )}
     />


### PR DESCRIPTION
[react-albus] Add function-as-children as an alternative to the render-prop to Step.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/americanexpress/react-albus/blob/master/src/utils/renderCallback.js
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
