### PR TITLE
[expo] Added missing 'installationId' and 'getWebViewUserAgentAsync()' to 'Constants'

### DIFF
--- a/types/expo/expo-tests.tsx
+++ b/types/expo/expo-tests.tsx
@@ -40,7 +40,8 @@ import {
     Location,
     Updates,
     MediaLibrary,
-    Haptic
+    Haptic,
+    Constants
 } from 'expo';
 
 const reverseGeocode: Promise<Location.GeocodeData[]> = Location.reverseGeocodeAsync({
@@ -873,4 +874,23 @@ Haptic.notification(Haptic.NotificationType.Success);
 Haptic.notification(Haptic.NotificationType.Error);
 
 Haptic.selection();
+// #endregion
+
+// #region Constants
+async () => {
+    const appOwnerShip = Constants.appOwnership;
+    const expoVersion = Constants.expoVersion;
+    const installationId = Constants.installationId;
+    const deviceId = Constants.deviceId;
+    const deviceName = Constants.deviceName;
+    const deviceYearClass = Constants.deviceYearClass;
+    const isDevice = Constants.isDevice;
+    const platform = Constants.platform;
+    const sessionId = Constants.sessionId;
+    const statusBarHeight = Constants.statusBarHeight;
+    const systemFonts = Constants.systemFonts;
+    const manifest = Constants.manifest;
+    const linkingUri = Constants.linkingUri;
+    const userAgent: string = await Constants.getWebViewUserAgentAsync();
+};
 // #endregion

--- a/types/expo/index.d.ts
+++ b/types/expo/index.d.ts
@@ -877,6 +877,7 @@ export class Camera extends Component<CameraProps> {
 export namespace Constants {
     const appOwnership: 'expo' | 'standalone' | 'guest';
     const expoVersion: string;
+    const installationId: string;
     const deviceId: string;
     const deviceName: string;
     const deviceYearClass: number;
@@ -991,6 +992,8 @@ export namespace Constants {
     }
     const manifest: Manifest;
     const linkingUri: string;
+
+    function getWebViewUserAgentAsync(): Promise<string>;
 }
 
 /**


### PR DESCRIPTION
While I made this PR because we need the `Constants.getWebViewUserAgentAsync()` in our project; I also noticed that the property `installationId` was missing. No test were defined so I also added them. See the [Expo documentation for Constants](https://docs.expo.io/versions/latest/sdk/constants) for more info.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.expo.io/versions/latest/sdk/constants
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
