### PR TITLE
OfficeRuntime:  Add missing "onRuntimeError"

### DIFF
--- a/types/office-runtime/index.d.ts
+++ b/types/office-runtime/index.d.ts
@@ -118,8 +118,13 @@ declare namespace OfficeRuntime {
         onClose?: () => void;
         /*
          * @beta
-         * Callback that is run when the dialog box sends an error.
+         * Callback that is run when the dialog sends a message to its parent.
          */
         onMessage?(message: string, dialog?: Dialog): void;
+        /*
+         * @beta
+         * Callback that is run when the dialog box sends an error.
+         */
+        onRuntimeError?(message: string, dialog?: Dialog): void;
     }
 }


### PR DESCRIPTION
Add missing `onRuntimeError` to OfficeRuntime's DisplayWebDialogOptions

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
