### PR TITLE
[file-url] Allow including via `import` syntax

### DIFF
--- a/types/file-url/index.d.ts
+++ b/types/file-url/index.d.ts
@@ -27,6 +27,8 @@ interface FileUrlOptions {
  */
 declare function fileUrl(path: string, options?: FileUrlOptions): string;
 
+declare namespace fileUrl { }
+
 /**
  * Convert a path to a file URL.
  */


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

This change prevents TypeScript from complaining about `file-url` resolving to a non-module entity when including via `import * as fileUrl from 'fileUrl'`, similar to how [`@types/strip-json-comments`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/strip-json-comments/index.d.ts) works.

Verified fix by editing my local `node_modules/@types/file-url/index.d.ts`
