### PR TITLE
Added missing onclone option to the HTML2CanvasOptions interface in the package html2canvas accordingly with official documentation

### DIFF
--- a/types/html2canvas/index.d.ts
+++ b/types/html2canvas/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for html2canvas.js 1.0-alpha
 // Project: https://github.com/niklasvh/html2canvas
-// Definitions by: Richard Hepburn <https://github.com/rwhepburn>, Pei-Tang Huang <https://github.com/tan9>, Sebastian Schocke <https://github.com/sschocke>
+// Definitions by: Richard Hepburn <https://github.com/rwhepburn>, Pei-Tang Huang <https://github.com/tan9>, Sebastian Schocke <https://github.com/sschocke>, Rickard Staaf <https://github.com/Ristaaf>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -34,6 +34,9 @@ declare namespace Html2Canvas {
 
         /** Whether to log events in the console. */
         logging?: boolean;
+
+        /** Callback function which is called when the Document has been cloned for rendering, can be used to modify the contents that will be rendered without affecting the original source document. */
+        onclone?: { (doc: HTMLDocument): void };
 
         /** Url to the proxy which is to be used for loading cross-origin images. If left empty, cross-origin images won't be loaded. */
         proxy?: string;


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://html2canvas.hertzen.com/configuration>>
- [X] Increase the version number in the header if appropriate.
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
