### PR TITLE
[jquery] Change return type of the index function to be Element

### DIFF
--- a/types/jquery/v2/index.d.ts
+++ b/types/jquery/v2/index.d.ts
@@ -3385,7 +3385,7 @@ interface JQuery {
      * @see {@link https://api.jquery.com/selector/}
      */
     selector: string;
-    [index: number]: HTMLElement;
+    [index: number]: Element;
 
     /**
      * Add elements to the set of matched elements.


### PR DESCRIPTION
This reflects the fact that jQuery can be used to select elements other than HTMLElements, such as SVGElement

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Test won't run due to breakages from another package.
Lint fails on a test that I did not make changes to.

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: **https://api.jquery.com/jQuery/ (note it says Element, not HTML Element)**
- [ ] Increase the version number in the header if appropriate. **Should be non breaking**
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

`.
