### PR TITLE
[react-navigation] withNavigation function will work with Partial<NavigationInjectedProps>

### DIFF
--- a/types/react-navigation/index.d.ts
+++ b/types/react-navigation/index.d.ts
@@ -1239,7 +1239,7 @@ export interface NavigationInjectedProps<P = NavigationParams> {
 }
 
 export function withNavigation<T = {}, P = NavigationParams>(
-  Component: React.ComponentType<T & NavigationInjectedProps<P>>
+  Component: React.ComponentType<T | (T & NavigationInjectedProps<P>)>
 ): React.ComponentType<T & { onRef?: React.Ref<React.Component<T & NavigationInjectedProps<P>>> }>;
 
 export interface NavigationFocusInjectedProps extends NavigationInjectedProps {


### PR DESCRIPTION
On this current version, TS gives an error when you use this with Partial<NavigationInjectedProps>

With this change, It will work.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
