### PR TITLE
Add definitions for Dropbox Chooser

### DIFF
--- a/types/dropbox-chooser/dropbox-chooser-tests.ts
+++ b/types/dropbox-chooser/dropbox-chooser-tests.ts
@@ -1,0 +1,20 @@
+// Tests for Dropbox Chooser DefinitelyTyped TS definitions
+
+const options: DropboxChooserOptions = {
+  success: (files: ReadonlyArray<DropboxChooserFile>) => {
+    console.log('Success, selected files were:', files);
+  },
+};
+
+const Dropbox = window.Dropbox!;
+Dropbox.choose(options);
+
+const sampleFile: DropboxChooserFile = {
+  id: 'SAMPLE_ID',
+  name: 'HelloBox.jpg',
+  link: 'http://localhost/1.png',
+  bytes: 1024,
+  icon: 'http://localhost/icons/png.png',
+  thumbnailLink: 'http://localhost/thumbnails/1.png',
+  isDir: false,
+};

--- a/types/dropbox-chooser/index.d.ts
+++ b/types/dropbox-chooser/index.d.ts
@@ -1,0 +1,66 @@
+// Type definitions for Dropbox Chooser 1.0
+// Project: https://www.dropbox.com/developers/chooser
+// Definitions by: Michael Su <https://github.com/quas94>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare namespace Dropbox {
+    interface DropboxChooser {
+      choose(options: ChooserOptions): void;
+    }
+
+    interface ChooserOptions {
+        // alled when a user selects an item in the Chooser
+        success(files: ReadonlyArray<File>): void;
+
+        // called when the user closes the dialog without selecting a file
+        cancel?(): void;
+
+        // default: 'preview'
+        linkType?: 'preview' | 'direct';
+
+        // default: false
+        multiselect?: boolean;
+
+        // eg. '.png'
+        extensions?: string[];
+
+        // default: false
+        folderselect?: boolean;
+
+        // any positive number
+        sizeLimit?: number;
+    }
+
+    interface File {
+        // Unique ID for the file, compatible with Dropbox API v2.
+        id: string;
+
+        // Name of the file.
+        name: string;
+
+        // URL to access the file, which varies depending on the linkType specified when the
+        // Chooser was triggered.
+        link: string;
+
+        // Size of the file in bytes.
+        bytes: number;
+
+        // URL to a 64x64px icon for the file based on the file's extension.
+        icon: string;
+
+        // A thumbnail URL generated when the user selects images and videos.
+        // If the user didn't select an image or video, no thumbnail will be included.
+        thumbnailLink?: string;
+
+        // whether or not the file is actually a directory
+        isDir: boolean;
+    }
+}
+
+type DropboxChooser = Dropbox.DropboxChooser;
+type DropboxChooserOptions = Dropbox.ChooserOptions;
+type DropboxChooserFile = Dropbox.File;
+
+interface Window {
+    Dropbox?: DropboxChooser;
+}

--- a/types/dropbox-chooser/tsconfig.json
+++ b/types/dropbox-chooser/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "dom",
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "dropbox-chooser-tests.ts"
+    ]
+}

--- a/types/dropbox-chooser/tslint.json
+++ b/types/dropbox-chooser/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Introduces TS definitions for the Dropbox Chooser: https://www.dropbox.com/developers/chooser

- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.