### PR TITLE
node: Export Http2ServerRequest and Http2ServerResponse as class

### DIFF
--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -7680,7 +7680,8 @@ declare module "http2" {
         prependOnceListener(event: "unknownProtocol", listener: (socket: tls.TLSSocket) => void): this;
     }
 
-    export interface Http2ServerRequest extends stream.Readable {
+    export class Http2ServerRequest extends stream.Readable {
+        private constructor();
         headers: IncomingHttpHeaders;
         httpVersion: string;
         method: string;
@@ -7711,7 +7712,8 @@ declare module "http2" {
         prependOnceListener(event: "aborted", listener: (hadError: boolean, code: number) => void): this;
     }
 
-    export interface Http2ServerResponse extends events.EventEmitter {
+    export class Http2ServerResponse extends events.EventEmitter {
+        private constructor();
         addTrailers(trailers: OutgoingHttpHeaders): void;
         connection: net.Socket | tls.TLSSocket;
         end(callback?: () => void): void;

--- a/types/node/v8/index.d.ts
+++ b/types/node/v8/index.d.ts
@@ -6783,7 +6783,8 @@ declare module "http2" {
         prependOnceListener(event: "unknownProtocol", listener: (socket: tls.TLSSocket) => void): this;
     }
 
-    export interface Http2ServerRequest extends stream.Readable {
+    export class Http2ServerRequest extends stream.Readable {
+        private constructor();
         headers: IncomingHttpHeaders;
         httpVersion: string;
         method: string;
@@ -6814,7 +6815,8 @@ declare module "http2" {
         prependOnceListener(event: "aborted", listener: (hadError: boolean, code: number) => void): this;
     }
 
-    export interface Http2ServerResponse extends events.EventEmitter {
+    export class Http2ServerResponse extends events.EventEmitter {
+        private constructor();
         addTrailers(trailers: OutgoingHttpHeaders): void;
         connection: net.Socket | tls.TLSSocket;
         end(callback?: () => void): void;

--- a/types/node/v9/index.d.ts
+++ b/types/node/v9/index.d.ts
@@ -6873,7 +6873,8 @@ declare module "http2" {
         prependOnceListener(event: "unknownProtocol", listener: (socket: tls.TLSSocket) => void): this;
     }
 
-    export interface Http2ServerRequest extends stream.Readable {
+    export class Http2ServerRequest extends stream.Readable {
+        private constructor();
         headers: IncomingHttpHeaders;
         httpVersion: string;
         method: string;
@@ -6904,7 +6905,8 @@ declare module "http2" {
         prependOnceListener(event: "aborted", listener: (hadError: boolean, code: number) => void): this;
     }
 
-    export interface Http2ServerResponse extends events.EventEmitter {
+    export class Http2ServerResponse extends events.EventEmitter {
+        private constructor();
         addTrailers(trailers: OutgoingHttpHeaders): void;
         connection: net.Socket | tls.TLSSocket;
         end(callback?: () => void): void;


### PR DESCRIPTION
I'm basically refiling #26048 now that #26063 is merged.

----

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

> Sorry but `npm run lint package-name` gives me:
> 
> ```
> > definitely-typed@0.0.3 lint /data/notiflex/gits/DefinitelyTyped-wonderpush
> > dtslint types "node"
> 
> Error: Since this type definition includes a header (a comment starting with `// Type definitions for`), assumed this was a DefinitelyTyped package.
> But it is not in a `DefinitelyTyped/types/xxx` directory.
>     at assertPathIsInDefinitelyTyped (/data/notiflex/gits/DefinitelyTyped-wonderpush/node_modules/dtslint/bin/index.js:112:15)
>     at /data/notiflex/gits/DefinitelyTyped-wonderpush/node_modules/dtslint/bin/index.js:93:13
>     at Generator.next (<anonymous>)
>     at fulfilled (/data/notiflex/gits/DefinitelyTyped-wonderpush/node_modules/dtslint/bin/index.js:5:58)
>     at <anonymous>
> ```
> 
> And greping for `Type definitions for` only gives results under `node_modules/`.

> And `npm test` seems to fail for this reason.

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/dist/latest-v8.x/docs/api/http2.html#http2_class_http2_http2serverrequest and https://nodejs.org/dist/latest-v8.x/docs/api/http2.html#http2_class_http2_http2serverresponse
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
