### PR TITLE
Fix wrong optional `ChangeEvent` parameter for `InputProps.onChange`

### DIFF
--- a/types/react-autosuggest/index.d.ts
+++ b/types/react-autosuggest/index.d.ts
@@ -54,7 +54,7 @@ declare namespace Autosuggest {
 
     interface InputProps<TSuggestion>
         extends Omit<React.InputHTMLAttributes<any>, 'onChange' | 'onBlur'> {
-        onChange(event: React.FormEvent<any>, params?: ChangeEvent): void;
+        onChange(event: React.FormEvent<any>, params: ChangeEvent): void;
         onBlur?(event: React.FormEvent<any>, params?: BlurEvent<TSuggestion>): void;
         value: string;
         [key: string]: any;

--- a/types/react-autosuggest/react-autosuggest-tests.tsx
+++ b/types/react-autosuggest/react-autosuggest-tests.tsx
@@ -70,13 +70,6 @@ export class ReactAutosuggestBasicTest extends React.Component<any, any> {
     // endregion region Rendering methods
     render(): JSX.Element {
         const {value, suggestions} = this.state;
-        const inputProps = {
-            placeholder: `Type 'c'`,
-            value,
-            onChange: this
-                .onChange
-                .bind(this)
-        };
 
         const theme = {
             input: 'themed-input-class',
@@ -94,7 +87,11 @@ export class ReactAutosuggestBasicTest extends React.Component<any, any> {
             renderSuggestion={this.renderSuggestion}
             onSuggestionSelected={this.onSuggestionsSelected}
             alwaysRenderSuggestions={true}
-            inputProps={inputProps}
+            inputProps={{
+                placeholder: `Type 'c'`,
+                value,
+                onChange: (e, changeEvent) => this.onChange(e, changeEvent),
+            }}
             theme={theme}/>;
     }
 
@@ -107,7 +104,7 @@ export class ReactAutosuggestBasicTest extends React.Component<any, any> {
         return <span className={className}>{suggestion.name}</span>;
     }
     // endregion region Event handlers
-    protected onChange(event: React.FormEvent<any>, {newValue, method}: any): void {
+    protected onChange(event: React.FormEvent<any>, {newValue, method}: Autosuggest.ChangeEvent): void {
         this.setState({value: newValue});
     }
 
@@ -192,13 +189,6 @@ export class ReactAutosuggestTypedTest extends React.Component<any, any> {
     // endregion region Rendering methods
     render(): JSX.Element {
         const {value, suggestions} = this.state;
-        const inputProps = {
-            placeholder: `Type 'c'`,
-            value,
-            onChange: this
-                .onChange
-                .bind(this)
-        };
 
         const theme = {
             input: 'themed-input-class',
@@ -216,7 +206,11 @@ export class ReactAutosuggestTypedTest extends React.Component<any, any> {
             renderSuggestion={this.renderSuggestion}
             onSuggestionSelected={this.onSuggestionsSelected}
             alwaysRenderSuggestions={true}
-            inputProps={inputProps}
+            inputProps={{
+                placeholder: `Type 'c'`,
+                value,
+                onChange: (e, changeEvent) => this.onChange(e, changeEvent),
+            }}
             theme={theme}/>;
     }
 
@@ -229,7 +223,7 @@ export class ReactAutosuggestTypedTest extends React.Component<any, any> {
         return <span className={className}>{suggestion.name}</span>;
     }
     // endregion region Event handlers
-    protected onChange(event: React.FormEvent<any>, {newValue, method}: any): void {
+    protected onChange(event: React.FormEvent<any>, {newValue, method}: Autosuggest.ChangeEvent): void {
         this.setState({value: newValue});
     }
 
@@ -352,13 +346,6 @@ export class ReactAutosuggestMultipleTest extends React.Component<any, any> {
     // endregion region Rendering methods
     render(): JSX.Element {
         const {value, suggestions} = this.state;
-        const inputProps = {
-            placeholder: `Type 'c'`,
-            value,
-            onChange: this
-                .onChange
-                .bind(this)
-        };
 
         return <LanguageAutosuggest
             multiSection={true}
@@ -375,7 +362,11 @@ export class ReactAutosuggestMultipleTest extends React.Component<any, any> {
             highlightFirstSuggestion={true}
             renderInputComponent={this.renderInputComponent}
             renderSuggestionsContainer={this.renderSuggestionsContainer}
-            inputProps={inputProps}/>;
+            inputProps={{
+                placeholder: `Type 'c'`,
+                value,
+                onChange: (e, changeEvent) => this.onChange(e, changeEvent),
+            }}/>;
     }
 
     protected onSuggestionSelected(event: React.FormEvent<any>, data: Autosuggest.SuggestionSelectedEventData<Language>): void {
@@ -393,9 +384,10 @@ export class ReactAutosuggestMultipleTest extends React.Component<any, any> {
     }
 
     protected renderInputComponent(inputProps: Autosuggest.InputProps<Language>): JSX.Element {
+        const { onChange, onBlur, ...restInputProps } = inputProps;
         return (
             <div>
-                <input {...inputProps} />
+                <input {...restInputProps} />
             </div>
         );
     }
@@ -408,7 +400,7 @@ export class ReactAutosuggestMultipleTest extends React.Component<any, any> {
         );
     }
     // endregion region Event handlers
-    protected onChange(event: React.FormEvent<any>, {newValue, method}: any): void {
+    protected onChange(event: React.FormEvent<any>, {newValue, method}: Autosuggest.ChangeEvent): void {
         this.setState({value: newValue});
     }
 
@@ -496,20 +488,17 @@ export class ReactAutosuggestCustomTest extends React.Component<any, any> {
     // endregion region Rendering methods
     render(): JSX.Element {
         const {value, suggestions} = this.state;
-        const inputProps = {
-            placeholder: "Type 'c'",
-            value,
-            onChange: this
-                .onChange
-                .bind(this)
-        };
 
         return<PersonAutosuggest
             suggestions={suggestions}
             onSuggestionsFetchRequested={this.onSuggestionsFetchRequested}
             getSuggestionValue={this.getSuggestionValue}
             renderSuggestion={this.renderSuggestion}
-            inputProps={inputProps}/>;
+            inputProps={{
+                placeholder: "Type 'c'",
+                value,
+                onChange: (e, changeEvent) => this.onChange(e, changeEvent),
+            }}/>;
     }
 
     protected renderSuggestion(suggestion: Person, params: Autosuggest.RenderSuggestionParams): JSX.Element {
@@ -538,7 +527,7 @@ export class ReactAutosuggestCustomTest extends React.Component<any, any> {
        </span>;
     }
     // endregion region Event handlers
-    protected onChange(event: React.FormEvent<any>, {newValue, method}: any): void {
+    protected onChange(event: React.FormEvent<any>, {newValue, method}: Autosuggest.ChangeEvent): void {
         this.setState({value: newValue});
     }
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
  - [Readme](https://github.com/moroshko/react-autosuggest#inputpropsonchange-required)
  - [Code](https://github.com/moroshko/react-autosuggest/blob/11fcfe713201c7fb7be5e18bbbbb21333baf1ca0/src/Autosuggest.js#L320)
