### PR TITLE
feat(puppeteer): update 1.8 and improve typings

### DIFF
--- a/types/puppeteer/Errors.d.ts
+++ b/types/puppeteer/Errors.d.ts
@@ -1,0 +1,6 @@
+/**
+ * TimeoutError is emitted whenever certain operations are terminated due to timeout,
+ * e.g. page.waitForSelector(selector[, options]) or puppeteer.launch([options]).
+ */
+export class TimeoutError extends Error {
+}

--- a/types/puppeteer/index.d.ts
+++ b/types/puppeteer/index.d.ts
@@ -1,8 +1,9 @@
-// Type definitions for puppeteer 1.6
+// Type definitions for puppeteer 1.8
 // Project: https://github.com/GoogleChrome/puppeteer#readme
 // Definitions by: Marvin Hagemeister <https://github.com/marvinhagemeister>
 //                 Christopher Deutsch <https://github.com/cdeutsch>
 //                 Konstantin Simon Maria Möllers <https://github.com/ksm2>
+//                 Simon Schick <https://github.com/SimonSchick>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -353,13 +354,13 @@ export interface AuthOptions {
 export type MouseButtons = "left" | "right" | "middle";
 
 export interface ClickOptions {
-  /** defaults to left */
+  /** @default MouseButtons.Left */
   button?: MouseButtons;
-  /** defaults to 1 */
+  /** @default 1 */
   clickCount?: number;
   /**
    * Time to wait between mousedown and mouseup in milliseconds.
-   * Defaults to 0.
+   * @default 0
    */
   delay?: number;
 }
@@ -473,6 +474,13 @@ export interface NavigationOptions {
    * @default load Navigation is consider when the `load` event is fired.
    */
   waitUntil?: LoadEvent | LoadEvent[];
+
+  /**
+   * Referer header value.
+   * If provided it will take preference over the referer header value set by
+   * [page.setExtraHTTPHeaders()](#pagesetextrahttpheadersheaders).
+   */
+  referer?: string;
 }
 
 export type PDFFormat =
@@ -533,11 +541,14 @@ export interface PDFOptions {
    */
   landscape?: boolean;
   /**
-   * Paper ranges to print, e.g., '1-5, 8, 11-13'. Defaults to the empty
-   * string, which means print all pages.
+   * Paper ranges to print, e.g., '1-5, 8, 11-13'.
+   * @default '' which means print all pages.
    */
   pageRanges?: string;
-  /** Paper format. If set, takes priority over width or height options. Defaults to 'Letter'. */
+  /**
+   * Paper format. If set, takes priority over width or height options.
+   * @default 'Letter'
+   */
   format?: PDFFormat;
   /** Paper width, accepts values labeled with units. */
   width?: string;
@@ -554,6 +565,13 @@ export interface PDFOptions {
     /** Left margin, accepts values labeled with units. */
     left?: string;
   };
+
+  /**
+   * Give any CSS @page size declared in the page priority over what is declared in width and
+   * height or format options.
+   * @default false which will scale the content to fit the paper size.
+   */
+  preferCSSPageSize?: boolean;
 }
 
 /** Defines the screenshot options. */
