### PR TITLE
[console-ui] Add typings for console-ui

### DIFF
--- a/types/console-ui/console-ui-tests.ts
+++ b/types/console-ui/console-ui-tests.ts
@@ -1,0 +1,60 @@
+import { Question } from 'inquirer';
+import UI = require('console-ui');
+
+new UI({
+    inputStream: process.stdin,
+    outputStream: process.stderr,
+    errorStream: process.stdout,
+    writeLevel: 'DEBUG',
+    ci: false
+});
+
+const ui = new UI();
+
+ui.write(); // $ExpectError
+ui.write('hello');
+ui.write('hello', 'DEBUG');
+ui.write('hello', 'INFO');
+ui.write('hello', 'WARNING');
+ui.write('hello', 'ERROR');
+ui.write('hello', 'NONEXISTENT'); // $ExpectError
+
+ui.writeLine(); // $ExpectError
+ui.writeLine('hello');
+ui.writeLine('hello', 'DEBUG');
+ui.writeLine('hello', 'INFO');
+ui.writeLine('hello', 'WARNING');
+ui.writeLine('hello', 'ERROR');
+ui.writeLine('hello', 'NONEXISTENT'); // $ExpectError
+
+ui.writeDebugLine('hello');
+
+ui.writeWarnLine('hello');
+ui.writeWarnLine('hello', true);
+ui.writeWarnLine('hello', false, true);
+
+ui.writeDeprecateLine('hello');
+ui.writeDeprecateLine('hello', true);
+ui.writeDeprecateLine('hello', false, true);
+
+ui.writeError(new Error('boom!'));
+ui.writeError('boom!'); // $ExpectError
+
+ui.setWriteLevel('DEBUG');
+ui.setWriteLevel('INFO');
+ui.setWriteLevel('WARNING');
+ui.setWriteLevel('ERROR');
+ui.setWriteLevel('NONEXISTENT'); // $ExpectError
+
+ui.startProgress('hello');
+ui.stopProgress();
+ui.stopProgress('hello'); // $ExpectError
+
+const question: Question<{ answer: boolean }> = {
+    message: 'Yes / No?',
+    type: 'confirm'
+};
+
+ui.prompt(question).then(result => {
+    result.answer; // $ExpectType boolean
+});

--- a/types/console-ui/index.d.ts
+++ b/types/console-ui/index.d.ts
@@ -1,0 +1,93 @@
+// Type definitions for console-ui 2.2
+// Project: https://github.com/ember-cli/console-ui#readme
+// Definitions by: Dan Freeman <https://github.com/dfreeman>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
+
+import { Readable, Writable } from 'stream';
+import { Questions } from 'inquirer';
+
+type WriteLevel = 'DEBUG' | 'INFO' | 'WARNING' | 'ERROR';
+
+export = UI;
+
+/**
+ * The UI provides the CLI with a unified mechanism for providing output and
+ * requesting input from the user. This becomes useful when wanting to adjust
+ * logLevels, or mock input/output for tests.
+ */
+declare class UI {
+    constructor(options?: {
+        inputStream?: Readable;
+        outputStream?: Writable;
+        errorStream?: Writable;
+        writeLevel?: WriteLevel;
+        ci?: boolean;
+    });
+
+    /**
+     * Unified mechanism to write a string to the console.
+     * Optionally include a writeLevel, this is used to decide if the specific
+     * logging mechanism should or should not be printed.
+     */
+    write(message: string, level?: WriteLevel): void;
+
+    /**
+     * Unified mechanism to write a string and new line to the console.
+     * Optionally include a writeLevel, this is used to decide if the specific
+     * logging mechanism should or should not be printed.
+     */
+    writeLine(message: string, level?: WriteLevel): void;
+
+    /**
+     * Helper method to write a string with the DEBUG writeLevel and gray chalk
+     */
+    writeDebugLine(message: string): void;
+
+    /**
+     * Helper method to write a string with the INFO writeLevel and cyan chalk
+     */
+    writeInfoLine(message: string): void;
+
+    /**
+     * Helper method to write a string with the WARNING writeLevel and yellow chalk.
+     * Optionally include a test. If falsy, the warning will be printed. By default, warnings
+     * will be prepended with WARNING text when printed.
+     */
+    writeWarnLine(message: string, test?: boolean, prepend?: boolean): void;
+
+    /**
+     * Helper method to write a string with the WARNING writeLevel and yellow chalk.
+     * Optionally include a test. If falsy, the deprecation will be printed. By default deprecations
+     * will be prepended with DEPRECATION text when printed.
+     */
+    writeDeprecateLine(message: string, test?: boolean, prepend?: boolean): void;
+
+    /**
+     * Unified mechanism to an Error to the console.
+     * This will occure at a writeLevel of ERROR
+     */
+    writeError(error: object): void;
+
+    /**
+     * Sets the write level for the UI. Valid write levels are 'DEBUG', 'INFO',
+     * 'WARNING', and 'ERROR'.
+     */
+    setWriteLevel(level: WriteLevel): void;
+
+    /**
+     * Begins a progress spinner with a message (only if the INFO write level is visible).
+     */
+    startProgress(message: string): void;
+
+    /**
+     * Ends the current progress spinner.
+     */
+    stopProgress(): void;
+
+    /**
+     * Launch the prompt interface (inquiry session) with (Array of Questions || Question)
+     * See [Inquirer.js#question](https://github.com/SBoudrias/Inquirer.js#question) for Question properties
+     */
+    prompt<T>(questions: Questions<T>, callback?: (answers: T) => void): Promise<T>;
+}

--- a/types/console-ui/tsconfig.json
+++ b/types/console-ui/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "console-ui-tests.ts"
+    ]
+}

--- a/types/console-ui/tslint.json
+++ b/types/console-ui/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
This adds typings for the [`console-ui` package](https://github.com/ember-cli/console-ui) based on its README and doc comments.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.