### PR TITLE
react-map-gl - Make mapboxApiAccessToken prop optional

### DIFF
--- a/types/react-map-gl/index.d.ts
+++ b/types/react-map-gl/index.d.ts
@@ -29,7 +29,7 @@ export interface MapRequest {
 
 export interface MapboxProps extends Partial<Viewport> {
     container?: {};
-    mapboxApiAccessToken: string;
+    mapboxApiAccessToken?: string;
     attributionControl?: boolean;
     preserveDrawingBuffer?: boolean;
     onLoad?: () => void;

--- a/types/react-map-gl/index.d.ts
+++ b/types/react-map-gl/index.d.ts
@@ -23,8 +23,8 @@ export interface MapError {
 
 export interface MapRequest {
     url: string;
-    headers: {};
-    credentials: string;
+    headers?: { [index: string]: string };
+    credentials?: string;
 }
 
 export interface MapboxProps extends Partial<Viewport> {
@@ -36,7 +36,7 @@ export interface MapboxProps extends Partial<Viewport> {
     onError?: (e: MapError) => void;
     resuseMaps?: boolean;
     resuseMap?: boolean;
-    transformRequest?: () => MapRequest;
+    transformRequest?: (url?: string, resourceType?: string) => MapRequest;
 
     mapStyle?: string | {};
 


### PR DESCRIPTION
Please fill in this template.

- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/uber/react-map-gl/blob/7f0909fff15339862ba78d93929a4505588bbebb/src/mapbox/mapbox.js#L59

---

`react-map-gl` works with tile providers other than `mapbox`. I've been using http://openmaptiles.org and passing an empty string to the prop `mapboxApiAccessToken`, and the library functions as expected, which indicates that the prop should be optional.