### PR TITLE
[jquery] Change all `HTMLElement` to be `Element`

### DIFF
--- a/types/jquery/v2/index.d.ts
+++ b/types/jquery/v2/index.d.ts
@@ -1411,16 +1411,6 @@ interface JQueryStatic {
      * @param keepScripts A Boolean indicating whether to include scripts passed in the HTML string
      * @see {@link https://api.jquery.com/jQuery.parseHTML/}
      */
-    parseHTML(data: string, context?: Element, keepScripts?: boolean): any[];
-
-    /**
-     * Parses a string into an array of DOM nodes.
-     *
-     * @param data HTML string to be parsed
-     * @param context DOM element to serve as the context in which the HTML fragment will be created
-     * @param keepScripts A Boolean indicating whether to include scripts passed in the HTML string
-     * @see {@link https://api.jquery.com/jQuery.parseHTML/}
-     */
     parseHTML(data: string, context?: Document, keepScripts?: boolean): any[];
 }
 

--- a/types/jquery/v2/index.d.ts
+++ b/types/jquery/v2/index.d.ts
@@ -824,7 +824,7 @@ interface JQueryStatic {
      * @see {@link https://api.jquery.com/jQuery.ajaxTransport/}
      */
     ajaxTransport(dataType: string, handler: (opts: any, originalOpts: JQueryAjaxSettings, jqXHR: JQueryXHR) => any): void;
-    
+
     ajaxSettings: JQueryAjaxSettings;
 
      /**
@@ -1411,7 +1411,7 @@ interface JQueryStatic {
      * @param keepScripts A Boolean indicating whether to include scripts passed in the HTML string
      * @see {@link https://api.jquery.com/jQuery.parseHTML/}
      */
-    parseHTML(data: string, context?: HTMLElement, keepScripts?: boolean): any[];
+    parseHTML(data: string, context?: Element, keepScripts?: boolean): any[];
 
     /**
      * Parses a string into an array of DOM nodes.
@@ -3286,7 +3286,7 @@ interface JQuery {
      * @name toArray
      * @see {@link https://api.jquery.com/toArray/}
      */
-    toArray(): HTMLElement[];
+    toArray(): Element[];
 
     /**
      * Remove the parents of the set of matched elements from the DOM, leaving the matched elements in their place.
@@ -3353,13 +3353,13 @@ interface JQuery {
      * @param index A zero-based integer indicating which element to retrieve.
      * @see {@link https://api.jquery.com/get/#get-index}
      */
-    get(index: number): HTMLElement;
+    get(index: number): Element;
     /**
      * Retrieve the elements matched by the jQuery object.
      * @alias toArray
      * @see {@link https://api.jquery.com/get/#get}
      */
-    get(): HTMLElement[];
+    get(): Element[];
 
     /**
      * Search for a given element from among the matched elements.

--- a/types/jquery/v2/jquery-tests.ts
+++ b/types/jquery/v2/jquery-tests.ts
@@ -3554,3 +3554,12 @@ function test_promise_then_not_return_deferred() {
   promise = promise.fail();
   promise = promise.always();
 }
+
+function test_element() {
+    const itemEl = $('#item')[0];
+    $('li').toArray().indexOf(itemEl);
+    $('li').get().indexOf(itemEl);
+    let otherItemEl = $('li').get(0);
+    otherItemEl = itemEl;
+    $.parseHTML('<div>Hello World</div>', itemEl);
+}

--- a/types/jquery/v2/jquery-tests.ts
+++ b/types/jquery/v2/jquery-tests.ts
@@ -3561,5 +3561,4 @@ function test_element() {
     $('li').get().indexOf(itemEl);
     let otherItemEl = $('li').get(0);
     otherItemEl = itemEl;
-    $.parseHTML('<div>Hello World</div>', itemEl);
 }


### PR DESCRIPTION
This PR fixes the inconsistencies introduced by #29212 by changing **all** `HTMLElement` usages to `Element` to reflect the fact that jQuery can operate elements other than HTML (e.g. SVG).
Example of broken code after the change introduced in #29212:
```typescript
const itemEl = $('#item')[0];
$('li').toArray().indexOf(itemEl); // error TS2345: Argument of type 'Element' is not assignable to parameter of type 'HTMLElement'.
```

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://api.jquery.com/jQuery.parseHTML/>
<https://api.jquery.com/toArray/>
<https://api.jquery.com/get/#get-index>
<https://api.jquery.com/get/#get>
- [ ] Increase the version number in the header if appropriate. **Should be non-breaking**
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
