### PR TITLE
Fix Annotations - should be array

### DIFF
--- a/types/highcharts/index.d.ts
+++ b/types/highcharts/index.d.ts
@@ -6411,7 +6411,7 @@ declare namespace Highcharts {
         /**
          * Options for configuring annotations, for example labels, arrows or shapes.
          */
-        annotations?: AnnotationsOptions;
+        annotations?: AnnotationsOptions[];
         /**
          * Options regarding the chart area and plot area as well as general chart options.
          */


### PR DESCRIPTION
My mistake, the annotations field is an array not a singleton, see https://api.highcharts.com/highcharts/annotations

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://api.highcharts.com/highcharts/annotations
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
