### PR TITLE
[parse] Added fullText function to Parse.Query

### DIFF
--- a/types/parse/index.d.ts
+++ b/types/parse/index.d.ts
@@ -679,9 +679,9 @@ declare namespace Parse {
 
         // According to https://parseplatform.org/Parse-SDK-JS/api/2.1.0/Parse.Query.html#fullText
         interface FullTextOptions {
-          language:	string;
-          caseSensitive: boolean;
-          diacriticSensitive: boolean;
+          language?: string;
+          caseSensitive?: boolean;
+          diacriticSensitive?: boolean;
         }
     }
 

--- a/types/parse/index.d.ts
+++ b/types/parse/index.d.ts
@@ -634,6 +634,7 @@ declare namespace Parse {
         exists(key: string): Query<T>;
         find(options?: Query.FindOptions): Promise<T[]>;
         first(options?: Query.FirstOptions): Promise<T | undefined>;
+        fullText(key: string, value: string, options?: Query.FullTextOptions): Query<T>;
         get(objectId: string, options?: Query.GetOptions): Promise<T>;
         greaterThan(key: string, value: any): Query<T>;
         greaterThanOrEqualTo(key: string, value: any): Query<T>;
@@ -674,6 +675,13 @@ declare namespace Parse {
             skip?: number;
             // Sort documentation https://docs.mongodb.com/v3.2/reference/operator/aggregation/sort/#pipe._S_sort
             sort?: {[key: string]: 1|-1};
+        }
+
+        // According to https://parseplatform.org/Parse-SDK-JS/api/2.1.0/Parse.Query.html#fullText
+        interface FullTextOptions {
+          language:	string;
+          caseSensitive: boolean;
+          diacriticSensitive: boolean;
         }
     }
 

--- a/types/parse/parse-tests.ts
+++ b/types/parse/parse-tests.ts
@@ -83,6 +83,7 @@ function test_query() {
     const query = new Parse.Query(GameScore);
     query.equalTo("playerName", "Dan Stemkoski");
     query.notEqualTo("playerName", "Michael Yabuti");
+    query.fullText("playerName", "dan", { language: 'en', caseSensitive: false, diacriticSensitive: true });
     query.greaterThan("playerAge", 18);
     query.limit(10);
     query.skip(10);


### PR DESCRIPTION
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://parseplatform.org/Parse-SDK-JS/api/2.1.0/Parse.Query.html#fullText
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.