### PR TITLE
[graphql] fix GraphQL Error originalError property type

### DIFF
--- a/types/graphql/error/GraphQLError.d.ts
+++ b/types/graphql/error/GraphQLError.d.ts
@@ -59,7 +59,7 @@ export class GraphQLError extends Error {
     /**
      * The original error thrown from a field resolver during execution.
      */
-    readonly originalError: Maybe<Error> & { readonly extensions: any };
+    readonly originalError: Maybe<Error>;
 
     /**
      * Extension fields to add to the formatted error.


### PR DESCRIPTION
According to newest code, `originalError` property value doesn't have the `extensions` property at all. This PR revert the changes made in 202ed3a9.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/graphql/graphql-js/blob/master/src/error/GraphQLError.js#L84
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
