### PR TITLE
Decouple @types/react from @types/prop-types

### DIFF
--- a/types/prop-types/index.d.ts
+++ b/types/prop-types/index.d.ts
@@ -5,7 +5,24 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
-import { ReactNode, ReactElement } from 'react';
+export interface ReactElementLike {
+    type: string | ((...args: any[]) => ReactElementLike);
+    props: any;
+    key: string | number | null;
+    children?: ReactNodeLike;
+}
+
+export interface ReactNodeArray extends Array<ReactNodeLike> {}
+
+export type ReactNodeLike =
+    | {}
+    | ReactElementLike
+    | ReactNodeArray
+    | string
+    | number
+    | boolean
+    | null
+    | undefined;
 
 export const nominalTypeHack: unique symbol;
 
@@ -38,8 +55,8 @@ export const func: Requireable<(...args: any[]) => any>;
 export const number: Requireable<number>;
 export const object: Requireable<object>;
 export const string: Requireable<string>;
-export const node: Requireable<ReactNode>;
-export const element: Requireable<ReactElement<any>>;
+export const node: Requireable<ReactNodeLike>;
+export const element: Requireable<ReactElementLike>;
 export const symbol: Requireable<symbol>;
 export function instanceOf<T>(expectedClass: new (...args: any[]) => T): Requireable<T>;
 export function oneOf<T>(types: T[]): Requireable<T>;

--- a/types/prop-types/index.d.ts
+++ b/types/prop-types/index.d.ts
@@ -5,18 +5,46 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
-import { ReactNode, ReactElement } from 'react';
+export interface ReactElementLike {
+    type: string | ((...args: any[]) => ReactElementLike);
+    props: any;
+    key: string | number | null;
+    children?: ReactNodeLike;
+}
+
+export interface ReactNodeArray extends Array<ReactNodeLike> {}
+
+export type ReactNodeLike =
+    | {}
+    | ReactElementLike
+    | ReactNodeArray
+    | string
+    | number
+    | boolean
+    | null
+    | undefined;
 
 export const nominalTypeHack: unique symbol;
 
-export type IsOptional<T> = undefined | null extends T ? true : undefined extends T ? true : null extends T ? true : false;
-
-export type RequiredKeys<V> = { [K in keyof V]: V[K] extends Validator<infer T> ? IsOptional<T> extends true ? never : K : never }[keyof V];
+export type IsOptional<T> = undefined | null extends T
+    ? true
+    : undefined extends T ? true : null extends T ? true : false;
+export type RequiredKeys<V> = {
+    [K in keyof V]: V[K] extends Validator<infer T>
+        ? IsOptional<T> extends true ? never : K
+        : never
+}[keyof V];
 export type OptionalKeys<V> = Exclude<keyof V, RequiredKeys<V>>;
-export type InferPropsInner<V> = { [K in keyof V]: InferType<V[K]>; };
+export type InferPropsInner<V> = { [K in keyof V]: InferType<V[K]> };
 
 export interface Validator<T> {
-    (props: object, propName: string, componentName: string, location: string, propFullName: string): Error | null;
+    (
+        props: object,
+        propName: string,
+        componentName: string,
+        location: string,
+        propFullName: string,
+    ): Error | null;
     [nominalTypeHack]?: T;
 }
 
