### PR TITLE
Fix/@types/fastify-jwt typings

### DIFF
--- a/types/fastify-jwt/fastify-jwt-tests.ts
+++ b/types/fastify-jwt/fastify-jwt-tests.ts
@@ -1,5 +1,5 @@
 import { IncomingMessage, Server, ServerResponse } from "http";
-import { FastifyInstance, FastifyReply, FastifyRequest } from "fastify-jwt";
+import { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 
 const fastify: FastifyInstance<Server, IncomingMessage, ServerResponse> = {
   jwt: {

--- a/types/fastify-jwt/fastify-jwt-tests.ts
+++ b/types/fastify-jwt/fastify-jwt-tests.ts
@@ -1,34 +1,35 @@
 import { IncomingMessage, Server, ServerResponse } from "http";
-import { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
+import fastifyJwt = require("fastify-jwt");
+import fastify = require("fastify");
 
-const fastify: FastifyInstance<Server, IncomingMessage, ServerResponse> = {
-  jwt: {
-    decode: (token, options) => {
-      return token;
-    },
-    secret: "some-string",
-    sign: (payload, options) => {
-      return JSON.stringify(payload);
-    },
-    verify: (token, options) => {
-      return token;
-    },
-  },
-};
+const app = fastify();
 
-const req: FastifyRequest<IncomingMessage> = {
-  jwtVerify: (_options) => {
-    return req;
-  },
-};
+app.register<fastifyJwt.FastifyJwtOptions>(fastifyJwt, {
+  secret: "super-secret"
+});
 
-const res: FastifyReply<ServerResponse> = {
-  jwtSign: (_payload, _options, _next) => {
-    return res;
-  },
-};
+app.register<fastifyJwt.FastifyJwtOptions>(fastifyJwt, {
+  secret: (request, reply, callback) => {
+    return "";
+  }
+});
 
-fastify.jwt.sign({ a: "b" }, {}, (err, token) => {
+app.get("/path", (request, reply) => {
+  request.jwtVerify();
+  request.jwtVerify({});
+  request.jwtVerify({}, () => "string");
+  request.jwtVerify(() => "string", () => "string");
+
+  reply.jwtSign("payload");
+  reply.jwtSign("payload", {});
+  reply.jwtSign("payload", {}, () => "string");
+  reply.jwtSign({ a: "b" }, {}, () => "string");
+  reply.jwtSign([], {}, () => "string");
+  reply.jwtSign(new Buffer("buffer"), {}, () => "string");
+  reply.jwtSign("payload", () => "string", () => "string");
+});
+
+app.jwt.sign({ a: "b" }, {}, (err, token) => {
   if (err) {
     throw err;
   }
@@ -36,7 +37,7 @@ fastify.jwt.sign({ a: "b" }, {}, (err, token) => {
   return token;
 });
 
-fastify.jwt.sign("string", { algorithm: "some-algorithm" }, (err, token) => {
+app.jwt.sign("string", { algorithm: "some-algorithm" }, (err, token) => {
   if (err) {
     throw err;
   }
@@ -44,7 +45,7 @@ fastify.jwt.sign("string", { algorithm: "some-algorithm" }, (err, token) => {
   return token;
 });
 
-fastify.jwt.sign([], {}, (err, token) => {
+app.jwt.sign([], {}, (err, token) => {
   if (err) {
     throw err;
   }
@@ -52,7 +53,7 @@ fastify.jwt.sign([], {}, (err, token) => {
   return token;
 });
 
-fastify.jwt.sign(9999, {}, (err, token) => {
+app.jwt.sign(new Buffer("buffer"), {}, (err, token) => {
   if (err) {
     throw err;
   }
@@ -60,26 +61,13 @@ fastify.jwt.sign(9999, {}, (err, token) => {
   return token;
 });
 
-fastify.jwt.decode("some-token");
-fastify.jwt.decode("some-token");
-fastify.jwt.secret = "some-secret";
-fastify.jwt.verify("some-token", {}, (err) => {
+app.jwt.decode("some-token");
+app.jwt.decode("some-token");
+app.jwt.secret = "some-secret";
+app.jwt.verify("some-token", {}, (err) => {
   if (err) {
     throw err;
   }
 
   return true;
 });
-
-req.jwtVerify();
-req.jwtVerify({});
-req.jwtVerify({}, () => "string");
-req.jwtVerify(() => "string", () => "string");
-
-res.jwtSign("payload");
-res.jwtSign("payload", {});
-res.jwtSign("payload", {}, () => "string");
-res.jwtSign({ a: "b" }, {}, () => "string");
-res.jwtSign([], {}, () => "string");
-res.jwtSign(9999, {}, () => "string");
-res.jwtSign("payload", () => "string", () => "string");

--- a/types/fastify-jwt/index.d.ts
+++ b/types/fastify-jwt/index.d.ts
@@ -22,14 +22,10 @@ declare module "fastify" {
     (token: string, options?: VerifyOptions): object | string;
   }
 
-  interface DecodeFunction {
-    (token: string, options?: DecodeOptions): null | { [key: string]: any } | string;
-  }
-
   interface jwt {
       sign: SignFunction;
       verify: VerifyFunction;
-      decode: DecodeFunction;
+      decode(token: string, options?: DecodeOptions): null | { [key: string]: any } | string;
       secret: Secret;
   }
   

--- a/types/fastify-jwt/index.d.ts
+++ b/types/fastify-jwt/index.d.ts
@@ -11,11 +11,25 @@ declare module "fastify" {
   interface FastifyInstance<HttpServer, HttpRequest, HttpResponse> {
       jwt: jwt;
   }
-  
+
+  interface SignFunction {
+    (payload: any, options?: SignOptions): string;
+    (payload: any, options?: SignOptions, callback?: SignCallback): void;
+  }
+
+  interface VerifyFunction {
+    (token: string, options?: VerifyOptions, callback?: VerifyCallback): void;
+    (token: string, options?: VerifyOptions): object | string;
+  }
+
+  interface DecodeFunction {
+    (token: string, options?: DecodeOptions): null | { [key: string]: any } | string;
+  }
+
   interface jwt {
-      sign: (payload: any, options?: SignOptions, callback?: SignCallback) => void;
-      verify: (token: string, options?: VerifyOptions, callback?: VerifyCallback) => void;
-      decode: (token: string, options?: DecodeOptions) => null | { [key: string]: any } | string;
+      sign: SignFunction;
+      verify: VerifyFunction;
+      decode: DecodeFunction;
       secret: Secret;
   }
   

--- a/types/fastify-jwt/index.d.ts
+++ b/types/fastify-jwt/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for fastify-jwt 0.4
 // Project: https://github.com/fastify/fastify-jwt#readme
-// Definitions by: My Self <https://github.com/jannikkeye>
+// Definitions by: Jannik Keye <https://github.com/jannikkeye>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 import fastify = require("fastify");

--- a/types/fastify-jwt/index.d.ts
+++ b/types/fastify-jwt/index.d.ts
@@ -2,10 +2,11 @@
 // Project: https://github.com/fastify/fastify-jwt#readme
 // Definitions by: Jannik Keye <https://github.com/jannikkeye>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.4
 import fastify = require("fastify");
 
 import { Secret, SignOptions, VerifyOptions, VerifyCallback, SignCallback, DecodeOptions } from 'jsonwebtoken';
+import { IncomingMessage, ServerResponse } from 'http';
 
 declare module "fastify" {
   interface FastifyInstance<HttpServer, HttpRequest, HttpResponse> {
@@ -13,8 +14,8 @@ declare module "fastify" {
   }
 
   interface SignFunction {
-    (payload: any, options?: SignOptions): string;
-    (payload: any, options?: SignOptions, callback?: SignCallback): void;
+    (payload: string | Buffer | object, options?: SignOptions): string;
+    (payload: string | Buffer | object, options?: SignOptions, callback?: SignCallback): void;
   }
 
   interface VerifyFunction {
@@ -28,18 +29,24 @@ declare module "fastify" {
       decode(token: string, options?: DecodeOptions): null | { [key: string]: any } | string;
       secret: Secret;
   }
-  
+
   interface FastifyRequest<HttpRequest> {
       jwtVerify: (options?: VerifyOptions | VerifyCallback, next?: VerifyCallback) => Promise<null | { [key: string]: any } | string> | null | { [key: string]: any } | string;
   }
-  
+
   interface FastifyReply<HttpResponse> {
-      jwtSign: (payload: any, options?: SignOptions | SignCallback, next?: SignCallback) => void;
+      jwtSign: (payload: string | Buffer | object, options?: SignOptions | SignCallback, next?: SignCallback) => void;
   }
 }
 
-declare function fastifyJwt (): void;
+declare function fastifyJwt(): void;
 
-declare namespace fastifyJwt {}
+declare namespace fastifyJwt {
+    type SecretCallback = (request: fastify.FastifyRequest<IncomingMessage>, reply: string | Buffer | object, callback?: VerifyCallback | SignCallback) => void;
+
+    interface FastifyJwtOptions {
+        secret: string | SecretCallback;
+    }
+}
 
 export = fastifyJwt;

--- a/types/fastify-jwt/index.d.ts
+++ b/types/fastify-jwt/index.d.ts
@@ -3,24 +3,33 @@
 // Definitions by: My Self <https://github.com/jannikkeye>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
+import fastify = require("fastify");
 
 import { Secret, SignOptions, VerifyOptions, VerifyCallback, SignCallback, DecodeOptions } from 'jsonwebtoken';
 
-export interface FastifyInstance<HttpServer, HttpRequest, HttpResponse> {
-    jwt: jwt;
+declare module "fastify" {
+  interface FastifyInstance<HttpServer, HttpRequest, HttpResponse> {
+      jwt: jwt;
+  }
+  
+  interface jwt {
+      sign: (payload: any, options?: SignOptions, callback?: SignCallback) => void;
+      verify: (token: string, options?: VerifyOptions, callback?: VerifyCallback) => void;
+      decode: (token: string, options?: DecodeOptions) => null | { [key: string]: any } | string;
+      secret: Secret;
+  }
+  
+  interface FastifyRequest<HttpRequest> {
+      jwtVerify: (options?: VerifyOptions | VerifyCallback, next?: VerifyCallback) => Promise<null | { [key: string]: any } | string> | null | { [key: string]: any } | string;
+  }
+  
+  interface FastifyReply<HttpResponse> {
+      jwtSign: (payload: any, options?: SignOptions | SignCallback, next?: SignCallback) => void;
+  }
 }
 
-export interface jwt {
-    sign: (payload: any, options?: SignOptions, callback?: SignCallback) => void;
-    verify: (token: string, options?: VerifyOptions, callback?: VerifyCallback) => void;
-    decode: (token: string, options?: DecodeOptions) => null | { [key: string]: any } | string;
-    secret: Secret;
-}
+declare function fastifyJwt (): void;
 
-export interface FastifyRequest<HttpRequest> {
-    jwtVerify: (options?: VerifyOptions | VerifyCallback, next?: VerifyCallback) => Promise<null | { [key: string]: any } | string> | null | { [key: string]: any } | string;
-}
+declare namespace fastifyJwt {}
 
-export interface FastifyReply<HttpResponse> {
-    jwtSign: (payload: any, options?: SignOptions | SignCallback, next?: SignCallback) => void;
-}
+export = fastifyJwt;

--- a/types/fastify-jwt/package.json
+++ b/types/fastify-jwt/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "fastify": "^1.11.2"
+    }
+}


### PR DESCRIPTION
I am fixing the typings I added for fastify-jwt a few days ago. They now work with the existing fastify typings which I added to the whitelist of types-publisher. From now on, future plugin types can be written by anyone.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.