### PR TITLE
Fixed issue with incorrect type for Theme - Mailgen

### DIFF
--- a/types/mailgen/index.d.ts
+++ b/types/mailgen/index.d.ts
@@ -21,8 +21,13 @@ declare class Mailgen {
 
 declare namespace Mailgen {
     interface Option {
-        theme: string;
+        theme: string | CustomTheme;
         product: Product;
+    }
+
+    interface CustomTheme {
+        path: string;
+        plaintextPath?: string;
     }
 
     interface Product {


### PR DESCRIPTION
Error in the types for Mailgen theme specification,
The type for theme can either be a string or an object containing one mandatory field and one optional field
path: string (path to custom html template)
plaintextPath?: string (optional plain text email template path)


- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/eladnava/mailgen/blob/master/THEME.md
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