@@ -27,9 +55,8 @@ export interface Requireable<T> extends Validator<T | undefined | null> {
 export type ValidationMap<T> = { [K in keyof T]-?: Validator<T[K]> };
 
 export type InferType<V> = V extends Validator<infer T> ? T : any;
-export type InferProps<V> =
-    & InferPropsInner<Pick<V, RequiredKeys<V>>>
-    & Partial<InferPropsInner<Pick<V, OptionalKeys<V>>>>;
+export type InferProps<V> = InferPropsInner<Pick<V, RequiredKeys<V>>> &
+    Partial<InferPropsInner<Pick<V, OptionalKeys<V>>>>;
 
 export const any: Requireable<any>;
 export const array: Requireable<any[]>;
@@ -38,14 +65,16 @@ export const func: Requireable<(...args: any[]) => any>;
 export const number: Requireable<number>;
 export const object: Requireable<object>;
 export const string: Requireable<string>;
-export const node: Requireable<ReactNode>;
-export const element: Requireable<ReactElement<any>>;
+export const node: Requireable<ReactNodeLike>;
+export const element: Requireable<ReactElementLike>;
 export const symbol: Requireable<symbol>;
 export function instanceOf<T>(expectedClass: new (...args: any[]) => T): Requireable<T>;
 export function oneOf<T>(types: T[]): Requireable<T>;
-export function oneOfType<T extends Validator<any>>(types: T[]): Requireable<NonNullable<InferType<T>>>;
+export function oneOfType<T extends Validator<any>>(
+    types: T[],
+): Requireable<NonNullable<InferType<T>>>;
 export function arrayOf<T>(type: Validator<T>): Requireable<T[]>;
-export function objectOf<T>(type: Validator<T>): Requireable<{ [K in keyof any]: T; }>;
+export function objectOf<T>(type: Validator<T>): Requireable<{ [K in keyof any]: T }>;
 export function shape<P extends ValidationMap<any>>(type: P): Requireable<InferProps<P>>;
 export function exact<P extends ValidationMap<any>>(type: P): Requireable<Required<InferProps<P>>>;
 
@@ -59,4 +88,10 @@ export function exact<P extends ValidationMap<any>>(type: P): Requireable<Requir
  * @param componentName Name of the component for error messages.
  * @param getStack Returns the component stack.
  */
-export function checkPropTypes(typeSpecs: any, values: any, location: string, componentName: string, getStack?: () => any): void;
+export function checkPropTypes(
+    typeSpecs: any,
+    values: any,
+    location: string,
+    componentName: string,
+    getStack?: () => any,
+): void;

--- a/types/prop-types/index.d.ts
+++ b/types/prop-types/index.d.ts
@@ -5,46 +5,18 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
-export interface ReactElementLike {
-    type: string | ((...args: any[]) => ReactElementLike);
-    props: any;
-    key: string | number | null;
-    children?: ReactNodeLike;
-}
-
-export interface ReactNodeArray extends Array<ReactNodeLike> {}
-
-export type ReactNodeLike =
-    | {}
-    | ReactElementLike
-    | ReactNodeArray
-    | string
-    | number
-    | boolean
-    | null
-    | undefined;
+import { ReactNode, ReactElement } from 'react';
 
 export const nominalTypeHack: unique symbol;
 
-export type IsOptional<T> = undefined | null extends T
-    ? true
-    : undefined extends T ? true : null extends T ? true : false;
-export type RequiredKeys<V> = {
-    [K in keyof V]: V[K] extends Validator<infer T>
-        ? IsOptional<T> extends true ? never : K
-        : never
-}[keyof V];
+export type IsOptional<T> = undefined | null extends T ? true : undefined extends T ? true : null extends T ? true : false;
+
+export type RequiredKeys<V> = { [K in keyof V]: V[K] extends Validator<infer T> ? IsOptional<T> extends true ? never : K : never }[keyof V];
 export type OptionalKeys<V> = Exclude<keyof V, RequiredKeys<V>>;
-export type InferPropsInner<V> = { [K in keyof V]: InferType<V[K]> };
+export type InferPropsInner<V> = { [K in keyof V]: InferType<V[K]>; };
 
 export interface Validator<T> {
-    (
-        props: object,
-        propName: string,
-        componentName: string,
-        location: string,
-        propFullName: string,
-    ): Error | null;
+    (props: object, propName: string, componentName: string, location: string, propFullName: string): Error | null;
     [nominalTypeHack]?: T;
 }
 
@@ -55,8 +27,9 @@ export interface Requireable<T> extends Validator<T | undefined | null> {
 export type ValidationMap<T> = { [K in keyof T]-?: Validator<T[K]> };
 
 export type InferType<V> = V extends Validator<infer T> ? T : any;
-export type InferProps<V> = InferPropsInner<Pick<V, RequiredKeys<V>>> &
-    Partial<InferPropsInner<Pick<V, OptionalKeys<V>>>>;
+export type InferProps<V> =
+    & InferPropsInner<Pick<V, RequiredKeys<V>>>
+    & Partial<InferPropsInner<Pick<V, OptionalKeys<V>>>>;
 
 export const any: Requireable<any>;
 export const array: Requireable<any[]>;
@@ -65,16 +38,14 @@ export const func: Requireable<(...args: any[]) => any>;
 export const number: Requireable<number>;
 export const object: Requireable<object>;
 export const string: Requireable<string>;
-export const node: Requireable<ReactNodeLike>;
-export const element: Requireable<ReactElementLike>;
+export const node: Requireable<ReactNode>;
+export const element: Requireable<ReactElement<any>>;
 export const symbol: Requireable<symbol>;
 export function instanceOf<T>(expectedClass: new (...args: any[]) => T): Requireable<T>;
 export function oneOf<T>(types: T[]): Requireable<T>;
-export function oneOfType<T extends Validator<any>>(
-    types: T[],
-): Requireable<NonNullable<InferType<T>>>;
+export function oneOfType<T extends Validator<any>>(types: T[]): Requireable<NonNullable<InferType<T>>>;
 export function arrayOf<T>(type: Validator<T>): Requireable<T[]>;
-export function objectOf<T>(type: Validator<T>): Requireable<{ [K in keyof any]: T }>;
+export function objectOf<T>(type: Validator<T>): Requireable<{ [K in keyof any]: T; }>;
 export function shape<P extends ValidationMap<any>>(type: P): Requireable<InferProps<P>>;
 export function exact<P extends ValidationMap<any>>(type: P): Requireable<Required<InferProps<P>>>;
 
@@ -88,10 +59,4 @@ export function exact<P extends ValidationMap<any>>(type: P): Requireable<Requir
  * @param componentName Name of the component for error messages.
  * @param getStack Returns the component stack.
  */
-export function checkPropTypes(
-    typeSpecs: any,
-    values: any,
-    location: string,
-    componentName: string,
-    getStack?: () => any,
-): void;
+export function checkPropTypes(typeSpecs: any, values: any, location: string, componentName: string, getStack?: () => any): void;


### PR DESCRIPTION
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/28881

PropTypes is a stand-alone library that doesn't necessarily require React. This PR removes that dependency and breaks the circular reference.

to: @ferdaber @DovydasNavickas @adisbladis