### PR TITLE
quill: use quill-delta shipped types

### DIFF
--- a/types/quill/index.d.ts
+++ b/types/quill/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Quill 1.3
+// Type definitions for Quill 2.0
 // Project: https://github.com/quilljs/quill/
 // Definitions by: Sumit <https://github.com/sumitkm>
 //                 Guillaume <https://github.com/guillaume-ro-fr>
@@ -6,8 +6,10 @@
 //                 Aniello Falcone <https://github.com/AnielloFalcone>
 //                 Mohammad Hossein Amri <https://github.com/mhamri>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.9
 
 import { Blot } from 'parchment/dist/src/blot/abstract/blot';
+import Delta = require('quill-delta');
 
 /**
  * A stricter type definition would be:
@@ -32,9 +34,9 @@ export interface OptionalAttributes {
     attributes?: StringMap;
 }
 
-export type TextChangeHandler = (delta: DeltaStatic, oldContents: DeltaStatic, source: Sources) => any;
+export type TextChangeHandler = (delta: Delta, oldContents: Delta, source: Sources) => any;
 export type SelectionChangeHandler = (range: RangeStatic, oldRange: RangeStatic, source: Sources) => any;
-export type EditorChangeHandler = ((name: "text-change", delta: DeltaStatic, oldContents: DeltaStatic, source: Sources) => any)
+export type EditorChangeHandler = ((name: "text-change", delta: Delta, oldContents: Delta, source: Sources) => any)
     | ((name: "selection-change", range: RangeStatic, oldRange: RangeStatic, source: Sources) => any);
 
 export interface KeyboardStatic {
@@ -43,8 +45,8 @@ export interface KeyboardStatic {
 }
 
 export interface ClipboardStatic {
-    convert(html?: string): DeltaStatic;
-    addMatcher(selectorOrNodeType: string|number, callback: (node: any, delta: DeltaStatic) => DeltaStatic): void;
+    convert(html?: string): Delta;
+    addMatcher(selectorOrNodeType: string|number, callback: (node: any, delta: Delta) => Delta): void;
     dangerouslyPasteHTML(html: string, source?: Sources): void;
     dangerouslyPasteHTML(index: number, html: string, source?: Sources): void;
 }
@@ -68,51 +70,6 @@ export interface BoundsStatic {
     top: number;
     height: number;
     width: number;
-}
-
-export interface DeltaStatic {
-    ops?: DeltaOperation[];
-    retain(length: number, attributes?: StringMap): DeltaStatic;
-    delete(length: number): DeltaStatic;
-    filter(predicate: (op: DeltaOperation) => boolean): DeltaOperation[];
-    forEach(predicate: (op: DeltaOperation) => void): void;
-    insert(text: any, attributes?: StringMap): DeltaStatic;
-    map<T>(predicate: (op: DeltaOperation) => T): T[];
-    partition(predicate: (op: DeltaOperation) => boolean): [DeltaOperation[], DeltaOperation[]];
-    reduce<T>(predicate: (acc: T, curr: DeltaOperation, idx: number, arr: DeltaOperation[]) => T, initial: T): T;
-    chop(): DeltaStatic;
-    length(): number;
-    slice(start?: number, end?: number): DeltaStatic;
-    compose(other: DeltaStatic): DeltaStatic;
-    concat(other: DeltaStatic): DeltaStatic;
-    diff(other: DeltaStatic, index?: number): DeltaStatic;
-    eachLine(predicate: (line: DeltaStatic, attributes: StringMap, idx: number) => any, newline?: string): DeltaStatic;
-    transform(index: number, priority?: boolean): number;
-    transform(other: DeltaStatic, priority: boolean): DeltaStatic;
-    transformPosition(index: number, priority?: boolean): number;
-}
-
-export class Delta implements DeltaStatic {
-    constructor(ops?: DeltaOperation[] | { ops: DeltaOperation[] });
-    ops?: DeltaOperation[];
-    retain(length: number, attributes?: StringMap): DeltaStatic;
-    delete(length: number): DeltaStatic;
-    filter(predicate: (op: DeltaOperation) => boolean): DeltaOperation[];
-    forEach(predicate: (op: DeltaOperation) => void): void;
-    insert(text: any, attributes?: StringMap): DeltaStatic;
-    map<T>(predicate: (op: DeltaOperation) => T): T[];
-    partition(predicate: (op: DeltaOperation) => boolean): [DeltaOperation[], DeltaOperation[]];
-    reduce<T>(predicate: (acc: T, curr: DeltaOperation, idx: number, arr: DeltaOperation[]) => T, initial: T): T;
-    chop(): DeltaStatic;
-    length(): number;
-    slice(start?: number, end?: number): DeltaStatic;
-    compose(other: DeltaStatic): DeltaStatic;
-    concat(other: DeltaStatic): DeltaStatic;
-    diff(other: DeltaStatic, index?: number): DeltaStatic;
-    eachLine(predicate: (line: DeltaStatic, attributes: StringMap, idx: number) => any, newline?: string): DeltaStatic;
-    transform(index: number): number;
-    transform(other: DeltaStatic, priority: boolean): DeltaStatic;
-    transformPosition(index: number): number;
 }
 
 export interface RangeStatic {
@@ -147,16 +104,16 @@ export class Quill implements EventEmitter {
     scroll: Blot;
     keyboard: KeyboardStatic;
     constructor(container: string | Element, options?: QuillOptionsStatic);
-    deleteText(index: number, length: number, source?: Sources): DeltaStatic;
+    deleteText(index: number, length: number, source?: Sources): Delta;
     disable(): void;
     enable(enabled?: boolean): void;
-    getContents(index?: number, length?: number): DeltaStatic;
+    getContents(index?: number, length?: number): Delta;
     getLength(): number;
     getText(index?: number, length?: number): string;
-    insertEmbed(index: number, type: string, value: any, source?: Sources): DeltaStatic;
-    insertText(index: number, text: string, source?: Sources): DeltaStatic;
-    insertText(index: number, text: string, format: string, value: any, source?: Sources): DeltaStatic;
-    insertText(index: number, text: string, formats: StringMap, source?: Sources): DeltaStatic;
+    insertEmbed(index: number, type: string, value: any, source?: Sources): Delta;
+    insertText(index: number, text: string, source?: Sources): Delta;
+    insertText(index: number, text: string, format: string, value: any, source?: Sources): Delta;
+    insertText(index: number, text: string, formats: StringMap, source?: Sources): Delta;
     /**
      * @deprecated Remove in 2.0. Use clipboard.dangerouslyPasteHTML(index: number, html: string, source: Sources)
      */
