### PR TITLE
@types/chai - Add members to KeyFilter interface

### DIFF
--- a/types/chai/chai-tests.ts
+++ b/types/chai/chai-tests.ts
@@ -1145,6 +1145,8 @@ function members() {
     expect([5, 4]).not.members([]);
     expect([5, 4]).not.members([6, 3]);
     expect([5, 4]).not.members([5, 4, 2]);
+
+    expect([5, 4]).to.have.all.members([4, 5]);
 }
 
 function increaseDecreaseChange() {

--- a/types/chai/index.d.ts
+++ b/types/chai/index.d.ts
@@ -195,6 +195,7 @@ declare namespace Chai {
 
     interface KeyFilter {
         keys: Keys;
+        members: Members;
     }
 
     interface Equal {


### PR DESCRIPTION
We use `expect(foo).to.have.all.members(bar)` but the `KeyFilter` interface was missing the `members` definition.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://medium.com/building-ibotta/testing-arrays-and-objects-with-chai-js-4b372310fe6d
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
