### PR TITLE
[standard-error][standard-http-error] add typings for standard-error and standard-http-error packages

### DIFF
--- a/types/standard-error/index.d.ts
+++ b/types/standard-error/index.d.ts
@@ -1,0 +1,21 @@
+// Type definitions for standard-error 1.1
+// Project: https://github.com/moll/js-standard-error
+// Definitions by: Labat Robin <https://github.com/roblabat>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare module 'standard-error' {
+    const StandardError: StandardError.constructor;
+
+    namespace StandardError {
+        interface constructor {
+            new (message: string, props?: object): error;
+            new (props: object): error;
+        }
+
+        interface error extends Error {
+            [key: string]: any;
+        }
+    }
+
+    export = StandardError;
+}

--- a/types/standard-error/index.d.ts
+++ b/types/standard-error/index.d.ts
@@ -3,19 +3,13 @@
 // Definitions by: Labat Robin <https://github.com/roblabat>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare module 'standard-error' {
-    const StandardError: StandardError.constructor;
+// TypeScript Version: 2.2
 
-    namespace StandardError {
-        interface constructor {
-            new (message: string, props?: object): error;
-            new (props: object): error;
-        }
+export = StandardError;
 
-        interface error extends Error {
-            [key: string]: any;
-        }
-    }
+declare class StandardError extends Error {
+    [key: string]: any;
 
-    export = StandardError;
+    constructor(message: string, props?: any);
+    constructor(props: any);
 }

--- a/types/standard-error/standard-error-tests.ts
+++ b/types/standard-error/standard-error-tests.ts
@@ -1,13 +1,13 @@
-import * as StandardError from 'standard-error';
+import StandardError = require('standard-error');
 
-let error = new StandardError('test'); //$ExpectType StandardError.error
+let error = new StandardError('test'); // $ExpectType StandardError
 
-error.message; //$ExpectType string
-error.name; //$ExpectType string
-error.stack; //$ExpectType string
+error.message; // $ExpectType string
+error.name; // $ExpectType string
+error.stack; // $ExpectType string | undefined
 
-error = new StandardError({ name: 'test', foo: 'bar' }); //$ExpectType StandardError.error
+error = new StandardError({ name: 'test', foo: 'bar' }); // $ExpectType StandardError
 
-error.foo; //$ExpectType any
+error.foo; // $ExpectType any
 
-error = new StandardError('test', { foo: 'bar' }); //$ExpectType StandardError.error
+error = new StandardError('test', { foo: 'bar' }); // $ExpectType StandardError

--- a/types/standard-error/standard-error-tests.ts
+++ b/types/standard-error/standard-error-tests.ts
@@ -1,0 +1,13 @@
+import * as StandardError from 'standard-error';
+
+let error = new StandardError('test'); //$ExpectType StandardError.error
+
+error.message; //$ExpectType string
+error.name; //$ExpectType string
+error.stack; //$ExpectType string
+
+error = new StandardError({ name: 'test', foo: 'bar' }); //$ExpectType StandardError.error
+
+error.foo; //$ExpectType any
+
+error = new StandardError('test', { foo: 'bar' }); //$ExpectType StandardError.error

--- a/types/standard-error/tsconfig.json
+++ b/types/standard-error/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": ["index.d.ts", "standard-error-tests.ts"]
+}

--- a/types/standard-error/tsconfig.json
+++ b/types/standard-error/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "standard-error-tests.ts"
+    ]
+}

--- a/types/standard-error/tslint.json
+++ b/types/standard-error/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/standard-http-error/index.d.ts
+++ b/types/standard-http-error/index.d.ts
@@ -3,24 +3,15 @@
 // Definitions by: Labat Robin <https://github.com/roblabat>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-/// <reference types="standard-error" />
+// TypeScript Version: 2.2
 
