### PR TITLE
Adds alternative client side collection to meteor-publish-composite

### DIFF
--- a/types/meteor-publish-composite/index.d.ts
+++ b/types/meteor-publish-composite/index.d.ts
@@ -8,7 +8,7 @@
 /// <reference types="meteor" />
 
 declare interface PublishCompositeConfigN {
-    collection?: string;
+    collectionName?: string;
     children?: PublishCompositeConfigN[];
     find(
         ...args: any[]
@@ -16,7 +16,7 @@ declare interface PublishCompositeConfigN {
 }
 
 declare interface PublishCompositeConfig4<InLevel1, InLevel2, InLevel3, InLevel4, OutLevel> {
-    collection?: string;
+    collectionName?: string;
     children?: PublishCompositeConfigN[];
     find(
         arg4: InLevel4,
@@ -27,7 +27,7 @@ declare interface PublishCompositeConfig4<InLevel1, InLevel2, InLevel3, InLevel4
 }
 
 declare interface PublishCompositeConfig3<InLevel1, InLevel2, InLevel3, OutLevel> {
-    collection?: string;
+    collectionName?: string;
     children?: PublishCompositeConfig4<InLevel1, InLevel2, InLevel3, OutLevel, any>[];
     find(
         arg3: InLevel3,
@@ -37,7 +37,7 @@ declare interface PublishCompositeConfig3<InLevel1, InLevel2, InLevel3, OutLevel
 }
 
 declare interface PublishCompositeConfig2<InLevel1, InLevel2, OutLevel> {
-    collection?: string;
+    collectionName?: string;
     children?: PublishCompositeConfig3<InLevel1, InLevel2, OutLevel, any>[];
     find(
         arg2: InLevel2,
@@ -46,7 +46,7 @@ declare interface PublishCompositeConfig2<InLevel1, InLevel2, OutLevel> {
 }
 
 declare interface PublishCompositeConfig1<InLevel1, OutLevel> {
-    collection?: string;
+    collectionName?: string;
     children?: PublishCompositeConfig2<InLevel1, OutLevel, any>[];
     find(
         arg1: InLevel1
@@ -54,7 +54,7 @@ declare interface PublishCompositeConfig1<InLevel1, OutLevel> {
 }
 
 declare interface PublishCompositeConfig<OutLevel> {
-    collection?: string;
+    collectionName?: string;
     children?: PublishCompositeConfig1<OutLevel, any>[];
     find(): Mongo.Cursor<OutLevel>;
 }

--- a/types/meteor-publish-composite/index.d.ts
+++ b/types/meteor-publish-composite/index.d.ts
@@ -1,12 +1,14 @@
 // Type definitions for meteor-publish-composite
 // Project: https://github.com/englue/meteor-publish-composite
 // Definitions by: Robert Van Gorkom <https://github.com/vangorra>
+//                 Matthew Zartman <https://github.com/mrz5018>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
 /// <reference types="meteor" />
 
 declare interface PublishCompositeConfigN {
+    collection?: string;
     children?: PublishCompositeConfigN[];
     find(
         ...args: any[]
@@ -14,6 +16,7 @@ declare interface PublishCompositeConfigN {
 }
 
 declare interface PublishCompositeConfig4<InLevel1, InLevel2, InLevel3, InLevel4, OutLevel> {
+    collection?: string;
     children?: PublishCompositeConfigN[];
     find(
         arg4: InLevel4,
@@ -24,6 +27,7 @@ declare interface PublishCompositeConfig4<InLevel1, InLevel2, InLevel3, InLevel4
 }
 
 declare interface PublishCompositeConfig3<InLevel1, InLevel2, InLevel3, OutLevel> {
+    collection?: string;
     children?: PublishCompositeConfig4<InLevel1, InLevel2, InLevel3, OutLevel, any>[];
     find(
         arg3: InLevel3,
@@ -33,6 +37,7 @@ declare interface PublishCompositeConfig3<InLevel1, InLevel2, InLevel3, OutLevel
 }
 
 declare interface PublishCompositeConfig2<InLevel1, InLevel2, OutLevel> {
+    collection?: string;
     children?: PublishCompositeConfig3<InLevel1, InLevel2, OutLevel, any>[];
     find(
         arg2: InLevel2,
@@ -41,6 +46,7 @@ declare interface PublishCompositeConfig2<InLevel1, InLevel2, OutLevel> {
 }
 
 declare interface PublishCompositeConfig1<InLevel1, OutLevel> {
+    collection?: string;
     children?: PublishCompositeConfig2<InLevel1, OutLevel, any>[];
     find(
         arg1: InLevel1
@@ -48,6 +54,7 @@ declare interface PublishCompositeConfig1<InLevel1, OutLevel> {
 }
 
 declare interface PublishCompositeConfig<OutLevel> {
+    collection?: string;
     children?: PublishCompositeConfig1<OutLevel, any>[];
     find(): Mongo.Cursor<OutLevel>;
 }

--- a/types/meteor-publish-composite/meteor-publish-composite-tests.ts
+++ b/types/meteor-publish-composite/meteor-publish-composite-tests.ts
@@ -56,7 +56,7 @@ publishComposite('postsByUser', function(userId, limit) {
 						{
 								// Set a collection for an "alternative client side collections" as shown
 								// here: http://braindump.io/meteor/2014/09/20/publishing-to-an-alternative-clientside-collection-in-meteor.html
-								collection: 'user-post-comments',
+								collectionName: 'user-post-comments',
 								find: function(post) {
 										// Find all comments from these posts too
 										return Comments.find( { postId: post._id } );

--- a/types/meteor-publish-composite/meteor-publish-composite-tests.ts
+++ b/types/meteor-publish-composite/meteor-publish-composite-tests.ts
@@ -52,8 +52,16 @@ publishComposite('postsByUser', function(userId, limit) {
             // being used in query.
             return Posts.find({ authorId: userId }, { limit: limit });
         },
-        children: [
-            // This section will be similar to that of the previous example.
+        children: [ 
+						{
+								// Set a collection for an "alternative client side collections" as shown
+								// here: http://braindump.io/meteor/2014/09/20/publishing-to-an-alternative-clientside-collection-in-meteor.html
+								collection: 'user-post-comments',
+								find: function(post) {
+										// Find all comments from these posts too
+										return Comments.find( { postId: post._id } );
+								}
+						},
         ]
     }
 });


### PR DESCRIPTION
The library has the ability to create a name for a collection that the entire publication (or only a portion)
"belongs to" on the client side.  It is described in greater details on the meteor-publish-composite
post here:

http://braindump.io/meteor/2014/09/20/publishing-to-an-alternative-clientside-collection-in-meteor.html

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://braindump.io/meteor/2014/09/20/publishing-to-an-alternative-clientside-collection-in-meteor.html
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
