### PR TITLE
[@google-cloud/datastore] Fix ES6/ES2015 import syntax

### DIFF
--- a/types/google-cloud__datastore/google-cloud__datastore-tests.ts
+++ b/types/google-cloud__datastore/google-cloud__datastore-tests.ts
@@ -1,4 +1,4 @@
-import Datastore = require('@google-cloud/datastore');
+import * as Datastore from '@google-cloud/datastore';
 import {
     DatastoreDouble,
     DatastoreGeopoint,

--- a/types/google-cloud__datastore/index.d.ts
+++ b/types/google-cloud__datastore/index.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: Antoine Beauvais-Lacasse <https://github.com/beaulac>
 //                 Futa Ogawa <https://github.com/ogawa0071>
 //                 Thomas den Hollander <https://github.com/ThomasdenH>
+//                 Arjen van der Ende <https://github.com/arjenvanderende>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.7
 
@@ -11,6 +12,7 @@
 declare module '@google-cloud/datastore' {
     export = Datastore;
 
+    namespace Datastore {}
     import {
         DatastoreKey,
         KEY_SYMBOL,


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

This PR reintroduces the namespace that was removed in #27900. The removal broken ES6-style import for this package:

```javascript
import * as Datastore from "@google-cloud/datastore";
```

When the package is imported in this way, this results in the following compile error:

```
Module ''@google-cloud/datastore'' resolves to a non-module entity and cannot be imported using this construct.
```

This import style used to work with older versions of the type definitions for this package.
I've updated the import in the tests as well to cover this behaviour.