### PR TITLE
[webpack] expose rootContext on loader's context

### DIFF
--- a/types/webpack/index.d.ts
+++ b/types/webpack/index.d.ts
@@ -1579,6 +1579,12 @@ declare namespace webpack {
             context: string;
 
             /**
+             * Absolute path to the context of the entire compilation.
+             * @since v4.0.0
+             */
+            rootContext: string;
+
+            /**
              * The resolved request string.
              * In the example: "/abc/loader1.js?xyz!/abc/node_modules/loader2/index.js!/abc/resource.js?rrr"
              */

--- a/types/webpack/webpack-tests.ts
+++ b/types/webpack/webpack-tests.ts
@@ -545,6 +545,8 @@ configuration = {
 };
 
 function loader(this: webpack.loader.LoaderContext, source: string | Buffer, sourcemap?: RawSourceMap): void {
+    const rootContext: string = this.rootContext;
+
     this.cacheable();
 
     this.async();


### PR DESCRIPTION
checked runtime behavior and it's always defined (even if user didn't provide "context" in his webpack configuration)

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://webpack.js.org/api/loaders/#this-rootcontext
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.