### PR TITLE
Add missing Luxon DateTime isInLeapYear getter

### DIFF
--- a/types/luxon/index.d.ts
+++ b/types/luxon/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for luxon 1.2
+// Type definitions for luxon 1.4
 // Project: https://github.com/moment/luxon#readme
 // Definitions by: Colby DeHart <https://github.com/colbydehart>
 //                 Hyeonseok Yang <https://github.com/FourwingsY>
@@ -154,6 +154,7 @@ declare module 'luxon' {
             hour: number;
             invalidReason: string;
             isInDST: boolean;
+            isInLeapYear: boolean;
             isOffsetFixed: boolean;
             isValid: boolean;
             locale: string;

--- a/types/luxon/luxon-tests.ts
+++ b/types/luxon/luxon-tests.ts
@@ -33,6 +33,7 @@ getters.zoneName;
 getters.offset;
 getters.daysInMonth;
 getters.ordinal;
+getters.isInLeapYear;
 
 dt.toLocaleString();
 dt.toLocaleString(DateTime.DATE_MED);


### PR DESCRIPTION
See https://moment.github.io/luxon/docs/class/src/datetime.js~DateTime.html#instance-get-isInLeapYear