### PR TITLE
Add custom css modified from @types/jss/css.d.ts to allow jss-expand …

### DIFF
--- a/types/react-jss/index.d.ts
+++ b/types/react-jss/index.d.ts
@@ -1,10 +1,9 @@
 // Type definitions for react-jss 8.6
 // Project: https://github.com/cssinjs/react-jss#readme
-// Definitions by: Sebastian Silbermann <https://github.com/eps1lon>
+// Definitions by: Sebastian Silbermann <https://github.com/eps1lon>, Alan Williams <https://github.com/amwill04>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 import { createGenerateClassName, JSS, SheetsRegistry } from "jss";
-import * as React from "react";
 import { createTheming, ThemeProvider, withTheme } from "theming";
 
 import injectSheet from "./lib/injectSheet";

--- a/types/react-jss/index.d.ts
+++ b/types/react-jss/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/cssinjs/react-jss#readme
 // Definitions by: Sebastian Silbermann <https://github.com/eps1lon>, Alan Williams <https://github.com/amwill04>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.8
+// TypeScript Version: 2.9git
 import { createGenerateClassName, JSS, SheetsRegistry } from "jss";
 import { createTheming, ThemeProvider, withTheme } from "theming";
 

--- a/types/react-jss/index.d.ts
+++ b/types/react-jss/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/cssinjs/react-jss#readme
 // Definitions by: Sebastian Silbermann <https://github.com/eps1lon>, Alan Williams <https://github.com/amwill04>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.9git
+// TypeScript Version: 2.9
 import { createGenerateClassName, JSS, SheetsRegistry } from "jss";
 import { createTheming, ThemeProvider, withTheme } from "theming";
 

