### PR TITLE
helmet: proposed fix for missing callback type for reportUri/reportTo

### DIFF
--- a/types/helmet/helmet-tests.ts
+++ b/types/helmet/helmet-tests.ts
@@ -58,12 +58,18 @@ function contentSecurityPolicyTest() {
         disableAndroid: false
     };
 
+    function reportCb(req: express.Request, res: express.Response) { return '/some-uri'; }
+
     app.use(helmet.contentSecurityPolicy());
     app.use(helmet.contentSecurityPolicy({}));
     app.use(helmet.contentSecurityPolicy(config));
     app.use(helmet.contentSecurityPolicy({
         directives: {
-            defaultSrc: ["'self'"]
+            defaultSrc: ["'self'"],
+            reportUri: reportCb,
+            'report-uri': reportCb,
+            reportTo: reportCb,
+            'report-to': reportCb
         },
         loose: false,
         setAllHeaders: true

--- a/types/helmet/helmet-tests.ts
+++ b/types/helmet/helmet-tests.ts
@@ -76,14 +76,6 @@ function contentSecurityPolicyTest() {
         loose: false,
         setAllHeaders: true
     }));
-    app.use(helmet.contentSecurityPolicy({
-        directives: {
-            reportUri: false,
-            'report-uri': false,
-            reportTo: false,
-            'report-to': false
-        }
-    }));
 }
 
 /**

--- a/types/helmet/helmet-tests.ts
+++ b/types/helmet/helmet-tests.ts
@@ -76,6 +76,14 @@ function contentSecurityPolicyTest() {
         loose: false,
         setAllHeaders: true
     }));
+    app.use(helmet.contentSecurityPolicy({
+        directives: {
+            reportUri: false,
+            'report-uri': false,
+            reportTo: false,
+            'report-to': false
+        }
+    }));
 }
 
 /**

--- a/types/helmet/helmet-tests.ts
+++ b/types/helmet/helmet-tests.ts
@@ -58,7 +58,8 @@ function contentSecurityPolicyTest() {
         disableAndroid: false
     };
 
-    function reportCb(req: express.Request, res: express.Response) { return '/some-uri'; }
+    function reportUriCb(req: express.Request, res: express.Response) { return '/some-uri'; }
+    function reportOnlyCb(req: express.Request, res: express.Response) { return false; }
 
     app.use(helmet.contentSecurityPolicy());
     app.use(helmet.contentSecurityPolicy({}));
@@ -66,11 +67,12 @@ function contentSecurityPolicyTest() {
     app.use(helmet.contentSecurityPolicy({
         directives: {
             defaultSrc: ["'self'"],
-            reportUri: reportCb,
-            'report-uri': reportCb,
-            reportTo: reportCb,
-            'report-to': reportCb
+            reportUri: reportUriCb,
+            'report-uri': reportUriCb,
+            reportTo: reportUriCb,
+            'report-to': reportUriCb
         },
+        reportOnly: reportOnlyCb,
         loose: false,
         setAllHeaders: true
     }));

--- a/types/helmet/index.d.ts
+++ b/types/helmet/index.d.ts
@@ -69,8 +69,8 @@ declare namespace helmet {
         objectSrc?: HelmetCspDirectiveValue[];
         pluginTypes?: HelmetCspDirectiveValue[];
         prefetchSrc?: HelmetCspDirectiveValue[];
-        reportTo?: HelmetCspDirectiveValue | false;
-        reportUri?: HelmetCspDirectiveValue | false;
+        reportTo?: HelmetCspDirectiveValue;
+        reportUri?: HelmetCspDirectiveValue;
         requireSriFor?: HelmetCspRequireSriForValue[];
         sandbox?: HelmetCspSandboxDirective[];
         scriptSrc?: HelmetCspDirectiveValue[];
@@ -95,8 +95,8 @@ declare namespace helmet {
         'object-src'?: HelmetCspDirectiveValue[];
         'plugin-types'?: HelmetCspDirectiveValue[];
         'prefetch-src'?: HelmetCspDirectiveValue[];
-        'report-to'?: HelmetCspDirectiveValue | false;
-        'report-uri'?: HelmetCspDirectiveValue | false;
+        'report-to'?: HelmetCspDirectiveValue;
+        'report-uri'?: HelmetCspDirectiveValue;
         'require-sri-for'?: HelmetCspRequireSriForValue[];
         'sandbox'?: HelmetCspSandboxDirective[];
         'script-src'?: HelmetCspDirectiveValue;
@@ -105,12 +105,8 @@ declare namespace helmet {
         'worker-src'?: HelmetCspDirectiveValue;
     }
 
-    export interface IHelmetContentSecurityReportOnlyFunction {
-        (req: express.Request, res: express.Response): boolean;
-    }
-
     export interface IHelmetContentSecurityPolicyConfiguration {
-        reportOnly?: boolean | IHelmetContentSecurityReportOnlyFunction;
+        reportOnly?: boolean | ((req: express.Request, res: express.Response) => boolean);
         setAllHeaders?: boolean;
         disableAndroid?: boolean;
         browserSniff?: boolean;

--- a/types/helmet/index.d.ts
+++ b/types/helmet/index.d.ts
@@ -105,8 +105,12 @@ declare namespace helmet {
         'worker-src'?: HelmetCspDirectiveValue;
     }
 
+    export interface IHelmetContentSecurityReportOnlyFunction {
+        (req: express.Request, res: express.Response): boolean;
+    }
+
     export interface IHelmetContentSecurityPolicyConfiguration {
-        reportOnly?: boolean;
+        reportOnly?: boolean | IHelmetContentSecurityReportOnlyFunction;
         setAllHeaders?: boolean;
         disableAndroid?: boolean;
         browserSniff?: boolean;

--- a/types/helmet/index.d.ts
+++ b/types/helmet/index.d.ts
@@ -69,8 +69,8 @@ declare namespace helmet {
         objectSrc?: HelmetCspDirectiveValue[];
         pluginTypes?: HelmetCspDirectiveValue[];
         prefetchSrc?: HelmetCspDirectiveValue[];
-        reportTo?: HelmetCspDirectiveValue;
-        reportUri?: HelmetCspDirectiveValue;
+        reportTo?: HelmetCspDirectiveValue | false;
+        reportUri?: HelmetCspDirectiveValue | false;
         requireSriFor?: HelmetCspRequireSriForValue[];
         sandbox?: HelmetCspSandboxDirective[];
         scriptSrc?: HelmetCspDirectiveValue[];
@@ -95,8 +95,8 @@ declare namespace helmet {
         'object-src'?: HelmetCspDirectiveValue[];
         'plugin-types'?: HelmetCspDirectiveValue[];
         'prefetch-src'?: HelmetCspDirectiveValue[];
-        'report-to'?: HelmetCspDirectiveValue;
-        'report-uri'?: HelmetCspDirectiveValue;
+        'report-to'?: HelmetCspDirectiveValue | false;
+        'report-uri'?: HelmetCspDirectiveValue | false;
         'require-sri-for'?: HelmetCspRequireSriForValue[];
         'sandbox'?: HelmetCspSandboxDirective[];
         'script-src'?: HelmetCspDirectiveValue;

--- a/types/helmet/index.d.ts
+++ b/types/helmet/index.d.ts
@@ -69,8 +69,8 @@ declare namespace helmet {
         objectSrc?: HelmetCspDirectiveValue[];
         pluginTypes?: HelmetCspDirectiveValue[];
         prefetchSrc?: HelmetCspDirectiveValue[];
-        reportTo?: string;
-        reportUri?: string;
+        reportTo?: HelmetCspDirectiveValue;
+        reportUri?: HelmetCspDirectiveValue;
         requireSriFor?: HelmetCspRequireSriForValue[];
         sandbox?: HelmetCspSandboxDirective[];
         scriptSrc?: HelmetCspDirectiveValue[];
@@ -95,8 +95,8 @@ declare namespace helmet {
         'object-src'?: HelmetCspDirectiveValue[];
         'plugin-types'?: HelmetCspDirectiveValue[];
         'prefetch-src'?: HelmetCspDirectiveValue[];
-        'report-to'?: string;
-        'report-uri'?: string;
+        'report-to'?: HelmetCspDirectiveValue;
+        'report-uri'?: HelmetCspDirectiveValue;
         'require-sri-for'?: HelmetCspRequireSriForValue[];
         'sandbox'?: HelmetCspSandboxDirective[];
         'script-src'?: HelmetCspDirectiveValue;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - `reportUri`and `reportTo`: Not mentioned in the docs, but can be seen in code here: https://github.com/helmetjs/csp/blob/master/lib/check-options/check-directive/report-uri.js
  - `reportOnly`: https://helmetjs.github.io/docs/csp/#csp-violations
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
