### PR TITLE
chore(hapi): narrow types for credentials

### DIFF
--- a/types/hapi/index.d.ts
+++ b/types/hapi/index.d.ts
@@ -16,21 +16,21 @@
  +                                                                           +
  + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + */
 
-/// <reference types="node" />
+/// <reference types='node' />
 
-import * as Boom from "boom";
-import * as catbox from "catbox";
-import * as http from "http";
-import * as https from "https";
-import * as Shot from "shot";
-import * as stream from "stream";
-import * as url from "url";
-import * as zlib from "zlib";
+import * as Boom from 'boom';
+import * as catbox from 'catbox';
+import * as http from 'http';
+import * as https from 'https';
+import * as Shot from 'shot';
+import * as stream from 'stream';
+import * as url from 'url';
+import * as zlib from 'zlib';
 
-import { MimosOptions } from "mimos";
-import { SealOptions, SealOptionsSub } from "iron";
-import { AnySchema, ValidationOptions } from "joi";
-import Podium = require("podium");
+import { MimosOptions } from 'mimos';
+import { SealOptions, SealOptionsSub } from 'iron';
+import { AnySchema, ValidationOptions } from 'joi';
+import Podium = require('podium');
 
 /* + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + +
  +                                                                           +
@@ -145,11 +145,37 @@ export type Plugin<T> = PluginBase<T> & (PluginNameVersion | PluginPackage);
  + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + + */
 
 /**
+ * User extensible types user credentials.
+ */
+// tslint:disable-next-line:no-empty-interface
+export interface UserCredentials {
+}
+
+/**
+ * User extensible types app credentials.
+ */
+// tslint:disable-next-line:no-empty-interface
+export interface AppCredentials {
+}
+
+/**
  * User-extensible type for request.auth credentials.
  */
-
-/* tslint:disable-next-line:no-empty-interface */
 export interface AuthCredentials {
+    /**
+     * The application scopes to be granted.
+     * [See docs](https://github.com/hapijs/hapi/blob/master/API.md#-routeoptionsauthaccessscope)
+     */
+    scope?: string[];
+    /**
+     * If set, will only work with routes that set `access.entity` to `user`.
+     */
+    user?: UserCredentials;
+
+    /**
+     * If set, will only work with routes that set `access.entity` to `app`.
+     */
+    app?: AppCredentials;
 }
 
 /**
@@ -190,7 +216,7 @@ export interface RequestAuth {
  * 'disconnect' - emitted when a request errors or aborts unexpectedly.
  * For context [See docs](https://github.com/hapijs/hapi/blob/master/API.md#-requestevents)
  */
-export type RequestEventType = "peek" | "finish" | "disconnect";
+export type RequestEventType = 'peek' | 'finish' | 'disconnect';
 
 /**
  * Access: read only and the public podium interface.
@@ -209,9 +235,9 @@ export interface RequestEvents extends Podium {
      * * 'disconnect' - emitted when a request errors or aborts unexpectedly.
      * [See docs](https://github.com/hapijs/hapi/blob/master/API.md#-requestevents)
      */
-    on(criteria: "peek", listener: PeekListener): void;
+    on(criteria: 'peek', listener: PeekListener): void;
 
-    on(criteria: "finish" | "disconnect", listener: (data: undefined) => void): void;
+    on(criteria: 'finish' | 'disconnect', listener: (data: undefined) => void): void;
 
     /**
      * Access: read only and the public podium interface.
@@ -221,9 +247,9 @@ export interface RequestEvents extends Podium {
      * * 'disconnect' - emitted when a request errors or aborts unexpectedly.
      * [See docs](https://github.com/hapijs/hapi/blob/master/API.md#-requestevents)
      */
-    once(criteria: "peek", listener: PeekListener): void;
+    once(criteria: 'peek', listener: PeekListener): void;
 
