### PR TITLE
[recompose] Improve type inference of static property helpers

### DIFF
--- a/types/recompose/index.d.ts
+++ b/types/recompose/index.d.ts
@@ -1,10 +1,11 @@
-// Type definitions for Recompose 0.26
+// Type definitions for Recompose 0.27
 // Project: https://github.com/acdlite/recompose
 // Definitions by: Iskander Sierra <https://github.com/iskandersierra>
 //                 Samuel DeSota <https://github.com/mrapogee>
 //                 Curtis Layne <https://github.com/clayne11>
 //                 Rasmus Eneman <https://github.com/Pajn>
 //                 Lucas Terra <https://github.com/lucasterra>
+//                 Brian Adams <https://github.com/brian-lives-outdoors>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -269,19 +270,19 @@ declare module 'recompose' {
     // Static property helpers: https://github.com/acdlite/recompose/blob/master/docs/API.md#static-property-helpers
 
     // setStatic: https://github.com/acdlite/recompose/blob/master/docs/API.md#setStatic
-    export function setStatic<TOutter>(
+    export function setStatic(
         key: string, value: any
-    ): ComponentEnhancer<TOutter, TOutter>;
+    ): <T extends Component>(component: T) => T;
 
     // setPropTypes: https://github.com/acdlite/recompose/blob/master/docs/API.md#setPropTypes
-    export function setPropTypes<TOutter>(
-        propTypes: ValidationMap<TOutter>
-    ): ComponentEnhancer<any, TOutter>;
+    export function setPropTypes<P>(
+        propTypes: ValidationMap<P>
+    ): <T extends Component<P>>(component: T) => T;
 
     // setDisplayName: https://github.com/acdlite/recompose/blob/master/docs/API.md#setDisplayName
-    export function setDisplayName<TOutter>(
+    export function setDisplayName(
         displayName: string
-    ): ComponentEnhancer<TOutter, TOutter>;
+    ): <T extends Component>(component: T) => T;
 
 
     // Utilities: https://github.com/acdlite/recompose/blob/master/docs/API.md#utilities

--- a/types/recompose/recompose-tests.tsx
+++ b/types/recompose/recompose-tests.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import * as PropTypes from 'prop-types';
 import {
     // Higher-order components
     mapProps, withProps, withPropsOnChange, withHandlers,
@@ -411,4 +412,87 @@ function testLifecycle() {
             this.instanceValue = 2
         }
     })(component)
+}
+
+function testSetStatic() {
+    interface Props {
+        foo: string;
+    }
+
+    let SfcResult: React.SFC<Props>;
+    const SfcComp: React.SFC<Props> = (props) => (<div>{props.foo}</div>);
+
+    let ClassResult: React.ComponentClass<Props, {}>;
+    class ClassComp extends React.Component<Props> {
+        render() {
+            return (<div>{this.props.foo}</div>);
+        }
+    }
+
+    const hoc1 = setStatic('bar', 'a string');
+    const hoc2 = setStatic('bar', 5);
+    const hoc3 = setStatic('bar', { a: 'b' });
+
+    SfcResult = hoc1(SfcComp);
+    SfcResult = hoc2(SfcComp);
+    SfcResult = hoc3(SfcComp);
+    SfcResult = hoc1(ClassComp); // $ExpectError
+
+    ClassResult = hoc1(ClassComp);
+    ClassResult = hoc2(ClassComp);
+    ClassResult = hoc3(ClassComp);
+    ClassResult = hoc1(SfcComp); // $ExpectError
+}
+
+function testSetPropTypes() {
+    interface Props {
+        foo: string;
+    }
+    const validationMap = {
+        foo: PropTypes.string.isRequired
+    }
+
+    let SfcResult: React.SFC<Props>;
+    const SfcComp: React.SFC<Props> = (props) => (<div>{props.foo}</div>);
+
+    let ClassResult: React.ComponentClass<Props, {}>;
+    class ClassComp extends React.Component<Props> {
+        render() {
+            return (<div>{this.props.foo}</div>);
+        }
+    }
+
+    const hoc = setPropTypes(validationMap);
+
+    SfcResult = hoc(SfcComp);
+    SfcResult = hoc(ClassComp); // $ExpectError
+
+    ClassResult = hoc(ClassComp);
+    ClassResult = hoc(SfcComp); // $ExpectError
+
+    SfcResult = setPropTypes({ bar: PropTypes.string })(SfcComp); // $ExpectError
+}
+
+function testSetDisplayName() {
+    interface Props {
+        foo: string;
+    }
+
+    let SfcResult: React.SFC<Props>;
+    const SfcComp: React.SFC<Props> = (props) => (<div>{props.foo}</div>);
+
+    let ClassResult: React.ComponentClass<Props, {}>;
+    class ClassComp extends React.Component<Props> {
+        render() {
+            return (<div>{this.props.foo}</div>);
+        }
+    }
+
+    const hoc = setDisplayName('NewDisplayName');
+
+    SfcResult = hoc(SfcComp);
+    SfcResult = hoc(ClassComp); // $ExpectError
+
+    ClassResult = hoc(ClassComp);
+    ClassResult = hoc(SfcComp); // $ExpectError
 }


### PR DESCRIPTION
<!-- language-all: lang-tsx -->

Summary
---

I improved the type inference for the three static property helpers (`setStatic`, `setPropTypes`, and `setDisplayName`) and added tests for each.

Details
---

The static property helpers simply set a static property on the component and return it.

The previous definitions could not infer the type argument and required the user to provide it, essentially forcing a type assertion.  They also returned a `ComponentEnhancer` which always returns a `ComponentClass` even though the HOC's generated by the static property helpers can also be called on (and therefore return) stateless functional components:

```tsx
interface Props {
    foo: string;
}
const Comp: React.SFC<Props> = (props) => (<div>{props.foo}</div>);

const Result1 = setStatic('key', 'value')(Comp);
const element1 = (<Result1 foo="foo"/>); // Error: "Property 'foo' doesn't exist on type..."

const Result2 = setStatic<Props>('key', 'value')(Comp);
const element2 = (<Result2 foo="foo"/>); // Works with Props explicitly passed as type argument...

const instance = new Result2({ foo: "foo" }); // ...but incorrectly returns a new-able ComponentClass
```

This PR improves the type inference of the static property helpers and updates them to return a function that accepts a `React.ComponentType` (either `React.ComponentClass` or `React.StatelessComponent`) and returns a value of the same type:

```tsx
interface Props {
    foo: string;
}
const Comp: React.SFC<Props> = (props) => (<div>{props.foo}</div>);

const Result = setStatic('key', 'value')(Comp);
const element = (<Result foo="foo"/>);  // SUCCESS

const instance = new Result({ foo: "foo" }); // correctly causes an error since Result is a React.StatelessComponent
```

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Increase the version number in the header if appropriate.
