### PR TITLE
Allow more Falsey returns and allow scope string arrays

### DIFF
--- a/types/oauth2-server/index.d.ts
+++ b/types/oauth2-server/index.d.ts
@@ -123,7 +123,7 @@ declare namespace OAuth2Server {
         /**
          * The scope(s) to authenticate.
          */
-        scope?: string;
+        scope?: string | string[];
 
         /**
          * Set the X-Accepted-OAuth-Scopes HTTP header on response objects.
@@ -200,7 +200,7 @@ declare namespace OAuth2Server {
          * Invoked to generate a new access token.
          *
          */
-        generateAccessToken?(client: Client, user: User, scope: string, callback?: Callback<string>): Promise<string>;
+        generateAccessToken?(client: Client, user: User, scope: string | string[], callback?: Callback<string>): Promise<string>;
 
         /**
          * Invoked to retrieve a client using a client id or a client id/client secret combination, depending on the grant type.
@@ -212,7 +212,7 @@ declare namespace OAuth2Server {
          * Invoked to save an access token and optionally a refresh token, depending on the grant type.
          *
          */
-        saveToken(token: Token, client: Client, user: User, callback?: Callback<Token>): Promise<Token>;
+        saveToken(token: Token, client: Client, user: User, callback?: Callback<Token>): Promise<Token | Falsey>;
     }
 
     interface RequestAuthenticationModel {
@@ -220,13 +220,13 @@ declare namespace OAuth2Server {
          * Invoked to retrieve an existing access token previously saved through Model#saveToken().
          *
          */
-        getAccessToken(accessToken: string, callback?: Callback<Token>): Promise<Token>;
+        getAccessToken(accessToken: string, callback?: Callback<Token>): Promise<Token | Falsey>;
 
         /**
          * Invoked during request authentication to check if the provided access token was authorized the requested scopes.
          *
          */
-        verifyScope(token: Token, scope: string, callback?: Callback<boolean>): Promise<boolean>;
+        verifyScope(token: Token, scope: string | string[], callback?: Callback<boolean>): Promise<boolean>;
     }
 
     interface AuthorizationCodeModel extends BaseModel, RequestAuthenticationModel {
@@ -234,25 +234,25 @@ declare namespace OAuth2Server {
          * Invoked to generate a new refresh token.
          *
          */
-        generateRefreshToken?(client: Client, user: User, scope: string, callback?: Callback<string>): Promise<string>;
+        generateRefreshToken?(client: Client, user: User, scope: string | string[], callback?: Callback<string>): Promise<string>;
 
         /**
          * Invoked to generate a new authorization code.
          *
          */
-        generateAuthorizationCode?(client: Client, user: User, scope: string, callback?: Callback<string>): Promise<string>;
+        generateAuthorizationCode?(client: Client, user: User, scope: string | string[], callback?: Callback<string>): Promise<string>;
 
         /**
          * Invoked to retrieve an existing authorization code previously saved through Model#saveAuthorizationCode().
          *
          */
-        getAuthorizationCode(authorizationCode: string, callback?: Callback<AuthorizationCode>): Promise<AuthorizationCode>;
+        getAuthorizationCode(authorizationCode: string, callback?: Callback<AuthorizationCode>): Promise<AuthorizationCode | Falsey>;
 
         /**
          * Invoked to save an authorization code.
          *
          */
-        saveAuthorizationCode(code: AuthorizationCode, client: Client, user: User, callback?: Callback<AuthorizationCode>): Promise<AuthorizationCode>;
+        saveAuthorizationCode(code: AuthorizationCode, client: Client, user: User, callback?: Callback<AuthorizationCode>): Promise<AuthorizationCode | Falsey>;
 
         /**
          * Invoked to revoke an authorization code.
@@ -264,7 +264,7 @@ declare namespace OAuth2Server {
          * Invoked to check if the requested scope is valid for a particular client/user combination.
          *
          */
-        validateScope?(user: User, client: Client, scope: string, callback?: Callback<string | Falsey>): Promise<string | Falsey>;
+        validateScope?(user: User, client: Client, scope: string | string[], callback?: Callback<string | Falsey>): Promise<string | string[] | Falsey>;
     }
 
     interface PasswordModel extends BaseModel, RequestAuthenticationModel {
@@ -272,7 +272,7 @@ declare namespace OAuth2Server {
          * Invoked to generate a new refresh token.
          *
          */
-        generateRefreshToken?(client: Client, user: User, scope: string, callback?: Callback<string>): Promise<string>;
+        generateRefreshToken?(client: Client, user: User, scope: string | string[], callback?: Callback<string>): Promise<string>;
 
         /**
          * Invoked to retrieve a user using a username/password combination.
@@ -284,7 +284,7 @@ declare namespace OAuth2Server {
          * Invoked to check if the requested scope is valid for a particular client/user combination.
          *
          */
-        validateScope?(user: User, client: Client, scope: string, callback?: Callback<string | Falsey>): Promise<string | Falsey>;
+        validateScope?(user: User, client: Client, scope: string | string[], callback?: Callback<string | Falsey>): Promise<string | string[] | Falsey>;
     }
 
     interface RefreshTokenModel extends BaseModel, RequestAuthenticationModel {
@@ -292,19 +292,19 @@ declare namespace OAuth2Server {
          * Invoked to generate a new refresh token.
          *
          */
-        generateRefreshToken?(client: Client, user: User, scope: string, callback?: Callback<string>): Promise<string>;
+        generateRefreshToken?(client: Client, user: User, scope: string | string[], callback?: Callback<string>): Promise<string>;
 
         /**
          * Invoked to retrieve an existing refresh token previously saved through Model#saveToken().
          *
          */
-        getRefreshToken(refreshToken: string, callback?: Callback<RefreshToken>): Promise<RefreshToken>;
+        getRefreshToken(refreshToken: string, callback?: Callback<RefreshToken>): Promise<RefreshToken | Falsey>;
 
         /**
          * Invoked to revoke a refresh token.
          *
          */
-        revokeToken(token: Token, callback?: Callback<boolean>): Promise<boolean>;
+        revokeToken(token: RefreshToken | Token, callback?: Callback<boolean>): Promise<boolean>;
     }
 
     interface ClientCredentialsModel extends BaseModel, RequestAuthenticationModel {
@@ -318,7 +318,7 @@ declare namespace OAuth2Server {
          * Invoked to check if the requested scope is valid for a particular client/user combination.
          *
          */
-        validateScope?(user: User, client: Client, scope: string, callback?: Callback<string | Falsey>): Promise<string | Falsey>;
+        validateScope?(user: User, client: Client, scope: string | string[], callback?: Callback<string | Falsey>): Promise<string | string[] | Falsey>;
     }
 
     interface ExtensionModel extends BaseModel, RequestAuthenticationModel {}
@@ -336,8 +336,8 @@ declare namespace OAuth2Server {
      */
     interface Client {
         id: string;
-        redirectUris?: string[];
-        grants: string[];
+        redirectUris?: string | string[];
+        grants: string | string[];
         accessTokenLifetime?: number;
         refreshTokenLifetime?: number;
         [key: string]: any;
@@ -350,7 +350,7 @@ declare namespace OAuth2Server {
         authorizationCode: string;
         expiresAt: Date;
         redirectUri: string;
-        scope?: string;
+        scope?: string | string[];
         client: Client;
         user: User;
         [key: string]: any;
@@ -364,7 +364,7 @@ declare namespace OAuth2Server {
         accessTokenExpiresAt?: Date;
         refreshToken?: string;
         refreshTokenExpiresAt?: Date;
-        scope?: string;
+        scope?: string | string[];
         client: Client;
         user: User;
         [key: string]: any;
@@ -376,7 +376,7 @@ declare namespace OAuth2Server {
     interface RefreshToken {
         refreshToken: string;
         refreshTokenExpiresAt?: Date;
-        scope?: string;
+        scope?: string | string[];
         client: Client;
         user: User;
         [key: string]: any;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

Changes:
* `scopes` can be string arrays; this allows transformation immediately from the database instead of in each model.
  * It doesn't appear `oauth2-server` manipulates `scope` and only passes the value between models. `string[]` works fine in my models.
* Also, `grants` and `redirectURIs` can be strings or string arrays for the same reason as above.
* Additional models can return `Falsey` types. They aren't all documented but when testing, `oauth2-server` returns proper errors when the database fails and `false` is returned.
* Revoke Token accepts `Token` or `RefreshToken` (should really only be `RefreshToken`, though)