### PR TITLE
Add marking props to calendarList

### DIFF
--- a/types/react-native-calendars/index.d.ts
+++ b/types/react-native-calendars/index.d.ts
@@ -321,7 +321,7 @@ export interface CalendarListBaseProps extends CalendarBaseProps {
     showScrollIndicator?: boolean;
 }
 
-export class CalendarList extends React.Component<CalendarListBaseProps> { }
+export class CalendarList extends React.Component<CalendarMarkingProps & CalendarListBaseProps> { }
 
 export interface AgendaThemeStyle extends CalendarTheme {
     agendaDayNumColor?: string;


### PR DESCRIPTION
Original definitions missed the required marking parameters for the CalendarList.

Test classes have them; this now adds them to the defs
