### PR TITLE
grunt - fix grunt.file.expand errors

### DIFF
--- a/types/grunt/grunt-tests.ts
+++ b/types/grunt/grunt-tests.ts
@@ -133,4 +133,9 @@ exports.exports = function(grunt: IGrunt) {
 let myTest = function (grunt: IGrunt) {
     grunt.file.expand(['*.ts']);
     grunt.file.expand('*.ts');
+
+    // 'cwd' in options, and string pattern
+    grunt.file.expand({
+        cwd: '.'
+    }, '*.ts');
 }

--- a/types/grunt/index.d.ts
+++ b/types/grunt/index.d.ts
@@ -446,7 +446,7 @@ declare namespace grunt {
              * grunt.file.setBase or the --base command-line option.
              */
             expand(patterns: string | string[]): string[];
-            expand(options: IFilesConfig, patterns: string[]): string[];
+            expand(options: IFilesConfig, patterns: string | string[]): string[];
 
             /**
              * Returns an array of src-dest file mapping objects.
@@ -595,6 +595,12 @@ declare namespace grunt {
             // filter?: string
             // filter?: (src: string) => boolean
             filter?: any;
+
+            /**
+             * Patterns will be matched relative to this path, and all returned filepaths will
+             * also be relative to this path.
+             */
+            cwd?: string;
         }
 
         /**


### PR DESCRIPTION
- patterns can be a string or a string array
- options can have a 'cwd' property

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://gruntjs.com/api/grunt.file#grunt.file.expand
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
