### PR TITLE
[@types/next] Update types for next@7.

### DIFF
--- a/types/next/app.d.ts
+++ b/types/next/app.d.ts
@@ -42,10 +42,15 @@ export interface AppProps<Q extends DefaultQuery = DefaultQuery> {
  * App component type. Differs from the default type because the context it passes
  * to getInitialProps and the props is passes to the component are different.
  *
+ * @template P Component props.
  * @template IP Initial props returned from getInitialProps.
  * @template C Context passed to getInitialProps.
  */
-export type AppComponentType<IP = {}, C = NextAppContext> = NextComponentType<IP & AppProps, IP, C>;
+export type AppComponentType<P = {}, IP = P, C = NextAppContext> = NextComponentType<
+    P & AppProps,
+    IP,
+    C
+>;
 
 export class Container extends React.Component {}
 export default class App<P = {}> extends React.Component<P & DefaultAppIProps & AppProps> {

--- a/types/next/app.d.ts
+++ b/types/next/app.d.ts
@@ -20,6 +20,14 @@ export interface NextAppContext<Q extends DefaultQuery = DefaultQuery> {
 }
 
 /**
+ * Initial Props returned from base App class.
+ * https://github.com/zeit/next.js/blob/7.0.0/lib/app.js#L16
+ */
+export interface DefaultAppIProps {
+    pageProps: any;
+}
+
+/**
  * Props passed to the App component.
  * Component and pageProps are dynamic - cannot infer type.
  *
@@ -28,7 +36,6 @@ export interface NextAppContext<Q extends DefaultQuery = DefaultQuery> {
 export interface AppProps<Q extends DefaultQuery = DefaultQuery> {
     Component: NextComponentType<any, any, NextContext<Q>>;
     router: RouterProps<Q>;
-    pageProps: any;
 }
 
 /**
@@ -41,6 +48,6 @@ export interface AppProps<Q extends DefaultQuery = DefaultQuery> {
 export type AppComponentType<IP = {}, C = NextAppContext> = NextComponentType<IP & AppProps, IP, C>;
 
 export class Container extends React.Component {}
-export default class App<P = {}> extends React.Component<P & AppProps> {
-    static getInitialProps(context: NextAppContext): Promise<{ pageProps: any }>;
+export default class App<P = {}> extends React.Component<P & DefaultAppIProps & AppProps> {
+    static getInitialProps(context: NextAppContext): Promise<DefaultAppIProps>;
 }

--- a/types/next/config.d.ts
+++ b/types/next/config.d.ts
@@ -1,1 +1,1 @@
-export default function(): {serverRuntimeConfig: any, publicRuntimeConfig: any};
+export default function(): { serverRuntimeConfig: any; publicRuntimeConfig: any };

--- a/types/next/document.d.ts
+++ b/types/next/document.d.ts
@@ -5,7 +5,7 @@ import { DefaultQuery } from "./router";
 export interface RenderPageResponse {
     buildManifest: Record<string, any>;
     html?: string;
-    head?: React.ReactElement<any>[];
+    head?: Array<React.ReactElement<any>>;
 }
 
 export interface PageProps {
@@ -37,7 +37,7 @@ export interface NextDocumentContext<Q extends DefaultQuery = DefaultQuery> exte
  * https://github.com/zeit/next.js/blob/7.0.0/server/document.js#L16
  */
 export interface DefaultDocumentIProps extends RenderPageResponse {
-    styles?: React.ReactElement<any>[];
+    styles?: Array<React.ReactElement<any>>;
 }
 
 /**

--- a/types/next/document.d.ts
+++ b/types/next/document.d.ts
@@ -3,14 +3,9 @@ import { NextContext, NextComponentType } from ".";
 import { DefaultQuery } from "./router";
 
 export interface RenderPageResponse {
-    buildManifest: { [key: string]: any };
-    chunks: {
-        names: string[];
-        filenames: string[];
-    };
+    buildManifest: Record<string, any>;
     html?: string;
-    head: Array<React.ReactElement<any>>;
-    errorHtml: string;
+    head?: Array<React.ReactElement<any>>;
 }
 
 export interface PageProps {
@@ -38,24 +33,42 @@ export interface NextDocumentContext<Q extends DefaultQuery = DefaultQuery> exte
 }
 
 /**
- * Props passed to the Document component.
+ * Initial Props returned from base Document class.
+ * https://github.com/zeit/next.js/blob/7.0.0/server/document.js#L16
  */
-export interface DocumentProps {
-    __NEXT_DATA__?: any;
-    dev?: boolean;
-    chunks?: {
-        names: string[];
-        filenames: string[];
-    };
-    html?: string;
-    head?: Array<React.ReactElement<any>>;
-    errorHtml?: string;
+export interface DefaultDocumentIProps extends RenderPageResponse {
     styles?: Array<React.ReactElement<any>>;
-    [key: string]: any;
+}
+
+/**
+ * Props passed to the Document component.
+ * https://github.com/zeit/next.js/blob/7.0.0/server/render.js#L165
+ */
+export interface DocumentProps<Q extends DefaultQuery = DefaultQuery> {
+    __NEXT_DATA__: {
+        props: any;
+        page: string;
+        pathname: string;
+        query: Q;
+        buildId: string;
+        assetPrefix?: string;
+        runtimeConfig?: any;
+        nextExport?: boolean;
+        err?: any;
+    };
+    dev: boolean;
+    dir?: string;
+    staticMarkup: boolean;
+    buildManifest: Record<string, any>;
+    devFiles: string[];
+    files: string[];
+    dynamicImports: string[];
+    assetPrefix: string;
 }
 
 /**
  * Props supported by the Head component.
+ * https://github.com/zeit/next.js/blob/7.0.0/server/document.js#L42
  */
 export interface HeadProps {
     nonce?: string;
@@ -64,6 +77,7 @@ export interface HeadProps {
 
 /**
  * Props supported by the NextScript component.
+ * https://github.com/zeit/next.js/blob/7.0.0/server/document.js#L141
  */
 export interface NextScriptProps {
     nonce?: string;
@@ -86,6 +100,8 @@ export type DocumentComponentType<IP = {}, C = NextDocumentContext> = NextCompon
 export class Head extends React.Component<HeadProps> {}
 export class Main extends React.Component {}
 export class NextScript extends React.Component<NextScriptProps> {}
-export default class Document<P = {}> extends React.Component<P & DocumentProps> {
-    static getInitialProps(context: NextDocumentContext): DocumentProps;
+export default class Document<P = {}> extends React.Component<
+    P & DefaultDocumentIProps & DocumentProps
+> {
+    static getInitialProps(context: NextDocumentContext): DefaultDocumentIProps;
 }

--- a/types/next/document.d.ts
+++ b/types/next/document.d.ts
@@ -88,11 +88,12 @@ export interface NextScriptProps {
  * Document component type. Differs from the default type because the context it passes
  * to getInitialProps and the props is passes to the component are different.
  *
+ * @template P Component props.
  * @template IP Initial props returned from getInitialProps.
  * @template C Context passed to getInitialProps.
  */
-export type DocumentComponentType<IP = {}, C = NextDocumentContext> = NextComponentType<
-    IP & DocumentProps,
+export type DocumentComponentType<P = {}, IP = P, C = NextDocumentContext> = NextComponentType<
+    P & DocumentProps,
     IP,
     C
 >;

--- a/types/next/document.d.ts
+++ b/types/next/document.d.ts
@@ -5,7 +5,7 @@ import { DefaultQuery } from "./router";
 export interface RenderPageResponse {
     buildManifest: Record<string, any>;
     html?: string;
-    head?: Array<React.ReactElement<any>>;
+    head?: React.ReactElement<any>[];
 }
 
 export interface PageProps {
@@ -37,7 +37,7 @@ export interface NextDocumentContext<Q extends DefaultQuery = DefaultQuery> exte
  * https://github.com/zeit/next.js/blob/7.0.0/server/document.js#L16
  */
 export interface DefaultDocumentIProps extends RenderPageResponse {
-    styles?: Array<React.ReactElement<any>>;
+    styles?: React.ReactElement<any>[];
 }
 
 /**

--- a/types/next/dynamic.d.ts
+++ b/types/next/dynamic.d.ts
@@ -7,16 +7,10 @@ import {
 
 type Omit<T, K> = Pick<T, Exclude<keyof T, K>>;
 
-type AsyncComponent<P> = Promise<React.ComponentType<P>>;
-type AsyncComponentLoader<P> = () => AsyncComponent<P>;
-
-interface ModuleMapping {
-    [moduleName: string]: AsyncComponent<any>;
-}
-
-interface LoadedModuleMapping {
-    [moduleName: string]: React.ComponentType<any>;
-}
+type AsyncComponent<P = any> = Promise<React.ComponentType<P>>;
+type AsyncComponentLoader<P = any> = () => AsyncComponent<P>;
+type ModuleMapping = Record<string, AsyncComponent>;
+type LoadedModuleMapping = Record<string, React.ComponentType>;
 
 interface NextDynamicOptions<P = {}> extends Omit<LoadableOptions, "loading" | "modules"> {
     modules?: () => ModuleMapping; // overridden

--- a/types/next/dynamic.d.ts
+++ b/types/next/dynamic.d.ts
@@ -1,29 +1,48 @@
 import * as React from "react";
+import {
+    LoadableComponent,
+    CommonOptions as LoadableOptions,
+    LoadingComponentProps as LoadableLoadingComponentProps
+} from "react-loadable";
 
-export interface DynamicOptions<TCProps, TLProps> {
-    loading?: React.ComponentType<TLProps>;
+type Omit<T, K> = Pick<T, Exclude<keyof T, K>>;
+
+type AsyncComponent<P> = Promise<React.ComponentType<P>>;
+type AsyncComponentLoader<P> = () => AsyncComponent<P>;
+
+interface ModuleMapping {
+    [moduleName: string]: AsyncComponent<any>;
+}
+
+interface LoadedModuleMapping {
+    [moduleName: string]: React.ComponentType<any>;
+}
+
+interface NextDynamicOptions<P = {}> extends Omit<LoadableOptions, "loading" | "modules"> {
+    modules?: () => ModuleMapping; // overridden
+    loading?: LoadableOptions["loading"]; // optional
+    loader?: AsyncComponentLoader<P>; // optional, overriden
+    render?: (props: P, loaded: LoadedModuleMapping) => React.ReactNode; // optional, overriden
     ssr?: boolean;
-    modules?(
-        props: TCProps & TLProps,
-    ): { [key: string]: Promise<React.ComponentType<any>> };
-    render?(
-        props: TCProps & TLProps,
-        modules: { [key: string]: React.ComponentType<any> },
-    ): void;
+    loadableGenerated?: {
+        webpack?: any;
+        modules?: any;
+    };
 }
 
-export class SameLoopPromise<T> extends Promise<T> {
-    constructor(
-        executor: (
-            resolve: (value?: T) => void,
-            reject: (reason?: any) => void,
-        ) => void,
-    );
-    setResult(value: T): void;
-    setError(value: any): void;
-    runIfNeeded(): void;
-}
-export default function<TCProps, TLProps>(
-    componentPromise: Promise<React.ComponentType<TCProps>>,
-    options?: DynamicOptions<TCProps, TLProps>,
-): React.ComponentType<TCProps & TLProps>;
+type DynamicComponent<P> = React.ComponentType<P> & LoadableComponent;
+
+/**
+ * Overloaded dynamic function.
+ * https://github.com/zeit/next.js/blob/7.0.0/lib/dynamic.js#L55
+ */
+declare function dynamic<P = {}>(
+    options: AsyncComponent<P> | NextDynamicOptions<P>
+): DynamicComponent<P>;
+declare function dynamic<P = {}>(
+    asyncModule: AsyncComponent<P>,
+    options: NextDynamicOptions<P>
+): DynamicComponent<P>;
+
+export type LoadingComponentProps = LoadableLoadingComponentProps;
+export default dynamic;

--- a/types/next/error.d.ts
+++ b/types/next/error.d.ts
@@ -1,2 +1,14 @@
 import * as React from "react";
-export default class extends React.Component<{ statusCode: number }> {}
+import { NextContext } from ".";
+
+/**
+ * Initial props returned from base Error class.
+ * https://github.com/zeit/next.js/blob/7.0.0/lib/error.js#L7
+ */
+export interface DefaultErrorIProps {
+    statusCode: number;
+}
+
+export default class Error<P = {}> extends React.Component<P & DefaultErrorIProps> {
+    static getInitialProps(context: NextContext): DefaultErrorIProps;
+}

--- a/types/next/head.d.ts
+++ b/types/next/head.d.ts
@@ -3,6 +3,6 @@ import * as React from "react";
 export function defaultHead(): JSX.Element[];
 export default class Head extends React.Component {
     static canUseDOM: boolean;
-    static peek(): Array<React.ReactElement<any>>;
-    static rewind(): Array<React.ReactElement<any>>;
+    static peek(): React.ReactElement<any>[];
+    static rewind(): React.ReactElement<any>[];
 }

--- a/types/next/head.d.ts
+++ b/types/next/head.d.ts
@@ -1,7 +1,7 @@
 import * as React from "react";
 
 export function defaultHead(): JSX.Element[];
-export default class extends React.Component {
+export default class Head extends React.Component {
     static canUseDOM: boolean;
     static peek(): Array<React.ReactElement<any>>;
     static rewind(): Array<React.ReactElement<any>>;

--- a/types/next/head.d.ts
+++ b/types/next/head.d.ts
@@ -3,6 +3,6 @@ import * as React from "react";
 export function defaultHead(): JSX.Element[];
 export default class Head extends React.Component {
     static canUseDOM: boolean;
-    static peek(): React.ReactElement<any>[];
-    static rewind(): React.ReactElement<any>[];
+    static peek(): Array<React.ReactElement<any>>;
+    static rewind(): Array<React.ReactElement<any>>;
 }

--- a/types/next/index.d.ts
+++ b/types/next/index.d.ts
@@ -13,9 +13,7 @@
 
 import * as http from "http";
 import * as url from "url";
-
 import { Response as NodeResponse } from "node-fetch";
-
 import { SingletonRouter, DefaultQuery, UrlLike } from "./router";
 
 declare namespace next {

--- a/types/next/index.d.ts
+++ b/types/next/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for next 6.1
+// Type definitions for next 7.0
 // Project: https://github.com/zeit/next.js
 // Definitions by: Drew Hays <https://github.com/dru89>
 //                 Brice BERNARD <https://github.com/brikou>
@@ -16,7 +16,7 @@ import * as url from "url";
 
 import { Response as NodeResponse } from "node-fetch";
 
-import { SingletonRouter, DefaultQuery } from "./router";
+import { SingletonRouter, DefaultQuery, UrlLike } from "./router";
 
 declare namespace next {
     // Deprecated
@@ -24,12 +24,10 @@ declare namespace next {
     type ServerConfig = NextConfig;
     // End Deprecated
 
-    type UrlLike = url.UrlObject | url.Url;
-
     /**
      * Context object used in methods like `getInitialProps()`
-     * https://github.com/zeit/next.js/blob/6.1.1/server/render.js#L77
-     * https://github.com/zeit/next.js/blob/6.1.1/readme.md#fetching-data-and-component-lifecycle
+     * https://github.com/zeit/next.js/blob/7.0.0/server/render.js#L97
+     * https://github.com/zeit/next.js/blob/7.0.0/README.md#fetching-data-and-component-lifecycle
      *
      * @template Q Query object schema.
      */
@@ -52,7 +50,7 @@ declare namespace next {
 
     /**
      * Next.js config schema.
-     * https://github.com/zeit/next.js/blob/6.1.1/server/config.js#L10
+     * https://github.com/zeit/next.js/blob/7.0.0/server/config.js#L9
      */
     interface NextConfig {
         webpack?: any;
@@ -74,7 +72,7 @@ declare namespace next {
 
     /**
      * Options passed to the Server constructor in Node.js.
-     * https://github.com/zeit/next.js/blob/6.1.1/server/index.js#L30
+     * https://github.com/zeit/next.js/blob/7.0.0/server/index.js#L25
      */
     interface ServerOptions {
         dir?: string;
@@ -89,7 +87,7 @@ declare namespace next {
      */
     interface Server {
         // From constructor
-        // https://github.com/zeit/next.js/blob/6.1.1/server/index.js#L30
+        // https://github.com/zeit/next.js/blob/7.0.0/server/index.js#L25
         dir: string;
         dev: boolean;
         quiet: boolean;
@@ -105,7 +103,6 @@ declare namespace next {
             distDir: string;
             hotReloader: any;
             buildId: string;
-            availableChunks: object;
             generateETags: boolean;
             runtimeConfig?: object;
         };
@@ -172,9 +169,7 @@ declare namespace next {
         ): Promise<void>;
         isServeableUrl(path: string): boolean;
         readBuildId(): string;
-        handleBuildId(buildId: string, res: http.ServerResponse): boolean;
         getCompilationError(): Promise<any>;
-        send404(res: http.ServerResponse): void;
     }
 
     /**

--- a/types/next/link.d.ts
+++ b/types/next/link.d.ts
@@ -1,8 +1,12 @@
 import * as url from "url";
 import * as React from "react";
+import { UrlLike } from "./router";
 
-export type UrlLike = url.UrlObject | url.Url;
-export interface LinkState {
+// Deprecated
+export type LinkState = LinkProps;
+// End Deprecated
+
+export interface LinkProps {
     prefetch?: boolean;
     shallow?: boolean;
     scroll?: boolean;
@@ -14,4 +18,4 @@ export interface LinkState {
     children: React.ReactElement<any>;
 }
 
-export default class extends React.Component<LinkState> {}
+export default class Link extends React.Component<LinkProps> {}

--- a/types/next/router.d.ts
+++ b/types/next/router.d.ts
@@ -1,14 +1,13 @@
 import * as React from "react";
 import * as url from "url";
 
-type UrlLike = url.UrlObject | url.Url;
-
-type EventName = 'routeChangeStart'
-    | 'routeChangeComplete'
-    | 'routeChangeError'
-    | 'beforeHistoryChange'
-    | 'hashChangeStart'
-    | 'hashChangeComplete';
+type EventName =
+    | "routeChangeStart"
+    | "routeChangeComplete"
+    | "routeChangeError"
+    | "beforeHistoryChange"
+    | "hashChangeStart"
+    | "hashChangeComplete";
 
 interface RouteChangeError {
     cancelled: boolean;
@@ -16,6 +15,8 @@ interface RouteChangeError {
 
 type EventHandler = (url: string) => any;
 type ErrorEventHandler = (err: RouteChangeError, url: string) => any;
+
+export type UrlLike = url.UrlObject | url.Url;
 
 export interface EventChangeOptions {
     shallow?: boolean;
@@ -47,13 +48,13 @@ export interface RouterProps<Q = DefaultQuery> {
     push(
         url: string | UrlLike,
         as?: string | UrlLike,
-        options?: EventChangeOptions,
+        options?: EventChangeOptions
     ): Promise<boolean>;
     reload(route: string): Promise<void>;
     replace(
         url: string | UrlLike,
         as?: string | UrlLike,
-        options?: EventChangeOptions,
+        options?: EventChangeOptions
     ): Promise<boolean>;
 
     // events (deprecated soonish)
@@ -87,7 +88,7 @@ export interface WithRouterProps<Q = DefaultQuery> {
 // without defining props explicitly
 export function withRouter<T extends {}, Q = DefaultQuery>(
     // tslint:disable-next-line:no-unnecessary-generics
-    Component: React.ComponentType<T & WithRouterProps<Q>>,
+    Component: React.ComponentType<T & WithRouterProps<Q>>
 ): React.ComponentType<T>;
 
 declare const Router: SingletonRouter;

--- a/types/next/test/next-app-tests.tsx
+++ b/types/next/test/next-app-tests.tsx
@@ -2,8 +2,8 @@ import * as React from "react";
 import App, { Container, NextAppContext, AppProps, AppComponentType } from "next/app";
 import { DefaultQuery } from "next/router";
 
-interface NextComponentProps {
-    example: string;
+interface TestAppProps {
+    pageProps: any;
 }
 
 interface TypedQuery extends DefaultQuery {
@@ -21,10 +21,10 @@ class TestApp extends App {
     }
 }
 
-class TestAppWithProps extends App<NextComponentProps> {
+class TestAppWithProps extends App<TestAppProps & WithExampleProps> {
     static async getInitialProps({ Component, router, ctx }: NextAppContext) {
         const pageProps = Component.getInitialProps && (await Component.getInitialProps(ctx));
-        return { pageProps, example: "foobar" };
+        return { pageProps };
     }
 
     render() {
@@ -56,7 +56,7 @@ interface TestProps {
 
 // Stateful HOC that adds props to wrapped component. Similar to what withRedux does.
 // tslint:disable-next-line no-unnecessary-generics
-const withExample = <P extends {}>(App: AppComponentType<P & WithExampleProps>) =>
+const withExample = <P extends {}>(App: AppComponentType<P & WithExampleProps, P>) =>
     class extends React.Component<P & AppProps & WithExampleHocProps> {
         test: string;
 
@@ -79,7 +79,7 @@ const withExample = <P extends {}>(App: AppComponentType<P & WithExampleProps>) 
 
 // Basic stateless HOC. Similar to what withAuth would do.
 // tslint:disable-next-line no-unnecessary-generics
-const withBasic = <P extends {}, C extends {}>(App: AppComponentType<P, C>) =>
+const withBasic = <P extends {}, C extends {}>(App: AppComponentType<P, P, C>) =>
     class extends React.Component<P & AppProps> {
         static async getInitialProps(context: C) {
             const pageProps = App.getInitialProps && (await App.getInitialProps(context));

--- a/types/next/test/next-app-tests.tsx
+++ b/types/next/test/next-app-tests.tsx
@@ -55,7 +55,7 @@ interface TestProps {
 }
 
 // Stateful HOC that adds props to wrapped component. Similar to what withRedux does.
-// tslint:disable-next-line no-unnecessary-generics
+// tslint:disable-next-line no-unnecessary-generics, use-default-type-parameter
 const withExample = <P extends {}>(App: AppComponentType<P & WithExampleProps, P>) =>
     class extends React.Component<P & AppProps & WithExampleHocProps> {
         test: string;

--- a/types/next/test/next-document-tests.tsx
+++ b/types/next/test/next-document-tests.tsx
@@ -1,62 +1,48 @@
-import Document, { DocumentProps, Enhancer, Head, Main, NextScript, NextDocumentContext, PageProps } from 'next/document';
+import Document, { Enhancer, Head, Main, NextScript, NextDocumentContext, PageProps } from 'next/document';
 import * as React from "react";
 
-const basicResults = (
-    <Document any="property" should="work" here>
-        <Head some="more" properties>
-            <meta name="description" content="Head can have children, too!" />
-        </Head>
-        <Main />
-        <NextScript />
-    </Document>
-);
+interface WithUrlProps {
+    url: string;
+}
 
-const withNonce = (
-    <Document>
-        <Head nonce="12345" />
-        <NextScript nonce="12345" />
-    </Document>
-);
-
-class MyDoc extends Document {
-    static async getInitialProps({ renderPage }: NextDocumentContext) {
+class MyDoc extends Document<WithUrlProps> {
+    static getInitialProps({ req, renderPage }: NextDocumentContext) {
         // without callback
         const _page = renderPage();
 
         // with callback
         const enhancer: Enhancer<PageProps, {}> = (App) => (props) => (<App />);
-        const { html, head, errorHtml, chunks, buildManifest } = renderPage(enhancer);
+        const { html, head, buildManifest } = renderPage(enhancer);
 
-        const style = {};
+        const styles = [
+            <style />
+        ];
 
-        return { html, head, errorHtml, chunks, buildManifest, style };
+        // Custom prop
+        const url = req!.url;
+
+        return { html, head, buildManifest, styles, url };
     }
 
     render() {
+        const { pathname, query } = this.props.__NEXT_DATA__;
+
         return (
             <html>
-                <Head>
+                <Head nonce="nonce" any="property" should="work" here>
                     <title>My page</title>
-                    <style id='cxs-style' dangerouslySetInnerHTML={{ __html: this.props.style }} />
+                    { this.props.styles }
                 </Head>
                 <body>
                     <Main />
                     <NextScript />
+                    <p>{this.props.url}</p>
                     {this.props.children}
                 </body>
             </html>
         );
     }
 }
-
-const extendedResults = (
-    <MyDoc any="property" should="work" here>
-        <Head some="more" properties>
-            <meta name="description" content="Head can have children, too!" />
-        </Head>
-        <h1>Hey there</h1>
-    </MyDoc>
-);
 
 const renderPage: NextDocumentContext['renderPage'] = (enhancer) => ({
     buildManifest: {},

--- a/types/next/test/next-document-tests.tsx
+++ b/types/next/test/next-document-tests.tsx
@@ -1,4 +1,11 @@
-import Document, { Enhancer, Head, Main, NextScript, NextDocumentContext, PageProps } from 'next/document';
+import Document, {
+    Enhancer,
+    Head,
+    Main,
+    NextScript,
+    NextDocumentContext,
+    PageProps
+} from "next/document";
 import * as React from "react";
 
 interface WithUrlProps {
@@ -11,12 +18,10 @@ class MyDoc extends Document<WithUrlProps> {
         const _page = renderPage();
 
         // with callback
-        const enhancer: Enhancer<PageProps, {}> = (App) => (props) => (<App />);
+        const enhancer: Enhancer<PageProps, {}> = App => props => <App />;
         const { html, head, buildManifest } = renderPage(enhancer);
 
-        const styles = [
-            <style />
-        ];
+        const styles = [<style />];
 
         // Custom prop
         const url = req!.url;
@@ -31,7 +36,7 @@ class MyDoc extends Document<WithUrlProps> {
             <html>
                 <Head nonce="nonce" any="property" should="work" here>
                     <title>My page</title>
-                    { this.props.styles }
+                    {this.props.styles}
                 </Head>
                 <body>
                     <Main />
@@ -44,12 +49,12 @@ class MyDoc extends Document<WithUrlProps> {
     }
 }
 
-const renderPage: NextDocumentContext['renderPage'] = (enhancer) => ({
+const renderPage: NextDocumentContext["renderPage"] = enhancer => ({
     buildManifest: {},
     chunks: { names: [], filenames: [] },
-    html: '',
+    html: "",
     head: [<React.Fragment />],
-    errorHtml: '',
+    errorHtml: ""
 });
 
 interface PageInitialProps extends PageProps {
@@ -62,11 +67,18 @@ interface ProcessedInitialProps {
     bar: boolean;
 }
 
-const enhancerExplicit: Enhancer<PageProps, {}> = (App) => (props) => (<App />);
-const enhancerInferred = (App: React.ComponentType<ProcessedInitialProps>) => ({ foo, bar }: PageInitialProps) => (<App fooLength={foo.length} bar={!!bar} />);
+const enhancerExplicit: Enhancer<PageProps, {}> = App => props => <App />;
+const enhancerInferred = (App: React.ComponentType<ProcessedInitialProps>) => ({
+    foo,
+    bar
+}: PageInitialProps) => <App fooLength={foo.length} bar={!!bar} />;
 const explicitEnhancerRenderResponse = renderPage(enhancerExplicit);
 const inferredEnhancerRenderResponse = renderPage(enhancerInferred);
-const defaultedTypesRenderResponse = renderPage((App) => (props) => (<App url={props.url} />));
-const defaultedTypesExtendedRenderResponse = renderPage((App) => (props) => (<App foo="bar" url={props.url} />));
-const explicitTypesRenderResponseOne = renderPage<PageProps, {}>((App) => (props) => (<App />));
-const explicitTypesRenderResponseTwo = renderPage<PageInitialProps, ProcessedInitialProps>((App) => ({ foo, bar }) => (<App fooLength={foo.length} bar={!!bar} />));
+const defaultedTypesRenderResponse = renderPage(App => props => <App url={props.url} />);
+const defaultedTypesExtendedRenderResponse = renderPage(App => props => (
+    <App foo="bar" url={props.url} />
+));
+const explicitTypesRenderResponseOne = renderPage<PageProps, {}>(App => props => <App />);
+const explicitTypesRenderResponseTwo = renderPage<PageInitialProps, ProcessedInitialProps>(
+    App => ({ foo, bar }) => <App fooLength={foo.length} bar={!!bar} />
+);

--- a/types/next/test/next-error-tests.tsx
+++ b/types/next/test/next-error-tests.tsx
@@ -1,4 +1,19 @@
 import * as React from "react";
-import ErrorComponent from "next/error";
+import Error from "next/error";
 
-const result = <ErrorComponent statusCode={404} />;
+interface WithFooProps {
+    foo: string;
+}
+
+const result = <Error statusCode={404} />;
+
+class MyError extends Error<WithFooProps> {
+    static getInitialProps() {
+        return { statusCode: 404, foo: 'bar'};
+    }
+
+    render() {
+        const { statusCode, foo } = this.props;
+        return <div>{statusCode} {foo}</div>;
+    }
+}

--- a/types/next/test/next-tests.ts
+++ b/types/next/test/next-tests.ts
@@ -77,9 +77,7 @@ function handle(req: http.IncomingMessage, res: http.ServerResponse) {
 
     let b: boolean;
     b = server.isServeableUrl("/path/to/thing");
-    b = server.handleBuildId("{buildId}", res);
 
     const s: string = server.readBuildId();
     server.getCompilationError().then(err => err.thisIsAnAny);
-    server.send404(res);
 }


### PR DESCRIPTION
Updated types for Next.js v7.0.x. The majority of the changes are on `next/dynamic` and refactor of the `DocumentProps`.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: Added URLs above type definitions
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