--- a/types/react-jss/lib/css.d.ts
+++ b/types/react-jss/lib/css.d.ts
@@ -1,0 +1,151 @@
+// These CSS typings adapted from TypeStyle: https://github.com/typestyle/typestyle
+// Modified to fix issue with JssExpand attributes not being correctly types
+
+import { Observable } from 'indefinite-observable';
+import * as csstype from 'csstype';
+
+export type Length = string | number;
+
+export type ObservableProperties<P> = {
+    [K in keyof P]: P[K] | Observable<P[K]>
+};
+
+export type CSSProperties =
+    & ObservableProperties<csstype.Properties<Length>>
+    & ObservableProperties<csstype.PropertiesHyphen<Length>>;
+
+export interface JssProps {
+    '@global'?: CSSProperties;
+    extend?: string;
+    composes?: string | string[];
+}
+
+export type JssExpanAttr =
+    | 'animation'
+    | 'background'
+    | 'border'
+    | 'boxShadow'
+    | 'flex'
+    | 'font'
+    | 'listStyle'
+    | 'margin'
+    | 'padding'
+    | 'outline'
+    | 'textShadow'
+    | 'transition';
+
+export interface JssExpand extends Pick<CSSProperties, Exclude<keyof CSSProperties, JssExpanAttr>> {
+    animation:
+        | {
+        delay: CSSProperties['animationDelay'];
+        direction: CSSProperties['animationDirection'];
+        duration: CSSProperties['animationDuration'];
+        iterationCount: CSSProperties['animationIterationCount'];
+        name: CSSProperties['animationName'];
+        playState: CSSProperties['animationPlayState'];
+        timingFunction: CSSProperties['animationTimingFunction'];
+    }
+        | CSSProperties['animation'];
+    background:
+        | {
+        attachment: CSSProperties['backgroundAttachment'];
+        color: CSSProperties['backgroundColor'];
+        image: CSSProperties['backgroundImage'];
+        position:
+            | CSSProperties['backgroundPosition']
+            | [csstype.Properties['backgroundPosition'], csstype.Properties['backgroundPosition']]; // Can be written using array e.g. `[0 0]`
+        repeat: CSSProperties['backgroundRepeat'];
+        size:
+            | CSSProperties['backgroundSize']
+            | [csstype.Properties['backgroundSize'], csstype.Properties['backgroundSize']]; // Can be written using array e.g. `['center' 'center']`
+    }
+        | CSSProperties['background'];
+    border:
+        | {
+        color: CSSProperties['borderColor'];
+        style: CSSProperties['borderStyle'];
+        width: CSSProperties['borderWidth'];
+    }
+        | CSSProperties['border'];
+    boxShadow:
+        | {
+        x: Length;
+        y: Length;
+        blur: Length;
+        spread: Length;
+        color: CSSProperties['color'];
+        inset?: 'inset'; // If you want to add inset you need to write 'inset: 'inset''
+    }
+        | CSSProperties['boxShadow'];
+    flex:
+        | {
+        basis?: CSSProperties['flexBasis'];
+        direction?: CSSProperties['flexDirection'];
+        flow?: CSSProperties['flexFlow'];
+        grow?: CSSProperties['flexGrow'];
+        shrink?: CSSProperties['flexShrink'];
+        wrap?: CSSProperties['flexWrap'];
+    }
+        | CSSProperties['flex'];
+    font:
+        | {
+        family?: CSSProperties['fontFamily'];
+        size?: CSSProperties['fontSize'];
+        stretch?: CSSProperties['fontStretch'];
+        style?: CSSProperties['fontStyle'];
+        variant?: CSSProperties['fontVariant'];
+        weight?: CSSProperties['fontWeight'];
+    }
+        | CSSProperties['font'];
+    listStyle:
+        | {
+        image: CSSProperties['listStyleImage'];
+        position: CSSProperties['listStylePosition'];
+        type: CSSProperties['listStyleType'];
+    }
+        | CSSProperties['listStyle'];
+    margin:
+        | {
+        bottom?: CSSProperties['marginBottom'];
+        left?: CSSProperties['marginLeft'];
+        right?: CSSProperties['marginRight'];
+        top?: CSSProperties['marginTop'];
+    }
+        | CSSProperties['margin'];
+    padding:
+        | {
+        bottom?: CSSProperties['paddingBottom'];
+        left?: CSSProperties['paddingLeft'];
+        right?: CSSProperties['paddingRight'];
+        top?: CSSProperties['paddingTop'];
+    }
+        | CSSProperties['padding'];
+    outline:
+        | {
+        color: CSSProperties['outlineColor'];
+        style: CSSProperties['outlineStyle'];
+        width: CSSProperties['outlineWidth'];
+    }
+        | CSSProperties['outline'];
+    textShadow:
+        | {
+        x: Length;
+        y: Length;
+        blur: Length;
+        color: CSSProperties['color'];
+    }
+        | CSSProperties['textShadow'];
+    transition:
+        | {
+        delay: CSSProperties['transitionDelay'];
+        duration: CSSProperties['transitionDuration'];
+        property: CSSProperties['transitionProperty'];
+        timingFunction: CSSProperties['transitionTimingFunction'];
+    }
+        | CSSProperties['transition'];
+}
+
+export type JssExpandArr = { [k in keyof JssExpand]?: JssExpand[k] | Array<JssExpand[k]> };
+
+export type SimpleStyle = JssExpandArr;
+export type Style = SimpleStyle | Observable<csstype.PropertiesHyphen<Length>>;

