### PR TITLE
Add type definitions to lambda-tester package

### DIFF
--- a/types/lambda-tester/index.d.ts
+++ b/types/lambda-tester/index.d.ts
@@ -1,0 +1,33 @@
+// Type definitions for lambda-tester 3.5
+// Project: https://github.com/vandium-io/lambda-tester#readme
+// Definitions by: Ivan Kerin <https://github.com/ivank>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
+
+import { Context, ClientContext, CognitoIdentity, Handler } from "aws-lambda";
+
+declare namespace lambdaTester {
+    type Verifier = (result: any) => void;
+
+    class LambdaTester {
+        event(event: any): this;
+        context(context: Context): this;
+        clientContext(clientContext: ClientContext): this;
+        identity(
+            cognitoIdentityId: string,
+            cognitoIdentityPoolId: string
+        ): this;
+        timeout(seconds: number): this;
+        xray(): this;
+        expectSucceed(verifier: Verifier): this;
+        expectFail(verifier: Verifier): this;
+        expectError(verifier: Verifier): this;
+        expectResult(verifier: Verifier): this;
+        expectReject(verifier: Verifier): this;
+        expectResolve(verifier: Verifier): this;
+    }
+}
+
+declare function lambdaTester(handler: Handler): lambdaTester.LambdaTester;
+
+export = lambdaTester;

--- a/types/lambda-tester/lambda-tester-tests.ts
+++ b/types/lambda-tester/lambda-tester-tests.ts
@@ -1,0 +1,38 @@
+import * as lambdaTester from "lambda-tester";
+import { Handler, Context, ClientContext } from "aws-lambda";
+
+const handler: Handler = () => Promise.resolve();
+const context: Context = {} as any;
+const clientContext: ClientContext = {} as any;
+
+interface TResult {
+    data: string;
+}
+interface TError {
+    message: string;
+}
+
+lambdaTester(handler)
+    .event({ test: "123" })
+    .context(context)
+    .clientContext(clientContext)
+    .xray()
+    .identity("123", "123")
+    .expectSucceed((result: TResult) => {
+        const t: string = result.data;
+    })
+    .expectFail((error: TError) => {
+        const t: string = error.message;
+    })
+    .expectResolve((result: TResult) => {
+        const t: string = result.data;
+    })
+    .expectReject((error: TError) => {
+        const t: string = error.message;
+    })
+    .expectResult((result: TResult) => {
+        const t: string = result.data;
+    })
+    .expectError((error: TError) => {
+        const t: string = error.message;
+    });

--- a/types/lambda-tester/tsconfig.json
+++ b/types/lambda-tester/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": ["index.d.ts", "lambda-tester-tests.ts"]
+}

--- a/types/lambda-tester/tslint.json
+++ b/types/lambda-tester/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