@@ -165,23 +122,23 @@ export class Quill implements EventEmitter {
      * @deprecated Remove in 2.0. Use clipboard.dangerouslyPasteHTML(html: string, source: Sources): void;
      */
     pasteHTML(html: string, source?: Sources): string;
-    setContents(delta: DeltaStatic, source?: Sources): DeltaStatic;
-    setText(text: string, source?: Sources): DeltaStatic;
+    setContents(delta: Delta, source?: Sources): Delta;
+    setText(text: string, source?: Sources): Delta;
     update(source?: Sources): void;
-    updateContents(delta: DeltaStatic, source?: Sources): DeltaStatic;
+    updateContents(delta: Delta, source?: Sources): Delta;
 
-    format(name: string, value: any, source?: Sources): DeltaStatic;
-    formatLine(index: number, length: number, source?: Sources): DeltaStatic;
-    formatLine(index: number, length: number, format: string, value: any, source?: Sources): DeltaStatic;
-    formatLine(index: number, length: number, formats: StringMap, source?: Sources): DeltaStatic;
-    formatText(index: number, length: number, source?: Sources): DeltaStatic;
-    formatText(index: number, length: number, format: string, value: any, source?: Sources): DeltaStatic;
-    formatText(index: number, length: number, formats: StringMap, source?: Sources): DeltaStatic;
-    formatText(range: RangeStatic, format: string, value: any, source?: Sources): DeltaStatic;
-    formatText(range: RangeStatic, formats: StringMap, source?: Sources): DeltaStatic;
+    format(name: string, value: any, source?: Sources): Delta;
+    formatLine(index: number, length: number, source?: Sources): Delta;
+    formatLine(index: number, length: number, format: string, value: any, source?: Sources): Delta;
+    formatLine(index: number, length: number, formats: StringMap, source?: Sources): Delta;
+    formatText(index: number, length: number, source?: Sources): Delta;
+    formatText(index: number, length: number, format: string, value: any, source?: Sources): Delta;
+    formatText(index: number, length: number, formats: StringMap, source?: Sources): Delta;
+    formatText(range: RangeStatic, format: string, value: any, source?: Sources): Delta;
+    formatText(range: RangeStatic, formats: StringMap, source?: Sources): Delta;
     getFormat(range?: RangeStatic): StringMap;
     getFormat(index: number, length?: number): StringMap;
-    removeFormat(index: number, length: number, source?: Sources): DeltaStatic;
+    removeFormat(index: number, length: number, source?: Sources): Delta;
 
     blur(): void;
     focus(): void;

--- a/types/quill/package.json
+++ b/types/quill/package.json
@@ -1,6 +1,7 @@
 {
     "private": true,
     "dependencies": {
-        "parchment": "^1.1.2"
+        "parchment": "^1.1.2",
+        "quill-delta": "^4.0.1"
     }
 }

--- a/types/quill/quill-tests.ts
+++ b/types/quill/quill-tests.ts
@@ -1,5 +1,6 @@
-import { Quill, Delta, DeltaStatic, RangeStatic, StringMap } from 'quill';
+import { Quill, RangeStatic, StringMap } from 'quill';
 import { Blot } from 'parchment/src/blot/abstract/blot';
+import Delta = require('quill-delta');
 
 function test_quill() {
     const quillEditor = new Quill('#editor', {
@@ -38,7 +39,7 @@ function test_enable_false() {
 
 function test_getContents() {
     const quillEditor = new Quill('#editor');
-    const delta: DeltaStatic = quillEditor.getContents();
+    const delta: Delta = quillEditor.getContents();
 }
 
 function test_getLength() {
@@ -192,7 +193,7 @@ function test_addContainer() {
 }
 
 function test_on_Events() {
-    const textChangeHandler = (newDelta: DeltaStatic, oldDelta: DeltaStatic, source: string) => { };
+    const textChangeHandler = (newDelta: Delta, oldDelta: Delta, source: string) => { };
     const selectionChangeHandler = (newRange: RangeStatic, oldRange: RangeStatic, source: string) => { };
     const editorChangeHandler = (name: string, ...args: any[]) => { };
 
@@ -318,7 +319,7 @@ function test_DeltaEachLine() {
                            .insert('\n', { align: 'right' })
                            .insert('!');
 
-    delta.eachLine((line: DeltaStatic, attributes: StringMap, i: number) => console.log(line, attributes, i));
+    delta.eachLine((line: Delta, attributes: StringMap, i: number) => console.log(line, attributes, i));
     // Should log:
     // { ops: [{ insert: 'Hello' }] }, {}, 0
     // { ops: [] }, {}, 1
@@ -330,8 +331,8 @@ function test_DeltaTransform() {
     const a = new Delta().insert('a');
     const b = new Delta().insert('b').retain(5).insert('c');
 
-    const d1: DeltaStatic = a.transform(b, true);  // new Delta().retain(1).insert('b').retain(5).insert('c');
-    const d2: DeltaStatic = a.transform(b, false); // new Delta().insert('b').retain(6).insert('c');
+    const d1: Delta = a.transform(b, true);  // new Delta().retain(1).insert('b').retain(5).insert('c');
+    const d2: Delta = a.transform(b, false); // new Delta().insert('b').retain(6).insert('c');
     const n1: number = a.transform(5);
     const n2: number = a.transform(5, true);
     const n3: number = a.transform(5, false);


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/quilljs/delta
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

---

Fixes #29253.

Depends on Microsoft/types-publisher#490.

I had to increase the TS requirement to 2.9 as 2.8 couldn't locate the types.. im not sure why. maybe quill-delta uses some >=2.9 features or resolution changed?