-declare module 'standard-http-error' {
-    import * as StandardError from 'standard-error';
+import StandardError = require('standard-error');
 
-    const HttpError: HttpError.constructor;
+export = HttpError;
 
-    namespace HttpError {
-        interface constructor {
-            new (code: number | string, message?: string, props?: object): error;
-            new (code: number | string, props?: object): error;
-            [key: string]: number | undefined;
-        }
+declare class HttpError extends StandardError {
+    code: number;
 
-        interface error extends StandardError.error {
-            code: number;
-        }
-    }
-
-    export = HttpError;
+    constructor(code: number | string, message?: string, props?: object);
+    constructor(code: number | string, props?: object);
 }

--- a/types/standard-http-error/index.d.ts
+++ b/types/standard-http-error/index.d.ts
@@ -1,0 +1,26 @@
+// Type definitions for standard-http-error 2.0
+// Project: https://github.com/moll/js-standard-http-error
+// Definitions by: Labat Robin <https://github.com/roblabat>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types="standard-error" />
+
+declare module 'standard-http-error' {
+    import * as StandardError from 'standard-error';
+
+    const HttpError: HttpError.constructor;
+
+    namespace HttpError {
+        interface constructor {
+            new (code: number | string, message?: string, props?: object): error;
+            new (code: number | string, props?: object): error;
+            [key: string]: number | undefined;
+        }
+
+        interface error extends StandardError.error {
+            code: number;
+        }
+    }
+
+    export = HttpError;
+}

--- a/types/standard-http-error/standard-http-error-tests.ts
+++ b/types/standard-http-error/standard-http-error-tests.ts
@@ -1,16 +1,16 @@
-import * as HttpError from 'standard-http-error';
+import HttpError = require('standard-http-error');
 
-let error = new HttpError(200); //$ExpectType HttpError.error
+let error = new HttpError(200); // $ExpectType HttpError
 
-error.code; //$ExpectType number
-error.message; //$ExpectType string
-error.name; //$ExpectType string
-error.stack; //$ExpectType string
+error.code; // $ExpectType number
+error.message; // $ExpectType string
+error.name; // $ExpectType string
+error.stack; // $ExpectType string | undefined
 
-error = new HttpError(200, 'test'); //$ExpectType HttpError.error
-error = new HttpError('OK', 'test'); //$ExpectType HttpError.error
-error = new HttpError(200, 'test', { foo: 'bar' }); //$ExpectType HttpError.error
+error = new HttpError(200, 'test'); // $ExpectType HttpError
+error = new HttpError('OK', 'test'); // $ExpectType HttpError
+error = new HttpError(200, 'test', { foo: 'bar' }); // $ExpectType HttpError
 
-error.foo; //$ExpectType any
+error.foo; // $ExpectType any
 
-error = new HttpError(200, { message: 'test', foo: 'bar' }); //$ExpectType HttpError.error
+error = new HttpError(200, { message: 'test', foo: 'bar' }); // $ExpectType HttpError

--- a/types/standard-http-error/standard-http-error-tests.ts
+++ b/types/standard-http-error/standard-http-error-tests.ts
@@ -1,0 +1,16 @@
+import * as HttpError from 'standard-http-error';
+
+let error = new HttpError(200); //$ExpectType HttpError.error
+
+error.code; //$ExpectType number
+error.message; //$ExpectType string
+error.name; //$ExpectType string
+error.stack; //$ExpectType string
+
+error = new HttpError(200, 'test'); //$ExpectType HttpError.error
+error = new HttpError('OK', 'test'); //$ExpectType HttpError.error
+error = new HttpError(200, 'test', { foo: 'bar' }); //$ExpectType HttpError.error
+
+error.foo; //$ExpectType any
+
+error = new HttpError(200, { message: 'test', foo: 'bar' }); //$ExpectType HttpError.error

--- a/types/standard-http-error/tsconfig.json
+++ b/types/standard-http-error/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": ["index.d.ts", "standard-http-error-tests.ts"]
+}

--- a/types/standard-http-error/tslint.json
+++ b/types/standard-http-error/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