-    once(criteria: "finish" | "disconnect", listener: (data: undefined) => void): void;
+    once(criteria: 'finish' | 'disconnect', listener: (data: undefined) => void): void;
 }
 
 /**
@@ -916,8 +942,14 @@ export interface ResponseSettings {
 export type ResponseValue = string | object;
 
 export interface AuthenticationData {
-    credentials: object;
+    credentials: AuthCredentials;
     artifacts?: object;
+}
+
+export interface Auth {
+    readonly isAuth: true;
+    readonly error?: Error | null;
+    readonly data?: AuthenticationData;
 }
 
 /**
@@ -972,7 +1004,7 @@ export interface ResponseToolkit {
      * * artifacts - (optional) authentication artifacts object specific to the authentication scheme.
      * @return Return value: an internal authentication object.
      */
-    authenticated(data: AuthenticationData): object;
+    authenticated(data: AuthenticationData): Auth;
 
     /**
      * Sets the response 'ETag' and 'Last-Modified' headers and checks for any conditional request headers to decide if
@@ -2198,7 +2230,7 @@ export interface LogEvent {
     /** an array of tags identifying the event (e.g. ['error', 'http']) */
     tags: string[];
     /** set to 'internal' for internally generated events, otherwise 'app' for events generated by server.log() */
-    channel: "internal" | "app";
+    channel: 'internal' | 'app';
     /** the request identifier. */
     request: string;
     /** event-specific information. Available when event data was provided and is not an error. Errors are passed via error. */
