### PR TITLE
chore(node): apply lint

### DIFF
--- a/types/browser-sync/index.d.ts
+++ b/types/browser-sync/index.d.ts
@@ -368,7 +368,7 @@ declare namespace browserSync {
         ws?: boolean;
         reqHeaders?: (config: object) => Hash<object>;
         proxyRes?: ProxyResponseMiddleware | ProxyResponseMiddleware[];
-        proxyReq?: ((res: http.ServerRequest) => void)[] | ((res: http.ServerRequest) => void);
+        proxyReq?: ((res: http.IncomingMessage) => void)[] | ((res: http.IncomingMessage) => void);
         error?: (err: NodeJS.ErrnoException, req: http.IncomingMessage, res: http.ServerResponse) => void;
     }
 
@@ -457,7 +457,7 @@ declare namespace browserSync {
          */
         (config?: Options, callback?: (err: Error, bs: object) => any): BrowserSyncInstance;
         /**
-         * 
+         *
          */
         instances: Array<BrowserSyncInstance>;
         /**
@@ -547,7 +547,7 @@ declare namespace browserSync {
          *
          * @method use
          * @param {object} module The object to be `required`.
-         * @param {object} options The 
+         * @param {object} options The
          * @param {any} cb A callback function that will return any errors.
          */
         use(module: { "plugin:name"?: string, plugin: (opts: object, bs: BrowserSyncInstance) => any }, options?: object, cb?: any): void;

--- a/types/charset/index.d.ts
+++ b/types/charset/index.d.ts
@@ -4,7 +4,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />
-import { ClientResponse, IncomingHttpHeaders } from 'http';
+import { IncomingMessage, IncomingHttpHeaders } from 'http';
 
 /**
  * guess data charset from req.headers, xml, html content-type meta tag
@@ -27,7 +27,7 @@ import { ClientResponse, IncomingHttpHeaders } from 'http';
  * @return charset, lower case, e.g.: utf8, gbk, gb2312, .... If can\'t guess, return null
  */
 // tslint:disable-next-line strict-export-declare-modifiers
-declare function charset(obj: string | IncomingHttpHeaders | ClientResponse, data?: Buffer, peekSize?: number): string | null;
+declare function charset(obj: string | IncomingHttpHeaders | IncomingMessage, data?: Buffer, peekSize?: number): string | null;
 
 // tslint:disable-next-line strict-export-declare-modifiers
 export = charset;

--- a/types/finalhandler/finalhandler-tests.ts
+++ b/types/finalhandler/finalhandler-tests.ts
@@ -1,10 +1,10 @@
-import { ServerRequest, ServerResponse } from "http";
+import { IncomingMessage, ServerResponse } from "http";
 import finalHandler = require("finalhandler");
 
-let req: ServerRequest;
+let req: IncomingMessage;
 let res: ServerResponse;
 let options: {
-	onerror: (err: any, req: ServerRequest, res: ServerResponse) => void;
+	onerror: (err: any, req: IncomingMessage, res: ServerResponse) => void;
 	message: boolean|((err: any, status: number) => string);
 	stacktrace: boolean;
 };

--- a/types/finalhandler/index.d.ts
+++ b/types/finalhandler/index.d.ts
@@ -5,14 +5,14 @@
 
 /// <reference types="node" />
 
-import { ServerRequest, ServerResponse } from "http";
+import { IncomingMessage, ServerResponse } from "http";
 
-declare function finalHandler(req: ServerRequest, res: ServerResponse, options?: finalHandler.Options): (err: any) => void;
+declare function finalHandler(req: IncomingMessage, res: ServerResponse, options?: finalHandler.Options): (err: any) => void;
 
 declare namespace finalHandler {
 	export interface Options {
 		message?: boolean|((err: any, status: number) => string);
-		onerror?: (err: any, req: ServerRequest, res: ServerResponse) => void;
+		onerror?: (err: any, req: IncomingMessage, res: ServerResponse) => void;
 		stacktrace?: boolean;
 	}
 }

--- a/types/grunt/grunt-tests.ts
+++ b/types/grunt/grunt-tests.ts
@@ -13,7 +13,8 @@ interface MyOptions {
 }
 
 // exports should work same as module.exports
-exports = (grunt: IGrunt) => {
+// assigning exports is an error in node, hence the cast
+(<any>exports) = (grunt: IGrunt) => {
 
     // Project configuration.
     grunt.initConfig({

--- a/types/grunt/grunt-tests.ts
+++ b/types/grunt/grunt-tests.ts
@@ -14,7 +14,7 @@ interface MyOptions {
 
 // exports should work same as module.exports
 // assigning exports is an error in node, hence the cast
-(<any>exports) = (grunt: IGrunt) => {
+(<any>global).exports = (grunt: IGrunt) => {
 
     // Project configuration.
     grunt.initConfig({

--- a/types/grunt/grunt-tests.ts
+++ b/types/grunt/grunt-tests.ts
@@ -14,7 +14,7 @@ interface MyOptions {
 
 // exports should work same as module.exports
 // assigning exports is an error in node, hence the cast
-(<any>global).exports = (grunt: IGrunt) => {
+(global as any).exports = (grunt: IGrunt) => {
 
     // Project configuration.
     grunt.initConfig({

--- a/types/meteor/globals/tools.d.ts
+++ b/types/meteor/globals/tools.d.ts
@@ -98,5 +98,3 @@ declare interface PackageAPI {
     }): void;
     versionsFrom(meteorRelease: string | string[]): void;
 }
-
-declare var console: Console;

--- a/types/node-static/index.d.ts
+++ b/types/node-static/index.d.ts
@@ -37,18 +37,18 @@ export class Server {
 	serverInfo: string;
 	constructor(root: string, options?: Options);
 
-	serveDir: (pathname: string, req: http.ServerRequest, res: http.ServerResponse, finish: Finish) => void;
-	serveFile: (pathname: string, status: number, headers: Headers, req: http.ServerRequest, res: http.ServerResponse) => events.EventEmitter;
-	finish: (status: number, headers: Headers, req: http.ServerRequest, res: http.ServerResponse, promise: events.EventEmitter, callback: Callback) => void;
-	servePath: (pathname: string, status: number, headers: Headers, req: http.ServerRequest, res: http.ServerResponse, finish: Finish) => events.EventEmitter;
+	serveDir: (pathname: string, req: http.IncomingMessage, res: http.ServerResponse, finish: Finish) => void;
+	serveFile: (pathname: string, status: number, headers: Headers, req: http.IncomingMessage, res: http.ServerResponse) => events.EventEmitter;
+	finish: (status: number, headers: Headers, req: http.IncomingMessage, res: http.ServerResponse, promise: events.EventEmitter, callback: Callback) => void;
+	servePath: (pathname: string, status: number, headers: Headers, req: http.IncomingMessage, res: http.ServerResponse, finish: Finish) => events.EventEmitter;
 	resolve: (pathname: string) => string;
-	serve: (req: http.ServerRequest, res: http.ServerResponse, callback?: Callback) => events.EventEmitter;
-	gzipOk: (req: http.ServerRequest, contentType: string) => boolean;
-	respondGzip: (pathname: string, status: number, contentType: string, _headers: Headers, files: string[], stat: fs.Stats, req: http.ServerRequest, res: http.ServerResponse, finish: Finish) => void;
-	parseByteRange: (req: http.ServerRequest, stat: fs.Stats) => ByteRange;
+	serve: (req: http.IncomingMessage, res: http.ServerResponse, callback?: Callback) => events.EventEmitter;
+	gzipOk: (req: http.IncomingMessage, contentType: string) => boolean;
+	respondGzip: (pathname: string, status: number, contentType: string, _headers: Headers, files: string[], stat: fs.Stats, req: http.IncomingMessage, res: http.ServerResponse, finish: Finish) => void;
+	parseByteRange: (req: http.IncomingMessage, stat: fs.Stats) => ByteRange;
 	// tslint:disable-next-line max-line-length
-	respondNoGzip: (pathname: string, status: number, contentType: string, _headers: Headers, files: string[], stat: fs.Stats, req: http.ServerRequest, res: http.ServerResponse, finish: Finish) => void;
-	respond: (pathname: string, status: number, _headers: Headers, files: string[], stat: fs.Stats, req: http.ServerRequest, res: http.ServerResponse, finish: Finish) => void;
+	respondNoGzip: (pathname: string, status: number, contentType: string, _headers: Headers, files: string[], stat: fs.Stats, req: http.IncomingMessage, res: http.ServerResponse, finish: Finish) => void;
+	respond: (pathname: string, status: number, _headers: Headers, files: string[], stat: fs.Stats, req: http.IncomingMessage, res: http.ServerResponse, finish: Finish) => void;
 	stream: (pathname: string, files: string[], length: number, startByte: number, res: http.ServerResponse, callback: Callback) => void;
 }
 

--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -1302,7 +1302,7 @@ declare module "http" {
     function request(url: string | URL, options: RequestOptions, callback?: (res: IncomingMessage) => void): ClientRequest;
     function get(options: RequestOptions | string | URL, callback?: (res: IncomingMessage) => void): ClientRequest;
     function get(url: string | URL, options: RequestOptions, callback?: (res: IncomingMessage) => void): ClientRequest;
-    const globalAgent: Agent;
+    let globalAgent: Agent;
 }
 
 declare module "cluster" {
@@ -1934,7 +1934,7 @@ declare module "https" {
     function request(url: string | URL, options: RequestOptions, callback?: (res: http.IncomingMessage) => void): http.ClientRequest;
     function get(options: RequestOptions | string | URL, callback?: (res: http.IncomingMessage) => void): http.ClientRequest;
     function get(url: string | URL, options: RequestOptions, callback?: (res: http.IncomingMessage) => void): http.ClientRequest;
-    const globalAgent: Agent;
+    let globalAgent: Agent;
 }
 
 declare module "punycode" {

--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -1,7 +1,7 @@
-// Type definitions for Node.js 10.11.x
+// Type definitions for Node.js 10.11
 // Project: http://nodejs.org/
-// Definitions by: Microsoft TypeScript <http://typescriptlang.org>
-//                 DefinitelyTyped <https://github.com/DefinitelyTyped/DefinitelyTyped>
+// Definitions by: Microsoft TypeScript <https://github.com/Microsoft>
+//                 DefinitelyTyped <https://github.com/DefinitelyTyped>
 //                 Alberto Schiabel <https://github.com/jkomyno>
 //                 Alexander T. <https://github.com/a-tarasyuk>
 //                 Alvis HT Tang <https://github.com/alvis>
@@ -25,7 +25,7 @@
 //                 Nicolas Voigt <https://github.com/octo-sniffle>
 //                 Parambir Singh <https://github.com/parambirs>
 //                 Sebastian Silbermann <https://github.com/eps1lon>
-//                 Simon Schick <https://github.com/SimonSchick
+//                 Simon Schick <https://github.com/SimonSchick>
 //                 Thomas den Hollander <https://github.com/ThomasdenH>
 //                 Wilco Bakker <https://github.com/WilcoBakker>
 //                 wwwy3y3 <https://github.com/wwwy3y3>
@@ -174,7 +174,7 @@ interface SymbolConstructor {
     readonly iterator: symbol;
     readonly asyncIterator: symbol;
 }
-declare var Symbol: SymbolConstructor;
+// declare const Symbol: SymbolConstructor;
 interface SharedArrayBuffer {
     readonly byteLength: number;
     slice(begin?: number, end?: number): SharedArrayBuffer;
@@ -193,25 +193,25 @@ interface String {
  *                   GLOBAL                      *
  *                                               *
  ------------------------------------------------*/
-declare var process: NodeJS.Process;
-declare var global: NodeJS.Global;
-declare var console: Console;
+declare const process: NodeJS.Process;
+declare const global: NodeJS.Global;
+declare const console: Console;
 
-declare var __filename: string;
-declare var __dirname: string;
+declare const __filename: string;
+declare const __dirname: string;
 
 declare function setTimeout(callback: (...args: any[]) => void, ms: number, ...args: any[]): NodeJS.Timer;
 declare namespace setTimeout {
-    export function __promisify__(ms: number): Promise<void>;
-    export function __promisify__<T>(ms: number, value: T): Promise<T>;
+    function __promisify__(ms: number): Promise<void>;
+    function __promisify__<T>(ms: number, value: T): Promise<T>;
 }
 declare function clearTimeout(timeoutId: NodeJS.Timer): void;
 declare function setInterval(callback: (...args: any[]) => void, ms: number, ...args: any[]): NodeJS.Timer;
 declare function clearInterval(intervalId: NodeJS.Timer): void;
 declare function setImmediate(callback: (...args: any[]) => void, ...args: any[]): any;
 declare namespace setImmediate {
-    export function __promisify__(): Promise<void>;
-    export function __promisify__<T>(value: T): Promise<T>;
+    function __promisify__(): Promise<void>;
+    function __promisify__<T>(value: T): Promise<T>;
 }
 declare function clearImmediate(immediateId: any): void;
 
@@ -240,7 +240,7 @@ interface NodeExtensions {
     [ext: string]: (m: NodeModule, filename: string) => any;
 }
 
-declare var require: NodeRequire;
+declare const require: NodeRequire;
 
 interface NodeModule {
     exports: any;
@@ -253,11 +253,11 @@ interface NodeModule {
     paths: string[];
 }
 
-declare var module: NodeModule;
+declare const module: NodeModule;
 
 // Same as module.exports
-declare var exports: any;
-declare var SlowBuffer: {
+declare const exports: any;
+declare const SlowBuffer: {
     new(str: string, encoding?: string): Buffer;
     new(size: number): Buffer;
     new(size: Uint8Array): Buffer;
@@ -332,7 +332,7 @@ interface Buffer extends Uint8Array {
  * A Buffer is similar to an array of integers but corresponds to a raw memory allocation outside the V8 heap.  A Buffer cannot be resized.
  * Valid string encodings: 'ascii'|'utf8'|'utf16le'|'ucs2'(alias of 'utf16le')|'base64'|'binary'(deprecated)|'hex'
  */
-declare var Buffer: {
+declare const Buffer: {
     /**
      * Allocates a new buffer containing the given {str}.
      *
@@ -477,7 +477,7 @@ declare var Buffer: {
 *                                               *
 *-----------------------------------------------*/
 declare namespace NodeJS {
-    export interface InspectOptions {
+    interface InspectOptions {
         showHidden?: boolean;
         depth?: number | null;
         colors?: boolean;
@@ -488,12 +488,12 @@ declare namespace NodeJS {
         compact?: boolean;
     }
 
-    export interface ConsoleConstructor {
+    interface ConsoleConstructor {
         prototype: Console;
         new(stdout: WritableStream, stderr?: WritableStream): Console;
     }
 
-    export interface CallSite {
+    interface CallSite {
         /**
          * Value of "this"
          */
@@ -567,7 +567,7 @@ declare namespace NodeJS {
         isConstructor(): boolean;
     }
 
-    export interface ErrnoException extends Error {
+    interface ErrnoException extends Error {
         errno?: number;
         code?: string;
         path?: string;
@@ -575,7 +575,7 @@ declare namespace NodeJS {
         stack?: string;
     }
 
-    export class EventEmitter {
+    class EventEmitter {
         addListener(event: string | symbol, listener: (...args: any[]) => void): this;
         on(event: string | symbol, listener: (...args: any[]) => void): this;
         once(event: string | symbol, listener: (...args: any[]) => void): this;
@@ -594,7 +594,7 @@ declare namespace NodeJS {
         eventNames(): Array<string | symbol>;
     }
 
-    export interface ReadableStream extends EventEmitter {
+    interface ReadableStream extends EventEmitter {
         readable: boolean;
         read(size?: number): string | Buffer;
         setEncoding(encoding: string): this;
@@ -602,14 +602,14 @@ declare namespace NodeJS {
         resume(): this;
         isPaused(): boolean;
         pipe<T extends WritableStream>(destination: T, options?: { end?: boolean; }): T;
-        unpipe<T extends WritableStream>(destination?: T): this;
+        unpipe(destination?: WritableStream): this;
         unshift(chunk: string): void;
         unshift(chunk: Buffer): void;
         wrap(oldStream: ReadableStream): this;
         [Symbol.asyncIterator](): AsyncIterableIterator<string | Buffer>;
     }
 
-    export interface WritableStream extends EventEmitter {
+    interface WritableStream extends EventEmitter {
         writable: boolean;
         write(buffer: Buffer | string, cb?: Function): boolean;
         write(str: string, encoding?: string, cb?: Function): boolean;
@@ -619,11 +619,11 @@ declare namespace NodeJS {
         end(str: string, encoding?: string, cb?: Function): void;
     }
 
-    export interface ReadWriteStream extends ReadableStream, WritableStream { }
+    interface ReadWriteStream extends ReadableStream, WritableStream { }
 
-    export interface Events extends EventEmitter { }
+    interface Events extends EventEmitter { }
 
-    export interface Domain extends Events {
+    interface Domain extends Events {
         run(fn: Function): void;
         add(emitter: Events): void;
         remove(emitter: Events): void;
@@ -637,19 +637,19 @@ declare namespace NodeJS {
         removeAllListeners(event?: string): this;
     }
 
-    export interface MemoryUsage {
+    interface MemoryUsage {
         rss: number;
         heapTotal: number;
         heapUsed: number;
         external: number;
     }
 
-    export interface CpuUsage {
+    interface CpuUsage {
         user: number;
         system: number;
     }
 
-    export interface ProcessRelease {
+    interface ProcessRelease {
         name: string;
         sourceUrl?: string;
         headersUrl?: string;
@@ -657,7 +657,7 @@ declare namespace NodeJS {
         lts?: string;
     }
 
-    export interface ProcessVersions {
+    interface ProcessVersions {
         http_parser: string;
         node: string;
         v8: string;
@@ -696,15 +696,15 @@ declare namespace NodeJS {
     type NewListenerListener = (type: string | symbol, listener: (...args: any[]) => void) => void;
     type RemoveListenerListener = (type: string | symbol, listener: (...args: any[]) => void) => void;
 
-    export interface Socket extends ReadWriteStream {
+    interface Socket extends ReadWriteStream {
         isTTY?: true;
     }
 
-    export interface ProcessEnv {
+    interface ProcessEnv {
         [key: string]: string | undefined;
     }
 
-    export interface WriteStream extends Socket {
+    interface WriteStream extends Socket {
         readonly writableHighWaterMark: number;
         readonly writableLength: number;
         columns?: number;
@@ -717,7 +717,7 @@ declare namespace NodeJS {
         uncork(): void;
         destroy(error?: Error): void;
     }
-    export interface ReadStream extends Socket {
+    interface ReadStream extends Socket {
         readonly readableHighWaterMark: number;
         readonly readableLength: number;
         isRaw?: boolean;
@@ -728,7 +728,7 @@ declare namespace NodeJS {
         destroy(error?: Error): void;
     }
 
-    export interface Process extends EventEmitter {
+    interface Process extends EventEmitter {
         stdout: WriteStream;
         stderr: WriteStream;
         stdin: ReadStream;
@@ -913,7 +913,7 @@ declare namespace NodeJS {
         listeners(event: "removeListener"): RemoveListenerListener[];
     }
 
-    export interface Global {
+    interface Global {
         Array: typeof Array;
         ArrayBuffer: typeof ArrayBuffer;
         Boolean: typeof Boolean;
@@ -954,8 +954,8 @@ declare namespace NodeJS {
         WeakMap: WeakMapConstructor;
         WeakSet: WeakSetConstructor;
         clearImmediate: (immediateId: any) => void;
-        clearInterval: (intervalId: NodeJS.Timer) => void;
-        clearTimeout: (timeoutId: NodeJS.Timer) => void;
+        clearInterval: (intervalId: Timer) => void;
+        clearTimeout: (timeoutId: Timer) => void;
         console: typeof console;
         decodeURI: typeof decodeURI;
         decodeURIComponent: typeof decodeURIComponent;
@@ -971,15 +971,15 @@ declare namespace NodeJS {
         process: Process;
         root: Global;
         setImmediate: (callback: (...args: any[]) => void, ...args: any[]) => any;
-        setInterval: (callback: (...args: any[]) => void, ms: number, ...args: any[]) => NodeJS.Timer;
-        setTimeout: (callback: (...args: any[]) => void, ms: number, ...args: any[]) => NodeJS.Timer;
+        setInterval: (callback: (...args: any[]) => void, ms: number, ...args: any[]) => Timer;
+        setTimeout: (callback: (...args: any[]) => void, ms: number, ...args: any[]) => Timer;
         undefined: typeof undefined;
         unescape: (str: string) => string;
         gc: () => void;
         v8debug?: any;
     }
 
-    export interface Timer {
+    interface Timer {
         ref(): void;
         unref(): void;
     }
@@ -1014,36 +1014,36 @@ interface IterableIterator<T> { }
 *                                               *
 *-----------------------------------------------*/
 declare module "buffer" {
-    export var INSPECT_MAX_BYTES: number;
-    var BuffType: typeof Buffer;
-    var SlowBuffType: typeof SlowBuffer;
+    export const INSPECT_MAX_BYTES: number;
+    const BuffType: typeof Buffer;
+    const SlowBuffType: typeof SlowBuffer;
     export { BuffType as Buffer, SlowBuffType as SlowBuffer };
 }
 
 declare module "querystring" {
-    export interface StringifyOptions {
+     interface StringifyOptions {
         encodeURIComponent?: Function;
     }
 
-    export interface ParseOptions {
+     interface ParseOptions {
         maxKeys?: number;
         decodeURIComponent?: Function;
     }
 
     interface ParsedUrlQuery { [key: string]: string | string[] | undefined; }
 
-    export function stringify<T>(obj: T, sep?: string, eq?: string, options?: StringifyOptions): string;
-    export function parse(str: string, sep?: string, eq?: string, options?: ParseOptions): ParsedUrlQuery;
-    export function parse<T extends {}>(str: string, sep?: string, eq?: string, options?: ParseOptions): T;
-    export function escape(str: string): string;
-    export function unescape(str: string): string;
+    function stringify(obj: {}, sep?: string, eq?: string, options?: StringifyOptions): string;
+    function parse(str: string, sep?: string, eq?: string, options?: ParseOptions): ParsedUrlQuery;
+    function parse(str: string, sep?: string, eq?: string, options?: ParseOptions): {};
+    function escape(str: string): string;
+    function unescape(str: string): string;
 }
 
 declare module "events" {
     class internal extends NodeJS.EventEmitter { }
 
     namespace internal {
-        export class EventEmitter extends internal {
+         class EventEmitter extends internal {
             /** @deprecated since v4.0.0 */
             static listenerCount(emitter: EventEmitter, event: string | symbol): number;
             static defaultMaxListeners: number;
@@ -1076,7 +1076,7 @@ declare module "http" {
     import { URL } from "url";
 
     // incoming headers will never contain number
-    export interface IncomingHttpHeaders {
+     interface IncomingHttpHeaders {
         'accept'?: string;
         'access-control-allow-origin'?: string;
         'access-control-allow-credentials'?: string;
@@ -1124,11 +1124,11 @@ declare module "http" {
     }
 
     // outgoing headers allows numbers (as they are converted internally to strings)
-    export interface OutgoingHttpHeaders {
+     interface OutgoingHttpHeaders {
         [header: string]: number | string | string[] | undefined;
     }
 
-    export interface ClientRequestArgs {
+     interface ClientRequestArgs {
         protocol?: string;
         host?: string;
         hostname?: string;
@@ -1148,7 +1148,7 @@ declare module "http" {
         createConnection?: (options: ClientRequestArgs, oncreate: (err: Error, socket: net.Socket) => void) => net.Socket;
     }
 
-    export class Server extends net.Server {
+     class Server extends net.Server {
         constructor(requestListener?: (req: IncomingMessage, res: ServerResponse) => void);
 
         setTimeout(msecs?: number, callback?: () => void): this;
@@ -1160,12 +1160,12 @@ declare module "http" {
     /**
      * @deprecated Use IncomingMessage
      */
-    export class ServerRequest extends IncomingMessage {
+     class ServerRequest extends IncomingMessage {
         connection: net.Socket;
     }
 
     // https://github.com/nodejs/node/blob/master/lib/_http_outgoing.js
-    export class OutgoingMessage extends stream.Writable {
+     class OutgoingMessage extends stream.Writable {
         upgrading: boolean;
         chunkedEncoding: boolean;
         shouldKeepAlive: boolean;
@@ -1189,7 +1189,7 @@ declare module "http" {
     }
 
     // https://github.com/nodejs/node/blob/master/lib/_http_server.js#L108-L256
-    export class ServerResponse extends OutgoingMessage {
+     class ServerResponse extends OutgoingMessage {
         statusCode: number;
         statusMessage: string;
 
@@ -1205,7 +1205,7 @@ declare module "http" {
     }
 
     // https://github.com/nodejs/node/blob/master/lib/_http_client.js#L77
-    export class ClientRequest extends OutgoingMessage {
+     class ClientRequest extends OutgoingMessage {
         connection: net.Socket;
         socket: net.Socket;
         aborted: number;
@@ -1219,7 +1219,7 @@ declare module "http" {
         setSocketKeepAlive(enable?: boolean, initialDelay?: number): void;
     }
 
-    export class IncomingMessage extends stream.Readable {
+     class IncomingMessage extends stream.Readable {
         constructor(socket: net.Socket);
 
         httpVersion: string;
@@ -1254,9 +1254,9 @@ declare module "http" {
     /**
      * @deprecated Use IncomingMessage
      */
-    export class ClientResponse extends IncomingMessage { }
+     class ClientResponse extends IncomingMessage { }
 
-    export interface AgentOptions {
+     interface AgentOptions {
         /**
          * Keep sockets around in a pool to be used by other requests in the future. Default = false
          */
@@ -1280,7 +1280,7 @@ declare module "http" {
         timeout?: number;
     }
 
-    export class Agent {
+     class Agent {
         maxFreeSockets: number;
         maxSockets: number;
         sockets: any;
@@ -1297,24 +1297,24 @@ declare module "http" {
         destroy(): void;
     }
 
-    export var METHODS: string[];
+     const METHODS: string[];
 
-    export var STATUS_CODES: {
+     const STATUS_CODES: {
         [errorCode: number]: string | undefined;
         [errorCode: string]: string | undefined;
     };
 
-    export function createServer(requestListener?: (request: IncomingMessage, response: ServerResponse) => void): Server;
-    export function createClient(port?: number, host?: string): any;
+    function createServer(requestListener?: (request: IncomingMessage, response: ServerResponse) => void): Server;
+    function createClient(port?: number, host?: string): any;
 
     // although RequestOptions are passed as ClientRequestArgs to ClientRequest directly,
     // create interface RequestOptions would make the naming more clear to developers
-    export interface RequestOptions extends ClientRequestArgs { }
-    export function request(options: RequestOptions | string | URL, callback?: (res: IncomingMessage) => void): ClientRequest;
-    export function request(url: string | URL, options: RequestOptions, callback?: (res: IncomingMessage) => void): ClientRequest;
-    export function get(options: RequestOptions | string | URL, callback?: (res: IncomingMessage) => void): ClientRequest;
-    export function get(url: string | URL, options: RequestOptions, callback?: (res: IncomingMessage) => void): ClientRequest;
-    export var globalAgent: Agent;
+    interface RequestOptions extends ClientRequestArgs { }
+    function request(options: RequestOptions | string | URL, callback?: (res: IncomingMessage) => void): ClientRequest;
+    function request(url: string | URL, options: RequestOptions, callback?: (res: IncomingMessage) => void): ClientRequest;
+    function get(options: RequestOptions | string | URL, callback?: (res: IncomingMessage) => void): ClientRequest;
+    function get(url: string | URL, options: RequestOptions, callback?: (res: IncomingMessage) => void): ClientRequest;
+    const globalAgent: Agent;
 }
 
 declare module "cluster" {
@@ -1323,7 +1323,7 @@ declare module "cluster" {
     import * as net from "net";
 
     // interfaces
-    export interface ClusterSettings {
+    interface ClusterSettings {
         execArgv?: string[]; // default: process.execArgv
         exec?: string;
         args?: string[];
@@ -1334,13 +1334,13 @@ declare module "cluster" {
         inspectPort?: number | (() => number);
     }
 
-    export interface Address {
+    interface Address {
         address: string;
         port: number;
         addressType: number | "udp4" | "udp6";  // 4, 6, -1, "udp4", "udp6"
     }
 
-    export class Worker extends events.EventEmitter {
+    class Worker extends events.EventEmitter {
         id: number;
         process: child.ChildProcess;
         suicide: boolean;
@@ -1410,7 +1410,7 @@ declare module "cluster" {
         prependOnceListener(event: "online", listener: () => void): this;
     }
 
-    export interface Cluster extends events.EventEmitter {
+    interface Cluster extends events.EventEmitter {
         Worker: Worker;
         disconnect(callback?: Function): void;
         fork(env?: any): Worker;
@@ -1484,20 +1484,21 @@ declare module "cluster" {
         prependOnceListener(event: "exit", listener: (worker: Worker, code: number, signal: string) => void): this;
         prependOnceListener(event: "fork", listener: (worker: Worker) => void): this;
         prependOnceListener(event: "listening", listener: (worker: Worker, address: Address) => void): this;
-        prependOnceListener(event: "message", listener: (worker: Worker, message: any, handle: net.Socket | net.Server) => void): this;  // the handle is a net.Socket or net.Server object, or undefined.
+        // the handle is a net.Socket or net.Server object, or undefined.
+        prependOnceListener(event: "message", listener: (worker: Worker, message: any, handle: net.Socket | net.Server) => void): this;
         prependOnceListener(event: "online", listener: (worker: Worker) => void): this;
         prependOnceListener(event: "setup", listener: (settings: any) => void): this;
     }
 
-    export function disconnect(callback?: Function): void;
-    export function fork(env?: any): Worker;
-    export var isMaster: boolean;
-    export var isWorker: boolean;
+    function disconnect(callback?: Function): void;
+    function fork(env?: any): Worker;
+    const isMaster: boolean;
+    const isWorker: boolean;
     // TODO: cluster.schedulingPolicy
-    export var settings: ClusterSettings;
-    export function setupMaster(settings?: ClusterSettings): void;
-    export var worker: Worker;
-    export var workers: {
+    const settings: ClusterSettings;
+    function setupMaster(settings?: ClusterSettings): void;
+    const worker: Worker;
+    const workers: {
         [index: string]: Worker | undefined
     };
 
@@ -1511,74 +1512,77 @@ declare module "cluster" {
      *   6. online
      *   7. setup
      */
-    export function addListener(event: string, listener: (...args: any[]) => void): Cluster;
-    export function addListener(event: "disconnect", listener: (worker: Worker) => void): Cluster;
-    export function addListener(event: "exit", listener: (worker: Worker, code: number, signal: string) => void): Cluster;
-    export function addListener(event: "fork", listener: (worker: Worker) => void): Cluster;
-    export function addListener(event: "listening", listener: (worker: Worker, address: Address) => void): Cluster;
-    export function addListener(event: "message", listener: (worker: Worker, message: any, handle: net.Socket | net.Server) => void): Cluster;  // the handle is a net.Socket or net.Server object, or undefined.
-    export function addListener(event: "online", listener: (worker: Worker) => void): Cluster;
-    export function addListener(event: "setup", listener: (settings: any) => void): Cluster;
+     function addListener(event: string, listener: (...args: any[]) => void): Cluster;
+     function addListener(event: "disconnect", listener: (worker: Worker) => void): Cluster;
+     function addListener(event: "exit", listener: (worker: Worker, code: number, signal: string) => void): Cluster;
+     function addListener(event: "fork", listener: (worker: Worker) => void): Cluster;
+     function addListener(event: "listening", listener: (worker: Worker, address: Address) => void): Cluster;
+     // the handle is a net.Socket or net.Server object, or undefined.
+     function addListener(event: "message", listener: (worker: Worker, message: any, handle: net.Socket | net.Server) => void): Cluster;
+     function addListener(event: "online", listener: (worker: Worker) => void): Cluster;
+     function addListener(event: "setup", listener: (settings: any) => void): Cluster;
 
-    export function emit(event: string | symbol, ...args: any[]): boolean;
-    export function emit(event: "disconnect", worker: Worker): boolean;
-    export function emit(event: "exit", worker: Worker, code: number, signal: string): boolean;
-    export function emit(event: "fork", worker: Worker): boolean;
-    export function emit(event: "listening", worker: Worker, address: Address): boolean;
-    export function emit(event: "message", worker: Worker, message: any, handle: net.Socket | net.Server): boolean;
-    export function emit(event: "online", worker: Worker): boolean;
-    export function emit(event: "setup", settings: any): boolean;
+     function emit(event: string | symbol, ...args: any[]): boolean;
+     function emit(event: "disconnect", worker: Worker): boolean;
+     function emit(event: "exit", worker: Worker, code: number, signal: string): boolean;
+     function emit(event: "fork", worker: Worker): boolean;
+     function emit(event: "listening", worker: Worker, address: Address): boolean;
+     function emit(event: "message", worker: Worker, message: any, handle: net.Socket | net.Server): boolean;
+     function emit(event: "online", worker: Worker): boolean;
+     function emit(event: "setup", settings: any): boolean;
 
-    export function on(event: string, listener: (...args: any[]) => void): Cluster;
-    export function on(event: "disconnect", listener: (worker: Worker) => void): Cluster;
-    export function on(event: "exit", listener: (worker: Worker, code: number, signal: string) => void): Cluster;
-    export function on(event: "fork", listener: (worker: Worker) => void): Cluster;
-    export function on(event: "listening", listener: (worker: Worker, address: Address) => void): Cluster;
-    export function on(event: "message", listener: (worker: Worker, message: any, handle: net.Socket | net.Server) => void): Cluster;  // the handle is a net.Socket or net.Server object, or undefined.
-    export function on(event: "online", listener: (worker: Worker) => void): Cluster;
-    export function on(event: "setup", listener: (settings: any) => void): Cluster;
+     function on(event: string, listener: (...args: any[]) => void): Cluster;
+     function on(event: "disconnect", listener: (worker: Worker) => void): Cluster;
+     function on(event: "exit", listener: (worker: Worker, code: number, signal: string) => void): Cluster;
+     function on(event: "fork", listener: (worker: Worker) => void): Cluster;
+     function on(event: "listening", listener: (worker: Worker, address: Address) => void): Cluster;
+     function on(event: "message", listener: (worker: Worker, message: any, handle: net.Socket | net.Server) => void): Cluster;  // the handle is a net.Socket or net.Server object, or undefined.
+     function on(event: "online", listener: (worker: Worker) => void): Cluster;
+     function on(event: "setup", listener: (settings: any) => void): Cluster;
 
-    export function once(event: string, listener: (...args: any[]) => void): Cluster;
-    export function once(event: "disconnect", listener: (worker: Worker) => void): Cluster;
-    export function once(event: "exit", listener: (worker: Worker, code: number, signal: string) => void): Cluster;
-    export function once(event: "fork", listener: (worker: Worker) => void): Cluster;
-    export function once(event: "listening", listener: (worker: Worker, address: Address) => void): Cluster;
-    export function once(event: "message", listener: (worker: Worker, message: any, handle: net.Socket | net.Server) => void): Cluster;  // the handle is a net.Socket or net.Server object, or undefined.
-    export function once(event: "online", listener: (worker: Worker) => void): Cluster;
-    export function once(event: "setup", listener: (settings: any) => void): Cluster;
+     function once(event: string, listener: (...args: any[]) => void): Cluster;
+     function once(event: "disconnect", listener: (worker: Worker) => void): Cluster;
+     function once(event: "exit", listener: (worker: Worker, code: number, signal: string) => void): Cluster;
+     function once(event: "fork", listener: (worker: Worker) => void): Cluster;
+     function once(event: "listening", listener: (worker: Worker, address: Address) => void): Cluster;
+     function once(event: "message", listener: (worker: Worker, message: any, handle: net.Socket | net.Server) => void): Cluster;  // the handle is a net.Socket or net.Server object, or undefined.
+     function once(event: "online", listener: (worker: Worker) => void): Cluster;
+     function once(event: "setup", listener: (settings: any) => void): Cluster;
 
-    export function removeListener(event: string, listener: (...args: any[]) => void): Cluster;
-    export function removeAllListeners(event?: string): Cluster;
-    export function setMaxListeners(n: number): Cluster;
-    export function getMaxListeners(): number;
-    export function listeners(event: string): Function[];
-    export function listenerCount(type: string): number;
+     function removeListener(event: string, listener: (...args: any[]) => void): Cluster;
+     function removeAllListeners(event?: string): Cluster;
+     function setMaxListeners(n: number): Cluster;
+     function getMaxListeners(): number;
+     function listeners(event: string): Function[];
+     function listenerCount(type: string): number;
 
-    export function prependListener(event: string, listener: (...args: any[]) => void): Cluster;
-    export function prependListener(event: "disconnect", listener: (worker: Worker) => void): Cluster;
-    export function prependListener(event: "exit", listener: (worker: Worker, code: number, signal: string) => void): Cluster;
-    export function prependListener(event: "fork", listener: (worker: Worker) => void): Cluster;
-    export function prependListener(event: "listening", listener: (worker: Worker, address: Address) => void): Cluster;
-    export function prependListener(event: "message", listener: (worker: Worker, message: any, handle: net.Socket | net.Server) => void): Cluster;  // the handle is a net.Socket or net.Server object, or undefined.
-    export function prependListener(event: "online", listener: (worker: Worker) => void): Cluster;
-    export function prependListener(event: "setup", listener: (settings: any) => void): Cluster;
+     function prependListener(event: string, listener: (...args: any[]) => void): Cluster;
+     function prependListener(event: "disconnect", listener: (worker: Worker) => void): Cluster;
+     function prependListener(event: "exit", listener: (worker: Worker, code: number, signal: string) => void): Cluster;
+     function prependListener(event: "fork", listener: (worker: Worker) => void): Cluster;
+     function prependListener(event: "listening", listener: (worker: Worker, address: Address) => void): Cluster;
+     // the handle is a net.Socket or net.Server object, or undefined.
+     function prependListener(event: "message", listener: (worker: Worker, message: any, handle: net.Socket | net.Server) => void): Cluster;
+     function prependListener(event: "online", listener: (worker: Worker) => void): Cluster;
+     function prependListener(event: "setup", listener: (settings: any) => void): Cluster;
 
-    export function prependOnceListener(event: string, listener: (...args: any[]) => void): Cluster;
-    export function prependOnceListener(event: "disconnect", listener: (worker: Worker) => void): Cluster;
-    export function prependOnceListener(event: "exit", listener: (worker: Worker, code: number, signal: string) => void): Cluster;
-    export function prependOnceListener(event: "fork", listener: (worker: Worker) => void): Cluster;
-    export function prependOnceListener(event: "listening", listener: (worker: Worker, address: Address) => void): Cluster;
-    export function prependOnceListener(event: "message", listener: (worker: Worker, message: any, handle: net.Socket | net.Server) => void): Cluster;  // the handle is a net.Socket or net.Server object, or undefined.
-    export function prependOnceListener(event: "online", listener: (worker: Worker) => void): Cluster;
-    export function prependOnceListener(event: "setup", listener: (settings: any) => void): Cluster;
+     function prependOnceListener(event: string, listener: (...args: any[]) => void): Cluster;
+     function prependOnceListener(event: "disconnect", listener: (worker: Worker) => void): Cluster;
+     function prependOnceListener(event: "exit", listener: (worker: Worker, code: number, signal: string) => void): Cluster;
+     function prependOnceListener(event: "fork", listener: (worker: Worker) => void): Cluster;
+     function prependOnceListener(event: "listening", listener: (worker: Worker, address: Address) => void): Cluster;
+     // the handle is a net.Socket or net.Server object, or undefined.
+     function prependOnceListener(event: "message", listener: (worker: Worker, message: any, handle: net.Socket | net.Server) => void): Cluster;
+     function prependOnceListener(event: "online", listener: (worker: Worker) => void): Cluster;
+     function prependOnceListener(event: "setup", listener: (settings: any) => void): Cluster;
 
-    export function eventNames(): string[];
+     function eventNames(): string[];
 }
 
 declare module "zlib" {
     import * as stream from "stream";
 
-    export interface ZlibOptions {
+     interface ZlibOptions {
         flush?: number; // default: zlib.constants.Z_NO_FLUSH
         finishFlush?: number; // default: zlib.constants.Z_FINISH
         chunkSize?: number; // default: 16*1024
@@ -1589,133 +1593,133 @@ declare module "zlib" {
         dictionary?: Buffer | NodeJS.TypedArray | DataView | ArrayBuffer; // deflate/inflate only, empty dictionary by default
     }
 
-    export interface Zlib {
+     interface Zlib {
         readonly bytesRead: number;
         close(callback?: () => void): void;
         flush(kind?: number | (() => void), callback?: () => void): void;
     }
 
-    export interface ZlibParams {
+     interface ZlibParams {
         params(level: number, strategy: number, callback: () => void): void;
     }
 
-    export interface ZlibReset {
+     interface ZlibReset {
         reset(): void;
     }
 
-    export interface Gzip extends stream.Transform, Zlib { }
-    export interface Gunzip extends stream.Transform, Zlib { }
-    export interface Deflate extends stream.Transform, Zlib, ZlibReset, ZlibParams { }
-    export interface Inflate extends stream.Transform, Zlib, ZlibReset { }
-    export interface DeflateRaw extends stream.Transform, Zlib, ZlibReset, ZlibParams { }
-    export interface InflateRaw extends stream.Transform, Zlib, ZlibReset { }
-    export interface Unzip extends stream.Transform, Zlib { }
+     interface Gzip extends stream.Transform, Zlib { }
+     interface Gunzip extends stream.Transform, Zlib { }
+     interface Deflate extends stream.Transform, Zlib, ZlibReset, ZlibParams { }
+     interface Inflate extends stream.Transform, Zlib, ZlibReset { }
+     interface DeflateRaw extends stream.Transform, Zlib, ZlibReset, ZlibParams { }
+     interface InflateRaw extends stream.Transform, Zlib, ZlibReset { }
+     interface Unzip extends stream.Transform, Zlib { }
 
-    export function createGzip(options?: ZlibOptions): Gzip;
-    export function createGunzip(options?: ZlibOptions): Gunzip;
-    export function createDeflate(options?: ZlibOptions): Deflate;
-    export function createInflate(options?: ZlibOptions): Inflate;
-    export function createDeflateRaw(options?: ZlibOptions): DeflateRaw;
-    export function createInflateRaw(options?: ZlibOptions): InflateRaw;
-    export function createUnzip(options?: ZlibOptions): Unzip;
+     function createGzip(options?: ZlibOptions): Gzip;
+     function createGunzip(options?: ZlibOptions): Gunzip;
+     function createDeflate(options?: ZlibOptions): Deflate;
+     function createInflate(options?: ZlibOptions): Inflate;
+     function createDeflateRaw(options?: ZlibOptions): DeflateRaw;
+     function createInflateRaw(options?: ZlibOptions): InflateRaw;
+     function createUnzip(options?: ZlibOptions): Unzip;
 
     type InputType = string | Buffer | DataView | ArrayBuffer | NodeJS.TypedArray;
-    export function deflate(buf: InputType, callback: (error: Error | null, result: Buffer) => void): void;
-    export function deflate(buf: InputType, options: ZlibOptions, callback: (error: Error | null, result: Buffer) => void): void;
-    export function deflateSync(buf: InputType, options?: ZlibOptions): Buffer;
-    export function deflateRaw(buf: InputType, callback: (error: Error | null, result: Buffer) => void): void;
-    export function deflateRaw(buf: InputType, options: ZlibOptions, callback: (error: Error | null, result: Buffer) => void): void;
-    export function deflateRawSync(buf: InputType, options?: ZlibOptions): Buffer;
-    export function gzip(buf: InputType, callback: (error: Error | null, result: Buffer) => void): void;
-    export function gzip(buf: InputType, options: ZlibOptions, callback: (error: Error | null, result: Buffer) => void): void;
-    export function gzipSync(buf: InputType, options?: ZlibOptions): Buffer;
-    export function gunzip(buf: InputType, callback: (error: Error | null, result: Buffer) => void): void;
-    export function gunzip(buf: InputType, options: ZlibOptions, callback: (error: Error | null, result: Buffer) => void): void;
-    export function gunzipSync(buf: InputType, options?: ZlibOptions): Buffer;
-    export function inflate(buf: InputType, callback: (error: Error | null, result: Buffer) => void): void;
-    export function inflate(buf: InputType, options: ZlibOptions, callback: (error: Error | null, result: Buffer) => void): void;
-    export function inflateSync(buf: InputType, options?: ZlibOptions): Buffer;
-    export function inflateRaw(buf: InputType, callback: (error: Error | null, result: Buffer) => void): void;
-    export function inflateRaw(buf: InputType, options: ZlibOptions, callback: (error: Error | null, result: Buffer) => void): void;
-    export function inflateRawSync(buf: InputType, options?: ZlibOptions): Buffer;
-    export function unzip(buf: InputType, callback: (error: Error | null, result: Buffer) => void): void;
-    export function unzip(buf: InputType, options: ZlibOptions, callback: (error: Error | null, result: Buffer) => void): void;
-    export function unzipSync(buf: InputType, options?: ZlibOptions): Buffer;
+     function deflate(buf: InputType, callback: (error: Error | null, result: Buffer) => void): void;
+     function deflate(buf: InputType, options: ZlibOptions, callback: (error: Error | null, result: Buffer) => void): void;
+     function deflateSync(buf: InputType, options?: ZlibOptions): Buffer;
+    function deflateRaw(buf: InputType, callback: (error: Error | null, result: Buffer) => void): void;
+    function deflateRaw(buf: InputType, options: ZlibOptions, callback: (error: Error | null, result: Buffer) => void): void;
+    function deflateRawSync(buf: InputType, options?: ZlibOptions): Buffer;
+    function gzip(buf: InputType, callback: (error: Error | null, result: Buffer) => void): void;
+    function gzip(buf: InputType, options: ZlibOptions, callback: (error: Error | null, result: Buffer) => void): void;
+    function gzipSync(buf: InputType, options?: ZlibOptions): Buffer;
+    function gunzip(buf: InputType, callback: (error: Error | null, result: Buffer) => void): void;
+    function gunzip(buf: InputType, options: ZlibOptions, callback: (error: Error | null, result: Buffer) => void): void;
+    function gunzipSync(buf: InputType, options?: ZlibOptions): Buffer;
+    function inflate(buf: InputType, callback: (error: Error | null, result: Buffer) => void): void;
+    function inflate(buf: InputType, options: ZlibOptions, callback: (error: Error | null, result: Buffer) => void): void;
+    function inflateSync(buf: InputType, options?: ZlibOptions): Buffer;
+    function inflateRaw(buf: InputType, callback: (error: Error | null, result: Buffer) => void): void;
+    function inflateRaw(buf: InputType, options: ZlibOptions, callback: (error: Error | null, result: Buffer) => void): void;
+    function inflateRawSync(buf: InputType, options?: ZlibOptions): Buffer;
+    function unzip(buf: InputType, callback: (error: Error | null, result: Buffer) => void): void;
+    function unzip(buf: InputType, options: ZlibOptions, callback: (error: Error | null, result: Buffer) => void): void;
+    function unzipSync(buf: InputType, options?: ZlibOptions): Buffer;
 
-    export namespace constants {
+    namespace constants {
         // Allowed flush values.
 
-        export const Z_NO_FLUSH: number;
-        export const Z_PARTIAL_FLUSH: number;
-        export const Z_SYNC_FLUSH: number;
-        export const Z_FULL_FLUSH: number;
-        export const Z_FINISH: number;
-        export const Z_BLOCK: number;
-        export const Z_TREES: number;
+        const Z_NO_FLUSH: number;
+        const Z_PARTIAL_FLUSH: number;
+        const Z_SYNC_FLUSH: number;
+        const Z_FULL_FLUSH: number;
+        const Z_FINISH: number;
+        const Z_BLOCK: number;
+        const Z_TREES: number;
 
         // Return codes for the compression/decompression functions. Negative values are errors, positive values are used for special but normal events.
 
-        export const Z_OK: number;
-        export const Z_STREAM_END: number;
-        export const Z_NEED_DICT: number;
-        export const Z_ERRNO: number;
-        export const Z_STREAM_ERROR: number;
-        export const Z_DATA_ERROR: number;
-        export const Z_MEM_ERROR: number;
-        export const Z_BUF_ERROR: number;
-        export const Z_VERSION_ERROR: number;
+        const Z_OK: number;
+        const Z_STREAM_END: number;
+        const Z_NEED_DICT: number;
+        const Z_ERRNO: number;
+        const Z_STREAM_ERROR: number;
+        const Z_DATA_ERROR: number;
+        const Z_MEM_ERROR: number;
+        const Z_BUF_ERROR: number;
+        const Z_VERSION_ERROR: number;
 
         // Compression levels.
 
-        export const Z_NO_COMPRESSION: number;
-        export const Z_BEST_SPEED: number;
-        export const Z_BEST_COMPRESSION: number;
-        export const Z_DEFAULT_COMPRESSION: number;
+        const Z_NO_COMPRESSION: number;
+        const Z_BEST_SPEED: number;
+        const Z_BEST_COMPRESSION: number;
+        const Z_DEFAULT_COMPRESSION: number;
 
         // Compression strategy.
 
-        export const Z_FILTERED: number;
-        export const Z_HUFFMAN_ONLY: number;
-        export const Z_RLE: number;
-        export const Z_FIXED: number;
-        export const Z_DEFAULT_STRATEGY: number;
+        const Z_FILTERED: number;
+        const Z_HUFFMAN_ONLY: number;
+        const Z_RLE: number;
+        const Z_FIXED: number;
+        const Z_DEFAULT_STRATEGY: number;
     }
 
     // Constants
-    export var Z_NO_FLUSH: number;
-    export var Z_PARTIAL_FLUSH: number;
-    export var Z_SYNC_FLUSH: number;
-    export var Z_FULL_FLUSH: number;
-    export var Z_FINISH: number;
-    export var Z_BLOCK: number;
-    export var Z_TREES: number;
-    export var Z_OK: number;
-    export var Z_STREAM_END: number;
-    export var Z_NEED_DICT: number;
-    export var Z_ERRNO: number;
-    export var Z_STREAM_ERROR: number;
-    export var Z_DATA_ERROR: number;
-    export var Z_MEM_ERROR: number;
-    export var Z_BUF_ERROR: number;
-    export var Z_VERSION_ERROR: number;
-    export var Z_NO_COMPRESSION: number;
-    export var Z_BEST_SPEED: number;
-    export var Z_BEST_COMPRESSION: number;
-    export var Z_DEFAULT_COMPRESSION: number;
-    export var Z_FILTERED: number;
-    export var Z_HUFFMAN_ONLY: number;
-    export var Z_RLE: number;
-    export var Z_FIXED: number;
-    export var Z_DEFAULT_STRATEGY: number;
-    export var Z_BINARY: number;
-    export var Z_TEXT: number;
-    export var Z_ASCII: number;
-    export var Z_UNKNOWN: number;
-    export var Z_DEFLATED: number;
+    const Z_NO_FLUSH: number;
+    const Z_PARTIAL_FLUSH: number;
+    const Z_SYNC_FLUSH: number;
+    const Z_FULL_FLUSH: number;
+    const Z_FINISH: number;
+    const Z_BLOCK: number;
+    const Z_TREES: number;
+    const Z_OK: number;
+    const Z_STREAM_END: number;
+    const Z_NEED_DICT: number;
+    const Z_ERRNO: number;
+    const Z_STREAM_ERROR: number;
+    const Z_DATA_ERROR: number;
+    const Z_MEM_ERROR: number;
+    const Z_BUF_ERROR: number;
+    const Z_VERSION_ERROR: number;
+    const Z_NO_COMPRESSION: number;
+    const Z_BEST_SPEED: number;
+    const Z_BEST_COMPRESSION: number;
+    const Z_DEFAULT_COMPRESSION: number;
+    const Z_FILTERED: number;
+    const Z_HUFFMAN_ONLY: number;
+    const Z_RLE: number;
+    const Z_FIXED: number;
+    const Z_DEFAULT_STRATEGY: number;
+    const Z_BINARY: number;
+    const Z_TEXT: number;
+    const Z_ASCII: number;
+    const Z_UNKNOWN: number;
+    const Z_DEFLATED: number;
 }
 
 declare module "os" {
-    export interface CpuInfo {
+    interface CpuInfo {
         model: string;
         speed: number;
         times: {
@@ -1727,7 +1731,7 @@ declare module "os" {
         };
     }
 
-    export interface NetworkInterfaceBase {
+    interface NetworkInterfaceBase {
         address: string;
         netmask: string;
         mac: string;
@@ -1735,29 +1739,29 @@ declare module "os" {
         cidr: string | null;
     }
 
-    export interface NetworkInterfaceInfoIPv4 extends NetworkInterfaceBase {
+    interface NetworkInterfaceInfoIPv4 extends NetworkInterfaceBase {
         family: "IPv4";
     }
 
-    export interface NetworkInterfaceInfoIPv6 extends NetworkInterfaceBase {
+    interface NetworkInterfaceInfoIPv6 extends NetworkInterfaceBase {
         family: "IPv6";
         scopeid: number;
     }
 
-    export type NetworkInterfaceInfo = NetworkInterfaceInfoIPv4 | NetworkInterfaceInfoIPv6;
+    type NetworkInterfaceInfo = NetworkInterfaceInfoIPv4 | NetworkInterfaceInfoIPv6;
 
-    export function hostname(): string;
-    export function loadavg(): number[];
-    export function uptime(): number;
-    export function freemem(): number;
-    export function totalmem(): number;
-    export function cpus(): CpuInfo[];
-    export function type(): string;
-    export function release(): string;
-    export function networkInterfaces(): { [index: string]: NetworkInterfaceInfo[] };
-    export function homedir(): string;
-    export function userInfo(options?: { encoding: string }): { username: string, uid: number, gid: number, shell: any, homedir: string };
-    export const constants: {
+    function hostname(): string;
+    function loadavg(): number[];
+    function uptime(): number;
+    function freemem(): number;
+    function totalmem(): number;
+    function cpus(): CpuInfo[];
+    function type(): string;
+    function release(): string;
+    function networkInterfaces(): { [index: string]: NetworkInterfaceInfo[] };
+    function homedir(): string;
+    function userInfo(options?: { encoding: string }): { username: string, uid: number, gid: number, shell: any, homedir: string };
+    const constants: {
         UV_UDP_REUSEADDR: number;
         signals: {
             SIGHUP: number;
@@ -1885,26 +1889,26 @@ declare module "os" {
             PRIORITY_HIGHEST: number;
         }
     };
-    export function arch(): string;
-    export function platform(): NodeJS.Platform;
-    export function tmpdir(): string;
-    export const EOL: string;
-    export function endianness(): "BE" | "LE";
+    function arch(): string;
+    function platform(): NodeJS.Platform;
+    function tmpdir(): string;
+    const EOL: string;
+    function endianness(): "BE" | "LE";
     /**
      * Gets the priority of a process.
      * Defaults to current process.
      */
-    export function getPriority(pid?: number): number;
+    function getPriority(pid?: number): number;
     /**
      * Sets the priority of the current process.
      * @param priority Must be in range of -20 to 19
      */
-    export function setPriority(priority: number): void;
+    function setPriority(priority: number): void;
     /**
      * Sets the priority of the process specified process.
      * @param priority Must be in range of -20 to 19
      */
-    export function setPriority(pid: number, priority: number): void;
+    function setPriority(pid: number, priority: number): void;
 }
 
 declare module "https" {
@@ -1913,56 +1917,56 @@ declare module "https" {
     import * as http from "http";
     import { URL } from "url";
 
-    export type ServerOptions = tls.SecureContextOptions & tls.TlsOptions;
+    type ServerOptions = tls.SecureContextOptions & tls.TlsOptions;
 
-    export type RequestOptions = http.RequestOptions & tls.SecureContextOptions & {
+    type RequestOptions = http.RequestOptions & tls.SecureContextOptions & {
         rejectUnauthorized?: boolean; // Defaults to true
         servername?: string; // SNI TLS Extension
     };
 
-    export interface AgentOptions extends http.AgentOptions, tls.ConnectionOptions {
+    interface AgentOptions extends http.AgentOptions, tls.ConnectionOptions {
         rejectUnauthorized?: boolean;
         maxCachedSessions?: number;
     }
 
-    export class Agent extends http.Agent {
+    class Agent extends http.Agent {
         constructor(options?: AgentOptions);
         options: AgentOptions;
     }
 
-    export class Server extends tls.Server {
+    class Server extends tls.Server {
         setTimeout(callback: () => void): this;
         setTimeout(msecs?: number, callback?: () => void): this;
         timeout: number;
         keepAliveTimeout: number;
     }
 
-    export function createServer(options: ServerOptions, requestListener?: (req: http.IncomingMessage, res: http.ServerResponse) => void): Server;
-    export function request(options: RequestOptions | string | URL, callback?: (res: http.IncomingMessage) => void): http.ClientRequest;
-    export function request(url: string | URL, options: RequestOptions, callback?: (res: http.IncomingMessage) => void): http.ClientRequest;
-    export function get(options: RequestOptions | string | URL, callback?: (res: http.IncomingMessage) => void): http.ClientRequest;
-    export function get(url: string | URL, options: RequestOptions, callback?: (res: http.IncomingMessage) => void): http.ClientRequest;
-    export var globalAgent: Agent;
+    function createServer(options: ServerOptions, requestListener?: (req: http.IncomingMessage, res: http.ServerResponse) => void): Server;
+    function request(options: RequestOptions | string | URL, callback?: (res: http.IncomingMessage) => void): http.ClientRequest;
+    function request(url: string | URL, options: RequestOptions, callback?: (res: http.IncomingMessage) => void): http.ClientRequest;
+    function get(options: RequestOptions | string | URL, callback?: (res: http.IncomingMessage) => void): http.ClientRequest;
+    function get(url: string | URL, options: RequestOptions, callback?: (res: http.IncomingMessage) => void): http.ClientRequest;
+    const globalAgent: Agent;
 }
 
 declare module "punycode" {
-    export function decode(string: string): string;
-    export function encode(string: string): string;
-    export function toUnicode(domain: string): string;
-    export function toASCII(domain: string): string;
-    export var ucs2: ucs2;
+    function decode(string: string): string;
+    function encode(string: string): string;
+    function toUnicode(domain: string): string;
+    function toASCII(domain: string): string;
+    const ucs2: ucs2;
     interface ucs2 {
         decode(string: string): number[];
         encode(codePoints: number[]): string;
     }
-    export var version: any;
+    const version: any;
 }
 
 declare module "repl" {
     import * as stream from "stream";
     import * as readline from "readline";
 
-    export interface ReplOptions {
+    interface ReplOptions {
         prompt?: string;
         input?: NodeJS.ReadableStream;
         output?: NodeJS.WritableStream;
@@ -1977,7 +1981,7 @@ declare module "repl" {
         breakEvalOnSigint?: any;
     }
 
-    export interface REPLServer extends readline.ReadLine {
+    interface REPLServer extends readline.ReadLine {
         context: any;
         inputStream: NodeJS.ReadableStream;
         outputStream: NodeJS.WritableStream;
@@ -2016,9 +2020,9 @@ declare module "repl" {
         prependOnceListener(event: "reset", listener: (...args: any[]) => void): this;
     }
 
-    export function start(options?: string | ReplOptions): REPLServer;
+    function start(options?: string | ReplOptions): REPLServer;
 
-    export class Recoverable extends SyntaxError {
+    class Recoverable extends SyntaxError {
         err: Error;
 
         constructor(err: Error);
@@ -2029,7 +2033,7 @@ declare module "readline" {
     import * as events from "events";
     import * as stream from "stream";
 
-    export interface Key {
+    interface Key {
         sequence?: string;
         name?: string;
         ctrl?: boolean;
@@ -2037,7 +2041,7 @@ declare module "readline" {
         shift?: boolean;
     }
 
-    export interface ReadLine extends events.EventEmitter {
+    interface ReadLine extends events.EventEmitter {
         setPrompt(prompt: string): void;
         prompt(preserveCursor?: boolean): void;
         question(query: string, callback: (answer: string) => void): void;
@@ -2115,9 +2119,9 @@ declare module "readline" {
     type Completer = (line: string) => CompleterResult;
     type AsyncCompleter = (line: string, callback: (err: any, result: CompleterResult) => void) => any;
 
-    export type CompleterResult = [string[], string];
+    type CompleterResult = [string[], string];
 
-    export interface ReadLineOptions {
+    interface ReadLineOptions {
         input: NodeJS.ReadableStream;
         output?: NodeJS.WritableStream;
         completer?: Completer | AsyncCompleter;
@@ -2128,19 +2132,19 @@ declare module "readline" {
         removeHistoryDuplicates?: boolean;
     }
 
-    export function createInterface(input: NodeJS.ReadableStream, output?: NodeJS.WritableStream, completer?: Completer | AsyncCompleter, terminal?: boolean): ReadLine;
-    export function createInterface(options: ReadLineOptions): ReadLine;
+    function createInterface(input: NodeJS.ReadableStream, output?: NodeJS.WritableStream, completer?: Completer | AsyncCompleter, terminal?: boolean): ReadLine;
+    function createInterface(options: ReadLineOptions): ReadLine;
 
-    export function cursorTo(stream: NodeJS.WritableStream, x: number, y?: number): void;
-    export function emitKeypressEvents(stream: NodeJS.ReadableStream, interface?: ReadLine): void;
-    export function moveCursor(stream: NodeJS.WritableStream, dx: number | string, dy: number | string): void;
-    export function clearLine(stream: NodeJS.WritableStream, dir: number): void;
-    export function clearScreenDown(stream: NodeJS.WritableStream): void;
+    function cursorTo(stream: NodeJS.WritableStream, x: number, y?: number): void;
+    function emitKeypressEvents(stream: NodeJS.ReadableStream, interface?: ReadLine): void;
+    function moveCursor(stream: NodeJS.WritableStream, dx: number | string, dy: number | string): void;
+    function clearLine(stream: NodeJS.WritableStream, dir: number): void;
+    function clearScreenDown(stream: NodeJS.WritableStream): void;
 }
 
 declare module "vm" {
-    export interface Context { }
-    export interface BaseOptions {
+    interface Context { }
+    interface BaseOptions {
         /**
          * Specifies the filename used in stack traces produced by this script.
          * Default: `''`.
@@ -2157,17 +2161,17 @@ declare module "vm" {
          */
         columnOffset?: number;
     }
-    export interface ScriptOptions extends BaseOptions {
+    interface ScriptOptions extends BaseOptions {
         displayErrors?: boolean;
         timeout?: number;
         cachedData?: Buffer;
         produceCachedData?: boolean;
     }
-    export interface RunningScriptOptions extends BaseOptions {
+    interface RunningScriptOptions extends BaseOptions {
         displayErrors?: boolean;
         timeout?: number;
     }
-    export interface CompileFunctionOptions extends BaseOptions {
+    interface CompileFunctionOptions extends BaseOptions {
         /**
          * Provides an optional data with V8's code cache data for the supplied source.
          */
@@ -2187,20 +2191,20 @@ declare module "vm" {
          */
         contextExtensions?: Object[];
     }
-    export class Script {
+    class Script {
         constructor(code: string, options?: ScriptOptions);
         runInContext(contextifiedSandbox: Context, options?: RunningScriptOptions): any;
         runInNewContext(sandbox?: Context, options?: RunningScriptOptions): any;
         runInThisContext(options?: RunningScriptOptions): any;
     }
-    export function createContext(sandbox?: Context): Context;
-    export function isContext(sandbox: Context): boolean;
-    export function runInContext(code: string, contextifiedSandbox: Context, options?: RunningScriptOptions | string): any;
+    function createContext(sandbox?: Context): Context;
+    function isContext(sandbox: Context): boolean;
+    function runInContext(code: string, contextifiedSandbox: Context, options?: RunningScriptOptions | string): any;
     /** @deprecated */
-    export function runInDebugContext(code: string): any;
-    export function runInNewContext(code: string, sandbox?: Context, options?: RunningScriptOptions | string): any;
-    export function runInThisContext(code: string, options?: RunningScriptOptions | string): any;
-    export function compileFunction(code: string, params: string[], options: CompileFunctionOptions): Function;
+    function runInDebugContext(code: string): any;
+    function runInNewContext(code: string, sandbox?: Context, options?: RunningScriptOptions | string): any;
+    function runInThisContext(code: string, options?: RunningScriptOptions | string): any;
+    function compileFunction(code: string, params: string[], options: CompileFunctionOptions): Function;
 }
 
 declare module "child_process" {
@@ -2208,7 +2212,7 @@ declare module "child_process" {
     import * as stream from "stream";
     import * as net from "net";
 
-    export interface ChildProcess extends events.EventEmitter {
+    interface ChildProcess extends events.EventEmitter {
         stdin: stream.Writable;
         stdout: stream.Readable;
         stderr: stream.Readable;
@@ -2276,13 +2280,13 @@ declare module "child_process" {
         prependOnceListener(event: "message", listener: (message: any, sendHandle: net.Socket | net.Server) => void): this;
     }
 
-    export interface MessageOptions {
+    interface MessageOptions {
         keepOpen?: boolean;
     }
 
-    export type StdioOptions = "pipe" | "ignore" | "inherit" | Array<("pipe" | "ipc" | "ignore" | "inherit" | stream.Stream | number | null | undefined)>;
+    type StdioOptions = "pipe" | "ignore" | "inherit" | Array<("pipe" | "ipc" | "ignore" | "inherit" | stream.Stream | number | null | undefined)>;
 
-    export interface SpawnOptions {
+    interface SpawnOptions {
         cwd?: string;
         env?: NodeJS.ProcessEnv;
         argv0?: string;
@@ -2295,9 +2299,9 @@ declare module "child_process" {
         windowsHide?: boolean;
     }
 
-    export function spawn(command: string, args?: ReadonlyArray<string>, options?: SpawnOptions): ChildProcess;
+    function spawn(command: string, args?: ReadonlyArray<string>, options?: SpawnOptions): ChildProcess;
 
-    export interface ExecOptions {
+    interface ExecOptions {
         cwd?: string;
         env?: NodeJS.ProcessEnv;
         shell?: string;
@@ -2309,15 +2313,15 @@ declare module "child_process" {
         windowsHide?: boolean;
     }
 
-    export interface ExecOptionsWithStringEncoding extends ExecOptions {
+    interface ExecOptionsWithStringEncoding extends ExecOptions {
         encoding: BufferEncoding;
     }
 
-    export interface ExecOptionsWithBufferEncoding extends ExecOptions {
+    interface ExecOptionsWithBufferEncoding extends ExecOptions {
         encoding: string | null; // specify `null`.
     }
 
-    export interface ExecException extends Error {
+    interface ExecException extends Error {
         cmd?: string;
         killed?: boolean;
         code?: number;
@@ -2325,34 +2329,38 @@ declare module "child_process" {
     }
 
     // no `options` definitely means stdout/stderr are `string`.
-    export function exec(command: string, callback?: (error: ExecException | null, stdout: string, stderr: string) => void): ChildProcess;
+    function exec(command: string, callback?: (error: ExecException | null, stdout: string, stderr: string) => void): ChildProcess;
 
     // `options` with `"buffer"` or `null` for `encoding` means stdout/stderr are definitely `Buffer`.
-    export function exec(command: string, options: { encoding: "buffer" | null } & ExecOptions, callback?: (error: ExecException | null, stdout: Buffer, stderr: Buffer) => void): ChildProcess;
+    function exec(command: string, options: { encoding: "buffer" | null } & ExecOptions, callback?: (error: ExecException | null, stdout: Buffer, stderr: Buffer) => void): ChildProcess;
 
     // `options` with well known `encoding` means stdout/stderr are definitely `string`.
-    export function exec(command: string, options: { encoding: BufferEncoding } & ExecOptions, callback?: (error: ExecException | null, stdout: string, stderr: string) => void): ChildProcess;
+    function exec(command: string, options: { encoding: BufferEncoding } & ExecOptions, callback?: (error: ExecException | null, stdout: string, stderr: string) => void): ChildProcess;
 
     // `options` with an `encoding` whose type is `string` means stdout/stderr could either be `Buffer` or `string`.
     // There is no guarantee the `encoding` is unknown as `string` is a superset of `BufferEncoding`.
-    export function exec(command: string, options: { encoding: string } & ExecOptions, callback?: (error: ExecException | null, stdout: string | Buffer, stderr: string | Buffer) => void): ChildProcess;
+    function exec(command: string, options: { encoding: string } & ExecOptions, callback?: (error: ExecException | null, stdout: string | Buffer, stderr: string | Buffer) => void): ChildProcess;
 
     // `options` without an `encoding` means stdout/stderr are definitely `string`.
-    export function exec(command: string, options: ExecOptions, callback?: (error: ExecException | null, stdout: string, stderr: string) => void): ChildProcess;
+    function exec(command: string, options: ExecOptions, callback?: (error: ExecException | null, stdout: string, stderr: string) => void): ChildProcess;
 
     // fallback if nothing else matches. Worst case is always `string | Buffer`.
-    export function exec(command: string, options: ({ encoding?: string | null } & ExecOptions) | undefined | null, callback?: (error: ExecException | null, stdout: string | Buffer, stderr: string | Buffer) => void): ChildProcess;
+    function exec(
+        command: string,
+        options: ({ encoding?: string | null } & ExecOptions) | undefined | null,
+        callback?: (error: ExecException | null, stdout: string | Buffer, stderr: string | Buffer) => void,
+    ): ChildProcess;
 
     // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
-    export namespace exec {
-        export function __promisify__(command: string): Promise<{ stdout: string, stderr: string }>;
-        export function __promisify__(command: string, options: { encoding: "buffer" | null } & ExecOptions): Promise<{ stdout: Buffer, stderr: Buffer }>;
-        export function __promisify__(command: string, options: { encoding: BufferEncoding } & ExecOptions): Promise<{ stdout: string, stderr: string }>;
-        export function __promisify__(command: string, options: ExecOptions): Promise<{ stdout: string, stderr: string }>;
-        export function __promisify__(command: string, options?: ({ encoding?: string | null } & ExecOptions) | null): Promise<{ stdout: string | Buffer, stderr: string | Buffer }>;
+    namespace exec {
+        function __promisify__(command: string): Promise<{ stdout: string, stderr: string }>;
+        function __promisify__(command: string, options: { encoding: "buffer" | null } & ExecOptions): Promise<{ stdout: Buffer, stderr: Buffer }>;
+        function __promisify__(command: string, options: { encoding: BufferEncoding } & ExecOptions): Promise<{ stdout: string, stderr: string }>;
+        function __promisify__(command: string, options: ExecOptions): Promise<{ stdout: string, stderr: string }>;
+        function __promisify__(command: string, options?: ({ encoding?: string | null } & ExecOptions) | null): Promise<{ stdout: string | Buffer, stderr: string | Buffer }>;
     }
 
-    export interface ExecFileOptions {
+    interface ExecFileOptions {
         cwd?: string;
         env?: NodeJS.ProcessEnv;
         timeout?: number;
@@ -2363,63 +2371,95 @@ declare module "child_process" {
         windowsHide?: boolean;
         windowsVerbatimArguments?: boolean;
     }
-    export interface ExecFileOptionsWithStringEncoding extends ExecFileOptions {
+    interface ExecFileOptionsWithStringEncoding extends ExecFileOptions {
         encoding: BufferEncoding;
     }
-    export interface ExecFileOptionsWithBufferEncoding extends ExecFileOptions {
+    interface ExecFileOptionsWithBufferEncoding extends ExecFileOptions {
         encoding: 'buffer' | null;
     }
-    export interface ExecFileOptionsWithOtherEncoding extends ExecFileOptions {
+    interface ExecFileOptionsWithOtherEncoding extends ExecFileOptions {
         encoding: string;
     }
 
-    export function execFile(file: string): ChildProcess;
-    export function execFile(file: string, options: ({ encoding?: string | null } & ExecFileOptions) | undefined | null): ChildProcess;
-    export function execFile(file: string, args?: ReadonlyArray<string> | null): ChildProcess;
-    export function execFile(file: string, args: ReadonlyArray<string> | undefined | null, options: ({ encoding?: string | null } & ExecFileOptions) | undefined | null): ChildProcess;
+    function execFile(file: string): ChildProcess;
+    function execFile(file: string, options: ({ encoding?: string | null } & ExecFileOptions) | undefined | null): ChildProcess;
+    function execFile(file: string, args?: ReadonlyArray<string> | null): ChildProcess;
+    function execFile(file: string, args: ReadonlyArray<string> | undefined | null, options: ({ encoding?: string | null } & ExecFileOptions) | undefined | null): ChildProcess;
 
     // no `options` definitely means stdout/stderr are `string`.
-    export function execFile(file: string, callback: (error: Error | null, stdout: string, stderr: string) => void): ChildProcess;
-    export function execFile(file: string, args: ReadonlyArray<string> | undefined | null, callback: (error: Error | null, stdout: string, stderr: string) => void): ChildProcess;
+    function execFile(file: string, callback: (error: Error | null, stdout: string, stderr: string) => void): ChildProcess;
+    function execFile(file: string, args: ReadonlyArray<string> | undefined | null, callback: (error: Error | null, stdout: string, stderr: string) => void): ChildProcess;
 
     // `options` with `"buffer"` or `null` for `encoding` means stdout/stderr are definitely `Buffer`.
-    export function execFile(file: string, options: ExecFileOptionsWithBufferEncoding, callback: (error: Error | null, stdout: Buffer, stderr: Buffer) => void): ChildProcess;
-    export function execFile(file: string, args: ReadonlyArray<string> | undefined | null, options: ExecFileOptionsWithBufferEncoding, callback: (error: Error | null, stdout: Buffer, stderr: Buffer) => void): ChildProcess;
+    function execFile(file: string, options: ExecFileOptionsWithBufferEncoding, callback: (error: Error | null, stdout: Buffer, stderr: Buffer) => void): ChildProcess;
+    function execFile(
+        file: string,
+        args: ReadonlyArray<string> | undefined | null,
+        options: ExecFileOptionsWithBufferEncoding,
+        callback: (error: Error | null, stdout: Buffer, stderr: Buffer) => void,
+    ): ChildProcess;
 
     // `options` with well known `encoding` means stdout/stderr are definitely `string`.
-    export function execFile(file: string, options: ExecFileOptionsWithStringEncoding, callback: (error: Error | null, stdout: string, stderr: string) => void): ChildProcess;
-    export function execFile(file: string, args: ReadonlyArray<string> | undefined | null, options: ExecFileOptionsWithStringEncoding, callback: (error: Error | null, stdout: string, stderr: string) => void): ChildProcess;
+    function execFile(file: string, options: ExecFileOptionsWithStringEncoding, callback: (error: Error | null, stdout: string, stderr: string) => void): ChildProcess;
+    function execFile(
+        file: string,
+        args: ReadonlyArray<string> | undefined | null,
+        options: ExecFileOptionsWithStringEncoding,
+        callback: (error: Error | null, stdout: string, stderr: string) => void,
+    ): ChildProcess;
 
     // `options` with an `encoding` whose type is `string` means stdout/stderr could either be `Buffer` or `string`.
     // There is no guarantee the `encoding` is unknown as `string` is a superset of `BufferEncoding`.
-    export function execFile(file: string, options: ExecFileOptionsWithOtherEncoding, callback: (error: Error | null, stdout: string | Buffer, stderr: string | Buffer) => void): ChildProcess;
-    export function execFile(file: string, args: ReadonlyArray<string> | undefined | null, options: ExecFileOptionsWithOtherEncoding, callback: (error: Error | null, stdout: string | Buffer, stderr: string | Buffer) => void): ChildProcess;
+    function execFile(
+        file: string,
+        options: ExecFileOptionsWithOtherEncoding,
+        callback: (error: Error | null, stdout: string | Buffer, stderr: string | Buffer) => void,
+    ): ChildProcess;
+    function execFile(
+        file: string,
+        args: ReadonlyArray<string> | undefined | null,
+        options: ExecFileOptionsWithOtherEncoding,
+        callback: (error: Error | null, stdout: string | Buffer, stderr: string | Buffer) => void,
+    ): ChildProcess;
 
     // `options` without an `encoding` means stdout/stderr are definitely `string`.
-    export function execFile(file: string, options: ExecFileOptions, callback: (error: Error | null, stdout: string, stderr: string) => void): ChildProcess;
-    export function execFile(file: string, args: ReadonlyArray<string> | undefined | null, options: ExecFileOptions, callback: (error: Error | null, stdout: string, stderr: string) => void): ChildProcess;
+    function execFile(file: string, options: ExecFileOptions, callback: (error: Error | null, stdout: string, stderr: string) => void): ChildProcess;
+    function execFile(file: string, args: ReadonlyArray<string> | undefined | null, options: ExecFileOptions, callback: (error: Error | null, stdout: string, stderr: string) => void): ChildProcess;
 
     // fallback if nothing else matches. Worst case is always `string | Buffer`.
-    export function execFile(file: string, options: ({ encoding?: string | null } & ExecFileOptions) | undefined | null, callback: ((error: Error | null, stdout: string | Buffer, stderr: string | Buffer) => void) | undefined | null): ChildProcess;
-    export function execFile(file: string, args: ReadonlyArray<string> | undefined | null, options: ({ encoding?: string | null } & ExecFileOptions) | undefined | null, callback: ((error: Error | null, stdout: string | Buffer, stderr: string | Buffer) => void) | undefined | null): ChildProcess;
+    function execFile(
+        file: string,
+        options: ({ encoding?: string | null } & ExecFileOptions) | undefined | null,
+        callback: ((error: Error | null, stdout: string | Buffer, stderr: string | Buffer) => void) | undefined | null,
+    ): ChildProcess;
+    function execFile(
+        file: string,
+        args: ReadonlyArray<string> | undefined | null,
+        options: ({ encoding?: string | null } & ExecFileOptions) | undefined | null,
+        callback: ((error: Error | null, stdout: string | Buffer, stderr: string | Buffer) => void) | undefined | null,
+    ): ChildProcess;
 
     // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
-    export namespace execFile {
-        export function __promisify__(file: string): Promise<{ stdout: string, stderr: string }>;
-        export function __promisify__(file: string, args: string[] | undefined | null): Promise<{ stdout: string, stderr: string }>;
-        export function __promisify__(file: string, options: ExecFileOptionsWithBufferEncoding): Promise<{ stdout: Buffer, stderr: Buffer }>;
-        export function __promisify__(file: string, args: string[] | undefined | null, options: ExecFileOptionsWithBufferEncoding): Promise<{ stdout: Buffer, stderr: Buffer }>;
-        export function __promisify__(file: string, options: ExecFileOptionsWithStringEncoding): Promise<{ stdout: string, stderr: string }>;
-        export function __promisify__(file: string, args: string[] | undefined | null, options: ExecFileOptionsWithStringEncoding): Promise<{ stdout: string, stderr: string }>;
-        export function __promisify__(file: string, options: ExecFileOptionsWithOtherEncoding): Promise<{ stdout: string | Buffer, stderr: string | Buffer }>;
-        export function __promisify__(file: string, args: string[] | undefined | null, options: ExecFileOptionsWithOtherEncoding): Promise<{ stdout: string | Buffer, stderr: string | Buffer }>;
-        export function __promisify__(file: string, options: ExecFileOptions): Promise<{ stdout: string, stderr: string }>;
-        export function __promisify__(file: string, args: string[] | undefined | null, options: ExecFileOptions): Promise<{ stdout: string, stderr: string }>;
-        export function __promisify__(file: string, options: ({ encoding?: string | null } & ExecFileOptions) | undefined | null): Promise<{ stdout: string | Buffer, stderr: string | Buffer }>;
-        export function __promisify__(file: string, args: string[] | undefined | null, options: ({ encoding?: string | null } & ExecFileOptions) | undefined | null): Promise<{ stdout: string | Buffer, stderr: string | Buffer }>;
+    namespace execFile {
+        function __promisify__(file: string): Promise<{ stdout: string, stderr: string }>;
+        function __promisify__(file: string, args: string[] | undefined | null): Promise<{ stdout: string, stderr: string }>;
+        function __promisify__(file: string, options: ExecFileOptionsWithBufferEncoding): Promise<{ stdout: Buffer, stderr: Buffer }>;
+        function __promisify__(file: string, args: string[] | undefined | null, options: ExecFileOptionsWithBufferEncoding): Promise<{ stdout: Buffer, stderr: Buffer }>;
+        function __promisify__(file: string, options: ExecFileOptionsWithStringEncoding): Promise<{ stdout: string, stderr: string }>;
+        function __promisify__(file: string, args: string[] | undefined | null, options: ExecFileOptionsWithStringEncoding): Promise<{ stdout: string, stderr: string }>;
+        function __promisify__(file: string, options: ExecFileOptionsWithOtherEncoding): Promise<{ stdout: string | Buffer, stderr: string | Buffer }>;
+        function __promisify__(file: string, args: string[] | undefined | null, options: ExecFileOptionsWithOtherEncoding): Promise<{ stdout: string | Buffer, stderr: string | Buffer }>;
+        function __promisify__(file: string, options: ExecFileOptions): Promise<{ stdout: string, stderr: string }>;
+        function __promisify__(file: string, args: string[] | undefined | null, options: ExecFileOptions): Promise<{ stdout: string, stderr: string }>;
+        function __promisify__(file: string, options: ({ encoding?: string | null } & ExecFileOptions) | undefined | null): Promise<{ stdout: string | Buffer, stderr: string | Buffer }>;
+        function __promisify__(
+            file: string,
+            args: string[] | undefined | null,
+            options: ({ encoding?: string | null } & ExecFileOptions) | undefined | null,
+        ): Promise<{ stdout: string | Buffer, stderr: string | Buffer }>;
     }
 
-    export interface ForkOptions {
+    interface ForkOptions {
         cwd?: string;
         env?: NodeJS.ProcessEnv;
         execPath?: string;
@@ -2430,9 +2470,9 @@ declare module "child_process" {
         uid?: number;
         gid?: number;
     }
-    export function fork(modulePath: string, args?: ReadonlyArray<string>, options?: ForkOptions): ChildProcess;
+    function fork(modulePath: string, args?: ReadonlyArray<string>, options?: ForkOptions): ChildProcess;
 
-    export interface SpawnSyncOptions {
+    interface SpawnSyncOptions {
         argv0?: string; // Not specified in the docs
         cwd?: string;
         input?: string | Buffer | NodeJS.TypedArray | DataView;
@@ -2448,13 +2488,13 @@ declare module "child_process" {
         windowsVerbatimArguments?: boolean;
         windowsHide?: boolean;
     }
-    export interface SpawnSyncOptionsWithStringEncoding extends SpawnSyncOptions {
+    interface SpawnSyncOptionsWithStringEncoding extends SpawnSyncOptions {
         encoding: BufferEncoding;
     }
-    export interface SpawnSyncOptionsWithBufferEncoding extends SpawnSyncOptions {
+    interface SpawnSyncOptionsWithBufferEncoding extends SpawnSyncOptions {
         encoding: string; // specify `null`.
     }
-    export interface SpawnSyncReturns<T> {
+    interface SpawnSyncReturns<T> {
         pid: number;
         output: string[];
         stdout: T;
@@ -2463,15 +2503,15 @@ declare module "child_process" {
         signal: string;
         error: Error;
     }
-    export function spawnSync(command: string): SpawnSyncReturns<Buffer>;
-    export function spawnSync(command: string, options?: SpawnSyncOptionsWithStringEncoding): SpawnSyncReturns<string>;
-    export function spawnSync(command: string, options?: SpawnSyncOptionsWithBufferEncoding): SpawnSyncReturns<Buffer>;
-    export function spawnSync(command: string, options?: SpawnSyncOptions): SpawnSyncReturns<Buffer>;
-    export function spawnSync(command: string, args?: ReadonlyArray<string>, options?: SpawnSyncOptionsWithStringEncoding): SpawnSyncReturns<string>;
-    export function spawnSync(command: string, args?: ReadonlyArray<string>, options?: SpawnSyncOptionsWithBufferEncoding): SpawnSyncReturns<Buffer>;
-    export function spawnSync(command: string, args?: ReadonlyArray<string>, options?: SpawnSyncOptions): SpawnSyncReturns<Buffer>;
+    function spawnSync(command: string): SpawnSyncReturns<Buffer>;
+    function spawnSync(command: string, options?: SpawnSyncOptionsWithStringEncoding): SpawnSyncReturns<string>;
+    function spawnSync(command: string, options?: SpawnSyncOptionsWithBufferEncoding): SpawnSyncReturns<Buffer>;
+    function spawnSync(command: string, options?: SpawnSyncOptions): SpawnSyncReturns<Buffer>;
+    function spawnSync(command: string, args?: ReadonlyArray<string>, options?: SpawnSyncOptionsWithStringEncoding): SpawnSyncReturns<string>;
+    function spawnSync(command: string, args?: ReadonlyArray<string>, options?: SpawnSyncOptionsWithBufferEncoding): SpawnSyncReturns<Buffer>;
+    function spawnSync(command: string, args?: ReadonlyArray<string>, options?: SpawnSyncOptions): SpawnSyncReturns<Buffer>;
 
-    export interface ExecSyncOptions {
+    interface ExecSyncOptions {
         cwd?: string;
         input?: string | Buffer | Uint8Array;
         stdio?: StdioOptions;
@@ -2485,18 +2525,18 @@ declare module "child_process" {
         encoding?: string;
         windowsHide?: boolean;
     }
-    export interface ExecSyncOptionsWithStringEncoding extends ExecSyncOptions {
+    interface ExecSyncOptionsWithStringEncoding extends ExecSyncOptions {
         encoding: BufferEncoding;
     }
-    export interface ExecSyncOptionsWithBufferEncoding extends ExecSyncOptions {
+    interface ExecSyncOptionsWithBufferEncoding extends ExecSyncOptions {
         encoding: string; // specify `null`.
     }
-    export function execSync(command: string): Buffer;
-    export function execSync(command: string, options?: ExecSyncOptionsWithStringEncoding): string;
-    export function execSync(command: string, options?: ExecSyncOptionsWithBufferEncoding): Buffer;
-    export function execSync(command: string, options?: ExecSyncOptions): Buffer;
+    function execSync(command: string): Buffer;
+    function execSync(command: string, options?: ExecSyncOptionsWithStringEncoding): string;
+    function execSync(command: string, options?: ExecSyncOptionsWithBufferEncoding): Buffer;
+    function execSync(command: string, options?: ExecSyncOptions): Buffer;
 
-    export interface ExecFileSyncOptions {
+    interface ExecFileSyncOptions {
         cwd?: string;
         input?: string | Buffer | NodeJS.TypedArray | DataView;
         stdio?: StdioOptions;
@@ -2510,25 +2550,25 @@ declare module "child_process" {
         windowsHide?: boolean;
         shell?: boolean | string;
     }
-    export interface ExecFileSyncOptionsWithStringEncoding extends ExecFileSyncOptions {
+    interface ExecFileSyncOptionsWithStringEncoding extends ExecFileSyncOptions {
         encoding: BufferEncoding;
     }
-    export interface ExecFileSyncOptionsWithBufferEncoding extends ExecFileSyncOptions {
+    interface ExecFileSyncOptionsWithBufferEncoding extends ExecFileSyncOptions {
         encoding: string; // specify `null`.
     }
-    export function execFileSync(command: string): Buffer;
-    export function execFileSync(command: string, options?: ExecFileSyncOptionsWithStringEncoding): string;
-    export function execFileSync(command: string, options?: ExecFileSyncOptionsWithBufferEncoding): Buffer;
-    export function execFileSync(command: string, options?: ExecFileSyncOptions): Buffer;
-    export function execFileSync(command: string, args?: ReadonlyArray<string>, options?: ExecFileSyncOptionsWithStringEncoding): string;
-    export function execFileSync(command: string, args?: ReadonlyArray<string>, options?: ExecFileSyncOptionsWithBufferEncoding): Buffer;
-    export function execFileSync(command: string, args?: ReadonlyArray<string>, options?: ExecFileSyncOptions): Buffer;
+    function execFileSync(command: string): Buffer;
+    function execFileSync(command: string, options?: ExecFileSyncOptionsWithStringEncoding): string;
+    function execFileSync(command: string, options?: ExecFileSyncOptionsWithBufferEncoding): Buffer;
+    function execFileSync(command: string, options?: ExecFileSyncOptions): Buffer;
+    function execFileSync(command: string, args?: ReadonlyArray<string>, options?: ExecFileSyncOptionsWithStringEncoding): string;
+    function execFileSync(command: string, args?: ReadonlyArray<string>, options?: ExecFileSyncOptionsWithBufferEncoding): Buffer;
+    function execFileSync(command: string, args?: ReadonlyArray<string>, options?: ExecFileSyncOptions): Buffer;
 }
 
 declare module "url" {
     import { ParsedUrlQuery } from 'querystring';
 
-    export interface UrlObjectCommon {
+    interface UrlObjectCommon {
         auth?: string;
         hash?: string;
         host?: string;
@@ -2542,45 +2582,45 @@ declare module "url" {
     }
 
     // Input to `url.format`
-    export interface UrlObject extends UrlObjectCommon {
+    interface UrlObject extends UrlObjectCommon {
         port?: string | number;
         query?: string | null | { [key: string]: any };
     }
 
     // Output of `url.parse`
-    export interface Url extends UrlObjectCommon {
+    interface Url extends UrlObjectCommon {
         port?: string;
         query?: string | null | ParsedUrlQuery;
     }
 
-    export interface UrlWithParsedQuery extends Url {
+    interface UrlWithParsedQuery extends Url {
         query: ParsedUrlQuery;
     }
 
-    export interface UrlWithStringQuery extends Url {
+    interface UrlWithStringQuery extends Url {
         query: string | null;
     }
 
-    export function parse(urlStr: string): UrlWithStringQuery;
-    export function parse(urlStr: string, parseQueryString: false | undefined, slashesDenoteHost?: boolean): UrlWithStringQuery;
-    export function parse(urlStr: string, parseQueryString: true, slashesDenoteHost?: boolean): UrlWithParsedQuery;
-    export function parse(urlStr: string, parseQueryString: boolean, slashesDenoteHost?: boolean): Url;
+    function parse(urlStr: string): UrlWithStringQuery;
+    function parse(urlStr: string, parseQueryString: false | undefined, slashesDenoteHost?: boolean): UrlWithStringQuery;
+    function parse(urlStr: string, parseQueryString: true, slashesDenoteHost?: boolean): UrlWithParsedQuery;
+    function parse(urlStr: string, parseQueryString: boolean, slashesDenoteHost?: boolean): Url;
 
-    export function format(URL: URL, options?: URLFormatOptions): string;
-    export function format(urlObject: UrlObject | string): string;
-    export function resolve(from: string, to: string): string;
+    function format(URL: URL, options?: URLFormatOptions): string;
+    function format(urlObject: UrlObject | string): string;
+    function resolve(from: string, to: string): string;
 
-    export function domainToASCII(domain: string): string;
-    export function domainToUnicode(domain: string): string;
+    function domainToASCII(domain: string): string;
+    function domainToUnicode(domain: string): string;
 
-    export interface URLFormatOptions {
+    interface URLFormatOptions {
         auth?: boolean;
         fragment?: boolean;
         search?: boolean;
         unicode?: boolean;
     }
 
-    export class URL {
+    class URL {
         constructor(input: string, base?: string | URL);
         hash: string;
         host: string;
@@ -2598,7 +2638,7 @@ declare module "url" {
         toJSON(): string;
     }
 
-    export class URLSearchParams implements Iterable<[string, string]> {
+    class URLSearchParams implements Iterable<[string, string]> {
         constructor(init?: URLSearchParams | string | { [key: string]: string | string[] | undefined } | Iterable<[string, string]> | Array<[string, string]>);
         append(name: string, value: string): void;
         delete(name: string): void;
@@ -2618,81 +2658,81 @@ declare module "url" {
 
 declare module "dns" {
     // Supported getaddrinfo flags.
-    export const ADDRCONFIG: number;
-    export const V4MAPPED: number;
+    const ADDRCONFIG: number;
+    const V4MAPPED: number;
 
-    export interface LookupOptions {
+    interface LookupOptions {
         family?: number;
         hints?: number;
         all?: boolean;
     }
 
-    export interface LookupOneOptions extends LookupOptions {
+    interface LookupOneOptions extends LookupOptions {
         all?: false;
     }
 
-    export interface LookupAllOptions extends LookupOptions {
+    interface LookupAllOptions extends LookupOptions {
         all: true;
     }
 
-    export interface LookupAddress {
+    interface LookupAddress {
         address: string;
         family: number;
     }
 
-    export function lookup(hostname: string, family: number, callback: (err: NodeJS.ErrnoException, address: string, family: number) => void): void;
-    export function lookup(hostname: string, options: LookupOneOptions, callback: (err: NodeJS.ErrnoException, address: string, family: number) => void): void;
-    export function lookup(hostname: string, options: LookupAllOptions, callback: (err: NodeJS.ErrnoException, addresses: LookupAddress[]) => void): void;
-    export function lookup(hostname: string, options: LookupOptions, callback: (err: NodeJS.ErrnoException, address: string | LookupAddress[], family: number) => void): void;
-    export function lookup(hostname: string, callback: (err: NodeJS.ErrnoException, address: string, family: number) => void): void;
+    function lookup(hostname: string, family: number, callback: (err: NodeJS.ErrnoException, address: string, family: number) => void): void;
+    function lookup(hostname: string, options: LookupOneOptions, callback: (err: NodeJS.ErrnoException, address: string, family: number) => void): void;
+    function lookup(hostname: string, options: LookupAllOptions, callback: (err: NodeJS.ErrnoException, addresses: LookupAddress[]) => void): void;
+    function lookup(hostname: string, options: LookupOptions, callback: (err: NodeJS.ErrnoException, address: string | LookupAddress[], family: number) => void): void;
+    function lookup(hostname: string, callback: (err: NodeJS.ErrnoException, address: string, family: number) => void): void;
 
     // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
-    export namespace lookup {
-        export function __promisify__(hostname: string, options: LookupAllOptions): Promise<{ address: LookupAddress[] }>;
-        export function __promisify__(hostname: string, options?: LookupOneOptions | number): Promise<{ address: string, family: number }>;
-        export function __promisify__(hostname: string, options?: LookupOptions | number): Promise<{ address: string | LookupAddress[], family?: number }>;
+    namespace lookup {
+        function __promisify__(hostname: string, options: LookupAllOptions): Promise<{ address: LookupAddress[] }>;
+        function __promisify__(hostname: string, options?: LookupOneOptions | number): Promise<{ address: string, family: number }>;
+        function __promisify__(hostname: string, options?: LookupOptions | number): Promise<{ address: string | LookupAddress[], family?: number }>;
     }
 
-    export function lookupService(address: string, port: number, callback: (err: NodeJS.ErrnoException, hostname: string, service: string) => void): void;
+    function lookupService(address: string, port: number, callback: (err: NodeJS.ErrnoException, hostname: string, service: string) => void): void;
 
-    export namespace lookupService {
-        export function __promisify__(address: string, port: number): Promise<{ hostname: string, service: string }>;
+    namespace lookupService {
+        function __promisify__(address: string, port: number): Promise<{ hostname: string, service: string }>;
     }
 
-    export interface ResolveOptions {
+    interface ResolveOptions {
         ttl: boolean;
     }
 
-    export interface ResolveWithTtlOptions extends ResolveOptions {
+    interface ResolveWithTtlOptions extends ResolveOptions {
         ttl: true;
     }
 
-    export interface RecordWithTtl {
+    interface RecordWithTtl {
         address: string;
         ttl: number;
     }
 
     /** @deprecated Use AnyARecord or AnyAaaaRecord instead. */
-    export type AnyRecordWithTtl = AnyARecord | AnyAaaaRecord;
+    type AnyRecordWithTtl = AnyARecord | AnyAaaaRecord;
 
-    export interface AnyARecord extends RecordWithTtl {
+    interface AnyARecord extends RecordWithTtl {
         type: "A";
     }
 
-    export interface AnyAaaaRecord extends RecordWithTtl {
+    interface AnyAaaaRecord extends RecordWithTtl {
         type: "AAAA";
     }
 
-    export interface MxRecord {
+    interface MxRecord {
         priority: number;
         exchange: string;
     }
 
-    export interface AnyMxRecord extends MxRecord {
+    interface AnyMxRecord extends MxRecord {
         type: "MX";
     }
 
-    export interface NaptrRecord {
+    interface NaptrRecord {
         flags: string;
         service: string;
         regexp: string;
@@ -2701,11 +2741,11 @@ declare module "dns" {
         preference: number;
     }
 
-    export interface AnyNaptrRecord extends NaptrRecord {
+    interface AnyNaptrRecord extends NaptrRecord {
         type: "NAPTR";
     }
 
-    export interface SoaRecord {
+    interface SoaRecord {
         nsname: string;
         hostmaster: string;
         serial: number;
@@ -2715,42 +2755,42 @@ declare module "dns" {
         minttl: number;
     }
 
-    export interface AnySoaRecord extends SoaRecord {
+    interface AnySoaRecord extends SoaRecord {
         type: "SOA";
     }
 
-    export interface SrvRecord {
+    interface SrvRecord {
         priority: number;
         weight: number;
         port: number;
         name: string;
     }
 
-    export interface AnySrvRecord extends SrvRecord {
+    interface AnySrvRecord extends SrvRecord {
         type: "SRV";
     }
 
-    export interface AnyTxtRecord {
+    interface AnyTxtRecord {
         type: "TXT";
         entries: string[];
     }
 
-    export interface AnyNsRecord {
+    interface AnyNsRecord {
         type: "NS";
         value: string;
     }
 
-    export interface AnyPtrRecord {
+    interface AnyPtrRecord {
         type: "PTR";
         value: string;
     }
 
-    export interface AnyCnameRecord {
+    interface AnyCnameRecord {
         type: "CNAME";
         value: string;
     }
 
-    export type AnyRecord = AnyARecord |
+    type AnyRecord = AnyARecord |
         AnyAaaaRecord |
         AnyCnameRecord |
         AnyMxRecord |
@@ -2761,130 +2801,134 @@ declare module "dns" {
         AnySrvRecord |
         AnyTxtRecord;
 
-    export function resolve(hostname: string, callback: (err: NodeJS.ErrnoException, addresses: string[]) => void): void;
-    export function resolve(hostname: string, rrtype: "A", callback: (err: NodeJS.ErrnoException, addresses: string[]) => void): void;
-    export function resolve(hostname: string, rrtype: "AAAA", callback: (err: NodeJS.ErrnoException, addresses: string[]) => void): void;
-    export function resolve(hostname: string, rrtype: "ANY", callback: (err: NodeJS.ErrnoException, addresses: AnyRecord[]) => void): void;
-    export function resolve(hostname: string, rrtype: "CNAME", callback: (err: NodeJS.ErrnoException, addresses: string[]) => void): void;
-    export function resolve(hostname: string, rrtype: "MX", callback: (err: NodeJS.ErrnoException, addresses: MxRecord[]) => void): void;
-    export function resolve(hostname: string, rrtype: "NAPTR", callback: (err: NodeJS.ErrnoException, addresses: NaptrRecord[]) => void): void;
-    export function resolve(hostname: string, rrtype: "NS", callback: (err: NodeJS.ErrnoException, addresses: string[]) => void): void;
-    export function resolve(hostname: string, rrtype: "PTR", callback: (err: NodeJS.ErrnoException, addresses: string[]) => void): void;
-    export function resolve(hostname: string, rrtype: "SOA", callback: (err: NodeJS.ErrnoException, addresses: SoaRecord) => void): void;
-    export function resolve(hostname: string, rrtype: "SRV", callback: (err: NodeJS.ErrnoException, addresses: SrvRecord[]) => void): void;
-    export function resolve(hostname: string, rrtype: "TXT", callback: (err: NodeJS.ErrnoException, addresses: string[][]) => void): void;
-    export function resolve(hostname: string, rrtype: string, callback: (err: NodeJS.ErrnoException, addresses: string[] | MxRecord[] | NaptrRecord[] | SoaRecord | SrvRecord[] | string[][] | AnyRecord[]) => void): void;
+    function resolve(hostname: string, callback: (err: NodeJS.ErrnoException, addresses: string[]) => void): void;
+    function resolve(hostname: string, rrtype: "A", callback: (err: NodeJS.ErrnoException, addresses: string[]) => void): void;
+    function resolve(hostname: string, rrtype: "AAAA", callback: (err: NodeJS.ErrnoException, addresses: string[]) => void): void;
+    function resolve(hostname: string, rrtype: "ANY", callback: (err: NodeJS.ErrnoException, addresses: AnyRecord[]) => void): void;
+    function resolve(hostname: string, rrtype: "CNAME", callback: (err: NodeJS.ErrnoException, addresses: string[]) => void): void;
+    function resolve(hostname: string, rrtype: "MX", callback: (err: NodeJS.ErrnoException, addresses: MxRecord[]) => void): void;
+    function resolve(hostname: string, rrtype: "NAPTR", callback: (err: NodeJS.ErrnoException, addresses: NaptrRecord[]) => void): void;
+    function resolve(hostname: string, rrtype: "NS", callback: (err: NodeJS.ErrnoException, addresses: string[]) => void): void;
+    function resolve(hostname: string, rrtype: "PTR", callback: (err: NodeJS.ErrnoException, addresses: string[]) => void): void;
+    function resolve(hostname: string, rrtype: "SOA", callback: (err: NodeJS.ErrnoException, addresses: SoaRecord) => void): void;
+    function resolve(hostname: string, rrtype: "SRV", callback: (err: NodeJS.ErrnoException, addresses: SrvRecord[]) => void): void;
+    function resolve(hostname: string, rrtype: "TXT", callback: (err: NodeJS.ErrnoException, addresses: string[][]) => void): void;
+    function resolve(
+        hostname: string,
+        rrtype: string,
+        callback: (err: NodeJS.ErrnoException, addresses: string[] | MxRecord[] | NaptrRecord[] | SoaRecord | SrvRecord[] | string[][] | AnyRecord[]) => void,
+    ): void;
 
     // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
-    export namespace resolve {
-        export function __promisify__(hostname: string, rrtype?: "A" | "AAAA" | "CNAME" | "NS" | "PTR"): Promise<string[]>;
-        export function __promisify__(hostname: string, rrtype: "ANY"): Promise<AnyRecord[]>;
-        export function __promisify__(hostname: string, rrtype: "MX"): Promise<MxRecord[]>;
-        export function __promisify__(hostname: string, rrtype: "NAPTR"): Promise<NaptrRecord[]>;
-        export function __promisify__(hostname: string, rrtype: "SOA"): Promise<SoaRecord>;
-        export function __promisify__(hostname: string, rrtype: "SRV"): Promise<SrvRecord[]>;
-        export function __promisify__(hostname: string, rrtype: "TXT"): Promise<string[][]>;
-        export function __promisify__(hostname: string, rrtype: string): Promise<string[] | MxRecord[] | NaptrRecord[] | SoaRecord | SrvRecord[] | string[][] | AnyRecord[]>;
+    namespace resolve {
+        function __promisify__(hostname: string, rrtype?: "A" | "AAAA" | "CNAME" | "NS" | "PTR"): Promise<string[]>;
+        function __promisify__(hostname: string, rrtype: "ANY"): Promise<AnyRecord[]>;
+        function __promisify__(hostname: string, rrtype: "MX"): Promise<MxRecord[]>;
+        function __promisify__(hostname: string, rrtype: "NAPTR"): Promise<NaptrRecord[]>;
+        function __promisify__(hostname: string, rrtype: "SOA"): Promise<SoaRecord>;
+        function __promisify__(hostname: string, rrtype: "SRV"): Promise<SrvRecord[]>;
+        function __promisify__(hostname: string, rrtype: "TXT"): Promise<string[][]>;
+        function __promisify__(hostname: string, rrtype: string): Promise<string[] | MxRecord[] | NaptrRecord[] | SoaRecord | SrvRecord[] | string[][] | AnyRecord[]>;
     }
 
-    export function resolve4(hostname: string, callback: (err: NodeJS.ErrnoException, addresses: string[]) => void): void;
-    export function resolve4(hostname: string, options: ResolveWithTtlOptions, callback: (err: NodeJS.ErrnoException, addresses: RecordWithTtl[]) => void): void;
-    export function resolve4(hostname: string, options: ResolveOptions, callback: (err: NodeJS.ErrnoException, addresses: string[] | RecordWithTtl[]) => void): void;
+    function resolve4(hostname: string, callback: (err: NodeJS.ErrnoException, addresses: string[]) => void): void;
+    function resolve4(hostname: string, options: ResolveWithTtlOptions, callback: (err: NodeJS.ErrnoException, addresses: RecordWithTtl[]) => void): void;
+    function resolve4(hostname: string, options: ResolveOptions, callback: (err: NodeJS.ErrnoException, addresses: string[] | RecordWithTtl[]) => void): void;
 
     // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
-    export namespace resolve4 {
-        export function __promisify__(hostname: string): Promise<string[]>;
-        export function __promisify__(hostname: string, options: ResolveWithTtlOptions): Promise<RecordWithTtl[]>;
-        export function __promisify__(hostname: string, options?: ResolveOptions): Promise<string[] | RecordWithTtl[]>;
+    namespace resolve4 {
+        function __promisify__(hostname: string): Promise<string[]>;
+        function __promisify__(hostname: string, options: ResolveWithTtlOptions): Promise<RecordWithTtl[]>;
+        function __promisify__(hostname: string, options?: ResolveOptions): Promise<string[] | RecordWithTtl[]>;
     }
 
-    export function resolve6(hostname: string, callback: (err: NodeJS.ErrnoException, addresses: string[]) => void): void;
-    export function resolve6(hostname: string, options: ResolveWithTtlOptions, callback: (err: NodeJS.ErrnoException, addresses: RecordWithTtl[]) => void): void;
-    export function resolve6(hostname: string, options: ResolveOptions, callback: (err: NodeJS.ErrnoException, addresses: string[] | RecordWithTtl[]) => void): void;
+    function resolve6(hostname: string, callback: (err: NodeJS.ErrnoException, addresses: string[]) => void): void;
+    function resolve6(hostname: string, options: ResolveWithTtlOptions, callback: (err: NodeJS.ErrnoException, addresses: RecordWithTtl[]) => void): void;
+    function resolve6(hostname: string, options: ResolveOptions, callback: (err: NodeJS.ErrnoException, addresses: string[] | RecordWithTtl[]) => void): void;
 
     // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
-    export namespace resolve6 {
-        export function __promisify__(hostname: string): Promise<string[]>;
-        export function __promisify__(hostname: string, options: ResolveWithTtlOptions): Promise<RecordWithTtl[]>;
-        export function __promisify__(hostname: string, options?: ResolveOptions): Promise<string[] | RecordWithTtl[]>;
+    namespace resolve6 {
+        function __promisify__(hostname: string): Promise<string[]>;
+        function __promisify__(hostname: string, options: ResolveWithTtlOptions): Promise<RecordWithTtl[]>;
+        function __promisify__(hostname: string, options?: ResolveOptions): Promise<string[] | RecordWithTtl[]>;
     }
 
-    export function resolveCname(hostname: string, callback: (err: NodeJS.ErrnoException, addresses: string[]) => void): void;
-    export namespace resolveCname {
-        export function __promisify__(hostname: string): Promise<string[]>;
+    function resolveCname(hostname: string, callback: (err: NodeJS.ErrnoException, addresses: string[]) => void): void;
+    namespace resolveCname {
+        function __promisify__(hostname: string): Promise<string[]>;
     }
 
-    export function resolveMx(hostname: string, callback: (err: NodeJS.ErrnoException, addresses: MxRecord[]) => void): void;
-    export namespace resolveMx {
-        export function __promisify__(hostname: string): Promise<MxRecord[]>;
+    function resolveMx(hostname: string, callback: (err: NodeJS.ErrnoException, addresses: MxRecord[]) => void): void;
+    namespace resolveMx {
+        function __promisify__(hostname: string): Promise<MxRecord[]>;
     }
 
-    export function resolveNaptr(hostname: string, callback: (err: NodeJS.ErrnoException, addresses: NaptrRecord[]) => void): void;
-    export namespace resolveNaptr {
-        export function __promisify__(hostname: string): Promise<NaptrRecord[]>;
+    function resolveNaptr(hostname: string, callback: (err: NodeJS.ErrnoException, addresses: NaptrRecord[]) => void): void;
+    namespace resolveNaptr {
+        function __promisify__(hostname: string): Promise<NaptrRecord[]>;
     }
 
-    export function resolveNs(hostname: string, callback: (err: NodeJS.ErrnoException, addresses: string[]) => void): void;
-    export namespace resolveNs {
-        export function __promisify__(hostname: string): Promise<string[]>;
+    function resolveNs(hostname: string, callback: (err: NodeJS.ErrnoException, addresses: string[]) => void): void;
+    namespace resolveNs {
+        function __promisify__(hostname: string): Promise<string[]>;
     }
 
-    export function resolvePtr(hostname: string, callback: (err: NodeJS.ErrnoException, addresses: string[]) => void): void;
-    export namespace resolvePtr {
-        export function __promisify__(hostname: string): Promise<string[]>;
+    function resolvePtr(hostname: string, callback: (err: NodeJS.ErrnoException, addresses: string[]) => void): void;
+    namespace resolvePtr {
+        function __promisify__(hostname: string): Promise<string[]>;
     }
 
-    export function resolveSoa(hostname: string, callback: (err: NodeJS.ErrnoException, address: SoaRecord) => void): void;
-    export namespace resolveSoa {
-        export function __promisify__(hostname: string): Promise<SoaRecord>;
+    function resolveSoa(hostname: string, callback: (err: NodeJS.ErrnoException, address: SoaRecord) => void): void;
+    namespace resolveSoa {
+        function __promisify__(hostname: string): Promise<SoaRecord>;
     }
 
-    export function resolveSrv(hostname: string, callback: (err: NodeJS.ErrnoException, addresses: SrvRecord[]) => void): void;
-    export namespace resolveSrv {
-        export function __promisify__(hostname: string): Promise<SrvRecord[]>;
+    function resolveSrv(hostname: string, callback: (err: NodeJS.ErrnoException, addresses: SrvRecord[]) => void): void;
+    namespace resolveSrv {
+        function __promisify__(hostname: string): Promise<SrvRecord[]>;
     }
 
-    export function resolveTxt(hostname: string, callback: (err: NodeJS.ErrnoException, addresses: string[][]) => void): void;
-    export namespace resolveTxt {
-        export function __promisify__(hostname: string): Promise<string[][]>;
+    function resolveTxt(hostname: string, callback: (err: NodeJS.ErrnoException, addresses: string[][]) => void): void;
+    namespace resolveTxt {
+        function __promisify__(hostname: string): Promise<string[][]>;
     }
 
-    export function resolveAny(hostname: string, callback: (err: NodeJS.ErrnoException, addresses: AnyRecord[]) => void): void;
-    export namespace resolveAny {
-        export function __promisify__(hostname: string): Promise<AnyRecord[]>;
+    function resolveAny(hostname: string, callback: (err: NodeJS.ErrnoException, addresses: AnyRecord[]) => void): void;
+    namespace resolveAny {
+        function __promisify__(hostname: string): Promise<AnyRecord[]>;
     }
 
-    export function reverse(ip: string, callback: (err: NodeJS.ErrnoException, hostnames: string[]) => void): void;
-    export function setServers(servers: string[]): void;
-    export function getServers(): string[];
+    function reverse(ip: string, callback: (err: NodeJS.ErrnoException, hostnames: string[]) => void): void;
+    function setServers(servers: string[]): void;
+    function getServers(): string[];
 
     // Error codes
-    export var NODATA: string;
-    export var FORMERR: string;
-    export var SERVFAIL: string;
-    export var NOTFOUND: string;
-    export var NOTIMP: string;
-    export var REFUSED: string;
-    export var BADQUERY: string;
-    export var BADNAME: string;
-    export var BADFAMILY: string;
-    export var BADRESP: string;
-    export var CONNREFUSED: string;
-    export var TIMEOUT: string;
-    export var EOF: string;
-    export var FILE: string;
-    export var NOMEM: string;
-    export var DESTRUCTION: string;
-    export var BADSTR: string;
-    export var BADFLAGS: string;
-    export var NONAME: string;
-    export var BADHINTS: string;
-    export var NOTINITIALIZED: string;
-    export var LOADIPHLPAPI: string;
-    export var ADDRGETNETWORKPARAMS: string;
-    export var CANCELLED: string;
+    const NODATA: string;
+    const FORMERR: string;
+    const SERVFAIL: string;
+    const NOTFOUND: string;
+    const NOTIMP: string;
+    const REFUSED: string;
+    const BADQUERY: string;
+    const BADNAME: string;
+    const BADFAMILY: string;
+    const BADRESP: string;
+    const CONNREFUSED: string;
+    const TIMEOUT: string;
+    const EOF: string;
+    const FILE: string;
+    const NOMEM: string;
+    const DESTRUCTION: string;
+    const BADSTR: string;
+    const BADFLAGS: string;
+    const NONAME: string;
+    const BADHINTS: string;
+    const NOTINITIALIZED: string;
+    const LOADIPHLPAPI: string;
+    const ADDRGETNETWORKPARAMS: string;
+    const CANCELLED: string;
 
-    export class Resolver {
+    class Resolver {
         getServers: typeof getServers;
         setServers: typeof setServers;
         resolve: typeof resolve;
@@ -2911,20 +2955,20 @@ declare module "net" {
 
     type LookupFunction = (hostname: string, options: dns.LookupOneOptions, callback: (err: NodeJS.ErrnoException | null, address: string, family: number) => void) => void;
 
-    export interface AddressInfo {
+    interface AddressInfo {
         address: string;
         family: string;
         port: number;
     }
 
-    export interface SocketConstructorOpts {
+    interface SocketConstructorOpts {
         fd?: number;
         allowHalfOpen?: boolean;
         readable?: boolean;
         writable?: boolean;
     }
 
-    export interface TcpSocketConnectOpts {
+    interface TcpSocketConnectOpts {
         port: number;
         host?: string;
         localAddress?: string;
@@ -2934,13 +2978,13 @@ declare module "net" {
         lookup?: LookupFunction;
     }
 
-    export interface IpcSocketConnectOpts {
+    interface IpcSocketConnectOpts {
         path: string;
     }
 
-    export type SocketConnectOpts = TcpSocketConnectOpts | IpcSocketConnectOpts;
+    type SocketConnectOpts = TcpSocketConnectOpts | IpcSocketConnectOpts;
 
-    export class Socket extends stream.Duplex {
+    class Socket extends stream.Duplex {
         constructor(options?: SocketConstructorOpts);
 
         // Extended base methods
@@ -3056,7 +3100,7 @@ declare module "net" {
         prependOnceListener(event: "timeout", listener: () => void): this;
     }
 
-    export interface ListenOptions {
+    interface ListenOptions {
         port?: number;
         host?: string;
         backlog?: number;
@@ -3067,7 +3111,7 @@ declare module "net" {
     }
 
     // https://github.com/nodejs/node/blob/master/lib/net.js
-    export class Server extends events.EventEmitter {
+    class Server extends events.EventEmitter {
         constructor(connectionListener?: (socket: Socket) => void);
         constructor(options?: { allowHalfOpen?: boolean, pauseOnConnect?: boolean }, connectionListener?: (socket: Socket) => void);
 
@@ -3133,27 +3177,27 @@ declare module "net" {
         prependOnceListener(event: "listening", listener: () => void): this;
     }
 
-    export interface TcpNetConnectOpts extends TcpSocketConnectOpts, SocketConstructorOpts {
+    interface TcpNetConnectOpts extends TcpSocketConnectOpts, SocketConstructorOpts {
         timeout?: number;
     }
 
-    export interface IpcNetConnectOpts extends IpcSocketConnectOpts, SocketConstructorOpts {
+    interface IpcNetConnectOpts extends IpcSocketConnectOpts, SocketConstructorOpts {
         timeout?: number;
     }
 
-    export type NetConnectOpts = TcpNetConnectOpts | IpcNetConnectOpts;
+    type NetConnectOpts = TcpNetConnectOpts | IpcNetConnectOpts;
 
-    export function createServer(connectionListener?: (socket: Socket) => void): Server;
-    export function createServer(options?: { allowHalfOpen?: boolean, pauseOnConnect?: boolean }, connectionListener?: (socket: Socket) => void): Server;
-    export function connect(options: NetConnectOpts, connectionListener?: Function): Socket;
-    export function connect(port: number, host?: string, connectionListener?: Function): Socket;
-    export function connect(path: string, connectionListener?: Function): Socket;
-    export function createConnection(options: NetConnectOpts, connectionListener?: Function): Socket;
-    export function createConnection(port: number, host?: string, connectionListener?: Function): Socket;
-    export function createConnection(path: string, connectionListener?: Function): Socket;
-    export function isIP(input: string): number;
-    export function isIPv4(input: string): boolean;
-    export function isIPv6(input: string): boolean;
+    function createServer(connectionListener?: (socket: Socket) => void): Server;
+    function createServer(options?: { allowHalfOpen?: boolean, pauseOnConnect?: boolean }, connectionListener?: (socket: Socket) => void): Server;
+    function connect(options: NetConnectOpts, connectionListener?: Function): Socket;
+    function connect(port: number, host?: string, connectionListener?: Function): Socket;
+    function connect(path: string, connectionListener?: Function): Socket;
+    function createConnection(options: NetConnectOpts, connectionListener?: Function): Socket;
+    function createConnection(port: number, host?: string, connectionListener?: Function): Socket;
+    function createConnection(path: string, connectionListener?: Function): Socket;
+    function isIP(input: string): number;
+    function isIPv4(input: string): boolean;
+    function isIPv6(input: string): boolean;
 }
 
 declare module "dgram" {
@@ -3161,13 +3205,13 @@ declare module "dgram" {
     import * as dns from "dns";
     import * as events from "events";
 
-    export interface RemoteInfo {
+    interface RemoteInfo {
         address: string;
         family: string;
         port: number;
     }
 
-    export interface BindOptions {
+    interface BindOptions {
         port: number;
         address?: string;
         exclusive?: boolean;
@@ -3175,7 +3219,7 @@ declare module "dgram" {
 
     type SocketType = "udp4" | "udp6";
 
-    export interface SocketOptions {
+    interface SocketOptions {
         type: SocketType;
         reuseAddr?: boolean;
         recvBufferSize?: number;
@@ -3183,10 +3227,10 @@ declare module "dgram" {
         lookup?: (hostname: string, options: dns.LookupOneOptions, callback: (err: NodeJS.ErrnoException, address: string, family: number) => void) => void;
     }
 
-    export function createSocket(type: SocketType, callback?: (msg: Buffer, rinfo: RemoteInfo) => void): Socket;
-    export function createSocket(options: SocketOptions, callback?: (msg: Buffer, rinfo: RemoteInfo) => void): Socket;
+    function createSocket(type: SocketType, callback?: (msg: Buffer, rinfo: RemoteInfo) => void): Socket;
+    function createSocket(options: SocketOptions, callback?: (msg: Buffer, rinfo: RemoteInfo) => void): Socket;
 
-    export class Socket extends events.EventEmitter {
+    class Socket extends events.EventEmitter {
         send(msg: Buffer | string | Uint8Array | any[], port: number, address?: string, callback?: (error: Error | null, bytes: number) => void): void;
         send(msg: Buffer | string | Uint8Array, offset: number, length: number, port: number, address?: string, callback?: (error: Error | null, bytes: number) => void): void;
         bind(port?: number, address?: string, callback?: () => void): void;
@@ -3262,10 +3306,10 @@ declare module "fs" {
     /**
      * Valid types for path values in "fs".
      */
-    export type PathLike = string | Buffer | URL;
+    type PathLike = string | Buffer | URL;
 
-    export type BinaryData = Buffer | DataView | NodeJS.TypedArray;
-    export class Stats {
+    type BinaryData = Buffer | DataView | NodeJS.TypedArray;
+    class Stats {
         isFile(): boolean;
         isDirectory(): boolean;
         isBlockDevice(): boolean;
@@ -3293,7 +3337,7 @@ declare module "fs" {
         birthtime: Date;
     }
 
-    export class Dirent {
+    class Dirent {
         isFile(): boolean;
         isDirectory(): boolean;
         isBlockDevice(): boolean;
@@ -3304,7 +3348,7 @@ declare module "fs" {
         name: string;
     }
 
-    export interface FSWatcher extends events.EventEmitter {
+    interface FSWatcher extends events.EventEmitter {
         close(): void;
 
         /**
@@ -3333,7 +3377,7 @@ declare module "fs" {
         prependOnceListener(event: "error", listener: (error: Error) => void): this;
     }
 
-    export class ReadStream extends stream.Readable {
+    class ReadStream extends stream.Readable {
         close(): void;
         bytesRead: number;
         path: string | Buffer;
@@ -3364,7 +3408,7 @@ declare module "fs" {
         prependOnceListener(event: "close", listener: () => void): this;
     }
 
-    export class WriteStream extends stream.Writable {
+    class WriteStream extends stream.Writable {
         close(): void;
         bytesWritten: number;
         path: string | Buffer;
@@ -3402,10 +3446,10 @@ declare module "fs" {
      * @param newPath A path to a file. If a URL is provided, it must use the `file:` protocol.
      * URL support is _experimental_.
      */
-    export function rename(oldPath: PathLike, newPath: PathLike, callback: (err: NodeJS.ErrnoException) => void): void;
+    function rename(oldPath: PathLike, newPath: PathLike, callback: (err: NodeJS.ErrnoException) => void): void;
 
     // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
-    export namespace rename {
+    namespace rename {
         /**
          * Asynchronous rename(2) - Change the name or location of a file or directory.
          * @param oldPath A path to a file. If a URL is provided, it must use the `file:` protocol.
@@ -3413,7 +3457,7 @@ declare module "fs" {
          * @param newPath A path to a file. If a URL is provided, it must use the `file:` protocol.
          * URL support is _experimental_.
          */
-        export function __promisify__(oldPath: PathLike, newPath: PathLike): Promise<void>;
+        function __promisify__(oldPath: PathLike, newPath: PathLike): Promise<void>;
     }
 
     /**
@@ -3423,30 +3467,30 @@ declare module "fs" {
      * @param newPath A path to a file. If a URL is provided, it must use the `file:` protocol.
      * URL support is _experimental_.
      */
-    export function renameSync(oldPath: PathLike, newPath: PathLike): void;
+    function renameSync(oldPath: PathLike, newPath: PathLike): void;
 
     /**
      * Asynchronous truncate(2) - Truncate a file to a specified length.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      * @param len If not specified, defaults to `0`.
      */
-    export function truncate(path: PathLike, len: number | undefined | null, callback: (err: NodeJS.ErrnoException) => void): void;
+    function truncate(path: PathLike, len: number | undefined | null, callback: (err: NodeJS.ErrnoException) => void): void;
 
     /**
      * Asynchronous truncate(2) - Truncate a file to a specified length.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      * URL support is _experimental_.
      */
-    export function truncate(path: PathLike, callback: (err: NodeJS.ErrnoException) => void): void;
+    function truncate(path: PathLike, callback: (err: NodeJS.ErrnoException) => void): void;
 
     // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
-    export namespace truncate {
+    namespace truncate {
         /**
          * Asynchronous truncate(2) - Truncate a file to a specified length.
          * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
          * @param len If not specified, defaults to `0`.
          */
-        export function __promisify__(path: PathLike, len?: number | null): Promise<void>;
+        function __promisify__(path: PathLike, len?: number | null): Promise<void>;
     }
 
     /**
@@ -3454,29 +3498,29 @@ declare module "fs" {
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      * @param len If not specified, defaults to `0`.
      */
-    export function truncateSync(path: PathLike, len?: number | null): void;
+    function truncateSync(path: PathLike, len?: number | null): void;
 
     /**
      * Asynchronous ftruncate(2) - Truncate a file to a specified length.
      * @param fd A file descriptor.
      * @param len If not specified, defaults to `0`.
      */
-    export function ftruncate(fd: number, len: number | undefined | null, callback: (err: NodeJS.ErrnoException) => void): void;
+    function ftruncate(fd: number, len: number | undefined | null, callback: (err: NodeJS.ErrnoException) => void): void;
 
     /**
      * Asynchronous ftruncate(2) - Truncate a file to a specified length.
      * @param fd A file descriptor.
      */
-    export function ftruncate(fd: number, callback: (err: NodeJS.ErrnoException) => void): void;
+    function ftruncate(fd: number, callback: (err: NodeJS.ErrnoException) => void): void;
 
     // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
-    export namespace ftruncate {
+    namespace ftruncate {
         /**
          * Asynchronous ftruncate(2) - Truncate a file to a specified length.
          * @param fd A file descriptor.
          * @param len If not specified, defaults to `0`.
          */
-        export function __promisify__(fd: number, len?: number | null): Promise<void>;
+        function __promisify__(fd: number, len?: number | null): Promise<void>;
     }
 
     /**
@@ -3484,86 +3528,86 @@ declare module "fs" {
      * @param fd A file descriptor.
      * @param len If not specified, defaults to `0`.
      */
-    export function ftruncateSync(fd: number, len?: number | null): void;
+    function ftruncateSync(fd: number, len?: number | null): void;
 
     /**
      * Asynchronous chown(2) - Change ownership of a file.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      */
-    export function chown(path: PathLike, uid: number, gid: number, callback: (err: NodeJS.ErrnoException) => void): void;
+    function chown(path: PathLike, uid: number, gid: number, callback: (err: NodeJS.ErrnoException) => void): void;
 
     // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
-    export namespace chown {
+    namespace chown {
         /**
          * Asynchronous chown(2) - Change ownership of a file.
          * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
          */
-        export function __promisify__(path: PathLike, uid: number, gid: number): Promise<void>;
+        function __promisify__(path: PathLike, uid: number, gid: number): Promise<void>;
     }
 
     /**
      * Synchronous chown(2) - Change ownership of a file.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      */
-    export function chownSync(path: PathLike, uid: number, gid: number): void;
+    function chownSync(path: PathLike, uid: number, gid: number): void;
 
     /**
      * Asynchronous fchown(2) - Change ownership of a file.
      * @param fd A file descriptor.
      */
-    export function fchown(fd: number, uid: number, gid: number, callback: (err: NodeJS.ErrnoException) => void): void;
+    function fchown(fd: number, uid: number, gid: number, callback: (err: NodeJS.ErrnoException) => void): void;
 
     // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
-    export namespace fchown {
+    namespace fchown {
         /**
          * Asynchronous fchown(2) - Change ownership of a file.
          * @param fd A file descriptor.
          */
-        export function __promisify__(fd: number, uid: number, gid: number): Promise<void>;
+        function __promisify__(fd: number, uid: number, gid: number): Promise<void>;
     }
 
     /**
      * Synchronous fchown(2) - Change ownership of a file.
      * @param fd A file descriptor.
      */
-    export function fchownSync(fd: number, uid: number, gid: number): void;
+    function fchownSync(fd: number, uid: number, gid: number): void;
 
     /**
      * Asynchronous lchown(2) - Change ownership of a file. Does not dereference symbolic links.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      */
-    export function lchown(path: PathLike, uid: number, gid: number, callback: (err: NodeJS.ErrnoException) => void): void;
+    function lchown(path: PathLike, uid: number, gid: number, callback: (err: NodeJS.ErrnoException) => void): void;
 
     // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
-    export namespace lchown {
+    namespace lchown {
         /**
          * Asynchronous lchown(2) - Change ownership of a file. Does not dereference symbolic links.
          * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
          */
-        export function __promisify__(path: PathLike, uid: number, gid: number): Promise<void>;
+        function __promisify__(path: PathLike, uid: number, gid: number): Promise<void>;
     }
 
     /**
      * Synchronous lchown(2) - Change ownership of a file. Does not dereference symbolic links.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      */
-    export function lchownSync(path: PathLike, uid: number, gid: number): void;
+    function lchownSync(path: PathLike, uid: number, gid: number): void;
 
     /**
      * Asynchronous chmod(2) - Change permissions of a file.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      * @param mode A file mode. If a string is passed, it is parsed as an octal integer.
      */
-    export function chmod(path: PathLike, mode: string | number, callback: (err: NodeJS.ErrnoException) => void): void;
+    function chmod(path: PathLike, mode: string | number, callback: (err: NodeJS.ErrnoException) => void): void;
 
     // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
-    export namespace chmod {
+    namespace chmod {
         /**
          * Asynchronous chmod(2) - Change permissions of a file.
          * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
          * @param mode A file mode. If a string is passed, it is parsed as an octal integer.
          */
-        export function __promisify__(path: PathLike, mode: string | number): Promise<void>;
+        function __promisify__(path: PathLike, mode: string | number): Promise<void>;
     }
 
     /**
@@ -3571,23 +3615,23 @@ declare module "fs" {
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      * @param mode A file mode. If a string is passed, it is parsed as an octal integer.
      */
-    export function chmodSync(path: PathLike, mode: string | number): void;
+    function chmodSync(path: PathLike, mode: string | number): void;
 
     /**
      * Asynchronous fchmod(2) - Change permissions of a file.
      * @param fd A file descriptor.
      * @param mode A file mode. If a string is passed, it is parsed as an octal integer.
      */
-    export function fchmod(fd: number, mode: string | number, callback: (err: NodeJS.ErrnoException) => void): void;
+    function fchmod(fd: number, mode: string | number, callback: (err: NodeJS.ErrnoException) => void): void;
 
     // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
-    export namespace fchmod {
+    namespace fchmod {
         /**
          * Asynchronous fchmod(2) - Change permissions of a file.
          * @param fd A file descriptor.
          * @param mode A file mode. If a string is passed, it is parsed as an octal integer.
          */
-        export function __promisify__(fd: number, mode: string | number): Promise<void>;
+        function __promisify__(fd: number, mode: string | number): Promise<void>;
     }
 
     /**
@@ -3595,23 +3639,23 @@ declare module "fs" {
      * @param fd A file descriptor.
      * @param mode A file mode. If a string is passed, it is parsed as an octal integer.
      */
-    export function fchmodSync(fd: number, mode: string | number): void;
+    function fchmodSync(fd: number, mode: string | number): void;
 
     /**
      * Asynchronous lchmod(2) - Change permissions of a file. Does not dereference symbolic links.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      * @param mode A file mode. If a string is passed, it is parsed as an octal integer.
      */
-    export function lchmod(path: PathLike, mode: string | number, callback: (err: NodeJS.ErrnoException) => void): void;
+    function lchmod(path: PathLike, mode: string | number, callback: (err: NodeJS.ErrnoException) => void): void;
 
     // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
-    export namespace lchmod {
+    namespace lchmod {
         /**
          * Asynchronous lchmod(2) - Change permissions of a file. Does not dereference symbolic links.
          * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
          * @param mode A file mode. If a string is passed, it is parsed as an octal integer.
          */
-        export function __promisify__(path: PathLike, mode: string | number): Promise<void>;
+        function __promisify__(path: PathLike, mode: string | number): Promise<void>;
     }
 
     /**
@@ -3619,86 +3663,86 @@ declare module "fs" {
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      * @param mode A file mode. If a string is passed, it is parsed as an octal integer.
      */
-    export function lchmodSync(path: PathLike, mode: string | number): void;
+    function lchmodSync(path: PathLike, mode: string | number): void;
 
     /**
      * Asynchronous stat(2) - Get file status.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      */
-    export function stat(path: PathLike, callback: (err: NodeJS.ErrnoException, stats: Stats) => void): void;
+    function stat(path: PathLike, callback: (err: NodeJS.ErrnoException, stats: Stats) => void): void;
 
     // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
-    export namespace stat {
+    namespace stat {
         /**
          * Asynchronous stat(2) - Get file status.
          * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
          */
-        export function __promisify__(path: PathLike): Promise<Stats>;
+        function __promisify__(path: PathLike): Promise<Stats>;
     }
 
     /**
      * Synchronous stat(2) - Get file status.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      */
-    export function statSync(path: PathLike): Stats;
+    function statSync(path: PathLike): Stats;
 
     /**
      * Asynchronous fstat(2) - Get file status.
      * @param fd A file descriptor.
      */
-    export function fstat(fd: number, callback: (err: NodeJS.ErrnoException, stats: Stats) => void): void;
+    function fstat(fd: number, callback: (err: NodeJS.ErrnoException, stats: Stats) => void): void;
 
     // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
-    export namespace fstat {
+    namespace fstat {
         /**
          * Asynchronous fstat(2) - Get file status.
          * @param fd A file descriptor.
          */
-        export function __promisify__(fd: number): Promise<Stats>;
+        function __promisify__(fd: number): Promise<Stats>;
     }
 
     /**
      * Synchronous fstat(2) - Get file status.
      * @param fd A file descriptor.
      */
-    export function fstatSync(fd: number): Stats;
+    function fstatSync(fd: number): Stats;
 
     /**
      * Asynchronous lstat(2) - Get file status. Does not dereference symbolic links.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      */
-    export function lstat(path: PathLike, callback: (err: NodeJS.ErrnoException, stats: Stats) => void): void;
+    function lstat(path: PathLike, callback: (err: NodeJS.ErrnoException, stats: Stats) => void): void;
 
     // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
-    export namespace lstat {
+    namespace lstat {
         /**
          * Asynchronous lstat(2) - Get file status. Does not dereference symbolic links.
          * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
          */
-        export function __promisify__(path: PathLike): Promise<Stats>;
+        function __promisify__(path: PathLike): Promise<Stats>;
     }
 
     /**
      * Synchronous lstat(2) - Get file status. Does not dereference symbolic links.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      */
-    export function lstatSync(path: PathLike): Stats;
+    function lstatSync(path: PathLike): Stats;
 
     /**
      * Asynchronous link(2) - Create a new link (also known as a hard link) to an existing file.
      * @param existingPath A path to a file. If a URL is provided, it must use the `file:` protocol.
      * @param newPath A path to a file. If a URL is provided, it must use the `file:` protocol.
      */
-    export function link(existingPath: PathLike, newPath: PathLike, callback: (err: NodeJS.ErrnoException) => void): void;
+    function link(existingPath: PathLike, newPath: PathLike, callback: (err: NodeJS.ErrnoException) => void): void;
 
     // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
-    export namespace link {
+    namespace link {
         /**
          * Asynchronous link(2) - Create a new link (also known as a hard link) to an existing file.
          * @param existingPath A path to a file. If a URL is provided, it must use the `file:` protocol.
          * @param newPath A path to a file. If a URL is provided, it must use the `file:` protocol.
          */
-        export function link(existingPath: PathLike, newPath: PathLike): Promise<void>;
+        function link(existingPath: PathLike, newPath: PathLike): Promise<void>;
     }
 
     /**
@@ -3706,7 +3750,7 @@ declare module "fs" {
      * @param existingPath A path to a file. If a URL is provided, it must use the `file:` protocol.
      * @param newPath A path to a file. If a URL is provided, it must use the `file:` protocol.
      */
-    export function linkSync(existingPath: PathLike, newPath: PathLike): void;
+    function linkSync(existingPath: PathLike, newPath: PathLike): void;
 
     /**
      * Asynchronous symlink(2) - Create a new symbolic link to an existing file.
@@ -3715,17 +3759,17 @@ declare module "fs" {
      * @param type May be set to `'dir'`, `'file'`, or `'junction'` (default is `'file'`) and is only available on Windows (ignored on other platforms).
      * When using `'junction'`, the `target` argument will automatically be normalized to an absolute path.
      */
-    export function symlink(target: PathLike, path: PathLike, type: symlink.Type | undefined | null, callback: (err: NodeJS.ErrnoException) => void): void;
+    function symlink(target: PathLike, path: PathLike, type: symlink.Type | undefined | null, callback: (err: NodeJS.ErrnoException) => void): void;
 
     /**
      * Asynchronous symlink(2) - Create a new symbolic link to an existing file.
      * @param target A path to an existing file. If a URL is provided, it must use the `file:` protocol.
      * @param path A path to the new symlink. If a URL is provided, it must use the `file:` protocol.
      */
-    export function symlink(target: PathLike, path: PathLike, callback: (err: NodeJS.ErrnoException) => void): void;
+    function symlink(target: PathLike, path: PathLike, callback: (err: NodeJS.ErrnoException) => void): void;
 
     // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
-    export namespace symlink {
+    namespace symlink {
         /**
          * Asynchronous symlink(2) - Create a new symbolic link to an existing file.
          * @param target A path to an existing file. If a URL is provided, it must use the `file:` protocol.
@@ -3733,9 +3777,9 @@ declare module "fs" {
          * @param type May be set to `'dir'`, `'file'`, or `'junction'` (default is `'file'`) and is only available on Windows (ignored on other platforms).
          * When using `'junction'`, the `target` argument will automatically be normalized to an absolute path.
          */
-        export function __promisify__(target: PathLike, path: PathLike, type?: string | null): Promise<void>;
+        function __promisify__(target: PathLike, path: PathLike, type?: string | null): Promise<void>;
 
-        export type Type = "dir" | "file" | "junction";
+        type Type = "dir" | "file" | "junction";
     }
 
     /**
@@ -3745,57 +3789,57 @@ declare module "fs" {
      * @param type May be set to `'dir'`, `'file'`, or `'junction'` (default is `'file'`) and is only available on Windows (ignored on other platforms).
      * When using `'junction'`, the `target` argument will automatically be normalized to an absolute path.
      */
-    export function symlinkSync(target: PathLike, path: PathLike, type?: symlink.Type | null): void;
+    function symlinkSync(target: PathLike, path: PathLike, type?: symlink.Type | null): void;
 
     /**
      * Asynchronous readlink(2) - read value of a symbolic link.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
      */
-    export function readlink(path: PathLike, options: { encoding?: BufferEncoding | null } | BufferEncoding | undefined | null, callback: (err: NodeJS.ErrnoException, linkString: string) => void): void;
+    function readlink(path: PathLike, options: { encoding?: BufferEncoding | null } | BufferEncoding | undefined | null, callback: (err: NodeJS.ErrnoException, linkString: string) => void): void;
 
     /**
      * Asynchronous readlink(2) - read value of a symbolic link.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
      */
-    export function readlink(path: PathLike, options: { encoding: "buffer" } | "buffer", callback: (err: NodeJS.ErrnoException, linkString: Buffer) => void): void;
+    function readlink(path: PathLike, options: { encoding: "buffer" } | "buffer", callback: (err: NodeJS.ErrnoException, linkString: Buffer) => void): void;
 
     /**
      * Asynchronous readlink(2) - read value of a symbolic link.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
      */
-    export function readlink(path: PathLike, options: { encoding?: string | null } | string | undefined | null, callback: (err: NodeJS.ErrnoException, linkString: string | Buffer) => void): void;
+    function readlink(path: PathLike, options: { encoding?: string | null } | string | undefined | null, callback: (err: NodeJS.ErrnoException, linkString: string | Buffer) => void): void;
 
     /**
      * Asynchronous readlink(2) - read value of a symbolic link.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      */
-    export function readlink(path: PathLike, callback: (err: NodeJS.ErrnoException, linkString: string) => void): void;
+    function readlink(path: PathLike, callback: (err: NodeJS.ErrnoException, linkString: string) => void): void;
 
     // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
-    export namespace readlink {
+    namespace readlink {
         /**
          * Asynchronous readlink(2) - read value of a symbolic link.
          * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
          * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
          */
-        export function __promisify__(path: PathLike, options?: { encoding?: BufferEncoding | null } | BufferEncoding | null): Promise<string>;
+        function __promisify__(path: PathLike, options?: { encoding?: BufferEncoding | null } | BufferEncoding | null): Promise<string>;
 
         /**
          * Asynchronous readlink(2) - read value of a symbolic link.
          * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
          * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
          */
-        export function __promisify__(path: PathLike, options: { encoding: "buffer" } | "buffer"): Promise<Buffer>;
+        function __promisify__(path: PathLike, options: { encoding: "buffer" } | "buffer"): Promise<Buffer>;
 
         /**
          * Asynchronous readlink(2) - read value of a symbolic link.
          * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
          * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
          */
-        export function __promisify__(path: PathLike, options?: { encoding?: string | null } | string | null): Promise<string | Buffer>;
+        function __promisify__(path: PathLike, options?: { encoding?: string | null } | string | null): Promise<string | Buffer>;
     }
 
     /**
@@ -3803,76 +3847,76 @@ declare module "fs" {
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
      */
-    export function readlinkSync(path: PathLike, options?: { encoding?: BufferEncoding | null } | BufferEncoding | null): string;
+    function readlinkSync(path: PathLike, options?: { encoding?: BufferEncoding | null } | BufferEncoding | null): string;
 
     /**
      * Synchronous readlink(2) - read value of a symbolic link.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
      */
-    export function readlinkSync(path: PathLike, options: { encoding: "buffer" } | "buffer"): Buffer;
+    function readlinkSync(path: PathLike, options: { encoding: "buffer" } | "buffer"): Buffer;
 
     /**
      * Synchronous readlink(2) - read value of a symbolic link.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
      */
-    export function readlinkSync(path: PathLike, options?: { encoding?: string | null } | string | null): string | Buffer;
+    function readlinkSync(path: PathLike, options?: { encoding?: string | null } | string | null): string | Buffer;
 
     /**
      * Asynchronous realpath(3) - return the canonicalized absolute pathname.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
      */
-    export function realpath(path: PathLike, options: { encoding?: BufferEncoding | null } | BufferEncoding | undefined | null, callback: (err: NodeJS.ErrnoException, resolvedPath: string) => void): void;
+    function realpath(path: PathLike, options: { encoding?: BufferEncoding | null } | BufferEncoding | undefined | null, callback: (err: NodeJS.ErrnoException, resolvedPath: string) => void): void;
 
     /**
      * Asynchronous realpath(3) - return the canonicalized absolute pathname.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
      */
-    export function realpath(path: PathLike, options: { encoding: "buffer" } | "buffer", callback: (err: NodeJS.ErrnoException, resolvedPath: Buffer) => void): void;
+    function realpath(path: PathLike, options: { encoding: "buffer" } | "buffer", callback: (err: NodeJS.ErrnoException, resolvedPath: Buffer) => void): void;
 
     /**
      * Asynchronous realpath(3) - return the canonicalized absolute pathname.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
      */
-    export function realpath(path: PathLike, options: { encoding?: string | null } | string | undefined | null, callback: (err: NodeJS.ErrnoException, resolvedPath: string | Buffer) => void): void;
+    function realpath(path: PathLike, options: { encoding?: string | null } | string | undefined | null, callback: (err: NodeJS.ErrnoException, resolvedPath: string | Buffer) => void): void;
 
     /**
      * Asynchronous realpath(3) - return the canonicalized absolute pathname.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      */
-    export function realpath(path: PathLike, callback: (err: NodeJS.ErrnoException, resolvedPath: string) => void): void;
+    function realpath(path: PathLike, callback: (err: NodeJS.ErrnoException, resolvedPath: string) => void): void;
 
     // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
-    export namespace realpath {
+    namespace realpath {
         /**
          * Asynchronous realpath(3) - return the canonicalized absolute pathname.
          * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
          * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
          */
-        export function __promisify__(path: PathLike, options?: { encoding?: BufferEncoding | null } | BufferEncoding | null): Promise<string>;
+        function __promisify__(path: PathLike, options?: { encoding?: BufferEncoding | null } | BufferEncoding | null): Promise<string>;
 
         /**
          * Asynchronous realpath(3) - return the canonicalized absolute pathname.
          * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
          * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
          */
-        export function __promisify__(path: PathLike, options: { encoding: "buffer" } | "buffer"): Promise<Buffer>;
+        function __promisify__(path: PathLike, options: { encoding: "buffer" } | "buffer"): Promise<Buffer>;
 
         /**
          * Asynchronous realpath(3) - return the canonicalized absolute pathname.
          * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
          * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
          */
-        export function __promisify__(path: PathLike, options?: { encoding?: string | null } | string | null): Promise<string | Buffer>;
+        function __promisify__(path: PathLike, options?: { encoding?: string | null } | string | null): Promise<string | Buffer>;
 
-        export function native(path: PathLike, options: { encoding?: BufferEncoding | null } | BufferEncoding | undefined | null, callback: (err: NodeJS.ErrnoException, resolvedPath: string) => void): void;
-        export function native(path: PathLike, options: { encoding: "buffer" } | "buffer", callback: (err: NodeJS.ErrnoException, resolvedPath: Buffer) => void): void;
-        export function native(path: PathLike, options: { encoding?: string | null } | string | undefined | null, callback: (err: NodeJS.ErrnoException, resolvedPath: string | Buffer) => void): void;
-        export function native(path: PathLike, callback: (err: NodeJS.ErrnoException, resolvedPath: string) => void): void;
+        function native(path: PathLike, options: { encoding?: BufferEncoding | null } | BufferEncoding | undefined | null, callback: (err: NodeJS.ErrnoException, resolvedPath: string) => void): void;
+        function native(path: PathLike, options: { encoding: "buffer" } | "buffer", callback: (err: NodeJS.ErrnoException, resolvedPath: Buffer) => void): void;
+        function native(path: PathLike, options: { encoding?: string | null } | string | undefined | null, callback: (err: NodeJS.ErrnoException, resolvedPath: string | Buffer) => void): void;
+        function native(path: PathLike, callback: (err: NodeJS.ErrnoException, resolvedPath: string) => void): void;
     }
 
     /**
@@ -3880,91 +3924,91 @@ declare module "fs" {
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
      */
-    export function realpathSync(path: PathLike, options?: { encoding?: BufferEncoding | null } | BufferEncoding | null): string;
+    function realpathSync(path: PathLike, options?: { encoding?: BufferEncoding | null } | BufferEncoding | null): string;
 
     /**
      * Synchronous realpath(3) - return the canonicalized absolute pathname.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
      */
-    export function realpathSync(path: PathLike, options: { encoding: "buffer" } | "buffer"): Buffer;
+    function realpathSync(path: PathLike, options: { encoding: "buffer" } | "buffer"): Buffer;
 
     /**
      * Synchronous realpath(3) - return the canonicalized absolute pathname.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
      */
-    export function realpathSync(path: PathLike, options?: { encoding?: string | null } | string | null): string | Buffer;
+    function realpathSync(path: PathLike, options?: { encoding?: string | null } | string | null): string | Buffer;
 
-    export namespace realpathSync {
-        export function native(path: PathLike, options?: { encoding?: BufferEncoding | null } | BufferEncoding | null): string;
-        export function native(path: PathLike, options: { encoding: "buffer" } | "buffer"): Buffer;
-        export function native(path: PathLike, options?: { encoding?: string | null } | string | null): string | Buffer;
+    namespace realpathSync {
+        function native(path: PathLike, options?: { encoding?: BufferEncoding | null } | BufferEncoding | null): string;
+        function native(path: PathLike, options: { encoding: "buffer" } | "buffer"): Buffer;
+        function native(path: PathLike, options?: { encoding?: string | null } | string | null): string | Buffer;
     }
 
     /**
      * Asynchronous unlink(2) - delete a name and possibly the file it refers to.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      */
-    export function unlink(path: PathLike, callback: (err: NodeJS.ErrnoException) => void): void;
+    function unlink(path: PathLike, callback: (err: NodeJS.ErrnoException) => void): void;
 
     // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
-    export namespace unlink {
+    namespace unlink {
         /**
          * Asynchronous unlink(2) - delete a name and possibly the file it refers to.
          * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
          */
-        export function __promisify__(path: PathLike): Promise<void>;
+        function __promisify__(path: PathLike): Promise<void>;
     }
 
     /**
      * Synchronous unlink(2) - delete a name and possibly the file it refers to.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      */
-    export function unlinkSync(path: PathLike): void;
+    function unlinkSync(path: PathLike): void;
 
     /**
      * Asynchronous rmdir(2) - delete a directory.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      */
-    export function rmdir(path: PathLike, callback: (err: NodeJS.ErrnoException) => void): void;
+    function rmdir(path: PathLike, callback: (err: NodeJS.ErrnoException) => void): void;
 
     // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
-    export namespace rmdir {
+    namespace rmdir {
         /**
          * Asynchronous rmdir(2) - delete a directory.
          * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
          */
-        export function __promisify__(path: PathLike): Promise<void>;
+        function __promisify__(path: PathLike): Promise<void>;
     }
 
     /**
      * Synchronous rmdir(2) - delete a directory.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      */
-    export function rmdirSync(path: PathLike): void;
+    function rmdirSync(path: PathLike): void;
 
     /**
      * Asynchronous mkdir(2) - create a directory.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      * @param mode A file mode. If a string is passed, it is parsed as an octal integer. If not specified, defaults to `0o777`.
      */
-    export function mkdir(path: PathLike, mode: number | string | undefined | null, callback: (err: NodeJS.ErrnoException) => void): void;
+    function mkdir(path: PathLike, mode: number | string | undefined | null, callback: (err: NodeJS.ErrnoException) => void): void;
 
     /**
      * Asynchronous mkdir(2) - create a directory with a mode of `0o777`.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      */
-    export function mkdir(path: PathLike, callback: (err: NodeJS.ErrnoException) => void): void;
+    function mkdir(path: PathLike, callback: (err: NodeJS.ErrnoException) => void): void;
 
     // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
-    export namespace mkdir {
+    namespace mkdir {
         /**
          * Asynchronous mkdir(2) - create a directory.
          * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
          * @param mode A file mode. If a string is passed, it is parsed as an octal integer. If not specified, defaults to `0o777`.
          */
-        export function __promisify__(path: PathLike, mode?: number | string | null): Promise<void>;
+        function __promisify__(path: PathLike, mode?: number | string | null): Promise<void>;
     }
 
     /**
@@ -3972,57 +4016,57 @@ declare module "fs" {
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      * @param mode A file mode. If a string is passed, it is parsed as an octal integer. If not specified, defaults to `0o777`.
      */
-    export function mkdirSync(path: PathLike, mode?: number | string | null): void;
+    function mkdirSync(path: PathLike, mode?: number | string | null): void;
 
     /**
      * Asynchronously creates a unique temporary directory.
      * Generates six random characters to be appended behind a required prefix to create a unique temporary directory.
      * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
      */
-    export function mkdtemp(prefix: string, options: { encoding?: BufferEncoding | null } | BufferEncoding | undefined | null, callback: (err: NodeJS.ErrnoException, folder: string) => void): void;
+    function mkdtemp(prefix: string, options: { encoding?: BufferEncoding | null } | BufferEncoding | undefined | null, callback: (err: NodeJS.ErrnoException, folder: string) => void): void;
 
     /**
      * Asynchronously creates a unique temporary directory.
      * Generates six random characters to be appended behind a required prefix to create a unique temporary directory.
      * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
      */
-    export function mkdtemp(prefix: string, options: "buffer" | { encoding: "buffer" }, callback: (err: NodeJS.ErrnoException, folder: Buffer) => void): void;
+    function mkdtemp(prefix: string, options: "buffer" | { encoding: "buffer" }, callback: (err: NodeJS.ErrnoException, folder: Buffer) => void): void;
 
     /**
      * Asynchronously creates a unique temporary directory.
      * Generates six random characters to be appended behind a required prefix to create a unique temporary directory.
      * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
      */
-    export function mkdtemp(prefix: string, options: { encoding?: string | null } | string | undefined | null, callback: (err: NodeJS.ErrnoException, folder: string | Buffer) => void): void;
+    function mkdtemp(prefix: string, options: { encoding?: string | null } | string | undefined | null, callback: (err: NodeJS.ErrnoException, folder: string | Buffer) => void): void;
 
     /**
      * Asynchronously creates a unique temporary directory.
      * Generates six random characters to be appended behind a required prefix to create a unique temporary directory.
      */
-    export function mkdtemp(prefix: string, callback: (err: NodeJS.ErrnoException, folder: string) => void): void;
+    function mkdtemp(prefix: string, callback: (err: NodeJS.ErrnoException, folder: string) => void): void;
 
     // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
-    export namespace mkdtemp {
+    namespace mkdtemp {
         /**
          * Asynchronously creates a unique temporary directory.
          * Generates six random characters to be appended behind a required prefix to create a unique temporary directory.
          * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
          */
-        export function __promisify__(prefix: string, options?: { encoding?: BufferEncoding | null } | BufferEncoding | null): Promise<string>;
+        function __promisify__(prefix: string, options?: { encoding?: BufferEncoding | null } | BufferEncoding | null): Promise<string>;
 
         /**
          * Asynchronously creates a unique temporary directory.
          * Generates six random characters to be appended behind a required prefix to create a unique temporary directory.
          * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
          */
-        export function __promisify__(prefix: string, options: { encoding: "buffer" } | "buffer"): Promise<Buffer>;
+        function __promisify__(prefix: string, options: { encoding: "buffer" } | "buffer"): Promise<Buffer>;
 
         /**
          * Asynchronously creates a unique temporary directory.
          * Generates six random characters to be appended behind a required prefix to create a unique temporary directory.
          * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
          */
-        export function __promisify__(prefix: string, options?: { encoding?: string | null } | string | null): Promise<string | Buffer>;
+        function __promisify__(prefix: string, options?: { encoding?: string | null } | string | null): Promise<string | Buffer>;
     }
 
     /**
@@ -4030,85 +4074,93 @@ declare module "fs" {
      * Generates six random characters to be appended behind a required prefix to create a unique temporary directory.
      * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
      */
-    export function mkdtempSync(prefix: string, options?: { encoding?: BufferEncoding | null } | BufferEncoding | null): string;
+    function mkdtempSync(prefix: string, options?: { encoding?: BufferEncoding | null } | BufferEncoding | null): string;
 
     /**
      * Synchronously creates a unique temporary directory.
      * Generates six random characters to be appended behind a required prefix to create a unique temporary directory.
      * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
      */
-    export function mkdtempSync(prefix: string, options: { encoding: "buffer" } | "buffer"): Buffer;
+    function mkdtempSync(prefix: string, options: { encoding: "buffer" } | "buffer"): Buffer;
 
     /**
      * Synchronously creates a unique temporary directory.
      * Generates six random characters to be appended behind a required prefix to create a unique temporary directory.
      * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
      */
-    export function mkdtempSync(prefix: string, options?: { encoding?: string | null } | string | null): string | Buffer;
+    function mkdtempSync(prefix: string, options?: { encoding?: string | null } | string | null): string | Buffer;
 
     /**
      * Asynchronous readdir(3) - read a directory.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
      */
-    export function readdir(path: PathLike, options: { encoding: BufferEncoding | null; withFileTypes?: false } | BufferEncoding | undefined | null, callback: (err: NodeJS.ErrnoException, files: string[]) => void): void;
+    function readdir(
+        path: PathLike,
+        options: { encoding: BufferEncoding | null; withFileTypes?: false } | BufferEncoding | undefined | null,
+        callback: (err: NodeJS.ErrnoException, files: string[]) => void,
+    ): void;
 
     /**
      * Asynchronous readdir(3) - read a directory.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
      */
-    export function readdir(path: PathLike, options: { encoding: "buffer"; withFileTypes?: false } | "buffer", callback: (err: NodeJS.ErrnoException, files: Buffer[]) => void): void;
+    function readdir(path: PathLike, options: { encoding: "buffer"; withFileTypes?: false } | "buffer", callback: (err: NodeJS.ErrnoException, files: Buffer[]) => void): void;
 
     /**
      * Asynchronous readdir(3) - read a directory.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
      */
-    export function readdir(path: PathLike, options: { encoding?: string | null; withFileTypes?: false } | string | undefined | null, callback: (err: NodeJS.ErrnoException, files: string[] | Buffer[]) => void): void;
+    function readdir(
+        path: PathLike,
+        options: { encoding?: string | null; withFileTypes?: false } | string | undefined | null,
+        callback: (err: NodeJS.ErrnoException, files: string[] | Buffer[]) => void,
+    ): void;
 
     /**
      * Asynchronous readdir(3) - read a directory.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      */
-    export function readdir(path: PathLike, callback: (err: NodeJS.ErrnoException, files: string[]) => void): void;
+    function readdir(path: PathLike, callback: (err: NodeJS.ErrnoException, files: string[]) => void): void;
 
     /**
      * Asynchronous readdir(3) - read a directory.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      * @param options If called with `withFileTypes: true` the result data will be an array of Dirent.
      */
-    export function readdir(path: PathLike, options: { withFileTypes: true }, callback: (err: NodeJS.ErrnoException, files: Dirent[]) => void): void;
+    function readdir(path: PathLike, options: { withFileTypes: true }, callback: (err: NodeJS.ErrnoException, files: Dirent[]) => void): void;
 
     // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
-    export namespace readdir {
+    namespace readdir {
         /**
          * Asynchronous readdir(3) - read a directory.
          * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
          * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
          */
-        export function __promisify__(path: PathLike, options?: { encoding: BufferEncoding | null; withFileTypes?: false } | BufferEncoding | null): Promise<string[]>;
+        function __promisify__(path: PathLike, options?: { encoding: BufferEncoding | null; withFileTypes?: false } | BufferEncoding | null): Promise<string[]>;
 
         /**
          * Asynchronous readdir(3) - read a directory.
          * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
          * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
          */
-        export function __promisify__(path: PathLike, options: "buffer" | { encoding: "buffer"; withFileTypes?: false }): Promise<Buffer[]>;
+        function __promisify__(path: PathLike, options: "buffer" | { encoding: "buffer"; withFileTypes?: false }): Promise<Buffer[]>;
 
         /**
          * Asynchronous readdir(3) - read a directory.
          * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
          * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
          */
-        export function __promisify__(path: PathLike, options?: { encoding?: string | null; withFileTypes?: false } | string | null): Promise<string[] | Buffer[]>;
+        function __promisify__(path: PathLike, options?: { encoding?: string | null; withFileTypes?: false } | string | null): Promise<string[] | Buffer[]>;
 
         /**
          * Asynchronous readdir(3) - read a directory.
          * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
          * @param options If called with `withFileTypes: true` the result data will be an array of Dirent
          */
-        export function __promisify__(path: PathLike, options: { withFileTypes: true }): Promise<Dirent[]>;
+        function __promisify__(path: PathLike, options: { withFileTypes: true }): Promise<Dirent[]>;
     }
 
     /**
@@ -4116,71 +4168,71 @@ declare module "fs" {
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
      */
-    export function readdirSync(path: PathLike, options?: { encoding: BufferEncoding | null; withFileTypes?: false } | BufferEncoding | null): string[];
+    function readdirSync(path: PathLike, options?: { encoding: BufferEncoding | null; withFileTypes?: false } | BufferEncoding | null): string[];
 
     /**
      * Synchronous readdir(3) - read a directory.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
      */
-    export function readdirSync(path: PathLike, options: { encoding: "buffer"; withFileTypes?: false } | "buffer"): Buffer[];
+    function readdirSync(path: PathLike, options: { encoding: "buffer"; withFileTypes?: false } | "buffer"): Buffer[];
 
     /**
      * Synchronous readdir(3) - read a directory.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
      */
-    export function readdirSync(path: PathLike, options?: { encoding?: string | null; withFileTypes?: false } | string | null): string[] | Buffer[];
+    function readdirSync(path: PathLike, options?: { encoding?: string | null; withFileTypes?: false } | string | null): string[] | Buffer[];
 
     /**
      * Asynchronous readdir(3) - read a directory.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      * @param options If called with `withFileTypes: true` the result data will be an array of Dirent.
      */
-    export function readdirSync(path: PathLike, options: { withFileTypes: true }): Dirent[];
+    function readdirSync(path: PathLike, options: { withFileTypes: true }): Dirent[];
 
     /**
      * Asynchronous close(2) - close a file descriptor.
      * @param fd A file descriptor.
      */
-    export function close(fd: number, callback: (err: NodeJS.ErrnoException) => void): void;
+    function close(fd: number, callback: (err: NodeJS.ErrnoException) => void): void;
 
     // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
-    export namespace close {
+    namespace close {
         /**
          * Asynchronous close(2) - close a file descriptor.
          * @param fd A file descriptor.
          */
-        export function __promisify__(fd: number): Promise<void>;
+        function __promisify__(fd: number): Promise<void>;
     }
 
     /**
      * Synchronous close(2) - close a file descriptor.
      * @param fd A file descriptor.
      */
-    export function closeSync(fd: number): void;
+    function closeSync(fd: number): void;
 
     /**
      * Asynchronous open(2) - open and possibly create a file.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      * @param mode A file mode. If a string is passed, it is parsed as an octal integer. If not supplied, defaults to `0o666`.
      */
-    export function open(path: PathLike, flags: string | number, mode: string | number | undefined | null, callback: (err: NodeJS.ErrnoException, fd: number) => void): void;
+    function open(path: PathLike, flags: string | number, mode: string | number | undefined | null, callback: (err: NodeJS.ErrnoException, fd: number) => void): void;
 
     /**
      * Asynchronous open(2) - open and possibly create a file. If the file is created, its mode will be `0o666`.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      */
-    export function open(path: PathLike, flags: string | number, callback: (err: NodeJS.ErrnoException, fd: number) => void): void;
+    function open(path: PathLike, flags: string | number, callback: (err: NodeJS.ErrnoException, fd: number) => void): void;
 
     // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
-    export namespace open {
+    namespace open {
         /**
          * Asynchronous open(2) - open and possibly create a file.
          * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
          * @param mode A file mode. If a string is passed, it is parsed as an octal integer. If not supplied, defaults to `0o666`.
          */
-        export function __promisify__(path: PathLike, flags: string | number, mode?: string | number | null): Promise<number>;
+        function __promisify__(path: PathLike, flags: string | number, mode?: string | number | null): Promise<number>;
     }
 
     /**
@@ -4188,7 +4240,7 @@ declare module "fs" {
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      * @param mode A file mode. If a string is passed, it is parsed as an octal integer. If not supplied, defaults to `0o666`.
      */
-    export function openSync(path: PathLike, flags: string | number, mode?: string | number | null): number;
+    function openSync(path: PathLike, flags: string | number, mode?: string | number | null): number;
 
     /**
      * Asynchronously change file timestamps of the file referenced by the supplied path.
@@ -4196,17 +4248,17 @@ declare module "fs" {
      * @param atime The last access time. If a string is provided, it will be coerced to number.
      * @param mtime The last modified time. If a string is provided, it will be coerced to number.
      */
-    export function utimes(path: PathLike, atime: string | number | Date, mtime: string | number | Date, callback: (err: NodeJS.ErrnoException) => void): void;
+    function utimes(path: PathLike, atime: string | number | Date, mtime: string | number | Date, callback: (err: NodeJS.ErrnoException) => void): void;
 
     // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
-    export namespace utimes {
+    namespace utimes {
         /**
          * Asynchronously change file timestamps of the file referenced by the supplied path.
          * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
          * @param atime The last access time. If a string is provided, it will be coerced to number.
          * @param mtime The last modified time. If a string is provided, it will be coerced to number.
          */
-        export function __promisify__(path: PathLike, atime: string | number | Date, mtime: string | number | Date): Promise<void>;
+        function __promisify__(path: PathLike, atime: string | number | Date, mtime: string | number | Date): Promise<void>;
     }
 
     /**
@@ -4215,7 +4267,7 @@ declare module "fs" {
      * @param atime The last access time. If a string is provided, it will be coerced to number.
      * @param mtime The last modified time. If a string is provided, it will be coerced to number.
      */
-    export function utimesSync(path: PathLike, atime: string | number | Date, mtime: string | number | Date): void;
+    function utimesSync(path: PathLike, atime: string | number | Date, mtime: string | number | Date): void;
 
     /**
      * Asynchronously change file timestamps of the file referenced by the supplied file descriptor.
@@ -4223,17 +4275,17 @@ declare module "fs" {
      * @param atime The last access time. If a string is provided, it will be coerced to number.
      * @param mtime The last modified time. If a string is provided, it will be coerced to number.
      */
-    export function futimes(fd: number, atime: string | number | Date, mtime: string | number | Date, callback: (err: NodeJS.ErrnoException) => void): void;
+    function futimes(fd: number, atime: string | number | Date, mtime: string | number | Date, callback: (err: NodeJS.ErrnoException) => void): void;
 
     // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
-    export namespace futimes {
+    namespace futimes {
         /**
          * Asynchronously change file timestamps of the file referenced by the supplied file descriptor.
          * @param fd A file descriptor.
          * @param atime The last access time. If a string is provided, it will be coerced to number.
          * @param mtime The last modified time. If a string is provided, it will be coerced to number.
          */
-        export function __promisify__(fd: number, atime: string | number | Date, mtime: string | number | Date): Promise<void>;
+        function __promisify__(fd: number, atime: string | number | Date, mtime: string | number | Date): Promise<void>;
     }
 
     /**
@@ -4242,28 +4294,28 @@ declare module "fs" {
      * @param atime The last access time. If a string is provided, it will be coerced to number.
      * @param mtime The last modified time. If a string is provided, it will be coerced to number.
      */
-    export function futimesSync(fd: number, atime: string | number | Date, mtime: string | number | Date): void;
+    function futimesSync(fd: number, atime: string | number | Date, mtime: string | number | Date): void;
 
     /**
      * Asynchronous fsync(2) - synchronize a file's in-core state with the underlying storage device.
      * @param fd A file descriptor.
      */
-    export function fsync(fd: number, callback: (err: NodeJS.ErrnoException) => void): void;
+    function fsync(fd: number, callback: (err: NodeJS.ErrnoException) => void): void;
 
     // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
-    export namespace fsync {
+    namespace fsync {
         /**
          * Asynchronous fsync(2) - synchronize a file's in-core state with the underlying storage device.
          * @param fd A file descriptor.
          */
-        export function __promisify__(fd: number): Promise<void>;
+        function __promisify__(fd: number): Promise<void>;
     }
 
     /**
      * Synchronous fsync(2) - synchronize a file's in-core state with the underlying storage device.
      * @param fd A file descriptor.
      */
-    export function fsyncSync(fd: number): void;
+    function fsyncSync(fd: number): void;
 
     /**
      * Asynchronously writes `buffer` to the file referenced by the supplied file descriptor.
@@ -4272,7 +4324,14 @@ declare module "fs" {
      * @param length The number of bytes to write. If not supplied, defaults to `buffer.length - offset`.
      * @param position The offset from the beginning of the file where this data should be written. If not supplied, defaults to the current position.
      */
-    export function write<TBuffer extends BinaryData>(fd: number, buffer: TBuffer, offset: number | undefined | null, length: number | undefined | null, position: number | undefined | null, callback: (err: NodeJS.ErrnoException, written: number, buffer: TBuffer) => void): void;
+    function write<TBuffer extends BinaryData>(
+        fd: number,
+        buffer: TBuffer,
+        offset: number | undefined | null,
+        length: number | undefined | null,
+        position: number | undefined | null,
+        callback: (err: NodeJS.ErrnoException, written: number, buffer: TBuffer) => void,
+    ): void;
 
     /**
      * Asynchronously writes `buffer` to the file referenced by the supplied file descriptor.
@@ -4280,20 +4339,26 @@ declare module "fs" {
      * @param offset The part of the buffer to be written. If not supplied, defaults to `0`.
      * @param length The number of bytes to write. If not supplied, defaults to `buffer.length - offset`.
      */
-    export function write<TBuffer extends BinaryData>(fd: number, buffer: TBuffer, offset: number | undefined | null, length: number | undefined | null, callback: (err: NodeJS.ErrnoException, written: number, buffer: TBuffer) => void): void;
+    function write<TBuffer extends BinaryData>(
+        fd: number,
+        buffer: TBuffer,
+        offset: number | undefined | null,
+        length: number | undefined | null,
+        callback: (err: NodeJS.ErrnoException, written: number, buffer: TBuffer) => void,
+    ): void;
 
     /**
      * Asynchronously writes `buffer` to the file referenced by the supplied file descriptor.
      * @param fd A file descriptor.
      * @param offset The part of the buffer to be written. If not supplied, defaults to `0`.
      */
-    export function write<TBuffer extends BinaryData>(fd: number, buffer: TBuffer, offset: number | undefined | null, callback: (err: NodeJS.ErrnoException, written: number, buffer: TBuffer) => void): void;
+    function write<TBuffer extends BinaryData>(fd: number, buffer: TBuffer, offset: number | undefined | null, callback: (err: NodeJS.ErrnoException, written: number, buffer: TBuffer) => void): void;
 
     /**
      * Asynchronously writes `buffer` to the file referenced by the supplied file descriptor.
      * @param fd A file descriptor.
      */
-    export function write<TBuffer extends BinaryData>(fd: number, buffer: TBuffer, callback: (err: NodeJS.ErrnoException, written: number, buffer: TBuffer) => void): void;
+    function write<TBuffer extends BinaryData>(fd: number, buffer: TBuffer, callback: (err: NodeJS.ErrnoException, written: number, buffer: TBuffer) => void): void;
 
     /**
      * Asynchronously writes `string` to the file referenced by the supplied file descriptor.
@@ -4302,7 +4367,13 @@ declare module "fs" {
      * @param position The offset from the beginning of the file where this data should be written. If not supplied, defaults to the current position.
      * @param encoding The expected string encoding.
      */
-    export function write(fd: number, string: any, position: number | undefined | null, encoding: string | undefined | null, callback: (err: NodeJS.ErrnoException, written: number, str: string) => void): void;
+    function write(
+        fd: number,
+        string: any,
+        position: number | undefined | null,
+        encoding: string | undefined | null,
+        callback: (err: NodeJS.ErrnoException, written: number, str: string) => void,
+    ): void;
 
     /**
      * Asynchronously writes `string` to the file referenced by the supplied file descriptor.
@@ -4310,17 +4381,17 @@ declare module "fs" {
      * @param string A string to write. If something other than a string is supplied it will be coerced to a string.
      * @param position The offset from the beginning of the file where this data should be written. If not supplied, defaults to the current position.
      */
-    export function write(fd: number, string: any, position: number | undefined | null, callback: (err: NodeJS.ErrnoException, written: number, str: string) => void): void;
+    function write(fd: number, string: any, position: number | undefined | null, callback: (err: NodeJS.ErrnoException, written: number, str: string) => void): void;
 
     /**
      * Asynchronously writes `string` to the file referenced by the supplied file descriptor.
      * @param fd A file descriptor.
      * @param string A string to write. If something other than a string is supplied it will be coerced to a string.
      */
-    export function write(fd: number, string: any, callback: (err: NodeJS.ErrnoException, written: number, str: string) => void): void;
+    function write(fd: number, string: any, callback: (err: NodeJS.ErrnoException, written: number, str: string) => void): void;
 
     // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
-    export namespace write {
+    namespace write {
         /**
          * Asynchronously writes `buffer` to the file referenced by the supplied file descriptor.
          * @param fd A file descriptor.
@@ -4328,7 +4399,13 @@ declare module "fs" {
          * @param length The number of bytes to write. If not supplied, defaults to `buffer.length - offset`.
          * @param position The offset from the beginning of the file where this data should be written. If not supplied, defaults to the current position.
          */
-        export function __promisify__<TBuffer extends BinaryData>(fd: number, buffer?: TBuffer, offset?: number, length?: number, position?: number | null): Promise<{ bytesWritten: number, buffer: TBuffer }>;
+        function __promisify__<TBuffer extends BinaryData>(
+            fd: number,
+            buffer?: TBuffer,
+            offset?: number,
+            length?: number,
+            position?: number | null,
+        ): Promise<{ bytesWritten: number, buffer: TBuffer }>;
 
         /**
          * Asynchronously writes `string` to the file referenced by the supplied file descriptor.
@@ -4337,7 +4414,7 @@ declare module "fs" {
          * @param position The offset from the beginning of the file where this data should be written. If not supplied, defaults to the current position.
          * @param encoding The expected string encoding.
          */
-        export function __promisify__(fd: number, string: any, position?: number | null, encoding?: string | null): Promise<{ bytesWritten: number, buffer: string }>;
+        function __promisify__(fd: number, string: any, position?: number | null, encoding?: string | null): Promise<{ bytesWritten: number, buffer: string }>;
     }
 
     /**
@@ -4347,7 +4424,7 @@ declare module "fs" {
      * @param length The number of bytes to write. If not supplied, defaults to `buffer.length - offset`.
      * @param position The offset from the beginning of the file where this data should be written. If not supplied, defaults to the current position.
      */
-    export function writeSync(fd: number, buffer: BinaryData, offset?: number | null, length?: number | null, position?: number | null): number;
+    function writeSync(fd: number, buffer: BinaryData, offset?: number | null, length?: number | null, position?: number | null): number;
 
     /**
      * Synchronously writes `string` to the file referenced by the supplied file descriptor, returning the number of bytes written.
@@ -4356,7 +4433,7 @@ declare module "fs" {
      * @param position The offset from the beginning of the file where this data should be written. If not supplied, defaults to the current position.
      * @param encoding The expected string encoding.
      */
-    export function writeSync(fd: number, string: any, position?: number | null, encoding?: string | null): number;
+    function writeSync(fd: number, string: any, position?: number | null, encoding?: string | null): number;
 
     /**
      * Asynchronously reads data from the file referenced by the supplied file descriptor.
@@ -4366,10 +4443,17 @@ declare module "fs" {
      * @param length The number of bytes to read.
      * @param position The offset from the beginning of the file from which data should be read. If `null`, data will be read from the current position.
      */
-    export function read<TBuffer extends BinaryData>(fd: number, buffer: TBuffer, offset: number, length: number, position: number | null, callback?: (err: NodeJS.ErrnoException, bytesRead: number, buffer: TBuffer) => void): void;
+    function read<TBuffer extends BinaryData>(
+        fd: number,
+        buffer: TBuffer,
+        offset: number,
+        length: number,
+        position: number | null,
+        callback?: (err: NodeJS.ErrnoException, bytesRead: number, buffer: TBuffer) => void,
+    ): void;
 
     // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
-    export namespace read {
+    namespace read {
         /**
          * @param fd A file descriptor.
          * @param buffer The buffer that the data will be written to.
@@ -4377,7 +4461,7 @@ declare module "fs" {
          * @param length The number of bytes to read.
          * @param position The offset from the beginning of the file from which data should be read. If `null`, data will be read from the current position.
          */
-        export function __promisify__<TBuffer extends BinaryData>(fd: number, buffer: TBuffer, offset: number, length: number, position: number | null): Promise<{ bytesRead: number, buffer: TBuffer }>;
+        function __promisify__<TBuffer extends BinaryData>(fd: number, buffer: TBuffer, offset: number, length: number, position: number | null): Promise<{ bytesRead: number, buffer: TBuffer }>;
     }
 
     /**
@@ -4388,7 +4472,7 @@ declare module "fs" {
      * @param length The number of bytes to read.
      * @param position The offset from the beginning of the file from which data should be read. If `null`, data will be read from the current position.
      */
-    export function readSync(fd: number, buffer: BinaryData, offset: number, length: number, position: number | null): number;
+    function readSync(fd: number, buffer: BinaryData, offset: number, length: number, position: number | null): number;
 
     /**
      * Asynchronously reads the entire contents of a file.
@@ -4397,7 +4481,7 @@ declare module "fs" {
      * @param options An object that may contain an optional flag.
      * If a flag is not provided, it defaults to `'r'`.
      */
-    export function readFile(path: PathLike | number, options: { encoding?: null; flag?: string; } | undefined | null, callback: (err: NodeJS.ErrnoException, data: Buffer) => void): void;
+    function readFile(path: PathLike | number, options: { encoding?: null; flag?: string; } | undefined | null, callback: (err: NodeJS.ErrnoException, data: Buffer) => void): void;
 
     /**
      * Asynchronously reads the entire contents of a file.
@@ -4407,7 +4491,7 @@ declare module "fs" {
      * @param options Either the encoding for the result, or an object that contains the encoding and an optional flag.
      * If a flag is not provided, it defaults to `'r'`.
      */
-    export function readFile(path: PathLike | number, options: { encoding: string; flag?: string; } | string, callback: (err: NodeJS.ErrnoException, data: string) => void): void;
+    function readFile(path: PathLike | number, options: { encoding: string; flag?: string; } | string, callback: (err: NodeJS.ErrnoException, data: string) => void): void;
 
     /**
      * Asynchronously reads the entire contents of a file.
@@ -4417,17 +4501,21 @@ declare module "fs" {
      * @param options Either the encoding for the result, or an object that contains the encoding and an optional flag.
      * If a flag is not provided, it defaults to `'r'`.
      */
-    export function readFile(path: PathLike | number, options: { encoding?: string | null; flag?: string; } | string | undefined | null, callback: (err: NodeJS.ErrnoException, data: string | Buffer) => void): void;
+    function readFile(
+        path: PathLike | number,
+        options: { encoding?: string | null; flag?: string; } | string | undefined | null,
+        callback: (err: NodeJS.ErrnoException, data: string | Buffer) => void,
+    ): void;
 
     /**
      * Asynchronously reads the entire contents of a file.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      * If a file descriptor is provided, the underlying file will _not_ be closed automatically.
      */
-    export function readFile(path: PathLike | number, callback: (err: NodeJS.ErrnoException, data: Buffer) => void): void;
+    function readFile(path: PathLike | number, callback: (err: NodeJS.ErrnoException, data: Buffer) => void): void;
 
     // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
-    export namespace readFile {
+    namespace readFile {
         /**
          * Asynchronously reads the entire contents of a file.
          * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
@@ -4435,7 +4523,7 @@ declare module "fs" {
          * @param options An object that may contain an optional flag.
          * If a flag is not provided, it defaults to `'r'`.
          */
-        export function __promisify__(path: PathLike | number, options?: { encoding?: null; flag?: string; } | null): Promise<Buffer>;
+        function __promisify__(path: PathLike | number, options?: { encoding?: null; flag?: string; } | null): Promise<Buffer>;
 
         /**
          * Asynchronously reads the entire contents of a file.
@@ -4445,7 +4533,7 @@ declare module "fs" {
          * @param options Either the encoding for the result, or an object that contains the encoding and an optional flag.
          * If a flag is not provided, it defaults to `'r'`.
          */
-        export function __promisify__(path: PathLike | number, options: { encoding: string; flag?: string; } | string): Promise<string>;
+        function __promisify__(path: PathLike | number, options: { encoding: string; flag?: string; } | string): Promise<string>;
 
         /**
          * Asynchronously reads the entire contents of a file.
@@ -4455,7 +4543,7 @@ declare module "fs" {
          * @param options Either the encoding for the result, or an object that contains the encoding and an optional flag.
          * If a flag is not provided, it defaults to `'r'`.
          */
-        export function __promisify__(path: PathLike | number, options?: { encoding?: string | null; flag?: string; } | string | null): Promise<string | Buffer>;
+        function __promisify__(path: PathLike | number, options?: { encoding?: string | null; flag?: string; } | string | null): Promise<string | Buffer>;
     }
 
     /**
@@ -4465,7 +4553,7 @@ declare module "fs" {
      * If a file descriptor is provided, the underlying file will _not_ be closed automatically.
      * @param options An object that may contain an optional flag. If a flag is not provided, it defaults to `'r'`.
      */
-    export function readFileSync(path: PathLike | number, options?: { encoding?: null; flag?: string; } | null): Buffer;
+    function readFileSync(path: PathLike | number, options?: { encoding?: null; flag?: string; } | null): Buffer;
 
     /**
      * Synchronously reads the entire contents of a file.
@@ -4475,7 +4563,7 @@ declare module "fs" {
      * @param options Either the encoding for the result, or an object that contains the encoding and an optional flag.
      * If a flag is not provided, it defaults to `'r'`.
      */
-    export function readFileSync(path: PathLike | number, options: { encoding: string; flag?: string; } | string): string;
+    function readFileSync(path: PathLike | number, options: { encoding: string; flag?: string; } | string): string;
 
     /**
      * Synchronously reads the entire contents of a file.
@@ -4485,9 +4573,9 @@ declare module "fs" {
      * @param options Either the encoding for the result, or an object that contains the encoding and an optional flag.
      * If a flag is not provided, it defaults to `'r'`.
      */
-    export function readFileSync(path: PathLike | number, options?: { encoding?: string | null; flag?: string; } | string | null): string | Buffer;
+    function readFileSync(path: PathLike | number, options?: { encoding?: string | null; flag?: string; } | string | null): string | Buffer;
 
-    export type WriteFileOptions = { encoding?: string | null; mode?: number | string; flag?: string; } | string | null;
+    type WriteFileOptions = { encoding?: string | null; mode?: number | string; flag?: string; } | string | null;
 
     /**
      * Asynchronously writes data to a file, replacing the file if it already exists.
@@ -4501,7 +4589,7 @@ declare module "fs" {
      * If `mode` is a string, it is parsed as an octal integer.
      * If `flag` is not supplied, the default of `'w'` is used.
      */
-    export function writeFile(path: PathLike | number, data: any, options: WriteFileOptions, callback: (err: NodeJS.ErrnoException) => void): void;
+    function writeFile(path: PathLike | number, data: any, options: WriteFileOptions, callback: (err: NodeJS.ErrnoException) => void): void;
 
     /**
      * Asynchronously writes data to a file, replacing the file if it already exists.
@@ -4510,10 +4598,10 @@ declare module "fs" {
      * If a file descriptor is provided, the underlying file will _not_ be closed automatically.
      * @param data The data to write. If something other than a Buffer or Uint8Array is provided, the value is coerced to a string.
      */
-    export function writeFile(path: PathLike | number, data: any, callback: (err: NodeJS.ErrnoException) => void): void;
+    function writeFile(path: PathLike | number, data: any, callback: (err: NodeJS.ErrnoException) => void): void;
 
     // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
-    export namespace writeFile {
+    namespace writeFile {
         /**
          * Asynchronously writes data to a file, replacing the file if it already exists.
          * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
@@ -4526,7 +4614,7 @@ declare module "fs" {
          * If `mode` is a string, it is parsed as an octal integer.
          * If `flag` is not supplied, the default of `'w'` is used.
          */
-        export function __promisify__(path: PathLike | number, data: any, options?: WriteFileOptions): Promise<void>;
+        function __promisify__(path: PathLike | number, data: any, options?: WriteFileOptions): Promise<void>;
     }
 
     /**
@@ -4541,7 +4629,7 @@ declare module "fs" {
      * If `mode` is a string, it is parsed as an octal integer.
      * If `flag` is not supplied, the default of `'w'` is used.
      */
-    export function writeFileSync(path: PathLike | number, data: any, options?: WriteFileOptions): void;
+    function writeFileSync(path: PathLike | number, data: any, options?: WriteFileOptions): void;
 
     /**
      * Asynchronously append data to a file, creating the file if it does not exist.
@@ -4555,7 +4643,7 @@ declare module "fs" {
      * If `mode` is a string, it is parsed as an octal integer.
      * If `flag` is not supplied, the default of `'a'` is used.
      */
-    export function appendFile(file: PathLike | number, data: any, options: WriteFileOptions, callback: (err: NodeJS.ErrnoException) => void): void;
+    function appendFile(file: PathLike | number, data: any, options: WriteFileOptions, callback: (err: NodeJS.ErrnoException) => void): void;
 
     /**
      * Asynchronously append data to a file, creating the file if it does not exist.
@@ -4564,10 +4652,10 @@ declare module "fs" {
      * If a file descriptor is provided, the underlying file will _not_ be closed automatically.
      * @param data The data to write. If something other than a Buffer or Uint8Array is provided, the value is coerced to a string.
      */
-    export function appendFile(file: PathLike | number, data: any, callback: (err: NodeJS.ErrnoException) => void): void;
+    function appendFile(file: PathLike | number, data: any, callback: (err: NodeJS.ErrnoException) => void): void;
 
     // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
-    export namespace appendFile {
+    namespace appendFile {
         /**
          * Asynchronously append data to a file, creating the file if it does not exist.
          * @param file A path to a file. If a URL is provided, it must use the `file:` protocol.
@@ -4580,7 +4668,7 @@ declare module "fs" {
          * If `mode` is a string, it is parsed as an octal integer.
          * If `flag` is not supplied, the default of `'a'` is used.
          */
-        export function __promisify__(file: PathLike | number, data: any, options?: WriteFileOptions): Promise<void>;
+        function __promisify__(file: PathLike | number, data: any, options?: WriteFileOptions): Promise<void>;
     }
 
     /**
@@ -4595,26 +4683,26 @@ declare module "fs" {
      * If `mode` is a string, it is parsed as an octal integer.
      * If `flag` is not supplied, the default of `'a'` is used.
      */
-    export function appendFileSync(file: PathLike | number, data: any, options?: WriteFileOptions): void;
+    function appendFileSync(file: PathLike | number, data: any, options?: WriteFileOptions): void;
 
     /**
      * Watch for changes on `filename`. The callback `listener` will be called each time the file is accessed.
      */
-    export function watchFile(filename: PathLike, options: { persistent?: boolean; interval?: number; } | undefined, listener: (curr: Stats, prev: Stats) => void): void;
+    function watchFile(filename: PathLike, options: { persistent?: boolean; interval?: number; } | undefined, listener: (curr: Stats, prev: Stats) => void): void;
 
     /**
      * Watch for changes on `filename`. The callback `listener` will be called each time the file is accessed.
      * @param filename A path to a file or directory. If a URL is provided, it must use the `file:` protocol.
      * URL support is _experimental_.
      */
-    export function watchFile(filename: PathLike, listener: (curr: Stats, prev: Stats) => void): void;
+    function watchFile(filename: PathLike, listener: (curr: Stats, prev: Stats) => void): void;
 
     /**
      * Stop watching for changes on `filename`.
      * @param filename A path to a file or directory. If a URL is provided, it must use the `file:` protocol.
      * URL support is _experimental_.
      */
-    export function unwatchFile(filename: PathLike, listener?: (curr: Stats, prev: Stats) => void): void;
+    function unwatchFile(filename: PathLike, listener?: (curr: Stats, prev: Stats) => void): void;
 
     /**
      * Watch for changes on `filename`, where `filename` is either a file or a directory, returning an `FSWatcher`.
@@ -4625,7 +4713,11 @@ declare module "fs" {
      * If `persistent` is not supplied, the default of `true` is used.
      * If `recursive` is not supplied, the default of `false` is used.
      */
-    export function watch(filename: PathLike, options: { encoding?: BufferEncoding | null, persistent?: boolean, recursive?: boolean } | BufferEncoding | undefined | null, listener?: (event: string, filename: string) => void): FSWatcher;
+    function watch(
+        filename: PathLike,
+        options: { encoding?: BufferEncoding | null, persistent?: boolean, recursive?: boolean } | BufferEncoding | undefined | null,
+        listener?: (event: string, filename: string) => void,
+    ): FSWatcher;
 
     /**
      * Watch for changes on `filename`, where `filename` is either a file or a directory, returning an `FSWatcher`.
@@ -4636,7 +4728,7 @@ declare module "fs" {
      * If `persistent` is not supplied, the default of `true` is used.
      * If `recursive` is not supplied, the default of `false` is used.
      */
-    export function watch(filename: PathLike, options: { encoding: "buffer", persistent?: boolean, recursive?: boolean } | "buffer", listener?: (event: string, filename: Buffer) => void): FSWatcher;
+    function watch(filename: PathLike, options: { encoding: "buffer", persistent?: boolean, recursive?: boolean } | "buffer", listener?: (event: string, filename: Buffer) => void): FSWatcher;
 
     /**
      * Watch for changes on `filename`, where `filename` is either a file or a directory, returning an `FSWatcher`.
@@ -4647,14 +4739,18 @@ declare module "fs" {
      * If `persistent` is not supplied, the default of `true` is used.
      * If `recursive` is not supplied, the default of `false` is used.
      */
-    export function watch(filename: PathLike, options: { encoding?: string | null, persistent?: boolean, recursive?: boolean } | string | null, listener?: (event: string, filename: string | Buffer) => void): FSWatcher;
+    function watch(
+        filename: PathLike,
+        options: { encoding?: string | null, persistent?: boolean, recursive?: boolean } | string | null,
+        listener?: (event: string, filename: string | Buffer) => void,
+    ): FSWatcher;
 
     /**
      * Watch for changes on `filename`, where `filename` is either a file or a directory, returning an `FSWatcher`.
      * @param filename A path to a file or directory. If a URL is provided, it must use the `file:` protocol.
      * URL support is _experimental_.
      */
-    export function watch(filename: PathLike, listener?: (event: string, filename: string) => any): FSWatcher;
+    function watch(filename: PathLike, listener?: (event: string, filename: string) => any): FSWatcher;
 
     /**
      * Asynchronously tests whether or not the given path exists by checking with the file system.
@@ -4662,10 +4758,10 @@ declare module "fs" {
      * @param path A path to a file or directory. If a URL is provided, it must use the `file:` protocol.
      * URL support is _experimental_.
      */
-    export function exists(path: PathLike, callback: (exists: boolean) => void): void;
+    function exists(path: PathLike, callback: (exists: boolean) => void): void;
 
     // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
-    export namespace exists {
+    namespace exists {
         /**
          * @param path A path to a file or directory. If a URL is provided, it must use the `file:` protocol.
          * URL support is _experimental_.
@@ -4678,147 +4774,162 @@ declare module "fs" {
      * @param path A path to a file or directory. If a URL is provided, it must use the `file:` protocol.
      * URL support is _experimental_.
      */
-    export function existsSync(path: PathLike): boolean;
+    function existsSync(path: PathLike): boolean;
 
-    export namespace constants {
+    namespace constants {
         // File Access Constants
 
         /** Constant for fs.access(). File is visible to the calling process. */
-        export const F_OK: number;
+        const F_OK: number;
 
         /** Constant for fs.access(). File can be read by the calling process. */
-        export const R_OK: number;
+        const R_OK: number;
 
         /** Constant for fs.access(). File can be written by the calling process. */
-        export const W_OK: number;
+        const W_OK: number;
 
         /** Constant for fs.access(). File can be executed by the calling process. */
-        export const X_OK: number;
+        const X_OK: number;
 
         // File Copy Constants
 
         /** Constant for fs.copyFile. Flag indicating the destination file should not be overwritten if it already exists. */
-        export const COPYFILE_EXCL: number;
+        const COPYFILE_EXCL: number;
 
-        /** Constant for fs.copyFile. copy operation will attempt to create a copy-on-write reflink. If the underlying platform does not support copy-on-write, then a fallback copy mechanism is used. */
-        export const COPYFILE_FICLONE: number;
+        /**
+         * Constant for fs.copyFile. copy operation will attempt to create a copy-on-write reflink.
+         * If the underlying platform does not support copy-on-write, then a fallback copy mechanism is used.
+         */
+        const COPYFILE_FICLONE: number;
 
-        /** Constant for fs.copyFile. Copy operation will attempt to create a copy-on-write reflink. If the underlying platform does not support copy-on-write, then the operation will fail with an error. */
-        export const COPYFILE_FICLONE_FORCE: number;
+        /**
+         * Constant for fs.copyFile. Copy operation will attempt to create a copy-on-write reflink.
+         * If the underlying platform does not support copy-on-write, then the operation will fail with an error.
+         */
+        const COPYFILE_FICLONE_FORCE: number;
 
         // File Open Constants
 
         /** Constant for fs.open(). Flag indicating to open a file for read-only access. */
-        export const O_RDONLY: number;
+        const O_RDONLY: number;
 
         /** Constant for fs.open(). Flag indicating to open a file for write-only access. */
-        export const O_WRONLY: number;
+        const O_WRONLY: number;
 
         /** Constant for fs.open(). Flag indicating to open a file for read-write access. */
-        export const O_RDWR: number;
+        const O_RDWR: number;
 
         /** Constant for fs.open(). Flag indicating to create the file if it does not already exist. */
-        export const O_CREAT: number;
+        const O_CREAT: number;
 
         /** Constant for fs.open(). Flag indicating that opening a file should fail if the O_CREAT flag is set and the file already exists. */
-        export const O_EXCL: number;
+        const O_EXCL: number;
 
-        /** Constant for fs.open(). Flag indicating that if path identifies a terminal device, opening the path shall not cause that terminal to become the controlling terminal for the process (if the process does not already have one). */
-        export const O_NOCTTY: number;
+        /**
+         * Constant for fs.open(). Flag indicating that if path identifies a terminal device,
+         * opening the path shall not cause that terminal to become the controlling terminal for the process
+         * (if the process does not already have one).
+         */
+        const O_NOCTTY: number;
 
         /** Constant for fs.open(). Flag indicating that if the file exists and is a regular file, and the file is opened successfully for write access, its length shall be truncated to zero. */
-        export const O_TRUNC: number;
+        const O_TRUNC: number;
 
         /** Constant for fs.open(). Flag indicating that data will be appended to the end of the file. */
-        export const O_APPEND: number;
+        const O_APPEND: number;
 
         /** Constant for fs.open(). Flag indicating that the open should fail if the path is not a directory. */
-        export const O_DIRECTORY: number;
+        const O_DIRECTORY: number;
 
-        /** Constant for fs.open(). Flag indicating reading accesses to the file system will no longer result in an update to the atime information associated with the file. This flag is available on Linux operating systems only. */
-        export const O_NOATIME: number;
+        /**
+         * constant for fs.open().
+         * Flag indicating reading accesses to the file system will no longer result in
+         * an update to the atime information associated with the file.
+         * This flag is available on Linux operating systems only.
+         */
+        const O_NOATIME: number;
 
         /** Constant for fs.open(). Flag indicating that the open should fail if the path is a symbolic link. */
-        export const O_NOFOLLOW: number;
+        const O_NOFOLLOW: number;
 
         /** Constant for fs.open(). Flag indicating that the file is opened for synchronous I/O. */
-        export const O_SYNC: number;
+        const O_SYNC: number;
 
         /** Constant for fs.open(). Flag indicating that the file is opened for synchronous I/O with write operations waiting for data integrity. */
-        export const O_DSYNC: number;
+        const O_DSYNC: number;
 
         /** Constant for fs.open(). Flag indicating to open the symbolic link itself rather than the resource it is pointing to. */
-        export const O_SYMLINK: number;
+        const O_SYMLINK: number;
 
         /** Constant for fs.open(). When set, an attempt will be made to minimize caching effects of file I/O. */
-        export const O_DIRECT: number;
+        const O_DIRECT: number;
 
         /** Constant for fs.open(). Flag indicating to open the file in nonblocking mode when possible. */
-        export const O_NONBLOCK: number;
+        const O_NONBLOCK: number;
 
         // File Type Constants
 
         /** Constant for fs.Stats mode property for determining a file's type. Bit mask used to extract the file type code. */
-        export const S_IFMT: number;
+        const S_IFMT: number;
 
         /** Constant for fs.Stats mode property for determining a file's type. File type constant for a regular file. */
-        export const S_IFREG: number;
+        const S_IFREG: number;
 
         /** Constant for fs.Stats mode property for determining a file's type. File type constant for a directory. */
-        export const S_IFDIR: number;
+        const S_IFDIR: number;
 
         /** Constant for fs.Stats mode property for determining a file's type. File type constant for a character-oriented device file. */
-        export const S_IFCHR: number;
+        const S_IFCHR: number;
 
         /** Constant for fs.Stats mode property for determining a file's type. File type constant for a block-oriented device file. */
-        export const S_IFBLK: number;
+        const S_IFBLK: number;
 
         /** Constant for fs.Stats mode property for determining a file's type. File type constant for a FIFO/pipe. */
-        export const S_IFIFO: number;
+        const S_IFIFO: number;
 
         /** Constant for fs.Stats mode property for determining a file's type. File type constant for a symbolic link. */
-        export const S_IFLNK: number;
+        const S_IFLNK: number;
 
         /** Constant for fs.Stats mode property for determining a file's type. File type constant for a socket. */
-        export const S_IFSOCK: number;
+        const S_IFSOCK: number;
 
         // File Mode Constants
 
         /** Constant for fs.Stats mode property for determining access permissions for a file. File mode indicating readable, writable and executable by owner. */
-        export const S_IRWXU: number;
+        const S_IRWXU: number;
 
         /** Constant for fs.Stats mode property for determining access permissions for a file. File mode indicating readable by owner. */
-        export const S_IRUSR: number;
+        const S_IRUSR: number;
 
         /** Constant for fs.Stats mode property for determining access permissions for a file. File mode indicating writable by owner. */
-        export const S_IWUSR: number;
+        const S_IWUSR: number;
 
         /** Constant for fs.Stats mode property for determining access permissions for a file. File mode indicating executable by owner. */
-        export const S_IXUSR: number;
+        const S_IXUSR: number;
 
         /** Constant for fs.Stats mode property for determining access permissions for a file. File mode indicating readable, writable and executable by group. */
-        export const S_IRWXG: number;
+        const S_IRWXG: number;
 
         /** Constant for fs.Stats mode property for determining access permissions for a file. File mode indicating readable by group. */
-        export const S_IRGRP: number;
+        const S_IRGRP: number;
 
         /** Constant for fs.Stats mode property for determining access permissions for a file. File mode indicating writable by group. */
-        export const S_IWGRP: number;
+        const S_IWGRP: number;
 
         /** Constant for fs.Stats mode property for determining access permissions for a file. File mode indicating executable by group. */
-        export const S_IXGRP: number;
+        const S_IXGRP: number;
 
         /** Constant for fs.Stats mode property for determining access permissions for a file. File mode indicating readable, writable and executable by others. */
-        export const S_IRWXO: number;
+        const S_IRWXO: number;
 
         /** Constant for fs.Stats mode property for determining access permissions for a file. File mode indicating readable by others. */
-        export const S_IROTH: number;
+        const S_IROTH: number;
 
         /** Constant for fs.Stats mode property for determining access permissions for a file. File mode indicating writable by others. */
-        export const S_IWOTH: number;
+        const S_IWOTH: number;
 
         /** Constant for fs.Stats mode property for determining access permissions for a file. File mode indicating executable by others. */
-        export const S_IXOTH: number;
+        const S_IXOTH: number;
     }
 
     /**
@@ -4826,23 +4937,23 @@ declare module "fs" {
      * @param path A path to a file or directory. If a URL is provided, it must use the `file:` protocol.
      * URL support is _experimental_.
      */
-    export function access(path: PathLike, mode: number | undefined, callback: (err: NodeJS.ErrnoException) => void): void;
+    function access(path: PathLike, mode: number | undefined, callback: (err: NodeJS.ErrnoException) => void): void;
 
     /**
      * Asynchronously tests a user's permissions for the file specified by path.
      * @param path A path to a file or directory. If a URL is provided, it must use the `file:` protocol.
      * URL support is _experimental_.
      */
-    export function access(path: PathLike, callback: (err: NodeJS.ErrnoException) => void): void;
+    function access(path: PathLike, callback: (err: NodeJS.ErrnoException) => void): void;
 
     // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
-    export namespace access {
+    namespace access {
         /**
          * Asynchronously tests a user's permissions for the file specified by path.
          * @param path A path to a file or directory. If a URL is provided, it must use the `file:` protocol.
          * URL support is _experimental_.
          */
-        export function __promisify__(path: PathLike, mode?: number): Promise<void>;
+        function __promisify__(path: PathLike, mode?: number): Promise<void>;
     }
 
     /**
@@ -4850,14 +4961,14 @@ declare module "fs" {
      * @param path A path to a file or directory. If a URL is provided, it must use the `file:` protocol.
      * URL support is _experimental_.
      */
-    export function accessSync(path: PathLike, mode?: number): void;
+    function accessSync(path: PathLike, mode?: number): void;
 
     /**
      * Returns a new `ReadStream` object.
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      * URL support is _experimental_.
      */
-    export function createReadStream(path: PathLike, options?: string | {
+    function createReadStream(path: PathLike, options?: string | {
         flags?: string;
         encoding?: string;
         fd?: number;
@@ -4873,7 +4984,7 @@ declare module "fs" {
      * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
      * URL support is _experimental_.
      */
-    export function createWriteStream(path: PathLike, options?: string | {
+    function createWriteStream(path: PathLike, options?: string | {
         flags?: string;
         encoding?: string;
         fd?: number;
@@ -4886,22 +4997,22 @@ declare module "fs" {
      * Asynchronous fdatasync(2) - synchronize a file's in-core state with storage device.
      * @param fd A file descriptor.
      */
-    export function fdatasync(fd: number, callback: (err: NodeJS.ErrnoException) => void): void;
+    function fdatasync(fd: number, callback: (err: NodeJS.ErrnoException) => void): void;
 
     // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
-    export namespace fdatasync {
+    namespace fdatasync {
         /**
          * Asynchronous fdatasync(2) - synchronize a file's in-core state with storage device.
          * @param fd A file descriptor.
          */
-        export function __promisify__(fd: number): Promise<void>;
+        function __promisify__(fd: number): Promise<void>;
     }
 
     /**
      * Synchronous fdatasync(2) - synchronize a file's in-core state with storage device.
      * @param fd A file descriptor.
      */
-    export function fdatasyncSync(fd: number): void;
+    function fdatasyncSync(fd: number): void;
 
     /**
      * Asynchronously copies src to dest. By default, dest is overwritten if it already exists.
@@ -4912,7 +5023,7 @@ declare module "fs" {
      * @param src A path to the source file.
      * @param dest A path to the destination file.
      */
-    export function copyFile(src: PathLike, dest: PathLike, callback: (err: NodeJS.ErrnoException) => void): void;
+    function copyFile(src: PathLike, dest: PathLike, callback: (err: NodeJS.ErrnoException) => void): void;
     /**
      * Asynchronously copies src to dest. By default, dest is overwritten if it already exists.
      * No arguments other than a possible exception are given to the callback function.
@@ -4923,10 +5034,10 @@ declare module "fs" {
      * @param dest A path to the destination file.
      * @param flags An integer that specifies the behavior of the copy operation. The only supported flag is fs.constants.COPYFILE_EXCL, which causes the copy operation to fail if dest already exists.
      */
-    export function copyFile(src: PathLike, dest: PathLike, flags: number, callback: (err: NodeJS.ErrnoException) => void): void;
+    function copyFile(src: PathLike, dest: PathLike, flags: number, callback: (err: NodeJS.ErrnoException) => void): void;
 
     // NOTE: This namespace provides design-time support for util.promisify. Exported members do not exist at runtime.
-    export namespace copyFile {
+    namespace copyFile {
         /**
          * Asynchronously copies src to dest. By default, dest is overwritten if it already exists.
          * No arguments other than a possible exception are given to the callback function.
@@ -4935,9 +5046,11 @@ declare module "fs" {
          * to remove the destination.
          * @param src A path to the source file.
          * @param dest A path to the destination file.
-         * @param flags An optional integer that specifies the behavior of the copy operation. The only supported flag is fs.constants.COPYFILE_EXCL, which causes the copy operation to fail if dest already exists.
+         * @param flags An optional integer that specifies the behavior of the copy operation.
+         * The only supported flag is fs.constants.COPYFILE_EXCL,
+         * which causes the copy operation to fail if dest already exists.
          */
-        export function __promisify__(src: PathLike, dst: PathLike, flags?: number): Promise<void>;
+        function __promisify__(src: PathLike, dst: PathLike, flags?: number): Promise<void>;
     }
 
     /**
@@ -4947,11 +5060,12 @@ declare module "fs" {
      * to remove the destination.
      * @param src A path to the source file.
      * @param dest A path to the destination file.
-     * @param flags An optional integer that specifies the behavior of the copy operation. The only supported flag is fs.constants.COPYFILE_EXCL, which causes the copy operation to fail if dest already exists.
+     * @param flags An optional integer that specifies the behavior of the copy operation.
+     * The only supported flag is fs.constants.COPYFILE_EXCL, which causes the copy operation to fail if dest already exists.
      */
-    export function copyFileSync(src: PathLike, dest: PathLike, flags?: number): void;
+    function copyFileSync(src: PathLike, dest: PathLike, flags?: number): void;
 
-    export namespace promises {
+    namespace promises {
         interface FileHandle {
             /**
              * Gets the file descriptor for this file handle.
@@ -5056,7 +5170,8 @@ declare module "fs" {
             /**
              * Asynchronously writes `string` to the file.
              * The `FileHandle` must have been opened for writing.
-             * It is unsafe to call `write()` multiple times on the same file without waiting for the `Promise` to be resolved (or rejected). For this scenario, `fs.createWriteStream` is strongly recommended.
+             * It is unsafe to call `write()` multiple times on the same file without waiting for the `Promise`
+             * to be resolved (or rejected). For this scenario, `fs.createWriteStream` is strongly recommended.
              * @param string A string to write. If something other than a string is supplied it will be coerced to a string.
              * @param position The offset from the beginning of the file where this data should be written. If not supplied, defaults to the current position.
              * @param encoding The expected string encoding.
@@ -5119,22 +5234,34 @@ declare module "fs" {
          * @param position The offset from the beginning of the file from which data should be read. If
          * `null`, data will be read from the current position.
          */
-        function read<TBuffer extends Buffer | Uint8Array>(handle: FileHandle, buffer: TBuffer, offset?: number | null, length?: number | null, position?: number | null): Promise<{ bytesRead: number, buffer: TBuffer }>;
+        function read<TBuffer extends Buffer | Uint8Array>(
+            handle: FileHandle,
+            buffer: TBuffer,
+            offset?: number | null,
+            length?: number | null,
+            position?: number | null,
+        ): Promise<{ bytesRead: number, buffer: TBuffer }>;
 
         /**
          * Asynchronously writes `buffer` to the file referenced by the supplied `FileHandle`.
-         * It is unsafe to call `fsPromises.write()` multiple times on the same file without waiting for the `Promise` to be resolved (or rejected). For this scenario, `fs.createWriteStream` is strongly recommended.
+         * It is unsafe to call `fsPromises.write()` multiple times on the same file without waiting for the `Promise`
+         * to be resolved (or rejected). For this scenario, `fs.createWriteStream` is strongly recommended.
          * @param handle A `FileHandle`.
          * @param buffer The buffer that the data will be written to.
          * @param offset The part of the buffer to be written. If not supplied, defaults to `0`.
          * @param length The number of bytes to write. If not supplied, defaults to `buffer.length - offset`.
          * @param position The offset from the beginning of the file where this data should be written. If not supplied, defaults to the current position.
          */
-        function write<TBuffer extends Buffer | Uint8Array>(handle: FileHandle, buffer: TBuffer, offset?: number | null, length?: number | null, position?: number | null): Promise<{ bytesWritten: number, buffer: TBuffer }>;
+        function write<TBuffer extends Buffer | Uint8Array>(
+            handle: FileHandle,
+            buffer: TBuffer,
+            offset?: number | null,
+            length?: number | null, position?: number | null): Promise<{ bytesWritten: number, buffer: TBuffer }>;
 
         /**
          * Asynchronously writes `string` to the file referenced by the supplied `FileHandle`.
-         * It is unsafe to call `fsPromises.write()` multiple times on the same file without waiting for the `Promise` to be resolved (or rejected). For this scenario, `fs.createWriteStream` is strongly recommended.
+         * It is unsafe to call `fsPromises.write()` multiple times on the same file without waiting for the `Promise`
+         * to be resolved (or rejected). For this scenario, `fs.createWriteStream` is strongly recommended.
          * @param handle A `FileHandle`.
          * @param string A string to write. If something other than a string is supplied it will be coerced to a string.
          * @param position The offset from the beginning of the file where this data should be written. If not supplied, defaults to the current position.
@@ -5431,7 +5558,7 @@ declare module "path" {
     /**
      * A parsed path object generated by path.parse() or consumed by path.format().
      */
-    export interface ParsedPath {
+    interface ParsedPath {
         /**
          * The root of the path such as '/' or 'c:\'
          */
@@ -5453,7 +5580,7 @@ declare module "path" {
          */
         name: string;
     }
-    export interface FormatInputPathObject {
+    interface FormatInputPathObject {
         /**
          * The root of the path such as '/' or 'c:\'
          */
@@ -5482,41 +5609,44 @@ declare module "path" {
      *
      * @param p string path to normalize.
      */
-    export function normalize(p: string): string;
+    function normalize(p: string): string;
     /**
      * Join all arguments together and normalize the resulting path.
      * Arguments must be strings. In v0.8, non-string arguments were silently ignored. In v0.10 and up, an exception is thrown.
      *
      * @param paths paths to join.
      */
-    export function join(...paths: string[]): string;
+    function join(...paths: string[]): string;
     /**
      * The right-most parameter is considered {to}.  Other parameters are considered an array of {from}.
      *
      * Starting from leftmost {from} paramter, resolves {to} to an absolute path.
      *
-     * If {to} isn't already absolute, {from} arguments are prepended in right to left order, until an absolute path is found. If after using all {from} paths still no absolute path is found, the current working directory is used as well. The resulting path is normalized, and trailing slashes are removed unless the path gets resolved to the root directory.
+     * If {to} isn't already absolute, {from} arguments are prepended in right to left order,
+     * until an absolute path is found. If after using all {from} paths still no absolute path is found,
+     * the current working directory is used as well. The resulting path is normalized,
+     * and trailing slashes are removed unless the path gets resolved to the root directory.
      *
      * @param pathSegments string paths to join.  Non-string arguments are ignored.
      */
-    export function resolve(...pathSegments: string[]): string;
+    function resolve(...pathSegments: string[]): string;
     /**
      * Determines whether {path} is an absolute path. An absolute path will always resolve to the same location, regardless of the working directory.
      *
      * @param path path to test.
      */
-    export function isAbsolute(path: string): boolean;
+    function isAbsolute(path: string): boolean;
     /**
      * Solve the relative path from {from} to {to}.
      * At times we have two absolute paths, and we need to derive the relative path from one to the other. This is actually the reverse transform of path.resolve.
      */
-    export function relative(from: string, to: string): string;
+    function relative(from: string, to: string): string;
     /**
      * Return the directory name of a path. Similar to the Unix dirname command.
      *
      * @param p the path to evaluate.
      */
-    export function dirname(p: string): string;
+    function dirname(p: string): string;
     /**
      * Return the last portion of a path. Similar to the Unix basename command.
      * Often used to extract the file name from a fully qualified path.
@@ -5524,72 +5654,72 @@ declare module "path" {
      * @param p the path to evaluate.
      * @param ext optionally, an extension to remove from the result.
      */
-    export function basename(p: string, ext?: string): string;
+    function basename(p: string, ext?: string): string;
     /**
      * Return the extension of the path, from the last '.' to end of string in the last portion of the path.
      * If there is no '.' in the last portion of the path or the first character of it is '.', then it returns an empty string
      *
      * @param p the path to evaluate.
      */
-    export function extname(p: string): string;
+    function extname(p: string): string;
     /**
      * The platform-specific file separator. '\\' or '/'.
      */
-    export var sep: '\\' | '/';
+    const sep: '\\' | '/';
     /**
      * The platform-specific file delimiter. ';' or ':'.
      */
-    export var delimiter: ';' | ':';
+    const delimiter: ';' | ':';
     /**
      * Returns an object from a path string - the opposite of format().
      *
      * @param pathString path to evaluate.
      */
-    export function parse(pathString: string): ParsedPath;
+    function parse(pathString: string): ParsedPath;
     /**
      * Returns a path string from an object - the opposite of parse().
      *
      * @param pathString path to evaluate.
      */
-    export function format(pathObject: FormatInputPathObject): string;
+    function format(pathObject: FormatInputPathObject): string;
 
-    export module posix {
-        export function normalize(p: string): string;
-        export function join(...paths: any[]): string;
-        export function resolve(...pathSegments: any[]): string;
-        export function isAbsolute(p: string): boolean;
-        export function relative(from: string, to: string): string;
-        export function dirname(p: string): string;
-        export function basename(p: string, ext?: string): string;
-        export function extname(p: string): string;
-        export var sep: string;
-        export var delimiter: string;
-        export function parse(p: string): ParsedPath;
-        export function format(pP: FormatInputPathObject): string;
+    namespace posix {
+        function normalize(p: string): string;
+        function join(...paths: any[]): string;
+        function resolve(...pathSegments: any[]): string;
+        function isAbsolute(p: string): boolean;
+        function relative(from: string, to: string): string;
+        function dirname(p: string): string;
+        function basename(p: string, ext?: string): string;
+        function extname(p: string): string;
+        const sep: string;
+        const delimiter: string;
+        function parse(p: string): ParsedPath;
+        function format(pP: FormatInputPathObject): string;
     }
 
-    export module win32 {
-        export function normalize(p: string): string;
-        export function join(...paths: any[]): string;
-        export function resolve(...pathSegments: any[]): string;
-        export function isAbsolute(p: string): boolean;
-        export function relative(from: string, to: string): string;
-        export function dirname(p: string): string;
-        export function basename(p: string, ext?: string): string;
-        export function extname(p: string): string;
-        export var sep: string;
-        export var delimiter: string;
-        export function parse(p: string): ParsedPath;
-        export function format(pP: FormatInputPathObject): string;
+    namespace win32 {
+        function normalize(p: string): string;
+        function join(...paths: any[]): string;
+        function resolve(...pathSegments: any[]): string;
+        function isAbsolute(p: string): boolean;
+        function relative(from: string, to: string): string;
+        function dirname(p: string): string;
+        function basename(p: string, ext?: string): string;
+        function extname(p: string): string;
+        const sep: string;
+        const delimiter: string;
+        function parse(p: string): ParsedPath;
+        function format(pP: FormatInputPathObject): string;
     }
 }
 
 declare module "string_decoder" {
-    export interface NodeStringDecoder {
+    interface NodeStringDecoder {
         write(buffer: Buffer): string;
         end(buffer?: Buffer): string;
     }
-    export var StringDecoder: {
+    const StringDecoder: {
         new(encoding?: string): NodeStringDecoder;
     };
 }
@@ -5600,10 +5730,10 @@ declare module "tls" {
     import * as net from "net";
     import * as stream from "stream";
 
-    var CLIENT_RENEG_LIMIT: number;
-    var CLIENT_RENEG_WINDOW: number;
+    const CLIENT_RENEG_LIMIT: number;
+    const CLIENT_RENEG_WINDOW: number;
 
-    export interface Certificate {
+    interface Certificate {
         /**
          * Country code.
          */
@@ -5630,7 +5760,7 @@ declare module "tls" {
         CN: string;
     }
 
-    export interface PeerCertificate {
+    interface PeerCertificate {
         subject: Certificate;
         issuer: Certificate;
         subjectaltname: string;
@@ -5645,11 +5775,11 @@ declare module "tls" {
         raw: Buffer;
     }
 
-    export interface DetailedPeerCertificate extends PeerCertificate {
+    interface DetailedPeerCertificate extends PeerCertificate {
         issuerCertificate: DetailedPeerCertificate;
     }
 
-    export interface CipherNameAndProtocol {
+    interface CipherNameAndProtocol {
         /**
          * The cipher name.
          */
@@ -5660,7 +5790,7 @@ declare module "tls" {
         version: string;
     }
 
-    export class TLSSocket extends net.Socket {
+    class TLSSocket extends net.Socket {
         /**
          * Construct a new tls.TLSSocket object from an existing TCP socket.
          */
@@ -5829,7 +5959,7 @@ declare module "tls" {
         prependOnceListener(event: "secureConnect", listener: () => void): this;
     }
 
-    export interface TlsOptions extends SecureContextOptions {
+    interface TlsOptions extends SecureContextOptions {
         handshakeTimeout?: number;
         requestCert?: boolean;
         rejectUnauthorized?: boolean;
@@ -5840,7 +5970,7 @@ declare module "tls" {
         ticketKeys?: Buffer;
     }
 
-    export interface ConnectionOptions extends SecureContextOptions {
+    interface ConnectionOptions extends SecureContextOptions {
         host?: string;
         port?: number;
         path?: string; // Creates unix socket connection to path. If this option is specified, `host` and `port` are ignored.
@@ -5856,7 +5986,7 @@ declare module "tls" {
         lookup?: net.LookupFunction;
     }
 
-    export class Server extends net.Server {
+    class Server extends net.Server {
         addContext(hostName: string, credentials: {
             key: string;
             cert: string;
@@ -5914,12 +6044,12 @@ declare module "tls" {
         prependOnceListener(event: "secureConnection", listener: (tlsSocket: TLSSocket) => void): this;
     }
 
-    export interface SecurePair {
+    interface SecurePair {
         encrypted: any;
         cleartext: any;
     }
 
-    export interface SecureContextOptions {
+    interface SecureContextOptions {
         pfx?: string | Buffer | Array<string | Buffer | Object>;
         key?: string | Buffer | Array<Buffer | Object>;
         passphrase?: string;
@@ -5936,7 +6066,7 @@ declare module "tls" {
         sessionIdContext?: string;
     }
 
-    export interface SecureContext {
+    interface SecureContext {
         context: any;
     }
 
@@ -5947,35 +6077,35 @@ declare module "tls" {
      *
      * Returns Error object, populating it with the reason, host and cert on failure.  On success, returns undefined.
      */
-    export function checkServerIdentity(host: string, cert: PeerCertificate): Error | undefined;
-    export function createServer(options: TlsOptions, secureConnectionListener?: (socket: TLSSocket) => void): Server;
-    export function connect(options: ConnectionOptions, secureConnectionListener?: () => void): TLSSocket;
-    export function connect(port: number, host?: string, options?: ConnectionOptions, secureConnectListener?: () => void): TLSSocket;
-    export function connect(port: number, options?: ConnectionOptions, secureConnectListener?: () => void): TLSSocket;
-    export function createSecurePair(credentials?: crypto.Credentials, isServer?: boolean, requestCert?: boolean, rejectUnauthorized?: boolean): SecurePair;
-    export function createSecureContext(details: SecureContextOptions): SecureContext;
-    export function getCiphers(): string[];
+    function checkServerIdentity(host: string, cert: PeerCertificate): Error | undefined;
+    function createServer(options: TlsOptions, secureConnectionListener?: (socket: TLSSocket) => void): Server;
+    function connect(options: ConnectionOptions, secureConnectionListener?: () => void): TLSSocket;
+    function connect(port: number, host?: string, options?: ConnectionOptions, secureConnectListener?: () => void): TLSSocket;
+    function connect(port: number, options?: ConnectionOptions, secureConnectListener?: () => void): TLSSocket;
+    function createSecurePair(credentials?: crypto.Credentials, isServer?: boolean, requestCert?: boolean, rejectUnauthorized?: boolean): SecurePair;
+    function createSecureContext(details: SecureContextOptions): SecureContext;
+    function getCiphers(): string[];
 
-    export var DEFAULT_ECDH_CURVE: string;
+    const DEFAULT_ECDH_CURVE: string;
 }
 
 declare module "crypto" {
     import * as stream from "stream";
 
-    export interface Certificate {
+    interface Certificate {
         exportChallenge(spkac: string | Buffer | NodeJS.TypedArray | DataView): Buffer;
         exportPublicKey(spkac: string | Buffer | NodeJS.TypedArray | DataView): Buffer;
         verifySpkac(spkac: Buffer | NodeJS.TypedArray | DataView): boolean;
     }
-    export var Certificate: {
+    const Certificate: {
         new(): Certificate;
         (): Certificate;
     };
 
     /** @deprecated since v10.0.0 */
-    export var fips: boolean;
+    const fips: boolean;
 
-    export interface CredentialDetails {
+    interface CredentialDetails {
         pfx: string;
         key: string;
         passphrase: string;
@@ -5984,10 +6114,10 @@ declare module "crypto" {
         crl: string | string[];
         ciphers: string;
     }
-    export interface Credentials { context?: any; }
-    export function createCredentials(details: CredentialDetails): Credentials;
-    export function createHash(algorithm: string, options?: stream.TransformOptions): Hash;
-    export function createHmac(algorithm: string, key: string | Buffer | NodeJS.TypedArray | DataView, options?: stream.TransformOptions): Hmac;
+    interface Credentials { context?: any; }
+    function createCredentials(details: CredentialDetails): Credentials;
+    function createHash(algorithm: string, options?: stream.TransformOptions): Hash;
+    function createHmac(algorithm: string, key: string | Buffer | NodeJS.TypedArray | DataView, options?: stream.TransformOptions): Hmac;
 
     type Utf8AsciiLatin1Encoding = "utf8" | "ascii" | "latin1";
     type HexBase64Latin1Encoding = "latin1" | "hex" | "base64";
@@ -5995,38 +6125,38 @@ declare module "crypto" {
     type HexBase64BinaryEncoding = "binary" | "base64" | "hex";
     type ECDHKeyFormat = "compressed" | "uncompressed" | "hybrid";
 
-    export interface Hash extends NodeJS.ReadWriteStream {
+    interface Hash extends NodeJS.ReadWriteStream {
         update(data: string | Buffer | NodeJS.TypedArray | DataView): Hash;
         update(data: string, input_encoding: Utf8AsciiLatin1Encoding): Hash;
         digest(): Buffer;
         digest(encoding: HexBase64Latin1Encoding): string;
     }
-    export interface Hmac extends NodeJS.ReadWriteStream {
+    interface Hmac extends NodeJS.ReadWriteStream {
         update(data: string | Buffer | NodeJS.TypedArray | DataView): Hmac;
         update(data: string, input_encoding: Utf8AsciiLatin1Encoding): Hmac;
         digest(): Buffer;
         digest(encoding: HexBase64Latin1Encoding): string;
     }
-    export type CipherCCMTypes = 'aes-128-ccm' | 'aes-192-ccm' | 'aes-256-ccm';
-    export type CipherGCMTypes = 'aes-128-gcm' | 'aes-192-gcm' | 'aes-256-gcm';
-    export interface CipherCCMOptions extends stream.TransformOptions {
+    type CipherCCMTypes = 'aes-128-ccm' | 'aes-192-ccm' | 'aes-256-ccm';
+    type CipherGCMTypes = 'aes-128-gcm' | 'aes-192-gcm' | 'aes-256-gcm';
+    interface CipherCCMOptions extends stream.TransformOptions {
         authTagLength: number;
     }
-    export interface CipherGCMOptions extends stream.TransformOptions {
+    interface CipherGCMOptions extends stream.TransformOptions {
         authTagLength?: number;
     }
     /** @deprecated since v10.0.0 use createCipheriv() */
-    export function createCipher(algorithm: CipherCCMTypes, password: string | Buffer | NodeJS.TypedArray | DataView, options: CipherCCMOptions): CipherCCM;
+    function createCipher(algorithm: CipherCCMTypes, password: string | Buffer | NodeJS.TypedArray | DataView, options: CipherCCMOptions): CipherCCM;
     /** @deprecated since v10.0.0 use createCipheriv() */
-    export function createCipher(algorithm: CipherGCMTypes, password: string | Buffer | NodeJS.TypedArray | DataView, options?: CipherGCMOptions): CipherGCM;
+    function createCipher(algorithm: CipherGCMTypes, password: string | Buffer | NodeJS.TypedArray | DataView, options?: CipherGCMOptions): CipherGCM;
     /** @deprecated since v10.0.0 use createCipheriv() */
-    export function createCipher(algorithm: string, password: string | Buffer | NodeJS.TypedArray | DataView, options?: stream.TransformOptions): Cipher;
+    function createCipher(algorithm: string, password: string | Buffer | NodeJS.TypedArray | DataView, options?: stream.TransformOptions): Cipher;
 
-    export function createCipheriv(algorithm: CipherCCMTypes, key: string | Buffer | NodeJS.TypedArray | DataView, iv: string | Buffer | NodeJS.TypedArray | DataView, options: CipherCCMOptions): CipherCCM;
-    export function createCipheriv(algorithm: CipherGCMTypes, key: string | Buffer | NodeJS.TypedArray | DataView, iv: string | Buffer | NodeJS.TypedArray | DataView, options?: CipherGCMOptions): CipherGCM;
-    export function createCipheriv(algorithm: string, key: string | Buffer | NodeJS.TypedArray | DataView, iv: string | Buffer | NodeJS.TypedArray | DataView, options?: stream.TransformOptions): Cipher;
+    function createCipheriv(algorithm: CipherCCMTypes, key: string | Buffer | NodeJS.TypedArray | DataView, iv: string | Buffer | NodeJS.TypedArray | DataView, options: CipherCCMOptions): CipherCCM;
+    function createCipheriv(algorithm: CipherGCMTypes, key: string | Buffer | NodeJS.TypedArray | DataView, iv: string | Buffer | NodeJS.TypedArray | DataView, options?: CipherGCMOptions): CipherGCM;
+    function createCipheriv(algorithm: string, key: string | Buffer | NodeJS.TypedArray | DataView, iv: string | Buffer | NodeJS.TypedArray | DataView, options?: stream.TransformOptions): Cipher;
 
-    export interface Cipher extends NodeJS.ReadWriteStream {
+    interface Cipher extends NodeJS.ReadWriteStream {
         update(data: string | Buffer | NodeJS.TypedArray | DataView): Buffer;
         update(data: string, input_encoding: Utf8AsciiBinaryEncoding): Buffer;
         update(data: Buffer | NodeJS.TypedArray | DataView, output_encoding: HexBase64BinaryEncoding): string;
@@ -6039,26 +6169,36 @@ declare module "crypto" {
         // getAuthTag(): Buffer;
         // setAAD(buffer: Buffer): this; // docs only say buffer
     }
-    export interface CipherCCM extends Cipher {
+    interface CipherCCM extends Cipher {
         setAAD(buffer: Buffer, options: { plaintextLength: number }): this;
         getAuthTag(): Buffer;
     }
-    export interface CipherGCM extends Cipher {
+    interface CipherGCM extends Cipher {
         setAAD(buffer: Buffer, options?: { plaintextLength: number }): this;
         getAuthTag(): Buffer;
     }
     /** @deprecated since v10.0.0 use createCipheriv() */
-    export function createDecipher(algorithm: CipherCCMTypes, password: string | Buffer | NodeJS.TypedArray | DataView, options: CipherCCMOptions): DecipherCCM;
+    function createDecipher(algorithm: CipherCCMTypes, password: string | Buffer | NodeJS.TypedArray | DataView, options: CipherCCMOptions): DecipherCCM;
     /** @deprecated since v10.0.0 use createCipheriv() */
-    export function createDecipher(algorithm: CipherGCMTypes, password: string | Buffer | NodeJS.TypedArray | DataView, options?: CipherGCMOptions): DecipherGCM;
+    function createDecipher(algorithm: CipherGCMTypes, password: string | Buffer | NodeJS.TypedArray | DataView, options?: CipherGCMOptions): DecipherGCM;
     /** @deprecated since v10.0.0 use createCipheriv() */
-    export function createDecipher(algorithm: string, password: string | Buffer | NodeJS.TypedArray | DataView, options?: stream.TransformOptions): Decipher;
+    function createDecipher(algorithm: string, password: string | Buffer | NodeJS.TypedArray | DataView, options?: stream.TransformOptions): Decipher;
 
-    export function createDecipheriv(algorithm: CipherCCMTypes, key: string | Buffer | NodeJS.TypedArray | DataView, iv: string | Buffer | NodeJS.TypedArray | DataView, options: CipherCCMOptions): DecipherCCM;
-    export function createDecipheriv(algorithm: CipherGCMTypes, key: string | Buffer | NodeJS.TypedArray | DataView, iv: string | Buffer | NodeJS.TypedArray | DataView, options?: CipherGCMOptions): DecipherGCM;
-    export function createDecipheriv(algorithm: string, key: string | Buffer | NodeJS.TypedArray | DataView, iv: string | Buffer | NodeJS.TypedArray | DataView, options?: stream.TransformOptions): Decipher;
+    function createDecipheriv(
+        algorithm: CipherCCMTypes,
+        key: string | Buffer | NodeJS.TypedArray | DataView,
+        iv: string | Buffer | NodeJS.TypedArray | DataView,
+        options: CipherCCMOptions,
+    ): DecipherCCM;
+    function createDecipheriv(
+        algorithm: CipherGCMTypes,
+        key: string | Buffer | NodeJS.TypedArray | DataView,
+        iv: string | Buffer | NodeJS.TypedArray | DataView,
+        options?: CipherGCMOptions,
+    ): DecipherGCM;
+    function createDecipheriv(algorithm: string, key: string | Buffer | NodeJS.TypedArray | DataView, iv: string | Buffer | NodeJS.TypedArray | DataView, options?: stream.TransformOptions): Decipher;
 
-    export interface Decipher extends NodeJS.ReadWriteStream {
+    interface Decipher extends NodeJS.ReadWriteStream {
         update(data: Buffer | NodeJS.TypedArray | DataView): Buffer;
         update(data: string, input_encoding: HexBase64BinaryEncoding): Buffer;
         update(data: Buffer | NodeJS.TypedArray | DataView, input_encoding: any, output_encoding: Utf8AsciiBinaryEncoding): string;
@@ -6070,24 +6210,24 @@ declare module "crypto" {
         // setAuthTag(tag: Buffer | NodeJS.TypedArray | DataView): this;
         // setAAD(buffer: Buffer | NodeJS.TypedArray | DataView): this;
     }
-    export interface DecipherCCM extends Decipher {
+    interface DecipherCCM extends Decipher {
         setAuthTag(buffer: Buffer | NodeJS.TypedArray | DataView): this;
         setAAD(buffer: Buffer | NodeJS.TypedArray | DataView, options: { plaintextLength: number }): this;
     }
-    export interface DecipherGCM extends Decipher {
+    interface DecipherGCM extends Decipher {
         setAuthTag(buffer: Buffer | NodeJS.TypedArray | DataView): this;
         setAAD(buffer: Buffer | NodeJS.TypedArray | DataView, options?: { plaintextLength: number }): this;
     }
 
-    export function createSign(algorithm: string, options?: stream.WritableOptions): Signer;
-    export interface Signer extends NodeJS.WritableStream {
+    function createSign(algorithm: string, options?: stream.WritableOptions): Signer;
+    interface Signer extends NodeJS.WritableStream {
         update(data: string | Buffer | NodeJS.TypedArray | DataView): Signer;
         update(data: string, input_encoding: Utf8AsciiLatin1Encoding): Signer;
         sign(private_key: string | { key: string; passphrase: string, padding?: number, saltLength?: number }): Buffer;
         sign(private_key: string | { key: string; passphrase: string, padding?: number, saltLength?: number }, output_format: HexBase64Latin1Encoding): string;
     }
-    export function createVerify(algorith: string, options?: stream.WritableOptions): Verify;
-    export interface Verify extends NodeJS.WritableStream {
+    function createVerify(algorith: string, options?: stream.WritableOptions): Verify;
+    interface Verify extends NodeJS.WritableStream {
         update(data: string | Buffer | NodeJS.TypedArray | DataView): Verify;
         update(data: string, input_encoding: Utf8AsciiLatin1Encoding): Verify;
         verify(object: string | Object, signature: Buffer | NodeJS.TypedArray | DataView): boolean;
@@ -6095,12 +6235,12 @@ declare module "crypto" {
         // https://nodejs.org/api/crypto.html#crypto_verifier_verify_object_signature_signature_format
         // The signature field accepts a TypedArray type, but it is only available starting ES2017
     }
-    export function createDiffieHellman(prime_length: number, generator?: number | Buffer | NodeJS.TypedArray | DataView): DiffieHellman;
-    export function createDiffieHellman(prime: Buffer | NodeJS.TypedArray | DataView): DiffieHellman;
-    export function createDiffieHellman(prime: string, prime_encoding: HexBase64Latin1Encoding): DiffieHellman;
-    export function createDiffieHellman(prime: string, prime_encoding: HexBase64Latin1Encoding, generator: number | Buffer | NodeJS.TypedArray | DataView): DiffieHellman;
-    export function createDiffieHellman(prime: string, prime_encoding: HexBase64Latin1Encoding, generator: string, generator_encoding: HexBase64Latin1Encoding): DiffieHellman;
-    export interface DiffieHellman {
+    function createDiffieHellman(prime_length: number, generator?: number | Buffer | NodeJS.TypedArray | DataView): DiffieHellman;
+    function createDiffieHellman(prime: Buffer | NodeJS.TypedArray | DataView): DiffieHellman;
+    function createDiffieHellman(prime: string, prime_encoding: HexBase64Latin1Encoding): DiffieHellman;
+    function createDiffieHellman(prime: string, prime_encoding: HexBase64Latin1Encoding, generator: number | Buffer | NodeJS.TypedArray | DataView): DiffieHellman;
+    function createDiffieHellman(prime: string, prime_encoding: HexBase64Latin1Encoding, generator: string, generator_encoding: HexBase64Latin1Encoding): DiffieHellman;
+    interface DiffieHellman {
         generateKeys(): Buffer;
         generateKeys(encoding: HexBase64Latin1Encoding): string;
         computeSecret(other_public_key: Buffer | NodeJS.TypedArray | DataView): Buffer;
@@ -6121,48 +6261,71 @@ declare module "crypto" {
         setPrivateKey(private_key: string, encoding: string): void;
         verifyError: number;
     }
-    export function getDiffieHellman(group_name: string): DiffieHellman;
-    export function pbkdf2(password: string | Buffer | NodeJS.TypedArray | DataView, salt: string | Buffer | NodeJS.TypedArray | DataView, iterations: number, keylen: number, digest: string, callback: (err: Error | null, derivedKey: Buffer) => any): void;
-    export function pbkdf2Sync(password: string | Buffer | NodeJS.TypedArray | DataView, salt: string | Buffer | NodeJS.TypedArray | DataView, iterations: number, keylen: number, digest: string): Buffer;
+    function getDiffieHellman(group_name: string): DiffieHellman;
+    function pbkdf2(
+        password: string | Buffer | NodeJS.TypedArray | DataView,
+        salt: string | Buffer | NodeJS.TypedArray | DataView,
+        iterations: number,
+        keylen: number,
+        digest: string,
+        callback: (err: Error | null, derivedKey: Buffer) => any,
+    ): void;
+    function pbkdf2Sync(password: string | Buffer | NodeJS.TypedArray | DataView, salt: string | Buffer | NodeJS.TypedArray | DataView, iterations: number, keylen: number, digest: string): Buffer;
 
-    export function randomBytes(size: number): Buffer;
-    export function randomBytes(size: number, callback: (err: Error | null, buf: Buffer) => void): void;
-    export function pseudoRandomBytes(size: number): Buffer;
-    export function pseudoRandomBytes(size: number, callback: (err: Error | null, buf: Buffer) => void): void;
+    function randomBytes(size: number): Buffer;
+    function randomBytes(size: number, callback: (err: Error | null, buf: Buffer) => void): void;
+    function pseudoRandomBytes(size: number): Buffer;
+    function pseudoRandomBytes(size: number, callback: (err: Error | null, buf: Buffer) => void): void;
 
-    export function randomFillSync<T extends Buffer | NodeJS.TypedArray | DataView>(buffer: T, offset?: number, size?: number): T;
-    export function randomFill<T extends Buffer | NodeJS.TypedArray | DataView>(buffer: T, callback: (err: Error | null, buf: T) => void): void;
-    export function randomFill<T extends Buffer | NodeJS.TypedArray | DataView>(buffer: T, offset: number, callback: (err: Error | null, buf: T) => void): void;
-    export function randomFill<T extends Buffer | NodeJS.TypedArray | DataView>(buffer: T, offset: number, size: number, callback: (err: Error | null, buf: T) => void): void;
+    function randomFillSync<T extends Buffer | NodeJS.TypedArray | DataView>(buffer: T, offset?: number, size?: number): T;
+    function randomFill<T extends Buffer | NodeJS.TypedArray | DataView>(buffer: T, callback: (err: Error | null, buf: T) => void): void;
+    function randomFill<T extends Buffer | NodeJS.TypedArray | DataView>(buffer: T, offset: number, callback: (err: Error | null, buf: T) => void): void;
+    function randomFill<T extends Buffer | NodeJS.TypedArray | DataView>(buffer: T, offset: number, size: number, callback: (err: Error | null, buf: T) => void): void;
 
-    export interface ScryptOptions {
+    interface ScryptOptions {
         N?: number;
         r?: number;
         p?: number;
         maxmem?: number;
     }
-    export function scrypt(password: string | Buffer | NodeJS.TypedArray | DataView, salt: string | Buffer | NodeJS.TypedArray | DataView, keylen: number, callback: (err: Error | null, derivedKey: Buffer) => void): void;
-    export function scrypt(password: string | Buffer | NodeJS.TypedArray | DataView, salt: string | Buffer | NodeJS.TypedArray | DataView, keylen: number, options: ScryptOptions, callback: (err: Error | null, derivedKey: Buffer) => void): void;
-    export function scryptSync(password: string | Buffer | NodeJS.TypedArray | DataView, salt: string | Buffer | NodeJS.TypedArray | DataView, keylen: number, options?: ScryptOptions): Buffer;
+    function scrypt(
+        password: string | Buffer | NodeJS.TypedArray | DataView,
+        salt: string | Buffer | NodeJS.TypedArray | DataView,
+        keylen: number, callback: (err: Error | null, derivedKey: Buffer) => void,
+    ): void;
+    function scrypt(
+        password: string | Buffer | NodeJS.TypedArray | DataView,
+        salt: string | Buffer | NodeJS.TypedArray | DataView,
+        keylen: number,
+        options: ScryptOptions,
+        callback: (err: Error | null, derivedKey: Buffer) => void,
+    ): void;
+    function scryptSync(password: string | Buffer | NodeJS.TypedArray | DataView, salt: string | Buffer | NodeJS.TypedArray | DataView, keylen: number, options?: ScryptOptions): Buffer;
 
-    export interface RsaPublicKey {
+    interface RsaPublicKey {
         key: string;
         padding?: number;
     }
-    export interface RsaPrivateKey {
+    interface RsaPrivateKey {
         key: string;
         passphrase?: string;
         padding?: number;
     }
-    export function publicEncrypt(public_key: string | RsaPublicKey, buffer: Buffer | NodeJS.TypedArray | DataView): Buffer;
-    export function privateDecrypt(private_key: string | RsaPrivateKey, buffer: Buffer | NodeJS.TypedArray | DataView): Buffer;
-    export function privateEncrypt(private_key: string | RsaPrivateKey, buffer: Buffer | NodeJS.TypedArray | DataView): Buffer;
-    export function publicDecrypt(public_key: string | RsaPublicKey, buffer: Buffer | NodeJS.TypedArray | DataView): Buffer;
-    export function getCiphers(): string[];
-    export function getCurves(): string[];
-    export function getHashes(): string[];
-    export class ECDH {
-        static convertKey(key: string | Buffer | NodeJS.TypedArray | DataView, curve: string, inputEncoding?: HexBase64Latin1Encoding, outputEncoding?: "latin1" | "hex" | "base64", format?: "uncompressed" | "compressed" | "hybrid"): Buffer | string;
+    function publicEncrypt(public_key: string | RsaPublicKey, buffer: Buffer | NodeJS.TypedArray | DataView): Buffer;
+    function privateDecrypt(private_key: string | RsaPrivateKey, buffer: Buffer | NodeJS.TypedArray | DataView): Buffer;
+    function privateEncrypt(private_key: string | RsaPrivateKey, buffer: Buffer | NodeJS.TypedArray | DataView): Buffer;
+    function publicDecrypt(public_key: string | RsaPublicKey, buffer: Buffer | NodeJS.TypedArray | DataView): Buffer;
+    function getCiphers(): string[];
+    function getCurves(): string[];
+    function getHashes(): string[];
+    class ECDH {
+        static convertKey(
+            key: string | Buffer | NodeJS.TypedArray | DataView,
+            curve: string,
+            inputEncoding?: HexBase64Latin1Encoding,
+            outputEncoding?: "latin1" | "hex" | "base64",
+            format?: "uncompressed" | "compressed" | "hybrid",
+        ): Buffer | string;
         generateKeys(): Buffer;
         generateKeys(encoding: HexBase64Latin1Encoding, format?: ECDHKeyFormat): string;
         computeSecret(other_public_key: Buffer | NodeJS.TypedArray | DataView): Buffer;
@@ -6176,10 +6339,10 @@ declare module "crypto" {
         setPrivateKey(private_key: Buffer | NodeJS.TypedArray | DataView): void;
         setPrivateKey(private_key: string, encoding: HexBase64Latin1Encoding): void;
     }
-    export function createECDH(curve_name: string): ECDH;
-    export function timingSafeEqual(a: Buffer | NodeJS.TypedArray | DataView, b: Buffer | NodeJS.TypedArray | DataView): boolean;
+    function createECDH(curve_name: string): ECDH;
+    function timingSafeEqual(a: Buffer | NodeJS.TypedArray | DataView, b: Buffer | NodeJS.TypedArray | DataView): boolean;
     /** @deprecated since v10.0.0 */
-    export var DEFAULT_ENCODING: string;
+    const DEFAULT_ENCODING: string;
 }
 
 declare module "stream" {
@@ -6190,9 +6353,9 @@ declare module "stream" {
     }
 
     namespace internal {
-        export class Stream extends internal { }
+        class Stream extends internal { }
 
-        export interface ReadableOptions {
+        interface ReadableOptions {
             highWaterMark?: number;
             encoding?: string;
             objectMode?: boolean;
@@ -6200,7 +6363,7 @@ declare module "stream" {
             destroy?(this: Readable, error: Error | null, callback: (error: Error | null) => void): void;
         }
 
-        export class Readable extends Stream implements NodeJS.ReadableStream {
+        class Readable extends Stream implements NodeJS.ReadableStream {
             readable: boolean;
             readonly readableHighWaterMark: number;
             readonly readableLength: number;
@@ -6211,7 +6374,7 @@ declare module "stream" {
             pause(): this;
             resume(): this;
             isPaused(): boolean;
-            unpipe<T extends NodeJS.WritableStream>(destination?: T): this;
+            unpipe(destination?: NodeJS.WritableStream): this;
             unshift(chunk: any): void;
             wrap(oldStream: NodeJS.ReadableStream): this;
             push(chunk: any, encoding?: string): boolean;
@@ -6279,7 +6442,7 @@ declare module "stream" {
             [Symbol.asyncIterator](): AsyncIterableIterator<any>;
         }
 
-        export interface WritableOptions {
+        interface WritableOptions {
             highWaterMark?: number;
             decodeStrings?: boolean;
             objectMode?: boolean;
@@ -6289,7 +6452,7 @@ declare module "stream" {
             final?(this: Writable, callback: (error?: Error | null) => void): void;
         }
 
-        export class Writable extends Stream implements NodeJS.WritableStream {
+        class Writable extends Stream implements NodeJS.WritableStream {
             writable: boolean;
             readonly writableHighWaterMark: number;
             readonly writableLength: number;
@@ -6375,7 +6538,7 @@ declare module "stream" {
             removeListener(event: string | symbol, listener: (...args: any[]) => void): this;
         }
 
-        export interface DuplexOptions extends ReadableOptions, WritableOptions {
+        interface DuplexOptions extends ReadableOptions, WritableOptions {
             allowHalfOpen?: boolean;
             readableObjectMode?: boolean;
             writableObjectMode?: boolean;
@@ -6387,7 +6550,7 @@ declare module "stream" {
         }
 
         // Note: Duplex extends both Readable and Writable.
-        export class Duplex extends Readable implements Writable {
+        class Duplex extends Readable implements Writable {
             writable: boolean;
             readonly writableHighWaterMark: number;
             readonly writableLength: number;
@@ -6408,7 +6571,7 @@ declare module "stream" {
 
         type TransformCallback = (error?: Error, data?: any) => void;
 
-        export interface TransformOptions extends DuplexOptions {
+        interface TransformOptions extends DuplexOptions {
             read?(this: Transform, size: number): void;
             write?(this: Transform, chunk: any, encoding: string, callback: (error?: Error | null) => void): void;
             writev?(this: Transform, chunks: Array<{ chunk: any, encoding: string }>, callback: (error?: Error | null) => void): void;
@@ -6418,32 +6581,59 @@ declare module "stream" {
             flush?(this: Transform, callback: TransformCallback): void;
         }
 
-        export class Transform extends Duplex {
+        class Transform extends Duplex {
             constructor(opts?: TransformOptions);
             _transform(chunk: any, encoding: string, callback: TransformCallback): void;
             _flush(callback: TransformCallback): void;
         }
 
-        export class PassThrough extends Transform { }
+        class PassThrough extends Transform { }
 
-        export function finished(stream: NodeJS.ReadableStream | NodeJS.WritableStream | NodeJS.ReadWriteStream, callback: (err?: NodeJS.ErrnoException) => void): () => void;
-        export namespace finished {
-            export function __promisify__(stream: NodeJS.ReadableStream | NodeJS.WritableStream | NodeJS.ReadWriteStream): Promise<void>;
+        function finished(stream: NodeJS.ReadableStream | NodeJS.WritableStream | NodeJS.ReadWriteStream, callback: (err?: NodeJS.ErrnoException) => void): () => void;
+        namespace finished {
+            function __promisify__(stream: NodeJS.ReadableStream | NodeJS.WritableStream | NodeJS.ReadWriteStream): Promise<void>;
         }
 
-        export function pipeline<T extends NodeJS.WritableStream>(stream1: NodeJS.ReadableStream, stream2: T, callback?: (err: NodeJS.ErrnoException) => void): T;
-        export function pipeline<T extends NodeJS.WritableStream>(stream1: NodeJS.ReadableStream, stream2: NodeJS.ReadWriteStream, stream3: T, callback?: (err: NodeJS.ErrnoException) => void): T;
-        export function pipeline<T extends NodeJS.WritableStream>(stream1: NodeJS.ReadableStream, stream2: NodeJS.ReadWriteStream, stream3: NodeJS.ReadWriteStream, stream4: T, callback?: (err: NodeJS.ErrnoException) => void): T;
-        export function pipeline<T extends NodeJS.WritableStream>(stream1: NodeJS.ReadableStream, stream2: NodeJS.ReadWriteStream, stream3: NodeJS.ReadWriteStream, stream4: NodeJS.ReadWriteStream, stream5: T, callback?: (err: NodeJS.ErrnoException) => void): T;
-        export function pipeline(streams: Array<NodeJS.ReadableStream | NodeJS.WritableStream | NodeJS.ReadWriteStream>, callback?: (err: NodeJS.ErrnoException) => void): NodeJS.WritableStream;
-        export function pipeline(stream1: NodeJS.ReadableStream, stream2: NodeJS.ReadWriteStream | NodeJS.WritableStream, ...streams: Array<NodeJS.ReadWriteStream | NodeJS.WritableStream | ((err: NodeJS.ErrnoException) => void)>): NodeJS.WritableStream;
-        export namespace pipeline {
-            export function __promisify__<T extends NodeJS.WritableStream>(stream1: NodeJS.ReadableStream, stream2: T): Promise<void>;
-            export function __promisify__<T extends NodeJS.WritableStream>(stream1: NodeJS.ReadableStream, stream2: NodeJS.ReadWriteStream, stream3: T): Promise<void>;
-            export function __promisify__<T extends NodeJS.WritableStream>(stream1: NodeJS.ReadableStream, stream2: NodeJS.ReadWriteStream, stream3: NodeJS.ReadWriteStream, stream4: T): Promise<void>;
-            export function __promisify__<T extends NodeJS.WritableStream>(stream1: NodeJS.ReadableStream, stream2: NodeJS.ReadWriteStream, stream3: NodeJS.ReadWriteStream, stream4: NodeJS.ReadWriteStream, stream5: T): Promise<void>;
-            export function __promisify__(streams: Array<NodeJS.ReadableStream | NodeJS.WritableStream | NodeJS.ReadWriteStream>): Promise<void>;
-            export function __promisify__(stream1: NodeJS.ReadableStream, stream2: NodeJS.ReadWriteStream | NodeJS.WritableStream, ...streams: Array<NodeJS.ReadWriteStream | NodeJS.WritableStream>): Promise<void>;
+        function pipeline<T extends NodeJS.WritableStream>(stream1: NodeJS.ReadableStream, stream2: T, callback?: (err: NodeJS.ErrnoException) => void): T;
+        function pipeline<T extends NodeJS.WritableStream>(stream1: NodeJS.ReadableStream, stream2: NodeJS.ReadWriteStream, stream3: T, callback?: (err: NodeJS.ErrnoException) => void): T;
+        function pipeline<T extends NodeJS.WritableStream>(
+            stream1: NodeJS.ReadableStream,
+            stream2: NodeJS.ReadWriteStream,
+            stream3: NodeJS.ReadWriteStream,
+            stream4: T,
+            callback?: (err: NodeJS.ErrnoException) => void,
+        ): T;
+        function pipeline<T extends NodeJS.WritableStream>(
+            stream1: NodeJS.ReadableStream,
+            stream2: NodeJS.ReadWriteStream,
+            stream3: NodeJS.ReadWriteStream,
+            stream4: NodeJS.ReadWriteStream,
+            stream5: T,
+            callback?: (err: NodeJS.ErrnoException) => void,
+        ): T;
+        function pipeline(streams: Array<NodeJS.ReadableStream | NodeJS.WritableStream | NodeJS.ReadWriteStream>, callback?: (err: NodeJS.ErrnoException) => void): NodeJS.WritableStream;
+        function pipeline(
+            stream1: NodeJS.ReadableStream,
+            stream2: NodeJS.ReadWriteStream | NodeJS.WritableStream,
+            ...streams: Array<NodeJS.ReadWriteStream | NodeJS.WritableStream | ((err: NodeJS.ErrnoException) => void)>,
+        ): NodeJS.WritableStream;
+        namespace pipeline {
+            function __promisify__(stream1: NodeJS.ReadableStream, stream2: NodeJS.WritableStream): Promise<void>;
+            function __promisify__(stream1: NodeJS.ReadableStream, stream2: NodeJS.ReadWriteStream, stream3: NodeJS.WritableStream): Promise<void>;
+            function __promisify__(stream1: NodeJS.ReadableStream, stream2: NodeJS.ReadWriteStream, stream3: NodeJS.ReadWriteStream, stream4: NodeJS.WritableStream): Promise<void>;
+            function __promisify__(
+                stream1: NodeJS.ReadableStream,
+                stream2: NodeJS.ReadWriteStream,
+                stream3: NodeJS.ReadWriteStream,
+                stream4: NodeJS.ReadWriteStream,
+                stream5: NodeJS.WritableStream,
+            ): Promise<void>;
+            function __promisify__(streams: Array<NodeJS.ReadableStream | NodeJS.WritableStream | NodeJS.ReadWriteStream>): Promise<void>;
+            function __promisify__(
+                stream1: NodeJS.ReadableStream,
+                stream2: NodeJS.ReadWriteStream | NodeJS.WritableStream,
+                ...streams: Array<NodeJS.ReadWriteStream | NodeJS.WritableStream>,
+            ): Promise<void>;
         }
     }
 
@@ -6451,20 +6641,20 @@ declare module "stream" {
 }
 
 declare module "util" {
-    export interface InspectOptions extends NodeJS.InspectOptions { }
-    export function format(format: any, ...param: any[]): string;
-    export function formatWithOptions(inspectOptions: InspectOptions, format: string, ...param: any[]): string;
+    interface InspectOptions extends NodeJS.InspectOptions { }
+    function format(format: any, ...param: any[]): string;
+    function formatWithOptions(inspectOptions: InspectOptions, format: string, ...param: any[]): string;
     /** @deprecated since v0.11.3 - use `console.error()` instead. */
-    export function debug(string: string): void;
+    function debug(string: string): void;
     /** @deprecated since v0.11.3 - use `console.error()` instead. */
-    export function error(...param: any[]): void;
+    function error(...param: any[]): void;
     /** @deprecated since v0.11.3 - use `console.log()` instead. */
-    export function puts(...param: any[]): void;
+    function puts(...param: any[]): void;
     /** @deprecated since v0.11.3 - use `console.log()` instead. */
-    export function print(...param: any[]): void;
+    function print(...param: any[]): void;
     /** @deprecated since v0.11.3 - use a third party module instead. */
-    export function log(string: string): void;
-    export var inspect: {
+    function log(string: string): void;
+    const inspect: {
         (object: any, showHidden?: boolean, depth?: number | null, color?: boolean): string;
         (object: any, options: InspectOptions): string;
         colors: {
@@ -6477,117 +6667,133 @@ declare module "util" {
         custom: symbol;
     };
     /** @deprecated since v4.0.0 - use `Array.isArray()` instead. */
-    export function isArray(object: any): object is any[];
+    function isArray(object: any): object is any[];
     /** @deprecated since v4.0.0 - use `util.types.isRegExp()` instead. */
-    export function isRegExp(object: any): object is RegExp;
+    function isRegExp(object: any): object is RegExp;
     /** @deprecated since v4.0.0 - use `util.types.isDate()` instead. */
-    export function isDate(object: any): object is Date;
+    function isDate(object: any): object is Date;
     /** @deprecated since v4.0.0 - use `util.types.isNativeError()` instead. */
-    export function isError(object: any): object is Error;
-    export function inherits(constructor: any, superConstructor: any): void;
-    export function debuglog(key: string): (msg: string, ...param: any[]) => void;
+    function isError(object: any): object is Error;
+    function inherits(constructor: any, superConstructor: any): void;
+    function debuglog(key: string): (msg: string, ...param: any[]) => void;
     /** @deprecated since v4.0.0 - use `typeof value === 'boolean'` instead. */
-    export function isBoolean(object: any): object is boolean;
+    function isBoolean(object: any): object is boolean;
     /** @deprecated since v4.0.0 - use `Buffer.isBuffer()` instead. */
-    export function isBuffer(object: any): object is Buffer;
+    function isBuffer(object: any): object is Buffer;
     /** @deprecated since v4.0.0 - use `typeof value === 'function'` instead. */
-    export function isFunction(object: any): boolean;
+    function isFunction(object: any): boolean;
     /** @deprecated since v4.0.0 - use `value === null` instead. */
-    export function isNull(object: any): object is null;
+    function isNull(object: any): object is null;
     /** @deprecated since v4.0.0 - use `value === null || value === undefined` instead. */
-    export function isNullOrUndefined(object: any): object is null | undefined;
+    function isNullOrUndefined(object: any): object is null | undefined;
     /** @deprecated since v4.0.0 - use `typeof value === 'number'` instead. */
-    export function isNumber(object: any): object is number;
+    function isNumber(object: any): object is number;
     /** @deprecated since v4.0.0 - use `value !== null && typeof value === 'object'` instead. */
-    export function isObject(object: any): boolean;
+    function isObject(object: any): boolean;
     /** @deprecated since v4.0.0 - use `(typeof value !== 'object' && typeof value !== 'function') || value === null` instead. */
-    export function isPrimitive(object: any): boolean;
+    function isPrimitive(object: any): boolean;
     /** @deprecated since v4.0.0 - use `typeof value === 'string'` instead. */
-    export function isString(object: any): object is string;
+    function isString(object: any): object is string;
     /** @deprecated since v4.0.0 - use `typeof value === 'symbol'` instead. */
-    export function isSymbol(object: any): object is symbol;
+    function isSymbol(object: any): object is symbol;
     /** @deprecated since v4.0.0 - use `value === undefined` instead. */
-    export function isUndefined(object: any): object is undefined;
-    export function deprecate<T extends Function>(fn: T, message: string): T;
-    export function isDeepStrictEqual(val1: any, val2: any): boolean;
+    function isUndefined(object: any): object is undefined;
+    function deprecate<T extends Function>(fn: T, message: string): T;
+    function isDeepStrictEqual(val1: any, val2: any): boolean;
 
-    export interface CustomPromisify<TCustom extends Function> extends Function {
+    interface CustomPromisify<TCustom extends Function> extends Function {
         __promisify__: TCustom;
     }
 
-    export function callbackify(fn: () => Promise<void>): (callback: (err: NodeJS.ErrnoException) => void) => void;
-    export function callbackify<TResult>(fn: () => Promise<TResult>): (callback: (err: NodeJS.ErrnoException, result: TResult) => void) => void;
-    export function callbackify<T1>(fn: (arg1: T1) => Promise<void>): (arg1: T1, callback: (err: NodeJS.ErrnoException) => void) => void;
-    export function callbackify<T1, TResult>(fn: (arg1: T1) => Promise<TResult>): (arg1: T1, callback: (err: NodeJS.ErrnoException, result: TResult) => void) => void;
-    export function callbackify<T1, T2>(fn: (arg1: T1, arg2: T2) => Promise<void>): (arg1: T1, arg2: T2, callback: (err: NodeJS.ErrnoException) => void) => void;
-    export function callbackify<T1, T2, TResult>(fn: (arg1: T1, arg2: T2) => Promise<TResult>): (arg1: T1, arg2: T2, callback: (err: NodeJS.ErrnoException, result: TResult) => void) => void;
-    export function callbackify<T1, T2, T3>(fn: (arg1: T1, arg2: T2, arg3: T3) => Promise<void>): (arg1: T1, arg2: T2, arg3: T3, callback: (err: NodeJS.ErrnoException) => void) => void;
-    export function callbackify<T1, T2, T3, TResult>(fn: (arg1: T1, arg2: T2, arg3: T3) => Promise<TResult>): (arg1: T1, arg2: T2, arg3: T3, callback: (err: NodeJS.ErrnoException, result: TResult) => void) => void;
-    export function callbackify<T1, T2, T3, T4>(fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4) => Promise<void>): (arg1: T1, arg2: T2, arg3: T3, arg4: T4, callback: (err: NodeJS.ErrnoException) => void) => void;
-    export function callbackify<T1, T2, T3, T4, TResult>(fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4) => Promise<TResult>): (arg1: T1, arg2: T2, arg3: T3, arg4: T4, callback: (err: NodeJS.ErrnoException, result: TResult) => void) => void;
-    export function callbackify<T1, T2, T3, T4, T5>(fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5) => Promise<void>): (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, callback: (err: NodeJS.ErrnoException) => void) => void;
-    export function callbackify<T1, T2, T3, T4, T5, TResult>(fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5) => Promise<TResult>): (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, callback: (err: NodeJS.ErrnoException, result: TResult) => void) => void;
-    export function callbackify<T1, T2, T3, T4, T5, T6>(fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6) => Promise<void>): (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, callback: (err: NodeJS.ErrnoException) => void) => void;
-    export function callbackify<T1, T2, T3, T4, T5, T6, TResult>(fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6) => Promise<TResult>): (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, callback: (err: NodeJS.ErrnoException, result: TResult) => void) => void;
+    function callbackify(fn: () => Promise<void>): (callback: (err: NodeJS.ErrnoException) => void) => void;
+    function callbackify<TResult>(fn: () => Promise<TResult>): (callback: (err: NodeJS.ErrnoException, result: TResult) => void) => void;
+    function callbackify<T1>(fn: (arg1: T1) => Promise<void>): (arg1: T1, callback: (err: NodeJS.ErrnoException) => void) => void;
+    function callbackify<T1, TResult>(fn: (arg1: T1) => Promise<TResult>): (arg1: T1, callback: (err: NodeJS.ErrnoException, result: TResult) => void) => void;
+    function callbackify<T1, T2>(fn: (arg1: T1, arg2: T2) => Promise<void>): (arg1: T1, arg2: T2, callback: (err: NodeJS.ErrnoException) => void) => void;
+    function callbackify<T1, T2, TResult>(fn: (arg1: T1, arg2: T2) => Promise<TResult>): (arg1: T1, arg2: T2, callback: (err: NodeJS.ErrnoException, result: TResult) => void) => void;
+    function callbackify<T1, T2, T3>(fn: (arg1: T1, arg2: T2, arg3: T3) => Promise<void>): (arg1: T1, arg2: T2, arg3: T3, callback: (err: NodeJS.ErrnoException) => void) => void;
+    function callbackify<T1, T2, T3, TResult>(
+        fn: (arg1: T1, arg2: T2, arg3: T3) => Promise<TResult>): (arg1: T1, arg2: T2, arg3: T3, callback: (err: NodeJS.ErrnoException, result: TResult) => void) => void;
+    function callbackify<T1, T2, T3, T4>(
+        fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4) => Promise<void>): (arg1: T1, arg2: T2, arg3: T3, arg4: T4, callback: (err: NodeJS.ErrnoException) => void) => void;
+    function callbackify<T1, T2, T3, T4, TResult>(
+        fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4) => Promise<TResult>): (arg1: T1, arg2: T2, arg3: T3, arg4: T4, callback: (err: NodeJS.ErrnoException, result: TResult) => void) => void;
+    function callbackify<T1, T2, T3, T4, T5>(
+        fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5) => Promise<void>): (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, callback: (err: NodeJS.ErrnoException) => void) => void;
+    function callbackify<T1, T2, T3, T4, T5, TResult>(
+        fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5) => Promise<TResult>,
+    ): (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, callback: (err: NodeJS.ErrnoException, result: TResult) => void) => void;
+    function callbackify<T1, T2, T3, T4, T5, T6>(
+        fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6) => Promise<void>,
+    ): (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, callback: (err: NodeJS.ErrnoException) => void) => void;
+    function callbackify<T1, T2, T3, T4, T5, T6, TResult>(
+        fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6) => Promise<TResult>
+    ): (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, callback: (err: NodeJS.ErrnoException, result: TResult) => void) => void;
 
-    export function promisify<TCustom extends Function>(fn: CustomPromisify<TCustom>): TCustom;
-    export function promisify<TResult>(fn: (callback: (err: Error | null, result: TResult) => void) => void): () => Promise<TResult>;
-    export function promisify(fn: (callback: (err?: Error | null) => void) => void): () => Promise<void>;
-    export function promisify<T1, TResult>(fn: (arg1: T1, callback: (err: Error | null, result: TResult) => void) => void): (arg1: T1) => Promise<TResult>;
-    export function promisify<T1>(fn: (arg1: T1, callback: (err?: Error | null) => void) => void): (arg1: T1) => Promise<void>;
-    export function promisify<T1, T2, TResult>(fn: (arg1: T1, arg2: T2, callback: (err: Error | null, result: TResult) => void) => void): (arg1: T1, arg2: T2) => Promise<TResult>;
-    export function promisify<T1, T2>(fn: (arg1: T1, arg2: T2, callback: (err?: Error | null) => void) => void): (arg1: T1, arg2: T2) => Promise<void>;
-    export function promisify<T1, T2, T3, TResult>(fn: (arg1: T1, arg2: T2, arg3: T3, callback: (err: Error | null, result: TResult) => void) => void): (arg1: T1, arg2: T2, arg3: T3) => Promise<TResult>;
-    export function promisify<T1, T2, T3>(fn: (arg1: T1, arg2: T2, arg3: T3, callback: (err?: Error | null) => void) => void): (arg1: T1, arg2: T2, arg3: T3) => Promise<void>;
-    export function promisify<T1, T2, T3, T4, TResult>(fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, callback: (err: Error | null, result: TResult) => void) => void): (arg1: T1, arg2: T2, arg3: T3, arg4: T4) => Promise<TResult>;
-    export function promisify<T1, T2, T3, T4>(fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, callback: (err?: Error | null) => void) => void): (arg1: T1, arg2: T2, arg3: T3, arg4: T4) => Promise<void>;
-    export function promisify<T1, T2, T3, T4, T5, TResult>(fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, callback: (err: Error | null, result: TResult) => void) => void): (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5) => Promise<TResult>;
-    export function promisify<T1, T2, T3, T4, T5>(fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, callback: (err?: Error | null) => void) => void): (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5) => Promise<void>;
-    export function promisify(fn: Function): Function;
-    export namespace promisify {
+    function promisify<TCustom extends Function>(fn: CustomPromisify<TCustom>): TCustom;
+    function promisify<TResult>(fn: (callback: (err: Error | null, result: TResult) => void) => void): () => Promise<TResult>;
+    function promisify(fn: (callback: (err?: Error | null) => void) => void): () => Promise<void>;
+    function promisify<T1, TResult>(fn: (arg1: T1, callback: (err: Error | null, result: TResult) => void) => void): (arg1: T1) => Promise<TResult>;
+    function promisify<T1>(fn: (arg1: T1, callback: (err?: Error | null) => void) => void): (arg1: T1) => Promise<void>;
+    function promisify<T1, T2, TResult>(fn: (arg1: T1, arg2: T2, callback: (err: Error | null, result: TResult) => void) => void): (arg1: T1, arg2: T2) => Promise<TResult>;
+    function promisify<T1, T2>(fn: (arg1: T1, arg2: T2, callback: (err?: Error | null) => void) => void): (arg1: T1, arg2: T2) => Promise<void>;
+    function promisify<T1, T2, T3, TResult>(fn: (arg1: T1, arg2: T2, arg3: T3, callback: (err: Error | null, result: TResult) => void) => void): (arg1: T1, arg2: T2, arg3: T3) => Promise<TResult>;
+    function promisify<T1, T2, T3>(fn: (arg1: T1, arg2: T2, arg3: T3, callback: (err?: Error | null) => void) => void): (arg1: T1, arg2: T2, arg3: T3) => Promise<void>;
+    function promisify<T1, T2, T3, T4, TResult>(
+        fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, callback: (err: Error | null, result: TResult) => void) => void,
+    ): (arg1: T1, arg2: T2, arg3: T3, arg4: T4) => Promise<TResult>;
+    function promisify<T1, T2, T3, T4>(fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, callback: (err?: Error | null) => void) => void): (arg1: T1, arg2: T2, arg3: T3, arg4: T4) => Promise<void>;
+    function promisify<T1, T2, T3, T4, T5, TResult>(
+        fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, callback: (err: Error | null, result: TResult) => void) => void,
+    ): (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5) => Promise<TResult>;
+    function promisify<T1, T2, T3, T4, T5>(
+        fn: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, callback: (err?: Error | null) => void) => void,
+    ): (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5) => Promise<void>;
+    function promisify(fn: Function): Function;
+    namespace promisify {
         const custom: symbol;
     }
 
-    export namespace types {
-        export function isAnyArrayBuffer(object: any): boolean;
-        export function isArgumentsObject(object: any): object is IArguments;
-        export function isArrayBuffer(object: any): object is ArrayBuffer;
-        export function isAsyncFunction(object: any): boolean;
-        export function isBooleanObject(object: any): object is Boolean;
-        export function isBoxedPrimitive(object: any): object is (Number | Boolean | String | Symbol /* BigInt */);
-        export function isDataView(object: any): object is DataView;
-        export function isDate(object: any): object is Date;
-        export function isExternal(object: any): boolean;
-        export function isFloat32Array(object: any): object is Float32Array;
-        export function isFloat64Array(object: any): object is Float64Array;
-        export function isGeneratorFunction(object: any): boolean;
-        export function isGeneratorObject(object: any): boolean;
-        export function isInt8Array(object: any): object is Int8Array;
-        export function isInt16Array(object: any): object is Int16Array;
-        export function isInt32Array(object: any): object is Int32Array;
-        export function isMap(object: any): boolean;
-        export function isMapIterator(object: any): boolean;
-        export function isNativeError(object: any): object is Error;
-        export function isNumberObject(object: any): object is Number;
-        export function isPromise(object: any): boolean;
-        export function isProxy(object: any): boolean;
-        export function isRegExp(object: any): object is RegExp;
-        export function isSet(object: any): boolean;
-        export function isSetIterator(object: any): boolean;
-        export function isSharedArrayBuffer(object: any): boolean;
-        export function isStringObject(object: any): boolean;
-        export function isSymbolObject(object: any): boolean;
-        export function isTypedArray(object: any): object is NodeJS.TypedArray;
-        export function isUint8Array(object: any): object is Uint8Array;
-        export function isUint8ClampedArray(object: any): object is Uint8ClampedArray;
-        export function isUint16Array(object: any): object is Uint16Array;
-        export function isUint32Array(object: any): object is Uint32Array;
-        export function isWeakMap(object: any): boolean;
-        export function isWeakSet(object: any): boolean;
-        export function isWebAssemblyCompiledModule(object: any): boolean;
+    namespace types {
+        function isAnyArrayBuffer(object: any): boolean;
+        function isArgumentsObject(object: any): object is IArguments;
+        function isArrayBuffer(object: any): object is ArrayBuffer;
+        function isAsyncFunction(object: any): boolean;
+        function isBooleanObject(object: any): object is Boolean;
+        function isBoxedPrimitive(object: any): object is (Number | Boolean | String | Symbol /* BigInt */);
+        function isDataView(object: any): object is DataView;
+        function isDate(object: any): object is Date;
+        function isExternal(object: any): boolean;
+        function isFloat32Array(object: any): object is Float32Array;
+        function isFloat64Array(object: any): object is Float64Array;
+        function isGeneratorFunction(object: any): boolean;
+        function isGeneratorObject(object: any): boolean;
+        function isInt8Array(object: any): object is Int8Array;
+        function isInt16Array(object: any): object is Int16Array;
+        function isInt32Array(object: any): object is Int32Array;
+        function isMap(object: any): boolean;
+        function isMapIterator(object: any): boolean;
+        function isNativeError(object: any): object is Error;
+        function isNumberObject(object: any): object is Number;
+        function isPromise(object: any): boolean;
+        function isProxy(object: any): boolean;
+        function isRegExp(object: any): object is RegExp;
+        function isSet(object: any): boolean;
+        function isSetIterator(object: any): boolean;
+        function isSharedArrayBuffer(object: any): boolean;
+        function isStringObject(object: any): boolean;
+        function isSymbolObject(object: any): boolean;
+        function isTypedArray(object: any): object is NodeJS.TypedArray;
+        function isUint8Array(object: any): object is Uint8Array;
+        function isUint8ClampedArray(object: any): object is Uint8ClampedArray;
+        function isUint16Array(object: any): object is Uint16Array;
+        function isUint32Array(object: any): object is Uint32Array;
+        function isWeakMap(object: any): boolean;
+        function isWeakSet(object: any): boolean;
+        function isWebAssemblyCompiledModule(object: any): boolean;
     }
 
-    export class TextDecoder {
+    class TextDecoder {
         readonly encoding: string;
         readonly fatal: boolean;
         readonly ignoreBOM: boolean;
@@ -6601,7 +6807,7 @@ declare module "util" {
         ): string;
     }
 
-    export class TextEncoder {
+    class TextEncoder {
         readonly encoding: string;
         constructor();
         encode(input?: string): Uint8Array;
@@ -6611,7 +6817,7 @@ declare module "util" {
 declare module "assert" {
     function internal(value: any, message?: string | Error): void;
     namespace internal {
-        export class AssertionError implements Error {
+        class AssertionError implements Error {
             name: string;
             message: string;
             actual: any;
@@ -6626,36 +6832,36 @@ declare module "assert" {
             });
         }
 
-        export function fail(message?: string | Error): never;
+        function fail(message?: string | Error): never;
         /** @deprecated since v10.0.0 - use fail([message]) or other assert functions instead. */
-        export function fail(actual: any, expected: any, message?: string | Error, operator?: string, stackStartFn?: Function): never;
-        export function ok(value: any, message?: string | Error): void;
+        function fail(actual: any, expected: any, message?: string | Error, operator?: string, stackStartFn?: Function): never;
+        function ok(value: any, message?: string | Error): void;
         /** @deprecated since v9.9.0 - use strictEqual() instead. */
-        export function equal(actual: any, expected: any, message?: string | Error): void;
+        function equal(actual: any, expected: any, message?: string | Error): void;
         /** @deprecated since v9.9.0 - use notStrictEqual() instead. */
-        export function notEqual(actual: any, expected: any, message?: string | Error): void;
+        function notEqual(actual: any, expected: any, message?: string | Error): void;
         /** @deprecated since v9.9.0 - use deepStrictEqual() instead. */
-        export function deepEqual(actual: any, expected: any, message?: string | Error): void;
+        function deepEqual(actual: any, expected: any, message?: string | Error): void;
         /** @deprecated since v9.9.0 - use notDeepStrictEqual() instead. */
-        export function notDeepEqual(actual: any, expected: any, message?: string | Error): void;
-        export function strictEqual(actual: any, expected: any, message?: string | Error): void;
-        export function notStrictEqual(actual: any, expected: any, message?: string | Error): void;
-        export function deepStrictEqual(actual: any, expected: any, message?: string | Error): void;
-        export function notDeepStrictEqual(actual: any, expected: any, message?: string | Error): void;
+        function notDeepEqual(actual: any, expected: any, message?: string | Error): void;
+        function strictEqual(actual: any, expected: any, message?: string | Error): void;
+        function notStrictEqual(actual: any, expected: any, message?: string | Error): void;
+        function deepStrictEqual(actual: any, expected: any, message?: string | Error): void;
+        function notDeepStrictEqual(actual: any, expected: any, message?: string | Error): void;
 
-        export function throws(block: Function, message?: string | Error): void;
-        export function throws(block: Function, error: RegExp | Function | Object | Error, message?: string | Error): void;
-        export function doesNotThrow(block: Function, message?: string | Error): void;
-        export function doesNotThrow(block: Function, error: RegExp | Function, message?: string | Error): void;
+        function throws(block: Function, message?: string | Error): void;
+        function throws(block: Function, error: RegExp | Function | Object | Error, message?: string | Error): void;
+        function doesNotThrow(block: Function, message?: string | Error): void;
+        function doesNotThrow(block: Function, error: RegExp | Function, message?: string | Error): void;
 
-        export function ifError(value: any): void;
+        function ifError(value: any): void;
 
-        export function rejects(block: Function | Promise<any>, message?: string | Error): Promise<void>;
-        export function rejects(block: Function | Promise<any>, error: RegExp | Function | Object | Error, message?: string | Error): Promise<void>;
-        export function doesNotReject(block: Function | Promise<any>, message?: string | Error): Promise<void>;
-        export function doesNotReject(block: Function | Promise<any>, error: RegExp | Function, message?: string | Error): Promise<void>;
+        function rejects(block: Function | Promise<any>, message?: string | Error): Promise<void>;
+        function rejects(block: Function | Promise<any>, error: RegExp | Function | Object | Error, message?: string | Error): Promise<void>;
+        function doesNotReject(block: Function | Promise<any>, message?: string | Error): Promise<void>;
+        function doesNotReject(block: Function | Promise<any>, error: RegExp | Function, message?: string | Error): Promise<void>;
 
-        export var strict: typeof internal;
+        const strict: typeof internal;
     }
 
     export = internal;
@@ -6664,13 +6870,13 @@ declare module "assert" {
 declare module "tty" {
     import * as net from "net";
 
-    export function isatty(fd: number): boolean;
-    export class ReadStream extends net.Socket {
+    function isatty(fd: number): boolean;
+    class ReadStream extends net.Socket {
         isRaw: boolean;
         setRawMode(mode: boolean): void;
         isTTY: boolean;
     }
-    export class WriteStream extends net.Socket {
+    class WriteStream extends net.Socket {
         columns: number;
         rows: number;
         isTTY: boolean;
@@ -6680,7 +6886,7 @@ declare module "tty" {
 declare module "domain" {
     import * as events from "events";
 
-    export class Domain extends events.EventEmitter implements NodeJS.Domain {
+    class Domain extends events.EventEmitter implements NodeJS.Domain {
         run(fn: Function): void;
         add(emitter: events.EventEmitter): void;
         remove(emitter: events.EventEmitter): void;
@@ -6691,287 +6897,287 @@ declare module "domain" {
         exit(): void;
     }
 
-    export function create(): Domain;
+    function create(): Domain;
 }
 
 declare module "constants" {
-    export var E2BIG: number;
-    export var EACCES: number;
-    export var EADDRINUSE: number;
-    export var EADDRNOTAVAIL: number;
-    export var EAFNOSUPPORT: number;
-    export var EAGAIN: number;
-    export var EALREADY: number;
-    export var EBADF: number;
-    export var EBADMSG: number;
-    export var EBUSY: number;
-    export var ECANCELED: number;
-    export var ECHILD: number;
-    export var ECONNABORTED: number;
-    export var ECONNREFUSED: number;
-    export var ECONNRESET: number;
-    export var EDEADLK: number;
-    export var EDESTADDRREQ: number;
-    export var EDOM: number;
-    export var EEXIST: number;
-    export var EFAULT: number;
-    export var EFBIG: number;
-    export var EHOSTUNREACH: number;
-    export var EIDRM: number;
-    export var EILSEQ: number;
-    export var EINPROGRESS: number;
-    export var EINTR: number;
-    export var EINVAL: number;
-    export var EIO: number;
-    export var EISCONN: number;
-    export var EISDIR: number;
-    export var ELOOP: number;
-    export var EMFILE: number;
-    export var EMLINK: number;
-    export var EMSGSIZE: number;
-    export var ENAMETOOLONG: number;
-    export var ENETDOWN: number;
-    export var ENETRESET: number;
-    export var ENETUNREACH: number;
-    export var ENFILE: number;
-    export var ENOBUFS: number;
-    export var ENODATA: number;
-    export var ENODEV: number;
-    export var ENOENT: number;
-    export var ENOEXEC: number;
-    export var ENOLCK: number;
-    export var ENOLINK: number;
-    export var ENOMEM: number;
-    export var ENOMSG: number;
-    export var ENOPROTOOPT: number;
-    export var ENOSPC: number;
-    export var ENOSR: number;
-    export var ENOSTR: number;
-    export var ENOSYS: number;
-    export var ENOTCONN: number;
-    export var ENOTDIR: number;
-    export var ENOTEMPTY: number;
-    export var ENOTSOCK: number;
-    export var ENOTSUP: number;
-    export var ENOTTY: number;
-    export var ENXIO: number;
-    export var EOPNOTSUPP: number;
-    export var EOVERFLOW: number;
-    export var EPERM: number;
-    export var EPIPE: number;
-    export var EPROTO: number;
-    export var EPROTONOSUPPORT: number;
-    export var EPROTOTYPE: number;
-    export var ERANGE: number;
-    export var EROFS: number;
-    export var ESPIPE: number;
-    export var ESRCH: number;
-    export var ETIME: number;
-    export var ETIMEDOUT: number;
-    export var ETXTBSY: number;
-    export var EWOULDBLOCK: number;
-    export var EXDEV: number;
-    export var WSAEINTR: number;
-    export var WSAEBADF: number;
-    export var WSAEACCES: number;
-    export var WSAEFAULT: number;
-    export var WSAEINVAL: number;
-    export var WSAEMFILE: number;
-    export var WSAEWOULDBLOCK: number;
-    export var WSAEINPROGRESS: number;
-    export var WSAEALREADY: number;
-    export var WSAENOTSOCK: number;
-    export var WSAEDESTADDRREQ: number;
-    export var WSAEMSGSIZE: number;
-    export var WSAEPROTOTYPE: number;
-    export var WSAENOPROTOOPT: number;
-    export var WSAEPROTONOSUPPORT: number;
-    export var WSAESOCKTNOSUPPORT: number;
-    export var WSAEOPNOTSUPP: number;
-    export var WSAEPFNOSUPPORT: number;
-    export var WSAEAFNOSUPPORT: number;
-    export var WSAEADDRINUSE: number;
-    export var WSAEADDRNOTAVAIL: number;
-    export var WSAENETDOWN: number;
-    export var WSAENETUNREACH: number;
-    export var WSAENETRESET: number;
-    export var WSAECONNABORTED: number;
-    export var WSAECONNRESET: number;
-    export var WSAENOBUFS: number;
-    export var WSAEISCONN: number;
-    export var WSAENOTCONN: number;
-    export var WSAESHUTDOWN: number;
-    export var WSAETOOMANYREFS: number;
-    export var WSAETIMEDOUT: number;
-    export var WSAECONNREFUSED: number;
-    export var WSAELOOP: number;
-    export var WSAENAMETOOLONG: number;
-    export var WSAEHOSTDOWN: number;
-    export var WSAEHOSTUNREACH: number;
-    export var WSAENOTEMPTY: number;
-    export var WSAEPROCLIM: number;
-    export var WSAEUSERS: number;
-    export var WSAEDQUOT: number;
-    export var WSAESTALE: number;
-    export var WSAEREMOTE: number;
-    export var WSASYSNOTREADY: number;
-    export var WSAVERNOTSUPPORTED: number;
-    export var WSANOTINITIALISED: number;
-    export var WSAEDISCON: number;
-    export var WSAENOMORE: number;
-    export var WSAECANCELLED: number;
-    export var WSAEINVALIDPROCTABLE: number;
-    export var WSAEINVALIDPROVIDER: number;
-    export var WSAEPROVIDERFAILEDINIT: number;
-    export var WSASYSCALLFAILURE: number;
-    export var WSASERVICE_NOT_FOUND: number;
-    export var WSATYPE_NOT_FOUND: number;
-    export var WSA_E_NO_MORE: number;
-    export var WSA_E_CANCELLED: number;
-    export var WSAEREFUSED: number;
-    export var SIGHUP: number;
-    export var SIGINT: number;
-    export var SIGILL: number;
-    export var SIGABRT: number;
-    export var SIGFPE: number;
-    export var SIGKILL: number;
-    export var SIGSEGV: number;
-    export var SIGTERM: number;
-    export var SIGBREAK: number;
-    export var SIGWINCH: number;
-    export var SSL_OP_ALL: number;
-    export var SSL_OP_ALLOW_UNSAFE_LEGACY_RENEGOTIATION: number;
-    export var SSL_OP_CIPHER_SERVER_PREFERENCE: number;
-    export var SSL_OP_CISCO_ANYCONNECT: number;
-    export var SSL_OP_COOKIE_EXCHANGE: number;
-    export var SSL_OP_CRYPTOPRO_TLSEXT_BUG: number;
-    export var SSL_OP_DONT_INSERT_EMPTY_FRAGMENTS: number;
-    export var SSL_OP_EPHEMERAL_RSA: number;
-    export var SSL_OP_LEGACY_SERVER_CONNECT: number;
-    export var SSL_OP_MICROSOFT_BIG_SSLV3_BUFFER: number;
-    export var SSL_OP_MICROSOFT_SESS_ID_BUG: number;
-    export var SSL_OP_MSIE_SSLV2_RSA_PADDING: number;
-    export var SSL_OP_NETSCAPE_CA_DN_BUG: number;
-    export var SSL_OP_NETSCAPE_CHALLENGE_BUG: number;
-    export var SSL_OP_NETSCAPE_DEMO_CIPHER_CHANGE_BUG: number;
-    export var SSL_OP_NETSCAPE_REUSE_CIPHER_CHANGE_BUG: number;
-    export var SSL_OP_NO_COMPRESSION: number;
-    export var SSL_OP_NO_QUERY_MTU: number;
-    export var SSL_OP_NO_SESSION_RESUMPTION_ON_RENEGOTIATION: number;
-    export var SSL_OP_NO_SSLv2: number;
-    export var SSL_OP_NO_SSLv3: number;
-    export var SSL_OP_NO_TICKET: number;
-    export var SSL_OP_NO_TLSv1: number;
-    export var SSL_OP_NO_TLSv1_1: number;
-    export var SSL_OP_NO_TLSv1_2: number;
-    export var SSL_OP_PKCS1_CHECK_1: number;
-    export var SSL_OP_PKCS1_CHECK_2: number;
-    export var SSL_OP_SINGLE_DH_USE: number;
-    export var SSL_OP_SINGLE_ECDH_USE: number;
-    export var SSL_OP_SSLEAY_080_CLIENT_DH_BUG: number;
-    export var SSL_OP_SSLREF2_REUSE_CERT_TYPE_BUG: number;
-    export var SSL_OP_TLS_BLOCK_PADDING_BUG: number;
-    export var SSL_OP_TLS_D5_BUG: number;
-    export var SSL_OP_TLS_ROLLBACK_BUG: number;
-    export var ENGINE_METHOD_DSA: number;
-    export var ENGINE_METHOD_DH: number;
-    export var ENGINE_METHOD_RAND: number;
-    export var ENGINE_METHOD_ECDH: number;
-    export var ENGINE_METHOD_ECDSA: number;
-    export var ENGINE_METHOD_CIPHERS: number;
-    export var ENGINE_METHOD_DIGESTS: number;
-    export var ENGINE_METHOD_STORE: number;
-    export var ENGINE_METHOD_PKEY_METHS: number;
-    export var ENGINE_METHOD_PKEY_ASN1_METHS: number;
-    export var ENGINE_METHOD_ALL: number;
-    export var ENGINE_METHOD_NONE: number;
-    export var DH_CHECK_P_NOT_SAFE_PRIME: number;
-    export var DH_CHECK_P_NOT_PRIME: number;
-    export var DH_UNABLE_TO_CHECK_GENERATOR: number;
-    export var DH_NOT_SUITABLE_GENERATOR: number;
-    export var NPN_ENABLED: number;
-    export var RSA_PKCS1_PADDING: number;
-    export var RSA_SSLV23_PADDING: number;
-    export var RSA_NO_PADDING: number;
-    export var RSA_PKCS1_OAEP_PADDING: number;
-    export var RSA_X931_PADDING: number;
-    export var RSA_PKCS1_PSS_PADDING: number;
-    export var POINT_CONVERSION_COMPRESSED: number;
-    export var POINT_CONVERSION_UNCOMPRESSED: number;
-    export var POINT_CONVERSION_HYBRID: number;
-    export var O_RDONLY: number;
-    export var O_WRONLY: number;
-    export var O_RDWR: number;
-    export var S_IFMT: number;
-    export var S_IFREG: number;
-    export var S_IFDIR: number;
-    export var S_IFCHR: number;
-    export var S_IFBLK: number;
-    export var S_IFIFO: number;
-    export var S_IFSOCK: number;
-    export var S_IRWXU: number;
-    export var S_IRUSR: number;
-    export var S_IWUSR: number;
-    export var S_IXUSR: number;
-    export var S_IRWXG: number;
-    export var S_IRGRP: number;
-    export var S_IWGRP: number;
-    export var S_IXGRP: number;
-    export var S_IRWXO: number;
-    export var S_IROTH: number;
-    export var S_IWOTH: number;
-    export var S_IXOTH: number;
-    export var S_IFLNK: number;
-    export var O_CREAT: number;
-    export var O_EXCL: number;
-    export var O_NOCTTY: number;
-    export var O_DIRECTORY: number;
-    export var O_NOATIME: number;
-    export var O_NOFOLLOW: number;
-    export var O_SYNC: number;
-    export var O_DSYNC: number;
-    export var O_SYMLINK: number;
-    export var O_DIRECT: number;
-    export var O_NONBLOCK: number;
-    export var O_TRUNC: number;
-    export var O_APPEND: number;
-    export var F_OK: number;
-    export var R_OK: number;
-    export var W_OK: number;
-    export var X_OK: number;
-    export var COPYFILE_EXCL: number;
-    export var COPYFILE_FICLONE: number;
-    export var COPYFILE_FICLONE_FORCE: number;
-    export var UV_UDP_REUSEADDR: number;
-    export var SIGQUIT: number;
-    export var SIGTRAP: number;
-    export var SIGIOT: number;
-    export var SIGBUS: number;
-    export var SIGUSR1: number;
-    export var SIGUSR2: number;
-    export var SIGPIPE: number;
-    export var SIGALRM: number;
-    export var SIGCHLD: number;
-    export var SIGSTKFLT: number;
-    export var SIGCONT: number;
-    export var SIGSTOP: number;
-    export var SIGTSTP: number;
-    export var SIGTTIN: number;
-    export var SIGTTOU: number;
-    export var SIGURG: number;
-    export var SIGXCPU: number;
-    export var SIGXFSZ: number;
-    export var SIGVTALRM: number;
-    export var SIGPROF: number;
-    export var SIGIO: number;
-    export var SIGPOLL: number;
-    export var SIGPWR: number;
-    export var SIGSYS: number;
-    export var SIGUNUSED: number;
-    export var defaultCoreCipherList: string;
-    export var defaultCipherList: string;
-    export var ENGINE_METHOD_RSA: number;
-    export var ALPN_ENABLED: number;
+    const E2BIG: number;
+    const EACCES: number;
+    const EADDRINUSE: number;
+    const EADDRNOTAVAIL: number;
+    const EAFNOSUPPORT: number;
+    const EAGAIN: number;
+    const EALREADY: number;
+    const EBADF: number;
+    const EBADMSG: number;
+    const EBUSY: number;
+    const ECANCELED: number;
+    const ECHILD: number;
+    const ECONNABORTED: number;
+    const ECONNREFUSED: number;
+    const ECONNRESET: number;
+    const EDEADLK: number;
+    const EDESTADDRREQ: number;
+    const EDOM: number;
+    const EEXIST: number;
+    const EFAULT: number;
+    const EFBIG: number;
+    const EHOSTUNREACH: number;
+    const EIDRM: number;
+    const EILSEQ: number;
+    const EINPROGRESS: number;
+    const EINTR: number;
+    const EINVAL: number;
+    const EIO: number;
+    const EISCONN: number;
+    const EISDIR: number;
+    const ELOOP: number;
+    const EMFILE: number;
+    const EMLINK: number;
+    const EMSGSIZE: number;
+    const ENAMETOOLONG: number;
+    const ENETDOWN: number;
+    const ENETRESET: number;
+    const ENETUNREACH: number;
+    const ENFILE: number;
+    const ENOBUFS: number;
+    const ENODATA: number;
+    const ENODEV: number;
+    const ENOENT: number;
+    const ENOEXEC: number;
+    const ENOLCK: number;
+    const ENOLINK: number;
+    const ENOMEM: number;
+    const ENOMSG: number;
+    const ENOPROTOOPT: number;
+    const ENOSPC: number;
+    const ENOSR: number;
+    const ENOSTR: number;
+    const ENOSYS: number;
+    const ENOTCONN: number;
+    const ENOTDIR: number;
+    const ENOTEMPTY: number;
+    const ENOTSOCK: number;
+    const ENOTSUP: number;
+    const ENOTTY: number;
+    const ENXIO: number;
+    const EOPNOTSUPP: number;
+    const EOVERFLOW: number;
+    const EPERM: number;
+    const EPIPE: number;
+    const EPROTO: number;
+    const EPROTONOSUPPORT: number;
+    const EPROTOTYPE: number;
+    const ERANGE: number;
+    const EROFS: number;
+    const ESPIPE: number;
+    const ESRCH: number;
+    const ETIME: number;
+    const ETIMEDOUT: number;
+    const ETXTBSY: number;
+    const EWOULDBLOCK: number;
+    const EXDEV: number;
+    const WSAEINTR: number;
+    const WSAEBADF: number;
+    const WSAEACCES: number;
+    const WSAEFAULT: number;
+    const WSAEINVAL: number;
+    const WSAEMFILE: number;
+    const WSAEWOULDBLOCK: number;
+    const WSAEINPROGRESS: number;
+    const WSAEALREADY: number;
+    const WSAENOTSOCK: number;
+    const WSAEDESTADDRREQ: number;
+    const WSAEMSGSIZE: number;
+    const WSAEPROTOTYPE: number;
+    const WSAENOPROTOOPT: number;
+    const WSAEPROTONOSUPPORT: number;
+    const WSAESOCKTNOSUPPORT: number;
+    const WSAEOPNOTSUPP: number;
+    const WSAEPFNOSUPPORT: number;
+    const WSAEAFNOSUPPORT: number;
+    const WSAEADDRINUSE: number;
+    const WSAEADDRNOTAVAIL: number;
+    const WSAENETDOWN: number;
+    const WSAENETUNREACH: number;
+    const WSAENETRESET: number;
+    const WSAECONNABORTED: number;
+    const WSAECONNRESET: number;
+    const WSAENOBUFS: number;
+    const WSAEISCONN: number;
+    const WSAENOTCONN: number;
+    const WSAESHUTDOWN: number;
+    const WSAETOOMANYREFS: number;
+    const WSAETIMEDOUT: number;
+    const WSAECONNREFUSED: number;
+    const WSAELOOP: number;
+    const WSAENAMETOOLONG: number;
+    const WSAEHOSTDOWN: number;
+    const WSAEHOSTUNREACH: number;
+    const WSAENOTEMPTY: number;
+    const WSAEPROCLIM: number;
+    const WSAEUSERS: number;
+    const WSAEDQUOT: number;
+    const WSAESTALE: number;
+    const WSAEREMOTE: number;
+    const WSASYSNOTREADY: number;
+    const WSAVERNOTSUPPORTED: number;
+    const WSANOTINITIALISED: number;
+    const WSAEDISCON: number;
+    const WSAENOMORE: number;
+    const WSAECANCELLED: number;
+    const WSAEINVALIDPROCTABLE: number;
+    const WSAEINVALIDPROVIDER: number;
+    const WSAEPROVIDERFAILEDINIT: number;
+    const WSASYSCALLFAILURE: number;
+    const WSASERVICE_NOT_FOUND: number;
+    const WSATYPE_NOT_FOUND: number;
+    const WSA_E_NO_MORE: number;
+    const WSA_E_CANCELLED: number;
+    const WSAEREFUSED: number;
+    const SIGHUP: number;
+    const SIGINT: number;
+    const SIGILL: number;
+    const SIGABRT: number;
+    const SIGFPE: number;
+    const SIGKILL: number;
+    const SIGSEGV: number;
+    const SIGTERM: number;
+    const SIGBREAK: number;
+    const SIGWINCH: number;
+    const SSL_OP_ALL: number;
+    const SSL_OP_ALLOW_UNSAFE_LEGACY_RENEGOTIATION: number;
+    const SSL_OP_CIPHER_SERVER_PREFERENCE: number;
+    const SSL_OP_CISCO_ANYCONNECT: number;
+    const SSL_OP_COOKIE_EXCHANGE: number;
+    const SSL_OP_CRYPTOPRO_TLSEXT_BUG: number;
+    const SSL_OP_DONT_INSERT_EMPTY_FRAGMENTS: number;
+    const SSL_OP_EPHEMERAL_RSA: number;
+    const SSL_OP_LEGACY_SERVER_CONNECT: number;
+    const SSL_OP_MICROSOFT_BIG_SSLV3_BUFFER: number;
+    const SSL_OP_MICROSOFT_SESS_ID_BUG: number;
+    const SSL_OP_MSIE_SSLV2_RSA_PADDING: number;
+    const SSL_OP_NETSCAPE_CA_DN_BUG: number;
+    const SSL_OP_NETSCAPE_CHALLENGE_BUG: number;
+    const SSL_OP_NETSCAPE_DEMO_CIPHER_CHANGE_BUG: number;
+    const SSL_OP_NETSCAPE_REUSE_CIPHER_CHANGE_BUG: number;
+    const SSL_OP_NO_COMPRESSION: number;
+    const SSL_OP_NO_QUERY_MTU: number;
+    const SSL_OP_NO_SESSION_RESUMPTION_ON_RENEGOTIATION: number;
+    const SSL_OP_NO_SSLv2: number;
+    const SSL_OP_NO_SSLv3: number;
+    const SSL_OP_NO_TICKET: number;
+    const SSL_OP_NO_TLSv1: number;
+    const SSL_OP_NO_TLSv1_1: number;
+    const SSL_OP_NO_TLSv1_2: number;
+    const SSL_OP_PKCS1_CHECK_1: number;
+    const SSL_OP_PKCS1_CHECK_2: number;
+    const SSL_OP_SINGLE_DH_USE: number;
+    const SSL_OP_SINGLE_ECDH_USE: number;
+    const SSL_OP_SSLEAY_080_CLIENT_DH_BUG: number;
+    const SSL_OP_SSLREF2_REUSE_CERT_TYPE_BUG: number;
+    const SSL_OP_TLS_BLOCK_PADDING_BUG: number;
+    const SSL_OP_TLS_D5_BUG: number;
+    const SSL_OP_TLS_ROLLBACK_BUG: number;
+    const ENGINE_METHOD_DSA: number;
+    const ENGINE_METHOD_DH: number;
+    const ENGINE_METHOD_RAND: number;
+    const ENGINE_METHOD_ECDH: number;
+    const ENGINE_METHOD_ECDSA: number;
+    const ENGINE_METHOD_CIPHERS: number;
+    const ENGINE_METHOD_DIGESTS: number;
+    const ENGINE_METHOD_STORE: number;
+    const ENGINE_METHOD_PKEY_METHS: number;
+    const ENGINE_METHOD_PKEY_ASN1_METHS: number;
+    const ENGINE_METHOD_ALL: number;
+    const ENGINE_METHOD_NONE: number;
+    const DH_CHECK_P_NOT_SAFE_PRIME: number;
+    const DH_CHECK_P_NOT_PRIME: number;
+    const DH_UNABLE_TO_CHECK_GENERATOR: number;
+    const DH_NOT_SUITABLE_GENERATOR: number;
+    const NPN_ENABLED: number;
+    const RSA_PKCS1_PADDING: number;
+    const RSA_SSLV23_PADDING: number;
+    const RSA_NO_PADDING: number;
+    const RSA_PKCS1_OAEP_PADDING: number;
+    const RSA_X931_PADDING: number;
+    const RSA_PKCS1_PSS_PADDING: number;
+    const POINT_CONVERSION_COMPRESSED: number;
+    const POINT_CONVERSION_UNCOMPRESSED: number;
+    const POINT_CONVERSION_HYBRID: number;
+    const O_RDONLY: number;
+    const O_WRONLY: number;
+    const O_RDWR: number;
+    const S_IFMT: number;
+    const S_IFREG: number;
+    const S_IFDIR: number;
+    const S_IFCHR: number;
+    const S_IFBLK: number;
+    const S_IFIFO: number;
+    const S_IFSOCK: number;
+    const S_IRWXU: number;
+    const S_IRUSR: number;
+    const S_IWUSR: number;
+    const S_IXUSR: number;
+    const S_IRWXG: number;
+    const S_IRGRP: number;
+    const S_IWGRP: number;
+    const S_IXGRP: number;
+    const S_IRWXO: number;
+    const S_IROTH: number;
+    const S_IWOTH: number;
+    const S_IXOTH: number;
+    const S_IFLNK: number;
+    const O_CREAT: number;
+    const O_EXCL: number;
+    const O_NOCTTY: number;
+    const O_DIRECTORY: number;
+    const O_NOATIME: number;
+    const O_NOFOLLOW: number;
+    const O_SYNC: number;
+    const O_DSYNC: number;
+    const O_SYMLINK: number;
+    const O_DIRECT: number;
+    const O_NONBLOCK: number;
+    const O_TRUNC: number;
+    const O_APPEND: number;
+    const F_OK: number;
+    const R_OK: number;
+    const W_OK: number;
+    const X_OK: number;
+    const COPYFILE_EXCL: number;
+    const COPYFILE_FICLONE: number;
+    const COPYFILE_FICLONE_FORCE: number;
+    const UV_UDP_REUSEADDR: number;
+    const SIGQUIT: number;
+    const SIGTRAP: number;
+    const SIGIOT: number;
+    const SIGBUS: number;
+    const SIGUSR1: number;
+    const SIGUSR2: number;
+    const SIGPIPE: number;
+    const SIGALRM: number;
+    const SIGCHLD: number;
+    const SIGSTKFLT: number;
+    const SIGCONT: number;
+    const SIGSTOP: number;
+    const SIGTSTP: number;
+    const SIGTTIN: number;
+    const SIGTTOU: number;
+    const SIGURG: number;
+    const SIGXCPU: number;
+    const SIGXFSZ: number;
+    const SIGVTALRM: number;
+    const SIGPROF: number;
+    const SIGIO: number;
+    const SIGPOLL: number;
+    const SIGPWR: number;
+    const SIGSYS: number;
+    const SIGUNUSED: number;
+    const defaultCoreCipherList: string;
+    const defaultCipherList: string;
+    const ENGINE_METHOD_RSA: number;
+    const ALPN_ENABLED: number;
 }
 
 declare module "module" {
@@ -7006,26 +7212,26 @@ declare module "v8" {
         does_zap_garbage: DoesZapCodeSpaceFlag;
     }
 
-    export function getHeapStatistics(): HeapInfo;
-    export function getHeapSpaceStatistics(): HeapSpaceInfo[];
-    export function setFlagsFromString(flags: string): void;
+    function getHeapStatistics(): HeapInfo;
+    function getHeapSpaceStatistics(): HeapSpaceInfo[];
+    function setFlagsFromString(flags: string): void;
 }
 
 declare module "timers" {
-    export function setTimeout(callback: (...args: any[]) => void, ms: number, ...args: any[]): NodeJS.Timer;
-    export namespace setTimeout {
-        export function __promisify__(ms: number): Promise<void>;
-        export function __promisify__<T>(ms: number, value: T): Promise<T>;
+    function setTimeout(callback: (...args: any[]) => void, ms: number, ...args: any[]): NodeJS.Timer;
+    namespace setTimeout {
+        function __promisify__(ms: number): Promise<void>;
+        function __promisify__<T>(ms: number, value: T): Promise<T>;
     }
-    export function clearTimeout(timeoutId: NodeJS.Timer): void;
-    export function setInterval(callback: (...args: any[]) => void, ms: number, ...args: any[]): NodeJS.Timer;
-    export function clearInterval(intervalId: NodeJS.Timer): void;
-    export function setImmediate(callback: (...args: any[]) => void, ...args: any[]): any;
-    export namespace setImmediate {
-        export function __promisify__(): Promise<void>;
-        export function __promisify__<T>(value: T): Promise<T>;
+    function clearTimeout(timeoutId: NodeJS.Timer): void;
+    function setInterval(callback: (...args: any[]) => void, ms: number, ...args: any[]): NodeJS.Timer;
+    function clearInterval(intervalId: NodeJS.Timer): void;
+    function setImmediate(callback: (...args: any[]) => void, ...args: any[]): any;
+    namespace setImmediate {
+        function __promisify__(): Promise<void>;
+        function __promisify__<T>(value: T): Promise<T>;
     }
-    export function clearImmediate(immediateId: any): void;
+    function clearImmediate(immediateId: any): void;
 }
 
 declare module "console" {
@@ -7039,14 +7245,14 @@ declare module "async_hooks" {
     /**
      * Returns the asyncId of the current execution context.
      */
-    export function executionAsyncId(): number;
+    function executionAsyncId(): number;
 
     /**
      * Returns the ID of the resource responsible for calling the callback that is currently being executed.
      */
-    export function triggerAsyncId(): number;
+    function triggerAsyncId(): number;
 
-    export interface HookCallbacks {
+    interface HookCallbacks {
         /**
          * Called when a class is constructed that has the possibility to emit an asynchronous event.
          * @param asyncId a unique ID for the async resource
@@ -7083,7 +7289,7 @@ declare module "async_hooks" {
         destroy?(asyncId: number): void;
     }
 
-    export interface AsyncHook {
+    interface AsyncHook {
         /**
          * Enable the callbacks for a given AsyncHook instance. If no callbacks are provided enabling is a noop.
          */
@@ -7100,9 +7306,9 @@ declare module "async_hooks" {
      * @param options the callbacks to register
      * @return an AsyncHooks instance used for disabling and enabling hooks
      */
-    export function createHook(options: HookCallbacks): AsyncHook;
+    function createHook(options: HookCallbacks): AsyncHook;
 
-    export interface AsyncResourceOptions {
+    interface AsyncResourceOptions {
       /**
        * The ID of the execution context that created this async event.
        * Default: `executionAsyncId()`
@@ -7123,7 +7329,7 @@ declare module "async_hooks" {
      * The class AsyncResource was designed to be extended by the embedder's async resources.
      * Using this users can easily trigger the lifetime events of their own resources.
      */
-    export class AsyncResource {
+    class AsyncResource {
         /**
          * AsyncResource() is meant to be extended. Instantiating a
          * new AsyncResource() also triggers init. If triggerAsyncId is omitted then
@@ -7791,214 +7997,214 @@ declare module "http2" {
     // Public API
 
     export namespace constants {
-        export const NGHTTP2_SESSION_SERVER: number;
-        export const NGHTTP2_SESSION_CLIENT: number;
-        export const NGHTTP2_STREAM_STATE_IDLE: number;
-        export const NGHTTP2_STREAM_STATE_OPEN: number;
-        export const NGHTTP2_STREAM_STATE_RESERVED_LOCAL: number;
-        export const NGHTTP2_STREAM_STATE_RESERVED_REMOTE: number;
-        export const NGHTTP2_STREAM_STATE_HALF_CLOSED_LOCAL: number;
-        export const NGHTTP2_STREAM_STATE_HALF_CLOSED_REMOTE: number;
-        export const NGHTTP2_STREAM_STATE_CLOSED: number;
-        export const NGHTTP2_NO_ERROR: number;
-        export const NGHTTP2_PROTOCOL_ERROR: number;
-        export const NGHTTP2_INTERNAL_ERROR: number;
-        export const NGHTTP2_FLOW_CONTROL_ERROR: number;
-        export const NGHTTP2_SETTINGS_TIMEOUT: number;
-        export const NGHTTP2_STREAM_CLOSED: number;
-        export const NGHTTP2_FRAME_SIZE_ERROR: number;
-        export const NGHTTP2_REFUSED_STREAM: number;
-        export const NGHTTP2_CANCEL: number;
-        export const NGHTTP2_COMPRESSION_ERROR: number;
-        export const NGHTTP2_CONNECT_ERROR: number;
-        export const NGHTTP2_ENHANCE_YOUR_CALM: number;
-        export const NGHTTP2_INADEQUATE_SECURITY: number;
-        export const NGHTTP2_HTTP_1_1_REQUIRED: number;
-        export const NGHTTP2_ERR_FRAME_SIZE_ERROR: number;
-        export const NGHTTP2_FLAG_NONE: number;
-        export const NGHTTP2_FLAG_END_STREAM: number;
-        export const NGHTTP2_FLAG_END_HEADERS: number;
-        export const NGHTTP2_FLAG_ACK: number;
-        export const NGHTTP2_FLAG_PADDED: number;
-        export const NGHTTP2_FLAG_PRIORITY: number;
-        export const DEFAULT_SETTINGS_HEADER_TABLE_SIZE: number;
-        export const DEFAULT_SETTINGS_ENABLE_PUSH: number;
-        export const DEFAULT_SETTINGS_INITIAL_WINDOW_SIZE: number;
-        export const DEFAULT_SETTINGS_MAX_FRAME_SIZE: number;
-        export const MAX_MAX_FRAME_SIZE: number;
-        export const MIN_MAX_FRAME_SIZE: number;
-        export const MAX_INITIAL_WINDOW_SIZE: number;
-        export const NGHTTP2_DEFAULT_WEIGHT: number;
-        export const NGHTTP2_SETTINGS_HEADER_TABLE_SIZE: number;
-        export const NGHTTP2_SETTINGS_ENABLE_PUSH: number;
-        export const NGHTTP2_SETTINGS_MAX_CONCURRENT_STREAMS: number;
-        export const NGHTTP2_SETTINGS_INITIAL_WINDOW_SIZE: number;
-        export const NGHTTP2_SETTINGS_MAX_FRAME_SIZE: number;
-        export const NGHTTP2_SETTINGS_MAX_HEADER_LIST_SIZE: number;
-        export const PADDING_STRATEGY_NONE: number;
-        export const PADDING_STRATEGY_MAX: number;
-        export const PADDING_STRATEGY_CALLBACK: number;
-        export const HTTP2_HEADER_STATUS: string;
-        export const HTTP2_HEADER_METHOD: string;
-        export const HTTP2_HEADER_AUTHORITY: string;
-        export const HTTP2_HEADER_SCHEME: string;
-        export const HTTP2_HEADER_PATH: string;
-        export const HTTP2_HEADER_ACCEPT_CHARSET: string;
-        export const HTTP2_HEADER_ACCEPT_ENCODING: string;
-        export const HTTP2_HEADER_ACCEPT_LANGUAGE: string;
-        export const HTTP2_HEADER_ACCEPT_RANGES: string;
-        export const HTTP2_HEADER_ACCEPT: string;
-        export const HTTP2_HEADER_ACCESS_CONTROL_ALLOW_ORIGIN: string;
-        export const HTTP2_HEADER_AGE: string;
-        export const HTTP2_HEADER_ALLOW: string;
-        export const HTTP2_HEADER_AUTHORIZATION: string;
-        export const HTTP2_HEADER_CACHE_CONTROL: string;
-        export const HTTP2_HEADER_CONNECTION: string;
-        export const HTTP2_HEADER_CONTENT_DISPOSITION: string;
-        export const HTTP2_HEADER_CONTENT_ENCODING: string;
-        export const HTTP2_HEADER_CONTENT_LANGUAGE: string;
-        export const HTTP2_HEADER_CONTENT_LENGTH: string;
-        export const HTTP2_HEADER_CONTENT_LOCATION: string;
-        export const HTTP2_HEADER_CONTENT_MD5: string;
-        export const HTTP2_HEADER_CONTENT_RANGE: string;
-        export const HTTP2_HEADER_CONTENT_TYPE: string;
-        export const HTTP2_HEADER_COOKIE: string;
-        export const HTTP2_HEADER_DATE: string;
-        export const HTTP2_HEADER_ETAG: string;
-        export const HTTP2_HEADER_EXPECT: string;
-        export const HTTP2_HEADER_EXPIRES: string;
-        export const HTTP2_HEADER_FROM: string;
-        export const HTTP2_HEADER_HOST: string;
-        export const HTTP2_HEADER_IF_MATCH: string;
-        export const HTTP2_HEADER_IF_MODIFIED_SINCE: string;
-        export const HTTP2_HEADER_IF_NONE_MATCH: string;
-        export const HTTP2_HEADER_IF_RANGE: string;
-        export const HTTP2_HEADER_IF_UNMODIFIED_SINCE: string;
-        export const HTTP2_HEADER_LAST_MODIFIED: string;
-        export const HTTP2_HEADER_LINK: string;
-        export const HTTP2_HEADER_LOCATION: string;
-        export const HTTP2_HEADER_MAX_FORWARDS: string;
-        export const HTTP2_HEADER_PREFER: string;
-        export const HTTP2_HEADER_PROXY_AUTHENTICATE: string;
-        export const HTTP2_HEADER_PROXY_AUTHORIZATION: string;
-        export const HTTP2_HEADER_RANGE: string;
-        export const HTTP2_HEADER_REFERER: string;
-        export const HTTP2_HEADER_REFRESH: string;
-        export const HTTP2_HEADER_RETRY_AFTER: string;
-        export const HTTP2_HEADER_SERVER: string;
-        export const HTTP2_HEADER_SET_COOKIE: string;
-        export const HTTP2_HEADER_STRICT_TRANSPORT_SECURITY: string;
-        export const HTTP2_HEADER_TRANSFER_ENCODING: string;
-        export const HTTP2_HEADER_TE: string;
-        export const HTTP2_HEADER_UPGRADE: string;
-        export const HTTP2_HEADER_USER_AGENT: string;
-        export const HTTP2_HEADER_VARY: string;
-        export const HTTP2_HEADER_VIA: string;
-        export const HTTP2_HEADER_WWW_AUTHENTICATE: string;
-        export const HTTP2_HEADER_HTTP2_SETTINGS: string;
-        export const HTTP2_HEADER_KEEP_ALIVE: string;
-        export const HTTP2_HEADER_PROXY_CONNECTION: string;
-        export const HTTP2_METHOD_ACL: string;
-        export const HTTP2_METHOD_BASELINE_CONTROL: string;
-        export const HTTP2_METHOD_BIND: string;
-        export const HTTP2_METHOD_CHECKIN: string;
-        export const HTTP2_METHOD_CHECKOUT: string;
-        export const HTTP2_METHOD_CONNECT: string;
-        export const HTTP2_METHOD_COPY: string;
-        export const HTTP2_METHOD_DELETE: string;
-        export const HTTP2_METHOD_GET: string;
-        export const HTTP2_METHOD_HEAD: string;
-        export const HTTP2_METHOD_LABEL: string;
-        export const HTTP2_METHOD_LINK: string;
-        export const HTTP2_METHOD_LOCK: string;
-        export const HTTP2_METHOD_MERGE: string;
-        export const HTTP2_METHOD_MKACTIVITY: string;
-        export const HTTP2_METHOD_MKCALENDAR: string;
-        export const HTTP2_METHOD_MKCOL: string;
-        export const HTTP2_METHOD_MKREDIRECTREF: string;
-        export const HTTP2_METHOD_MKWORKSPACE: string;
-        export const HTTP2_METHOD_MOVE: string;
-        export const HTTP2_METHOD_OPTIONS: string;
-        export const HTTP2_METHOD_ORDERPATCH: string;
-        export const HTTP2_METHOD_PATCH: string;
-        export const HTTP2_METHOD_POST: string;
-        export const HTTP2_METHOD_PRI: string;
-        export const HTTP2_METHOD_PROPFIND: string;
-        export const HTTP2_METHOD_PROPPATCH: string;
-        export const HTTP2_METHOD_PUT: string;
-        export const HTTP2_METHOD_REBIND: string;
-        export const HTTP2_METHOD_REPORT: string;
-        export const HTTP2_METHOD_SEARCH: string;
-        export const HTTP2_METHOD_TRACE: string;
-        export const HTTP2_METHOD_UNBIND: string;
-        export const HTTP2_METHOD_UNCHECKOUT: string;
-        export const HTTP2_METHOD_UNLINK: string;
-        export const HTTP2_METHOD_UNLOCK: string;
-        export const HTTP2_METHOD_UPDATE: string;
-        export const HTTP2_METHOD_UPDATEREDIRECTREF: string;
-        export const HTTP2_METHOD_VERSION_CONTROL: string;
-        export const HTTP_STATUS_CONTINUE: number;
-        export const HTTP_STATUS_SWITCHING_PROTOCOLS: number;
-        export const HTTP_STATUS_PROCESSING: number;
-        export const HTTP_STATUS_OK: number;
-        export const HTTP_STATUS_CREATED: number;
-        export const HTTP_STATUS_ACCEPTED: number;
-        export const HTTP_STATUS_NON_AUTHORITATIVE_INFORMATION: number;
-        export const HTTP_STATUS_NO_CONTENT: number;
-        export const HTTP_STATUS_RESET_CONTENT: number;
-        export const HTTP_STATUS_PARTIAL_CONTENT: number;
-        export const HTTP_STATUS_MULTI_STATUS: number;
-        export const HTTP_STATUS_ALREADY_REPORTED: number;
-        export const HTTP_STATUS_IM_USED: number;
-        export const HTTP_STATUS_MULTIPLE_CHOICES: number;
-        export const HTTP_STATUS_MOVED_PERMANENTLY: number;
-        export const HTTP_STATUS_FOUND: number;
-        export const HTTP_STATUS_SEE_OTHER: number;
-        export const HTTP_STATUS_NOT_MODIFIED: number;
-        export const HTTP_STATUS_USE_PROXY: number;
-        export const HTTP_STATUS_TEMPORARY_REDIRECT: number;
-        export const HTTP_STATUS_PERMANENT_REDIRECT: number;
-        export const HTTP_STATUS_BAD_REQUEST: number;
-        export const HTTP_STATUS_UNAUTHORIZED: number;
-        export const HTTP_STATUS_PAYMENT_REQUIRED: number;
-        export const HTTP_STATUS_FORBIDDEN: number;
-        export const HTTP_STATUS_NOT_FOUND: number;
-        export const HTTP_STATUS_METHOD_NOT_ALLOWED: number;
-        export const HTTP_STATUS_NOT_ACCEPTABLE: number;
-        export const HTTP_STATUS_PROXY_AUTHENTICATION_REQUIRED: number;
-        export const HTTP_STATUS_REQUEST_TIMEOUT: number;
-        export const HTTP_STATUS_CONFLICT: number;
-        export const HTTP_STATUS_GONE: number;
-        export const HTTP_STATUS_LENGTH_REQUIRED: number;
-        export const HTTP_STATUS_PRECONDITION_FAILED: number;
-        export const HTTP_STATUS_PAYLOAD_TOO_LARGE: number;
-        export const HTTP_STATUS_URI_TOO_LONG: number;
-        export const HTTP_STATUS_UNSUPPORTED_MEDIA_TYPE: number;
-        export const HTTP_STATUS_RANGE_NOT_SATISFIABLE: number;
-        export const HTTP_STATUS_EXPECTATION_FAILED: number;
-        export const HTTP_STATUS_TEAPOT: number;
-        export const HTTP_STATUS_MISDIRECTED_REQUEST: number;
-        export const HTTP_STATUS_UNPROCESSABLE_ENTITY: number;
-        export const HTTP_STATUS_LOCKED: number;
-        export const HTTP_STATUS_FAILED_DEPENDENCY: number;
-        export const HTTP_STATUS_UNORDERED_COLLECTION: number;
-        export const HTTP_STATUS_UPGRADE_REQUIRED: number;
-        export const HTTP_STATUS_PRECONDITION_REQUIRED: number;
-        export const HTTP_STATUS_TOO_MANY_REQUESTS: number;
-        export const HTTP_STATUS_REQUEST_HEADER_FIELDS_TOO_LARGE: number;
-        export const HTTP_STATUS_UNAVAILABLE_FOR_LEGAL_REASONS: number;
-        export const HTTP_STATUS_INTERNAL_SERVER_ERROR: number;
-        export const HTTP_STATUS_NOT_IMPLEMENTED: number;
-        export const HTTP_STATUS_BAD_GATEWAY: number;
-        export const HTTP_STATUS_SERVICE_UNAVAILABLE: number;
-        export const HTTP_STATUS_GATEWAY_TIMEOUT: number;
-        export const HTTP_STATUS_HTTP_VERSION_NOT_SUPPORTED: number;
-        export const HTTP_STATUS_VARIANT_ALSO_NEGOTIATES: number;
-        export const HTTP_STATUS_INSUFFICIENT_STORAGE: number;
-        export const HTTP_STATUS_LOOP_DETECTED: number;
-        export const HTTP_STATUS_BANDWIDTH_LIMIT_EXCEEDED: number;
-        export const HTTP_STATUS_NOT_EXTENDED: number;
-        export const HTTP_STATUS_NETWORK_AUTHENTICATION_REQUIRED: number;
+        const NGHTTP2_SESSION_SERVER: number;
+        const NGHTTP2_SESSION_CLIENT: number;
+        const NGHTTP2_STREAM_STATE_IDLE: number;
+        const NGHTTP2_STREAM_STATE_OPEN: number;
+        const NGHTTP2_STREAM_STATE_RESERVED_LOCAL: number;
+        const NGHTTP2_STREAM_STATE_RESERVED_REMOTE: number;
+        const NGHTTP2_STREAM_STATE_HALF_CLOSED_LOCAL: number;
+        const NGHTTP2_STREAM_STATE_HALF_CLOSED_REMOTE: number;
+        const NGHTTP2_STREAM_STATE_CLOSED: number;
+        const NGHTTP2_NO_ERROR: number;
+        const NGHTTP2_PROTOCOL_ERROR: number;
+        const NGHTTP2_INTERNAL_ERROR: number;
+        const NGHTTP2_FLOW_CONTROL_ERROR: number;
+        const NGHTTP2_SETTINGS_TIMEOUT: number;
+        const NGHTTP2_STREAM_CLOSED: number;
+        const NGHTTP2_FRAME_SIZE_ERROR: number;
+        const NGHTTP2_REFUSED_STREAM: number;
+        const NGHTTP2_CANCEL: number;
+        const NGHTTP2_COMPRESSION_ERROR: number;
+        const NGHTTP2_CONNECT_ERROR: number;
+        const NGHTTP2_ENHANCE_YOUR_CALM: number;
+        const NGHTTP2_INADEQUATE_SECURITY: number;
+        const NGHTTP2_HTTP_1_1_REQUIRED: number;
+        const NGHTTP2_ERR_FRAME_SIZE_ERROR: number;
+        const NGHTTP2_FLAG_NONE: number;
+        const NGHTTP2_FLAG_END_STREAM: number;
+        const NGHTTP2_FLAG_END_HEADERS: number;
+        const NGHTTP2_FLAG_ACK: number;
+        const NGHTTP2_FLAG_PADDED: number;
+        const NGHTTP2_FLAG_PRIORITY: number;
+        const DEFAULT_SETTINGS_HEADER_TABLE_SIZE: number;
+        const DEFAULT_SETTINGS_ENABLE_PUSH: number;
+        const DEFAULT_SETTINGS_INITIAL_WINDOW_SIZE: number;
+        const DEFAULT_SETTINGS_MAX_FRAME_SIZE: number;
+        const MAX_MAX_FRAME_SIZE: number;
+        const MIN_MAX_FRAME_SIZE: number;
+        const MAX_INITIAL_WINDOW_SIZE: number;
+        const NGHTTP2_DEFAULT_WEIGHT: number;
+        const NGHTTP2_SETTINGS_HEADER_TABLE_SIZE: number;
+        const NGHTTP2_SETTINGS_ENABLE_PUSH: number;
+        const NGHTTP2_SETTINGS_MAX_CONCURRENT_STREAMS: number;
+        const NGHTTP2_SETTINGS_INITIAL_WINDOW_SIZE: number;
+        const NGHTTP2_SETTINGS_MAX_FRAME_SIZE: number;
+        const NGHTTP2_SETTINGS_MAX_HEADER_LIST_SIZE: number;
+        const PADDING_STRATEGY_NONE: number;
+        const PADDING_STRATEGY_MAX: number;
+        const PADDING_STRATEGY_CALLBACK: number;
+        const HTTP2_HEADER_STATUS: string;
+        const HTTP2_HEADER_METHOD: string;
+        const HTTP2_HEADER_AUTHORITY: string;
+        const HTTP2_HEADER_SCHEME: string;
+        const HTTP2_HEADER_PATH: string;
+        const HTTP2_HEADER_ACCEPT_CHARSET: string;
+        const HTTP2_HEADER_ACCEPT_ENCODING: string;
+        const HTTP2_HEADER_ACCEPT_LANGUAGE: string;
+        const HTTP2_HEADER_ACCEPT_RANGES: string;
+        const HTTP2_HEADER_ACCEPT: string;
+        const HTTP2_HEADER_ACCESS_CONTROL_ALLOW_ORIGIN: string;
+        const HTTP2_HEADER_AGE: string;
+        const HTTP2_HEADER_ALLOW: string;
+        const HTTP2_HEADER_AUTHORIZATION: string;
+        const HTTP2_HEADER_CACHE_CONTROL: string;
+        const HTTP2_HEADER_CONNECTION: string;
+        const HTTP2_HEADER_CONTENT_DISPOSITION: string;
+        const HTTP2_HEADER_CONTENT_ENCODING: string;
+        const HTTP2_HEADER_CONTENT_LANGUAGE: string;
+        const HTTP2_HEADER_CONTENT_LENGTH: string;
+        const HTTP2_HEADER_CONTENT_LOCATION: string;
+        const HTTP2_HEADER_CONTENT_MD5: string;
+        const HTTP2_HEADER_CONTENT_RANGE: string;
+        const HTTP2_HEADER_CONTENT_TYPE: string;
+        const HTTP2_HEADER_COOKIE: string;
+        const HTTP2_HEADER_DATE: string;
+        const HTTP2_HEADER_ETAG: string;
+        const HTTP2_HEADER_EXPECT: string;
+        const HTTP2_HEADER_EXPIRES: string;
+        const HTTP2_HEADER_FROM: string;
+        const HTTP2_HEADER_HOST: string;
+        const HTTP2_HEADER_IF_MATCH: string;
+        const HTTP2_HEADER_IF_MODIFIED_SINCE: string;
+        const HTTP2_HEADER_IF_NONE_MATCH: string;
+        const HTTP2_HEADER_IF_RANGE: string;
+        const HTTP2_HEADER_IF_UNMODIFIED_SINCE: string;
+        const HTTP2_HEADER_LAST_MODIFIED: string;
+        const HTTP2_HEADER_LINK: string;
+        const HTTP2_HEADER_LOCATION: string;
+        const HTTP2_HEADER_MAX_FORWARDS: string;
+        const HTTP2_HEADER_PREFER: string;
+        const HTTP2_HEADER_PROXY_AUTHENTICATE: string;
+        const HTTP2_HEADER_PROXY_AUTHORIZATION: string;
+        const HTTP2_HEADER_RANGE: string;
+        const HTTP2_HEADER_REFERER: string;
+        const HTTP2_HEADER_REFRESH: string;
+        const HTTP2_HEADER_RETRY_AFTER: string;
+        const HTTP2_HEADER_SERVER: string;
+        const HTTP2_HEADER_SET_COOKIE: string;
+        const HTTP2_HEADER_STRICT_TRANSPORT_SECURITY: string;
+        const HTTP2_HEADER_TRANSFER_ENCODING: string;
+        const HTTP2_HEADER_TE: string;
+        const HTTP2_HEADER_UPGRADE: string;
+        const HTTP2_HEADER_USER_AGENT: string;
+        const HTTP2_HEADER_VARY: string;
+        const HTTP2_HEADER_VIA: string;
+        const HTTP2_HEADER_WWW_AUTHENTICATE: string;
+        const HTTP2_HEADER_HTTP2_SETTINGS: string;
+        const HTTP2_HEADER_KEEP_ALIVE: string;
+        const HTTP2_HEADER_PROXY_CONNECTION: string;
+        const HTTP2_METHOD_ACL: string;
+        const HTTP2_METHOD_BASELINE_CONTROL: string;
+        const HTTP2_METHOD_BIND: string;
+        const HTTP2_METHOD_CHECKIN: string;
+        const HTTP2_METHOD_CHECKOUT: string;
+        const HTTP2_METHOD_CONNECT: string;
+        const HTTP2_METHOD_COPY: string;
+        const HTTP2_METHOD_DELETE: string;
+        const HTTP2_METHOD_GET: string;
+        const HTTP2_METHOD_HEAD: string;
+        const HTTP2_METHOD_LABEL: string;
+        const HTTP2_METHOD_LINK: string;
+        const HTTP2_METHOD_LOCK: string;
+        const HTTP2_METHOD_MERGE: string;
+        const HTTP2_METHOD_MKACTIVITY: string;
+        const HTTP2_METHOD_MKCALENDAR: string;
+        const HTTP2_METHOD_MKCOL: string;
+        const HTTP2_METHOD_MKREDIRECTREF: string;
+        const HTTP2_METHOD_MKWORKSPACE: string;
+        const HTTP2_METHOD_MOVE: string;
+        const HTTP2_METHOD_OPTIONS: string;
+        const HTTP2_METHOD_ORDERPATCH: string;
+        const HTTP2_METHOD_PATCH: string;
+        const HTTP2_METHOD_POST: string;
+        const HTTP2_METHOD_PRI: string;
+        const HTTP2_METHOD_PROPFIND: string;
+        const HTTP2_METHOD_PROPPATCH: string;
+        const HTTP2_METHOD_PUT: string;
+        const HTTP2_METHOD_REBIND: string;
+        const HTTP2_METHOD_REPORT: string;
+        const HTTP2_METHOD_SEARCH: string;
+        const HTTP2_METHOD_TRACE: string;
+        const HTTP2_METHOD_UNBIND: string;
+        const HTTP2_METHOD_UNCHECKOUT: string;
+        const HTTP2_METHOD_UNLINK: string;
+        const HTTP2_METHOD_UNLOCK: string;
+        const HTTP2_METHOD_UPDATE: string;
+        const HTTP2_METHOD_UPDATEREDIRECTREF: string;
+        const HTTP2_METHOD_VERSION_CONTROL: string;
+        const HTTP_STATUS_CONTINUE: number;
+        const HTTP_STATUS_SWITCHING_PROTOCOLS: number;
+        const HTTP_STATUS_PROCESSING: number;
+        const HTTP_STATUS_OK: number;
+        const HTTP_STATUS_CREATED: number;
+        const HTTP_STATUS_ACCEPTED: number;
+        const HTTP_STATUS_NON_AUTHORITATIVE_INFORMATION: number;
+        const HTTP_STATUS_NO_CONTENT: number;
+        const HTTP_STATUS_RESET_CONTENT: number;
+        const HTTP_STATUS_PARTIAL_CONTENT: number;
+        const HTTP_STATUS_MULTI_STATUS: number;
+        const HTTP_STATUS_ALREADY_REPORTED: number;
+        const HTTP_STATUS_IM_USED: number;
+        const HTTP_STATUS_MULTIPLE_CHOICES: number;
+        const HTTP_STATUS_MOVED_PERMANENTLY: number;
+        const HTTP_STATUS_FOUND: number;
+        const HTTP_STATUS_SEE_OTHER: number;
+        const HTTP_STATUS_NOT_MODIFIED: number;
+        const HTTP_STATUS_USE_PROXY: number;
+        const HTTP_STATUS_TEMPORARY_REDIRECT: number;
+        const HTTP_STATUS_PERMANENT_REDIRECT: number;
+        const HTTP_STATUS_BAD_REQUEST: number;
+        const HTTP_STATUS_UNAUTHORIZED: number;
+        const HTTP_STATUS_PAYMENT_REQUIRED: number;
+        const HTTP_STATUS_FORBIDDEN: number;
+        const HTTP_STATUS_NOT_FOUND: number;
+        const HTTP_STATUS_METHOD_NOT_ALLOWED: number;
+        const HTTP_STATUS_NOT_ACCEPTABLE: number;
+        const HTTP_STATUS_PROXY_AUTHENTICATION_REQUIRED: number;
+        const HTTP_STATUS_REQUEST_TIMEOUT: number;
+        const HTTP_STATUS_CONFLICT: number;
+        const HTTP_STATUS_GONE: number;
+        const HTTP_STATUS_LENGTH_REQUIRED: number;
+        const HTTP_STATUS_PRECONDITION_FAILED: number;
+        const HTTP_STATUS_PAYLOAD_TOO_LARGE: number;
+        const HTTP_STATUS_URI_TOO_LONG: number;
+        const HTTP_STATUS_UNSUPPORTED_MEDIA_TYPE: number;
+        const HTTP_STATUS_RANGE_NOT_SATISFIABLE: number;
+        const HTTP_STATUS_EXPECTATION_FAILED: number;
+        const HTTP_STATUS_TEAPOT: number;
+        const HTTP_STATUS_MISDIRECTED_REQUEST: number;
+        const HTTP_STATUS_UNPROCESSABLE_ENTITY: number;
+        const HTTP_STATUS_LOCKED: number;
+        const HTTP_STATUS_FAILED_DEPENDENCY: number;
+        const HTTP_STATUS_UNORDERED_COLLECTION: number;
+        const HTTP_STATUS_UPGRADE_REQUIRED: number;
+        const HTTP_STATUS_PRECONDITION_REQUIRED: number;
+        const HTTP_STATUS_TOO_MANY_REQUESTS: number;
+        const HTTP_STATUS_REQUEST_HEADER_FIELDS_TOO_LARGE: number;
+        const HTTP_STATUS_UNAVAILABLE_FOR_LEGAL_REASONS: number;
+        const HTTP_STATUS_INTERNAL_SERVER_ERROR: number;
+        const HTTP_STATUS_NOT_IMPLEMENTED: number;
+        const HTTP_STATUS_BAD_GATEWAY: number;
+        const HTTP_STATUS_SERVICE_UNAVAILABLE: number;
+        const HTTP_STATUS_GATEWAY_TIMEOUT: number;
+        const HTTP_STATUS_HTTP_VERSION_NOT_SUPPORTED: number;
+        const HTTP_STATUS_VARIANT_ALSO_NEGOTIATES: number;
+        const HTTP_STATUS_INSUFFICIENT_STORAGE: number;
+        const HTTP_STATUS_LOOP_DETECTED: number;
+        const HTTP_STATUS_BANDWIDTH_LIMIT_EXCEEDED: number;
+        const HTTP_STATUS_NOT_EXTENDED: number;
+        const HTTP_STATUS_NETWORK_AUTHENTICATION_REQUIRED: number;
     }
 
     export function getDefaultSettings(): Settings;
@@ -8012,13 +8218,17 @@ declare module "http2" {
     export function createSecureServer(options: SecureServerOptions, onRequestHandler?: (request: Http2ServerRequest, response: Http2ServerResponse) => void): Http2SecureServer;
 
     export function connect(authority: string | url.URL, listener?: (session: ClientHttp2Session, socket: net.Socket | tls.TLSSocket) => void): ClientHttp2Session;
-    export function connect(authority: string | url.URL, options?: ClientSessionOptions | SecureClientSessionOptions, listener?: (session: ClientHttp2Session, socket: net.Socket | tls.TLSSocket) => void): ClientHttp2Session;
+    export function connect(
+        authority: string | url.URL,
+        options?: ClientSessionOptions | SecureClientSessionOptions,
+        listener?: (session: ClientHttp2Session, socket: net.Socket | tls.TLSSocket) => void,
+    ): ClientHttp2Session;
 }
 
 declare module "perf_hooks" {
     import { AsyncResource } from "async_hooks";
 
-    export interface PerformanceEntry {
+    interface PerformanceEntry {
         /**
          * The total number of milliseconds elapsed for this entry.
          * This value will not be meaningful for all Performance Entry types.
@@ -8049,7 +8259,7 @@ declare module "perf_hooks" {
         readonly kind?: number;
     }
 
-    export interface PerformanceNodeTiming extends PerformanceEntry {
+    interface PerformanceNodeTiming extends PerformanceEntry {
         /**
          * The high resolution millisecond timestamp at which the Node.js process completed bootstrap.
          */
@@ -8116,7 +8326,7 @@ declare module "perf_hooks" {
         readonly v8Start: number;
     }
 
-    export interface Performance {
+    interface Performance {
         /**
          * If name is not provided, removes all PerformanceFunction objects from the Performance Timeline.
          * If name is provided, removes entries with name.
@@ -8209,7 +8419,7 @@ declare module "perf_hooks" {
         timerify<T extends (...optionalParams: any[]) => any>(fn: T): T;
     }
 
-    export interface PerformanceObserverEntryList {
+    interface PerformanceObserverEntryList {
         /**
          * @return a list of PerformanceEntry objects in chronological order with respect to performanceEntry.startTime.
          */
@@ -8228,9 +8438,9 @@ declare module "perf_hooks" {
         getEntriesByType(type: string): PerformanceEntry[];
     }
 
-    export type PerformanceObserverCallback = (list: PerformanceObserverEntryList, observer: PerformanceObserver) => void;
+    type PerformanceObserverCallback = (list: PerformanceObserverEntryList, observer: PerformanceObserver) => void;
 
-    export class PerformanceObserver extends AsyncResource {
+    class PerformanceObserver extends AsyncResource {
         constructor(callback: PerformanceObserverCallback);
 
         /**
@@ -8247,11 +8457,11 @@ declare module "perf_hooks" {
         observe(options: { entryTypes: string[], buffered?: boolean }): void;
     }
 
-    export namespace constants {
-        export const NODE_PERFORMANCE_GC_MAJOR: number;
-        export const NODE_PERFORMANCE_GC_MINOR: number;
-        export const NODE_PERFORMANCE_GC_INCREMENTAL: number;
-        export const NODE_PERFORMANCE_GC_WEAKCB: number;
+    namespace constants {
+        const NODE_PERFORMANCE_GC_MAJOR: number;
+        const NODE_PERFORMANCE_GC_MINOR: number;
+        const NODE_PERFORMANCE_GC_INCREMENTAL: number;
+        const NODE_PERFORMANCE_GC_WEAKCB: number;
     }
 
     const performance: Performance;

--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -1021,11 +1021,11 @@ declare module "buffer" {
 }
 
 declare module "querystring" {
-     interface StringifyOptions {
+    interface StringifyOptions {
         encodeURIComponent?: Function;
     }
 
-     interface ParseOptions {
+    interface ParseOptions {
         maxKeys?: number;
         decodeURIComponent?: Function;
     }
@@ -1075,7 +1075,7 @@ declare module "http" {
     import { URL } from "url";
 
     // incoming headers will never contain number
-     interface IncomingHttpHeaders {
+    interface IncomingHttpHeaders {
         'accept'?: string;
         'access-control-allow-origin'?: string;
         'access-control-allow-credentials'?: string;
@@ -1123,11 +1123,11 @@ declare module "http" {
     }
 
     // outgoing headers allows numbers (as they are converted internally to strings)
-     interface OutgoingHttpHeaders {
+    interface OutgoingHttpHeaders {
         [header: string]: number | string | string[] | undefined;
     }
 
-     interface ClientRequestArgs {
+    interface ClientRequestArgs {
         protocol?: string;
         host?: string;
         hostname?: string;
@@ -1147,7 +1147,7 @@ declare module "http" {
         createConnection?: (options: ClientRequestArgs, oncreate: (err: Error, socket: net.Socket) => void) => net.Socket;
     }
 
-     class Server extends net.Server {
+    class Server extends net.Server {
         constructor(requestListener?: (req: IncomingMessage, res: ServerResponse) => void);
 
         setTimeout(msecs?: number, callback?: () => void): this;
@@ -1156,15 +1156,9 @@ declare module "http" {
         timeout: number;
         keepAliveTimeout: number;
     }
-    /**
-     * @deprecated Use IncomingMessage
-     */
-     class ServerRequest extends IncomingMessage {
-        connection: net.Socket;
-    }
 
     // https://github.com/nodejs/node/blob/master/lib/_http_outgoing.js
-     class OutgoingMessage extends stream.Writable {
+    class OutgoingMessage extends stream.Writable {
         upgrading: boolean;
         chunkedEncoding: boolean;
         shouldKeepAlive: boolean;
@@ -1188,7 +1182,7 @@ declare module "http" {
     }
 
     // https://github.com/nodejs/node/blob/master/lib/_http_server.js#L108-L256
-     class ServerResponse extends OutgoingMessage {
+    class ServerResponse extends OutgoingMessage {
         statusCode: number;
         statusMessage: string;
 
@@ -1204,7 +1198,7 @@ declare module "http" {
     }
 
     // https://github.com/nodejs/node/blob/master/lib/_http_client.js#L77
-     class ClientRequest extends OutgoingMessage {
+    class ClientRequest extends OutgoingMessage {
         connection: net.Socket;
         socket: net.Socket;
         aborted: number;
@@ -1218,7 +1212,7 @@ declare module "http" {
         setSocketKeepAlive(enable?: boolean, initialDelay?: number): void;
     }
 
-     class IncomingMessage extends stream.Readable {
+    class IncomingMessage extends stream.Readable {
         constructor(socket: net.Socket);
 
         httpVersion: string;
@@ -1250,12 +1244,7 @@ declare module "http" {
         destroy(error?: Error): void;
     }
 
-    /**
-     * @deprecated Use IncomingMessage
-     */
-     class ClientResponse extends IncomingMessage { }
-
-     interface AgentOptions {
+    interface AgentOptions {
         /**
          * Keep sockets around in a pool to be used by other requests in the future. Default = false
          */
@@ -1279,7 +1268,7 @@ declare module "http" {
         timeout?: number;
     }
 
-     class Agent {
+    class Agent {
         maxFreeSockets: number;
         maxSockets: number;
         sockets: any;
@@ -1296,9 +1285,9 @@ declare module "http" {
         destroy(): void;
     }
 
-     const METHODS: string[];
+    const METHODS: string[];
 
-     const STATUS_CODES: {
+    const STATUS_CODES: {
         [errorCode: number]: string | undefined;
         [errorCode: string]: string | undefined;
     };
@@ -1511,77 +1500,77 @@ declare module "cluster" {
      *   6. online
      *   7. setup
      */
-     function addListener(event: string, listener: (...args: any[]) => void): Cluster;
-     function addListener(event: "disconnect", listener: (worker: Worker) => void): Cluster;
-     function addListener(event: "exit", listener: (worker: Worker, code: number, signal: string) => void): Cluster;
-     function addListener(event: "fork", listener: (worker: Worker) => void): Cluster;
-     function addListener(event: "listening", listener: (worker: Worker, address: Address) => void): Cluster;
+    function addListener(event: string, listener: (...args: any[]) => void): Cluster;
+    function addListener(event: "disconnect", listener: (worker: Worker) => void): Cluster;
+    function addListener(event: "exit", listener: (worker: Worker, code: number, signal: string) => void): Cluster;
+    function addListener(event: "fork", listener: (worker: Worker) => void): Cluster;
+    function addListener(event: "listening", listener: (worker: Worker, address: Address) => void): Cluster;
      // the handle is a net.Socket or net.Server object, or undefined.
-     function addListener(event: "message", listener: (worker: Worker, message: any, handle: net.Socket | net.Server) => void): Cluster;
-     function addListener(event: "online", listener: (worker: Worker) => void): Cluster;
-     function addListener(event: "setup", listener: (settings: any) => void): Cluster;
+    function addListener(event: "message", listener: (worker: Worker, message: any, handle: net.Socket | net.Server) => void): Cluster;
+    function addListener(event: "online", listener: (worker: Worker) => void): Cluster;
+    function addListener(event: "setup", listener: (settings: any) => void): Cluster;
 
-     function emit(event: string | symbol, ...args: any[]): boolean;
-     function emit(event: "disconnect", worker: Worker): boolean;
-     function emit(event: "exit", worker: Worker, code: number, signal: string): boolean;
-     function emit(event: "fork", worker: Worker): boolean;
-     function emit(event: "listening", worker: Worker, address: Address): boolean;
-     function emit(event: "message", worker: Worker, message: any, handle: net.Socket | net.Server): boolean;
-     function emit(event: "online", worker: Worker): boolean;
-     function emit(event: "setup", settings: any): boolean;
+    function emit(event: string | symbol, ...args: any[]): boolean;
+    function emit(event: "disconnect", worker: Worker): boolean;
+    function emit(event: "exit", worker: Worker, code: number, signal: string): boolean;
+    function emit(event: "fork", worker: Worker): boolean;
+    function emit(event: "listening", worker: Worker, address: Address): boolean;
+    function emit(event: "message", worker: Worker, message: any, handle: net.Socket | net.Server): boolean;
+    function emit(event: "online", worker: Worker): boolean;
+    function emit(event: "setup", settings: any): boolean;
 
-     function on(event: string, listener: (...args: any[]) => void): Cluster;
-     function on(event: "disconnect", listener: (worker: Worker) => void): Cluster;
-     function on(event: "exit", listener: (worker: Worker, code: number, signal: string) => void): Cluster;
-     function on(event: "fork", listener: (worker: Worker) => void): Cluster;
-     function on(event: "listening", listener: (worker: Worker, address: Address) => void): Cluster;
-     function on(event: "message", listener: (worker: Worker, message: any, handle: net.Socket | net.Server) => void): Cluster;  // the handle is a net.Socket or net.Server object, or undefined.
-     function on(event: "online", listener: (worker: Worker) => void): Cluster;
-     function on(event: "setup", listener: (settings: any) => void): Cluster;
+    function on(event: string, listener: (...args: any[]) => void): Cluster;
+    function on(event: "disconnect", listener: (worker: Worker) => void): Cluster;
+    function on(event: "exit", listener: (worker: Worker, code: number, signal: string) => void): Cluster;
+    function on(event: "fork", listener: (worker: Worker) => void): Cluster;
+    function on(event: "listening", listener: (worker: Worker, address: Address) => void): Cluster;
+    function on(event: "message", listener: (worker: Worker, message: any, handle: net.Socket | net.Server) => void): Cluster;  // the handle is a net.Socket or net.Server object, or undefined.
+    function on(event: "online", listener: (worker: Worker) => void): Cluster;
+    function on(event: "setup", listener: (settings: any) => void): Cluster;
 
-     function once(event: string, listener: (...args: any[]) => void): Cluster;
-     function once(event: "disconnect", listener: (worker: Worker) => void): Cluster;
-     function once(event: "exit", listener: (worker: Worker, code: number, signal: string) => void): Cluster;
-     function once(event: "fork", listener: (worker: Worker) => void): Cluster;
-     function once(event: "listening", listener: (worker: Worker, address: Address) => void): Cluster;
-     function once(event: "message", listener: (worker: Worker, message: any, handle: net.Socket | net.Server) => void): Cluster;  // the handle is a net.Socket or net.Server object, or undefined.
-     function once(event: "online", listener: (worker: Worker) => void): Cluster;
-     function once(event: "setup", listener: (settings: any) => void): Cluster;
+    function once(event: string, listener: (...args: any[]) => void): Cluster;
+    function once(event: "disconnect", listener: (worker: Worker) => void): Cluster;
+    function once(event: "exit", listener: (worker: Worker, code: number, signal: string) => void): Cluster;
+    function once(event: "fork", listener: (worker: Worker) => void): Cluster;
+    function once(event: "listening", listener: (worker: Worker, address: Address) => void): Cluster;
+    function once(event: "message", listener: (worker: Worker, message: any, handle: net.Socket | net.Server) => void): Cluster;  // the handle is a net.Socket or net.Server object, or undefined.
+    function once(event: "online", listener: (worker: Worker) => void): Cluster;
+    function once(event: "setup", listener: (settings: any) => void): Cluster;
 
-     function removeListener(event: string, listener: (...args: any[]) => void): Cluster;
-     function removeAllListeners(event?: string): Cluster;
-     function setMaxListeners(n: number): Cluster;
-     function getMaxListeners(): number;
-     function listeners(event: string): Function[];
-     function listenerCount(type: string): number;
+    function removeListener(event: string, listener: (...args: any[]) => void): Cluster;
+    function removeAllListeners(event?: string): Cluster;
+    function setMaxListeners(n: number): Cluster;
+    function getMaxListeners(): number;
+    function listeners(event: string): Function[];
+    function listenerCount(type: string): number;
 
-     function prependListener(event: string, listener: (...args: any[]) => void): Cluster;
-     function prependListener(event: "disconnect", listener: (worker: Worker) => void): Cluster;
-     function prependListener(event: "exit", listener: (worker: Worker, code: number, signal: string) => void): Cluster;
-     function prependListener(event: "fork", listener: (worker: Worker) => void): Cluster;
-     function prependListener(event: "listening", listener: (worker: Worker, address: Address) => void): Cluster;
+    function prependListener(event: string, listener: (...args: any[]) => void): Cluster;
+    function prependListener(event: "disconnect", listener: (worker: Worker) => void): Cluster;
+    function prependListener(event: "exit", listener: (worker: Worker, code: number, signal: string) => void): Cluster;
+    function prependListener(event: "fork", listener: (worker: Worker) => void): Cluster;
+    function prependListener(event: "listening", listener: (worker: Worker, address: Address) => void): Cluster;
      // the handle is a net.Socket or net.Server object, or undefined.
-     function prependListener(event: "message", listener: (worker: Worker, message: any, handle: net.Socket | net.Server) => void): Cluster;
-     function prependListener(event: "online", listener: (worker: Worker) => void): Cluster;
-     function prependListener(event: "setup", listener: (settings: any) => void): Cluster;
+    function prependListener(event: "message", listener: (worker: Worker, message: any, handle: net.Socket | net.Server) => void): Cluster;
+    function prependListener(event: "online", listener: (worker: Worker) => void): Cluster;
+    function prependListener(event: "setup", listener: (settings: any) => void): Cluster;
 
-     function prependOnceListener(event: string, listener: (...args: any[]) => void): Cluster;
-     function prependOnceListener(event: "disconnect", listener: (worker: Worker) => void): Cluster;
-     function prependOnceListener(event: "exit", listener: (worker: Worker, code: number, signal: string) => void): Cluster;
-     function prependOnceListener(event: "fork", listener: (worker: Worker) => void): Cluster;
-     function prependOnceListener(event: "listening", listener: (worker: Worker, address: Address) => void): Cluster;
+    function prependOnceListener(event: string, listener: (...args: any[]) => void): Cluster;
+    function prependOnceListener(event: "disconnect", listener: (worker: Worker) => void): Cluster;
+    function prependOnceListener(event: "exit", listener: (worker: Worker, code: number, signal: string) => void): Cluster;
+    function prependOnceListener(event: "fork", listener: (worker: Worker) => void): Cluster;
+    function prependOnceListener(event: "listening", listener: (worker: Worker, address: Address) => void): Cluster;
      // the handle is a net.Socket or net.Server object, or undefined.
-     function prependOnceListener(event: "message", listener: (worker: Worker, message: any, handle: net.Socket | net.Server) => void): Cluster;
-     function prependOnceListener(event: "online", listener: (worker: Worker) => void): Cluster;
-     function prependOnceListener(event: "setup", listener: (settings: any) => void): Cluster;
+    function prependOnceListener(event: "message", listener: (worker: Worker, message: any, handle: net.Socket | net.Server) => void): Cluster;
+    function prependOnceListener(event: "online", listener: (worker: Worker) => void): Cluster;
+    function prependOnceListener(event: "setup", listener: (settings: any) => void): Cluster;
 
-     function eventNames(): string[];
+    function eventNames(): string[];
 }
 
 declare module "zlib" {
     import * as stream from "stream";
 
-     interface ZlibOptions {
+    interface ZlibOptions {
         flush?: number; // default: zlib.constants.Z_NO_FLUSH
         finishFlush?: number; // default: zlib.constants.Z_FINISH
         chunkSize?: number; // default: 16*1024
@@ -1592,40 +1581,40 @@ declare module "zlib" {
         dictionary?: Buffer | NodeJS.TypedArray | DataView | ArrayBuffer; // deflate/inflate only, empty dictionary by default
     }
 
-     interface Zlib {
+    interface Zlib {
         readonly bytesRead: number;
         close(callback?: () => void): void;
         flush(kind?: number | (() => void), callback?: () => void): void;
     }
 
-     interface ZlibParams {
+    interface ZlibParams {
         params(level: number, strategy: number, callback: () => void): void;
     }
 
-     interface ZlibReset {
+    interface ZlibReset {
         reset(): void;
     }
 
-     interface Gzip extends stream.Transform, Zlib { }
-     interface Gunzip extends stream.Transform, Zlib { }
-     interface Deflate extends stream.Transform, Zlib, ZlibReset, ZlibParams { }
-     interface Inflate extends stream.Transform, Zlib, ZlibReset { }
-     interface DeflateRaw extends stream.Transform, Zlib, ZlibReset, ZlibParams { }
-     interface InflateRaw extends stream.Transform, Zlib, ZlibReset { }
-     interface Unzip extends stream.Transform, Zlib { }
+    interface Gzip extends stream.Transform, Zlib { }
+    interface Gunzip extends stream.Transform, Zlib { }
+    interface Deflate extends stream.Transform, Zlib, ZlibReset, ZlibParams { }
+    interface Inflate extends stream.Transform, Zlib, ZlibReset { }
+    interface DeflateRaw extends stream.Transform, Zlib, ZlibReset, ZlibParams { }
+    interface InflateRaw extends stream.Transform, Zlib, ZlibReset { }
+    interface Unzip extends stream.Transform, Zlib { }
 
-     function createGzip(options?: ZlibOptions): Gzip;
-     function createGunzip(options?: ZlibOptions): Gunzip;
-     function createDeflate(options?: ZlibOptions): Deflate;
-     function createInflate(options?: ZlibOptions): Inflate;
-     function createDeflateRaw(options?: ZlibOptions): DeflateRaw;
-     function createInflateRaw(options?: ZlibOptions): InflateRaw;
-     function createUnzip(options?: ZlibOptions): Unzip;
+    function createGzip(options?: ZlibOptions): Gzip;
+    function createGunzip(options?: ZlibOptions): Gunzip;
+    function createDeflate(options?: ZlibOptions): Deflate;
+    function createInflate(options?: ZlibOptions): Inflate;
+    function createDeflateRaw(options?: ZlibOptions): DeflateRaw;
+    function createInflateRaw(options?: ZlibOptions): InflateRaw;
+    function createUnzip(options?: ZlibOptions): Unzip;
 
     type InputType = string | Buffer | DataView | ArrayBuffer | NodeJS.TypedArray;
-     function deflate(buf: InputType, callback: (error: Error | null, result: Buffer) => void): void;
-     function deflate(buf: InputType, options: ZlibOptions, callback: (error: Error | null, result: Buffer) => void): void;
-     function deflateSync(buf: InputType, options?: ZlibOptions): Buffer;
+    function deflate(buf: InputType, callback: (error: Error | null, result: Buffer) => void): void;
+    function deflate(buf: InputType, options: ZlibOptions, callback: (error: Error | null, result: Buffer) => void): void;
+    function deflateSync(buf: InputType, options?: ZlibOptions): Buffer;
     function deflateRaw(buf: InputType, callback: (error: Error | null, result: Buffer) => void): void;
     function deflateRaw(buf: InputType, options: ZlibOptions, callback: (error: Error | null, result: Buffer) => void): void;
     function deflateRawSync(buf: InputType, options?: ZlibOptions): Buffer;
@@ -2199,8 +2188,6 @@ declare module "vm" {
     function createContext(sandbox?: Context): Context;
     function isContext(sandbox: Context): boolean;
     function runInContext(code: string, contextifiedSandbox: Context, options?: RunningScriptOptions | string): any;
-    /** @deprecated */
-    function runInDebugContext(code: string): any;
     function runInNewContext(code: string, sandbox?: Context, options?: RunningScriptOptions | string): any;
     function runInThisContext(code: string, options?: RunningScriptOptions | string): any;
     function compileFunction(code: string, params: string[], options: CompileFunctionOptions): Function;

--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -1030,11 +1030,10 @@ declare module "querystring" {
         decodeURIComponent?: Function;
     }
 
-    interface ParsedUrlQuery { [key: string]: string | string[] | undefined; }
+    interface ParsedUrlQuery { [key: string]: string | string[]; }
 
-    function stringify(obj: {}, sep?: string, eq?: string, options?: StringifyOptions): string;
+    function stringify(obj?: {}, sep?: string, eq?: string, options?: StringifyOptions): string;
     function parse(str: string, sep?: string, eq?: string, options?: ParseOptions): ParsedUrlQuery;
-    function parse(str: string, sep?: string, eq?: string, options?: ParseOptions): {};
     function escape(str: string): string;
     function unescape(str: string): string;
 }

--- a/types/node/inspector.d.ts
+++ b/types/node/inspector.d.ts
@@ -1,3 +1,4 @@
+// tslint:disable-next-line:dt-header
 // Type definitions for inspector
 
 // These definitions are auto-generated.
@@ -7,19 +8,20 @@
 /**
  * The inspector module provides an API for interacting with the V8 inspector.
  */
+// tslint:disable-next-line:no-single-declare-module
 declare module "inspector" {
     import { EventEmitter } from 'events';
 
-    export interface InspectorNotification<T> {
+    interface InspectorNotification<T> {
         method: string;
         params: T;
     }
 
-    export namespace Console {
+    namespace Console {
         /**
          * Console message.
          */
-        export interface ConsoleMessage {
+        interface ConsoleMessage {
             /**
              * Message source.
              */
@@ -46,7 +48,7 @@ declare module "inspector" {
             column?: number;
         }
 
-        export interface MessageAddedEventDataType {
+        interface MessageAddedEventDataType {
             /**
              * Console message that has been added.
              */
@@ -54,21 +56,21 @@ declare module "inspector" {
         }
     }
 
-    export namespace Debugger {
+    namespace Debugger {
         /**
          * Breakpoint identifier.
          */
-        export type BreakpointId = string;
+        type BreakpointId = string;
 
         /**
          * Call frame identifier.
          */
-        export type CallFrameId = string;
+        type CallFrameId = string;
 
         /**
          * Location in the source code.
          */
-        export interface Location {
+        interface Location {
             /**
              * Script identifier as reported in the `Debugger.scriptParsed`.
              */
@@ -87,7 +89,7 @@ declare module "inspector" {
          * Location in the source code.
          * @experimental
          */
-        export interface ScriptPosition {
+        interface ScriptPosition {
             lineNumber: number;
             columnNumber: number;
         }
@@ -95,7 +97,7 @@ declare module "inspector" {
         /**
          * JavaScript call frame. Array of call frames form the call stack.
          */
-        export interface CallFrame {
+        interface CallFrame {
             /**
              * Call frame identifier. This identifier is only valid while the virtual machine is paused.
              */
@@ -133,15 +135,15 @@ declare module "inspector" {
         /**
          * Scope description.
          */
-        export interface Scope {
+        interface Scope {
             /**
              * Scope type.
              */
             type: string;
             /**
              * Object representing the scope. For `global` and `with` scopes it represents the actual
-object; for the rest of the scopes, it is artificial transient object enumerating scope
-variables as its properties.
+             * object; for the rest of the scopes, it is artificial transient object enumerating scope
+             * variables as its properties.
              */
             object: Runtime.RemoteObject;
             name?: string;
@@ -158,7 +160,7 @@ variables as its properties.
         /**
          * Search match for resource.
          */
-        export interface SearchMatch {
+        interface SearchMatch {
             /**
              * Line number in resource content.
              */
@@ -169,7 +171,7 @@ variables as its properties.
             lineContent: string;
         }
 
-        export interface BreakLocation {
+        interface BreakLocation {
             /**
              * Script identifier as reported in the `Debugger.scriptParsed`.
              */
@@ -185,7 +187,7 @@ variables as its properties.
             type?: string;
         }
 
-        export interface ContinueToLocationParameterType {
+        interface ContinueToLocationParameterType {
             /**
              * Location to continue to.
              */
@@ -193,7 +195,7 @@ variables as its properties.
             targetCallFrames?: string;
         }
 
-        export interface EvaluateOnCallFrameParameterType {
+        interface EvaluateOnCallFrameParameterType {
             /**
              * Call frame identifier to evaluate on.
              */
@@ -204,17 +206,17 @@ variables as its properties.
             expression: string;
             /**
              * String object group name to put result into (allows rapid releasing resulting object handles
-using `releaseObjectGroup`).
+             * using `releaseObjectGroup`).
              */
             objectGroup?: string;
             /**
              * Specifies whether command line API should be available to the evaluated expression, defaults
-to false.
+             * to false.
              */
             includeCommandLineAPI?: boolean;
             /**
              * In silent mode exceptions thrown during evaluation are not reported and do not pause
-execution. Overrides `setPauseOnException` state.
+             * execution. Overrides `setPauseOnException` state.
              */
             silent?: boolean;
             /**
@@ -232,14 +234,14 @@ execution. Overrides `setPauseOnException` state.
             throwOnSideEffect?: boolean;
         }
 
-        export interface GetPossibleBreakpointsParameterType {
+        interface GetPossibleBreakpointsParameterType {
             /**
              * Start of range to search possible breakpoint locations in.
              */
             start: Debugger.Location;
             /**
              * End of range to search possible breakpoint locations in (excluding). When not specified, end
-of scripts is used as end of range.
+             * of scripts is used as end of range.
              */
             end?: Debugger.Location;
             /**
@@ -248,36 +250,36 @@ of scripts is used as end of range.
             restrictToFunction?: boolean;
         }
 
-        export interface GetScriptSourceParameterType {
+        interface GetScriptSourceParameterType {
             /**
              * Id of the script to get source for.
              */
             scriptId: Runtime.ScriptId;
         }
 
-        export interface GetStackTraceParameterType {
+        interface GetStackTraceParameterType {
             stackTraceId: Runtime.StackTraceId;
         }
 
-        export interface PauseOnAsyncCallParameterType {
+        interface PauseOnAsyncCallParameterType {
             /**
              * Debugger will pause when async call with given stack trace is started.
              */
             parentStackTraceId: Runtime.StackTraceId;
         }
 
-        export interface RemoveBreakpointParameterType {
+        interface RemoveBreakpointParameterType {
             breakpointId: Debugger.BreakpointId;
         }
 
-        export interface RestartFrameParameterType {
+        interface RestartFrameParameterType {
             /**
              * Call frame identifier to evaluate on.
              */
             callFrameId: Debugger.CallFrameId;
         }
 
-        export interface SearchInContentParameterType {
+        interface SearchInContentParameterType {
             /**
              * Id of the script to search in.
              */
@@ -296,22 +298,22 @@ of scripts is used as end of range.
             isRegex?: boolean;
         }
 
-        export interface SetAsyncCallStackDepthParameterType {
+        interface SetAsyncCallStackDepthParameterType {
             /**
              * Maximum depth of async call stacks. Setting to `0` will effectively disable collecting async
-call stacks (default).
+             * call stacks (default).
              */
             maxDepth: number;
         }
 
-        export interface SetBlackboxPatternsParameterType {
+        interface SetBlackboxPatternsParameterType {
             /**
              * Array of regexps that will be used to check script url for blackbox state.
              */
             patterns: string[];
         }
 
-        export interface SetBlackboxedRangesParameterType {
+        interface SetBlackboxedRangesParameterType {
             /**
              * Id of the script.
              */
@@ -319,19 +321,19 @@ call stacks (default).
             positions: Debugger.ScriptPosition[];
         }
 
-        export interface SetBreakpointParameterType {
+        interface SetBreakpointParameterType {
             /**
              * Location to set breakpoint in.
              */
             location: Debugger.Location;
             /**
              * Expression to use as a breakpoint condition. When specified, debugger will only stop on the
-breakpoint if this expression evaluates to true.
+             * breakpoint if this expression evaluates to true.
              */
             condition?: string;
         }
 
-        export interface SetBreakpointByUrlParameterType {
+        interface SetBreakpointByUrlParameterType {
             /**
              * Line number to set breakpoint at.
              */
@@ -342,7 +344,7 @@ breakpoint if this expression evaluates to true.
             url?: string;
             /**
              * Regex pattern for the URLs of the resources to set breakpoints on. Either `url` or
-`urlRegex` must be specified.
+             * `urlRegex` must be specified.
              */
             urlRegex?: string;
             /**
@@ -355,33 +357,33 @@ breakpoint if this expression evaluates to true.
             columnNumber?: number;
             /**
              * Expression to use as a breakpoint condition. When specified, debugger will only stop on the
-breakpoint if this expression evaluates to true.
+             * breakpoint if this expression evaluates to true.
              */
             condition?: string;
         }
 
-        export interface SetBreakpointsActiveParameterType {
+        interface SetBreakpointsActiveParameterType {
             /**
              * New value for breakpoints active state.
              */
             active: boolean;
         }
 
-        export interface SetPauseOnExceptionsParameterType {
+        interface SetPauseOnExceptionsParameterType {
             /**
              * Pause on exceptions mode.
              */
             state: string;
         }
 
-        export interface SetReturnValueParameterType {
+        interface SetReturnValueParameterType {
             /**
              * New return value.
              */
             newValue: Runtime.CallArgument;
         }
 
-        export interface SetScriptSourceParameterType {
+        interface SetScriptSourceParameterType {
             /**
              * Id of the script to edit.
              */
@@ -392,22 +394,22 @@ breakpoint if this expression evaluates to true.
             scriptSource: string;
             /**
              * If true the change will not actually be applied. Dry run may be used to get result
-description without actually modifying the code.
+             * description without actually modifying the code.
              */
             dryRun?: boolean;
         }
 
-        export interface SetSkipAllPausesParameterType {
+        interface SetSkipAllPausesParameterType {
             /**
              * New value for skip pauses state.
              */
             skip: boolean;
         }
 
-        export interface SetVariableValueParameterType {
+        interface SetVariableValueParameterType {
             /**
              * 0-based number of scope as was listed in scope chain. Only 'local', 'closure' and 'catch'
-scope types are allowed. Other scopes could be manipulated manually.
+             * scope types are allowed. Other scopes could be manipulated manually.
              */
             scopeNumber: number;
             /**
@@ -424,16 +426,16 @@ scope types are allowed. Other scopes could be manipulated manually.
             callFrameId: Debugger.CallFrameId;
         }
 
-        export interface StepIntoParameterType {
+        interface StepIntoParameterType {
             /**
              * Debugger will issue additional Debugger.paused notification if any async task is scheduled
-before next pause.
+             * before next pause.
              * @experimental
              */
             breakOnAsyncCall?: boolean;
         }
 
-        export interface EnableReturnType {
+        interface EnableReturnType {
             /**
              * Unique identifier of the debugger.
              * @experimental
@@ -441,7 +443,7 @@ before next pause.
             debuggerId: Runtime.UniqueDebuggerId;
         }
 
-        export interface EvaluateOnCallFrameReturnType {
+        interface EvaluateOnCallFrameReturnType {
             /**
              * Object wrapper for the evaluation result.
              */
@@ -452,25 +454,25 @@ before next pause.
             exceptionDetails?: Runtime.ExceptionDetails;
         }
 
-        export interface GetPossibleBreakpointsReturnType {
+        interface GetPossibleBreakpointsReturnType {
             /**
              * List of the possible breakpoint locations.
              */
             locations: Debugger.BreakLocation[];
         }
 
-        export interface GetScriptSourceReturnType {
+        interface GetScriptSourceReturnType {
             /**
              * Script source.
              */
             scriptSource: string;
         }
 
-        export interface GetStackTraceReturnType {
+        interface GetStackTraceReturnType {
             stackTrace: Runtime.StackTrace;
         }
 
-        export interface RestartFrameReturnType {
+        interface RestartFrameReturnType {
             /**
              * New stack trace.
              */
@@ -486,14 +488,14 @@ before next pause.
             asyncStackTraceId?: Runtime.StackTraceId;
         }
 
-        export interface SearchInContentReturnType {
+        interface SearchInContentReturnType {
             /**
              * List of search matches.
              */
             result: Debugger.SearchMatch[];
         }
 
-        export interface SetBreakpointReturnType {
+        interface SetBreakpointReturnType {
             /**
              * Id of the created breakpoint for further reference.
              */
@@ -504,7 +506,7 @@ before next pause.
             actualLocation: Debugger.Location;
         }
 
-        export interface SetBreakpointByUrlReturnType {
+        interface SetBreakpointByUrlReturnType {
             /**
              * Id of the created breakpoint for further reference.
              */
@@ -515,7 +517,7 @@ before next pause.
             locations: Debugger.Location[];
         }
 
-        export interface SetScriptSourceReturnType {
+        interface SetScriptSourceReturnType {
             /**
              * New stack trace in case editing has happened while VM was stopped.
              */
@@ -539,7 +541,7 @@ before next pause.
             exceptionDetails?: Runtime.ExceptionDetails;
         }
 
-        export interface BreakpointResolvedEventDataType {
+        interface BreakpointResolvedEventDataType {
             /**
              * Breakpoint unique identifier.
              */
@@ -550,7 +552,7 @@ before next pause.
             location: Debugger.Location;
         }
 
-        export interface PausedEventDataType {
+        interface PausedEventDataType {
             /**
              * Call stack the virtual machine stopped on.
              */
@@ -578,13 +580,13 @@ before next pause.
             asyncStackTraceId?: Runtime.StackTraceId;
             /**
              * Just scheduled async call will have this stack trace as parent stack during async execution.
-This field is available only after `Debugger.stepInto` call with `breakOnAsynCall` flag.
+             * This field is available only after `Debugger.stepInto` call with `breakOnAsynCall` flag.
              * @experimental
              */
             asyncCallStackTraceId?: Runtime.StackTraceId;
         }
 
-        export interface ScriptFailedToParseEventDataType {
+        interface ScriptFailedToParseEventDataType {
             /**
              * Identifier of the script parsed.
              */
@@ -644,7 +646,7 @@ This field is available only after `Debugger.stepInto` call with `breakOnAsynCal
             stackTrace?: Runtime.StackTrace;
         }
 
-        export interface ScriptParsedEventDataType {
+        interface ScriptParsedEventDataType {
             /**
              * Identifier of the script parsed.
              */
@@ -710,16 +712,16 @@ This field is available only after `Debugger.stepInto` call with `breakOnAsynCal
         }
     }
 
-    export namespace HeapProfiler {
+    namespace HeapProfiler {
         /**
          * Heap snapshot object id.
          */
-        export type HeapSnapshotObjectId = string;
+        type HeapSnapshotObjectId = string;
 
         /**
          * Sampling Heap Profile node. Holds callsite information, allocation statistics and child nodes.
          */
-        export interface SamplingHeapProfileNode {
+        interface SamplingHeapProfileNode {
             /**
              * Function location.
              */
@@ -737,25 +739,25 @@ This field is available only after `Debugger.stepInto` call with `breakOnAsynCal
         /**
          * Profile.
          */
-        export interface SamplingHeapProfile {
+        interface SamplingHeapProfile {
             head: HeapProfiler.SamplingHeapProfileNode;
         }
 
-        export interface AddInspectedHeapObjectParameterType {
+        interface AddInspectedHeapObjectParameterType {
             /**
              * Heap snapshot object id to be accessible by means of $x command line API.
              */
             heapObjectId: HeapProfiler.HeapSnapshotObjectId;
         }
 
-        export interface GetHeapObjectIdParameterType {
+        interface GetHeapObjectIdParameterType {
             /**
              * Identifier of the object to get heap object id for.
              */
             objectId: Runtime.RemoteObjectId;
         }
 
-        export interface GetObjectByHeapObjectIdParameterType {
+        interface GetObjectByHeapObjectIdParameterType {
             objectId: HeapProfiler.HeapSnapshotObjectId;
             /**
              * Symbolic group name that can be used to release multiple objects.
@@ -763,91 +765,91 @@ This field is available only after `Debugger.stepInto` call with `breakOnAsynCal
             objectGroup?: string;
         }
 
-        export interface StartSamplingParameterType {
+        interface StartSamplingParameterType {
             /**
              * Average sample interval in bytes. Poisson distribution is used for the intervals. The
-default value is 32768 bytes.
+             * default value is 32768 bytes.
              */
             samplingInterval?: number;
         }
 
-        export interface StartTrackingHeapObjectsParameterType {
+        interface StartTrackingHeapObjectsParameterType {
             trackAllocations?: boolean;
         }
 
-        export interface StopTrackingHeapObjectsParameterType {
+        interface StopTrackingHeapObjectsParameterType {
             /**
              * If true 'reportHeapSnapshotProgress' events will be generated while snapshot is being taken
-when the tracking is stopped.
+             * when the tracking is stopped.
              */
             reportProgress?: boolean;
         }
 
-        export interface TakeHeapSnapshotParameterType {
+        interface TakeHeapSnapshotParameterType {
             /**
              * If true 'reportHeapSnapshotProgress' events will be generated while snapshot is being taken.
              */
             reportProgress?: boolean;
         }
 
-        export interface GetHeapObjectIdReturnType {
+        interface GetHeapObjectIdReturnType {
             /**
              * Id of the heap snapshot object corresponding to the passed remote object id.
              */
             heapSnapshotObjectId: HeapProfiler.HeapSnapshotObjectId;
         }
 
-        export interface GetObjectByHeapObjectIdReturnType {
+        interface GetObjectByHeapObjectIdReturnType {
             /**
              * Evaluation result.
              */
             result: Runtime.RemoteObject;
         }
 
-        export interface GetSamplingProfileReturnType {
+        interface GetSamplingProfileReturnType {
             /**
              * Return the sampling profile being collected.
              */
             profile: HeapProfiler.SamplingHeapProfile;
         }
 
-        export interface StopSamplingReturnType {
+        interface StopSamplingReturnType {
             /**
              * Recorded sampling heap profile.
              */
             profile: HeapProfiler.SamplingHeapProfile;
         }
 
-        export interface AddHeapSnapshotChunkEventDataType {
+        interface AddHeapSnapshotChunkEventDataType {
             chunk: string;
         }
 
-        export interface HeapStatsUpdateEventDataType {
+        interface HeapStatsUpdateEventDataType {
             /**
              * An array of triplets. Each triplet describes a fragment. The first integer is the fragment
-index, the second integer is a total count of objects for the fragment, the third integer is
-a total size of the objects for the fragment.
+             * index, the second integer is a total count of objects for the fragment, the third integer is
+             * a total size of the objects for the fragment.
              */
             statsUpdate: number[];
         }
 
-        export interface LastSeenObjectIdEventDataType {
+        interface LastSeenObjectIdEventDataType {
             lastSeenObjectId: number;
             timestamp: number;
         }
 
-        export interface ReportHeapSnapshotProgressEventDataType {
+        interface ReportHeapSnapshotProgressEventDataType {
             done: number;
             total: number;
             finished?: boolean;
         }
     }
 
-    export namespace Profiler {
+    namespace Profiler {
         /**
          * Profile node. Holds callsite information, execution statistics and child nodes.
          */
-        export interface ProfileNode {
+        interface ProfileNode {
             /**
              * Unique id of the node.
              */
@@ -866,7 +868,7 @@ a total size of the objects for the fragment.
             children?: number[];
             /**
              * The reason of being not optimized. The function may be deoptimized or marked as don't
-optimize.
+             * optimize.
              */
             deoptReason?: string;
             /**
@@ -878,7 +880,7 @@ optimize.
         /**
          * Profile.
          */
-        export interface Profile {
+        interface Profile {
             /**
              * The list of profile nodes. First item is the root node.
              */
@@ -897,7 +899,7 @@ optimize.
             samples?: number[];
             /**
              * Time intervals between adjacent samples in microseconds. The first delta is relative to the
-profile startTime.
+             * profile startTime.
              */
             timeDeltas?: number[];
         }
@@ -905,7 +907,7 @@ profile startTime.
         /**
          * Specifies a number of samples attributed to a certain source position.
          */
-        export interface PositionTickInfo {
+        interface PositionTickInfo {
             /**
              * Source line number (1-based).
              */
@@ -919,7 +921,7 @@ profile startTime.
         /**
          * Coverage data for a source range.
          */
-        export interface CoverageRange {
+        interface CoverageRange {
             /**
              * JavaScript script source offset for the range start.
              */
@@ -937,7 +939,7 @@ profile startTime.
         /**
          * Coverage data for a JavaScript function.
          */
-        export interface FunctionCoverage {
+        interface FunctionCoverage {
             /**
              * JavaScript function name.
              */
@@ -955,7 +957,7 @@ profile startTime.
         /**
          * Coverage data for a JavaScript script.
          */
-        export interface ScriptCoverage {
+        interface ScriptCoverage {
             /**
              * JavaScript script id.
              */
@@ -974,7 +976,7 @@ profile startTime.
          * Describes a type collected during runtime.
          * @experimental
          */
-        export interface TypeObject {
+        interface TypeObject {
             /**
              * Name of a type collected with type profiling.
              */
@@ -985,7 +987,7 @@ profile startTime.
          * Source offset and types for a parameter or return value.
          * @experimental
          */
-        export interface TypeProfileEntry {
+        interface TypeProfileEntry {
             /**
              * Source offset of the parameter or end of function for return values.
              */
@@ -1000,7 +1002,7 @@ profile startTime.
          * Type profile data collected during runtime for a JavaScript script.
          * @experimental
          */
-        export interface ScriptTypeProfile {
+        interface ScriptTypeProfile {
             /**
              * JavaScript script id.
              */
@@ -1015,14 +1017,14 @@ profile startTime.
             entries: Profiler.TypeProfileEntry[];
         }
 
-        export interface SetSamplingIntervalParameterType {
+        interface SetSamplingIntervalParameterType {
             /**
              * New sampling interval in microseconds.
              */
             interval: number;
         }
 
-        export interface StartPreciseCoverageParameterType {
+        interface StartPreciseCoverageParameterType {
             /**
              * Collect accurate call counts beyond simple 'covered' or 'not covered'.
              */
@@ -1033,35 +1035,35 @@ profile startTime.
             detailed?: boolean;
         }
 
-        export interface GetBestEffortCoverageReturnType {
+        interface GetBestEffortCoverageReturnType {
             /**
              * Coverage data for the current isolate.
              */
             result: Profiler.ScriptCoverage[];
         }
 
-        export interface StopReturnType {
+        interface StopReturnType {
             /**
              * Recorded profile.
              */
             profile: Profiler.Profile;
         }
 
-        export interface TakePreciseCoverageReturnType {
+        interface TakePreciseCoverageReturnType {
             /**
              * Coverage data for the current isolate.
              */
             result: Profiler.ScriptCoverage[];
         }
 
-        export interface TakeTypeProfileReturnType {
+        interface TakeTypeProfileReturnType {
             /**
              * Type profile for all scripts since startTypeProfile() was turned on.
              */
             result: Profiler.ScriptTypeProfile[];
         }
 
-        export interface ConsoleProfileFinishedEventDataType {
+        interface ConsoleProfileFinishedEventDataType {
             id: string;
             /**
              * Location of console.profileEnd().
@@ -1074,7 +1076,7 @@ profile startTime.
             title?: string;
         }
 
-        export interface ConsoleProfileStartedEventDataType {
+        interface ConsoleProfileStartedEventDataType {
             id: string;
             /**
              * Location of console.profile().
@@ -1087,27 +1089,27 @@ profile startTime.
         }
     }
 
-    export namespace Runtime {
+    namespace Runtime {
         /**
          * Unique script identifier.
          */
-        export type ScriptId = string;
+        type ScriptId = string;
 
         /**
          * Unique object identifier.
          */
-        export type RemoteObjectId = string;
+        type RemoteObjectId = string;
 
         /**
          * Primitive value which cannot be JSON-stringified. Includes values `-0`, `NaN`, `Infinity`,
-`-Infinity`, and bigint literals.
+         * `-Infinity`, and bigint literals.
          */
-        export type UnserializableValue = string;
+        type UnserializableValue = string;
 
         /**
          * Mirror object referencing original JavaScript object.
          */
-        export interface RemoteObject {
+        interface RemoteObject {
             /**
              * Object type.
              */
@@ -1126,7 +1128,7 @@ profile startTime.
             value?: any;
             /**
              * Primitive value which can not be JSON-stringified does not have `value`, but gets this
-property.
+             * property.
              */
             unserializableValue?: Runtime.UnserializableValue;
             /**
@@ -1151,7 +1153,7 @@ property.
         /**
          * @experimental
          */
-        export interface CustomPreview {
+        interface CustomPreview {
             header: string;
             hasBody: boolean;
             formatterObjectId: Runtime.RemoteObjectId;
@@ -1163,7 +1165,7 @@ property.
          * Object containing abbreviated remote object value.
          * @experimental
          */
-        export interface ObjectPreview {
+        interface ObjectPreview {
             /**
              * Object type.
              */
@@ -1193,7 +1195,7 @@ property.
         /**
          * @experimental
          */
-        export interface PropertyPreview {
+        interface PropertyPreview {
             /**
              * Property name.
              */
@@ -1219,7 +1221,7 @@ property.
         /**
          * @experimental
          */
-        export interface EntryPreview {
+        interface EntryPreview {
             /**
              * Preview of the key. Specified for map-like collection entries.
              */
@@ -1233,7 +1235,7 @@ property.
         /**
          * Object property descriptor.
          */
-        export interface PropertyDescriptor {
+        interface PropertyDescriptor {
             /**
              * Property name or symbol description.
              */
@@ -1248,22 +1250,22 @@ property.
             writable?: boolean;
             /**
              * A function which serves as a getter for the property, or `undefined` if there is no getter
-(accessor descriptors only).
+             * (accessor descriptors only).
              */
             get?: Runtime.RemoteObject;
             /**
              * A function which serves as a setter for the property, or `undefined` if there is no setter
-(accessor descriptors only).
+             * (accessor descriptors only).
              */
             set?: Runtime.RemoteObject;
             /**
              * True if the type of this property descriptor may be changed and if the property may be
-deleted from the corresponding object.
+             * deleted from the corresponding object.
              */
             configurable: boolean;
             /**
              * True if this property shows up during enumeration of the properties on the corresponding
-object.
+             * object.
              */
             enumerable: boolean;
             /**
@@ -1283,7 +1285,7 @@ object.
         /**
          * Object internal property descriptor. This property isn't normally visible in JavaScript code.
          */
-        export interface InternalPropertyDescriptor {
+        interface InternalPropertyDescriptor {
             /**
              * Conventional property name.
              */
@@ -1296,9 +1298,9 @@ object.
 
         /**
          * Represents function call argument. Either remote object id `objectId`, primitive `value`,
-unserializable primitive value or neither of (for undefined) them should be specified.
+         * unserializable primitive value or neither of (for undefined) them should be specified.
          */
-        export interface CallArgument {
+        interface CallArgument {
             /**
              * Primitive value or serializable javascript object.
              */
@@ -1316,15 +1318,15 @@ unserializable primitive value or neither of (for undefined) them should be spec
         /**
          * Id of an execution context.
          */
-        export type ExecutionContextId = number;
+        type ExecutionContextId = number;
 
         /**
          * Description of an isolated world.
          */
-        export interface ExecutionContextDescription {
+        interface ExecutionContextDescription {
             /**
              * Unique id of the execution context. It can be used to specify in which execution context
-script evaluation should be performed.
+             * script evaluation should be performed.
              */
             id: Runtime.ExecutionContextId;
             /**
@@ -1343,9 +1345,9 @@ script evaluation should be performed.
 
         /**
          * Detailed information about exception (or error) that was thrown during script compilation or
-execution.
+         * execution.
          */
-        export interface ExceptionDetails {
+        interface ExceptionDetails {
             /**
              * Exception id.
              */
@@ -1387,12 +1389,12 @@ execution.
         /**
          * Number of milliseconds since epoch.
          */
-        export type Timestamp = number;
+        type Timestamp = number;
 
         /**
          * Stack entry for runtime errors and assertions.
          */
-        export interface CallFrame {
+        interface CallFrame {
             /**
              * JavaScript function name.
              */
@@ -1418,10 +1420,10 @@ execution.
         /**
          * Call frames for assertions or error messages.
          */
-        export interface StackTrace {
+        interface StackTrace {
             /**
              * String label of this stack trace. For async traces this may be a name of the function that
-initiated the async call.
+             * initiated the async call.
              */
             description?: string;
             /**
@@ -1443,19 +1445,19 @@ initiated the async call.
          * Unique identifier of current debugger.
          * @experimental
          */
-        export type UniqueDebuggerId = string;
+        type UniqueDebuggerId = string;
 
         /**
          * If `debuggerId` is set stack trace comes from another debugger and can be resolved there. This
-allows to track cross-debugger calls. See `Runtime.StackTrace` and `Debugger.paused` for usages.
+         * allows to track cross-debugger calls. See `Runtime.StackTrace` and `Debugger.paused` for usages.
          * @experimental
          */
-        export interface StackTraceId {
+        interface StackTraceId {
             id: string;
             debuggerId?: Runtime.UniqueDebuggerId;
         }
 
-        export interface AwaitPromiseParameterType {
+        interface AwaitPromiseParameterType {
             /**
              * Identifier of the promise.
              */
@@ -1470,24 +1472,24 @@ allows to track cross-debugger calls. See `Runtime.StackTrace` and `Debugger.pau
             generatePreview?: boolean;
         }
 
-        export interface CallFunctionOnParameterType {
+        interface CallFunctionOnParameterType {
             /**
              * Declaration of the function to call.
              */
             functionDeclaration: string;
             /**
              * Identifier of the object to call function on. Either objectId or executionContextId should
-be specified.
+             * be specified.
              */
             objectId?: Runtime.RemoteObjectId;
             /**
              * Call arguments. All call arguments must belong to the same JavaScript world as the target
-object.
+             * object.
              */
             arguments?: Runtime.CallArgument[];
             /**
              * In silent mode exceptions thrown during evaluation are not reported and do not pause
-execution. Overrides `setPauseOnException` state.
+             * execution. Overrides `setPauseOnException` state.
              */
             silent?: boolean;
             /**
@@ -1505,22 +1507,22 @@ execution. Overrides `setPauseOnException` state.
             userGesture?: boolean;
             /**
              * Whether execution should `await` for resulting value and return once awaited promise is
-resolved.
+             * resolved.
              */
             awaitPromise?: boolean;
             /**
              * Specifies execution context which global object will be used to call function on. Either
-executionContextId or objectId should be specified.
+             * executionContextId or objectId should be specified.
              */
             executionContextId?: Runtime.ExecutionContextId;
             /**
              * Symbolic group name that can be used to release multiple objects. If objectGroup is not
-specified and objectId is, objectGroup will be inherited from object.
+             * specified and objectId is, objectGroup will be inherited from object.
              */
             objectGroup?: string;
         }
 
-        export interface CompileScriptParameterType {
+        interface CompileScriptParameterType {
             /**
              * Expression to compile.
              */
@@ -1535,12 +1537,12 @@ specified and objectId is, objectGroup will be inherited from object.
             persistScript: boolean;
             /**
              * Specifies in which execution context to perform script run. If the parameter is omitted the
-evaluation will be performed in the context of the inspected page.
+             * evaluation will be performed in the context of the inspected page.
              */
             executionContextId?: Runtime.ExecutionContextId;
         }
 
-        export interface EvaluateParameterType {
+        interface EvaluateParameterType {
             /**
              * Expression to evaluate.
              */
@@ -1555,12 +1557,12 @@ evaluation will be performed in the context of the inspected page.
             includeCommandLineAPI?: boolean;
             /**
              * In silent mode exceptions thrown during evaluation are not reported and do not pause
-execution. Overrides `setPauseOnException` state.
+             * execution. Overrides `setPauseOnException` state.
              */
             silent?: boolean;
             /**
              * Specifies in which execution context to perform evaluation. If the parameter is omitted the
-evaluation will be performed in the context of the inspected page.
+             * evaluation will be performed in the context of the inspected page.
              */
             contextId?: Runtime.ExecutionContextId;
             /**
@@ -1578,7 +1580,7 @@ evaluation will be performed in the context of the inspected page.
             userGesture?: boolean;
             /**
              * Whether execution should `await` for resulting value and return once awaited promise is
-resolved.
+             * resolved.
              */
             awaitPromise?: boolean;
             /**
@@ -1588,19 +1590,19 @@ resolved.
             throwOnSideEffect?: boolean;
         }
 
-        export interface GetPropertiesParameterType {
+        interface GetPropertiesParameterType {
             /**
              * Identifier of the object to return properties for.
              */
             objectId: Runtime.RemoteObjectId;
             /**
              * If true, returns properties belonging only to the element itself, not to its prototype
-chain.
+             * chain.
              */
             ownProperties?: boolean;
             /**
              * If true, returns accessor properties (with getter/setter) only; internal properties are not
-returned either.
+             * returned either.
              * @experimental
              */
             accessorPropertiesOnly?: boolean;
@@ -1611,14 +1613,14 @@ returned either.
             generatePreview?: boolean;
         }
 
-        export interface GlobalLexicalScopeNamesParameterType {
+        interface GlobalLexicalScopeNamesParameterType {
             /**
              * Specifies in which execution context to lookup global scope variables.
              */
             executionContextId?: Runtime.ExecutionContextId;
         }
 
-        export interface QueryObjectsParameterType {
+        interface QueryObjectsParameterType {
             /**
              * Identifier of the prototype to return objects for.
              */
@@ -1629,28 +1631,28 @@ returned either.
             objectGroup?: string;
         }
 
-        export interface ReleaseObjectParameterType {
+        interface ReleaseObjectParameterType {
             /**
              * Identifier of the object to release.
              */
             objectId: Runtime.RemoteObjectId;
         }
 
-        export interface ReleaseObjectGroupParameterType {
+        interface ReleaseObjectGroupParameterType {
             /**
              * Symbolic object group name.
              */
             objectGroup: string;
         }
 
-        export interface RunScriptParameterType {
+        interface RunScriptParameterType {
             /**
              * Id of the script to run.
              */
             scriptId: Runtime.ScriptId;
             /**
              * Specifies in which execution context to perform script run. If the parameter is omitted the
-evaluation will be performed in the context of the inspected page.
+             * evaluation will be performed in the context of the inspected page.
              */
             executionContextId?: Runtime.ExecutionContextId;
             /**
@@ -1659,7 +1661,7 @@ evaluation will be performed in the context of the inspected page.
             objectGroup?: string;
             /**
              * In silent mode exceptions thrown during evaluation are not reported and do not pause
-execution. Overrides `setPauseOnException` state.
+             * execution. Overrides `setPauseOnException` state.
              */
             silent?: boolean;
             /**
@@ -1676,16 +1678,16 @@ execution. Overrides `setPauseOnException` state.
             generatePreview?: boolean;
             /**
              * Whether execution should `await` for resulting value and return once awaited promise is
-resolved.
+             * resolved.
              */
             awaitPromise?: boolean;
         }
 
-        export interface SetCustomObjectFormatterEnabledParameterType {
+        interface SetCustomObjectFormatterEnabledParameterType {
             enabled: boolean;
         }
 
-        export interface AwaitPromiseReturnType {
+        interface AwaitPromiseReturnType {
             /**
              * Promise result. Will contain rejected value if promise was rejected.
              */
@@ -1696,7 +1698,7 @@ resolved.
             exceptionDetails?: Runtime.ExceptionDetails;
         }
 
-        export interface CallFunctionOnReturnType {
+        interface CallFunctionOnReturnType {
             /**
              * Call result.
              */
@@ -1707,7 +1709,7 @@ resolved.
             exceptionDetails?: Runtime.ExceptionDetails;
         }
 
-        export interface CompileScriptReturnType {
+        interface CompileScriptReturnType {
             /**
              * Id of the script.
              */
@@ -1718,7 +1720,7 @@ resolved.
             exceptionDetails?: Runtime.ExceptionDetails;
         }
 
-        export interface EvaluateReturnType {
+        interface EvaluateReturnType {
             /**
              * Evaluation result.
              */
@@ -1729,14 +1731,14 @@ resolved.
             exceptionDetails?: Runtime.ExceptionDetails;
         }
 
-        export interface GetIsolateIdReturnType {
+        interface GetIsolateIdReturnType {
             /**
              * The isolate id.
              */
             id: string;
         }
 
-        export interface GetHeapUsageReturnType {
+        interface GetHeapUsageReturnType {
             /**
              * Used heap size in bytes.
              */
@@ -1747,7 +1749,7 @@ resolved.
             totalSize: number;
         }
 
-        export interface GetPropertiesReturnType {
+        interface GetPropertiesReturnType {
             /**
              * Object properties.
              */
@@ -1762,18 +1764,18 @@ resolved.
             exceptionDetails?: Runtime.ExceptionDetails;
         }
 
-        export interface GlobalLexicalScopeNamesReturnType {
+        interface GlobalLexicalScopeNamesReturnType {
             names: string[];
         }
 
-        export interface QueryObjectsReturnType {
+        interface QueryObjectsReturnType {
             /**
              * Array with objects.
              */
             objects: Runtime.RemoteObject;
         }
 
-        export interface RunScriptReturnType {
+        interface RunScriptReturnType {
             /**
              * Run result.
              */
@@ -1784,7 +1786,7 @@ resolved.
             exceptionDetails?: Runtime.ExceptionDetails;
         }
 
-        export interface ConsoleAPICalledEventDataType {
+        interface ConsoleAPICalledEventDataType {
             /**
              * Type of the call.
              */
@@ -1807,14 +1809,14 @@ resolved.
             stackTrace?: Runtime.StackTrace;
             /**
              * Console context descriptor for calls on non-default console context (not console.*):
-'anonymous#unique-logger-id' for call on unnamed context, 'name#unique-logger-id' for call
-on named context.
+             * 'anonymous#unique-logger-id' for call on unnamed context, 'name#unique-logger-id' for call
+             * on named context.
              * @experimental
              */
             context?: string;
         }
 
-        export interface ExceptionRevokedEventDataType {
+        interface ExceptionRevokedEventDataType {
             /**
              * Reason describing why exception was revoked.
              */
@@ -1825,7 +1827,7 @@ on named context.
             exceptionId: number;
         }
 
-        export interface ExceptionThrownEventDataType {
+        interface ExceptionThrownEventDataType {
             /**
              * Timestamp of the exception.
              */
@@ -1833,31 +1835,31 @@ on named context.
             exceptionDetails: Runtime.ExceptionDetails;
         }
 
-        export interface ExecutionContextCreatedEventDataType {
+        interface ExecutionContextCreatedEventDataType {
             /**
              * A newly created execution context.
              */
             context: Runtime.ExecutionContextDescription;
         }
 
-        export interface ExecutionContextDestroyedEventDataType {
+        interface ExecutionContextDestroyedEventDataType {
             /**
              * Id of the destroyed context
              */
             executionContextId: Runtime.ExecutionContextId;
         }
 
-        export interface InspectRequestedEventDataType {
+        interface InspectRequestedEventDataType {
             object: Runtime.RemoteObject;
             hints: {};
         }
     }
 
-    export namespace Schema {
+    namespace Schema {
         /**
          * Description of the protocol domain.
          */
-        export interface Domain {
+        interface Domain {
             /**
              * Domain name.
              */
@@ -1868,7 +1870,7 @@ on named context.
             version: string;
         }
 
-        export interface GetDomainsReturnType {
+        interface GetDomainsReturnType {
             /**
              * List of supported domains.
              */
@@ -1879,24 +1881,27 @@ on named context.
     /**
      * The inspector.Session is used for dispatching messages to the V8 inspector back-end and receiving message responses and notifications.
      */
-    export class Session extends EventEmitter {
+    class Session extends EventEmitter {
         /**
          * Create a new instance of the inspector.Session class. The inspector session needs to be connected through session.connect() before the messages can be dispatched to the inspector backend.
          */
         constructor();
 
         /**
-         * Connects a session to the inspector back-end. An exception will be thrown if there is already a connected session established either through the API or by a front-end connected to the Inspector WebSocket port.
+         * Connects a session to the inspector back-end.
+         * An exception will be thrown if there is already a connected session established either through the API or by a front-end connected to the Inspector WebSocket port.
          */
         connect(): void;
 
         /**
-         * Immediately close the session. All pending message callbacks will be called with an error. session.connect() will need to be called to be able to send messages again. Reconnected session will lose all inspector state, such as enabled agents or configured breakpoints.
+         * Immediately close the session. All pending message callbacks will be called with an error.
+         * session.connect() will need to be called to be able to send messages again. Reconnected session will lose all inspector state, such as enabled agents or configured breakpoints.
          */
         disconnect(): void;
 
         /**
-         * Posts a message to the inspector back-end. callback will be notified when a response is received. callback is a function that accepts two optional arguments - error and message-specific result.
+         * Posts a message to the inspector back-end. callback will be notified when a response is received.
+         * callback is a function that accepts two optional arguments - error and message-specific result.
          */
         post(method: string, params?: {}, callback?: (err: Error | null, params?: {}) => void): void;
         post(method: string, callback?: (err: Error | null, params?: {}) => void): void;
@@ -1913,7 +1918,7 @@ on named context.
 
         /**
          * Enables console domain, sends the messages collected so far to the client by means of the
-`messageAdded` notification.
+         * `messageAdded` notification.
          */
         post(method: "Console.enable", callback?: (err: Error | null) => void): void;
         /**
@@ -1929,7 +1934,7 @@ on named context.
 
         /**
          * Enables debugger for the given page. Clients should not assume that the debugging has been
-enabled until the result for this command is received.
+         * enabled until the result for this command is received.
          */
         post(method: "Debugger.enable", callback?: (err: Error | null, params: Debugger.EnableReturnType) => void): void;
 
@@ -1941,9 +1946,13 @@ enabled until the result for this command is received.
 
         /**
          * Returns possible locations for breakpoint. scriptId in start and end range locations should be
-the same.
+         * the same.
          */
-        post(method: "Debugger.getPossibleBreakpoints", params?: Debugger.GetPossibleBreakpointsParameterType, callback?: (err: Error | null, params: Debugger.GetPossibleBreakpointsReturnType) => void): void;
+        post(
+            method: "Debugger.getPossibleBreakpoints",
+            params?: Debugger.GetPossibleBreakpointsParameterType,
+            callback?: (err: Error | null, params: Debugger.GetPossibleBreakpointsReturnType) => void,
+        ): void;
         post(method: "Debugger.getPossibleBreakpoints", callback?: (err: Error | null, params: Debugger.GetPossibleBreakpointsReturnType) => void): void;
 
         /**
@@ -1989,9 +1998,9 @@ the same.
 
         /**
          * This method is deprecated - use Debugger.stepInto with breakOnAsyncCall and
-Debugger.pauseOnAsyncTask instead. Steps into next scheduled async task if any is scheduled
-before next pause. Returns success when async task is actually scheduled, returns error if no
-task were scheduled or another scheduleStepIntoAsync was called.
+         * Debugger.pauseOnAsyncTask instead. Steps into next scheduled async task if any is scheduled
+         * before next pause. Returns success when async task is actually scheduled, returns error if no
+         * task were scheduled or another scheduleStepIntoAsync was called.
          * @experimental
          */
         post(method: "Debugger.scheduleStepIntoAsync", callback?: (err: Error | null) => void): void;
@@ -2010,8 +2019,8 @@ task were scheduled or another scheduleStepIntoAsync was called.
 
         /**
          * Replace previous blackbox patterns with passed ones. Forces backend to skip stepping/pausing in
-scripts with url matching one of the patterns. VM will try to leave blackboxed script by
-performing 'step in' several times, finally resorting to 'step out' if unsuccessful.
+         * scripts with url matching one of the patterns. VM will try to leave blackboxed script by
+         * performing 'step in' several times, finally resorting to 'step out' if unsuccessful.
          * @experimental
          */
         post(method: "Debugger.setBlackboxPatterns", params?: Debugger.SetBlackboxPatternsParameterType, callback?: (err: Error | null) => void): void;
@@ -2019,9 +2028,9 @@ performing 'step in' several times, finally resorting to 'step out' if unsuccess
 
         /**
          * Makes backend skip steps in the script in blackboxed ranges. VM will try leave blacklisted
-scripts by performing 'step in' several times, finally resorting to 'step out' if unsuccessful.
-Positions array contains positions where blackbox state is changed. First interval isn't
-blackboxed. Array should be sorted.
+         * scripts by performing 'step in' several times, finally resorting to 'step out' if unsuccessful.
+         * Positions array contains positions where blackbox state is changed. First interval isn't
+         * blackboxed. Array should be sorted.
          * @experimental
          */
         post(method: "Debugger.setBlackboxedRanges", params?: Debugger.SetBlackboxedRangesParameterType, callback?: (err: Error | null) => void): void;
@@ -2035,9 +2044,9 @@ blackboxed. Array should be sorted.
 
         /**
          * Sets JavaScript breakpoint at given location specified either by URL or URL regex. Once this
-command is issued, all existing parsed scripts will have breakpoints resolved and returned in
-`locations` property. Further matching script parsing will result in subsequent
-`breakpointResolved` events issued. This logical breakpoint will survive page reloads.
+         * command is issued, all existing parsed scripts will have breakpoints resolved and returned in
+         * `locations` property. Further matching script parsing will result in subsequent
+         * `breakpointResolved` events issued. This logical breakpoint will survive page reloads.
          */
         post(method: "Debugger.setBreakpointByUrl", params?: Debugger.SetBreakpointByUrlParameterType, callback?: (err: Error | null, params: Debugger.SetBreakpointByUrlReturnType) => void): void;
         post(method: "Debugger.setBreakpointByUrl", callback?: (err: Error | null, params: Debugger.SetBreakpointByUrlReturnType) => void): void;
@@ -2050,7 +2059,7 @@ command is issued, all existing parsed scripts will have breakpoints resolved an
 
         /**
          * Defines pause on exceptions state. Can be set to stop on all exceptions, uncaught exceptions or
-no exceptions. Initial pause on exceptions state is `none`.
+         * no exceptions. Initial pause on exceptions state is `none`.
          */
         post(method: "Debugger.setPauseOnExceptions", params?: Debugger.SetPauseOnExceptionsParameterType, callback?: (err: Error | null) => void): void;
         post(method: "Debugger.setPauseOnExceptions", callback?: (err: Error | null) => void): void;
@@ -2076,7 +2085,7 @@ no exceptions. Initial pause on exceptions state is `none`.
 
         /**
          * Changes value of variable in a callframe. Object-based scopes are not supported and must be
-mutated manually.
+         * mutated manually.
          */
         post(method: "Debugger.setVariableValue", params?: Debugger.SetVariableValueParameterType, callback?: (err: Error | null) => void): void;
         post(method: "Debugger.setVariableValue", callback?: (err: Error | null) => void): void;
@@ -2098,7 +2107,7 @@ mutated manually.
         post(method: "Debugger.stepOver", callback?: (err: Error | null) => void): void;
         /**
          * Enables console to refer to the node with given id via $x (see Command Line API for more details
-$x functions).
+         * $x functions).
          */
         post(method: "HeapProfiler.addInspectedHeapObject", params?: HeapProfiler.AddInspectedHeapObjectParameterType, callback?: (err: Error | null) => void): void;
         post(method: "HeapProfiler.addInspectedHeapObject", callback?: (err: Error | null) => void): void;
@@ -2112,7 +2121,11 @@ $x functions).
         post(method: "HeapProfiler.getHeapObjectId", params?: HeapProfiler.GetHeapObjectIdParameterType, callback?: (err: Error | null, params: HeapProfiler.GetHeapObjectIdReturnType) => void): void;
         post(method: "HeapProfiler.getHeapObjectId", callback?: (err: Error | null, params: HeapProfiler.GetHeapObjectIdReturnType) => void): void;
 
-        post(method: "HeapProfiler.getObjectByHeapObjectId", params?: HeapProfiler.GetObjectByHeapObjectIdParameterType, callback?: (err: Error | null, params: HeapProfiler.GetObjectByHeapObjectIdReturnType) => void): void;
+        post(
+            method: "HeapProfiler.getObjectByHeapObjectId",
+            params?: HeapProfiler.GetObjectByHeapObjectIdParameterType,
+            callback?: (err: Error | null, params: HeapProfiler.GetObjectByHeapObjectIdReturnType) => void,
+        ): void;
         post(method: "HeapProfiler.getObjectByHeapObjectId", callback?: (err: Error | null, params: HeapProfiler.GetObjectByHeapObjectIdReturnType) => void): void;
 
         post(method: "HeapProfiler.getSamplingProfile", callback?: (err: Error | null, params: HeapProfiler.GetSamplingProfileReturnType) => void): void;
@@ -2136,7 +2149,7 @@ $x functions).
 
         /**
          * Collect coverage data for the current isolate. The coverage data may be incomplete due to
-garbage collection.
+         * garbage collection.
          */
         post(method: "Profiler.getBestEffortCoverage", callback?: (err: Error | null, params: Profiler.GetBestEffortCoverageReturnType) => void): void;
 
@@ -2150,8 +2163,8 @@ garbage collection.
 
         /**
          * Enable precise code coverage. Coverage data for JavaScript executed before enabling precise code
-coverage may be incomplete. Enabling prevents running optimized code and resets execution
-counters.
+         * coverage may be incomplete. Enabling prevents running optimized code and resets execution
+         * counters.
          */
         post(method: "Profiler.startPreciseCoverage", params?: Profiler.StartPreciseCoverageParameterType, callback?: (err: Error | null) => void): void;
         post(method: "Profiler.startPreciseCoverage", callback?: (err: Error | null) => void): void;
@@ -2166,7 +2179,7 @@ counters.
 
         /**
          * Disable precise code coverage. Disabling releases unnecessary execution count records and allows
-executing optimized code.
+         * executing optimized code.
          */
         post(method: "Profiler.stopPreciseCoverage", callback?: (err: Error | null) => void): void;
 
@@ -2178,7 +2191,7 @@ executing optimized code.
 
         /**
          * Collect coverage data for the current isolate, and resets execution counters. Precise code
-coverage needs to have started.
+         * coverage needs to have started.
          */
         post(method: "Profiler.takePreciseCoverage", callback?: (err: Error | null, params: Profiler.TakePreciseCoverageReturnType) => void): void;
 
@@ -2195,7 +2208,7 @@ coverage needs to have started.
 
         /**
          * Calls function with given declaration on the given object. Object group of the result is
-inherited from the target object.
+         * inherited from the target object.
          */
         post(method: "Runtime.callFunctionOn", params?: Runtime.CallFunctionOnParameterType, callback?: (err: Error | null, params: Runtime.CallFunctionOnReturnType) => void): void;
         post(method: "Runtime.callFunctionOn", callback?: (err: Error | null, params: Runtime.CallFunctionOnReturnType) => void): void;
@@ -2218,8 +2231,8 @@ inherited from the target object.
 
         /**
          * Enables reporting of execution contexts creation by means of `executionContextCreated` event.
-When the reporting gets enabled the event will be sent immediately for each existing execution
-context.
+         * When the reporting gets enabled the event will be sent immediately for each existing execution
+         * context.
          */
         post(method: "Runtime.enable", callback?: (err: Error | null) => void): void;
 
@@ -2237,14 +2250,14 @@ context.
 
         /**
          * Returns the JavaScript heap usage.
-It is the total usage of the corresponding isolate not scoped to a particular Runtime.
+         * It is the total usage of the corresponding isolate not scoped to a particular Runtime.
          * @experimental
          */
         post(method: "Runtime.getHeapUsage", callback?: (err: Error | null, params: Runtime.GetHeapUsageReturnType) => void): void;
 
         /**
          * Returns properties of a given object. Object group of the result is inherited from the target
-object.
+         * object.
          */
         post(method: "Runtime.getProperties", params?: Runtime.GetPropertiesParameterType, callback?: (err: Error | null, params: Runtime.GetPropertiesReturnType) => void): void;
         post(method: "Runtime.getProperties", callback?: (err: Error | null, params: Runtime.GetPropertiesReturnType) => void): void;
@@ -2252,7 +2265,11 @@ object.
         /**
          * Returns all let, const and class variables from global scope.
          */
-        post(method: "Runtime.globalLexicalScopeNames", params?: Runtime.GlobalLexicalScopeNamesParameterType, callback?: (err: Error | null, params: Runtime.GlobalLexicalScopeNamesReturnType) => void): void;
+        post(
+            method: "Runtime.globalLexicalScopeNames",
+            params?: Runtime.GlobalLexicalScopeNamesParameterType,
+            callback?: (err: Error | null, params: Runtime.GlobalLexicalScopeNamesReturnType) => void,
+        ): void;
         post(method: "Runtime.globalLexicalScopeNames", callback?: (err: Error | null, params: Runtime.GlobalLexicalScopeNamesReturnType) => void): void;
 
         post(method: "Runtime.queryObjects", params?: Runtime.QueryObjectsParameterType, callback?: (err: Error | null, params: Runtime.QueryObjectsReturnType) => void): void;
@@ -2289,7 +2306,7 @@ object.
 
         /**
          * Terminate current or next JavaScript execution.
-Will cancel the termination when the outer-most script execution ends.
+         * Will cancel the termination when the outer-most script execution ends.
          * @experimental
          */
         post(method: "Runtime.terminateExecution", callback?: (err: Error | null) => void): void;
@@ -2334,7 +2351,7 @@ Will cancel the termination when the outer-most script execution ends.
 
         /**
          * Fired when virtual machine parses script. This event is also fired for all known and uncollected
-scripts upon enabling debugger.
+         * scripts upon enabling debugger.
          */
         addListener(event: "Debugger.scriptParsed", listener: (message: InspectorNotification<Debugger.ScriptParsedEventDataType>) => void): this;
 
@@ -2347,8 +2364,8 @@ scripts upon enabling debugger.
 
         /**
          * If heap objects tracking has been started then backend regularly sends a current value for last
-seen object id and corresponding timestamp. If the were changes in the heap since last event
-then one or more heapStatsUpdate events will be sent before a new lastSeenObjectId event.
+         * seen object id and corresponding timestamp. If the were changes in the heap since last event
+         * then one or more heapStatsUpdate events will be sent before a new lastSeenObjectId event.
          */
         addListener(event: "HeapProfiler.lastSeenObjectId", listener: (message: InspectorNotification<HeapProfiler.LastSeenObjectIdEventDataType>) => void): this;
 
@@ -2393,7 +2410,7 @@ then one or more heapStatsUpdate events will be sent before a new lastSeenObject
 
         /**
          * Issued when object should be inspected (for example, as a result of inspect() command line API
-call).
+         * call).
          */
         addListener(event: "Runtime.inspectRequested", listener: (message: InspectorNotification<Runtime.InspectRequestedEventDataType>) => void): this;
 
@@ -2454,7 +2471,7 @@ call).
 
         /**
          * Fired when virtual machine parses script. This event is also fired for all known and uncollected
-scripts upon enabling debugger.
+         * scripts upon enabling debugger.
          */
         on(event: "Debugger.scriptParsed", listener: (message: InspectorNotification<Debugger.ScriptParsedEventDataType>) => void): this;
 
@@ -2467,8 +2484,8 @@ scripts upon enabling debugger.
 
         /**
          * If heap objects tracking has been started then backend regularly sends a current value for last
-seen object id and corresponding timestamp. If the were changes in the heap since last event
-then one or more heapStatsUpdate events will be sent before a new lastSeenObjectId event.
+         * seen object id and corresponding timestamp. If the were changes in the heap since last event
+         * then one or more heapStatsUpdate events will be sent before a new lastSeenObjectId event.
          */
         on(event: "HeapProfiler.lastSeenObjectId", listener: (message: InspectorNotification<HeapProfiler.LastSeenObjectIdEventDataType>) => void): this;
 
@@ -2513,7 +2530,7 @@ then one or more heapStatsUpdate events will be sent before a new lastSeenObject
 
         /**
          * Issued when object should be inspected (for example, as a result of inspect() command line API
-call).
+         * call).
          */
         on(event: "Runtime.inspectRequested", listener: (message: InspectorNotification<Runtime.InspectRequestedEventDataType>) => void): this;
 
@@ -2551,7 +2568,7 @@ call).
 
         /**
          * Fired when virtual machine parses script. This event is also fired for all known and uncollected
-scripts upon enabling debugger.
+         * scripts upon enabling debugger.
          */
         once(event: "Debugger.scriptParsed", listener: (message: InspectorNotification<Debugger.ScriptParsedEventDataType>) => void): this;
 
@@ -2564,8 +2581,8 @@ scripts upon enabling debugger.
 
         /**
          * If heap objects tracking has been started then backend regularly sends a current value for last
-seen object id and corresponding timestamp. If the were changes in the heap since last event
-then one or more heapStatsUpdate events will be sent before a new lastSeenObjectId event.
+         * seen object id and corresponding timestamp. If the were changes in the heap since last event
+         * then one or more heapStatsUpdate events will be sent before a new lastSeenObjectId event.
          */
         once(event: "HeapProfiler.lastSeenObjectId", listener: (message: InspectorNotification<HeapProfiler.LastSeenObjectIdEventDataType>) => void): this;
 
@@ -2610,7 +2627,7 @@ then one or more heapStatsUpdate events will be sent before a new lastSeenObject
 
         /**
          * Issued when object should be inspected (for example, as a result of inspect() command line API
-call).
+         * call).
          */
         once(event: "Runtime.inspectRequested", listener: (message: InspectorNotification<Runtime.InspectRequestedEventDataType>) => void): this;
 
@@ -2648,7 +2665,7 @@ call).
 
         /**
          * Fired when virtual machine parses script. This event is also fired for all known and uncollected
-scripts upon enabling debugger.
+         * scripts upon enabling debugger.
          */
         prependListener(event: "Debugger.scriptParsed", listener: (message: InspectorNotification<Debugger.ScriptParsedEventDataType>) => void): this;
 
@@ -2661,8 +2678,8 @@ scripts upon enabling debugger.
 
         /**
          * If heap objects tracking has been started then backend regularly sends a current value for last
-seen object id and corresponding timestamp. If the were changes in the heap since last event
-then one or more heapStatsUpdate events will be sent before a new lastSeenObjectId event.
+         * seen object id and corresponding timestamp. If the were changes in the heap since last event
+         * then one or more heapStatsUpdate events will be sent before a new lastSeenObjectId event.
          */
         prependListener(event: "HeapProfiler.lastSeenObjectId", listener: (message: InspectorNotification<HeapProfiler.LastSeenObjectIdEventDataType>) => void): this;
 
@@ -2707,7 +2724,7 @@ then one or more heapStatsUpdate events will be sent before a new lastSeenObject
 
         /**
          * Issued when object should be inspected (for example, as a result of inspect() command line API
-call).
+         * call).
          */
         prependListener(event: "Runtime.inspectRequested", listener: (message: InspectorNotification<Runtime.InspectRequestedEventDataType>) => void): this;
 
@@ -2745,7 +2762,7 @@ call).
 
         /**
          * Fired when virtual machine parses script. This event is also fired for all known and uncollected
-scripts upon enabling debugger.
+         * scripts upon enabling debugger.
          */
         prependOnceListener(event: "Debugger.scriptParsed", listener: (message: InspectorNotification<Debugger.ScriptParsedEventDataType>) => void): this;
 
@@ -2758,8 +2775,8 @@ scripts upon enabling debugger.
 
         /**
          * If heap objects tracking has been started then backend regularly sends a current value for last
-seen object id and corresponding timestamp. If the were changes in the heap since last event
-then one or more heapStatsUpdate events will be sent before a new lastSeenObjectId event.
+         * seen object id and corresponding timestamp. If the were changes in the heap since last event
+         * then one or more heapStatsUpdate events will be sent before a new lastSeenObjectId event.
          */
         prependOnceListener(event: "HeapProfiler.lastSeenObjectId", listener: (message: InspectorNotification<HeapProfiler.LastSeenObjectIdEventDataType>) => void): this;
 
@@ -2804,7 +2821,7 @@ then one or more heapStatsUpdate events will be sent before a new lastSeenObject
 
         /**
          * Issued when object should be inspected (for example, as a result of inspect() command line API
-call).
+         * call).
          */
         prependOnceListener(event: "Runtime.inspectRequested", listener: (message: InspectorNotification<Runtime.InspectRequestedEventDataType>) => void): this;
     }
@@ -2818,15 +2835,15 @@ call).
      * @param host Host to listen on for inspector connections. Optional, defaults to what was specified on the CLI.
      * @param wait Block until a client has connected. Optional, defaults to false.
      */
-    export function open(port?: number, host?: string, wait?: boolean): void;
+    function open(port?: number, host?: string, wait?: boolean): void;
 
     /**
      * Deactivate the inspector. Blocks until there are no active connections.
      */
-    export function close(): void;
+    function close(): void;
 
     /**
      * Return the URL of the active inspector, or undefined if there is none.
      */
-    export function url(): string;
+    function url(): string;
 }

--- a/types/node/inspector.d.ts
+++ b/types/node/inspector.d.ts
@@ -52,7 +52,7 @@ declare module "inspector" {
             /**
              * Console message that has been added.
              */
-            message: Console.ConsoleMessage;
+            message: ConsoleMessage;
         }
     }
 
@@ -101,7 +101,7 @@ declare module "inspector" {
             /**
              * Call frame identifier. This identifier is only valid while the virtual machine is paused.
              */
-            callFrameId: Debugger.CallFrameId;
+            callFrameId: CallFrameId;
             /**
              * Name of the JavaScript function called on this call frame.
              */
@@ -109,11 +109,11 @@ declare module "inspector" {
             /**
              * Location in the source code.
              */
-            functionLocation?: Debugger.Location;
+            functionLocation?: Location;
             /**
              * Location in the source code.
              */
-            location: Debugger.Location;
+            location: Location;
             /**
              * JavaScript script name or url.
              */
@@ -121,7 +121,7 @@ declare module "inspector" {
             /**
              * Scope chain for this call frame.
              */
-            scopeChain: Debugger.Scope[];
+            scopeChain: Scope[];
             /**
              * `this` object for this call frame.
              */
@@ -150,11 +150,11 @@ declare module "inspector" {
             /**
              * Location in the source code where scope starts
              */
-            startLocation?: Debugger.Location;
+            startLocation?: Location;
             /**
              * Location in the source code where scope ends
              */
-            endLocation?: Debugger.Location;
+            endLocation?: Location;
         }
 
         /**
@@ -191,7 +191,7 @@ declare module "inspector" {
             /**
              * Location to continue to.
              */
-            location: Debugger.Location;
+            location: Location;
             targetCallFrames?: string;
         }
 
@@ -199,7 +199,7 @@ declare module "inspector" {
             /**
              * Call frame identifier to evaluate on.
              */
-            callFrameId: Debugger.CallFrameId;
+            callFrameId: CallFrameId;
             /**
              * Expression to evaluate.
              */
@@ -232,18 +232,23 @@ declare module "inspector" {
              * Whether to throw an exception if side effect cannot be ruled out during evaluation.
              */
             throwOnSideEffect?: boolean;
+            /**
+             * Terminate execution after timing out (number of milliseconds).
+             * @experimental
+             */
+            timeout?: Runtime.TimeDelta;
         }
 
         interface GetPossibleBreakpointsParameterType {
             /**
              * Start of range to search possible breakpoint locations in.
              */
-            start: Debugger.Location;
+            start: Location;
             /**
              * End of range to search possible breakpoint locations in (excluding). When not specified, end
              * of scripts is used as end of range.
              */
-            end?: Debugger.Location;
+            end?: Location;
             /**
              * Only consider locations which are in the same (non-nested) function as start.
              */
@@ -269,14 +274,14 @@ declare module "inspector" {
         }
 
         interface RemoveBreakpointParameterType {
-            breakpointId: Debugger.BreakpointId;
+            breakpointId: BreakpointId;
         }
 
         interface RestartFrameParameterType {
             /**
              * Call frame identifier to evaluate on.
              */
-            callFrameId: Debugger.CallFrameId;
+            callFrameId: CallFrameId;
         }
 
         interface SearchInContentParameterType {
@@ -318,14 +323,14 @@ declare module "inspector" {
              * Id of the script.
              */
             scriptId: Runtime.ScriptId;
-            positions: Debugger.ScriptPosition[];
+            positions: ScriptPosition[];
         }
 
         interface SetBreakpointParameterType {
             /**
              * Location to set breakpoint in.
              */
-            location: Debugger.Location;
+            location: Location;
             /**
              * Expression to use as a breakpoint condition. When specified, debugger will only stop on the
              * breakpoint if this expression evaluates to true.
@@ -358,6 +363,18 @@ declare module "inspector" {
             /**
              * Expression to use as a breakpoint condition. When specified, debugger will only stop on the
              * breakpoint if this expression evaluates to true.
+             */
+            condition?: string;
+        }
+
+        interface SetBreakpointOnFunctionCallParameterType {
+            /**
+             * Function object id.
+             */
+            objectId: Runtime.RemoteObjectId;
+            /**
+             * Expression to use as a breakpoint condition. When specified, debugger will
+             * stop on the breakpoint if this expression evaluates to true.
              */
             condition?: string;
         }
@@ -423,7 +440,7 @@ declare module "inspector" {
             /**
              * Id of callframe that holds variable.
              */
-            callFrameId: Debugger.CallFrameId;
+            callFrameId: CallFrameId;
         }
 
         interface StepIntoParameterType {
@@ -458,7 +475,7 @@ declare module "inspector" {
             /**
              * List of the possible breakpoint locations.
              */
-            locations: Debugger.BreakLocation[];
+            locations: BreakLocation[];
         }
 
         interface GetScriptSourceReturnType {
@@ -476,7 +493,7 @@ declare module "inspector" {
             /**
              * New stack trace.
              */
-            callFrames: Debugger.CallFrame[];
+            callFrames: CallFrame[];
             /**
              * Async stack trace, if any.
              */
@@ -492,36 +509,43 @@ declare module "inspector" {
             /**
              * List of search matches.
              */
-            result: Debugger.SearchMatch[];
+            result: SearchMatch[];
         }
 
         interface SetBreakpointReturnType {
             /**
              * Id of the created breakpoint for further reference.
              */
-            breakpointId: Debugger.BreakpointId;
+            breakpointId: BreakpointId;
             /**
              * Location this breakpoint resolved into.
              */
-            actualLocation: Debugger.Location;
+            actualLocation: Location;
         }
 
         interface SetBreakpointByUrlReturnType {
             /**
              * Id of the created breakpoint for further reference.
              */
-            breakpointId: Debugger.BreakpointId;
+            breakpointId: BreakpointId;
             /**
              * List of the locations this breakpoint resolved into upon addition.
              */
-            locations: Debugger.Location[];
+            locations: Location[];
+        }
+
+        interface SetBreakpointOnFunctionCallReturnType {
+            /**
+             * Id of the created breakpoint for further reference.
+             */
+            breakpointId: BreakpointId;
         }
 
         interface SetScriptSourceReturnType {
             /**
              * New stack trace in case editing has happened while VM was stopped.
              */
-            callFrames?: Debugger.CallFrame[];
+            callFrames?: CallFrame[];
             /**
              * Whether current call stack  was modified after applying the changes.
              */
@@ -545,18 +569,18 @@ declare module "inspector" {
             /**
              * Breakpoint unique identifier.
              */
-            breakpointId: Debugger.BreakpointId;
+            breakpointId: BreakpointId;
             /**
              * Actual breakpoint location.
              */
-            location: Debugger.Location;
+            location: Location;
         }
 
         interface PausedEventDataType {
             /**
              * Call stack the virtual machine stopped on.
              */
-            callFrames: Debugger.CallFrame[];
+            callFrames: CallFrame[];
             /**
              * Pause reason.
              */
@@ -733,21 +757,21 @@ declare module "inspector" {
             /**
              * Child nodes.
              */
-            children: HeapProfiler.SamplingHeapProfileNode[];
+            children: SamplingHeapProfileNode[];
         }
 
         /**
          * Profile.
          */
         interface SamplingHeapProfile {
-            head: HeapProfiler.SamplingHeapProfileNode;
+            head: SamplingHeapProfileNode;
         }
 
         interface AddInspectedHeapObjectParameterType {
             /**
              * Heap snapshot object id to be accessible by means of $x command line API.
              */
-            heapObjectId: HeapProfiler.HeapSnapshotObjectId;
+            heapObjectId: HeapSnapshotObjectId;
         }
 
         interface GetHeapObjectIdParameterType {
@@ -758,7 +782,7 @@ declare module "inspector" {
         }
 
         interface GetObjectByHeapObjectIdParameterType {
-            objectId: HeapProfiler.HeapSnapshotObjectId;
+            objectId: HeapSnapshotObjectId;
             /**
              * Symbolic group name that can be used to release multiple objects.
              */
@@ -796,7 +820,7 @@ declare module "inspector" {
             /**
              * Id of the heap snapshot object corresponding to the passed remote object id.
              */
-            heapSnapshotObjectId: HeapProfiler.HeapSnapshotObjectId;
+            heapSnapshotObjectId: HeapSnapshotObjectId;
         }
 
         interface GetObjectByHeapObjectIdReturnType {
@@ -810,14 +834,14 @@ declare module "inspector" {
             /**
              * Return the sampling profile being collected.
              */
-            profile: HeapProfiler.SamplingHeapProfile;
+            profile: SamplingHeapProfile;
         }
 
         interface StopSamplingReturnType {
             /**
              * Recorded sampling heap profile.
              */
-            profile: HeapProfiler.SamplingHeapProfile;
+            profile: SamplingHeapProfile;
         }
 
         interface AddHeapSnapshotChunkEventDataType {
@@ -874,7 +898,7 @@ declare module "inspector" {
             /**
              * An array of source position ticks.
              */
-            positionTicks?: Profiler.PositionTickInfo[];
+            positionTicks?: PositionTickInfo[];
         }
 
         /**
@@ -884,7 +908,7 @@ declare module "inspector" {
             /**
              * The list of profile nodes. First item is the root node.
              */
-            nodes: Profiler.ProfileNode[];
+            nodes: ProfileNode[];
             /**
              * Profiling start timestamp in microseconds.
              */
@@ -947,7 +971,7 @@ declare module "inspector" {
             /**
              * Source ranges inside the function with coverage data.
              */
-            ranges: Profiler.CoverageRange[];
+            ranges: CoverageRange[];
             /**
              * Whether coverage data for this function has block granularity.
              */
@@ -969,7 +993,7 @@ declare module "inspector" {
             /**
              * Functions contained in the script that has coverage data.
              */
-            functions: Profiler.FunctionCoverage[];
+            functions: FunctionCoverage[];
         }
 
         /**
@@ -995,7 +1019,7 @@ declare module "inspector" {
             /**
              * The types for this parameter or return value.
              */
-            types: Profiler.TypeObject[];
+            types: TypeObject[];
         }
 
         /**
@@ -1014,7 +1038,7 @@ declare module "inspector" {
             /**
              * Type profile entries for parameters and return values of the functions in the script.
              */
-            entries: Profiler.TypeProfileEntry[];
+            entries: TypeProfileEntry[];
         }
 
         interface SetSamplingIntervalParameterType {
@@ -1039,28 +1063,28 @@ declare module "inspector" {
             /**
              * Coverage data for the current isolate.
              */
-            result: Profiler.ScriptCoverage[];
+            result: ScriptCoverage[];
         }
 
         interface StopReturnType {
             /**
              * Recorded profile.
              */
-            profile: Profiler.Profile;
+            profile: Profile;
         }
 
         interface TakePreciseCoverageReturnType {
             /**
              * Coverage data for the current isolate.
              */
-            result: Profiler.ScriptCoverage[];
+            result: ScriptCoverage[];
         }
 
         interface TakeTypeProfileReturnType {
             /**
              * Type profile for all scripts since startTypeProfile() was turned on.
              */
-            result: Profiler.ScriptTypeProfile[];
+            result: ScriptTypeProfile[];
         }
 
         interface ConsoleProfileFinishedEventDataType {
@@ -1069,7 +1093,7 @@ declare module "inspector" {
              * Location of console.profileEnd().
              */
             location: Debugger.Location;
-            profile: Profiler.Profile;
+            profile: Profile;
             /**
              * Profile title passed as an argument to console.profile().
              */
@@ -1130,7 +1154,7 @@ declare module "inspector" {
              * Primitive value which can not be JSON-stringified does not have `value`, but gets this
              * property.
              */
-            unserializableValue?: Runtime.UnserializableValue;
+            unserializableValue?: UnserializableValue;
             /**
              * String representation of the object.
              */
@@ -1138,16 +1162,16 @@ declare module "inspector" {
             /**
              * Unique object identifier (for non-primitive values).
              */
-            objectId?: Runtime.RemoteObjectId;
+            objectId?: RemoteObjectId;
             /**
              * Preview containing abbreviated property values. Specified for `object` type values only.
              * @experimental
              */
-            preview?: Runtime.ObjectPreview;
+            preview?: ObjectPreview;
             /**
              * @experimental
              */
-            customPreview?: Runtime.CustomPreview;
+            customPreview?: CustomPreview;
         }
 
         /**
@@ -1156,9 +1180,9 @@ declare module "inspector" {
         interface CustomPreview {
             header: string;
             hasBody: boolean;
-            formatterObjectId: Runtime.RemoteObjectId;
-            bindRemoteObjectFunctionId: Runtime.RemoteObjectId;
-            configObjectId?: Runtime.RemoteObjectId;
+            formatterObjectId: RemoteObjectId;
+            bindRemoteObjectFunctionId: RemoteObjectId;
+            configObjectId?: RemoteObjectId;
         }
 
         /**
@@ -1185,11 +1209,11 @@ declare module "inspector" {
             /**
              * List of the properties.
              */
-            properties: Runtime.PropertyPreview[];
+            properties: PropertyPreview[];
             /**
              * List of the entries. Specified for `map` and `set` subtype values only.
              */
-            entries?: Runtime.EntryPreview[];
+            entries?: EntryPreview[];
         }
 
         /**
@@ -1211,7 +1235,7 @@ declare module "inspector" {
             /**
              * Nested value preview.
              */
-            valuePreview?: Runtime.ObjectPreview;
+            valuePreview?: ObjectPreview;
             /**
              * Object subtype hint. Specified for `object` type values only.
              */
@@ -1225,11 +1249,11 @@ declare module "inspector" {
             /**
              * Preview of the key. Specified for map-like collection entries.
              */
-            key?: Runtime.ObjectPreview;
+            key?: ObjectPreview;
             /**
              * Preview of the value.
              */
-            value: Runtime.ObjectPreview;
+            value: ObjectPreview;
         }
 
         /**
@@ -1243,7 +1267,7 @@ declare module "inspector" {
             /**
              * The value associated with the property.
              */
-            value?: Runtime.RemoteObject;
+            value?: RemoteObject;
             /**
              * True if the value associated with the property may be changed (data descriptors only).
              */
@@ -1252,12 +1276,12 @@ declare module "inspector" {
              * A function which serves as a getter for the property, or `undefined` if there is no getter
              * (accessor descriptors only).
              */
-            get?: Runtime.RemoteObject;
+            get?: RemoteObject;
             /**
              * A function which serves as a setter for the property, or `undefined` if there is no setter
              * (accessor descriptors only).
              */
-            set?: Runtime.RemoteObject;
+            set?: RemoteObject;
             /**
              * True if the type of this property descriptor may be changed and if the property may be
              * deleted from the corresponding object.
@@ -1279,7 +1303,7 @@ declare module "inspector" {
             /**
              * Property symbol object, if the property is of the `symbol` type.
              */
-            symbol?: Runtime.RemoteObject;
+            symbol?: RemoteObject;
         }
 
         /**
@@ -1293,7 +1317,7 @@ declare module "inspector" {
             /**
              * The value associated with the property.
              */
-            value?: Runtime.RemoteObject;
+            value?: RemoteObject;
         }
 
         /**
@@ -1308,11 +1332,11 @@ declare module "inspector" {
             /**
              * Primitive value which can not be JSON-stringified.
              */
-            unserializableValue?: Runtime.UnserializableValue;
+            unserializableValue?: UnserializableValue;
             /**
              * Remote object handle.
              */
-            objectId?: Runtime.RemoteObjectId;
+            objectId?: RemoteObjectId;
         }
 
         /**
@@ -1328,7 +1352,7 @@ declare module "inspector" {
              * Unique id of the execution context. It can be used to specify in which execution context
              * script evaluation should be performed.
              */
-            id: Runtime.ExecutionContextId;
+            id: ExecutionContextId;
             /**
              * Execution context origin.
              */
@@ -1367,7 +1391,7 @@ declare module "inspector" {
             /**
              * Script ID of the exception location.
              */
-            scriptId?: Runtime.ScriptId;
+            scriptId?: ScriptId;
             /**
              * URL of the exception location, to be used when the script was not reported.
              */
@@ -1375,21 +1399,26 @@ declare module "inspector" {
             /**
              * JavaScript stack trace if available.
              */
-            stackTrace?: Runtime.StackTrace;
+            stackTrace?: StackTrace;
             /**
              * Exception object if available.
              */
-            exception?: Runtime.RemoteObject;
+            exception?: RemoteObject;
             /**
              * Identifier of the context where exception happened.
              */
-            executionContextId?: Runtime.ExecutionContextId;
+            executionContextId?: ExecutionContextId;
         }
 
         /**
          * Number of milliseconds since epoch.
          */
         type Timestamp = number;
+
+        /**
+         * Number of milliseconds.
+         */
+        type TimeDelta = number;
 
         /**
          * Stack entry for runtime errors and assertions.
@@ -1402,7 +1431,7 @@ declare module "inspector" {
             /**
              * JavaScript script id.
              */
-            scriptId: Runtime.ScriptId;
+            scriptId: ScriptId;
             /**
              * JavaScript script name or url.
              */
@@ -1429,16 +1458,16 @@ declare module "inspector" {
             /**
              * JavaScript function name.
              */
-            callFrames: Runtime.CallFrame[];
+            callFrames: CallFrame[];
             /**
              * Asynchronous JavaScript stack trace that preceded this stack, if available.
              */
-            parent?: Runtime.StackTrace;
+            parent?: StackTrace;
             /**
              * Asynchronous JavaScript stack trace that preceded this stack, if available.
              * @experimental
              */
-            parentId?: Runtime.StackTraceId;
+            parentId?: StackTraceId;
         }
 
         /**
@@ -1454,14 +1483,14 @@ declare module "inspector" {
          */
         interface StackTraceId {
             id: string;
-            debuggerId?: Runtime.UniqueDebuggerId;
+            debuggerId?: UniqueDebuggerId;
         }
 
         interface AwaitPromiseParameterType {
             /**
              * Identifier of the promise.
              */
-            promiseObjectId: Runtime.RemoteObjectId;
+            promiseObjectId: RemoteObjectId;
             /**
              * Whether the result is expected to be a JSON object that should be sent by value.
              */
@@ -1481,12 +1510,12 @@ declare module "inspector" {
              * Identifier of the object to call function on. Either objectId or executionContextId should
              * be specified.
              */
-            objectId?: Runtime.RemoteObjectId;
+            objectId?: RemoteObjectId;
             /**
              * Call arguments. All call arguments must belong to the same JavaScript world as the target
              * object.
              */
-            arguments?: Runtime.CallArgument[];
+            arguments?: CallArgument[];
             /**
              * In silent mode exceptions thrown during evaluation are not reported and do not pause
              * execution. Overrides `setPauseOnException` state.
@@ -1514,7 +1543,7 @@ declare module "inspector" {
              * Specifies execution context which global object will be used to call function on. Either
              * executionContextId or objectId should be specified.
              */
-            executionContextId?: Runtime.ExecutionContextId;
+            executionContextId?: ExecutionContextId;
             /**
              * Symbolic group name that can be used to release multiple objects. If objectGroup is not
              * specified and objectId is, objectGroup will be inherited from object.
@@ -1539,7 +1568,7 @@ declare module "inspector" {
              * Specifies in which execution context to perform script run. If the parameter is omitted the
              * evaluation will be performed in the context of the inspected page.
              */
-            executionContextId?: Runtime.ExecutionContextId;
+            executionContextId?: ExecutionContextId;
         }
 
         interface EvaluateParameterType {
@@ -1564,7 +1593,7 @@ declare module "inspector" {
              * Specifies in which execution context to perform evaluation. If the parameter is omitted the
              * evaluation will be performed in the context of the inspected page.
              */
-            contextId?: Runtime.ExecutionContextId;
+            contextId?: ExecutionContextId;
             /**
              * Whether the result is expected to be a JSON object that should be sent by value.
              */
@@ -1588,13 +1617,18 @@ declare module "inspector" {
              * @experimental
              */
             throwOnSideEffect?: boolean;
+            /**
+             * Terminate execution after timing out (number of milliseconds).
+             * @experimental
+             */
+            timeout?: TimeDelta;
         }
 
         interface GetPropertiesParameterType {
             /**
              * Identifier of the object to return properties for.
              */
-            objectId: Runtime.RemoteObjectId;
+            objectId: RemoteObjectId;
             /**
              * If true, returns properties belonging only to the element itself, not to its prototype
              * chain.
@@ -1617,14 +1651,14 @@ declare module "inspector" {
             /**
              * Specifies in which execution context to lookup global scope variables.
              */
-            executionContextId?: Runtime.ExecutionContextId;
+            executionContextId?: ExecutionContextId;
         }
 
         interface QueryObjectsParameterType {
             /**
              * Identifier of the prototype to return objects for.
              */
-            prototypeObjectId: Runtime.RemoteObjectId;
+            prototypeObjectId: RemoteObjectId;
             /**
              * Symbolic group name that can be used to release the results.
              */
@@ -1635,7 +1669,7 @@ declare module "inspector" {
             /**
              * Identifier of the object to release.
              */
-            objectId: Runtime.RemoteObjectId;
+            objectId: RemoteObjectId;
         }
 
         interface ReleaseObjectGroupParameterType {
@@ -1649,12 +1683,12 @@ declare module "inspector" {
             /**
              * Id of the script to run.
              */
-            scriptId: Runtime.ScriptId;
+            scriptId: ScriptId;
             /**
              * Specifies in which execution context to perform script run. If the parameter is omitted the
              * evaluation will be performed in the context of the inspected page.
              */
-            executionContextId?: Runtime.ExecutionContextId;
+            executionContextId?: ExecutionContextId;
             /**
              * Symbolic group name that can be used to release multiple objects.
              */
@@ -1691,44 +1725,44 @@ declare module "inspector" {
             /**
              * Promise result. Will contain rejected value if promise was rejected.
              */
-            result: Runtime.RemoteObject;
+            result: RemoteObject;
             /**
              * Exception details if stack strace is available.
              */
-            exceptionDetails?: Runtime.ExceptionDetails;
+            exceptionDetails?: ExceptionDetails;
         }
 
         interface CallFunctionOnReturnType {
             /**
              * Call result.
              */
-            result: Runtime.RemoteObject;
+            result: RemoteObject;
             /**
              * Exception details.
              */
-            exceptionDetails?: Runtime.ExceptionDetails;
+            exceptionDetails?: ExceptionDetails;
         }
 
         interface CompileScriptReturnType {
             /**
              * Id of the script.
              */
-            scriptId?: Runtime.ScriptId;
+            scriptId?: ScriptId;
             /**
              * Exception details.
              */
-            exceptionDetails?: Runtime.ExceptionDetails;
+            exceptionDetails?: ExceptionDetails;
         }
 
         interface EvaluateReturnType {
             /**
              * Evaluation result.
              */
-            result: Runtime.RemoteObject;
+            result: RemoteObject;
             /**
              * Exception details.
              */
-            exceptionDetails?: Runtime.ExceptionDetails;
+            exceptionDetails?: ExceptionDetails;
         }
 
         interface GetIsolateIdReturnType {
@@ -1753,15 +1787,15 @@ declare module "inspector" {
             /**
              * Object properties.
              */
-            result: Runtime.PropertyDescriptor[];
+            result: PropertyDescriptor[];
             /**
              * Internal object properties (only of the element itself).
              */
-            internalProperties?: Runtime.InternalPropertyDescriptor[];
+            internalProperties?: InternalPropertyDescriptor[];
             /**
              * Exception details.
              */
-            exceptionDetails?: Runtime.ExceptionDetails;
+            exceptionDetails?: ExceptionDetails;
         }
 
         interface GlobalLexicalScopeNamesReturnType {
@@ -1772,18 +1806,18 @@ declare module "inspector" {
             /**
              * Array with objects.
              */
-            objects: Runtime.RemoteObject;
+            objects: RemoteObject;
         }
 
         interface RunScriptReturnType {
             /**
              * Run result.
              */
-            result: Runtime.RemoteObject;
+            result: RemoteObject;
             /**
              * Exception details.
              */
-            exceptionDetails?: Runtime.ExceptionDetails;
+            exceptionDetails?: ExceptionDetails;
         }
 
         interface ConsoleAPICalledEventDataType {
@@ -1794,19 +1828,19 @@ declare module "inspector" {
             /**
              * Call arguments.
              */
-            args: Runtime.RemoteObject[];
+            args: RemoteObject[];
             /**
              * Identifier of the context where the call was made.
              */
-            executionContextId: Runtime.ExecutionContextId;
+            executionContextId: ExecutionContextId;
             /**
              * Call timestamp.
              */
-            timestamp: Runtime.Timestamp;
+            timestamp: Timestamp;
             /**
              * Stack trace captured when the call was made.
              */
-            stackTrace?: Runtime.StackTrace;
+            stackTrace?: StackTrace;
             /**
              * Console context descriptor for calls on non-default console context (not console.*):
              * 'anonymous#unique-logger-id' for call on unnamed context, 'name#unique-logger-id' for call
@@ -1831,26 +1865,26 @@ declare module "inspector" {
             /**
              * Timestamp of the exception.
              */
-            timestamp: Runtime.Timestamp;
-            exceptionDetails: Runtime.ExceptionDetails;
+            timestamp: Timestamp;
+            exceptionDetails: ExceptionDetails;
         }
 
         interface ExecutionContextCreatedEventDataType {
             /**
              * A newly created execution context.
              */
-            context: Runtime.ExecutionContextDescription;
+            context: ExecutionContextDescription;
         }
 
         interface ExecutionContextDestroyedEventDataType {
             /**
              * Id of the destroyed context
              */
-            executionContextId: Runtime.ExecutionContextId;
+            executionContextId: ExecutionContextId;
         }
 
         interface InspectRequestedEventDataType {
-            object: Runtime.RemoteObject;
+            object: RemoteObject;
             hints: {};
         }
     }
@@ -1874,7 +1908,7 @@ declare module "inspector" {
             /**
              * List of supported domains.
              */
-            domains: Schema.Domain[];
+            domains: Domain[];
         }
     }
 
@@ -1883,19 +1917,22 @@ declare module "inspector" {
      */
     class Session extends EventEmitter {
         /**
-         * Create a new instance of the inspector.Session class. The inspector session needs to be connected through session.connect() before the messages can be dispatched to the inspector backend.
+         * Create a new instance of the inspector.Session class.
+         * The inspector session needs to be connected through session.connect() before the messages can be dispatched to the inspector backend.
          */
         constructor();
 
         /**
          * Connects a session to the inspector back-end.
-         * An exception will be thrown if there is already a connected session established either through the API or by a front-end connected to the Inspector WebSocket port.
+         * An exception will be thrown if there is already a connected session established either
+         * through the API or by a front-end connected to the Inspector WebSocket port.
          */
         connect(): void;
 
         /**
          * Immediately close the session. All pending message callbacks will be called with an error.
-         * session.connect() will need to be called to be able to send messages again. Reconnected session will lose all inspector state, such as enabled agents or configured breakpoints.
+         * session.connect() will need to be called to be able to send messages again.
+         * Reconnected session will lose all inspector state, such as enabled agents or configured breakpoints.
          */
         disconnect(): void;
 
@@ -1951,7 +1988,7 @@ declare module "inspector" {
         post(
             method: "Debugger.getPossibleBreakpoints",
             params?: Debugger.GetPossibleBreakpointsParameterType,
-            callback?: (err: Error | null, params: Debugger.GetPossibleBreakpointsReturnType) => void,
+            callback?: (err: Error | null, params: Debugger.GetPossibleBreakpointsReturnType) => void
         ): void;
         post(method: "Debugger.getPossibleBreakpoints", callback?: (err: Error | null, params: Debugger.GetPossibleBreakpointsReturnType) => void): void;
 
@@ -2052,6 +2089,19 @@ declare module "inspector" {
         post(method: "Debugger.setBreakpointByUrl", callback?: (err: Error | null, params: Debugger.SetBreakpointByUrlReturnType) => void): void;
 
         /**
+         * Sets JavaScript breakpoint before each call to the given function.
+         * If another function was created from the same source as a given one,
+         * calling it will also trigger the breakpoint.
+         * @experimental
+         */
+        post(
+            method: "Debugger.setBreakpointOnFunctionCall",
+            params?: Debugger.SetBreakpointOnFunctionCallParameterType,
+            callback?: (err: Error | null, params: Debugger.SetBreakpointOnFunctionCallReturnType) => void
+        ): void;
+        post(method: "Debugger.setBreakpointOnFunctionCall", callback?: (err: Error | null, params: Debugger.SetBreakpointOnFunctionCallReturnType) => void): void;
+
+        /**
          * Activates / deactivates all breakpoints on the page.
          */
         post(method: "Debugger.setBreakpointsActive", params?: Debugger.SetBreakpointsActiveParameterType, callback?: (err: Error | null) => void): void;
@@ -2124,7 +2174,7 @@ declare module "inspector" {
         post(
             method: "HeapProfiler.getObjectByHeapObjectId",
             params?: HeapProfiler.GetObjectByHeapObjectIdParameterType,
-            callback?: (err: Error | null, params: HeapProfiler.GetObjectByHeapObjectIdReturnType) => void,
+            callback?: (err: Error | null, params: HeapProfiler.GetObjectByHeapObjectIdReturnType) => void
         ): void;
         post(method: "HeapProfiler.getObjectByHeapObjectId", callback?: (err: Error | null, params: HeapProfiler.GetObjectByHeapObjectIdReturnType) => void): void;
 
@@ -2268,7 +2318,7 @@ declare module "inspector" {
         post(
             method: "Runtime.globalLexicalScopeNames",
             params?: Runtime.GlobalLexicalScopeNamesParameterType,
-            callback?: (err: Error | null, params: Runtime.GlobalLexicalScopeNamesReturnType) => void,
+            callback?: (err: Error | null, params: Runtime.GlobalLexicalScopeNamesReturnType) => void
         ): void;
         post(method: "Runtime.globalLexicalScopeNames", callback?: (err: Error | null, params: Runtime.GlobalLexicalScopeNamesReturnType) => void): void;
 

--- a/types/node/node-tests.ts
+++ b/types/node/node-tests.ts
@@ -2971,11 +2971,6 @@ async function asyncStreamPipelineFinished() {
     }
 
     {
-        const Debug = vm.runInDebugContext('Debug');
-        Debug.scripts().forEach((script: any) => { console.log(script.name); });
-    }
-
-    {
         vm.runInThisContext('console.log("hello world"', './my-file.js');
     }
 

--- a/types/node/node-tests.ts
+++ b/types/node/node-tests.ts
@@ -38,10 +38,10 @@ import { Buffer as ImportedBuffer, SlowBuffer as ImportedSlowBuffer } from "buff
 //////////////////////////////////////////////////////////
 /// Global Tests : https://nodejs.org/api/global.html  ///
 //////////////////////////////////////////////////////////
-namespace global_tests {
+{
     {
-        let x: NodeModule;
-        let y: NodeModule;
+        const x: NodeModule = <any> {};
+        const y: NodeModule = <any> {};
         x.children.push(y);
         x.parent = require.main;
         require.main = y;
@@ -52,7 +52,7 @@ namespace global_tests {
 /// Assert Tests : https://nodejs.org/api/assert.html ///
 //////////////////////////////////////////////////////////
 
-namespace assert_tests {
+{
     {
         assert(1 + 1 - 2 === 0, "The universe isn't how it should.");
 
@@ -96,11 +96,11 @@ namespace assert_tests {
 /// Events tests : http://nodejs.org/api/events.html
 ////////////////////////////////////////////////////
 
-namespace events_tests {
-    let emitter: events.EventEmitter;
-    let event: string | symbol;
-    let listener: (...args: any[]) => void;
-    let any: any;
+{
+    const emitter: events.EventEmitter = new events.EventEmitter();
+    const event: string | symbol = '';
+    const listener: (...args: any[]) => void = () => {};
+    const any: any = 1;
 
     {
         let result: events.EventEmitter;
@@ -167,7 +167,7 @@ namespace events_tests {
 /// File system tests : http://nodejs.org/api/fs.html
 ////////////////////////////////////////////////////
 
-namespace fs_tests {
+{
     {
         fs.writeFile("thebible.txt",
             "Do unto others as you would have them do unto you.",
@@ -200,8 +200,8 @@ namespace fs_tests {
         let content: string;
         let buffer: Buffer;
         let stringOrBuffer: string | Buffer;
-        let nullEncoding: string | null = null;
-        let stringEncoding: string | null = 'utf8';
+        const nullEncoding: string | null = null;
+        const stringEncoding: string | null = 'utf8';
 
         content = fs.readFileSync('testfile', 'utf8');
         content = fs.readFileSync('testfile', { encoding: 'utf8' });
@@ -263,9 +263,9 @@ namespace fs_tests {
         listB = fs.readdirSync('path', { encoding: 'buffer' });
         listB = fs.readdirSync("path", 'buffer');
 
-        let enc = 'buffer';
-        fs.readdirSync('path', { encoding: enc }); // $ExpectType string[] | Buffer[]
-        fs.readdirSync('path', { }); // $ExpectType string[] | Buffer[]
+        const enc = 'buffer';
+        fs.readdirSync('path', { encoding: enc });
+        fs.readdirSync('path', { });
 
         fs.readdir('path', { withFileTypes: true }, (err: NodeJS.ErrnoException, files: fs.Dirent[]) => {});
     }
@@ -421,18 +421,18 @@ namespace fs_tests {
 ///////////////////////////////////////////////////////
 
 function bufferTests() {
-    let utf8Buffer = new Buffer('test');
-    let base64Buffer = new Buffer('', 'base64');
-    let octets: Uint8Array = null;
-    let octetBuffer = new Buffer(octets);
-    let sharedBuffer = new Buffer(octets.buffer);
-    let copiedBuffer = new Buffer(utf8Buffer);
+    const utf8Buffer = new Buffer('test');
+    const base64Buffer = new Buffer('', 'base64');
+    const octets: Uint8Array = null;
+    const octetBuffer = new Buffer(octets);
+    const sharedBuffer = new Buffer(octets.buffer);
+    const copiedBuffer = new Buffer(utf8Buffer);
     console.log(Buffer.isBuffer(octetBuffer));
     console.log(Buffer.isEncoding('utf8'));
     console.log(Buffer.byteLength('xyz123'));
     console.log(Buffer.byteLength('xyz123', 'ascii'));
-    let result1 = Buffer.concat([utf8Buffer, base64Buffer]);
-    let result2 = Buffer.concat([utf8Buffer, base64Buffer], 9999999);
+    const result1 = Buffer.concat([utf8Buffer, base64Buffer]);
+    const result2 = Buffer.concat([utf8Buffer, base64Buffer], 9999999);
 
     // Class Methods: Buffer.swap16(), Buffer.swa32(), Buffer.swap64()
     {
@@ -531,7 +531,7 @@ function bufferTests() {
     }
 
     // write* methods return offsets.
-    let b = new Buffer(16);
+    const b = new Buffer(16);
     let result: number = b.writeUInt32LE(0, 0);
     result = b.writeUInt16LE(0, 4);
     result = b.writeUInt8(0, 6);
@@ -542,7 +542,7 @@ function bufferTests() {
     b.fill('a').fill('b');
 
     {
-        let buffer = new Buffer('123');
+        const buffer = new Buffer('123');
         let index: number;
         index = buffer.indexOf("23");
         index = buffer.indexOf("23", 1);
@@ -552,7 +552,7 @@ function bufferTests() {
     }
 
     {
-        let buffer = new Buffer('123');
+        const buffer = new Buffer('123');
         let index: number;
         index = buffer.lastIndexOf("23");
         index = buffer.lastIndexOf("23", 1);
@@ -562,8 +562,8 @@ function bufferTests() {
     }
 
     {
-        let buffer = new Buffer('123');
-        let val: [number, number];
+        const buffer = new Buffer('123');
+        const val: [number, number] = [1, 1];
 
         /* comment out for --target es5
         for (let entry of buffer.entries()) {
@@ -573,7 +573,7 @@ function bufferTests() {
     }
 
     {
-        let buffer = new Buffer('123');
+        const buffer = new Buffer('123');
         let includes: boolean;
         includes = buffer.includes("23");
         includes = buffer.includes("23", 1);
@@ -587,8 +587,8 @@ function bufferTests() {
     }
 
     {
-        let buffer = new Buffer('123');
-        let val: number;
+        const buffer = new Buffer('123');
+        const val = 1;
 
         /* comment out for --target es5
         for (let key of buffer.keys()) {
@@ -598,8 +598,8 @@ function bufferTests() {
     }
 
     {
-        let buffer = new Buffer('123');
-        let val: number;
+        const buffer = new Buffer('123');
+        const val = 1;
 
         /* comment out for --target es5
         for (let value of buffer.values()) {
@@ -610,16 +610,16 @@ function bufferTests() {
 
     // Imported Buffer from buffer module works properly
     {
-        let b = new ImportedBuffer('123');
+        const b = new ImportedBuffer('123');
         b.writeUInt8(0, 6);
-        let sb = new ImportedSlowBuffer(43);
+        const sb = new ImportedSlowBuffer(43);
         b.writeUInt8(0, 6);
     }
 
     // Buffer has Uint8Array's buffer field (an ArrayBuffer).
     {
-        let buffer = new Buffer('123');
-        let octets = new Uint8Array(buffer.buffer);
+        const buffer = new Buffer('123');
+        const octets = new Uint8Array(buffer.buffer);
     }
 }
 
@@ -627,7 +627,7 @@ function bufferTests() {
 /// Url tests : http://nodejs.org/api/url.html
 ////////////////////////////////////////////////////
 
-namespace url_tests {
+{
     {
         url.format(url.parse('http://www.example.com/xyz'));
 
@@ -756,7 +756,7 @@ namespace url_tests {
 
     {
         // Using an array
-        let params = new url.URLSearchParams([
+        const params = new url.URLSearchParams([
             ['user', 'abc'],
             ['query', 'first'],
             ['query', 'second']
@@ -769,7 +769,7 @@ namespace url_tests {
 /// util tests : https://nodejs.org/api/util.html ///
 /////////////////////////////////////////////////////
 
-namespace util_tests {
+{
     {
         // Old and new util.inspect APIs
         util.inspect(["This is nice"], false, 5);
@@ -848,14 +848,14 @@ namespace util_tests {
             }
 
             static test(): void {
-                let cfn = util.callbackify(this.fn);
-                let cfnE = util.callbackify(this.fnE);
-                let cfnT1 = util.callbackify(this.fnT1);
-                let cfnT1E = util.callbackify(this.fnT1E);
-                let cfnTResult = util.callbackify(this.fnTResult);
-                let cfnTResultE = util.callbackify(this.fnTResultE);
-                let cfnT1TResult = util.callbackify(this.fnT1TResult);
-                let cfnT1TResultE = util.callbackify(this.fnT1TResultE);
+                const cfn = util.callbackify(this.fn);
+                const cfnE = util.callbackify(this.fnE);
+                const cfnT1 = util.callbackify(this.fnT1);
+                const cfnT1E = util.callbackify(this.fnT1E);
+                const cfnTResult = util.callbackify(this.fnTResult);
+                const cfnTResultE = util.callbackify(this.fnTResultE);
+                const cfnT1TResult = util.callbackify(this.fnT1TResult);
+                const cfnT1TResultE = util.callbackify(this.fnT1TResultE);
 
                 cfn((err: NodeJS.ErrnoException, ...args: string[]) => assert(err === null && args.length === 1 && args[0] === undefined));
                 cfnE((err: NodeJS.ErrnoException, ...args: string[]) => assert(err.message === 'fail' && args.length === 0));
@@ -870,13 +870,13 @@ namespace util_tests {
         callbackifyTest.test();
 
         // util.promisify
-        let readPromised = util.promisify(fs.readFile);
-        let sampleRead: Promise<any> = readPromised(__filename).then((data: Buffer): void => { }).catch((error: Error): void => { });
-        let arg0: () => Promise<number> = util.promisify((cb: (err: Error, result: number) => void): void => { });
-        let arg0NoResult: () => Promise<any> = util.promisify((cb: (err: Error) => void): void => { });
-        let arg1: (arg: string) => Promise<number> = util.promisify((arg: string, cb: (err: Error, result: number) => void): void => { });
-        let arg1NoResult: (arg: string) => Promise<any> = util.promisify((arg: string, cb: (err: Error) => void): void => { });
-        let cbOptionalError: () => Promise<void | {}> = util.promisify((cb: (err?: Error | null) => void): void => { cb(); }); // tslint:disable-line void-return
+        const readPromised = util.promisify(fs.readFile);
+        const sampleRead: Promise<any> = readPromised(__filename).then((data: Buffer): void => { }).catch((error: Error): void => { });
+        const arg0: () => Promise<number> = util.promisify((cb: (err: Error, result: number) => void): void => { });
+        const arg0NoResult: () => Promise<any> = util.promisify((cb: (err: Error) => void): void => { });
+        const arg1: (arg: string) => Promise<number> = util.promisify((arg: string, cb: (err: Error, result: number) => void): void => { });
+        const arg1NoResult: (arg: string) => Promise<any> = util.promisify((arg: string, cb: (err: Error) => void): void => { });
+        const cbOptionalError: () => Promise<void | {}> = util.promisify((cb: (err?: Error | null) => void): void => { cb(); }); // tslint:disable-line void-return
         assert(typeof util.promisify.custom === 'symbol');
         // util.deprecate
         const foo = () => {};
@@ -889,13 +889,13 @@ namespace util_tests {
         util.isDeepStrictEqual({foo: 'bar'}, {foo: 'bar'});
 
         // util.TextDecoder()
-        let td = new util.TextDecoder();
+        const td = new util.TextDecoder();
         new util.TextDecoder("utf-8");
         new util.TextDecoder("utf-8", { fatal: true });
         new util.TextDecoder("utf-8", { fatal: true, ignoreBOM: true });
-        let ignoreBom: boolean = td.ignoreBOM;
-        let fatal: boolean = td.fatal;
-        let encoding: string = td.encoding;
+        const ignoreBom: boolean = td.ignoreBOM;
+        const fatal: boolean = td.fatal;
+        const encoding: string = td.encoding;
         td.decode(new Int8Array(1));
         td.decode(new Int16Array(1));
         td.decode(new Int32Array(1));
@@ -910,16 +910,16 @@ namespace util_tests {
         td.decode(null);
         td.decode(null, { stream: true });
         td.decode(new Int8Array(1), { stream: true });
-        let decode: string = td.decode(new Int8Array(1));
+        const decode: string = td.decode(new Int8Array(1));
 
         // util.TextEncoder()
-        let te = new util.TextEncoder();
-        let teEncoding: string = te.encoding;
-        let teEncodeRes: Uint8Array = te.encode("TextEncoder");
+        const te = new util.TextEncoder();
+        const teEncoding: string = te.encoding;
+        const teEncodeRes: Uint8Array = te.encode("TextEncoder");
 
         // util.types
 
-        // tslint:disable-next-line:no-construct
+        // tslint:disable-next-line:no-construct ban-types
         const maybeBoxed: number | Number = new Number(1);
         if (util.types.isBoxedPrimitive(maybeBoxed)) {
             const boxed: Number = maybeBoxed;
@@ -937,10 +937,10 @@ namespace util_tests {
 
 // http://nodejs.org/api/stream.html#stream_readable_pipe_destination_options
 function stream_readable_pipe_test() {
-    let rs = fs.createReadStream(Buffer.from('file.txt'));
-    let r = fs.createReadStream('file.txt');
-    let z = zlib.createGzip({ finishFlush: zlib.constants.Z_FINISH });
-    let w = fs.createWriteStream('file.txt.gz');
+    const rs = fs.createReadStream(Buffer.from('file.txt'));
+    const r = fs.createReadStream('file.txt');
+    const z = zlib.createGzip({ finishFlush: zlib.constants.Z_FINISH });
+    const w = fs.createWriteStream('file.txt.gz');
 
     assert(typeof z.bytesRead === 'number');
     assert(typeof r.bytesRead === 'number');
@@ -969,7 +969,11 @@ const inflatedString = zlib.inflateSync(zlib.deflateSync(compressMeString));
 zlib.deflateRaw(compressMe, (err: Error, result: Buffer) => zlib.inflateRaw(result, (err: Error, result: Buffer) => result));
 zlib.deflateRaw(compressMe, { finishFlush: zlib.Z_SYNC_FLUSH }, (err: Error, result: Buffer) => zlib.inflateRaw(result, { finishFlush: zlib.Z_SYNC_FLUSH }, (err: Error, result: Buffer) => result));
 zlib.deflateRaw(compressMeString, (err: Error, result: Buffer) => zlib.inflateRaw(result, (err: Error, result: Buffer) => result));
-zlib.deflateRaw(compressMeString, { finishFlush: zlib.Z_SYNC_FLUSH }, (err: Error, result: Buffer) => zlib.inflateRaw(result, { finishFlush: zlib.Z_SYNC_FLUSH }, (err: Error, result: Buffer) => result));
+zlib.deflateRaw(
+    compressMeString,
+    { finishFlush: zlib.Z_SYNC_FLUSH },
+    (err: Error, result: Buffer) => zlib.inflateRaw(result, { finishFlush: zlib.Z_SYNC_FLUSH }, (err: Error, result: Buffer) => result),
+);
 const inflatedRaw: Buffer = zlib.inflateRawSync(zlib.deflateRawSync(compressMe));
 const inflatedRawString: Buffer = zlib.inflateRawSync(zlib.deflateRawSync(compressMeString));
 
@@ -1154,69 +1158,69 @@ async function asyncStreamPipelineFinished() {
 /// Crypto tests : http://nodejs.org/api/crypto.html ///
 ////////////////////////////////////////////////////////
 
-namespace crypto_tests {
+{
     {
         // crypto_hash_string_test
-        let hashResult: string = crypto.createHash('md5').update('world').digest('hex');
+        const hashResult: string = crypto.createHash('md5').update('world').digest('hex');
     }
 
     {
         // crypto_hash_buffer_test
-        let hashResult: string = crypto.createHash('md5')
+        const hashResult: string = crypto.createHash('md5')
             .update(new Buffer('world')).digest('hex');
     }
 
     {
         // crypto_hash_dataview_test
-        let hashResult: string = crypto.createHash('md5')
+        const hashResult: string = crypto.createHash('md5')
             .update(new DataView(new Buffer('world').buffer)).digest('hex');
     }
 
     {
         // crypto_hash_int8array_test
-        let hashResult: string = crypto.createHash('md5')
+        const hashResult: string = crypto.createHash('md5')
             .update(new Int8Array(new Buffer('world').buffer)).digest('hex');
     }
 
     {
         // crypto_hmac_string_test
-        let hmacResult: string = crypto.createHmac('md5', 'hello').update('world').digest('hex');
+        const hmacResult: string = crypto.createHmac('md5', 'hello').update('world').digest('hex');
     }
 
     {
         // crypto_hmac_buffer_test
-        let hmacResult: string = crypto.createHmac('md5', 'hello')
+        const hmacResult: string = crypto.createHmac('md5', 'hello')
             .update(new Buffer('world')).digest('hex');
     }
 
     {
         // crypto_hmac_dataview_test
-        let hmacResult: string = crypto.createHmac('md5', 'hello')
+        const hmacResult: string = crypto.createHmac('md5', 'hello')
             .update(new DataView(new Buffer('world').buffer)).digest('hex');
     }
 
     {
         // crypto_hmac_int8array_test
-        let hmacResult: string = crypto.createHmac('md5', 'hello')
+        const hmacResult: string = crypto.createHmac('md5', 'hello')
             .update(new Int8Array(new Buffer('world').buffer)).digest('hex');
     }
 
     {
         let hmac: crypto.Hmac;
         (hmac = crypto.createHmac('md5', 'hello')).end('world', 'utf8', () => {
-            let hash: Buffer | string = hmac.read();
+            const hash: Buffer | string = hmac.read();
         });
     }
 
     {
         // crypto_cipher_decipher_string_test
-        let key: Buffer = new Buffer([1, 2, 3, 4, 5, 6, 7, 8, 9, 1, 2, 3, 4, 5, 6, 7]);
-        let clearText: string = "This is the clear text.";
-        let cipher: crypto.Cipher = crypto.createCipher("aes-128-ecb", key);
+        const key: Buffer = new Buffer([1, 2, 3, 4, 5, 6, 7, 8, 9, 1, 2, 3, 4, 5, 6, 7]);
+        const clearText = "This is the clear text.";
+        const cipher: crypto.Cipher = crypto.createCipher("aes-128-ecb", key);
         let cipherText: string = cipher.update(clearText, "utf8", "hex");
         cipherText += cipher.final("hex");
 
-        let decipher: crypto.Decipher = crypto.createDecipher("aes-128-ecb", key);
+        const decipher: crypto.Decipher = crypto.createDecipher("aes-128-ecb", key);
         let clearText2: string = decipher.update(cipherText, "hex", "utf8");
         clearText2 += decipher.final("utf8");
 
@@ -1225,42 +1229,42 @@ namespace crypto_tests {
 
     {
         // crypto_cipher_decipher_buffer_test
-        let key: Buffer = new Buffer([1, 2, 3, 4, 5, 6, 7, 8, 9, 1, 2, 3, 4, 5, 6, 7]);
-        let clearText: Buffer = new Buffer([1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4]);
-        let cipher: crypto.Cipher = crypto.createCipher("aes-128-ecb", key);
-        let cipherBuffers: Buffer[] = [];
+        const key: Buffer = new Buffer([1, 2, 3, 4, 5, 6, 7, 8, 9, 1, 2, 3, 4, 5, 6, 7]);
+        const clearText: Buffer = new Buffer([1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4]);
+        const cipher: crypto.Cipher = crypto.createCipher("aes-128-ecb", key);
+        const cipherBuffers: Buffer[] = [];
         cipherBuffers.push(cipher.update(clearText));
         cipherBuffers.push(cipher.final());
 
-        let cipherText: Buffer = Buffer.concat(cipherBuffers);
+        const cipherText: Buffer = Buffer.concat(cipherBuffers);
 
-        let decipher: crypto.Decipher = crypto.createDecipher("aes-128-ecb", key);
-        let decipherBuffers: Buffer[] = [];
+        const decipher: crypto.Decipher = crypto.createDecipher("aes-128-ecb", key);
+        const decipherBuffers: Buffer[] = [];
         decipherBuffers.push(decipher.update(cipherText));
         decipherBuffers.push(decipher.final());
 
-        let clearText2: Buffer = Buffer.concat(decipherBuffers);
+        const clearText2: Buffer = Buffer.concat(decipherBuffers);
 
         assert.deepEqual(clearText2, clearText);
     }
 
     {
         // crypto_cipher_decipher_dataview_test
-        let key: Buffer = new Buffer([1, 2, 3, 4, 5, 6, 7, 8, 9, 1, 2, 3, 4, 5, 6, 7]);
-        let clearText: DataView = new DataView(new Buffer([1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4]).buffer);
-        let cipher: crypto.Cipher = crypto.createCipher("aes-128-ecb", key);
-        let cipherBuffers: Buffer[] = [];
+        const key: Buffer = new Buffer([1, 2, 3, 4, 5, 6, 7, 8, 9, 1, 2, 3, 4, 5, 6, 7]);
+        const clearText: DataView = new DataView(new Buffer([1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4]).buffer);
+        const cipher: crypto.Cipher = crypto.createCipher("aes-128-ecb", key);
+        const cipherBuffers: Buffer[] = [];
         cipherBuffers.push(cipher.update(clearText));
         cipherBuffers.push(cipher.final());
 
-        let cipherText: DataView = new DataView(Buffer.concat(cipherBuffers).buffer);
+        const cipherText: DataView = new DataView(Buffer.concat(cipherBuffers).buffer);
 
-        let decipher: crypto.Decipher = crypto.createDecipher("aes-128-ecb", key);
-        let decipherBuffers: Buffer[] = [];
+        const decipher: crypto.Decipher = crypto.createDecipher("aes-128-ecb", key);
+        const decipherBuffers: Buffer[] = [];
         decipherBuffers.push(decipher.update(cipherText));
         decipherBuffers.push(decipher.final());
 
-        let clearText2: Buffer = Buffer.concat(decipherBuffers);
+        const clearText2: Buffer = Buffer.concat(decipherBuffers);
 
         assert.deepEqual(clearText2, clearText);
     }
@@ -1317,9 +1321,9 @@ namespace crypto_tests {
 
     {
         // crypto_timingsafeequal_buffer_test
-        let buffer1: Buffer = new Buffer([1, 2, 3, 4, 5]);
-        let buffer2: Buffer = new Buffer([1, 2, 3, 4, 5]);
-        let buffer3: Buffer = new Buffer([5, 4, 3, 2, 1]);
+        const buffer1: Buffer = new Buffer([1, 2, 3, 4, 5]);
+        const buffer2: Buffer = new Buffer([1, 2, 3, 4, 5]);
+        const buffer3: Buffer = new Buffer([5, 4, 3, 2, 1]);
 
         assert(crypto.timingSafeEqual(buffer1, buffer2));
         assert(!crypto.timingSafeEqual(buffer1, buffer3));
@@ -1327,9 +1331,9 @@ namespace crypto_tests {
 
     {
         // crypto_timingsafeequal_uint32array_test
-        let arr1: Uint32Array = Uint32Array.of(1, 2, 3, 4, 5);
-        let arr2: Uint32Array = Uint32Array.of(1, 2, 3, 4, 5);
-        let arr3: Uint32Array = Uint32Array.of(5, 4, 3, 2, 1);
+        const arr1: Uint32Array = Uint32Array.of(1, 2, 3, 4, 5);
+        const arr2: Uint32Array = Uint32Array.of(1, 2, 3, 4, 5);
+        const arr3: Uint32Array = Uint32Array.of(5, 4, 3, 2, 1);
 
         assert(crypto.timingSafeEqual(arr1, arr2));
         assert(!crypto.timingSafeEqual(arr1, arr3));
@@ -1337,9 +1341,9 @@ namespace crypto_tests {
 
     {
         // crypto_timingsafeequal_safe_typedarray_variant_test
-        let arr1: Uint32Array = Uint32Array.of(1, 2, 3, 4, 5);
-        let arr2: Int32Array = Int32Array.of(1, 2, 3, 4, 5);
-        let arr3: Uint32Array = Uint32Array.of(5, 4, 3, 2, 1);
+        const arr1: Uint32Array = Uint32Array.of(1, 2, 3, 4, 5);
+        const arr2: Int32Array = Int32Array.of(1, 2, 3, 4, 5);
+        const arr3: Uint32Array = Uint32Array.of(5, 4, 3, 2, 1);
 
         assert(crypto.timingSafeEqual(arr1, arr2));
         assert(!crypto.timingSafeEqual(arr1, arr3));
@@ -1347,9 +1351,9 @@ namespace crypto_tests {
 
     {
         // crypto_timingsafeequal_safe_int8array_variant_test
-        let arr1: Int8Array = Int8Array.of(1, 2, 3, 4, 5, ~0, ~1, ~2, ~3, ~4);
-        let arr2: Uint8Array = Uint8Array.of(1, 2, 3, 4, 5, ~0, ~1, ~2, ~3, ~4);
-        let arr3: Uint8ClampedArray = Uint8ClampedArray.of(1, 2, 3, 4, 5, ~0, ~1, ~2, ~3, ~4);
+        const arr1: Int8Array = Int8Array.of(1, 2, 3, 4, 5, ~0, ~1, ~2, ~3, ~4);
+        const arr2: Uint8Array = Uint8Array.of(1, 2, 3, 4, 5, ~0, ~1, ~2, ~3, ~4);
+        const arr3: Uint8ClampedArray = Uint8ClampedArray.of(1, 2, 3, 4, 5, ~0, ~1, ~2, ~3, ~4);
 
         assert(crypto.timingSafeEqual(arr1, arr2)); // binary same
         assert(!crypto.timingSafeEqual(arr1, arr3)); // binary differ
@@ -1379,14 +1383,14 @@ namespace crypto_tests {
 
     {
         // crypto_timingsafeequal_dataview_test
-        let dv1B: Uint8Array = Uint8Array.of(1, 2, 3, 4, 5);
-        let dv2B: Int8Array = Int8Array.of(1, 2, 3, 4, 5);
-        let dv3B: Buffer = Buffer.of(5, 4, 3, 2, 1);
-        let dv4B: Uint8ClampedArray = Uint8ClampedArray.of(5, 4, 3, 2, 1);
-        let dv1: DataView = new DataView(dv1B.buffer, dv1B.byteOffset, dv1B.byteLength);
-        let dv2: DataView = new DataView(dv2B.buffer, dv2B.byteOffset, dv2B.byteLength);
-        let dv3: DataView = new DataView(dv3B.buffer, dv3B.byteOffset, dv3B.byteLength);
-        let dv4: DataView = new DataView(dv4B.buffer, dv4B.byteOffset, dv4B.byteLength);
+        const dv1B: Uint8Array = Uint8Array.of(1, 2, 3, 4, 5);
+        const dv2B: Int8Array = Int8Array.of(1, 2, 3, 4, 5);
+        const dv3B: Buffer = Buffer.of(5, 4, 3, 2, 1);
+        const dv4B: Uint8ClampedArray = Uint8ClampedArray.of(5, 4, 3, 2, 1);
+        const dv1: DataView = new DataView(dv1B.buffer, dv1B.byteOffset, dv1B.byteLength);
+        const dv2: DataView = new DataView(dv2B.buffer, dv2B.byteOffset, dv2B.byteLength);
+        const dv3: DataView = new DataView(dv3B.buffer, dv3B.byteOffset, dv3B.byteLength);
+        const dv4: DataView = new DataView(dv4B.buffer, dv4B.byteOffset, dv4B.byteLength);
 
         assert(crypto.timingSafeEqual(dv1, dv2));
         assert(crypto.timingSafeEqual(dv1, dv1B));
@@ -1401,9 +1405,9 @@ namespace crypto_tests {
 
     {
         // crypto_timingsafeequal_uint32array_test
-        let ui32_1: Uint32Array = Uint32Array.of(1, 2, 3, 4, 5);
-        let ui32_2: Uint32Array = Uint32Array.of(1, 2, 3, 4, 5);
-        let ui32_3: Uint32Array = Uint32Array.of(5, 4, 3, 2, 1);
+        const ui32_1: Uint32Array = Uint32Array.of(1, 2, 3, 4, 5);
+        const ui32_2: Uint32Array = Uint32Array.of(1, 2, 3, 4, 5);
+        const ui32_3: Uint32Array = Uint32Array.of(5, 4, 3, 2, 1);
 
         assert(crypto.timingSafeEqual(ui32_1, ui32_2));
         assert(!crypto.timingSafeEqual(ui32_1, ui32_3));
@@ -1411,7 +1415,7 @@ namespace crypto_tests {
 
     {
         // crypto_randomfill_buffer_test
-        let buffer: Buffer = new Buffer(10);
+        const buffer: Buffer = new Buffer(10);
         crypto.randomFillSync(buffer);
         crypto.randomFillSync(buffer, 2);
         crypto.randomFillSync(buffer, 2, 3);
@@ -1421,7 +1425,7 @@ namespace crypto_tests {
         crypto.randomFill(buffer, 2, 3, (err: Error, buf: Buffer) => void {});
 
         // crypto_randomfill_uint8array_test
-        let ui8arr: Uint8Array = new Uint8Array(10);
+        const ui8arr: Uint8Array = new Uint8Array(10);
         crypto.randomFillSync(ui8arr);
         crypto.randomFillSync(ui8arr, 2);
         crypto.randomFillSync(ui8arr, 2, 3);
@@ -1431,7 +1435,7 @@ namespace crypto_tests {
         crypto.randomFill(ui8arr, 2, 3, (err: Error, buf: Uint8Array) => void {});
 
         // crypto_randomfill_int32array_test
-        let i32arr: Int32Array = new Int32Array(10);
+        const i32arr: Int32Array = new Int32Array(10);
         crypto.randomFillSync(i32arr);
         crypto.randomFillSync(i32arr, 2);
         crypto.randomFillSync(i32arr, 2, 3);
@@ -1461,7 +1465,7 @@ namespace crypto_tests {
 
     {
         let key: string | Buffer = Buffer.from("buf");
-        let curve = "secp256k1";
+        const curve = "secp256k1";
         let ret: string | Buffer = crypto.ECDH.convertKey(key, curve);
         key = "0xfff";
         ret = crypto.ECDH.convertKey(key, curve);
@@ -1477,19 +1481,19 @@ namespace crypto_tests {
 /// TLS tests : http://nodejs.org/api/tls.html ///
 //////////////////////////////////////////////////
 
-namespace tls_tests {
+{
     {
-        let ctx: tls.SecureContext = tls.createSecureContext({
+        const ctx: tls.SecureContext = tls.createSecureContext({
             key: "NOT REALLY A KEY",
             cert: "SOME CERTIFICATE",
         });
-        let blah = ctx.context;
+        const blah = ctx.context;
 
-        let connOpts: tls.ConnectionOptions = {
+        const connOpts: tls.ConnectionOptions = {
             host: "127.0.0.1",
             port: 55
         };
-        let tlsSocket = tls.connect(connOpts);
+        const tlsSocket = tls.connect(connOpts);
 
         const ciphers: string[] = tls.getCiphers();
         const curve: string = tls.DEFAULT_ECDH_CURVE;
@@ -1498,8 +1502,8 @@ namespace tls_tests {
     {
         let _server: tls.Server;
         let _boolean: boolean;
-        let _func1 = (err: Error, resp: Buffer) => { };
-        let _func2 = (err: Error, sessionData: any) => { };
+        const _func1 = (err: Error, resp: Buffer) => { };
+        const _func2 = (err: Error, sessionData: any) => { };
         /**
          * events.EventEmitter
          * 1. tlsClientError
@@ -1510,32 +1514,32 @@ namespace tls_tests {
          */
 
         _server = _server.addListener("tlsClientError", (err, tlsSocket) => {
-            let _err: Error = err;
-            let _tlsSocket: tls.TLSSocket = tlsSocket;
+            const _err: Error = err;
+            const _tlsSocket: tls.TLSSocket = tlsSocket;
         });
         _server = _server.addListener("newSession", (sessionId, sessionData, callback) => {
-            let _sessionId: any = sessionId;
-            let _sessionData: any = sessionData;
-            let _func1 = callback;
+            const _sessionId: any = sessionId;
+            const _sessionData: any = sessionData;
+            const _func1 = callback;
         });
         _server = _server.addListener("OCSPRequest", (certificate, issuer, callback) => {
-            let _certificate: Buffer = certificate;
-            let _issuer: Buffer = issuer;
-            let _callback: Function = callback;
+            const _certificate: Buffer = certificate;
+            const _issuer: Buffer = issuer;
+            const _callback: Function = callback;
         });
         _server = _server.addListener("resumeSession", (sessionId, callback) => {
-            let _sessionId: any = sessionId;
-            let _func2 = callback;
+            const _sessionId: any = sessionId;
+            const _func2 = callback;
         });
         _server = _server.addListener("secureConnection", (tlsSocket) => {
-            let _tlsSocket: tls.TLSSocket = tlsSocket;
+            const _tlsSocket: tls.TLSSocket = tlsSocket;
         });
 
-        let _err: Error;
-        let _tlsSocket: tls.TLSSocket;
-        let _any: any;
-        let _func: Function;
-        let _buffer: Buffer;
+        const _err: Error = new Error();
+        const _tlsSocket: tls.TLSSocket = tls.connect(1);
+        const _any: any = 1;
+        const _func: Function = () => {};
+        const _buffer: Buffer = Buffer.from('a');
         _boolean = _server.emit("tlsClientError", _err, _tlsSocket);
         _boolean = _server.emit("newSession", _any, _any, _func1);
         _boolean = _server.emit("OCSPRequest", _buffer, _buffer, _func);
@@ -1543,91 +1547,91 @@ namespace tls_tests {
         _boolean = _server.emit("secureConnection", _tlsSocket);
 
         _server = _server.on("tlsClientError", (err, tlsSocket) => {
-            let _err: Error = err;
-            let _tlsSocket: tls.TLSSocket = tlsSocket;
+            const _err: Error = err;
+            const _tlsSocket: tls.TLSSocket = tlsSocket;
         });
         _server = _server.on("newSession", (sessionId, sessionData, callback) => {
-            let _sessionId: any = sessionId;
-            let _sessionData: any = sessionData;
-            let _func1 = callback;
+            const _sessionId: any = sessionId;
+            const _sessionData: any = sessionData;
+            const _func1 = callback;
         });
         _server = _server.on("OCSPRequest", (certificate, issuer, callback) => {
-            let _certificate: Buffer = certificate;
-            let _issuer: Buffer = issuer;
-            let _callback: Function = callback;
+            const _certificate: Buffer = certificate;
+            const _issuer: Buffer = issuer;
+            const _callback: Function = callback;
         });
         _server = _server.on("resumeSession", (sessionId, callback) => {
-            let _sessionId: any = sessionId;
-            let _func2 = callback;
+            const _sessionId: any = sessionId;
+            const _func2 = callback;
         });
         _server = _server.on("secureConnection", (tlsSocket) => {
-            let _tlsSocket: tls.TLSSocket = tlsSocket;
+            const _tlsSocket: tls.TLSSocket = tlsSocket;
         });
 
         _server = _server.once("tlsClientError", (err, tlsSocket) => {
-            let _err: Error = err;
-            let _tlsSocket: tls.TLSSocket = tlsSocket;
+            const _err: Error = err;
+            const _tlsSocket: tls.TLSSocket = tlsSocket;
         });
         _server = _server.once("newSession", (sessionId, sessionData, callback) => {
-            let _sessionId: any = sessionId;
-            let _sessionData: any = sessionData;
-            let _func1 = callback;
+            const _sessionId: any = sessionId;
+            const _sessionData: any = sessionData;
+            const _func1 = callback;
         });
         _server = _server.once("OCSPRequest", (certificate, issuer, callback) => {
-            let _certificate: Buffer = certificate;
-            let _issuer: Buffer = issuer;
-            let _callback: Function = callback;
+            const _certificate: Buffer = certificate;
+            const _issuer: Buffer = issuer;
+            const _callback: Function = callback;
         });
         _server = _server.once("resumeSession", (sessionId, callback) => {
-            let _sessionId: any = sessionId;
-            let _func2 = callback;
+            const _sessionId: any = sessionId;
+            const _func2 = callback;
         });
         _server = _server.once("secureConnection", (tlsSocket) => {
-            let _tlsSocket: tls.TLSSocket = tlsSocket;
+            const _tlsSocket: tls.TLSSocket = tlsSocket;
         });
 
         _server = _server.prependListener("tlsClientError", (err, tlsSocket) => {
-            let _err: Error = err;
-            let _tlsSocket: tls.TLSSocket = tlsSocket;
+            const _err: Error = err;
+            const _tlsSocket: tls.TLSSocket = tlsSocket;
         });
         _server = _server.prependListener("newSession", (sessionId, sessionData, callback) => {
-            let _sessionId: any = sessionId;
-            let _sessionData: any = sessionData;
-            let _func1 = callback;
+            const _sessionId: any = sessionId;
+            const _sessionData: any = sessionData;
+            const _func1 = callback;
         });
         _server = _server.prependListener("OCSPRequest", (certificate, issuer, callback) => {
-            let _certificate: Buffer = certificate;
-            let _issuer: Buffer = issuer;
-            let _callback: Function = callback;
+            const _certificate: Buffer = certificate;
+            const _issuer: Buffer = issuer;
+            const _callback: Function = callback;
         });
         _server = _server.prependListener("resumeSession", (sessionId, callback) => {
-            let _sessionId: any = sessionId;
-            let _func2 = callback;
+            const _sessionId: any = sessionId;
+            const _func2 = callback;
         });
         _server = _server.prependListener("secureConnection", (tlsSocket) => {
-            let _tlsSocket: tls.TLSSocket = tlsSocket;
+            const _tlsSocket: tls.TLSSocket = tlsSocket;
         });
 
         _server = _server.prependOnceListener("tlsClientError", (err, tlsSocket) => {
-            let _err: Error = err;
-            let _tlsSocket: tls.TLSSocket = tlsSocket;
+            const _err: Error = err;
+            const _tlsSocket: tls.TLSSocket = tlsSocket;
         });
         _server = _server.prependOnceListener("newSession", (sessionId, sessionData, callback) => {
-            let _sessionId: any = sessionId;
-            let _sessionData: any = sessionData;
-            let _func1 = callback;
+            const _sessionId: any = sessionId;
+            const _sessionData: any = sessionData;
+            const _func1 = callback;
         });
         _server = _server.prependOnceListener("OCSPRequest", (certificate, issuer, callback) => {
-            let _certificate: Buffer = certificate;
-            let _issuer: Buffer = issuer;
-            let _callback: Function = callback;
+            const _certificate: Buffer = certificate;
+            const _issuer: Buffer = issuer;
+            const _callback: Function = callback;
         });
         _server = _server.prependOnceListener("resumeSession", (sessionId, callback) => {
-            let _sessionId: any = sessionId;
-            let _func2 = callback;
+            const _sessionId: any = sessionId;
+            const _func2 = callback;
         });
         _server = _server.prependOnceListener("secureConnection", (tlsSocket) => {
-            let _tlsSocket: tls.TLSSocket = tlsSocket;
+            const _tlsSocket: tls.TLSSocket = tlsSocket;
         });
 
         // close callback parameter is optional
@@ -1651,31 +1655,31 @@ namespace tls_tests {
          */
 
         _TLSSocket = _TLSSocket.addListener("OCSPResponse", (response) => {
-            let _response: Buffer = response;
+            const _response: Buffer = response;
         });
         _TLSSocket = _TLSSocket.addListener("secureConnect", () => { });
 
-        let _buffer: Buffer;
+        const _buffer: Buffer = Buffer.from("");
         _boolean = _TLSSocket.emit("OCSPResponse", _buffer);
         _boolean = _TLSSocket.emit("secureConnect");
 
         _TLSSocket = _TLSSocket.on("OCSPResponse", (response) => {
-            let _response: Buffer = response;
+            const _response: Buffer = response;
         });
         _TLSSocket = _TLSSocket.on("secureConnect", () => { });
 
         _TLSSocket = _TLSSocket.once("OCSPResponse", (response) => {
-            let _response: Buffer = response;
+            const _response: Buffer = response;
         });
         _TLSSocket = _TLSSocket.once("secureConnect", () => { });
 
         _TLSSocket = _TLSSocket.prependListener("OCSPResponse", (response) => {
-            let _response: Buffer = response;
+            const _response: Buffer = response;
         });
         _TLSSocket = _TLSSocket.prependListener("secureConnect", () => { });
 
         _TLSSocket = _TLSSocket.prependOnceListener("OCSPResponse", (response) => {
-            let _response: Buffer = response;
+            const _response: Buffer = response;
         });
         _TLSSocket = _TLSSocket.prependOnceListener("secureConnect", () => { });
     }
@@ -1685,10 +1689,10 @@ namespace tls_tests {
 /// Http tests : http://nodejs.org/api/http.html ///
 ////////////////////////////////////////////////////
 
-namespace http_tests {
+{
     // http Server
     {
-        let server: http.Server = new http.Server();
+        const server: http.Server = new http.Server();
 
         // test public props
         const maxHeadersCount: number = server.maxHeadersCount;
@@ -1702,7 +1706,7 @@ namespace http_tests {
     // http ServerResponse
     {
         // incoming
-        let incoming: http.IncomingMessage = new http.IncomingMessage(new net.Socket());
+        const incoming: http.IncomingMessage = new http.IncomingMessage(new net.Socket());
 
         incoming.setEncoding('utf8');
 
@@ -1711,12 +1715,12 @@ namespace http_tests {
         incoming.resume();
 
         // response
-        let res: http.ServerResponse = new http.ServerResponse(incoming);
+        const res: http.ServerResponse = new http.ServerResponse(incoming);
 
         // test headers
         res.setHeader('Content-Type', 'text/plain');
-        let bool: boolean = res.hasHeader('Content-Type');
-        let headers: string[] = res.getHeaderNames();
+        const bool: boolean = res.hasHeader('Content-Type');
+        const headers: string[] = res.getHeaderNames();
 
         // trailers
         res.addTrailers([
@@ -1756,8 +1760,8 @@ namespace http_tests {
 
         // header
         req.setHeader('Content-Type', 'text/plain');
-        let bool: boolean = req.hasHeader('Content-Type');
-        let headers: string[] = req.getHeaderNames();
+        const bool: boolean = req.hasHeader('Content-Type');
+        const headers: string[] = req.getHeaderNames();
         req.removeHeader('Date');
 
         // write
@@ -1827,7 +1831,7 @@ namespace http_tests {
     }
 
     {
-        let request = http.request({ path: 'http://0.0.0.0' });
+        const request = http.request({ path: 'http://0.0.0.0' });
         request.once('error', () => { });
         request.setNoDelay(true);
         request.abort();
@@ -1857,7 +1861,7 @@ namespace http_tests {
 /// Https tests : http://nodejs.org/api/https.html ///
 //////////////////////////////////////////////////////
 
-namespace https_tests {
+{
     let agent: https.Agent = new https.Agent({
         keepAlive: true,
         keepAliveMsecs: 10000,
@@ -1915,24 +1919,24 @@ namespace https_tests {
 /// TTY tests : http://nodejs.org/api/tty.html
 ////////////////////////////////////////////////////
 
-namespace tty_tests {
-    let rs: tty.ReadStream;
-    let ws: tty.WriteStream;
+{
+    const rs: tty.ReadStream = new tty.ReadStream();
+    const ws: tty.WriteStream = new tty.WriteStream();
 
-    let rsIsRaw: boolean = rs.isRaw;
+    const rsIsRaw: boolean = rs.isRaw;
     rs.setRawMode(true);
 
-    let wsColumns: number = ws.columns;
-    let wsRows: number = ws.rows;
+    const wsColumns: number = ws.columns;
+    const wsRows: number = ws.rows;
 
-    let isTTY: boolean = tty.isatty(1);
+    const isTTY: boolean = tty.isatty(1);
 }
 
 ////////////////////////////////////////////////////
 /// Dgram tests : http://nodejs.org/api/dgram.html
 ////////////////////////////////////////////////////
 
-namespace dgram_tests {
+{
     {
         let ds: dgram.Socket = dgram.createSocket("udp4", (msg: Buffer, rinfo: dgram.RemoteInfo): void => {
         });
@@ -1953,9 +1957,13 @@ namespace dgram_tests {
     {
         let _socket: dgram.Socket;
         let _boolean: boolean;
-        let _err: Error;
-        let _str: string;
-        let _rinfo: net.AddressInfo;
+        const _err: Error = new Error();
+        const _str = '';
+        const _rinfo: net.AddressInfo = {
+            address: 'asd',
+            family: 'asd',
+            port: 1,
+        };
         /**
          * events.EventEmitter
          * 1. close
@@ -1966,12 +1974,12 @@ namespace dgram_tests {
 
         _socket = _socket.addListener("close", () => { });
         _socket = _socket.addListener("error", (err) => {
-            let _err: Error = err;
+            const _err: Error = err;
         });
         _socket = _socket.addListener("listening", () => { });
         _socket = _socket.addListener("message", (msg, rinfo) => {
-            let _msg: Buffer = msg;
-            let _rinfo: net.AddressInfo = rinfo;
+            const _msg: Buffer = msg;
+            const _rinfo: net.AddressInfo = rinfo;
         });
 
         _boolean = _socket.emit("close");
@@ -1981,47 +1989,47 @@ namespace dgram_tests {
 
         _socket = _socket.on("close", () => { });
         _socket = _socket.on("error", (err) => {
-            let _err: Error = err;
+            const _err: Error = err;
         });
         _socket = _socket.on("listening", () => { });
         _socket = _socket.on("message", (msg, rinfo) => {
-            let _msg: Buffer = msg;
-            let _rinfo: net.AddressInfo = rinfo;
+            const _msg: Buffer = msg;
+            const _rinfo: net.AddressInfo = rinfo;
         });
 
         _socket = _socket.once("close", () => { });
         _socket = _socket.once("error", (err) => {
-            let _err: Error = err;
+            const _err: Error = err;
         });
         _socket = _socket.once("listening", () => { });
         _socket = _socket.once("message", (msg, rinfo) => {
-            let _msg: Buffer = msg;
-            let _rinfo: net.AddressInfo = rinfo;
+            const _msg: Buffer = msg;
+            const _rinfo: net.AddressInfo = rinfo;
         });
 
         _socket = _socket.prependListener("close", () => { });
         _socket = _socket.prependListener("error", (err) => {
-            let _err: Error = err;
+            const _err: Error = err;
         });
         _socket = _socket.prependListener("listening", () => { });
         _socket = _socket.prependListener("message", (msg, rinfo) => {
-            let _msg: Buffer = msg;
-            let _rinfo: net.AddressInfo = rinfo;
+            const _msg: Buffer = msg;
+            const _rinfo: net.AddressInfo = rinfo;
         });
 
         _socket = _socket.prependOnceListener("close", () => { });
         _socket = _socket.prependOnceListener("error", (err) => {
-            let _err: Error = err;
+            const _err: Error = err;
         });
         _socket = _socket.prependOnceListener("listening", () => { });
         _socket = _socket.prependOnceListener("message", (msg, rinfo) => {
-            let _msg: Buffer = msg;
-            let _rinfo: net.AddressInfo = rinfo;
+            const _msg: Buffer = msg;
+            const _rinfo: net.AddressInfo = rinfo;
         });
     }
 
     {
-        let ds: dgram.Socket = dgram.createSocket({
+        const ds: dgram.Socket = dgram.createSocket({
             type: 'udp4',
             recvBufferSize: 10000,
             sendBufferSize: 15000
@@ -2039,38 +2047,38 @@ namespace dgram_tests {
 /// Querystring tests : https://nodejs.org/api/querystring.html
 ////////////////////////////////////////////////////
 
-namespace querystring_tests {
-    interface SampleObject { a: string; b: number; }
+{
+    interface SampleObject { a: string; }
 
     {
-        let obj: SampleObject;
-        let sep: string;
-        let eq: string;
-        let options: querystring.StringifyOptions;
+        const obj: SampleObject = { a: "" };
+        const sep = '';
+        const eq = '';
+        const options: querystring.StringifyOptions = {};
         let result: string;
 
-        result = querystring.stringify<SampleObject>(obj);
-        result = querystring.stringify<SampleObject>(obj, sep);
-        result = querystring.stringify<SampleObject>(obj, sep, eq);
-        result = querystring.stringify<SampleObject>(obj, sep, eq);
-        result = querystring.stringify<SampleObject>(obj, sep, eq, options);
+        result = querystring.stringify(obj);
+        result = querystring.stringify(obj, sep);
+        result = querystring.stringify(obj, sep, eq);
+        result = querystring.stringify(obj, sep, eq);
+        result = querystring.stringify(obj, sep, eq, options);
     }
 
     {
-        let str: string;
-        let sep: string;
-        let eq: string;
-        let options: querystring.ParseOptions;
-        let result: SampleObject;
+        const str = '';
+        const sep = '';
+        const eq = '';
+        const options: querystring.ParseOptions = {};
+        let result: querystring.ParsedUrlQuery;
 
-        result = querystring.parse<SampleObject>(str);
-        result = querystring.parse<SampleObject>(str, sep);
-        result = querystring.parse<SampleObject>(str, sep, eq);
-        result = querystring.parse<SampleObject>(str, sep, eq, options);
+        result = querystring.parse(str);
+        result = querystring.parse(str, sep);
+        result = querystring.parse(str, sep, eq);
+        result = querystring.parse(str, sep, eq, options);
     }
 
     {
-        let str: string;
+        const str = '';
         let result: string;
 
         result = querystring.escape(str);
@@ -2082,7 +2090,7 @@ namespace querystring_tests {
 /// path tests : http://nodejs.org/api/path.html
 ////////////////////////////////////////////////////
 
-namespace path_tests {
+{
     path.normalize('/foo/bar//baz/asdf/quux/..');
 
     path.join('/foo', 'bar', 'baz/asdf', 'quux', '..');
@@ -2254,15 +2262,17 @@ namespace path_tests {
 /// readline tests : https://nodejs.org/api/readline.html
 ////////////////////////////////////////////////////
 
-namespace readline_tests {
-    let rl: readline.ReadLine;
+{
+    const rl: readline.ReadLine = readline.createInterface(new stream.Readable());
 
     {
-        let options: readline.ReadLineOptions;
-        let input: NodeJS.ReadableStream;
-        let output: NodeJS.WritableStream;
-        let completer: readline.Completer;
-        let terminal: boolean;
+        const options: readline.ReadLineOptions = {
+            input: new fs.ReadStream()
+        };
+        const input: NodeJS.ReadableStream = new stream.Readable();
+        const output: NodeJS.WritableStream = new stream.Writable();
+        const completer: readline.Completer = str => [['asd'], 'asd'];
+        const terminal = false;
 
         let result: readline.ReadLine;
 
@@ -2286,23 +2296,16 @@ namespace readline_tests {
     }
 
     {
-        let prompt: string;
-
-        rl.setPrompt(prompt);
+        rl.setPrompt("prompt");
     }
 
     {
-        let preserveCursor: boolean;
-
         rl.prompt();
-        rl.prompt(preserveCursor);
+        rl.prompt(true);
     }
 
     {
-        let query: string;
-        let callback: (answer: string) => void;
-
-        rl.question(query, callback);
+        rl.question("query", (answer: string) => {});
     }
 
     {
@@ -2322,49 +2325,47 @@ namespace readline_tests {
     }
 
     {
-        let data: string | Buffer;
-        let key: readline.Key;
+        const data: string | Buffer = "asd";
+        const key: readline.Key = {};
 
         rl.write(data);
         rl.write(null, key);
     }
 
     {
-        let stream: NodeJS.WritableStream;
-        let x: number;
-        let y: number;
+        const strm: NodeJS.WritableStream = new stream.Writable();
+        const x = 1;
+        const y = 1;
 
-        readline.cursorTo(stream, x);
-        readline.cursorTo(stream, x, y);
+        readline.cursorTo(strm, x);
+        readline.cursorTo(strm, x, y);
     }
 
     {
-        let stream: NodeJS.ReadableStream;
-        let readLineInterface: readline.ReadLine;
+        const strm: NodeJS.ReadableStream = new stream.Readable();
+        const readLineInterface: readline.ReadLine = readline.createInterface(new stream.Readable());
 
-        readline.emitKeypressEvents(stream);
-        readline.emitKeypressEvents(stream, readLineInterface);
+        readline.emitKeypressEvents(strm);
+        readline.emitKeypressEvents(strm, readLineInterface);
     }
 
     {
-        let stream: NodeJS.WritableStream;
-        let dx: number | string;
-        let dy: number | string;
+        const strm: NodeJS.WritableStream = new stream.Writable();
+        const dx: number | string = 1;
+        const dy: number | string = 1;
 
-        readline.moveCursor(stream, dx, dy);
+        readline.moveCursor(strm, dx, dy);
     }
 
     {
-        let stream: NodeJS.WritableStream;
-        let dir: number;
-
-        readline.clearLine(stream, dir);
+        const strm: NodeJS.WritableStream = new stream.Writable();
+        readline.clearLine(strm, 1);
     }
 
     {
-        let stream: NodeJS.WritableStream;
+        const strm: NodeJS.WritableStream = new stream.Writable();
 
-        readline.clearScreenDown(stream);
+        readline.clearScreenDown(strm);
     }
 
     {
@@ -2373,7 +2374,7 @@ namespace readline_tests {
 
         _rl = _rl.addListener("close", () => { });
         _rl = _rl.addListener("line", (input) => {
-            let _input: any = input;
+            const _input: any = input;
         });
         _rl = _rl.addListener("pause", () => { });
         _rl = _rl.addListener("resume", () => { });
@@ -2391,7 +2392,7 @@ namespace readline_tests {
 
         _rl = _rl.on("close", () => { });
         _rl = _rl.on("line", (input) => {
-            let _input: any = input;
+            const _input: any = input;
         });
         _rl = _rl.on("pause", () => { });
         _rl = _rl.on("resume", () => { });
@@ -2401,7 +2402,7 @@ namespace readline_tests {
 
         _rl = _rl.once("close", () => { });
         _rl = _rl.once("line", (input) => {
-            let _input: any = input;
+            const _input: any = input;
         });
         _rl = _rl.once("pause", () => { });
         _rl = _rl.once("resume", () => { });
@@ -2411,7 +2412,7 @@ namespace readline_tests {
 
         _rl = _rl.prependListener("close", () => { });
         _rl = _rl.prependListener("line", (input) => {
-            let _input: any = input;
+            const _input: any = input;
         });
         _rl = _rl.prependListener("pause", () => { });
         _rl = _rl.prependListener("resume", () => { });
@@ -2421,7 +2422,7 @@ namespace readline_tests {
 
         _rl = _rl.prependOnceListener("close", () => { });
         _rl = _rl.prependOnceListener("line", (input) => {
-            let _input: any = input;
+            const _input: any = input;
         });
         _rl = _rl.prependOnceListener("pause", () => { });
         _rl = _rl.prependOnceListener("resume", () => { });
@@ -2435,7 +2436,7 @@ namespace readline_tests {
 /// string_decoder tests : https://nodejs.org/api/string_decoder.html
 ////////////////////////////////////////////////////
 
-namespace string_decoder_tests {
+{
     const StringDecoder = string_decoder.StringDecoder;
     const buffer = new Buffer('test');
     const decoder1 = new StringDecoder();
@@ -2450,7 +2451,7 @@ namespace string_decoder_tests {
 /// Child Process tests: https://nodejs.org/api/child_process.html ///
 //////////////////////////////////////////////////////////////////////
 
-namespace child_process_tests {
+{
     {
         childProcess.exec("echo test");
         childProcess.exec("echo test", { windowsHide: true });
@@ -2491,8 +2492,8 @@ namespace child_process_tests {
 
     {
         let _cp: childProcess.ChildProcess;
-        let _socket: net.Socket;
-        let _server: net.Server;
+        const _socket: net.Socket = net.createConnection(1);
+        const _server: net.Server = net.createServer();
         let _boolean: boolean;
 
         _boolean = _cp.send(1);
@@ -2502,15 +2503,15 @@ namespace child_process_tests {
         });
 
         _boolean = _cp.send(1, (error) => {
-            let _err: Error = error;
+            const _err: Error = error;
         });
         _boolean = _cp.send('one', (error) => {
-            let _err: Error = error;
+            const _err: Error = error;
         });
         _boolean = _cp.send({
             type: 'test'
         }, (error) => {
-            let _err: Error = error;
+            const _err: Error = error;
         });
 
         _boolean = _cp.send(1, _socket);
@@ -2520,15 +2521,15 @@ namespace child_process_tests {
         }, _socket);
 
         _boolean = _cp.send(1, _socket, (error) => {
-            let _err: Error = error;
+            const _err: Error = error;
         });
         _boolean = _cp.send('one', _socket, (error) => {
-            let _err: Error = error;
+            const _err: Error = error;
         });
         _boolean = _cp.send({
             type: 'test'
         }, _socket, (error) => {
-            let _err: Error = error;
+            const _err: Error = error;
         });
 
         _boolean = _cp.send(1, _socket, {
@@ -2546,19 +2547,19 @@ namespace child_process_tests {
         _boolean = _cp.send(1, _socket, {
             keepOpen: true
         }, (error) => {
-            let _err: Error = error;
+            const _err: Error = error;
         });
         _boolean = _cp.send('one', _socket, {
             keepOpen: true
         }, (error) => {
-            let _err: Error = error;
+            const _err: Error = error;
         });
         _boolean = _cp.send({
             type: 'test'
         }, _socket, {
                 keepOpen: true
             }, (error) => {
-                let _err: Error = error;
+                const _err: Error = error;
             });
 
         _boolean = _cp.send(1, _server);
@@ -2568,15 +2569,15 @@ namespace child_process_tests {
         }, _server);
 
         _boolean = _cp.send(1, _server, (error) => {
-            let _err: Error = error;
+            const _err: Error = error;
         });
         _boolean = _cp.send('one', _server, (error) => {
-            let _err: Error = error;
+            const _err: Error = error;
         });
         _boolean = _cp.send({
             type: 'test'
         }, _server, (error) => {
-            let _err: Error = error;
+            const _err: Error = error;
         });
 
         _boolean = _cp.send(1, _server, {
@@ -2594,36 +2595,36 @@ namespace child_process_tests {
         _boolean = _cp.send(1, _server, {
             keepOpen: true
         }, (error) => {
-            let _err: Error = error;
+            const _err: Error = error;
         });
         _boolean = _cp.send('one', _server, {
             keepOpen: true
         }, (error) => {
-            let _err: Error = error;
+            const _err: Error = error;
         });
         _boolean = _cp.send({
             type: 'test'
         }, _server, {
                 keepOpen: true
             }, (error) => {
-                let _err: Error = error;
+                const _err: Error = error;
             });
 
         _cp = _cp.addListener("close", (code, signal) => {
-            let _code: number = code;
-            let _signal: string = signal;
+            const _code: number = code;
+            const _signal: string = signal;
         });
         _cp = _cp.addListener("disconnect", () => { });
         _cp = _cp.addListener("error", (err) => {
-            let _err: Error = err;
+            const _err: Error = err;
         });
         _cp = _cp.addListener("exit", (code, signal) => {
-            let _code: number = code;
-            let _signal: string = signal;
+            const _code: number = code;
+            const _signal: string = signal;
         });
         _cp = _cp.addListener("message", (message, sendHandle) => {
-            let _message: any = message;
-            let _sendHandle: net.Socket | net.Server = sendHandle;
+            const _message: any = message;
+            const _sendHandle: net.Socket | net.Server = sendHandle;
         });
 
         _boolean = _cp.emit("close", () => { });
@@ -2633,71 +2634,71 @@ namespace child_process_tests {
         _boolean = _cp.emit("message", () => { });
 
         _cp = _cp.on("close", (code, signal) => {
-            let _code: number = code;
-            let _signal: string = signal;
+            const _code: number = code;
+            const _signal: string = signal;
         });
         _cp = _cp.on("disconnect", () => { });
         _cp = _cp.on("error", (err) => {
-            let _err: Error = err;
+            const _err: Error = err;
         });
         _cp = _cp.on("exit", (code, signal) => {
-            let _code: number = code;
-            let _signal: string = signal;
+            const _code: number = code;
+            const _signal: string = signal;
         });
         _cp = _cp.on("message", (message, sendHandle) => {
-            let _message: any = message;
-            let _sendHandle: net.Socket | net.Server = sendHandle;
+            const _message: any = message;
+            const _sendHandle: net.Socket | net.Server = sendHandle;
         });
 
         _cp = _cp.once("close", (code, signal) => {
-            let _code: number = code;
-            let _signal: string = signal;
+            const _code: number = code;
+            const _signal: string = signal;
         });
         _cp = _cp.once("disconnect", () => { });
         _cp = _cp.once("error", (err) => {
-            let _err: Error = err;
+            const _err: Error = err;
         });
         _cp = _cp.once("exit", (code, signal) => {
-            let _code: number = code;
-            let _signal: string = signal;
+            const _code: number = code;
+            const _signal: string = signal;
         });
         _cp = _cp.once("message", (message, sendHandle) => {
-            let _message: any = message;
-            let _sendHandle: net.Socket | net.Server = sendHandle;
+            const _message: any = message;
+            const _sendHandle: net.Socket | net.Server = sendHandle;
         });
 
         _cp = _cp.prependListener("close", (code, signal) => {
-            let _code: number = code;
-            let _signal: string = signal;
+            const _code: number = code;
+            const _signal: string = signal;
         });
         _cp = _cp.prependListener("disconnect", () => { });
         _cp = _cp.prependListener("error", (err) => {
-            let _err: Error = err;
+            const _err: Error = err;
         });
         _cp = _cp.prependListener("exit", (code, signal) => {
-            let _code: number = code;
-            let _signal: string = signal;
+            const _code: number = code;
+            const _signal: string = signal;
         });
         _cp = _cp.prependListener("message", (message, sendHandle) => {
-            let _message: any = message;
-            let _sendHandle: net.Socket | net.Server = sendHandle;
+            const _message: any = message;
+            const _sendHandle: net.Socket | net.Server = sendHandle;
         });
 
         _cp = _cp.prependOnceListener("close", (code, signal) => {
-            let _code: number = code;
-            let _signal: string = signal;
+            const _code: number = code;
+            const _signal: string = signal;
         });
         _cp = _cp.prependOnceListener("disconnect", () => { });
         _cp = _cp.prependOnceListener("error", (err) => {
-            let _err: Error = err;
+            const _err: Error = err;
         });
         _cp = _cp.prependOnceListener("exit", (code, signal) => {
-            let _code: number = code;
-            let _signal: string = signal;
+            const _code: number = code;
+            const _signal: string = signal;
         });
         _cp = _cp.prependOnceListener("message", (message, sendHandle) => {
-            let _message: any = message;
-            let _sendHandle: net.Socket | net.Server = sendHandle;
+            const _message: any = message;
+            const _sendHandle: net.Socket | net.Server = sendHandle;
         });
     }
     {
@@ -2722,11 +2723,11 @@ namespace child_process_tests {
         console.log(process.stdin instanceof net.Socket);
         console.log(process.stdout instanceof fs.ReadStream);
 
-        let stdin: stream.Readable = process.stdin;
+        const stdin: stream.Readable = process.stdin;
         console.log(stdin instanceof net.Socket);
         console.log(stdin instanceof fs.ReadStream);
 
-        let stdout: stream.Writable = process.stdout;
+        const stdout: stream.Writable = process.stdout;
         console.log(stdout instanceof net.Socket);
         console.log(stdout instanceof fs.WriteStream);
     }
@@ -2736,7 +2737,7 @@ namespace child_process_tests {
 /// cluster tests: https://nodejs.org/api/cluster.html ///
 //////////////////////////////////////////////////////////////////////
 
-namespace cluster_tests {
+{
     {
         cluster.fork();
         Object.keys(cluster.workers).forEach(key => {
@@ -2752,7 +2753,7 @@ namespace cluster_tests {
 /// os tests : https://nodejs.org/api/os.html
 ////////////////////////////////////////////////////
 
-namespace os_tests {
+{
     {
         let result: string;
 
@@ -2930,7 +2931,7 @@ namespace os_tests {
 /// vm tests : https://nodejs.org/api/vm.html
 ////////////////////////////////////////////////////
 
-namespace vm_tests {
+{
     {
         const sandbox = {
             animal: 'cat',
@@ -2963,7 +2964,7 @@ namespace vm_tests {
 
         console.log(util.inspect(sandboxes));
 
-        let localVar = 'initial value';
+        const localVar = 'initial value';
         vm.runInThisContext('localVar = "vm";');
 
         console.log(localVar);
@@ -2994,21 +2995,21 @@ namespace vm_tests {
 /// Timers tests : https://nodejs.org/api/timers.html
 /////////////////////////////////////////////////////
 
-namespace timers_tests {
+{
     {
-        let immediateId = timers.setImmediate(() => { console.log("immediate"); });
+        const immediateId = timers.setImmediate(() => { console.log("immediate"); });
         timers.clearImmediate(immediateId);
     }
     {
-        let counter = 0;
-        let timeout = timers.setInterval(() => { console.log("interval"); }, 20);
+        const counter = 0;
+        const timeout = timers.setInterval(() => { console.log("interval"); }, 20);
         timeout.unref();
         timeout.ref();
         timers.clearInterval(timeout);
     }
     {
-        let counter = 0;
-        let timeout = timers.setTimeout(() => { console.log("timeout"); }, 20);
+        const counter = 0;
+        const timeout = timers.setTimeout(() => { console.log("timeout"); }, 20);
         timeout.unref();
         timeout.ref();
         timers.clearTimeout(timeout);
@@ -3028,7 +3029,7 @@ namespace timers_tests {
 /// Errors Tests : https://nodejs.org/api/errors.html ///
 /////////////////////////////////////////////////////////
 
-namespace errors_tests {
+{
     {
         Error.stackTraceLimit = Infinity;
     }
@@ -3037,24 +3038,24 @@ namespace errors_tests {
         Error.captureStackTrace(myObject);
     }
     {
-        let frames: NodeJS.CallSite[] = [];
+        const frames: NodeJS.CallSite[] = [];
         Error.prepareStackTrace(new Error(), frames);
     }
     {
-        let frame: NodeJS.CallSite = null;
-        let frameThis: any = frame.getThis();
-        let typeName: string = frame.getTypeName();
-        let func: Function = frame.getFunction();
-        let funcName: string = frame.getFunctionName();
-        let meth: string = frame.getMethodName();
-        let fname: string = frame.getFileName();
-        let lineno: number = frame.getLineNumber();
-        let colno: number = frame.getColumnNumber();
-        let evalOrigin: string = frame.getEvalOrigin();
-        let isTop: boolean = frame.isToplevel();
-        let isEval: boolean = frame.isEval();
-        let isNative: boolean = frame.isNative();
-        let isConstr: boolean = frame.isConstructor();
+        const frame: NodeJS.CallSite = null;
+        const frameThis: any = frame.getThis();
+        const typeName: string = frame.getTypeName();
+        const func: Function = frame.getFunction();
+        const funcName: string = frame.getFunctionName();
+        const meth: string = frame.getMethodName();
+        const fname: string = frame.getFileName();
+        const lineno: number = frame.getLineNumber();
+        const colno: number = frame.getColumnNumber();
+        const evalOrigin: string = frame.getEvalOrigin();
+        const isTop: boolean = frame.isToplevel();
+        const isEval: boolean = frame.isEval();
+        const isNative: boolean = frame.isNative();
+        const isConstr: boolean = frame.isConstructor();
     }
 }
 
@@ -3063,7 +3064,7 @@ namespace errors_tests {
 ///////////////////////////////////////////////////////////
 
 import * as p from "process";
-namespace process_tests {
+{
     {
         let eventEmitter: events.EventEmitter;
         eventEmitter = process;                // Test that process implements EventEmitter...
@@ -3112,15 +3113,14 @@ namespace process_tests {
 /// Console Tests : https://nodejs.org/api/console.html ///
 ///////////////////////////////////////////////////////////
 
-import * as c from "console";
-namespace console_tests {
+{
     {
         let _c: Console = console;
-        _c = c;
+        _c = console2;
     }
     {
-        let writeStream = fs.createWriteStream('./index.d.ts');
-        let consoleInstance = new console.Console(writeStream);
+        const writeStream = fs.createWriteStream('./index.d.ts');
+        const consoleInstance = new console.Console(writeStream);
     }
 }
 
@@ -3128,7 +3128,7 @@ namespace console_tests {
 /// Net Tests : https://nodejs.org/api/net.html ///
 ///////////////////////////////////////////////////
 
-namespace net_tests {
+{
     {
         const connectOpts: net.NetConnectOpts = {
             allowHalfOpen: true,
@@ -3155,7 +3155,7 @@ namespace net_tests {
         server = server.close((...args: any[]) => { });
 
         // test the types of the address object fields
-        let address: net.AddressInfo | string = server.address();
+        const address: net.AddressInfo | string = server.address();
     }
 
     {
@@ -3185,10 +3185,10 @@ namespace net_tests {
         let str: string;
         let num: number;
 
-        let ipcConnectOpts: net.IpcSocketConnectOpts = {
+        const ipcConnectOpts: net.IpcSocketConnectOpts = {
             path: "/"
         };
-        let tcpConnectOpts: net.TcpSocketConnectOpts = {
+        const tcpConnectOpts: net.TcpSocketConnectOpts = {
             family: 4,
             hints: 0,
             host: "localhost",
@@ -3421,11 +3421,11 @@ namespace net_tests {
 /// repl Tests : https://nodejs.org/api/repl.html ///
 /////////////////////////////////////////////////////
 
-namespace repl_tests {
+{
     {
         let _server: repl.REPLServer;
         let _boolean: boolean;
-        let _ctx: any;
+        const _ctx: any = 1;
 
         _server = _server.addListener("exit", () => { });
         _server = _server.addListener("reset", () => { });
@@ -3446,9 +3446,11 @@ namespace repl_tests {
         _server = _server.prependOnceListener("reset", () => { });
 
         _server.outputStream.write("test");
-        let line = _server.inputStream.read();
+        const line = _server.inputStream.read();
 
-        throw new repl.Recoverable(new Error("test"));
+        function test() {
+            throw new repl.Recoverable(new Error("test"));
+        }
     }
 }
 
@@ -3456,7 +3458,7 @@ namespace repl_tests {
 /// DNS Tests : https://nodejs.org/api/dns.html ///
 ///////////////////////////////////////////////////
 
-namespace dns_tests {
+{
     dns.lookup("nodejs.org", (err, address, family) => {
         const _err: NodeJS.ErrnoException = err;
         const _address: string = address;
@@ -3572,8 +3574,7 @@ namespace dns_tests {
 ///////////////////////////////////////////////////////////
 
 import * as constants from 'constants';
-import { PerformanceObserver, PerformanceObserverCallback } from "perf_hooks";
-namespace constants_tests {
+{
     let str: string;
     let num: number;
     num = constants.SIGHUP;
@@ -3719,7 +3720,7 @@ namespace constants_tests {
 /// v8 tests : https://nodejs.org/api/v8.html
 ////////////////////////////////////////////////////
 
-namespace v8_tests {
+{
     const heapStats = v8.getHeapStatistics();
     const heapSpaceStats = v8.getHeapSpaceStatistics();
 
@@ -3731,7 +3732,7 @@ namespace v8_tests {
 ////////////////////////////////////////////////////
 /// PerfHooks tests : https://nodejs.org/api/perf_hooks.html
 ////////////////////////////////////////////////////
-namespace perf_hooks_tests {
+{
     perf_hooks.performance.mark('start');
     (
         () => {}
@@ -3741,7 +3742,7 @@ namespace perf_hooks_tests {
     const { duration } = perf_hooks.performance.getEntriesByName('discover')[0];
     const timeOrigin = perf_hooks.performance.timeOrigin;
 
-    const performanceObserverCallback: PerformanceObserverCallback = (list, obs) => {
+    const performanceObserverCallback: perf_hooks.PerformanceObserverCallback = (list, obs) => {
         const {
             duration,
             entryType,
@@ -3761,7 +3762,7 @@ namespace perf_hooks_tests {
 ////////////////////////////////////////////////////
 /// AsyncHooks tests : https://nodejs.org/api/async_hooks.html
 ////////////////////////////////////////////////////
-namespace async_hooks_tests {
+{
     const hooks: async_hooks.HookCallbacks = {
         init() {},
         before() {},
@@ -3813,7 +3814,7 @@ namespace async_hooks_tests {
 /// zlib tests : http://nodejs.org/api/zlib.html ///
 ////////////////////////////////////////////////////
 
-namespace zlib_tests {
+{
     {
         const gzipped = zlib.gzipSync('test');
         const unzipped = zlib.gunzipSync(gzipped.toString());
@@ -3829,17 +3830,17 @@ namespace zlib_tests {
 /// HTTP/2 Tests                                        ///
 ///////////////////////////////////////////////////////////
 
-namespace http2_tests {
+{
     // Headers & Settings
     {
-        let headers: http2.OutgoingHttpHeaders = {
+        const headers: http2.OutgoingHttpHeaders = {
             ':status': 200,
             'content-type': 'text-plain',
             ABC: ['has', 'more', 'than', 'one', 'value'],
             undef: undefined
         };
 
-        let settings: http2.Settings = {
+        const settings: http2.Settings = {
             headerTableSize: 0,
             enablePush: true,
             initialWindowSize: 0,
@@ -3851,8 +3852,8 @@ namespace http2_tests {
 
     // Http2Session
     {
-        let http2Session: http2.Http2Session;
-        let ee: events.EventEmitter = http2Session;
+        const http2Session: http2.Http2Session = <any> {};
+        const ee: events.EventEmitter = http2Session;
 
         http2Session.on('close', () => {});
         http2Session.on('connect', (session: http2.Http2Session, socket: net.Socket) => {});
@@ -3866,21 +3867,21 @@ namespace http2_tests {
 
         http2Session.destroy();
 
-        let alpnProtocol: string = http2Session.alpnProtocol;
-        let destroyed: boolean = http2Session.destroyed;
-        let encrypted: boolean = http2Session.encrypted;
-        let originSet: string[] = http2Session.originSet;
-        let pendingSettingsAck: boolean = http2Session.pendingSettingsAck;
+        const alpnProtocol: string = http2Session.alpnProtocol;
+        const destroyed: boolean = http2Session.destroyed;
+        const encrypted: boolean = http2Session.encrypted;
+        const originSet: string[] = http2Session.originSet;
+        const pendingSettingsAck: boolean = http2Session.pendingSettingsAck;
         let settings: http2.Settings = http2Session.localSettings;
-        let closed: boolean = http2Session.closed;
-        let connecting: boolean = http2Session.connecting;
+        const closed: boolean = http2Session.closed;
+        const connecting: boolean = http2Session.connecting;
         settings = http2Session.remoteSettings;
 
         http2Session.ref();
         http2Session.unref();
 
-        let headers: http2.OutgoingHttpHeaders;
-        let options: http2.ClientSessionRequestOptions = {
+        const headers: http2.OutgoingHttpHeaders = {};
+        const options: http2.ClientSessionRequestOptions = {
             endStream: true,
             exclusive: true,
             parent: 0,
@@ -3891,14 +3892,14 @@ namespace http2_tests {
         (http2Session as http2.ClientHttp2Session).request(headers);
         (http2Session as http2.ClientHttp2Session).request(headers, options);
 
-        let stream: http2.Http2Stream;
+        const stream: http2.Http2Stream = <any> {};
         http2Session.rstStream(stream);
         http2Session.rstStream(stream, 0);
 
         http2Session.setTimeout(100, () => {});
         http2Session.close(() => {});
 
-        let socket: net.Socket | tls.TLSSocket = http2Session.socket;
+        const socket: net.Socket | tls.TLSSocket = http2Session.socket;
         let state: http2.SessionState = http2Session.state;
         state = {
             effectiveLocalWindowSize: 0,
@@ -3928,8 +3929,8 @@ namespace http2_tests {
 
     // Http2Stream
     {
-        let http2Stream: http2.Http2Stream;
-        let duplex: stream.Duplex = http2Stream;
+        const http2Stream: http2.Http2Stream = <any> {};
+        const duplex: stream.Duplex = http2Stream;
 
         http2Stream.on('aborted', () => {});
         http2Stream.on('error', (err: Error) => {});
@@ -3938,10 +3939,10 @@ namespace http2_tests {
         http2Stream.on('timeout', () => {});
         http2Stream.on('trailers', (trailers: http2.IncomingHttpHeaders, flags: number) => {});
 
-        let aborted: boolean = http2Stream.aborted;
-        let closed: boolean = http2Stream.closed;
-        let destroyed: boolean = http2Stream.destroyed;
-        let pending: boolean = http2Stream.pending;
+        const aborted: boolean = http2Stream.aborted;
+        const closed: boolean = http2Stream.closed;
+        const destroyed: boolean = http2Stream.destroyed;
+        const pending: boolean = http2Stream.pending;
 
         http2Stream.priority({
             exclusive: true,
@@ -3950,7 +3951,7 @@ namespace http2_tests {
             silent: true
         });
 
-        let sesh: http2.Http2Session = http2Stream.session;
+        const sesh: http2.Http2Session = http2Stream.session;
 
         http2Stream.setTimeout(100, () => {});
 
@@ -3970,7 +3971,7 @@ namespace http2_tests {
         http2Stream.close(undefined, () => {});
 
         // ClientHttp2Stream
-        let clientHttp2Stream: http2.ClientHttp2Stream;
+        const clientHttp2Stream: http2.ClientHttp2Stream = <any> {};
         clientHttp2Stream.on('headers', (headers: http2.IncomingHttpHeaders, flags: number) => {});
         clientHttp2Stream.on('push', (headers: http2.IncomingHttpHeaders, flags: number) => {});
         clientHttp2Stream.on('response', (headers: http2.IncomingHttpHeaders & http2.IncomingHttpStatusHeader, flags: number) => {
@@ -3978,15 +3979,15 @@ namespace http2_tests {
         });
 
         // ServerHttp2Stream
-        let serverHttp2Stream: http2.ServerHttp2Stream;
-        let headers: http2.OutgoingHttpHeaders;
+        const serverHttp2Stream: http2.ServerHttp2Stream = <any> {};
+        const headers: http2.OutgoingHttpHeaders = {};
 
         serverHttp2Stream.additionalHeaders(headers);
-        let headerSent: boolean = serverHttp2Stream.headersSent;
-        let pushAllowed: boolean = serverHttp2Stream.pushAllowed;
+        const headerSent: boolean = serverHttp2Stream.headersSent;
+        const pushAllowed: boolean = serverHttp2Stream.pushAllowed;
         serverHttp2Stream.pushStream(headers, (err: Error | null, pushStream: http2.ServerHttp2Stream, headers: http2.OutgoingHttpHeaders) => {});
 
-        let options: http2.ServerStreamResponseOptions = {
+        const options: http2.ServerStreamResponseOptions = {
             endStream: true,
             getTrailers: (trailers: http2.OutgoingHttpHeaders) => {}
         };
@@ -3994,7 +3995,7 @@ namespace http2_tests {
         serverHttp2Stream.respond(headers);
         serverHttp2Stream.respond(headers, options);
 
-        let options2: http2.ServerStreamFileResponseOptions = {
+        const options2: http2.ServerStreamFileResponseOptions = {
             statCheck: (stats: fs.Stats, headers: http2.OutgoingHttpHeaders, statOptions: http2.StatOptions) => {},
             getTrailers: (trailers: http2.OutgoingHttpHeaders) => {},
             offset: 0,
@@ -4004,7 +4005,7 @@ namespace http2_tests {
         serverHttp2Stream.respondWithFD(0, headers);
         serverHttp2Stream.respondWithFD(0, headers, options2);
         serverHttp2Stream.respondWithFD(0, headers, {statCheck: () => false});
-        let options3: http2.ServerStreamFileResponseOptionsWithError = {
+        const options3: http2.ServerStreamFileResponseOptionsWithError = {
             onError: (err: NodeJS.ErrnoException) => {},
             statCheck: (stats: fs.Stats, headers: http2.OutgoingHttpHeaders, statOptions: http2.StatOptions) => {},
             getTrailers: (trailers: http2.OutgoingHttpHeaders) => {},
@@ -4019,10 +4020,10 @@ namespace http2_tests {
 
     // Http2Server / Http2SecureServer
     {
-        let http2Server: http2.Http2Server;
-        let http2SecureServer: http2.Http2SecureServer;
-        let s1: net.Server = http2Server;
-        let s2: tls.Server = http2SecureServer;
+        const http2Server: http2.Http2Server = http2.createServer();
+        const http2SecureServer: http2.Http2SecureServer = http2.createSecureServer();
+        const s1: net.Server = http2Server;
+        const s2: tls.Server = http2SecureServer;
         [http2Server, http2SecureServer].forEach((server) => {
             server.on('sessionError', (err: Error) => {});
             server.on('checkContinue', (stream: http2.ServerHttp2Stream, headers: http2.IncomingHttpHeaders, flags: number) => {});
@@ -4037,7 +4038,7 @@ namespace http2_tests {
     // Public API (except constants)
     {
         let settings: http2.Settings;
-        let serverOptions: http2.ServerOptions = {
+        const serverOptions: http2.ServerOptions = {
             maxDeflateDynamicTableSize: 0,
             maxReservedRemoteStreams: 0,
             maxSendHeaderBlockLength: 0,
@@ -4048,21 +4049,21 @@ namespace http2_tests {
             allowHTTP1: true
         };
         // tslint:disable-next-line prefer-object-spread (ts2.1 feature)
-        let secureServerOptions: http2.SecureServerOptions = Object.assign({}, serverOptions);
+        const secureServerOptions: http2.SecureServerOptions = Object.assign({}, serverOptions);
         secureServerOptions.ca = '';
-        let onRequestHandler = (request: http2.Http2ServerRequest, response: http2.Http2ServerResponse) => {
+        const onRequestHandler = (request: http2.Http2ServerRequest, response: http2.Http2ServerResponse) => {
             // Http2ServerRequest
 
-            let readable: stream.Readable = request;
+            const readable: stream.Readable = request;
             let incomingHeaders: http2.IncomingHttpHeaders = request.headers;
             incomingHeaders = request.trailers;
-            let httpVersion: string = request.httpVersion;
+            const httpVersion: string = request.httpVersion;
             let method: string = request.method;
             let rawHeaders: string[] = request.rawHeaders;
             rawHeaders = request.rawTrailers;
             let socket: net.Socket | tls.TLSSocket = request.socket;
             let stream: http2.ServerHttp2Stream = request.stream;
-            let url: string = request.url;
+            const url: string = request.url;
 
             request.setTimeout(0, () => {});
             request.on('aborted', (hadError: boolean, code: number) => {});
@@ -4072,7 +4073,7 @@ namespace http2_tests {
             let outgoingHeaders: http2.OutgoingHttpHeaders;
             response.addTrailers(outgoingHeaders);
             socket = response.connection;
-            let finished: boolean = response.finished;
+            const finished: boolean = response.finished;
             response.sendDate = true;
             response.statusCode = 200;
             response.statusMessage = '';
@@ -4080,14 +4081,14 @@ namespace http2_tests {
             stream = response.stream;
 
             method = response.getHeader(':method');
-            let headers: string[] = response.getHeaderNames();
+            const headers: string[] = response.getHeaderNames();
             outgoingHeaders = response.getHeaders();
-            let hasMethod = response.hasHeader(':method');
+            const hasMethod = response.hasHeader(':method');
             response.removeHeader(':method');
             response.setHeader(':method', 'GET');
             response.setHeader(':status', 200);
             response.setHeader('some-list', ['', '']);
-            let headersSent: boolean = response.headersSent;
+            const headersSent: boolean = response.headersSent;
 
             response.setTimeout(0, () => {});
             response.createPushResponse(outgoingHeaders, (err: Error | null, res: http2.Http2ServerResponse) => {});
@@ -4136,7 +4137,7 @@ namespace http2_tests {
         http2SecureServer = http2.createSecureServer(onRequestHandler);
         http2SecureServer = http2.createSecureServer(secureServerOptions, onRequestHandler);
 
-        let clientSessionOptions: http2.ClientSessionOptions = {
+        const clientSessionOptions: http2.ClientSessionOptions = {
             maxDeflateDynamicTableSize: 0,
             maxReservedRemoteStreams: 0,
             maxSendHeaderBlockLength: 0,
@@ -4146,11 +4147,11 @@ namespace http2_tests {
             settings
         };
         // tslint:disable-next-line prefer-object-spread (ts2.1 feature)
-        let secureClientSessionOptions: http2.SecureClientSessionOptions = Object.assign({}, clientSessionOptions);
+        const secureClientSessionOptions: http2.SecureClientSessionOptions = Object.assign({}, clientSessionOptions);
         secureClientSessionOptions.ca = '';
-        let onConnectHandler = (session: http2.Http2Session, socket: net.Socket) => {};
+        const onConnectHandler = (session: http2.Http2Session, socket: net.Socket) => {};
 
-        let serverHttp2Session: http2.ServerHttp2Session;
+        const serverHttp2Session: http2.ServerHttp2Session = <any> {};
 
         serverHttp2Session.altsvc('', '');
         serverHttp2Session.altsvc('', 0);
@@ -4395,7 +4396,7 @@ namespace http2_tests {
 /// Inspector Tests                                     ///
 ///////////////////////////////////////////////////////////
 
-namespace inspector_tests {
+{
     {
         inspector.open();
         inspector.open(0);
@@ -4440,7 +4441,7 @@ namespace inspector_tests {
 /// module tests : http://nodejs.org/api/modules.html
 ////////////////////////////////////////////////////
 
-namespace module_tests {
+{
     require.extensions[".ts"] = () => "";
 
     Module.runMain();
@@ -4457,8 +4458,8 @@ namespace module_tests {
 /// Node.js ESNEXT Support
 ////////////////////////////////////////////////////
 
-namespace esnext_string_tests {
-    const s: string = 'foo';
+{
+    const s = 'foo';
     const s1: string = s.trimLeft();
     const s2: string = s.trimRight();
 }

--- a/types/node/node-tests.ts
+++ b/types/node/node-tests.ts
@@ -40,8 +40,8 @@ import { Buffer as ImportedBuffer, SlowBuffer as ImportedSlowBuffer } from "buff
 //////////////////////////////////////////////////////////
 {
     {
-        const x: NodeModule = <any> {};
-        const y: NodeModule = <any> {};
+        const x: NodeModule = {} as any;
+        const y: NodeModule = {} as any;
         x.children.push(y);
         x.parent = require.main;
         require.main = y;
@@ -3847,7 +3847,7 @@ import * as constants from 'constants';
 
     // Http2Session
     {
-        const http2Session: http2.Http2Session = <any> {};
+        const http2Session: http2.Http2Session = {} as any;
         const ee: events.EventEmitter = http2Session;
 
         http2Session.on('close', () => {});
@@ -3887,7 +3887,7 @@ import * as constants from 'constants';
         (http2Session as http2.ClientHttp2Session).request(headers);
         (http2Session as http2.ClientHttp2Session).request(headers, options);
 
-        const stream: http2.Http2Stream = <any> {};
+        const stream: http2.Http2Stream = {} as any;
         http2Session.rstStream(stream);
         http2Session.rstStream(stream, 0);
 
@@ -3924,7 +3924,7 @@ import * as constants from 'constants';
 
     // Http2Stream
     {
-        const http2Stream: http2.Http2Stream = <any> {};
+        const http2Stream: http2.Http2Stream = {} as any;
         const duplex: stream.Duplex = http2Stream;
 
         http2Stream.on('aborted', () => {});
@@ -3966,7 +3966,7 @@ import * as constants from 'constants';
         http2Stream.close(undefined, () => {});
 
         // ClientHttp2Stream
-        const clientHttp2Stream: http2.ClientHttp2Stream = <any> {};
+        const clientHttp2Stream: http2.ClientHttp2Stream = {} as any;
         clientHttp2Stream.on('headers', (headers: http2.IncomingHttpHeaders, flags: number) => {});
         clientHttp2Stream.on('push', (headers: http2.IncomingHttpHeaders, flags: number) => {});
         clientHttp2Stream.on('response', (headers: http2.IncomingHttpHeaders & http2.IncomingHttpStatusHeader, flags: number) => {
@@ -3974,7 +3974,7 @@ import * as constants from 'constants';
         });
 
         // ServerHttp2Stream
-        const serverHttp2Stream: http2.ServerHttp2Stream = <any> {};
+        const serverHttp2Stream: http2.ServerHttp2Stream = {} as any;
         const headers: http2.OutgoingHttpHeaders = {};
 
         serverHttp2Stream.additionalHeaders(headers);
@@ -4146,7 +4146,7 @@ import * as constants from 'constants';
         secureClientSessionOptions.ca = '';
         const onConnectHandler = (session: http2.Http2Session, socket: net.Socket) => {};
 
-        const serverHttp2Session: http2.ServerHttp2Session = <any> {};
+        const serverHttp2Session: http2.ServerHttp2Session = {} as any;
 
         serverHttp2Session.altsvc('', '');
         serverHttp2Session.altsvc('', 0);

--- a/types/node/node-tests.ts
+++ b/types/node/node-tests.ts
@@ -4393,6 +4393,7 @@ import * as constants from 'constants';
 
 {
     {
+        const b: inspector.Console.ConsoleMessage = {source: 'test', text: 'test', level: 'error' };
         inspector.open();
         inspector.open(0);
         inspector.open(0, 'localhost');

--- a/types/node/scripts/generate-inspector/inspector.d.ts.template
+++ b/types/node/scripts/generate-inspector/inspector.d.ts.template
@@ -1,3 +1,4 @@
+// tslint:disable-next-line:dt-header
 // Type definitions for inspector
 
 // These definitions are auto-generated.
@@ -7,10 +8,11 @@
 /**
  * The inspector module provides an API for interacting with the V8 inspector.
  */
+// tslint:disable-next-line:no-single-declare-module
 declare module "inspector" {
     import { EventEmitter } from 'events';
 
-    export interface InspectorNotification<T> {
+    interface InspectorNotification<T> {
         method: string;
         params: T;
     }
@@ -20,24 +22,30 @@ declare module "inspector" {
     /**
      * The inspector.Session is used for dispatching messages to the V8 inspector back-end and receiving message responses and notifications.
      */
-    export class Session extends EventEmitter {
+    class Session extends EventEmitter {
         /**
-         * Create a new instance of the inspector.Session class. The inspector session needs to be connected through session.connect() before the messages can be dispatched to the inspector backend.
+         * Create a new instance of the inspector.Session class.
+         * The inspector session needs to be connected through session.connect() before the messages can be dispatched to the inspector backend.
          */
         constructor();
 
         /**
-         * Connects a session to the inspector back-end. An exception will be thrown if there is already a connected session established either through the API or by a front-end connected to the Inspector WebSocket port.
+         * Connects a session to the inspector back-end.
+         * An exception will be thrown if there is already a connected session established either
+         * through the API or by a front-end connected to the Inspector WebSocket port.
          */
         connect(): void;
 
         /**
-         * Immediately close the session. All pending message callbacks will be called with an error. session.connect() will need to be called to be able to send messages again. Reconnected session will lose all inspector state, such as enabled agents or configured breakpoints.
+         * Immediately close the session. All pending message callbacks will be called with an error.
+         * session.connect() will need to be called to be able to send messages again.
+         * Reconnected session will lose all inspector state, such as enabled agents or configured breakpoints.
          */
         disconnect(): void;
 
         /**
-         * Posts a message to the inspector back-end. callback will be notified when a response is received. callback is a function that accepts two optional arguments - error and message-specific result.
+         * Posts a message to the inspector back-end. callback will be notified when a response is received.
+         * callback is a function that accepts two optional arguments - error and message-specific result.
          */
         post(method: string, params?: {}, callback?: (err: Error | null, params?: {}) => void): void;
         post(method: string, callback?: (err: Error | null, params?: {}) => void): void;
@@ -58,15 +66,15 @@ declare module "inspector" {
      * @param host Host to listen on for inspector connections. Optional, defaults to what was specified on the CLI.
      * @param wait Block until a client has connected. Optional, defaults to false.
      */
-    export function open(port?: number, host?: string, wait?: boolean): void;
+    function open(port?: number, host?: string, wait?: boolean): void;
 
     /**
      * Deactivate the inspector. Blocks until there are no active connections.
      */
-    export function close(): void;
+    function close(): void;
 
     /**
      * Return the URL of the active inspector, or undefined if there is none.
      */
-    export function url(): string;
+    function url(): string;
 }

--- a/types/node/scripts/generate-inspector/utils.ts
+++ b/types/node/scripts/generate-inspector/utils.ts
@@ -7,7 +7,7 @@ import { Documentable, Field, ObjectReference } from "./devtools-protocol-schema
  * arrays.
  * @param inBetween A value to insert between groups of flattened values
  */
-export function flattenArgs<T = string>(inBetween?: T) {
+export function flattenArgs<T = string>(inBetween?: T): (acc: T[], next: T[]) => T[] {
     if (inBetween != null) {
         return (acc: T[], next: T[]) => {
             if (acc.length > 0) {
@@ -47,30 +47,17 @@ export function isObjectReference(t: Field): t is ObjectReference {
  * to populate a comment block.
  * @param documentable A Documentable object.
  */
-export const createDocs = (documentable: Documentable): string[] => {
-    const hasDocs = !!documentable.description ||
-        documentable.deprecated ||
-        documentable.experimental;
+export const createDocs = ({ deprecated, description, experimental }: Documentable): string[] => {
+    const hasDocs = !!description ||
+        deprecated ||
+        experimental;
     return hasDocs ? [
         "/**",
-        documentable.description && ` * ${documentable.description}`,
-        documentable.deprecated && " * @deprecated",
-        documentable.experimental && " * @experimental",
+        ...(description ? description.split(/\r?\n/).map(l => ` * ${l}`) : []),
+        deprecated && " * @deprecated",
+        experimental && " * @experimental",
         " */",
     ].filter(l => l != null) : [];
-};
-
-/**
- * Given a string, prepend a given domain string to it if applicable.
- * @param ref The name of a class within a domain to reference.
- * @param domain The domain string to prepend.
- */
-export const resolveReference = (ref: string, domain?: string): string => {
-    if (!domain || ref.indexOf(".") !== -1) {
-        return ref;
-    } else {
-        return `${domain}.${ref}`;
-    }
 };
 
 /**

--- a/types/node/tsconfig.json
+++ b/types/node/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "files": [
         "index.d.ts",
+        "inspector.d.ts",
         "node-tests.ts"
     ],
     "compilerOptions": {

--- a/types/node/tslint.json
+++ b/types/node/tslint.json
@@ -1,26 +1,9 @@
 {
   "extends": "dtslint/dt.json",
   "rules": {
-    // All are TODOs
     "ban-types": false,
-    "dt-header": false,
-    "max-line-length": false,
-    "no-any-union": false,
-    "no-duplicate-imports": false,
-    "no-duplicate-variable": false,
+    "unified-signatures": false,
     "no-empty-interface": false,
-    "no-inferrable-types": false,
-    "no-internal-module": false,
-    "no-namespace": false,
-    "no-redundant-jsdoc": false,
-    "no-redundant-jsdoc-2": false,
-    "no-unnecessary-class": false,
-    "no-unnecessary-generics": false,
-    "no-unnecessary-qualifier": false,
-    "no-var-keyword": false,
-    "prefer-const": false,
-    "prefer-method-signature": false,
-    "strict-export-declare-modifiers": false,
-    "unified-signatures": false
+    "strict-export-declare-modifiers": false // http2 needs this
   }
 }

--- a/types/oauth/oauth-tests.ts
+++ b/types/oauth/oauth-tests.ts
@@ -44,7 +44,7 @@ http.createServer((req, res) => {
     } else if (pLen === 2 && p[1].indexOf('code') === 0) {
         /** Github sends auth code so that access_token can be obtained */
         /** To obtain and parse code='...' from code?code='...' */
-        const qsObj = <{ code: string }> qs.parse(p[1].split('?')[1]);
+        const qsObj = qs.parse(p[1].split('?')[1]) as { code: string };
 
         /** Obtaining access_token */
         oauth2.getOAuthAccessToken(

--- a/types/oauth/oauth-tests.ts
+++ b/types/oauth/oauth-tests.ts
@@ -44,7 +44,7 @@ http.createServer((req, res) => {
     } else if (pLen === 2 && p[1].indexOf('code') === 0) {
         /** Github sends auth code so that access_token can be obtained */
         /** To obtain and parse code='...' from code?code='...' */
-        const qsObj = qs.parse<{[key: string]: string}>(p[1].split('?')[1]);
+        const qsObj = <{ code: string }> qs.parse(p[1].split('?')[1]);
 
         /** Obtaining access_token */
         oauth2.getOAuthAccessToken(

--- a/types/oauth2orize/index.d.ts
+++ b/types/oauth2orize/index.d.ts
@@ -7,7 +7,7 @@
 /// <reference types="node" />
 /// <reference types="express" />
 
-import { ServerRequest, ServerResponse } from "http";
+import { IncomingMessage, ServerResponse } from "http";
 
 export interface OAuth2 {
   client: any;
@@ -31,7 +31,7 @@ export interface OAuth2Info {
   scope: string;
 }
 
-export interface MiddlewareRequest extends ServerRequest {
+export interface MiddlewareRequest extends IncomingMessage {
   oauth2?: OAuth2;
   user?: any;
 }

--- a/types/twilio/index.d.ts
+++ b/types/twilio/index.d.ts
@@ -51,7 +51,7 @@ declare namespace twilio {
     toPayload(): GrantPayload;
   }
 
-  export interface RequestCallback { (err: any, data: any, response: Http.ClientResponse): void; }
+  export interface RequestCallback { (err: any, data: any, response: Http.IncomingMessage): void; }
 
   export interface RestMethod {
     (callback: RequestCallback): Q.Promise<any>;


### PR DESCRIPTION
I changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: Does not apply
- [ ] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

This applies *most* lint rules, except ones that would introduce too many breaking changes.
The main changes here are:
 - Removal of almost all `export` keywords (http2 is a special case)
 - line lengths (ugh)
 - removals of generic that the linter didn't like, this _might_ cause some issues but ideally shouldn't.
 - All values are not `const` instead of `var`, this might be debatable because some may re-write globals, please advise.

This (for now) includes https://github.com/DefinitelyTyped/DefinitelyTyped/pull/29147