### PR TITLE
[@ember/routing] import declaration files that weren't published

### DIFF
--- a/types/ember__routing/index.d.ts
+++ b/types/ember__routing/index.d.ts
@@ -7,7 +7,8 @@
 export { default as Route } from '@ember/routing/route';
 export { default as Router } from '@ember/routing/router';
 import RouterService from '@ember/routing/router-service';
-
+import '@ember/routing/-private/router-dsl';
+import '@ember/routing/-private/transition';
 // tslint:disable-next-line:strict-export-declare-modifiers
 interface Registry {
     'router': RouterService;

--- a/types/ember__routing/tsconfig.json
+++ b/types/ember__routing/tsconfig.json
@@ -20,7 +20,6 @@
             "@ember/object/*": ["ember__object/*"],
             "@ember/array": ["ember__array"],
             "@ember/array/*": ["ember__array/*"],
-            "@ember/service": ["ember__service"],
             "@ember/service/*": ["ember__service/*"],
             "@ember/component": ["ember__component"],
             "@ember/component/*": ["ember__component/*"],


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

In the most recent release of this package, all declaration files in the `./-private/` folder were not published to npm. I'm importing them into `index.d.ts` in the hope that this will cause them to be published in the next release.

CC: @pixelhandler