--- a/types/react-jss/lib/injectSheet.d.ts
+++ b/types/react-jss/lib/injectSheet.d.ts
@@ -1,13 +1,14 @@
-import * as CSS from "csstype";
-import { CreateStyleSheetOptions, JSS } from "jss";
-import * as React from "react";
+import * as CSS from 'csstype';
+import { CreateStyleSheetOptions, JSS } from 'jss';
+import * as React from 'react';
 import {
-  channel,
-  createTheming,
-  themeListener,
-  ThemeProvider,
-  withTheme
-} from "theming";
+    channel,
+    createTheming,
+    themeListener,
+    ThemeProvider,
+    withTheme
+} from 'theming';
+import { Style } from './css';
 
 /**
  * omit from T every key K
@@ -22,11 +23,11 @@ export type Omit<T, K extends keyof any> = Pick<T, Exclude<keyof T, K>>;
  * @internal
  */
 export type ConsistentWith<DecorationTargetProps, InjectedProps> = {
-  [P in keyof DecorationTargetProps]: P extends keyof InjectedProps
-    ? InjectedProps[P] extends DecorationTargetProps[P]
-      ? DecorationTargetProps[P]
-      : InjectedProps[P]
-    : DecorationTargetProps[P]
+    [P in keyof DecorationTargetProps]: P extends keyof InjectedProps
+        ? InjectedProps[P] extends DecorationTargetProps[P]
+            ? DecorationTargetProps[P]
+            : InjectedProps[P]
+        : DecorationTargetProps[P]
 };
 
 /**
@@ -40,8 +41,8 @@ export type Overwrite<T, U> = Omit<T, keyof U> & U;
  * @internal
  */
 export type PropsOf<C> = C extends new (props: infer P) => React.Component
-  ? P
-  : C extends (props: infer P) => React.ReactElement<any> | null ? P : never;
+    ? P
+    : C extends (props: infer P) => React.ReactElement<any> | null ? P : never;
 
 /**
  * a function that takes {component} and returns a component that passes along
@@ -51,66 +52,50 @@ export type PropsOf<C> = C extends new (props: infer P) => React.Component
  * source mui-org/material-ui#12673
  * @internal
  */
-export type PropInjector<InjectedProps, AdditionalProps = {}> = <
-  C extends React.ComponentType<ConsistentWith<PropsOf<C>, InjectedProps>>
->(
-  component: C
-) => React.ComponentType<
-  Omit<JSX.LibraryManagedAttributes<C, PropsOf<C>>, keyof InjectedProps> &
-    AdditionalProps
->;
+export type PropInjector<InjectedProps, AdditionalProps = {}> = <C extends React.ComponentType<ConsistentWith<PropsOf<C>, InjectedProps>>>(
+    component: C
+) => React.ComponentType<Omit<JSX.LibraryManagedAttributes<C, PropsOf<C>>, keyof InjectedProps> &
+    AdditionalProps>;
 
-export interface CSSProperties extends CSS.Properties<number | string> {
-  // Allow pseudo selectors and media queries
-  [k: string]:
-    | CSS.Properties<number | string>[keyof CSS.Properties]
-    | CSSProperties;
-}
-export type Styles<ClassKey extends string = string> = Record<
-  ClassKey,
-  CSSProperties
->;
+export type Styles<ClassKey extends string = string> = Record<ClassKey, Style | {[k: string]: Style[keyof Style]}>;
 export type StyleCreator<C extends string = string, T extends {} = {}> = (
-  theme: T
+    theme: T
 ) => Styles<C>;
 
 export interface Theming {
-  channel: string;
-  createTheming: typeof createTheming;
-  themeListener: typeof themeListener;
-  ThemeProvider: typeof ThemeProvider;
-  withTheme: typeof withTheme;
+    channel: string;
+    createTheming: typeof createTheming;
+    themeListener: typeof themeListener;
+    ThemeProvider: typeof ThemeProvider;
+    withTheme: typeof withTheme;
 }
+
 export interface InjectOptions extends CreateStyleSheetOptions {
-  jss?: JSS;
-  theming?: Theming;
+    jss?: JSS;
+    theming?: Theming;
 }
 
 export type ClassNameMap<C extends string> = Record<C, string>;
