### PR TITLE
Make custom prop not required in emoji-mart Picker component

### DIFF
--- a/types/emoji-mart/dist-es/utils/shared-props.d.ts
+++ b/types/emoji-mart/dist-es/utils/shared-props.d.ts
@@ -75,7 +75,7 @@ export interface PickerProps {
     recent?: string[];
     autoFocus?: boolean;
     /** NOTE: custom emoji are copied into a singleton object on every new mount */
-    custom: CustomEmoji[];
+    custom?: CustomEmoji[];
     skinEmoji?: string;
     notFound?(): React.Component;
     notFoundEmoji?: string;


### PR DESCRIPTION
It's not marked as required in the docs

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/missive/emoji-mart#picker
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