@@ -2213,7 +2245,7 @@ export interface RequestEvent {
     /** an array of tags identifying the event (e.g. ['error', 'http']) */
     tags: string[];
     /** set to 'internal' for internally generated events, otherwise 'app' for events generated by server.log() */
-    channel: "internal" | "app" | "error";
+    channel: 'internal' | 'app' | 'error';
     /** event-specific information. Available when event data was provided and is not an error. Errors are passed via error. */
     data: object;
     /** the error object related to the event if applicable. Cannot appear together with data */
@@ -2271,17 +2303,17 @@ export interface ServerEvents extends Podium {
      * See ['start' event](https://github.com/hapijs/hapi/blob/master/API.md#-start-event)
      * See ['stop' event](https://github.com/hapijs/hapi/blob/master/API.md#-stop-event)
      */
-    on(criteria: "log" | ServerEventCriteria<"log">, listener: LogEventHandler): void;
+    on(criteria: 'log' | ServerEventCriteria<'log'>, listener: LogEventHandler): void;
 
-    on(criteria: "request" | ServerEventCriteria<"request">, listener: RequestEventHandler): void;
+    on(criteria: 'request' | ServerEventCriteria<'request'>, listener: RequestEventHandler): void;
 
-    on(criteria: "response" | ServerEventCriteria<"response">, listener: ResponseEventHandler): void;
+    on(criteria: 'response' | ServerEventCriteria<'response'>, listener: ResponseEventHandler): void;
 
-    on(criteria: "route" | ServerEventCriteria<"route">, listener: RouteEventHandler): void;
+    on(criteria: 'route' | ServerEventCriteria<'route'>, listener: RouteEventHandler): void;
 
-    on(criteria: "start" | ServerEventCriteria<"start">, listener: StartEventHandler): void;
+    on(criteria: 'start' | ServerEventCriteria<'start'>, listener: StartEventHandler): void;
 
-    on(criteria: "stop" | ServerEventCriteria<"stop">, listener: StopEventHandler): void;
+    on(criteria: 'stop' | ServerEventCriteria<'stop'>, listener: StopEventHandler): void;
 
     /**
      * Same as calling [server.events.on()](https://github.com/hapijs/hapi/blob/master/API.md#server.events.on()) with the count option set to 1.
@@ -2293,17 +2325,17 @@ export interface ServerEvents extends Podium {
      * @return Return value: none.
      * [See docs](https://github.com/hapijs/hapi/blob/master/API.md#-servereventsoncecriteria-listener)
      */
-    once(criteria: "log" | ServerEventCriteria<"log">, listener: LogEventHandler): void;
+    once(criteria: 'log' | ServerEventCriteria<'log'>, listener: LogEventHandler): void;
 
-    once(criteria: "request" | ServerEventCriteria<"request">, listener: RequestEventHandler): void;
+    once(criteria: 'request' | ServerEventCriteria<'request'>, listener: RequestEventHandler): void;
 
-    once(criteria: "response" | ServerEventCriteria<"response">, listener: ResponseEventHandler): void;
+    once(criteria: 'response' | ServerEventCriteria<'response'>, listener: ResponseEventHandler): void;
 
-    once(criteria: "route" | ServerEventCriteria<"route">, listener: RouteEventHandler): void;
+    once(criteria: 'route' | ServerEventCriteria<'route'>, listener: RouteEventHandler): void;
 
-    once(criteria: "start" | ServerEventCriteria<"start">, listener: StartEventHandler): void;
+    once(criteria: 'start' | ServerEventCriteria<'start'>, listener: StartEventHandler): void;
 
-    once(criteria: "stop" | ServerEventCriteria<"stop">, listener: StopEventHandler): void;
+    once(criteria: 'stop' | ServerEventCriteria<'stop'>, listener: StopEventHandler): void;
 
     /**
      * Same as calling server.events.on() with the count option set to 1.

--- a/types/hapi/test/request/auth.ts
+++ b/types/hapi/test/request/auth.ts
@@ -1,0 +1,18 @@
+import { Request } from 'hapi';
+
+declare module 'hapi' {
+    interface UserCredentials {
+        a: number;
+    }
+
+    interface AppCredentials {
+        b: number;
+    }
+}
+
+const req: Request = {} as any;
+const scope: string[] | undefined = req.auth.credentials.scope;
+const user = req.auth.credentials.user!;
+console.log(user.a);
+const app = req.auth.credentials.app!;
+console.log(app.b);

--- a/types/hapi/test/server/server-auth-api.ts
+++ b/types/hapi/test/server/server-auth-api.ts
@@ -21,7 +21,7 @@ const scheme: ServerAuthScheme = (server, options) => {
             if (!authorization) {
                 throw Boom.unauthorized(null, 'Custom');
             }
-            return h.authenticated({ credentials: { user: 'john' } });
+            return h.authenticated({ credentials: { user: { a: 1 } } });
         }
     };
 };

--- a/types/hapi/test/server/server-auth-default.ts
+++ b/types/hapi/test/server/server-auth-default.ts
@@ -4,8 +4,8 @@ import { Request, ResponseToolkit, Server, ServerAuthScheme, ServerAuthSchemeOpt
 import * as Boom from "boom";
 
 declare module 'hapi' {
-    interface AuthCredentials {
-        user?: string;
+    interface UserCredentials {
+        a: number;
     }
 }
 
@@ -21,7 +21,7 @@ const scheme: ServerAuthScheme = (server, options) => {
             if (!authorization) {
                 throw Boom.unauthorized(null, 'Custom');
             }
-            return h.authenticated({ credentials: { user: 'john' } });
+            return h.authenticated({ credentials: { user: { a: 1 }, scope: ['test'] } });
         }
     };
 };

--- a/types/hapi/test/server/server-auth-test.ts
+++ b/types/hapi/test/server/server-auth-test.ts
@@ -15,7 +15,7 @@ const scheme: ServerAuthScheme = (server, options) => {
             if (!authorization) {
                 throw Boom.unauthorized(null, 'Custom');
             }
-            return h.authenticated({ credentials: { user: 'john' } });
+            return h.authenticated({ credentials: { user: { a: 1} } });
         }
     };
 };

--- a/types/hapi/tsconfig.json
+++ b/types/hapi/tsconfig.json
@@ -18,6 +18,7 @@
     },
     "files": [
         "index.d.ts",
+        "test/request/auth.ts",
         "test/request/catch-all.ts",
         "test/request/event-types.ts",
         "test/request/get-log.ts",


### PR DESCRIPTION
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/hapijs/hapi/blob/master/lib/auth.js#L287 https://github.com/hapijs/hapi/blob/1c9a4f3d7c8cd583650292f4284c87ac5b935107/lib/request.js#L68
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

So this may be questionable so please be critical about it, strictly `user` and `app` do not need to be objects but are designed to be.

Also quote style!
