### PR TITLE
Update types for massive 5.x

### DIFF
--- a/types/massive/index.d.ts
+++ b/types/massive/index.d.ts
@@ -1,8 +1,9 @@
-// Type definitions for massive 4.6
+// Type definitions for massive 5.4
 // Project: https://github.com/dmfay/massive-js.git
 // Definitions by: Pascal Birchler <https://github.com/swissspidy>
 //                 Clarence Ho <https://github.com/clarenceh>
 //                 Felix Faust <https://github.com/AmazingTurtle>
+//                 Mike Engel <https://github.com/mike-engel>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -10,12 +11,18 @@
 
 export = massive;
 
-declare function massive(connection: massive.ConnectionInfo | string,
-                         loaderConfig?: massive.Loader,
-                         driverConfig?: object): Promise<massive.Database>;
+declare function massive(
+    connection: massive.ConnectionInfo | string,
+    loaderConfig?: massive.Loader,
+    driverConfig?: object
+): Promise<massive.Database>;
 
 declare namespace massive {
     type UUID = number | string;
+
+    interface AnyObject<T = any> {
+        [key: string]: T;
+    }
 
     interface Loader {
         blacklist?: string | string[];
@@ -42,35 +49,55 @@ declare namespace massive {
         fallback_application_name?: boolean;
     }
 
-    /** Bundled insert, select, update and delete query options.. Shame on me */
-    interface GenericQueryOptions {
-        columns?: string[];
+    interface RetrievalOptions {
+        fields?: string[];
+        exprs?: AnyObject<string>;
         limit?: number;
         offset?: number;
+        order?: OrderingOptions[];
+        pageLength?: number;
+    }
+
+    interface OrderingOptions {
+        field?: string;
+        expr?: string;
+        direction?: "ASC" | "asc" | "DESC" | "desc";
+        nulls?: "FIRST" | "first" | "LAST" | "last";
+        type?: string;
+        last?: string;
+    }
+
+    interface PersistenceInsertOptions {
+        onConflictIgnore?: boolean;
+        deepInsert?: boolean;
+    }
+
+    interface PersistenceUpdateDocOptions {
+        body?: string;
+    }
+
+    interface InheritanceOptions {
         only?: boolean;
-        order?: string[];
-        orderBody?: boolean;
+    }
+
+    interface ResultProcessingOptions {
         build?: boolean;
         document?: boolean;
         single?: boolean;
         stream?: boolean;
+        decompose?: DecomposeOptions;
+    }
+
+    interface DecomposeOptions {
+        pk: string;
+        columns?: string[] | AnyObject<string>;
+        [foreignTable: string]: DecomposeOptions | any;
     }
 
     interface SearchDefinition {
-        /** List of the fields to search. */
         fields: string[];
-
-        /** Search term. */
         term: string;
-    }
-
-    interface QueryOptions {
-        /** This is a query against a document table. */
-        document?: boolean;
-        /** True to return a single result object instead of an array of results. */
-        single?: boolean;
-        /** True to return a stream instead of a resultset. */
-        stream?: boolean;
+        where: AnyObject;
     }
 
     interface SearchCriteria {
@@ -78,121 +105,240 @@ declare namespace massive {
         term: string;
     }
 
-    class Table extends Queryable {
-        /** Delete a record or records. */
-        destroy(criteria: object, options?: GenericQueryOptions): Promise<void>;
-
-        /** Attempts to assemble primary key criteria for a record object representing a row in this table. The criteria must include the full primary key, and must not invoke any operations. */
-        getPkCriteria(record: object): object;
-
-        /** Insert a record or records into the table. */
-        insert(data: object | any[], options?: GenericQueryOptions): Promise<any>;
-
-        /**
-         * Update a document, adding new information and changing existing information.
-         * This function can be used with any JSON field, not just document tables; however, only document tables can use criteria objects which directly reference document fields.
-         * If calling modify with a criteria object for a non-document table, the criteria will be tested against the entire row (as opposed to the document body as it is for document tables).
-         * To test elements of the JSON field in a non-document table with a criteria object, use a JSON path string.
-         */
-        modify(criteria: object | UUID, changes: object, field?: string): Promise<any>;
-
-        /**
-         * Performs an upsert.
-         * If the record does not include a value for the primary key column, it will be inserted and the persisted record (including primary key) returned;
-         * if it does, the row will be updated and the modified record returned.
-         */
-        save(record: object, options?: GenericQueryOptions): Promise<any>;
-
-        /**
-         * Save a document to the database. This function replaces the entire document body.
-         */
-        saveDoc(record: object): Promise<any>;
-
-        /**
-         * Update a record.
-         * May be invoked with a complete record (including primary key), or with a criteria object and a map of fields to new values.
-         * Multi-row updates are only possible through the latter usage.
-         */
-        update(criteria: object, fields: object, options?: GenericQueryOptions): void;
-    }
-
     interface EntitySpecification {
         /** A Database. */
-        db: object;
+        db: Database;
         /** The entity's name. */
         name: string;
         /** Path to the entity, if a file. */
         path: string;
         /** Entity's owning schema, if a database object. */
         schema: string;
+        /** Name of the loader that discovered the entity. */
+        loader: string;
     }
 
     class Entity {
         constructor(spec: EntitySpecification);
     }
 
-    class Queryable extends Entity {
-        constructor(spec: EntitySpecification);
+    interface ExecutableSpecification {
+        /** A Database. */
+        db: Database;
+        /** The table or view's name. */
+        name: string;
+        /** The name of the schema owning the table or */
+        schema: string;
+        /** A function invocation statement or a pg-promise QueryFile. */
+        sql: string | any;
+        /** Number of parameters the executable expects. */
+        paramCount: number;
+        /** Whether a database function accepts variable-length argument lists as the last parameter. */
+        isVariadic: boolean;
+        /** True to enable single row/value results processing. */
+        enhancedFunctions: boolean;
+        /** If true, return the first result row as an object (with enhancedFunctions). */
+        singleRow: boolean;
+        /** If true, return results as a primitive or primitives (with enhancedFunctions). */
+        singleValue: boolean;
+    }
 
-        /**
-         * Count rows matching criteria. There are two ways to use this method: 1. find() style: db.mytable.count({field: value}); 2. where() style: db.mytable.count("field=$1", [value]);
-         *
-         * @param conditions A criteria object or SQL predicate.
-         * @param params Prepared statement parameters for use with raw SQL predicates.
-         */
-        count(conditions: object | string, params?: any): Promise<number>;
+    class Executable {
+        constructor(spec: ExecutableSpecification);
 
-        /**
-         * Count documents matching criteria. Unlike count, this function only supports criteria objects.
-         */
+        /** Invoke the function or script. */
+        invoke(options?: ResultProcessingOptions): Promise<AnyObject | any[]>;
+    }
+
+    interface ReadableSpecification {
+        /** A Database. */
+        db: Database;
+        /** The table or view's name. */
+        name: string;
+        /** The name of the schema owning the table or view. */
+        schema: string;
+        /** Whether the object is a materialized view (default false). */
+        is_matview?: boolean;
+    }
+
+    class Readable extends Entity {
+        constructor(spec: ReadableSpecification);
+
+        /** Count rows matching criteria. */
+        count(conditions: AnyObject): Promise<number>;
+        count(conditions: string, params: any[]): Promise<number>;
+
+        /** Count documents matching criteria. Unlike count, this function only supports criteria objects. */
         countDoc(criteria: object): Promise<number>;
 
-        /**
-         * Find rows matching criteria.
-         *
-         * @param criteria A criteria object or primary key value.
-         */
-        find(criteria: object | UUID, options?: GenericQueryOptions): Promise<any>;
+        /** Find rows matching criteria. */
+        find(
+            criteria?: AnyObject | UUID,
+            options?: RetrievalOptions & ResultProcessingOptions
+        ): Promise<any>;
 
-        /**
-         * Find a document by searching in the body.
-         *
-         * @param criteria A criteria object or primary key value.
-         */
-        findDoc(criteria?: object | UUID, options?: GenericQueryOptions): Promise<any>;
+        /** Find a document by searching in the body. */
+        findDoc(
+            criteria?: AnyObject | UUID,
+            options?: RetrievalOptions
+        ): Promise<any>;
 
-        /**
-         * Return a single record.
-         *
-         * @param criteria A criteria object or primary key value.
-         */
-        findOne(criteria?: object | UUID, options?: GenericQueryOptions): Promise<any>;
+        /** Return a single record. */
+        findOne(
+            criteria: AnyObject | UUID,
+            options?: RetrievalOptions & ResultProcessingOptions
+        ): Promise<any>;
 
         /**
          * Determine whether criteria represent a search by primary key.
          * If a number or uuid are passed, it is assumed to be a primary key value; if an object, it must have only one key, which must specify the primary key column.
          */
-        isPkSearch(criteria?: object | string | number): boolean;
+        isPkSearch(criteria: AnyObject | string | number): boolean;
+
+        /** Refresh a materialized view. */
+        refresh(concurrently?: boolean): Promise<void>;
 
         /**
          * Perform a full-text search on queryable fields. If options.document is true, looks in the document body fields instead of the table columns.
          */
-        search(plan: SearchDefinition, options?: GenericQueryOptions): Promise<any>;
+        search(
+            plan: SearchDefinition,
+            options?: RetrievalOptions
+        ): Promise<any[]>;
 
         /** Shortcut to perform a full text search on a document table. */
-        searchDoc(plan: SearchDefinition, options?: GenericQueryOptions): Promise<any>;
+        searchDoc(
+            plan: Pick<SearchDefinition, "fields" | "term">,
+            options?: RetrievalOptions
+        ): Promise<any[]>;
 
         /** Run a query with a raw SQL predicate, eg: db.mytable.where('id=$1', [123]).then(...); */
-        where(conditions: string, params?: any, options?: GenericQueryOptions): Promise<any>;
+        where(
+            conditions: string,
+            params?: any[],
+            options?: RetrievalOptions & ResultProcessingOptions
+        ): Promise<any[]>;
+    }
+
+    interface WritableSpecification {
+        /** A Database. */
+        db: Database;
+        /** The table or view's name. */
+        name: string;
+        /** The name of the schema owning the table. */
+        schema: string;
+        /** The table's primary key. */
+        pk: string;
+    }
+
+    class Writable extends Readable {
+        /** A database table or other writable object */
+        constructor(spec: WritableSpecification);
+
+        /** Delete a record or records. */
+        destroy(
+            criteria: AnyObject,
+            options?: ResultProcessingOptions
+        ): Promise<any[]>;
+
+        /**
+         * Attempts to assemble primary key criteria for a record object representing a row in this table.
+         * The criteria must include the full primary key, and must not invoke any operations.
+         */
+        getPkCriteria(record: AnyObject): AnyObject;
+
+        /** Insert a record or records into the table. */
+        insert(
+            data: AnyObject,
+            options?: PersistenceInsertOptions & ResultProcessingOptions
+        ): Promise<AnyObject>;
+        insert(
+            data: AnyObject[],
+            options?: PersistenceInsertOptions & ResultProcessingOptions
+        ): Promise<AnyObject[]>;
+
+        /**
+         * Saves an object.
+         * If the object does not include a value for the table's primary key, this will emit an INSERT to create a new record.
+         * if it does contain the primary key it will emit an UPDATE for the existing record.
+         * Either way, the newest available version of the record will be returned.
+         * This is not a true Postgres upsert! If you need the behavior of ON CONFLICT DO UPDATE, you'll need to use db.query or create an SQL script file.
+         */
+        save(
+            record: AnyObject,
+            options?: PersistenceInsertOptions &
+                PersistenceUpdateDocOptions &
+                ResultProcessingOptions
+        ): Promise<AnyObject>;
+
+        /** Save a document to the database. This function will create or replace the entire document body. */
+        saveDoc(doc: AnyObject): Promise<AnyObject>;
+
+        /**
+         * Update a record. May be invoked with a complete record (including primary key), or with a criteria object and a map of fields to new values.
+         * Multi-row updates are only possible through the latter usage.
+         */
+        update(
+            criteria: string | number,
+            changes: AnyObject,
+            options?: PersistenceUpdateDocOptions & ResultProcessingOptions
+        ): Promise<AnyObject>;
+        update(
+            criteria: AnyObject,
+            changes: AnyObject,
+            options?: PersistenceUpdateDocOptions & ResultProcessingOptions
+        ): Promise<AnyObject[]>;
+
+        /**
+         * Update a document, adding new information and changing existing information.
+         * This function can be used with any JSON field, not just document tables; however, only document tables can use criteria objects which directly reference document fields.
+         * If calling updateDoc with a criteria object for a non-document table, the criteria will be tested against the entire row (as opposed to the document body as it is for document tables).
+         * To test elements of the JSON field in a non-document table with a criteria object, use a JSON path string.
+         */
+        updateDoc(
+            criteria: string | number | AnyObject,
+            changes: AnyObject,
+            options?: PersistenceUpdateDocOptions & ResultProcessingOptions
+        ): Promise<AnyObject>;
+    }
+
+    class Sequence {
+        /** A database sequence. */
+        constructor(db: Database, name: string, schema: string);
+
+        /** Get the last value the sequence returned. */
+        lastValue(): Promise<any>;
+
+        /** Increment the sequence counter and return the next value. */
+        nextValue(): Promise<any>;
+
+        /** Reset the sequence. */
+        reset(initialValue: number): Promise<void>;
+    }
+
+    class SingleValueStream {
+        /** A stream which processes single-key results objects into their values for convenience on the client side. */
+        constructor(options: AnyObject);
+
+        /** Converts a single-key object into its value. */
+        singleValue(obj: AnyObject): any;
+
+        /** Implement the Transform stream that invokes singleValue on everything which passes through it. */
+        private _transform(
+            obj: AnyObject,
+            encoding: string,
+            cb: (err?: Error) => void
+        ): void;
     }
 
     /** Represents a SELECT query. */
     class Select {
-        /**
-         * @param source Database object to query.
-         * @param criteria A criteria object, prebuilt predicate, or primitive pk value.
-         */
-        constructor(source: Queryable, criteria: object | UUID, options?: GenericQueryOptions);
+        /** Represents an SELECT query. */
+        constructor(
+            source: Readable,
+            criteria: AnyObject | UUID,
+            options?: RetrievalOptions & ResultProcessingOptions
+        );
 
         /** Format this object into a SQL SELECT. */
         format(): string;
@@ -200,11 +346,12 @@ declare namespace massive {
 
     /** Represents a INSERT query. */
     class Insert {
-        /**
-         * @param source Database object to query.
-         * @param record A map of field names to values to be inserted, or an array of same.
-         */
-        constructor(source: Queryable, record: object | any[], options?: GenericQueryOptions);
+        /** Represents an INSERT query. */
+        constructor(
+            source: Readable,
+            record: AnyObject | any[],
+            options?: ResultProcessingOptions & PersistenceInsertOptions
+        );
 
         /** Format this object into a SQL SELECT. */
         format(): string;
@@ -212,12 +359,13 @@ declare namespace massive {
 
     /** Represents a UPDATE query. */
     class Update {
-        /**
-         * @param source Database object to query.
-         * @param changes A map of field names to new values.
-         * @param criteria A criteria object.
-         */
-        constructor(source: Queryable, changes: object, criteria: object, options?: GenericQueryOptions);
+        /** Represents an UPDATE query. */
+        constructor(
+            source: Readable,
+            changes: AnyObject,
+            criteria: AnyObject,
+            options?: ResultProcessingOptions & PersistenceUpdateDocOptions
+        );
 
         /** Format this object into a SQL SELECT. */
         format(): string;
@@ -225,11 +373,12 @@ declare namespace massive {
 
     /** Represents a UPDATE query. */
     class Delete {
-        /**
-         * @param source Database object to query.
-         * @param criteria A criteria object.
-         */
-        constructor(source: Queryable, criteria?: object, options?: GenericQueryOptions);
+        /** Represents a DELETE query. */
+        constructor(
+            source: Readable,
+            criteria?: AnyObject | string | number,
+            options?: ResultProcessingOptions & InheritanceOptions
+        );
 
         /** Format this object into a SQL SELECT. */
         format(): string;
@@ -239,22 +388,35 @@ declare namespace massive {
         /**
          * @param connection A connection object or connection string
          */
-        constructor(connection: object | string, loader?: Loader, driverConfig?: object);
+        constructor(
+            connection: object | string,
+            loader?: Loader,
+            driverConfig?: object
+        );
 
         /** Attach an entity to the connected instance. */
-        attach(ctor: any, ...sources: any[]): Promise<any[]>;
+        attach(entities: AnyObject | any[]): Promise<any[]>;
 
         /** Remove all attached entities from the instance, returning it to the pre- introspection state. */
         clean(): void;
 
+        /** Clones the database handle for a task or transaction, replacing the internal instance with a dedicated connection. */
+        clone(conn: ConnectionInfo): Database;
+
         /** Create a new document table and attach it to the Database for usage. */
         createDocumentTable(location: string): Promise<void>;
+
+        /**  Create an extension. */
+        createExtension(extensionName: string): Promise<void>;
 
         /** Create a new schema in the database. */
         createSchema(schemaName: string): Promise<void>;
 
         /** Forget an entity. */
         detach(entityPath: string): void;
+
+        /** Drop an extension. */
+        dropExtension(extensionName: string): Promise<void>;
 
         /** Drop a schema and remove it and its owned objects from the Database. */
         dropSchema(schemaName: string, options?: DropOptions): Promise<void>;
@@ -265,6 +427,9 @@ declare namespace massive {
         /** List all the functions and scripts attached to the connected instance. */
         listFunctions(): Promise<any[]>;
 
+        /** List all the non-pk sequences attached to the connected instance. */
+        listSequences(): Promise<any[]>;
+
         /** List all the tables attached to the connected instance. */
         listTables(): Promise<any[]>;
 
@@ -272,22 +437,36 @@ declare namespace massive {
         listViews(): Promise<any[]>;
 
         /** Execute a query. */
-        query(query: Select | Insert | Update | Delete | string, params?: any, options?: QueryOptions): Promise<any>;
+        query(
+            query: Select | Insert | Update | Delete | string,
+            params?: string[],
+            options?: Pick<
+                ResultProcessingOptions,
+                "document" | "single" | "stream"
+            >
+        ): Promise<any>;
 
         /**
          * Synchronize the database API with the current state by scanning for tables, views, functions, and scripts.
          * Objects and files which no longer exist are cleared and new objects and files added.
          */
-        reload(): void;
+        reload(): Promise<void>;
 
-        /**
-         * Save a document.
-         *
-         * @param collection Document table name to save to. If it does not already exist, it will be created.
-         * @param doc A JSON document.
-         */
-        saveDoc(collection: string, doc: object): Promise<any>;
+        /** Save a document. */
+        saveDoc(collection: string, doc: AnyObject): Promise<any>;
 
-        [tableName: string]: Table | any;
+        /** Begin a task, returning a copy of the connected instance which will route all queries made in the callback through the task scope. */
+        withConnection(
+            cb: (withTask: any) => any,
+            options?: AnyObject
+        ): Promise<any>;
+
+        /** Begin a transaction, returning a copy of the connected instance which will route all queries made in the callback through the transaction scope. */
+        withTransaction(
+            cb: (withTx: any) => any,
+            options?: AnyObject
+        ): Promise<any>;
+
+        [tableName: string]: Writable | any;
     }
 }

--- a/types/massive/index.d.ts
+++ b/types/massive/index.d.ts
@@ -18,7 +18,7 @@ declare function massive(
 ): Promise<massive.Database>;
 
 declare namespace massive {
-    type UUID = number | string;
+    type UUID = string;
 
     interface AnyObject<T = any> {
         [key: string]: T;
@@ -130,7 +130,7 @@ declare namespace massive {
         /** The name of the schema owning the table or */
         schema: string;
         /** A function invocation statement or a pg-promise QueryFile. */
-        sql: string | any;
+        sql: any;
         /** Number of parameters the executable expects. */
         paramCount: number;
         /** Whether a database function accepts variable-length argument lists as the last parameter. */
@@ -173,19 +173,19 @@ declare namespace massive {
 
         /** Find rows matching criteria. */
         find(
-            criteria?: AnyObject | UUID,
+            criteria?: AnyObject | number | UUID,
             options?: RetrievalOptions & ResultProcessingOptions
         ): Promise<any>;
 
         /** Find a document by searching in the body. */
         findDoc(
-            criteria?: AnyObject | UUID,
+            criteria?: AnyObject | number | UUID,
             options?: RetrievalOptions
         ): Promise<any>;
 
         /** Return a single record. */
         findOne(
-            criteria: AnyObject | UUID,
+            criteria: AnyObject | number | UUID,
             options?: RetrievalOptions & ResultProcessingOptions
         ): Promise<any>;
 
@@ -193,7 +193,7 @@ declare namespace massive {
          * Determine whether criteria represent a search by primary key.
          * If a number or uuid are passed, it is assumed to be a primary key value; if an object, it must have only one key, which must specify the primary key column.
          */
-        isPkSearch(criteria: AnyObject | string | number): boolean;
+        isPkSearch(criteria: AnyObject | UUID | number): boolean;
 
         /** Refresh a materialized view. */
         refresh(concurrently?: boolean): Promise<void>;
@@ -274,12 +274,9 @@ declare namespace massive {
         /** Save a document to the database. This function will create or replace the entire document body. */
         saveDoc(doc: AnyObject): Promise<AnyObject>;
 
-        /**
-         * Update a record. May be invoked with a complete record (including primary key), or with a criteria object and a map of fields to new values.
-         * Multi-row updates are only possible through the latter usage.
-         */
+        /** Update a record. */
         update(
-            criteria: string | number,
+            criteria: UUID | number,
             changes: AnyObject,
             options?: PersistenceUpdateDocOptions & ResultProcessingOptions
         ): Promise<AnyObject>;
@@ -296,7 +293,7 @@ declare namespace massive {
          * To test elements of the JSON field in a non-document table with a criteria object, use a JSON path string.
          */
         updateDoc(
-            criteria: string | number | AnyObject,
+            criteria: UUID | number | AnyObject,
             changes: AnyObject,
             options?: PersistenceUpdateDocOptions & ResultProcessingOptions
         ): Promise<AnyObject>;
@@ -306,11 +303,17 @@ declare namespace massive {
         /** A database sequence. */
         constructor(db: Database, name: string, schema: string);
 
-        /** Get the last value the sequence returned. */
-        lastValue(): Promise<any>;
+        /**
+         * Get the last value the sequence returned.
+         * The return value will be a stringified number.
+         */
+        lastValue(): Promise<string>;
 
-        /** Increment the sequence counter and return the next value. */
-        nextValue(): Promise<any>;
+        /**
+         * Increment the sequence counter and return the next value.
+         * The return value will be a stringified number.
+         */
+        nextValue(): Promise<string>;
 
         /** Reset the sequence. */
         reset(initialValue: number): Promise<void>;
@@ -376,7 +379,7 @@ declare namespace massive {
         /** Represents a DELETE query. */
         constructor(
             source: Readable,
-            criteria?: AnyObject | string | number,
+            criteria?: AnyObject | UUID | number,
             options?: ResultProcessingOptions & InheritanceOptions
         );
 
@@ -440,17 +443,14 @@ declare namespace massive {
         query(
             query: Select | Insert | Update | Delete | string,
             params?: string[],
-            options?: Pick<
-                ResultProcessingOptions,
-                "document" | "single" | "stream"
-            >
+            options?: ResultProcessingOptions
         ): Promise<any>;
 
         /**
          * Synchronize the database API with the current state by scanning for tables, views, functions, and scripts.
          * Objects and files which no longer exist are cleared and new objects and files added.
          */
-        reload(): Promise<void>;
+        reload(): Promise<Database>;
 
         /** Save a document. */
         saveDoc(collection: string, doc: AnyObject): Promise<any>;

--- a/types/massive/v4/index.d.ts
+++ b/types/massive/v4/index.d.ts
@@ -1,0 +1,293 @@
+// Type definitions for massive 4.6
+// Project: https://github.com/dmfay/massive-js.git
+// Definitions by: Pascal Birchler <https://github.com/swissspidy>
+//                 Clarence Ho <https://github.com/clarenceh>
+//                 Felix Faust <https://github.com/AmazingTurtle>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
+
+/// <reference types="node" />
+
+export = massive;
+
+declare function massive(connection: massive.ConnectionInfo | string,
+                         loaderConfig?: massive.Loader,
+                         driverConfig?: object): Promise<massive.Database>;
+
+declare namespace massive {
+    type UUID = number | string;
+
+    interface Loader {
+        blacklist?: string | string[];
+        whitelist?: string | string[];
+        functionBlacklist?: string | string[];
+        functionWhitelist?: string | string[];
+        allowedSchemas?: string | string[];
+        exceptions?: string | string[];
+        scripts?: string;
+    }
+
+    interface DropOptions {
+        cascade?: boolean;
+    }
+
+    interface ConnectionInfo {
+        user?: string;
+        database?: string;
+        password?: string | null;
+        port?: number;
+        host?: string;
+        ssl?: boolean;
+        application_name?: string;
+        fallback_application_name?: boolean;
+    }
+
+    /** Bundled insert, select, update and delete query options.. Shame on me */
+    interface GenericQueryOptions {
+        columns?: string[];
+        limit?: number;
+        offset?: number;
+        only?: boolean;
+        order?: string[];
+        orderBody?: boolean;
+        build?: boolean;
+        document?: boolean;
+        single?: boolean;
+        stream?: boolean;
+    }
+
+    interface SearchDefinition {
+        /** List of the fields to search. */
+        fields: string[];
+
+        /** Search term. */
+        term: string;
+    }
+
+    interface QueryOptions {
+        /** This is a query against a document table. */
+        document?: boolean;
+        /** True to return a single result object instead of an array of results. */
+        single?: boolean;
+        /** True to return a stream instead of a resultset. */
+        stream?: boolean;
+    }
+
+    interface SearchCriteria {
+        fields: string[];
+        term: string;
+    }
+
+    class Table extends Queryable {
+        /** Delete a record or records. */
+        destroy(criteria: object, options?: GenericQueryOptions): Promise<void>;
+
+        /** Attempts to assemble primary key criteria for a record object representing a row in this table. The criteria must include the full primary key, and must not invoke any operations. */
+        getPkCriteria(record: object): object;
+
+        /** Insert a record or records into the table. */
+        insert(data: object | any[], options?: GenericQueryOptions): Promise<any>;
+
+        /**
+         * Update a document, adding new information and changing existing information.
+         * This function can be used with any JSON field, not just document tables; however, only document tables can use criteria objects which directly reference document fields.
+         * If calling modify with a criteria object for a non-document table, the criteria will be tested against the entire row (as opposed to the document body as it is for document tables).
+         * To test elements of the JSON field in a non-document table with a criteria object, use a JSON path string.
+         */
+        modify(criteria: object | UUID, changes: object, field?: string): Promise<any>;
+
+        /**
+         * Performs an upsert.
+         * If the record does not include a value for the primary key column, it will be inserted and the persisted record (including primary key) returned;
+         * if it does, the row will be updated and the modified record returned.
+         */
+        save(record: object, options?: GenericQueryOptions): Promise<any>;
+
+        /**
+         * Save a document to the database. This function replaces the entire document body.
+         */
+        saveDoc(record: object): Promise<any>;
+
+        /**
+         * Update a record.
+         * May be invoked with a complete record (including primary key), or with a criteria object and a map of fields to new values.
+         * Multi-row updates are only possible through the latter usage.
+         */
+        update(criteria: object, fields: object, options?: GenericQueryOptions): void;
+    }
+
+    interface EntitySpecification {
+        /** A Database. */
+        db: object;
+        /** The entity's name. */
+        name: string;
+        /** Path to the entity, if a file. */
+        path: string;
+        /** Entity's owning schema, if a database object. */
+        schema: string;
+    }
+
+    class Entity {
+        constructor(spec: EntitySpecification);
+    }
+
+    class Queryable extends Entity {
+        constructor(spec: EntitySpecification);
+
+        /**
+         * Count rows matching criteria. There are two ways to use this method: 1. find() style: db.mytable.count({field: value}); 2. where() style: db.mytable.count("field=$1", [value]);
+         *
+         * @param conditions A criteria object or SQL predicate.
+         * @param params Prepared statement parameters for use with raw SQL predicates.
+         */
+        count(conditions: object | string, params?: any): Promise<number>;
+
+        /**
+         * Count documents matching criteria. Unlike count, this function only supports criteria objects.
+         */
+        countDoc(criteria: object): Promise<number>;
+
+        /**
+         * Find rows matching criteria.
+         *
+         * @param criteria A criteria object or primary key value.
+         */
+        find(criteria: object | UUID, options?: GenericQueryOptions): Promise<any>;
+
+        /**
+         * Find a document by searching in the body.
+         *
+         * @param criteria A criteria object or primary key value.
+         */
+        findDoc(criteria?: object | UUID, options?: GenericQueryOptions): Promise<any>;
+
+        /**
+         * Return a single record.
+         *
+         * @param criteria A criteria object or primary key value.
+         */
+        findOne(criteria?: object | UUID, options?: GenericQueryOptions): Promise<any>;
+
+        /**
+         * Determine whether criteria represent a search by primary key.
+         * If a number or uuid are passed, it is assumed to be a primary key value; if an object, it must have only one key, which must specify the primary key column.
+         */
+        isPkSearch(criteria?: object | string | number): boolean;
+
+        /**
+         * Perform a full-text search on queryable fields. If options.document is true, looks in the document body fields instead of the table columns.
+         */
+        search(plan: SearchDefinition, options?: GenericQueryOptions): Promise<any>;
+
+        /** Shortcut to perform a full text search on a document table. */
+        searchDoc(plan: SearchDefinition, options?: GenericQueryOptions): Promise<any>;
+
+        /** Run a query with a raw SQL predicate, eg: db.mytable.where('id=$1', [123]).then(...); */
+        where(conditions: string, params?: any, options?: GenericQueryOptions): Promise<any>;
+    }
+
+    /** Represents a SELECT query. */
+    class Select {
+        /**
+         * @param source Database object to query.
+         * @param criteria A criteria object, prebuilt predicate, or primitive pk value.
+         */
+        constructor(source: Queryable, criteria: object | UUID, options?: GenericQueryOptions);
+
+        /** Format this object into a SQL SELECT. */
+        format(): string;
+    }
+
+    /** Represents a INSERT query. */
+    class Insert {
+        /**
+         * @param source Database object to query.
+         * @param record A map of field names to values to be inserted, or an array of same.
+         */
+        constructor(source: Queryable, record: object | any[], options?: GenericQueryOptions);
+
+        /** Format this object into a SQL SELECT. */
+        format(): string;
+    }
+
+    /** Represents a UPDATE query. */
+    class Update {
+        /**
+         * @param source Database object to query.
+         * @param changes A map of field names to new values.
+         * @param criteria A criteria object.
+         */
+        constructor(source: Queryable, changes: object, criteria: object, options?: GenericQueryOptions);
+
+        /** Format this object into a SQL SELECT. */
+        format(): string;
+    }
+
+    /** Represents a UPDATE query. */
+    class Delete {
+        /**
+         * @param source Database object to query.
+         * @param criteria A criteria object.
+         */
+        constructor(source: Queryable, criteria?: object, options?: GenericQueryOptions);
+
+        /** Format this object into a SQL SELECT. */
+        format(): string;
+    }
+
+    class Database {
+        /**
+         * @param connection A connection object or connection string
+         */
+        constructor(connection: object | string, loader?: Loader, driverConfig?: object);
+
+        /** Attach an entity to the connected instance. */
+        attach(ctor: any, ...sources: any[]): Promise<any[]>;
+
+        /** Remove all attached entities from the instance, returning it to the pre- introspection state. */
+        clean(): void;
+
+        /** Create a new document table and attach it to the Database for usage. */
+        createDocumentTable(location: string): Promise<void>;
+
+        /** Create a new schema in the database. */
+        createSchema(schemaName: string): Promise<void>;
+
+        /** Forget an entity. */
+        detach(entityPath: string): void;
+
+        /** Drop a schema and remove it and its owned objects from the Database. */
+        dropSchema(schemaName: string, options?: DropOptions): Promise<void>;
+
+        /** Drop a table and remove it from the Database. */
+        dropTable(tablePath: string, options?: DropOptions): Promise<void>;
+
+        /** List all the functions and scripts attached to the connected instance. */
+        listFunctions(): Promise<any[]>;
+
+        /** List all the tables attached to the connected instance. */
+        listTables(): Promise<any[]>;
+
+        /** List all the views attached to the connected instance. */
+        listViews(): Promise<any[]>;
+
+        /** Execute a query. */
+        query(query: Select | Insert | Update | Delete | string, params?: any, options?: QueryOptions): Promise<any>;
+
+        /**
+         * Synchronize the database API with the current state by scanning for tables, views, functions, and scripts.
+         * Objects and files which no longer exist are cleared and new objects and files added.
+         */
+        reload(): void;
+
+        /**
+         * Save a document.
+         *
+         * @param collection Document table name to save to. If it does not already exist, it will be created.
+         * @param doc A JSON document.
+         */
+        saveDoc(collection: string, doc: object): Promise<any>;
+
+        [tableName: string]: Table | any;
+    }
+}

--- a/types/massive/v4/massive-tests.ts
+++ b/types/massive/v4/massive-tests.ts
@@ -1,0 +1,10 @@
+import massive = require('massive');
+
+let dbconn: massive.Database;
+
+massive('postgres://app:password@localhost:5432/app').then(db => {
+    console.log(`DB connected successfully`);
+    dbconn = db;
+}).catch(err => {
+    console.error(`Error connecting DB`);
+});

--- a/types/massive/v4/tsconfig.json
+++ b/types/massive/v4/tsconfig.json
@@ -6,8 +6,11 @@
         "noImplicitThis": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
-        "baseUrl": "../",
-        "typeRoots": ["../"],
+        "baseUrl": "../../",
+        "typeRoots": ["../../"],
+        "paths": {
+            "massive": ["massive/v4"]
+        },
         "types": [],
         "noEmit": true,
         "forceConsistentCasingInFileNames": true

--- a/types/massive/v4/tslint.json
+++ b/types/massive/v4/tslint.json
@@ -1,0 +1,8 @@
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        // TODOs
+        "no-any-union": false,
+        "no-unnecessary-class": false
+    }
+}


### PR DESCRIPTION
Howdy, massive 5.0 came out a while ago, but the types haven't been udpated. This also more closely matches the documentation provided through JSDoc in the source project. This also fixes a couple of bugs where the types had `void` being returned, when there was actually an object being returned.

I would like to have @dmfay (creator of massive) review this to make sure it's correct. This was almost all pulled from their API docs, so hopefully it is 😄 

Finally, one API change I was hoping to make was to make the `Database` type take a generic string union type which would be the table names, which would be used for the computed property names on that class. I haven't figured out a way to do it, so if you have any suggestions or ideas I would love to hear them!

```ts
class Database<T extends string> {
    // ...Database definition...
    
    [tableName in T]: Table
}
```

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [JSDoc API docs](https://dmfay.github.io/massive-js/api/index.html)
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.