-export type WithSheet<
-  S extends string | Styles | StyleCreator<string, any>,
-  GivenTheme = undefined
-> = {
-  classes: ClassNameMap<
-    S extends string
-      ? S
-      : S extends StyleCreator<infer C, any>
-        ? C
-        : S extends Styles<infer C> ? C : never
-  >;
+export type WithSheet<S extends string | Styles | StyleCreator<string, any>,
+    GivenTheme = undefined> = {
+    classes: ClassNameMap<S extends string
+        ? S
+        : S extends StyleCreator<infer C, any>
+            ? C
+            : S extends Styles<infer C> ? C : never>;
 } & WithTheme<S extends StyleCreator<string, infer T> ? T : GivenTheme>;
 
 export interface WithTheme<T> {
-  theme: T;
-  innerRef?: React.Ref<any> | React.RefObject<any>;
+    theme: T;
+    innerRef?: React.Ref<any> | React.RefObject<any>;
 }
 
 export interface StyledComponentProps<ClassKey extends string = string> {
-  classes?: Partial<ClassNameMap<ClassKey>>;
-  innerRef?: React.Ref<any> | React.RefObject<any>;
+    classes?: Partial<ClassNameMap<ClassKey>>;
+    innerRef?: React.Ref<any> | React.RefObject<any>;
 }
 
 export default function injectSheet<C extends string, T extends object>(
-  stylesOrCreator: Styles<C> | StyleCreator<C, T>,
-  options?: InjectOptions
+    stylesOrCreator: Styles<C> | StyleCreator<C, T>,
+    options?: InjectOptions
 ): PropInjector<WithSheet<C, T>, StyledComponentProps<C>>;

--- a/types/react-jss/package.json
+++ b/types/react-jss/package.json
@@ -1,6 +1,7 @@
 {
   "private": true,
   "dependencies": {
-    "csstype": "^2.0.0"
+    "csstype": "^2.0.0",
+    "indefinite-observable": "^1.0.1"
   }
 }

--- a/types/react-jss/package.json
+++ b/types/react-jss/package.json
@@ -3,6 +3,5 @@
   "dependencies": {
     "csstype": "^2.0.0",
     "indefinite-observable": "^1.0.1",
-    "typescript": "^3.0.3"
   }
 }

--- a/types/react-jss/package.json
+++ b/types/react-jss/package.json
@@ -2,6 +2,6 @@
   "private": true,
   "dependencies": {
     "csstype": "^2.0.0",
-    "indefinite-observable": "^1.0.1",
+    "indefinite-observable": "^1.0.1"
   }
 }

--- a/types/react-jss/package.json
+++ b/types/react-jss/package.json
@@ -2,6 +2,7 @@
   "private": true,
   "dependencies": {
     "csstype": "^2.0.0",
-    "indefinite-observable": "^1.0.1"
+    "indefinite-observable": "^1.0.1",
+    "typescript": "^3.0.3"
   }
 }

--- a/types/react-jss/react-jss-tests.tsx
+++ b/types/react-jss/react-jss-tests.tsx
@@ -1,97 +1,92 @@
-import * as React from "react";
+import * as React from 'react';
 import injectSheet, {
-  JssProvider,
-  SheetsRegistry,
-  Styles,
-  WithSheet,
-  ThemeProvider
-} from "react-jss";
+    JssProvider,
+    SheetsRegistry,
+    Styles,
+    WithSheet,
+    ThemeProvider
+} from 'react-jss';
 
 interface MyTheme {
-  color: {
-    primary: string;
-    secondary: string;
-  };
+    color: {
+        primary: string;
+        secondary: string;
+    };
 }
 
-/**
- * helper function to counter typescripts type widening
- */
-function createStyles<C extends string>(styles: Styles<C>): Styles<C> {
-  return styles;
-}
-
-const styles = (theme: MyTheme) =>
-  createStyles({
+const styles = (theme: any): Styles<'myButton' | 'myLabel'> => ({
     myButton: {
-      color: theme.color.primary,
-      margin: 1,
-      "& span": {
-        fontWeight: "revert"
-      }
+        color: theme.color.primary,
+        margin: [10, 10],
+        padding: {
+            left: 10,
+        },
+        '& span': {
+            fontWeight: 'revert',
+        }
     },
     myLabel: {
-      fontStyle: "italic"
+        fontStyle: 'italic'
     }
-  });
+});
 
 interface ButtonProps extends WithSheet<typeof styles> {
-  label: string;
+    label: string;
 }
 
