### PR TITLE
[react-select] Allow removing tabIndex

### DIFF
--- a/types/react-select/lib/Select.d.ts
+++ b/types/react-select/lib/Select.d.ts
@@ -194,7 +194,7 @@ export interface Props<OptionType> {
   /* Style modifier methods */
   styles?: StylesConfig;
   /* Sets the tabIndex attribute on the input */
-  tabIndex?: string;
+  tabIndex?: string | null;
   /* Select the currently focused option when the user presses tab */
   tabSelectsValue?: boolean;
   /* The value of the select; reflected by the selected option */


### PR DESCRIPTION
react-select sets input element's tabindex to 0 by default, setting tabIndex={null} will remove it, and this change will allow it in types

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/JedWatson/react-select/blob/18219f5271705ef150ad16177db43f0c44f0413d/src/Select.js#L267
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
