### PR TITLE
Add missing definition for markedDates

### DIFF
--- a/types/react-native-calendars/index.d.ts
+++ b/types/react-native-calendars/index.d.ts
@@ -319,6 +319,13 @@ export interface CalendarListBaseProps extends CalendarBaseProps {
      *  Enable or disable vertical scroll indicator. Default = false
      */
     showScrollIndicator?: boolean;
+
+    /**
+     * Show marked dates on the calendar
+     */
+    markedDates?:  {
+        [date: string]: PeriodMarking;
+    };
 }
 
 export class CalendarList extends React.Component<CalendarListBaseProps> { }


### PR DESCRIPTION
markedDates was missed on the original types, but was included in the test code.
This PR adds the missing definition to the defs