### PR TITLE
[web3]: remove `default` specification on types

### DIFF
--- a/scripts/fix-tslint.js
+++ b/scripts/fix-tslint.js
@@ -1,0 +1,48 @@
+"use strict";
+// Usage: ts-node fix-tslint.ts
+Object.defineProperty(exports, "__esModule", { value: true });
+/// <reference types="node" />
+const fs = require("fs");
+const path = require("path");
+const JSON = require("comment-json");
+const home = path.join(__dirname, "..", "types");
+for (const dirName of fs.readdirSync(home)) {
+    if (dirName.startsWith(".") || dirName === "node_modules" || dirName === "scripts") {
+        continue;
+    }
+    const dir = path.join(home, dirName);
+    const stats = fs.lstatSync(dir);
+    if (stats.isDirectory()) {
+        fixTslint(dir);
+        // Also do it for old versions
+        for (const subdir of fs.readdirSync(dir)) {
+            if (/^v\d+$/.test(subdir)) {
+                fixTslint(path.join(dir, subdir));
+            }
+        }
+    }
+}
+function fixTslint(dir) {
+    const target = path.join(dir, 'tslint.json');
+    if (!fs.existsSync(target))
+        return;
+    let json = JSON.parse(fs.readFileSync(target, 'utf-8'));
+    json = fix(json);
+    const text = Object.keys(json).length === 1 ? '{ "extends": "dtslint/dt.json" }' : JSON.stringify(json, undefined, 4);
+    fs.writeFileSync(target, text + "\n", "utf-8");
+}
+function fix(config) {
+    const out = {};
+    for (const key in config) {
+        let value = config[key];
+        out[key] = key === "rules" ? fixRules(value) : value;
+    }
+    return out;
+}
+function fixRules(rules) {
+    const out = {};
+    for (const key in rules) {
+        out[key] = rules[key];
+    }
+    return out;
+}

--- a/scripts/generate-tsconfigs.js
+++ b/scripts/generate-tsconfigs.js
@@ -1,0 +1,48 @@
+"use strict";
+// Usage: ts-node generate-tsconfigs.ts
+Object.defineProperty(exports, "__esModule", { value: true });
+/// <reference types="node" />
+const fs = require("fs");
+const path = require("path");
+const home = path.join(__dirname, "..", "types");
+for (const dirName of fs.readdirSync(home)) {
+    if (dirName.startsWith(".") || dirName === "node_modules" || dirName === "scripts") {
+        continue;
+    }
+    const dir = path.join(home, dirName);
+    const stats = fs.lstatSync(dir);
+    if (stats.isDirectory()) {
+        fixTsconfig(dir);
+        // Also do it for old versions
+        for (const subdir of fs.readdirSync(dir)) {
+            if (/^v\d+$/.test(subdir)) {
+                fixTsconfig(path.join(dir, subdir));
+            }
+        }
+    }
+}
+function fixTsconfig(dir) {
+    const target = path.join(dir, 'tsconfig.json');
+    let json = JSON.parse(fs.readFileSync(target, 'utf-8'));
+    json = fix(json);
+    fs.writeFileSync(target, JSON.stringify(json, undefined, 4), "utf-8");
+}
+function fix(config) {
+    const out = {};
+    for (const key in config) {
+        let value = config[key];
+        if (key === "compilerOptions") {
+            value = fixCompilerOptions(value);
+        }
+        out[key] = value;
+    }
+    return out;
+}
+function fixCompilerOptions(config) {
+    const out = {};
+    for (const key in config) {
+        out[key] = config[key];
+        // Do something interesting here
+    }
+    return out;
+}

