### PR TITLE
Add resolvesArg to sinon typings

### DIFF
--- a/types/sinon/index.d.ts
+++ b/types/sinon/index.d.ts
@@ -394,10 +394,9 @@ declare namespace Sinon {
          */
         resolves(value?: any): SinonStub;
         /**
-         * Causes the stub to return the argument at the provided index.
-         * stub.returnsArg(0); causes the stub to return the first argument.
-         * If the argument at the provided index is not available, prior to sinon@6.1.2, an undefined value will be
-         * returned; starting from sinon@6.1.2, a TypeError will be thrown.
+         * Causes the stub to return a Promise which resolves to the argument at the provided index.
+         * stub.resolvesArg(0); causes the stub to return a Promise which resolves to the first argument.
+         * If the argument at the provided index is not available, a TypeError will be thrown.
          */
         resolvesArg(index: number): SinonStub;
         /**

--- a/types/sinon/index.d.ts
+++ b/types/sinon/index.d.ts
@@ -392,6 +392,13 @@ declare namespace Sinon {
          * Since sinon@2.0.0
          */
         resolves(value?: any): SinonStub;
+	/**
+	 * Causes the stub to return the argument at the provided index.
+	 * stub.returnsArg(0); causes the stub to return the first argument.
+	 * If the argument at the provided index is not available, prior to sinon@6.1.2, an undefined value will be
+	 * returned; starting from sinon@6.1.2, a TypeError will be thrown.
+	 */
+	resolvesArg(index: number): SinonStub;
         /**
          * Causes the stub to throw an exception (Error).
          * @param type

--- a/types/sinon/index.d.ts
+++ b/types/sinon/index.d.ts
@@ -6,6 +6,7 @@
 //                 Nico Jansen <https://github.com/nicojs>
 //                 James Garbutt <https://github.com/43081j>
 //                 Josh Goldberg <https://github.com/joshuakgoldberg>
+//                 Greg Jednaszewski <https://github.com/gjednaszewski>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -392,13 +393,13 @@ declare namespace Sinon {
          * Since sinon@2.0.0
          */
         resolves(value?: any): SinonStub;
-	/**
-	 * Causes the stub to return the argument at the provided index.
-	 * stub.returnsArg(0); causes the stub to return the first argument.
-	 * If the argument at the provided index is not available, prior to sinon@6.1.2, an undefined value will be
-	 * returned; starting from sinon@6.1.2, a TypeError will be thrown.
-	 */
-	resolvesArg(index: number): SinonStub;
+        /**
+         * Causes the stub to return the argument at the provided index.
+         * stub.returnsArg(0); causes the stub to return the first argument.
+         * If the argument at the provided index is not available, prior to sinon@6.1.2, an undefined value will be
+         * returned; starting from sinon@6.1.2, a TypeError will be thrown.
+         */
+        resolvesArg(index: number): SinonStub;
         /**
          * Causes the stub to throw an exception (Error).
          * @param type

--- a/types/sinon/sinon-tests.ts
+++ b/types/sinon/sinon-tests.ts
@@ -403,6 +403,7 @@ function testStub() {
     stub.returnsThis();
     stub.resolves();
     stub.resolves('foo');
+    stub.resolvesArg(1);
     stub.throws();
     stub.throws('err');
     stub.throws(new Error('err'));


### PR DESCRIPTION
Small change to add resolvesArg() to sinon stub typings

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:
If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://sinonjs.org/releases/v6.3.4/stubs/
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
