### PR TITLE
Fix @types/react-test-renderer typings on ReactTestIntance type typing

### DIFF
--- a/types/react-test-renderer/index.d.ts
+++ b/types/react-test-renderer/index.d.ts
@@ -25,7 +25,7 @@ export interface ReactTestRendererTree extends ReactTestRendererJSON {
 }
 export interface ReactTestInstance {
     instance: any;
-    type: string;
+    type: ReactType;
     props: { [propName: string]: any };
     parent: null | ReactTestInstance;
     children: Array<ReactTestInstance | string>;


### PR DESCRIPTION
Based on:
https://github.com/facebook/react/blob/v16.0.0/src/renderers/testing/ReactTestRendererFiberEntry.js#L400
the type is of the same typing as `this._fiber.type` and:
https://github.com/facebook/react/blob/master/packages/react-reconciler/src/ReactFiber.js#L104
that typing is set to `any`.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - https://github.com/facebook/react/blob/v16.0.0/src/renderers/testing/ReactTestRendererFiberEntry.js#L400
  - https://github.com/facebook/react/blob/master/packages/react-reconciler/src/ReactFiber.js#L104
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
