### PR TITLE
[argparse] Add 'debug' to ArgumentParser's constructor options

### DIFF
--- a/types/argparse/index.d.ts
+++ b/types/argparse/index.d.ts
@@ -69,6 +69,7 @@ export interface ArgumentParserOptions {
     prog?: string;
     usage?: string;
     version?: string;
+    debug?: boolean;
 }
 
 export interface ArgumentGroupOptions {


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/nodeca/argparse/blob/master/lib/argument_parser.js#L47
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

Just added a missing option to `ArgumentParser`'s constructor options.