### PR TITLE
unzipper: autodrain promise

### DIFF
--- a/types/unzipper/index.d.ts
+++ b/types/unzipper/index.d.ts
@@ -119,5 +119,3 @@ export type ParseStream = PullStream & {
 export function Parse(opts?: ParseOptions): ParseStream;
 export function ParseOne(match: RegExp, opts: ParseOptions): Duplex;
 export function Extract(opts?: ParseOptions): ParseStream;
-
-

--- a/types/unzipper/index.d.ts
+++ b/types/unzipper/index.d.ts
@@ -7,7 +7,7 @@
 // TypeScript Version: 2.2
 /// <reference types="node" />
 
-import { Readable, Stream, PassThrough, Duplex } from "stream";
+import { Readable, Stream, PassThrough, Duplex, Transform } from "stream";
 import { ClientRequest, RequestOptions } from "http";
 
 export interface PullStream extends Duplex {
@@ -16,7 +16,9 @@ export interface PullStream extends Duplex {
 }
 
 export interface Entry extends PassThrough {
-    autodrain(): Promise<void>;
+    autodrain(): Transform & {
+        promise(): Promise<void>;
+    };
     buffer(): Promise<Buffer>;
     path: string;
 
@@ -117,3 +119,5 @@ export type ParseStream = PullStream & {
 export function Parse(opts?: ParseOptions): ParseStream;
 export function ParseOne(match: RegExp, opts: ParseOptions): Duplex;
 export function Extract(opts?: ParseOptions): ParseStream;
+
+

--- a/types/unzipper/unzipper-tests.ts
+++ b/types/unzipper/unzipper-tests.ts
@@ -1,8 +1,14 @@
-import { Parse, Open, Entry, CentralDirectory } from "unzipper";
+import { createReadStream } from 'fs';
+import { get } from 'http';
+import { CentralDirectory, Entry, Open, Parse } from 'unzipper';
 
-import { createReadStream } from "fs";
-
-import { get } from "http";
+createReadStream("http://example.org/path/to/archive.zip")
+    .pipe(Parse())
+    .on("entry", (entry: Entry) => {
+        entry.autodrain().promise().then(() => {
+            console.log("Finished draining stream");
+        });
+    });
 
 createReadStream("http://example.org/path/to/archive.zip")
     .pipe(Parse())


### PR DESCRIPTION
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] [Provide a URL](https://github.com/ZJONSSON/node-unzipper/commit/2fa6a5d42ce624baed9a72f8ab1db739ccd33133#diff-88d9026f89ee4a02e727818bcf3ef81cR31) to documentation or source code which provides context for the suggested changes.
- [ ] Increase the version number in the header if appropriate.
