### PR TITLE
Update utils.d.ts to include `isHexStrict` method in @types/web3

### DIFF
--- a/types/web3/utils.d.ts
+++ b/types/web3/utils.d.ts
@@ -51,7 +51,7 @@ export default interface Utils {
     isBigNumber(any: any): boolean;
     isAddress(any: any): boolean;
     isHex(any: any): boolean;
-    isHexStrict(val: Hex | string): boolean;
+    isHexStrict(val: Hex): boolean;
     _: us.UnderscoreStatic;
     asciiToHex(val: string): string;
     hexToAscii(val: string): string;

--- a/types/web3/utils.d.ts
+++ b/types/web3/utils.d.ts
@@ -49,6 +49,7 @@ export default interface Utils {
     isBigNumber(any: any): boolean;
     isAddress(any: any): boolean;
     isHex(any: any): boolean;
+    isHexStrict(any: any): boolean;
     _: us.UnderscoreStatic;
     asciiToHex(val: string): string;
     hexToAscii(val: string): string;

--- a/types/web3/utils.d.ts
+++ b/types/web3/utils.d.ts
@@ -43,13 +43,15 @@ type Mixed =
     v: string;
 };
 
+type Hex = string | number;
+
 export default interface Utils {
     BN: BigNumber; // TODO only static-definition
     isBN(any: any): boolean;
     isBigNumber(any: any): boolean;
     isAddress(any: any): boolean;
     isHex(any: any): boolean;
-    isHexStrict(any: any): boolean;
+    isHexStrict(val: Hex | string): boolean;
     _: us.UnderscoreStatic;
     asciiToHex(val: string): string;
     hexToAscii(val: string): string;

--- a/types/web3/web3-tests.ts
+++ b/types/web3/web3-tests.ts
@@ -77,4 +77,5 @@ const weiStr: string = web3.utils.toWei("100", "gwei");
 const weiBn: BigNumber = web3.utils.toWei(web3.utils.toBN("1"));
 const rndHex: string = Web3.utils.randomHex(10);
 const sha3: string = web3.utils.soliditySha3(0, 1, "abc");
-const isHex: boolean = web3.utils.isHexStrict("0xc1912");
+const isStrictHexString: boolean = web3.utils.isHexStrict("0xc1912");
+const isStrictHexNumber: boolean = web3.utils.isHexStrict(0xc1912);

--- a/types/web3/web3-tests.ts
+++ b/types/web3/web3-tests.ts
@@ -77,3 +77,4 @@ const weiStr: string = web3.utils.toWei("100", "gwei");
 const weiBn: BigNumber = web3.utils.toWei(web3.utils.toBN("1"));
 const rndHex: string = Web3.utils.randomHex(10);
 const sha3: string = web3.utils.soliditySha3(0, 1, "abc");
+const isHex: boolean = web3.utils.isHexStrict("0xc1912");


### PR DESCRIPTION
As per the documentation in beta 36, there is a method `isHexStrict` method that checks if the passed string is hex and additionally starts with the '0x' prefix.

Please fill in this template.

- [ x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ x] Test the change in your own code. (Compile and run.)
- [x ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: https://web3js.readthedocs.io/en/1.0/web3-utils.html#ishexstrict
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
