### PR TITLE
[web3]: fix eth.getBalance return type

### DIFF
--- a/types/web3/eth/index.d.ts
+++ b/types/web3/eth/index.d.ts
@@ -91,8 +91,8 @@ export default interface Eth {
     ): Promise<BigNumber>;
     getBalance(
         address: string,
-        defaultBlock?: BlockType,
-        cb?: Callback<BigNumber>
+        defaultBlock: BlockType,
+        cb: Callback<BigNumber>
     ): void;
     getBlock(
         number: BlockType,

--- a/types/web3/eth/index.d.ts
+++ b/types/web3/eth/index.d.ts
@@ -88,7 +88,7 @@ export default interface Eth {
     getBalance(
         address: string,
         defaultBlock?: BlockType,
-        cb?: Callback<number>
+        cb?: Callback<string>
     ): Promise<string>;
     getBlock(
         number: BlockType,

--- a/types/web3/eth/index.d.ts
+++ b/types/web3/eth/index.d.ts
@@ -88,8 +88,8 @@ export default interface Eth {
     getBalance(
         address: string,
         defaultBlock?: BlockType,
-        cb?: Callback<string>
-    ): Promise<string>;
+        cb?: Callback<BigNumber>
+    ): Promise<BigNumber>;
     getBlock(
         number: BlockType,
         returnTransactionObjects?: boolean,

--- a/types/web3/eth/index.d.ts
+++ b/types/web3/eth/index.d.ts
@@ -89,7 +89,7 @@ export default interface Eth {
         address: string,
         defaultBlock?: BlockType,
         cb?: Callback<number>
-    ): Promise<number>;
+    ): Promise<string>;
     getBlock(
         number: BlockType,
         returnTransactionObjects?: boolean,

--- a/types/web3/eth/index.d.ts
+++ b/types/web3/eth/index.d.ts
@@ -87,9 +87,13 @@ export default interface Eth {
     getAccounts(cb?: Callback<string[]>): Promise<string[]>;
     getBalance(
         address: string,
+        defaultBlock?: BlockType
+    ): Promise<BigNumber>;
+    getBalance(
+        address: string,
         defaultBlock?: BlockType,
         cb?: Callback<BigNumber>
-    ): Promise<BigNumber>;
+    ): void;
     getBlock(
         number: BlockType,
         returnTransactionObjects?: boolean,

--- a/types/web3/web3-tests.ts
+++ b/types/web3/web3-tests.ts
@@ -15,6 +15,9 @@ web3.eth.setProvider(myProvider);
 // web3.eth
 // --------------------------------------------------------------------------
 const storage: Promise<string> = web3.eth.getStorageAt(contractAddress, 0);
+const balance1: Promise<BigNumber> = web3.eth.getBalance(contractAddress);
+const balance2: Promise<BigNumber> = web3.eth.getBalance(contractAddress, "latest");
+web3.eth.getBalance(contractAddress, "latest", (error: Error, balance: BigNumber) => { });
 
 //
 // web3.eth.subscribe

--- a/types/web3/web3-tests.ts
+++ b/types/web3/web3-tests.ts
@@ -17,7 +17,9 @@ web3.eth.setProvider(myProvider);
 const storage: Promise<string> = web3.eth.getStorageAt(contractAddress, 0);
 const balance1: Promise<BigNumber> = web3.eth.getBalance(contractAddress);
 const balance2: Promise<BigNumber> = web3.eth.getBalance(contractAddress, "latest");
+const balance3: Promise<BigNumber> = web3.eth.getBalance(contractAddress, 1);
 web3.eth.getBalance(contractAddress, "latest", (error: Error, balance: BigNumber) => { });
+web3.eth.getBalance(contractAddress, 1, (error: Error, balance: BigNumber) => { });
 
 //
 // web3.eth.subscribe


### PR DESCRIPTION
fixes eth.getBalance return type (`number` => `BigNumber`)

docs: https://web3js.readthedocs.io/en/1.0/web3-eth.html?#getbalance

But note that the docs that specify `string` are in conflict with the code that specifies `BigNumber`:

```
        new Method({
            name: 'getBalance',
            call: 'eth_getBalance',
            params: 2,
            inputFormatter: [formatter.inputAddressFormatter, formatter.inputDefaultBlockNumberFormatter],
            outputFormatter: formatter.outputBigNumberFormatter
        }),
```

I would supply a link to the repository for the above code, but haven't been able to find the repository.