### PR TITLE
LineDashedMaterial support

### DIFF
--- a/types/three/three-core.d.ts
+++ b/types/three/three-core.d.ts
@@ -5236,12 +5236,10 @@ export class LOD extends Object3D {
 /**
  * An intermediate material type that casts more precisely the possible materials assignable to a [[Line]] object.
  *
- * [[LineDashedMaterial]] is omitted as it extends [[LineBasicMaterial]].
- *
  * // Todo:
  * // - can [[Line]] take in an array of materials ?
  */
-export type LineMaterialType = LineBasicMaterial | ShaderMaterial | MeshDepthMaterial;
+export type LineMaterialType = LineBasicMaterial | LineDashedMaterial | ShaderMaterial | MeshDepthMaterial;
 
 export class Line extends Object3D {
     constructor(


### PR DESCRIPTION
LineDashedMaterial was omitted from list of linematerialtypes (reasoning was that LineDashedMaterial  extends LineBasicMaterial which is not correct).

Please fill in this template.

- [Typings_Three_Core_LineMaterialType_Update] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/three/three-core.d.ts
- [ ] Increase the version number in the header if appropriate. 
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. 