### PR TITLE
nuke-carousel - Adds the withoutControls prop to the nuka carousel definition file

### DIFF
--- a/types/nuka-carousel/index.d.ts
+++ b/types/nuka-carousel/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for nuka-carousel 4.2
 // Project: https://github.com/FormidableLabs/nuka-carousel
-// Definitions by: Roman Charugin <https://github.com/Romic>
+// Definitions by: Roman Charugin <https://github.com/Romic>, Alex Smith <https://github.com/altaudio>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -222,6 +222,11 @@ export interface CarouselProps {
    * @default false
    */
   wrapAround?: boolean;
+  /**
+   * Used to remove all controls at once. Overwrites the render[Top, Right, Bottom, Left]CenterControls()
+   * @default false
+   */
+  withoutControls?: boolean;
 }
 
 export interface CarouselState {

--- a/types/nuka-carousel/index.d.ts
+++ b/types/nuka-carousel/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for nuka-carousel 4.2
+// Type definitions for nuka-carousel 4.3
 // Project: https://github.com/FormidableLabs/nuka-carousel
 // Definitions by: Roman Charugin <https://github.com/Romic>, Alex Smith <https://github.com/altaudio>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped


### PR DESCRIPTION
- Adds the withoutControls prop to the `@types/nuka-carousel` definition file