### PR TITLE
Added type definitions for elastic-apm-node

### DIFF
--- a/types/elastic-apm-node/elastic-apm-node-tests.ts
+++ b/types/elastic-apm-node/elastic-apm-node-tests.ts
@@ -1,0 +1,50 @@
+import {
+    Agent,
+    start
+} from 'elastic-apm-node';
+
+const agent: Agent = start({
+  serviceName: '',
+  secretToken: '',
+  serverUrl: ''
+});
+const started: boolean = agent.isStarted();
+
+function testCallbacks() {
+    const testError: Error = new Error("Test Error");
+    agent.captureError(testError, {error: "test"}, (err: Error) => err = testError);
+    agent.captureError(testError, {error: "test"});
+    agent.captureError(testError);
+
+    agent.addFilter((payload: any) => {
+        return payload;
+    });
+
+    agent.handleUncaughtExceptions((err: Error) => err = testError);
+
+    agent.flush((test: any) => test);
+}
+
+const customContext: boolean = agent.setCustomContext({
+    id: "test id",
+    username: "test user",
+    email: "testEmail@test.com"
+});
+
+const userContext: boolean = agent.setUserContext({
+    id: "test id",
+    username: "test user",
+    email: "testEmail@test.com"
+});
+
+const transactionName: any = agent.setTransactionName("new name");
+
+const tags: any = agent.setTag("name", "value");
+
+const addedTags: any = agent.addTags({name: "value"});
+
+const startSpan: any = agent.startSpan();
+
+const secondStartSpan: any = agent.startSpan("name", 13);
+
+const transaction = agent.startTransaction();

--- a/types/elastic-apm-node/index.d.ts
+++ b/types/elastic-apm-node/index.d.ts
@@ -1,0 +1,75 @@
+// Type definitions for Elastic APM Node.js Agent 1.x
+// Project: https://www.elastic.co/solutions/apm
+// Definitions by: Shahaed Hasan <https://github.com/shahaed>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.7
+
+export = a;
+
+declare const a: a.Agent;
+
+declare namespace a {
+    interface Agent {
+        currentTransaction: any;
+        logger: any;
+
+        start(opts?: AgentOptions): Agent;
+        isStarted(): boolean;
+        addFilter(filter: (payload: any) => any): void;
+        setUserContext(context: Context): boolean;
+        setCustomContext(context: any): boolean;
+        setTag(name: string, value: string): any;
+        addTags(tags: any): any;
+        captureError(error: Error | string | object, options?: object, callback?: (err?: any) => any): void;
+        startTransaction(name?: string, type?: string): any;
+        endTransaction(result?: any): any;
+        setTransactionName(name: string): any;
+        startSpan(name?: string, type?: any): any;
+        handleUncaughtExceptions(callback?: (err: Error) => any): any;
+        flush(callback?: any): any;
+        lambda(type: any, handler?: any): any;
+    }
+
+    interface AgentOptions {
+        serviceName?: string;
+        secretToken?: string;
+        serverUrl?: string;
+        verifyServerCert?: boolean;
+        serviceVersion?: string;
+        active?: boolean;
+        instrument?: boolean;
+        asyncHooks?: boolean;
+        ignoreUrls?: Array<RegExp | string>;
+        ignoreUserAgents?: Array<RegExp | string>;
+        captureBody?: string;
+        errorOnAbortedRequests?: boolean;
+        abortedErrorThreshold?: number;
+        transactionSampleRate?: number;
+        hostname?: string;
+        frameworkName?: string;
+        frameworkVersion?: string;
+        logLevel?: string;
+        logger?: any;
+        captureExceptions?: boolean;
+        captureErrorLogStackTraces?: string;
+        captureSpanStackTraces?: boolean;
+        sourceLinesErrorAppFrames?: number;
+        sourceLinesErrorLibraryFrames?: number;
+        sourceLinesSpanAppFrames?: number;
+        sourceLinesSpanLibraryFrames?: number;
+        errorMessageMaxLength?: number;
+        stackTraceLimit?: number;
+        transactionMaxSpans?: number;
+        flushInterval?: number;
+        serverTimeout?: number;
+        maxQueueSize?: number;
+        filterHttpHeaders?: boolean;
+        disableInstrumentations?: string;
+    }
+
+    interface Context {
+        id?: string;
+        username?: string;
+        email?: string;
+    }
+}

--- a/types/elastic-apm-node/start.d.ts
+++ b/types/elastic-apm-node/start.d.ts
@@ -1,0 +1,2 @@
+import * as agent from './';
+export = agent;

--- a/types/elastic-apm-node/tsconfig.json
+++ b/types/elastic-apm-node/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "elastic-apm-node-tests.ts",
+        "start.d.ts"
+    ]
+}

--- a/types/elastic-apm-node/tslint.json
+++ b/types/elastic-apm-node/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "dtslint/dt.json"
+}


### PR DESCRIPTION
Adding type definitions for this package: https://github.com/elastic/apm-agent-nodejs.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.