--- a/types/web3/eth/abi.d.ts
+++ b/types/web3/eth/abi.d.ts
@@ -10,7 +10,7 @@ export interface ABIDefinition {
 
 type ABIDataTypes = "uint256" | "boolean" | "string" | "bytes" | string; // TODO complete list
 
-export default interface ABI {
+export interface ABI {
     decodeLog(inputs: object, hexString: string, topics: string[]): object;
     encodeParameter(type: string, parameter: any): string;
     encodeParameters(types: string[], paramaters: any[]): string;

--- a/types/web3/eth/accounts.d.ts
+++ b/types/web3/eth/accounts.d.ts
@@ -1,71 +1,71 @@
 import { Tx } from "./types";
 
 export interface Account {
-	address: string;
-	privateKey: string;
-	publicKey: string;
+    address: string;
+    privateKey: string;
+    publicKey: string;
 }
 
 export interface Signature {
-	message: string;
-	hash: string;
-	r: string;
-	s: string;
-	v: string;
+    message: string;
+    hash: string;
+    r: string;
+    s: string;
+    v: string;
 }
 
 export interface PrivateKey {
-	address: string;
-	Crypto: {
-		cipher: string;
-		ciphertext: string;
-		cipherparams: {
-			iv: string;
-		};
-		kdf: string;
-		kdfparams: {
-			dklen: number;
-			n: number;
-			p: number;
-			r: number;
-			salt: string;
-		};
-		mac: string;
-	};
-	id: string;
-	version: number;
+    address: string;
+    Crypto: {
+        cipher: string;
+        ciphertext: string;
+        cipherparams: {
+            iv: string;
+        };
+        kdf: string;
+        kdfparams: {
+            dklen: number;
+            n: number;
+            p: number;
+            r: number;
+            salt: string;
+        };
+        mac: string;
+    };
+    id: string;
+    version: number;
 }
 
-export default interface Accounts {
-	create(entropy?: string): Account;
-	privateKeyToAccount(privKey: string): Account;
-	publicToAddress(key: string): string;
-	signTransaction(
-		tx: Tx,
-		privateKey: string,
-		returnSignature?: boolean,
-		cb?: (err: Error, result: string | Signature) => void
-	): Promise<string> | Signature;
-	recoverTransaction(signature: string | Signature): string;
-	sign(
-		data: string,
-		privateKey: string,
-		returnSignature?: boolean
-	): string | Signature;
-	recover(
-		sigOrHash: string | Signature,
-		sigOrV?: string,
-		r?: string,
-		s?: string
-	): string;
-	encrypt(privateKey: string, password: string): PrivateKey;
-	decrypt(privateKey: PrivateKey, password: string): Account;
-	wallet: {
-		create(numberOfAccounts: number, entropy: string): Account[];
-		add(account: string | Account): any;
-		remove(account: string | number): any;
-		save(password: string, keyname?: string): string;
-		load(password: string, keyname: string): any;
-		clear(): any;
-	};
+export interface Accounts {
+    create(entropy?: string): Account;
+    privateKeyToAccount(privKey: string): Account;
+    publicToAddress(key: string): string;
+    signTransaction(
+        tx: Tx,
+        privateKey: string,
+        returnSignature?: boolean,
+        cb?: (err: Error, result: string | Signature) => void
+    ): Promise<string> | Signature;
+    recoverTransaction(signature: string | Signature): string;
+    sign(
+        data: string,
+        privateKey: string,
+        returnSignature?: boolean
+    ): string | Signature;
+    recover(
+        sigOrHash: string | Signature,
+        sigOrV?: string,
+        r?: string,
+        s?: string
+    ): string;
+    encrypt(privateKey: string, password: string): PrivateKey;
+    decrypt(privateKey: PrivateKey, password: string): Account;
+    wallet: {
+        create(numberOfAccounts: number, entropy: string): Account[];
+        add(account: string | Account): any;
+        remove(account: string | number): any;
+        save(password: string, keyname?: string): string;
+        load(password: string, keyname: string): any;
+        clear(): any;
+    };
 }

--- a/types/web3/eth/contract.d.ts
+++ b/types/web3/eth/contract.d.ts
@@ -21,7 +21,7 @@ interface contractOptions {
     gas: number;
 }
 
-export default class Contract {
+export class Contract {
     constructor(
         jsonInterface: any[],
         address?: string,

--- a/types/web3/eth/index.d.ts
+++ b/types/web3/eth/index.d.ts
@@ -1,9 +1,9 @@
 import BigNumber = require("bn.js");
 import { Provider } from "../providers";
-import Contract, { CustomOptions as CustomContractOptions } from "./contract";
-import PromiEvent from "../promiEvent";
-import ABI from "./abi";
-import Accounts from "./accounts";
+import { Contract, CustomOptions as CustomContractOptions } from "./contract";
+import { PromiEvent } from "../promiEvent";
+import { ABI } from "./abi";
+import { Accounts } from "./accounts";
 import {
     BatchRequest,
     Iban,
@@ -25,7 +25,7 @@ import {
     EncodedTransaction
 } from "../types";
 
-export default interface Eth {
+export interface Eth {
     defaultAccount: string;
     defaultBlock: BlockType;
     BatchRequest: new () => BatchRequest;

--- a/types/web3/eth/types.d.ts
+++ b/types/web3/eth/types.d.ts
@@ -1,100 +1,100 @@
 import { Callback } from "../types";
-import PromiEvent from "../promiEvent";
+import { PromiEvent } from "../promiEvent";
 import { ABIDefinition } from "./abi";
 export interface Tx {
-	nonce?: string | number;
-	chainId?: string | number;
-	from?: string;
-	to?: string;
-	data?: string;
-	value?: string | number;
-	gas?: string | number;
-	gasPrice?: string | number;
+    nonce?: string | number;
+    chainId?: string | number;
+    from?: string;
+    to?: string;
+    data?: string;
+    value?: string | number;
+    gas?: string | number;
+    gasPrice?: string | number;
 }
 
 export class BatchRequest {
-	constructor();
-	add(request: object): void; //
-	execute(): void;
+    constructor();
+    add(request: object): void; //
+    execute(): void;
 }
 export class Iban {
-	constructor(address: string);
-	static toAddress(iban: Iban): string;
-	isValid(): boolean;
+    constructor(address: string);
+    static toAddress(iban: Iban): string;
+    isValid(): boolean;
 }
 export type BlockType = "latest" | "pending" | "genesis" | number;
 
 export interface BlockHeader {
-	number: number;
-	hash: string;
-	parentHash: string;
-	nonce: string;
-	sha3Uncles: string;
-	logsBloom: string;
-	transactionRoot: string;
-	stateRoot: string;
-	receiptRoot: string;
-	miner: string;
-	extraData: string;
-	gasLimit: number;
-	gasUsed: number;
-	timestamp: number;
+    number: number;
+    hash: string;
+    parentHash: string;
+    nonce: string;
+    sha3Uncles: string;
+    logsBloom: string;
+    transactionRoot: string;
+    stateRoot: string;
+    receiptRoot: string;
+    miner: string;
+    extraData: string;
+    gasLimit: number;
+    gasUsed: number;
+    timestamp: number;
 }
 export interface Block extends BlockHeader {
-	transactions: Transaction[];
-	size: number;
-	difficulty: number;
-	totalDifficulty: number;
-	uncles: string[];
+    transactions: Transaction[];
+    size: number;
+    difficulty: number;
+    totalDifficulty: number;
+    uncles: string[];
 }
 
 export class Net {
-	getId(cb?: Callback<number>): Promise<number>;
-	isListening(cb?: Callback<boolean>): Promise<boolean>;
-	getPeerCount(cb?: Callback<number>): Promise<number>;
+    getId(cb?: Callback<number>): Promise<number>;
+    isListening(cb?: Callback<boolean>): Promise<boolean>;
+    getPeerCount(cb?: Callback<number>): Promise<number>;
 }
 export class Personal {
-	newAccount(password: string, cb?: Callback<boolean>): Promise<string>;
-	importRawKey(): Promise<string>;
-	lockAccount(): Promise<boolean>;
-	unlockAccount(address: string, password: string, unlockDuration: number): void;
-	sign(): Promise<string>;
-	ecRecover(message: string, sig: string): void;
-	sendTransaction(tx: Tx, passphrase: string): Promise<string>;
+    newAccount(password: string, cb?: Callback<boolean>): Promise<string>;
+    importRawKey(): Promise<string>;
+    lockAccount(): Promise<boolean>;
+    unlockAccount(address: string, password: string, unlockDuration: number): void;
+    sign(): Promise<string>;
+    ecRecover(message: string, sig: string): void;
+    sendTransaction(tx: Tx, passphrase: string): Promise<string>;
 }
 
 export interface Transaction {
-	hash: string;
-	nonce: number;
-	blockHash: string;
-	blockNumber: number;
-	transactionIndex: number;
-	from: string;
-	to: string;
-	value: string;
-	gasPrice: string;
-	gas: number;
-	input: string;
-	v?: string;
-	r?: string;
-	s?: string;
+    hash: string;
+    nonce: number;
+    blockHash: string;
+    blockNumber: number;
+    transactionIndex: number;
+    from: string;
+    to: string;
+    value: string;
+    gasPrice: string;
+    gas: number;
+    input: string;
+    v?: string;
+    r?: string;
+    s?: string;
 }
 export interface TransactionObject<T> {
-	arguments: any[];
-	call(tx?: Tx): Promise<T>;
-	send(tx?: Tx): PromiEvent<T>;
-	estimateGas(tx?: Tx): Promise<number>;
-	encodeABI(): string;
+    arguments: any[];
+    call(tx?: Tx): Promise<T>;
+    send(tx?: Tx): PromiEvent<T>;
+    estimateGas(tx?: Tx): Promise<number>;
+    encodeABI(): string;
 }
 export interface CompileResult {
-	code: string;
-	info: {
-		source: string;
-		language: string;
-		languageVersion: string;
-		compilerVersion: string;
-		abiDefinition: ABIDefinition[];
-	};
-	userDoc: { methods: object };
-	developerDoc: { methods: object };
+    code: string;
+    info: {
+        source: string;
+        language: string;
+        languageVersion: string;
+        compilerVersion: string;
+        abiDefinition: ABIDefinition[];
+    };
+    userDoc: { methods: object };
+    developerDoc: { methods: object };
 }

--- a/types/web3/index.d.ts
+++ b/types/web3/index.d.ts
@@ -17,16 +17,17 @@
 //                 Konstantin Melnikov <https://github.com/archangel-irk>
 //                 Asgeir Sognefest <https://github.com/sogasg>
 //                 Donam Kim <https://github.com/donamk>
+//                 Doug Kent <https://github.com/dkent600>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.4
 
-import Providers, { Provider } from "./providers";
+import { Providers, Provider } from "./providers";
 import { Bzz, Shh } from "./types";
 import { BatchRequest, Net, Personal } from "./eth/types";
-import Utils from "./utils";
-import Eth from "./eth/index";
+import { Utils } from "./utils";
+import { Eth } from "./eth/index";
 
-declare class Web3 {
+export class Web3 {
     static providers: Providers;
     static givenProvider: Provider;
     static modules: {
@@ -50,5 +51,3 @@ declare class Web3 {
     setProvider(provider: Provider): void;
     utils: Utils;
 }
-
-export = Web3;

--- a/types/web3/promiEvent.d.ts
+++ b/types/web3/promiEvent.d.ts
@@ -2,7 +2,7 @@ import { TransactionReceipt } from "./types";
 
 type PromiEventType = "transactionHash" | "receipt" | "confirmation" | "error";
 
-export default interface PromiEvent<T> extends Promise<T> {
+export interface PromiEvent<T> extends Promise<T> {
     once(
         type: "transactionHash",
         handler: (receipt: string) => void

--- a/types/web3/providers.d.ts
+++ b/types/web3/providers.d.ts
@@ -54,7 +54,7 @@ export class IpcProvider extends Provider {
     reset(): undefined;
 }
 
-export default interface Providers {
+export interface Providers {
     WebsocketProvider: new (
         host: string,
         timeout?: number

--- a/types/web3/utils.d.ts
+++ b/types/web3/utils.d.ts
@@ -35,15 +35,15 @@ type Mixed =
     | number
     | BigNumber
     | {
-    type: string;
-    value: string;
-}
+        type: string;
+        value: string;
+    }
     | {
-    t: string;
-    v: string;
-};
+        t: string;
+        v: string;
+    };
 
-export default interface Utils {
+export interface Utils {
     BN: BigNumber; // TODO only static-definition
     isBN(any: any): boolean;
     isBigNumber(any: any): boolean;

--- a/types/web3/web3-tests.ts
+++ b/types/web3/web3-tests.ts
@@ -1,4 +1,4 @@
-import Web3 = require("web3");
+import { Web3 } from "web3";
 import BigNumber = require("bn.js");
 
 const contractAddress = "0xde0B295669a9FD93d5F28D9Ec85E40f4cb697BAe";


### PR DESCRIPTION
This removes the `default` specification from all types that have it.  

Most or all of the major types in these web3 type definitions were defined as `default` types.  This is a problem:

1. `default` types cannot be augmented.  Augmentation is desireable when working around bugs in the typings and for any application-idiomatic need to extend the web3 API.
2. making some types default and other types not default make inconsistent the syntax for importing the two.

As far as I can tell, there is no need for these types to be defined as `default`.

I don't see that this breaks anything, and it enables the conventional TypeScript import syntax to work:

```
import { Web3 } from "web3";
```

The following is no longer the only option, but still works:

```
const Web3 = require('web3');
```