### PR TITLE
Nightwatch: Update the pause method on Browser to correct support both arguments as optional

### DIFF
--- a/types/nightwatch/index.d.ts
+++ b/types/nightwatch/index.d.ts
@@ -1220,10 +1220,10 @@ export interface NightwatchAPI {
      *  browser.pause();
      * };
      * ```
-     * @param ms: The number of milliseconds to wait.
+     * @param ms: Optional - The number of milliseconds to wait.
      * @param callback: Optional callback function to be called when the command finishes.
      */
-    pause(ms: number, callback?: (result: NightwatchCallbackResult) => void): this;
+    pause(ms?: number, callback?: (result: NightwatchCallbackResult) => void): this;
 
     /**
      * A simple perform command which allows access to the "api" in a callback. Can be useful if you want to read variables set by other commands.


### PR DESCRIPTION
Change pause to actually make ms optional. The documentation states that you can provide zero arguments to suspend the browser indefinitely, but it requires the ms argument, which forces you to provide at least the first argument.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:
If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
