### PR TITLE
[ganache-core] add vmErrorsOnRPCResponse to GanacheOpts

### DIFF
--- a/types/ganache-core/ganache-core-tests.ts
+++ b/types/ganache-core/ganache-core-tests.ts
@@ -1,3 +1,3 @@
-import { provider } from "ganache-core";
+import { provider } from 'ganache-core';
 
-provider({ verbose: true });
+provider({ verbose: true, vmErrorsOnRPCResponse: false });

--- a/types/ganache-core/index.d.ts
+++ b/types/ganache-core/index.d.ts
@@ -4,7 +4,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.4
 
-import { Provider } from "ethereum-protocol";
+import { Provider } from 'ethereum-protocol';
 export interface GanacheOpts {
     verbose?: boolean;
     logger?: {
@@ -15,5 +15,6 @@ export interface GanacheOpts {
     networkId?: number;
     mnemonic?: string;
     gasLimit?: number;
+    vmErrorsOnRPCResponse?: boolean;
 }
 export function provider(opts: GanacheOpts): Provider;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/trufflesuite/ganache-core defines `vmErrorsOnRPCResponse`
