### PR TITLE
[expo] Bugfix, adds interface for params of fetchUpdateAsync()

### DIFF
--- a/types/expo/expo-tests.tsx
+++ b/types/expo/expo-tests.tsx
@@ -834,7 +834,7 @@ async () => {
         console.log(updateCheckResult.manifest);
     }
 
-    Updates.fetchUpdateAsync(updateEventListener);
+    Updates.fetchUpdateAsync({ eventListener: updateEventListener });
 
     const bundleFetchResult = await Updates.fetchUpdateAsync();
 

--- a/types/expo/index.d.ts
+++ b/types/expo/index.d.ts
@@ -2915,6 +2915,11 @@ export namespace Updates {
         message?: string;
     }
 
+    /** An optional params object passed to fetchUpdateAsync. */
+    interface FetchUpdateAsyncParams {
+        eventListener: UpdateEventListener;
+    }
+
     type UpdateEventListener = (event: UpdateEvent) => any;
 
     /**
@@ -2934,7 +2939,7 @@ export namespace Updates {
      * Downloads the most recent published version of your experience to the device's local cache.
      * Rejects if `updates.enabled` is `false` in app.json.
      */
-    function fetchUpdateAsync(listener?: UpdateEventListener): Promise<UpdateBundle>;
+    function fetchUpdateAsync(params?: FetchUpdateAsyncParams): Promise<UpdateBundle>;
 
     /**
      * Immediately reloads the current experience.


### PR DESCRIPTION
This PR fixes types for `fetchUpdateAsync` arguments.

It was accepting as argument an event listener but it needs an object with the `eventListener` key.

From [expo docs](https://docs.expo.io/versions/latest/sdk/updates#arguments):

> An optional params object with the following keys:
> - eventListener (function) -- A callback to receive updates events. Will be called with the same events as a function passed into Updates.addListener but will be subscribed and unsubscribed from events automatically.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.expo.io/versions/latest/sdk/updates#arguments