### PR TITLE
@AlgoliaSearch: Added facetingAfterDistinct to QueryParams 

### DIFF
--- a/types/algoliasearch/algoliasearch-tests.ts
+++ b/types/algoliasearch/algoliasearch-tests.ts
@@ -104,6 +104,7 @@ let _algoliaQueryParameters: QueryParameters = {
   attributesToRetrieve: [''],
   restrictSearchableAttributes: [''],
   facets: '',
+  facetingAfterDistinct: true,
   maxValuesPerFacet: 2,
   attributesToHighlight: [''],
   attributesToSnippet: [''],

--- a/types/algoliasearch/index.d.ts
+++ b/types/algoliasearch/index.d.ts
@@ -1129,6 +1129,14 @@ declare namespace algoliasearch {
      * https://github.com/algolia/algoliasearch-client-js#facets
      */
     facets?: string | string[];
+    /** 
+    * Force faceting to be applied after de-duplication (via the Distinct setting).
+    * When using the distinct setting in combination with faceting, facet counts may be higher than expected. 
+    * This is because the engine, by default, computes faceting before applying de-duplication (distinct). 
+    * When facetingAfterDistinct is set to true, the engine calculates faceting after the de-duplication has been applied.
+    * default ""
+    */
+    facetingAfterDistinct?: boolean;
     /**
      * Limit the number of facet values returned for each facet.
      * default: ""


### PR DESCRIPTION
Looked like the facetingAfterDistinct flag was missing from the type QueryParams interface.
Have added it and run the tests.

Was unable to run the lint script however, was just getting.

`> definitely-typed@0.0.3 lint c:\source\repos\DefinitelyTyped
> dtslint types "algoliasearch\"

Error: ENOENT: no such file or directory, open 'c:\source\repos\DefinitelyTyped\types\algoliasearch"\index.d.ts'`


Here's the docs showing that the flag should be available.
https://www.algolia.com/doc/api-reference/api-parameters/facetingAfterDistinct/.

Cheers :)
