### PR TITLE
[yargs] Fix showHidden() casing

### DIFF
--- a/types/yargs/index.d.ts
+++ b/types/yargs/index.d.ts
@@ -5,6 +5,7 @@
 //                 Jeffery Grajkowski <https://github.com/pushplay>
 //                 Jeff Kenney <https://github.com/jeffkenney>
 //                 Jimi (Dimitris) Charalampidis <https://github.com/JimiC>
+//                 Teddy Cross <https://github.com/tkazec>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
@@ -191,8 +192,8 @@ declare namespace yargs {
 
         showCompletionScript(): Argv;
 
-        showhidden(option?: string | boolean): Argv;
-        showhidden(option: string, description?: string): Argv;
+        showHidden(option?: string | boolean): Argv;
+        showHidden(option: string, description?: string): Argv;
 
         showHelp(consoleLevel?: string): Argv;
 

--- a/types/yargs/yargs-tests.ts
+++ b/types/yargs/yargs-tests.ts
@@ -654,12 +654,12 @@ function Argv$hide() {
         .hide('a');
 }
 
-function Argv$showhidden() {
+function Argv$showHidden() {
     const ya = yargs
-        .showhidden()
-        .showhidden(true)
-        .showhidden('show-hidden')
-        .showhidden('show-hidden', 'Show hidden options');
+        .showHidden()
+        .showHidden(true)
+        .showHidden('show-hidden')
+        .showHidden('show-hidden', 'Show hidden options');
 }
 
 function Argv$scriptName() {


### PR DESCRIPTION
1. Technically a breaking change, but not sure it actually qualifies since it doesn't seem like anybody using `showHidden()` would've been able to use these types.
2. Seems like the tests aren't actually running their methods, is there any way to fix this?

---

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/yargs/yargs/blob/66fd6f7e9831008eab6742c7782f2e255b838ea7/yargs.js#L842
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.