### PR TITLE
Fix bad return type in lazyJS ObjectLikeSequence.get()

### DIFF
--- a/types/lazy.js/index.d.ts
+++ b/types/lazy.js/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Lazy.js 0.3.3
+// Type definitions for Lazy.js 0.3.4
 // Project: https://github.com/dtao/lazy.js/
 // Definitions by: Bart van der Schoor <https://github.com/Bartvds>, Mike Doughty <https://github.com/miso440>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/lazy.js/index.d.ts
+++ b/types/lazy.js/index.d.ts
@@ -219,7 +219,7 @@ declare namespace LazyJS {
       //async(): X;
       defaults(defaults: any): ObjectLikeSequence<T>;
       functions(): Sequence<T>;
-      get(property: string): T;
+      get(property: string): any;
       invert(): ObjectLikeSequence<T>;
       keys(): Sequence<string>;
       merge(others: any | ObjectLikeSequence<T>, mergeFn?: Function): ObjectLikeSequence<T>;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [LazyJS Docs](http://danieltao.com/lazy.js/docs/)
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

Notes:
My last PR #28825 had `ObjectLikeSequence<T>.get(string)` returning the generic `T` type which obviously makes no sense. This single-line change corrects that mistake.