### PR TITLE
@types/knex - Fix join callback argument for on, andOn, orOn

### DIFF
--- a/types/knex/index.d.ts
+++ b/types/knex/index.d.ts
@@ -188,9 +188,13 @@ declare namespace Knex {
     interface Distinct extends ColumnNameQueryBuilder {
     }
 
+    interface JoinCallback {
+        (this: JoinClause, join: JoinClause): void;
+    }
+
     interface Join {
         (raw: Raw): QueryBuilder;
-        (tableName: TableName | QueryCallback, clause: (this: JoinClause, join: JoinClause) => void): QueryBuilder;
+        (tableName: TableName | QueryCallback, clause: JoinCallback): QueryBuilder;
         (tableName: TableName | QueryCallback, columns: { [key: string]: string | number | Raw }): QueryBuilder;
         (tableName: TableName | QueryCallback, raw: Raw): QueryBuilder;
         (tableName: TableName | QueryCallback, column1: string, column2: string): QueryBuilder;
@@ -200,19 +204,19 @@ declare namespace Knex {
 
     interface JoinClause {
         on(raw: Raw): JoinClause;
-        on(callback: QueryCallback): JoinClause;
+        on(callback: JoinCallback): JoinClause;
         on(columns: { [key: string]: string | Raw }): JoinClause;
         on(column1: string, column2: string): JoinClause;
         on(column1: string, raw: Raw): JoinClause;
         on(column1: string, operator: string, column2: string | Raw): JoinClause;
         andOn(raw: Raw): JoinClause;
-        andOn(callback: QueryCallback): JoinClause;
+        andOn(callback: JoinCallback): JoinClause;
         andOn(columns: { [key: string]: string | Raw }): JoinClause;
         andOn(column1: string, column2: string): JoinClause;
         andOn(column1: string, raw: Raw): JoinClause;
         andOn(column1: string, operator: string, column2: string | Raw): JoinClause;
         orOn(raw: Raw): JoinClause;
-        orOn(callback: QueryCallback): JoinClause;
+        orOn(callback: JoinCallback): JoinClause;
         orOn(columns: { [key: string]: string | Raw }): JoinClause;
         orOn(column1: string, column2: string): JoinClause;
         orOn(column1: string, raw: Raw): JoinClause;

--- a/types/knex/knex-tests.ts
+++ b/types/knex/knex-tests.ts
@@ -444,6 +444,13 @@ knex.select('*').from('users').leftJoin('accounts', (join: Knex.JoinClause) => {
   join.on('accounts.id', '=', 'users.account_id').orOn('accounts.owner_id', '=', 'users.id');
 });
 
+knex.select('*').from('users').leftJoin('accounts', (join) => {
+  join.on('accounts.id', '=', 'users.account_id').orOn('accounts.owner_id', '=', 'users.id')
+  .andOn((join2) => {
+    join2.on('col1', 'col2').orOn('col3', 'col4');
+  });
+});
+
 knex.select('*').from('users').leftOuterJoin('accounts', 'users.id', 'accounts.user_id');
 
 knex.select('*').from('users').leftOuterJoin('accounts', function() {
@@ -985,13 +992,13 @@ knex('users')
   .select('*')
   .join('contacts', function(builder) {
     this.on(function(builder) {
-      let self: Knex.QueryBuilder = this;
+      let self: Knex.JoinClause = this;
       self = builder;
     }).andOn(function(builder) {
-      let self: Knex.QueryBuilder = this;
+      let self: Knex.JoinClause = this;
       self = builder;
     }).orOn(function(builder) {
-      let self: Knex.QueryBuilder = this;
+      let self: Knex.JoinClause = this;
       self = builder;
     }).onExists(function(builder) {
       let self: Knex.QueryBuilder = this;


### PR DESCRIPTION
Changed the JoinClause's interface for `on`, `andOn` and `orOn` to accept a callback that takes another JoinClause, instead of QueryCallback. This was invalid and prevented deeper nesting join on statements.


- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://knexjs.org/#Builder-join>> __and then the 4th code example down from that__