### PR TITLE
[cote] add error argument to responder on callback for cote package 

### DIFF
--- a/types/cote/cote-tests.ts
+++ b/types/cote/cote-tests.ts
@@ -80,10 +80,10 @@ class Readme {
             payload: { val: number };
         }
 
-        randomResponder.on('randomRequest', (req: RandomRequest, callback: (answer: number) => void) => {
+        randomResponder.on('randomRequest', (req: RandomRequest, callback: (error: any, answer?: number) => void) => {
             const answer = Math.floor(Math.random() * 10);
             console.log('request', req.payload.val, 'answering with', answer);
-            callback(answer);
+            callback(null, answer);
         });
     }
 

--- a/types/cote/index.d.ts
+++ b/types/cote/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for cote 0.14
 // Project: https://github.com/dashersw/cote#readme
 // Definitions by: makepost <https://github.com/makepost>
+//                 Labat Robin <https://github.com/roblabat>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 import { EventEmitter2 } from "eventemitter2";
@@ -100,7 +101,7 @@ export class Responder extends Component {
     on<T extends Event>(
         type: string | string[],
         listener: (
-            ((event: T, callback: (result: any) => void) => void) |
+            ((event: T, callback: (error: any, result: any) => void) => void) |
             ((event: T) => Promise<any>)
         )
     ): this;

--- a/types/cote/index.d.ts
+++ b/types/cote/index.d.ts
@@ -283,7 +283,6 @@ export class PendingBalancedRequester extends Requester { }
  */
 export interface Event {
     type: string;
-    [key: string]: any;
 }
 
 /**

--- a/types/cote/index.d.ts
+++ b/types/cote/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for cote 0.14
+// Type definitions for cote 0.17
 // Project: https://github.com/dashersw/cote#readme
 // Definitions by: makepost <https://github.com/makepost>
 //                 Labat Robin <https://github.com/roblabat>

--- a/types/cote/index.d.ts
+++ b/types/cote/index.d.ts
@@ -283,6 +283,7 @@ export class PendingBalancedRequester extends Requester { }
  */
 export interface Event {
     type: string;
+    [key: string]: any;
 }
 
 /**

--- a/types/cote/index.d.ts
+++ b/types/cote/index.d.ts
@@ -4,10 +4,10 @@
 //                 Labat Robin <https://github.com/roblabat>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import { EventEmitter2 } from 'eventemitter2';
-import * as SocketIO from 'socket.io';
-import { Stream } from 'stream';
-import { Server } from 'http';
+import { EventEmitter2 } from "eventemitter2";
+import * as SocketIO from "socket.io";
+import { Stream } from "stream";
+import { Server } from "http";
 
 export abstract class Component extends EventEmitter2 {
     constructor(
@@ -15,6 +15,7 @@ export abstract class Component extends EventEmitter2 {
          * Configuration which controls the data being advertised for auto-discovery.
          */
         advertisement: Advertisement,
+
         /**
          * Controls the network-layer configuration and environments for components.
          */
@@ -33,6 +34,7 @@ export class Requester extends Component {
          * Configuration which controls the data being advertised for auto-discovery.
          */
         advertisement: RequesterAdvertisement,
+
         /**
          * Controls the network-layer configuration and environments for components.
          */
@@ -54,10 +56,7 @@ export class Requester extends Component {
      * @param event Request.
      * @param callback Function to execute after getting a result.
      */
-    send<T extends Event>(
-        event: T,
-        callback: (error: any, result: any) => void
-    ): void;
+    send<T extends Event>(event: T, callback: (error: any, result: any) => void): void;
 }
 
 /**
@@ -76,6 +75,7 @@ export class Responder extends Component {
          * Configuration which controls the data being advertised for auto-discovery.
          */
         advertisement: ResponderAdvertisement,
+
         /**
          * Controls the network-layer configuration and environments for components.
          */
@@ -100,9 +100,10 @@ export class Responder extends Component {
      */
     on<T extends Event>(
         type: string | string[],
-        listener:
-            | ((event: T, callback: (error: any, result: any) => void) => void)
-            | ((event: T) => Promise<any>)
+        listener: (
+            ((event: T, callback: (error: any, result: any) => void) => void) |
+            ((event: T) => Promise<any>)
+        )
     ): this;
 }
 
@@ -122,6 +123,7 @@ export class Publisher extends Component {
          * Configuration which controls the data being advertised for auto-discovery.
          */
         advertisement: PublisherAdvertisement,
+
         /**
          * Controls the network-layer configuration and environments for components.
          */
@@ -135,7 +137,10 @@ export class Publisher extends Component {
      * @param type EventEmitter-compatible type.
      * @param event Request.
      */
-    publish<T extends Event>(type: string, event: T): void;
+    publish<T extends Event>(
+        type: string,
+        event: T
+    ): void;
 }
 
 /**
@@ -154,6 +159,7 @@ export class Subscriber extends Component {
          * Configuration which controls the data being advertised for auto-discovery.
          */
         advertisement: SubscriberAdvertisement,
+
         /**
          * Controls the network-layer configuration and environments for components.
          */
@@ -188,10 +194,12 @@ export class Sockend extends Component {
      */
     constructor(
         io: SocketIO.Server,
+
         /**
          * Configuration which controls the data being advertised for auto-discovery.
          */
         advertisement: SockendAdvertisement,
+
         /**
          * Controls the network-layer configuration and environments for components.
          */
@@ -202,9 +210,7 @@ export class Sockend extends Component {
 /**
  * Configuration which controls the data being advertised for auto-discovery.
  */
-export interface SockendAdvertisement
-    extends ResponderAdvertisement,
-        PublisherAdvertisement {}
+export interface SockendAdvertisement extends ResponderAdvertisement, PublisherAdvertisement { }
 
 export class Monitor extends Component {
     constructor(
@@ -212,12 +218,14 @@ export class Monitor extends Component {
          * Configuration which controls the data being advertised for auto-discovery.
          */
         advertisement: MonitorAdvertisement,
+
         /**
          * Controls the network-layer configuration and environments for components.
          */
         discoveryOptions?: DiscoveryOptions,
+
         stream?: Stream
-    );
+    )
 }
 
 /**
@@ -235,11 +243,9 @@ export interface MonitorAdvertisement extends Advertisement {
  *
  * @param port Open in browser to see network graph in action.
  */
-export function MonitoringTool(
-    port: number
-): {
-    monitor: Monitor;
-    server: Server;
+export function MonitoringTool(port: number): {
+    monitor: Monitor,
+    server: Server
 };
 
 /**
@@ -270,7 +276,7 @@ export class TimeBalancedRequester extends Requester {
  * Keeps track of open, pending requests for each known Responder. Each new
  * request goes to the Responder with the minimum open requests.
  */
-export class PendingBalancedRequester extends Requester {}
+export class PendingBalancedRequester extends Requester { }
 
 /**
  * Event is nothing but object with `type`.
@@ -289,11 +295,11 @@ export interface Status extends Event {
 /**
  * Advertisement in internal `cote:added` and `cote:removed` events.
  */
-export interface StatusAdvertisement
-    extends RequesterAdvertisement,
-        ResponderAdvertisement,
-        PublisherAdvertisement,
-        SubscriberAdvertisement {}
+export interface StatusAdvertisement extends
+    RequesterAdvertisement,
+    ResponderAdvertisement,
+    PublisherAdvertisement,
+    SubscriberAdvertisement { }
 
 /**
  * Configuration which controls the data being advertised for auto-discovery.

--- a/types/cote/index.d.ts
+++ b/types/cote/index.d.ts
@@ -4,10 +4,10 @@
 //                 Labat Robin <https://github.com/roblabat>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import { EventEmitter2 } from "eventemitter2";
-import * as SocketIO from "socket.io";
-import { Stream } from "stream";
-import { Server } from "http";
+import { EventEmitter2 } from 'eventemitter2';
+import * as SocketIO from 'socket.io';
+import { Stream } from 'stream';
+import { Server } from 'http';
 
 export abstract class Component extends EventEmitter2 {
     constructor(
@@ -15,7 +15,6 @@ export abstract class Component extends EventEmitter2 {
          * Configuration which controls the data being advertised for auto-discovery.
          */
         advertisement: Advertisement,
-
         /**
          * Controls the network-layer configuration and environments for components.
          */
@@ -34,7 +33,6 @@ export class Requester extends Component {
          * Configuration which controls the data being advertised for auto-discovery.
          */
         advertisement: RequesterAdvertisement,
-
         /**
          * Controls the network-layer configuration and environments for components.
          */
@@ -56,7 +54,10 @@ export class Requester extends Component {
      * @param event Request.
      * @param callback Function to execute after getting a result.
      */
-    send<T extends Event>(event: T, callback: (result: any) => void): void;
+    send<T extends Event>(
+        event: T,
+        callback: (error: any, result: any) => void
+    ): void;
 }
 
 /**
@@ -75,7 +76,6 @@ export class Responder extends Component {
          * Configuration which controls the data being advertised for auto-discovery.
          */
         advertisement: ResponderAdvertisement,
-
         /**
          * Controls the network-layer configuration and environments for components.
          */
@@ -100,10 +100,9 @@ export class Responder extends Component {
      */
     on<T extends Event>(
         type: string | string[],
-        listener: (
-            ((event: T, callback: (error: any, result: any) => void) => void) |
-            ((event: T) => Promise<any>)
-        )
+        listener:
+            | ((event: T, callback: (error: any, result: any) => void) => void)
+            | ((event: T) => Promise<any>)
     ): this;
 }
 
@@ -123,7 +122,6 @@ export class Publisher extends Component {
          * Configuration which controls the data being advertised for auto-discovery.
          */
         advertisement: PublisherAdvertisement,
-
         /**
          * Controls the network-layer configuration and environments for components.
          */
@@ -137,10 +135,7 @@ export class Publisher extends Component {
      * @param type EventEmitter-compatible type.
      * @param event Request.
      */
-    publish<T extends Event>(
-        type: string,
-        event: T
-    ): void;
+    publish<T extends Event>(type: string, event: T): void;
 }
 
 /**
@@ -159,7 +154,6 @@ export class Subscriber extends Component {
          * Configuration which controls the data being advertised for auto-discovery.
          */
         advertisement: SubscriberAdvertisement,
-
         /**
          * Controls the network-layer configuration and environments for components.
          */
@@ -194,12 +188,10 @@ export class Sockend extends Component {
      */
     constructor(
         io: SocketIO.Server,
-
         /**
          * Configuration which controls the data being advertised for auto-discovery.
          */
         advertisement: SockendAdvertisement,
-
         /**
          * Controls the network-layer configuration and environments for components.
          */
@@ -210,7 +202,9 @@ export class Sockend extends Component {
 /**
  * Configuration which controls the data being advertised for auto-discovery.
  */
-export interface SockendAdvertisement extends ResponderAdvertisement, PublisherAdvertisement { }
+export interface SockendAdvertisement
+    extends ResponderAdvertisement,
+        PublisherAdvertisement {}
 
 export class Monitor extends Component {
     constructor(
@@ -218,14 +212,12 @@ export class Monitor extends Component {
          * Configuration which controls the data being advertised for auto-discovery.
          */
         advertisement: MonitorAdvertisement,
-
         /**
          * Controls the network-layer configuration and environments for components.
          */
         discoveryOptions?: DiscoveryOptions,
-
         stream?: Stream
-    )
+    );
 }
 
 /**
@@ -243,9 +235,11 @@ export interface MonitorAdvertisement extends Advertisement {
  *
  * @param port Open in browser to see network graph in action.
  */
-export function MonitoringTool(port: number): {
-    monitor: Monitor,
-    server: Server
+export function MonitoringTool(
+    port: number
+): {
+    monitor: Monitor;
+    server: Server;
 };
 
 /**
@@ -276,7 +270,7 @@ export class TimeBalancedRequester extends Requester {
  * Keeps track of open, pending requests for each known Responder. Each new
  * request goes to the Responder with the minimum open requests.
  */
-export class PendingBalancedRequester extends Requester { }
+export class PendingBalancedRequester extends Requester {}
 
 /**
  * Event is nothing but object with `type`.
@@ -295,11 +289,11 @@ export interface Status extends Event {
 /**
  * Advertisement in internal `cote:added` and `cote:removed` events.
  */
-export interface StatusAdvertisement extends
-    RequesterAdvertisement,
-    ResponderAdvertisement,
-    PublisherAdvertisement,
-    SubscriberAdvertisement { }
+export interface StatusAdvertisement
+    extends RequesterAdvertisement,
+        ResponderAdvertisement,
+        PublisherAdvertisement,
+        SubscriberAdvertisement {}
 
 /**
  * Configuration which controls the data being advertised for auto-discovery.


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.


This PR add typings for the error argument on the Responder.on callback as it is used in this workshop from the author https://github.com/dashersw/cote-workshop.

It seem's seems the documentation of this package is not up to date on this point. 
