### PR TITLE
Updated typescript def for react-big-calendar to include onRangeChanged

### DIFF
--- a/types/react-big-calendar/index.d.ts
+++ b/types/react-big-calendar/index.d.ts
@@ -159,6 +159,7 @@ export interface BigCalendarProps<T extends Event = Event> extends React.Props<B
     events?: T[];
     onNavigate?: (newDate: Date, action: Navigate) => void;
     onView?: (view: View) => void;
+    onRangeChange?: (range: DateRange) => void;                                  
     onDrillDown?: (date: Date, view: View) => void;
     onSelectSlot?: (slotInfo: { start: stringOrDate, end: stringOrDate, slots: Date[] | string[], action: 'select' | 'click' | 'doubleClick' }) => void;
     onDoubleClickEvent?: (event: T, e: React.SyntheticEvent<HTMLElement>) => void;


### PR DESCRIPTION
If changing an existing definition:

- [] Provide a URL to documentation or source code which provides context for the suggested changes: 

http://intljusticemission.github.io/react-big-calendar/examples/index.html#prop-onRangeChange

