### PR TITLE
fix(stripe): InvoiceItem.invoice can be null

### DIFF
--- a/types/stripe/index.d.ts
+++ b/types/stripe/index.d.ts
@@ -2363,7 +2363,10 @@ declare namespace Stripe {
              */
             discountable: boolean;
 
-            invoice: string;
+            /**
+             * If null, the invoice item is pending and will be included in the upcoming invoice.
+             */ 
+            invoice: string | null;
             livemode: boolean;
             metadata: IMetadata;
 


### PR DESCRIPTION
See https://stripe.com/docs/api?lang=node#invoiceitem_object-invoice, specifically the example response. Invoice items that do not have an invoice are pending and will be included in the upcoming invoice.