### PR TITLE
Updated react-onclickoutside typings (config object, better SFC support)

### DIFF
--- a/types/react-onclickoutside/index.d.ts
+++ b/types/react-onclickoutside/index.d.ts
@@ -1,6 +1,7 @@
-// Type definitions for react-onclickoutside 6.0
+// Type definitions for react-onclickoutside 6.7
 // Project: https://github.com/Pomax/react-onclickoutside
 // Definitions by: Karol Janyst <https://github.com/LKay>
+//                 Boris Sergeyev <https://github.com/surgeboris>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -10,12 +11,18 @@ export interface HandleClickOutside<T> {
     handleClickOutside: React.MouseEventHandler<T>;
 }
 
+export interface ConfigObject {
+    handleClickOutside?: HandleClickOutside<any>['handleClickOutside'];
+    excludeScrollbar?: boolean;
+}
+
 export interface InjectedOnClickOutProps {
     disableOnClickOutside(): void;
     enableOnClickOutside(): void;
 }
+export type WithoutInjectedClickOutProps<P> = Pick<P, Exclude<keyof P, keyof InjectedOnClickOutProps>>;
 
-export interface OnClickOutProps {
+export interface AdditionalProps extends ConfigObject {
     disableOnClickOutside?: boolean;
     eventTypes?: string | string[];
     outsideClickIgnoreClass?: string;
@@ -23,13 +30,15 @@ export interface OnClickOutProps {
     stopPropagation?: boolean;
 }
 
-export type ComponentConstructor<P> = React.ComponentClass<P> | React.StatelessComponent<P>;
+export type ComponentConstructor<P> = React.ComponentType<P>;
 
-export interface ClickOutComponentClass<P extends InjectedOnClickOutProps> extends React.ComponentClass<P> {
+export interface ClickOutComponentClass<P> extends React.ComponentClass<P> {
     new (props: P, context?: any): React.Component<P, React.ComponentState> & HandleClickOutside<any>;
 }
 
+export type OnClickOutProps<P> = WithoutInjectedClickOutProps<P> & AdditionalProps;
+
 export default function OnClickOut<P>(
-    component: ComponentConstructor<P & InjectedOnClickOutProps & HandleClickOutside<any>>
-        | ClickOutComponentClass<P & InjectedOnClickOutProps>
-): React.ComponentClass<P & OnClickOutProps>;
+    component: ComponentConstructor<P> | ClickOutComponentClass<P>,
+    config?: ConfigObject
+): React.ComponentClass<OnClickOutProps<P>>;

--- a/types/react-onclickoutside/react-onclickoutside-tests.tsx
+++ b/types/react-onclickoutside/react-onclickoutside-tests.tsx
@@ -3,22 +3,42 @@ import { Component, MouseEvent, StatelessComponent } from 'react';
 import { render } from 'react-dom';
 import onClickOutside from 'react-onclickoutside';
 
-function TestStateless(props: { handleClickOutside(): void; }) {
+interface TestStatelessProps {
+    disableOnClickOutside(): void;
+    enableOnClickOutside(): void;
+    nonClickOutsideProp: string;
+}
+
+function TestStateless(props: TestStatelessProps) {
     return (
-        <div>Test</div>
+        <div onKeyUp={props.enableOnClickOutside} onKeyDown={props.disableOnClickOutside}>
+            {props.nonClickOutsideProp}
+        </div>
     );
 }
+
+const TestConfigObject = onClickOutside(TestStateless, {
+    handleClickOutside: () => console.log('Stateless HandleClickOutside'),
+    excludeScrollbar: true
+});
+
+render(
+    <TestConfigObject nonClickOutsideProp="Test" />,
+    document.getElementById("main")
+);
 
 const TestStatelessWrapped = onClickOutside(TestStateless);
 
 render(
     <TestStatelessWrapped
+        nonClickOutsideProp="Test"
         eventTypes="click"
         disableOnClickOutside
         preventDefault
         stopPropagation
         outsideClickIgnoreClass="ignore"
         handleClickOutside={() => console.log('Stateless HandleClickOutside')}
+        excludeScrollbar
     />,
     document.getElementById("main")
 );
@@ -37,7 +57,7 @@ class TestComponent extends React.Component<{ disableOnClickOutside(): void; ena
     }
 }
 
-const WrappedComponent = onClickOutside<{}>(TestComponent);
+const WrappedComponent = onClickOutside(TestComponent);
 
 render(
     <WrappedComponent


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [SFC usage](https://github.com/Pomax/react-onclickoutside/pull/293), [config object](https://github.com/Pomax/react-onclickoutside#regulate-whether-or-not-to-listen-to-scrollbar-clicks)
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.