### PR TITLE
[chroma-js] updates types to v1.4.0

### DIFF
--- a/types/chroma-js/chroma-js-tests.ts
+++ b/types/chroma-js/chroma-js-tests.ts
@@ -82,6 +82,9 @@ function test_color() {
     chroma('aquamarine').luminance(0.5, 'lab');
     chroma('aquamarine').luminance(0.5, 'hsl');
     chroma('orange').hex();
+    chroma('orange').hex('auto');
+    chroma('orange').hex('rgb');
+    chroma('orange').alpha(0.5).hex('rgba');
     chroma('#ffa500').name();
     chroma('#ffa505').name();
     chroma('teal').css();
@@ -107,6 +110,12 @@ function test_color() {
     chroma('teal').alpha(0.5).css();
     chroma('teal').css('hsl');
     chroma('orange').rgb();
+
+
+    chroma('#000000').num();
+    chroma('#0000ff').num();
+    chroma('#00ff00').num();
+    chroma('#ff0000').num();
 }
 
 function test_scale() {

--- a/types/chroma-js/chroma-js-tests.ts
+++ b/types/chroma-js/chroma-js-tests.ts
@@ -111,7 +111,6 @@ function test_color() {
     chroma('teal').css('hsl');
     chroma('orange').rgb();
 
-
     chroma('#000000').num();
     chroma('#0000ff').num();
     chroma('#00ff00').num();

--- a/types/chroma-js/index.d.ts
+++ b/types/chroma-js/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Chroma.js 1.3
+// Type definitions for Chroma.js 1.4
 // Project: https://github.com/gka/chroma.js
 // Definitions by: Sebastian Brückner <https://github.com/invliD>, Marcin Pacholec <https://github.com/mpacholec>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -260,9 +260,18 @@ declare namespace chroma {
         luminance(l: number, colorSpace?: keyof ColorSpaces): Color;
 
         /**
-         * Get color as hexadecimal string. E.g. '#ffa500'
+         * Get color as hexadecimal string.
+         *
+         * @param mode `auto` - string will include alpha channel only if it's less than 1.
+         *             `rgb`  - string will not include alpha channel.
+         *             `rgba` - string will include alpha channel.
+         *
+         * @example
+         * chroma('orange').hex() === '#ffa500'
+         * chroma('orange').alpha(0.5).hex() === '#ffa50080'
+         * chroma('orange').alpha(0.5).hex('rgb') === '#ffa500'
          */
-        hex(): string;
+        hex(mode?: 'auto' | 'rgb' | 'rgba'): string;
 
         /**
          * Returns the named color. Falls back to hexadecimal RGB string, if the color isn't present.
@@ -280,6 +289,17 @@ declare namespace chroma {
          * [temperature gradient]{@link ChromaStatic.temperature} above.
          */
         temperature(): number;
+        
+        /**
+         * Returns the numeric representation of the hexadecimal RGB color.
+         *
+         * @example
+         * chroma('#000000').num() === 0
+         * chroma('#0000ff').num() === 255
+         * chroma('#00ff00').num() === 65280
+         * chroma('#ff0000').num() === 16711680
+         */
+        num(): number;
     } & {
         [K in keyof ColorSpaces]: () => ColorSpaces[K];
     };

--- a/types/chroma-js/index.d.ts
+++ b/types/chroma-js/index.d.ts
@@ -289,7 +289,7 @@ declare namespace chroma {
          * [temperature gradient]{@link ChromaStatic.temperature} above.
          */
         temperature(): number;
-        
+
         /**
          * Returns the numeric representation of the hexadecimal RGB color.
          *


### PR DESCRIPTION
- optional `mode` param for `Color.hex()`
- `Color.num()` was officially documented, so exposed in @types as well

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/gka/chroma.js/blob/master/CHANGELOG.md
https://gka.github.io/chroma.js/#color-hex
https://gka.github.io/chroma.js/#color-num
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
