### PR TITLE
fix: Moment-Range, export method error

### DIFF
--- a/types/moment-range/index.d.ts
+++ b/types/moment-range/index.d.ts
@@ -8,7 +8,7 @@
 
 import moment = require('moment');
 
-export class DateRange {
+export declare class DateRange {
     start: moment.Moment;
     end: moment.Moment;
 


### PR DESCRIPTION
I only changed one word, I did not test it.
"export class" should not appear "d.ts",  we should use "export declare class".
 