### PR TITLE
autoprefixer: updated to match postcss Plugin types for postcss 7.x

### DIFF
--- a/types/autoprefixer/autoprefixer-tests.ts
+++ b/types/autoprefixer/autoprefixer-tests.ts
@@ -1,17 +1,17 @@
-import * as autopref from 'autoprefixer';
+import autoprefixer = require("autoprefixer");
+import { Transformer } from 'postcss';
 
-const ap: autopref.Transformer = autopref({
-	browsers: ['> 5%', 'last 2 versions'],
-	env: '',
-	cascade: true,
-	add: true,
-	remove: true,
-	supports: true,
-	flexbox: true,
-	grid: true,
-	stats: {},
+const ap1: Transformer = autoprefixer();
+
+const ap2: Transformer = autoprefixer({
+  browsers: [],
+  env: "test",
+  cascade: false,
+  add: false,
+  remove: false,
+  supports: false,
+  flexbox: false,
+  grid: false,
+  stats: {},
+  ignoreUnknownVersions: false,
 });
-const ap2: autopref.Transformer = autopref({
-	flexbox: 'no-2009',
-});
-const info: string = ap.info();

--- a/types/autoprefixer/index.d.ts
+++ b/types/autoprefixer/index.d.ts
@@ -6,7 +6,7 @@
 import { Plugin } from "postcss";
 
 declare namespace autoprefixer {
-    interface AutoprefixerOptions {
+    interface Options {
         browsers?: string[] | string;
         env?: string;
         cascade?: boolean;
@@ -19,7 +19,7 @@ declare namespace autoprefixer {
         ignoreUnknownVersions?: boolean;
     }
 
-    type Autoprefixer = Plugin<AutoprefixerOptions>;
+    type Autoprefixer = Plugin<Options>;
 }
 
 declare const autoprefixer: autoprefixer.Autoprefixer;

--- a/types/autoprefixer/index.d.ts
+++ b/types/autoprefixer/index.d.ts
@@ -1,12 +1,12 @@
-// Type definitions for autoprefixer 6.7
+// Type definitions for autoprefixer 9.1
 // Project: https://github.com/postcss/autoprefixer
-// Definitions by: Armando Meziat <https://github.com/odnamrataizem>
+// Definitions by:  Armando Meziat <https://github.com/odnamrataizem>, murt <https://github.com/murt>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import { Plugin, Transformer as PostcssTransformer } from 'postcss';
+import { Plugin } from "postcss";
 
 declare namespace autoprefixer {
-    interface Options {
+    interface AutoprefixerOptions {
         browsers?: string[] | string;
         env?: string;
         cascade?: boolean;
@@ -16,15 +16,10 @@ declare namespace autoprefixer {
         flexbox?: boolean | 'no-2009';
         grid?: boolean;
         stats?: any;
+        ignoreUnknownVersions?: boolean;
     }
 
-    interface Transformer extends PostcssTransformer {
-        info(): string;
-    }
-
-    interface Autoprefixer extends Plugin<Options> {
-        (opts?: Options): Transformer;
-    }
+    type Autoprefixer = Plugin<AutoprefixerOptions>;
 }
 
 declare const autoprefixer: autoprefixer.Autoprefixer;

--- a/types/autoprefixer/package.json
+++ b/types/autoprefixer/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "postcss": "^5.2.15"
+        "postcss": "7.x.x"
     }
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

Resolve error with Transformer type, would complain about "postcss" not being present when using latest postcss (7.0.4), stuck on older 5.2.8 version of postcss (hence the dependency change too). May be worth investigating using version ranges (which cssnano does, specifying 5 - 7). Issues appear to be tied to updates in postcss Plugins in general, version of autoprefixer referenced was 6.7 which was over 3 majors behind. Added **ignoreUnknownVersions** as per the options specified [here](https://github.com/postcss/autoprefixer#options).