@@ -586,7 +604,7 @@ export interface ScreenshotOptions {
    */
   omitBackground?: boolean;
   /**
-   * The encoding of the image, can be either base64 or binary. Defaults to binary
+   * The encoding of the image, can be either base64 or binary.
    * @default binary
    */
   encoding?: "base64" | "binary";
@@ -984,6 +1002,13 @@ export interface RespondOptions {
   body?: Buffer | string;
 }
 
+export interface RemoteInfo {
+    /** the IP address of the remote server */
+    ip: string;
+    /** the port used to connect to the remote server */
+    port: number;
+}
+
 /** Response class represents responses which are received by page. */
 export interface Response {
   /** Promise which resolves to a buffer with response body. */
@@ -1001,14 +1026,39 @@ export interface Response {
   json(): Promise<any>;
   /** Contains a boolean stating whether the response was successful (status in the range 200-299) or not. */
   ok(): boolean;
+  /** Returns remote connection info */
+  remoteAddress(): RemoteInfo;
   /** A matching Request object. */
   request(): Request;
   /** Contains the status code of the response (e.g., 200 for a success). */
   status(): number;
+  /** Contains the status text of the response (e.g. usually an "OK" for a success).  */
+  statusText(): string;
   /** Promise which resolves to a text representation of response body. */
   text(): Promise<string>;
   /** Contains the URL of the response. */
   url(): string;
+}
+
+export interface WaitForSelectorOptions {
+    /**
+     * Wait for element to be present in DOM and to be visible,
+     * i.e. to not have display: none or visibility: hidden CSS properties.
+     * @default false
+     */
+    visible?: boolean;
+    /**
+     * Wait for element to not be found in the DOM or to be hidden,
+     * i.e. have display: none or visibility: hidden CSS properties.
+     * @default false
+     */
+    hidden?: boolean;
+    /**
+     * Maximum time to wait for in milliseconds.
+     * Pass 0 to disable timeout.
+     * @default 30000 (30 seconds).
+     */
+    timeout?: number;
 }
 
 export interface FrameBase extends Evalable {
@@ -1112,30 +1162,34 @@ export interface FrameBase extends Evalable {
   /** Returns frame's url. */
   url(): string;
 
-  waitFor(
-    // fn can be an abritary function
-    // tslint:disable-next-line ban-types
-    selectorOrFunctionOrTimeout: string | number | Function,
-    options?: any,
-    ...args: any[]
-  ): Promise<any>;
+  /**
+   * Waits for a certain amount of time before resolving.
+   * @param duration The time to wait for.
+   */
+  waitFor(duration: number): Promise<void>;
+  /**
+   * Shortcut for waitForSelector and waitForXPath
+   */
+  waitFor(selector: string, options?: WaitForSelectorOptions): Promise<ElementHandle>;
+  /**
+   * Shortcut for waitForFunction.
+   */
+  waitFor(selector: ((...args: any[]) => any) | string, options?: WaitForSelectorOptions, ...args: any[]): Promise<any>;
 
   waitForFunction(
-    // fn can be an abritary function
-    // tslint:disable-next-line ban-types
-    fn: string | Function,
+    fn: string | ((...args: any[]) => any),
     options?: PageFnOptions,
     ...args: any[]
   ): Promise<any>;
 
   waitForSelector(
     selector: string,
-    options?: { visible?: boolean; hidden?: boolean; timeout?: number }
+    options?: WaitForSelectorOptions,
   ): Promise<ElementHandle>;
 
   waitForXPath(
     xpath: string,
-    options?: { visible?: boolean; hidden?: boolean; timeout?: number }
+    options?: WaitForSelectorOptions,
   ): Promise<ElementHandle>;
 }
 
@@ -1178,9 +1232,9 @@ export interface PageEventObj {
    * Emitted when the JavaScript code makes a call to `console.timeStamp`.
    * For the list of metrics see `page.metrics`.
    */
-  metrics: { title: string, metrics: any };
+  metrics: { title: string, metrics: Metrics };
   /** Emitted when an uncaught exception happens within the page. */
-  pageerror: string;
+  pageerror: Error;
   /**
    * Emitted when a page issues a request. The request object is read-only.
    * In order to intercept and mutate requests, see page.setRequestInterceptionEnabled.
@@ -1199,8 +1253,26 @@ export interface PageEventObj {
 }
 
 export interface PageCloseOptions {
-  /** Defaults to `false`. Whether to run the before unload page handlers. */
+  /**
+   * Whether to run the before unload page handlers.
+   * @default false
+   */
   runBeforeUnload?: boolean;
+}
+
+export interface GeoOptions {
+  /**
+   * Latitude between -90 and 90.
+   */
+  latitude: number;
+  /**
+   * Longitude between -180 and 180.
+   */
+  longitude: number;
+  /**
+   * Non-negative accuracy value.
+   */
+  accuracy?: number;
 }
 
 /** Page provides methods to interact with a single tab in Chromium. One Browser instance might have multiple Page instances. */
@@ -1258,7 +1330,7 @@ export interface Page extends EventEmitter, FrameBase {
   deleteCookie(...cookies: DeleteCookie[]): Promise<void>;
 
   /** Emulates given device metrics and user agent. This method is a shortcut for `setUserAgent` and `setViewport`.  */
-  emulate(options: Partial<EmulateOptions>): Promise<void>;
+  emulate(options: EmulateOptions): Promise<void>;
 
   /** Emulates the media. */
   emulateMedia(mediaType: 'screen' | 'print' | null): Promise<void>;
@@ -1303,20 +1375,20 @@ export interface Page extends EventEmitter, FrameBase {
    * Navigate to the previous page in history.
    * @param options The navigation parameters.
    */
-  goBack(options?: Partial<NavigationOptions>): Promise<Response | null>;
+  goBack(options?: NavigationOptions): Promise<Response | null>;
 
   /**
    * Navigate to the next page in history.
    * @param options The navigation parameters.
    */
-  goForward(options?: Partial<NavigationOptions>): Promise<Response | null>;
+  goForward(options?: NavigationOptions): Promise<Response | null>;
 
   /**
    * Navigates to a URL.
    * @param url URL to navigate page to. The url should include scheme, e.g. `https://`
    * @param options The navigation parameters.
    */
-  goto(url: string, options?: Partial<NavigationOptions>): Promise<Response | null>;
+  goto(url: string, options?: NavigationOptions): Promise<Response | null>;
 
   /** Returns the virtual keyboard. */
   keyboard: Keyboard;
@@ -1338,7 +1410,7 @@ export interface Page extends EventEmitter, FrameBase {
    * To generate a pdf with `screen` media, call `page.emulateMedia('screen')` before calling `page.pdf()`:
    * @param options The PDF parameters.
    */
-  pdf(options?: Partial<PDFOptions>): Promise<Buffer>;
+  pdf(options?: PDFOptions): Promise<Buffer>;
 
   /**
    * The method iterates JavaScript heap and finds all the objects with the given prototype.
@@ -1404,6 +1476,11 @@ export interface Page extends EventEmitter, FrameBase {
    * @param headers An object containing additional http headers to be sent with every request. All header values must be strings.
    */
   setExtraHTTPHeaders(headers: Headers): Promise<void>;
+
+  /**
+   * Sets the page's geolocation.
+   */
+  setGeolocation(options: GeoOptions): Promise<void>;
 
   /**
    * Determines whether JavaScript is enabled on the page.
@@ -1523,6 +1600,12 @@ export interface Browser extends EventEmitter {
    */
   disconnect(): void;
 
+  /**
+   * Returns the default browser context.
+   * The default browser context can not be closed.
+   */
+  defaultBrowserContext(): BrowserContext;
+
   /** Promise which resolves to a new Page object. */
   newPage(): Promise<Page>;
 
@@ -1562,6 +1645,24 @@ export interface BrowserEventObj {
   targetdestroyed: Target;
 }
 
+export type Permission =
+    'geolocation' |
+    'midi' |
+    'midi-sysex' |
+    'notifications' |
+    'push' |
+    'camera' |
+    'microphone' |
+    'background-sync' |
+    'ambient-light-sensor' |
+    'accelerometer' |
+    'gyroscope' |
+    'magnetometer' |
+    'accessibility-events' |
+    'clipboard-read' |
+    'clipboard-write' |
+    'payment-handler';
+
 /**
  * BrowserContexts provide a way to operate multiple independent browser sessions.
  * When a browser is launched, it has a single BrowserContext used by default.
@@ -1594,6 +1695,11 @@ export interface BrowserContext extends EventEmitter {
   /** The browser this browser context belongs to. */
   browser(): Browser;
 
+  /**
+   * Clears all permission overrides for the browser context.
+   */
+  clearPermissionOverrides(): Promise<void>;
+
   /** Closes the browser context. All the targets that belong to the browser context will be closed. */
   close(): Promise<void>;
 
@@ -1605,6 +1711,17 @@ export interface BrowserContext extends EventEmitter {
 
   /** Creates a new page in the browser context. */
   newPage(): Promise<Page>;
+
+  /**
+   *
+   * @param origin The origin to grant permissions to, e.g. "https://example.com".
+   * @param permissions An array of permissions to grant.
+   * All permissions that are not listed here will be automatically denied.
+   */
+  overridePermissions(origin: string, permissions: Permission[]): Promise<void>;
+
+  /** Promise which resolves to an array of all open pages. */
+  pages(): Promise<Page[]>;
 
   /** An array of all active targets inside the browser context. */
   targets(): Target[];
@@ -1645,13 +1762,25 @@ export interface Target {
 }
 
 export interface LaunchOptions {
-  /** Whether to open chrome in appMode. Defaults to false. */
+  /**
+   * Whether to open chrome in appMode.
+   * @default false
+   */
   appMode?: boolean;
-  /** Whether to ignore HTTPS errors during navigation. Defaults to false. */
+  /**
+   * Whether to ignore HTTPS errors during navigation.
+   * @default false
+   */
   ignoreHTTPSErrors?: boolean;
-  /** Do not use `puppeteer.defaultArgs()` for launching Chromium. Defaults to false. */
-  ignoreDefaultArgs?: boolean;
-  /** Whether to run Chromium in headless mode. Defaults to true. */
+  /**
+   * Do not use `puppeteer.defaultArgs()` for launching Chromium.
+   * @default false
+   */
+  ignoreDefaultArgs?: boolean | string[];
+  /**
+   * Whether to run Chromium in headless mode.
+   * @default true
+   */
   headless?: boolean;
   /**
    * Path to a Chromium executable to run instead of bundled Chromium. If
@@ -1677,19 +1806,24 @@ export interface LaunchOptions {
      */
     height?: number;
     /**
-     * Specify device scale factor (can be thought of as dpr). Defaults to 1.
+     * Specify device scale factor (can be thought of as dpr).
+     * @default 1
      */
     deviceScaleFactor?: number;
     /**
-     * Whether the meta viewport tag is taken into account. Defaults to false.
+     * Whether the meta viewport tag is taken into account.
+     * @default false
      */
     isMobile?: boolean;
     /**
-     * Specifies if viewport supports touch events. Defaults to false.
+     *
+     * Specifies if viewport supports touch events.
+     * @default false
      */
     hasTouch?: boolean;
     /**
-     * Specifies if viewport is in landscape mode. Defaults to false.
+     * Specifies if viewport is in landscape mode.
+     * @default false
      */
     isLandscape?: boolean;
   };
@@ -1698,30 +1832,73 @@ export interface LaunchOptions {
    * flags can be found here.
    */
   args?: string[];
-  /** Close chrome process on Ctrl-C. Defaults to true. */
+  /**
+   * Close chrome process on Ctrl-C.
+   * @default true
+   */
   handleSIGINT?: boolean;
-  /** Close chrome process on SIGTERM. Defaults to true. */
+  /**
+   * Close chrome process on SIGTERM.
+   * @default true
+   */
   handleSIGTERM?: boolean;
-  /** Close chrome process on SIGHUP. Defaults to true. */
+  /**
+   * Close chrome process on SIGHUP.
+   * @default true
+   */
   handleSIGHUP?: boolean;
   /**
    * Maximum time in milliseconds to wait for the Chrome instance to start.
-   * Defaults to 30000 (30 seconds). Pass 0 to disable timeout.
+   * Pass 0 to disable timeout.
+   * @default 30000 (30 seconds).
    */
   timeout?: number;
   /**
    * Whether to pipe browser process stdout and stderr into process.stdout and
-   * process.stderr. Defaults to false.
+   * process.stderr.
+   * @default false
    */
   dumpio?: boolean;
   /** Path to a User Data Directory. */
   userDataDir?: string;
-  /** Specify environment variables that will be visible to Chromium. Defaults to process.env. */
-  env?: any;
-  /** Whether to auto-open DevTools panel for each tab. If this option is true, the headless option will be set false. */
+  /**
+   * Specify environment variables that will be visible to Chromium.
+   * @default `process.env`.
+   */
+  env?: {
+    [key: string]: string | boolean | number;
+  };
+  /**
+   * Whether to auto-open DevTools panel for each tab. If this option is true, the headless option will be set false.
+   */
   devtools?: boolean;
-  /** Connects to the browser over a pipe instead of a WebSocket. Defaults to false. */
+  /**
+   * Connects to the browser over a pipe instead of a WebSocket.
+   * @default false
+   */
   pipe?: boolean;
+}
+
+export interface DefaultArgsOptions {
+    /**
+     * Whether to run browser in headless mode.
+     * @default true unless the devtools option is true.
+     */
+    headless?: boolean;
+    /**
+     * Additional arguments to pass to the browser instance.
+     * The list of Chromium flags can be found here.
+     */
+    args?: string[];
+    /**
+     * Path to a User Data Directory.
+     */
+    userDataDir?: string;
+    /**
+     * Whether to auto-open a DevTools panel for each tab.
+     * If this option is true, the headless option will be set false.
+     */
+    devtools?: boolean;
 }
 
 export interface ConnectOptions {
@@ -1744,7 +1921,7 @@ export interface CDPSession extends EventEmitter {
   /**
    * @param method Protocol method name
    */
-  send(method: string, params?: object): Promise<any>;
+  send(method: string, params?: object): Promise<object>;
 }
 
 export interface Coverage {
@@ -1755,9 +1932,15 @@ export interface Coverage {
 }
 
 export interface StartCoverageOptions {
-  /** Whether to reset coverage on every navigation. Defaults to `true`. */
+  /**
+   * Whether to reset coverage on every navigation.
+   * @default true
+   */
   resetOnNavigation?: boolean;
-  /** Whether anonymous scripts generated by the page should be reported. Defaults to `false`. */
+  /**
+   * Whether anonymous scripts generated by the page should be reported.
+   * @default false
+   */
   reportAnonymousScripts?: boolean;
 }
 
@@ -1770,7 +1953,7 @@ export interface CoverageEntry {
 /** Attaches Puppeteer to an existing Chromium instance */
 export function connect(options?: ConnectOptions): Promise<Browser>;
 /** The default flags that Chromium will be launched with */
-export function defaultArgs(): string[];
+export function defaultArgs(options?: DefaultArgsOptions): string[];
 /** Path where Puppeteer expects to find bundled Chromium */
 export function executablePath(): string;
 /** The method launches a browser instance with given arguments. The browser will be closed when the parent node.js process is closed. */

--- a/types/puppeteer/index.d.ts
+++ b/types/puppeteer/index.d.ts
@@ -474,7 +474,12 @@ export interface NavigationOptions {
    * @default load Navigation is consider when the `load` event is fired.
    */
   waitUntil?: LoadEvent | LoadEvent[];
+}
 
+/**
+ * Navigation options for `page.goto`.
+ */
+export interface DirectNavigationOptions extends NavigationOptions {
   /**
    * Referer header value.
    * If provided it will take preference over the referer header value set by
@@ -1388,7 +1393,7 @@ export interface Page extends EventEmitter, FrameBase {
    * @param url URL to navigate page to. The url should include scheme, e.g. `https://`
    * @param options The navigation parameters.
    */
-  goto(url: string, options?: NavigationOptions): Promise<Response | null>;
+  goto(url: string, options?: DirectNavigationOptions): Promise<Response | null>;
 
   /** Returns the virtual keyboard. */
   keyboard: Keyboard;

--- a/types/puppeteer/puppeteer-tests.ts
+++ b/types/puppeteer/puppeteer-tests.ts
@@ -30,8 +30,10 @@ import { TimeoutError } from "puppeteer/Errors";
   // Get the "viewport" of the page, as reported by the page.
   const dimensions = await page.evaluate(() => {
     return {
-      width: document.documentElement.clientWidth,
-      height: document.documentElement.clientHeight,
+      // tslint:disable-next-line no-unnecessary-type-assertion
+      width: document.documentElement!.clientWidth,
+      // tslint:disable-next-line no-unnecessary-type-assertion
+      height: document.documentElement!.clientHeight,
       deviceScaleFactor: window.devicePixelRatio
     };
   });

--- a/types/puppeteer/puppeteer-tests.ts
+++ b/types/puppeteer/puppeteer-tests.ts
@@ -30,8 +30,8 @@ import { TimeoutError } from "puppeteer/Errors";
   // Get the "viewport" of the page, as reported by the page.
   const dimensions = await page.evaluate(() => {
     return {
-      width: document.documentElement!.clientWidth,
-      height: document.documentElement!.clientHeight,
+      width: document.documentElement.clientWidth,
+      height: document.documentElement.clientHeight,
       deviceScaleFactor: window.devicePixelRatio
     };
   });

--- a/types/puppeteer/puppeteer-tests.ts
+++ b/types/puppeteer/puppeteer-tests.ts
@@ -1,10 +1,13 @@
 import * as puppeteer from "puppeteer";
+import { TimeoutError } from "puppeteer/Errors";
 
-// Examples taken from README
+// Basic nagivation
 (async () => {
   const browser = await puppeteer.launch();
   const page = await browser.newPage();
-  await page.goto("https://example.com");
+  await page.goto("https://example.com", {
+    referer: 'http://google.com',
+  });
   await page.screenshot({ path: "example.png" });
 
   browser.close();
@@ -306,12 +309,19 @@ puppeteer.launch().then(async browser => {
   browser.close();
 })();
 
-// Test 0.13 features
+// Test request API
 (async () => {
   const browser = await puppeteer.launch();
   const page = await browser.newPage();
   const handler = (r: puppeteer.Request) => {
     const failure = r.failure();
+
+    const response = r.response();
+    if (!response) {
+      return;
+    }
+    const text: string = response.statusText();
+    const ip: string = response.remoteAddress().ip;
 
     if (failure == null) {
       console.error("Request completed successfully");
@@ -412,3 +422,51 @@ puppeteer.launch().then(async browser => {
 
   browser.close();
 })();
+
+// Test waitFor
+(async () => {
+  const browser = await puppeteer.launch();
+  const page = await browser.newPage();
+  await page.waitFor(1000);
+  await page.waitFor('selector');
+  await page.waitFor('selector', {
+      timeout: 123,
+  });
+  await page.waitFor(() => !!document.querySelector('.foo'), {
+      hidden: true,
+  });
+  await page.waitFor((stuff: string) => !!document.querySelector(stuff), {
+    hidden: true,
+  }, 'asd');
+})();
+
+// Permission tests
+(async () => {
+  const browser = await puppeteer.launch();
+  const page = await browser.newPage();
+  const ctx = browser.defaultBrowserContext();
+  await ctx.overridePermissions('https://example.com', ['accelerometer']);
+  await ctx.clearPermissionOverrides();
+});
+
+// Geoloc
+(async () => {
+  const browser = await puppeteer.launch();
+  const page = await browser.newPage();
+  page.setGeolocation({
+    accuracy: 10,
+    latitude: 0,
+    longitude: 0,
+  });
+});
+
+// Errors
+(async () => {
+  const browser = await puppeteer.launch();
+  const page = await browser.newPage();
+    try {
+        await page.waitFor('test');
+    } catch (err) {
+        console.log(err instanceof TimeoutError);
+    }
+});

--- a/types/puppeteer/tsconfig.json
+++ b/types/puppeteer/tsconfig.json
@@ -20,6 +20,7 @@
         "forceConsistentCasingInFileNames": true
     },
     "files": [
+        "Errors.d.ts",
         "index.d.ts",
         "puppeteer-tests.ts"
     ]


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/GoogleChrome/puppeteer/releases https://github.com/GoogleChrome/puppeteer/blob/v1.8.0/docs/api.md
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.


- Added changes from 1.7 and 1.8.
- Refactor docs to use `@default` correctly.
- Fixed `pageerror` event being declared as `string`.
- Use overloads for `waitFor` to improve type safety.
- Use `Metrics` interface for `metrics` event.
- Narrowed `env` parameter.
- Narrowed `CDPSession.send` return type.