### PR TITLE
@types/react-native-push-notification: Add missing permissions type on push notification options

### DIFF
--- a/types/react-native-push-notification/index.d.ts
+++ b/types/react-native-push-notification/index.d.ts
@@ -22,7 +22,7 @@ export interface PushNotification {
     finish: (fetchResult: string) => void;
 }
 
-export class PushNotificationOptions {
+export interface PushNotificationOptions {
     onRegister?: (token: { os: string, token: string }) => void;
     onNotification?: (notification: PushNotification) => void;
     senderID?: string;

--- a/types/react-native-push-notification/index.d.ts
+++ b/types/react-native-push-notification/index.d.ts
@@ -26,6 +26,7 @@ export class PushNotificationOptions {
     onRegister?: (token: { os: string, token: string }) => void;
     onNotification?: (notification: PushNotification) => void;
     senderID?: string;
+    permissions?: PushNotificationPermissions;
     popInitialNotification?: boolean;
     requestPermissions?: boolean;
 }

--- a/types/react-native-push-notification/react-native-push-notification-tests.ts
+++ b/types/react-native-push-notification/react-native-push-notification-tests.ts
@@ -6,6 +6,7 @@ PushNotification.configure({
     },
     onRegister: (token) => {},
     senderID: 'XXX',
+    permissions: { alert: true, badge: true, sound: true },
     popInitialNotification: false,
     requestPermissions: true,
 });


### PR DESCRIPTION
The `permissions` property is optional for iOS, but TypeScript wasn't recognizing it.

- Added the property using the existing `PushNotificationPermissions` type. 
- Refactored the `PushNotificationOptions` from a `class` to an `interface` since it's just a plain object.

---

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/zo0r/react-native-push-notification/blob/82544256b63c5cb0793b590ce5d60a298f4ee658/index.js#L51
