### PR TITLE
fix(ember__error): make EmberError extendable

### DIFF
--- a/types/ember/index.d.ts
+++ b/types/ember/index.d.ts
@@ -228,7 +228,7 @@ export namespace Ember {
     /**
      * A subclass of the JavaScript Error object for use in Ember.
      */
-    const Error: EmberError;
+    const Error: typeof EmberError;
 
     const Evented: typeof EmberObjectEventedNs.default;
 

--- a/types/ember__error/ember__error-tests.ts
+++ b/types/ember__error/ember__error-tests.ts
@@ -1,3 +1,7 @@
 import Error from '@ember/error';
 
-new Error('Fuuuuuuuu'); // $ExpectType Error
+new Error('Fuuuuuuuu'); // $ExpectType EmberError
+
+// allows to extend from EmberError
+class AjaxError extends Error {
+}

--- a/types/ember__error/index.d.ts
+++ b/types/ember__error/index.d.ts
@@ -7,4 +7,4 @@
 /**
  * A subclass of the JavaScript Error object for use in Ember.
  */
-export default ErrorConstructor;
+export default class EmberError extends Error {}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://emberjs.com/api/ember/release/classes/EmberError>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

This change makes it possible to extend from `@ember/error`. Previously it was an interface while the actual implementation [extended from Error](https://github.com/emberjs/ember.js/blob/v3.4.4/packages/%40ember/error/index.ts#L22).
This made it impossible to use the type definitions in ember-ajax as it's actually [extending the EmberError](https://github.com/ember-cli/ember-ajax/blob/master/addon/errors.ts#L3).