-const Button: React.SFC<ButtonProps> = ({ classes, children }) => {
-  return (
-    <button className={classes.myButton}>
-      <span className={classes.myLabel}>{children}</span>
-    </button>
-  );
+const Button: React.SFC<ButtonProps> = ({classes, children}) => {
+    return (
+        <button className={classes.myButton}>
+            <span className={classes.myLabel}>{children}</span>
+        </button>
+    );
 };
 
 const ManuallyStyles = () => {
-  return (
-    <Button
-      classes={{ myButton: "my-button", myLabel: "my-label" }}
-      label="Hello, World!"
-      theme={{ color: { primary: "red", secondary: "blue" } }}
-    />
-  );
+    return (
+        <Button
+            classes={{myButton: 'my-button', myLabel: 'my-label'}}
+            label="Hello, World!"
+            theme={{color: {primary: 'red', secondary: 'blue'}}}
+        />
+    );
 };
 
 const StyledButton = injectSheet(styles)(Button);
 
 const darkTheme: MyTheme = {
-  color: {
-    primary: "grey",
-    secondary: "brown"
-  }
+    color: {
+        primary: 'grey',
+        secondary: 'brown'
+    }
 };
 const App = () => (
-  <ThemeProvider theme={darkTheme}>
-    <StyledButton label="I'm dark" />
-  </ThemeProvider>
+    <ThemeProvider theme={darkTheme}>
+        <StyledButton label="I'm dark"/>
+    </ThemeProvider>
 );
 
 function ssrRender(req: any, res: { send: (text: string) => any }) {
-  const mockedRenderToString = (e: React.ReactElement<any>) => `${e}`;
-  const sheets = new SheetsRegistry();
+    const mockedRenderToString = (e: React.ReactElement<any>) => `${e}`;
+    const sheets = new SheetsRegistry();
 
-  const body = mockedRenderToString(
-    <JssProvider classNamePrefix="dt-" registry={sheets}>
-      <StyledButton label="I come from the server" />
-    </JssProvider>
-  );
+    const body = mockedRenderToString(
+        <JssProvider classNamePrefix="dt-" registry={sheets}>
+            <StyledButton label="I come from the server"/>
+        </JssProvider>
+    );
 
-  // Any instances of `injectSheet` within `<MyApp />` will have gotten sheets
-  // from `context` and added their Style Sheets to it by now.
+    // Any instances of `injectSheet` within `<MyApp />` will have gotten sheets
+    // from `context` and added their Style Sheets to it by now.
 
-  return res.send(
-    mockedRenderToString(
-      <html>
-        <head>
-          <style type="text/css">{sheets.toString()}</style>
-        </head>
-        <body>{body}</body>
-      </html>
-    )
-  );
+    return res.send(
+        mockedRenderToString(
+            <html>
+            <head>
+                <style type="text/css">{sheets.toString()}</style>
+            </head>
+            <body>{body}</body>
+            </html>
+        )
+    );
 }


### PR DESCRIPTION
`jss-expand` plugin was not being correctly typed. 

```
{
    padding: [10, 10] // failed
    margin: {
        top: 10 // failed
    }
}
```

Used `typescript 2.9` `Exclude` to omit `jss-expand` types and re-write them. Have used the types from `@types/jss` but probable the source in `jss` should be updated independently.

- [x ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ x] Test the change in your own code. (Compile and run.)
- [x ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
~- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>~
~- [ ] Increase the version number in the header if appropriate.~
~- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.~
