### PR TITLE
[web3]: improve sendTransaction callback

### DIFF
--- a/types/web3/eth/index.d.ts
+++ b/types/web3/eth/index.d.ts
@@ -166,12 +166,12 @@ export default interface Eth {
     ): Promise<EncodedTransaction>;
     sendSignedTransaction(
         data: string,
-        cb?: Callback<TransactionReceipt | string | { confNumber: number, receipt: TransactionReceipt }>
-    ): PromiEvent<TransactionReceipt | string | { confNumber: number, receipt: TransactionReceipt }>;
+        cb?: Callback<string>
+    ): PromiEvent<TransactionReceipt>;
     sendTransaction(
         tx: Tx,
-        cb?: Callback<TransactionReceipt | string | { confNumber: number, receipt: TransactionReceipt }>
-    ): PromiEvent<TransactionReceipt | string | { confNumber: number, receipt: TransactionReceipt }>;
+        cb?: Callback<string>
+    ): PromiEvent<TransactionReceipt>;
     submitWork(
         nonce: string,
         powHash: string,

--- a/types/web3/eth/index.d.ts
+++ b/types/web3/eth/index.d.ts
@@ -166,12 +166,12 @@ export default interface Eth {
     ): Promise<EncodedTransaction>;
     sendSignedTransaction(
         data: string,
-        cb?: Callback<string>
-    ): PromiEvent<TransactionReceipt>;
+        cb?: Callback<TransactionReceipt | string | { confNumber: number, receipt: TransactionReceipt }>
+    ): PromiEvent<TransactionReceipt | string | { confNumber: number, receipt: TransactionReceipt }>;
     sendTransaction(
         tx: Tx,
-        cb?: Callback<string>
-    ): PromiEvent<TransactionReceipt>;
+        cb?: Callback<TransactionReceipt | string | { confNumber: number, receipt: TransactionReceipt }>
+    ): PromiEvent<TransactionReceipt | string | { confNumber: number, receipt: TransactionReceipt }>;
     submitWork(
         nonce: string,
         powHash: string,

--- a/types/web3/index.d.ts
+++ b/types/web3/index.d.ts
@@ -17,6 +17,7 @@
 //                 Konstantin Melnikov <https://github.com/archangel-irk>
 //                 Asgeir Sognefest <https://github.com/sogasg>
 //                 Donam Kim <https://github.com/donamk>
+//                 Doug Kent <https://github.com/dkent600>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.4
 

--- a/types/web3/web3-tests.ts
+++ b/types/web3/web3-tests.ts
@@ -1,5 +1,7 @@
 import Web3 = require("web3");
 import BigNumber = require("bn.js");
+import { TransactionReceipt } from "web3/types";
+import PromiEvent from "web3/promiEvent";
 
 const contractAddress = "0xde0B295669a9FD93d5F28D9Ec85E40f4cb697BAe";
 
@@ -15,6 +17,31 @@ web3.eth.setProvider(myProvider);
 // web3.eth
 // --------------------------------------------------------------------------
 const storage: Promise<string> = web3.eth.getStorageAt(contractAddress, 0);
+
+const sendSignedTransactionTxReceipt0: PromiEvent<TransactionReceipt> = web3.eth.sendSignedTransaction("",
+    (error: Error, txHash: string) => { });
+const sendSignedTransactionTxReceipt1: PromiEvent<TransactionReceipt> = web3.eth.sendSignedTransaction("")
+    .on("transactionHash", (txHash: string) => { });
+const sendSignedTransactionTxReceipt2: PromiEvent<TransactionReceipt> = web3.eth.sendSignedTransaction("")
+    .on("receipt", (txReceipt: TransactionReceipt) => { });
+const sendSignedTransactionTxReceipt3: PromiEvent<TransactionReceipt> = web3.eth.sendSignedTransaction("")
+    .on("confirmation", (confNumber: number, receipt: TransactionReceipt) => { });
+const sendSignedTransactionTxReceipt4: PromiEvent<TransactionReceipt> = web3.eth.sendSignedTransaction("")
+    .on("receipt", (txReceipt: TransactionReceipt) => { })
+    .on("confirmation", (confNumber: number, receipt: TransactionReceipt) => { });
+
+
+const sendTransactionTxReceipt0: PromiEvent<TransactionReceipt> = web3.eth.sendTransaction({ to: "0x1" },
+    (error: Error, txHash: string) => { });
+const sendTransactionTxReceipt1: PromiEvent<TransactionReceipt> = web3.eth.sendTransaction({ to: "0x1" })
+    .on("transactionHash", (txHash: string) => { });
+const sendTransactionTxReceipt2: PromiEvent<TransactionReceipt> = web3.eth.sendTransaction({ to: "0x1" })
+    .on("receipt", (txReceipt: TransactionReceipt) => { });
+const sendTransactionTxReceipt3: PromiEvent<TransactionReceipt> = web3.eth.sendTransaction({ to: "0x1" })
+    .on("confirmation", (confNumber: number, receipt: TransactionReceipt) => { });
+const sendTransactionTxReceipt4: PromiEvent<TransactionReceipt> = web3.eth.sendTransaction({ to: "0x1" })
+    .on("receipt", (txReceipt: TransactionReceipt) => { })
+    .on("confirmation", (confNumber: number, receipt: TransactionReceipt) => { });
 
 //
 // web3.eth.subscribe

--- a/types/web3/web3-tests.ts
+++ b/types/web3/web3-tests.ts
@@ -30,7 +30,6 @@ const sendSignedTransactionTxReceipt4: PromiEvent<TransactionReceipt> = web3.eth
     .on("receipt", (txReceipt: TransactionReceipt) => { })
     .on("confirmation", (confNumber: number, receipt: TransactionReceipt) => { });
 
-
 const sendTransactionTxReceipt0: PromiEvent<TransactionReceipt> = web3.eth.sendTransaction({ to: "0x1" },
     (error: Error, txHash: string) => { });
 const sendTransactionTxReceipt1: PromiEvent<TransactionReceipt> = web3.eth.sendTransaction({ to: "0x1" })


### PR DESCRIPTION
This PR modifies the callback definition on `sendTransaction` and `sendSignedTransaction` to respect the different types that may be returned by the callback.

Docs:
https://web3js.readthedocs.io/en/1.0/web3-eth.html#sendtransaction
https://web3js.readthedocs.io/en/1.0/web3-eth.html?#sendsignedtransaction