### PR TITLE
Add typings for react-timeago package

### DIFF
--- a/types/react-timeago/index.d.ts
+++ b/types/react-timeago/index.d.ts
@@ -1,0 +1,35 @@
+// Type definitions for react-timeago 4.1
+// Project: https://github.com/nmn/react-timeago
+// Definitions by: Konstantin Lebedev <https://github.com/koss-lebedev>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.8
+
+import * as React from "react";
+
+declare namespace ReactTimeago {
+    type Unit = 'second' | 'minute' | 'hour' | 'day' | 'week' | 'month' | 'year';
+
+    type Suffix = 'ago' | 'from now';
+
+    type Formatter = (
+      value: number,
+      unit: Unit,
+      suffix: Suffix,
+      epochMiliseconds: number,
+      nextFormatter?: Formatter
+    ) => React.ReactNode;
+
+    interface ReactTimeagoProps {
+      readonly live?: boolean;
+      readonly minPeriod?: number;
+      readonly maxPeriod?: number;
+      readonly component?: string | React.ComponentType<any>;
+      readonly title?: string;
+      readonly formatter?: Formatter;
+      readonly date: string | number | Date;
+      readonly now?: () => number;
+    }
+}
+
+declare const ReactTimeago: React.ComponentClass<ReactTimeago.ReactTimeagoProps>;
+export = ReactTimeago;

--- a/types/react-timeago/react-timeago-tests.tsx
+++ b/types/react-timeago/react-timeago-tests.tsx
@@ -1,0 +1,27 @@
+import ReactTimeago, { Unit, Suffix } from "react-timeago";
+import * as React from "react";
+
+const ReactTimeagoRequiredOptions: JSX.Element = (
+    <ReactTimeago
+        date={new Date()}
+    />
+);
+
+const customFormatter = (value: number, unit: Unit, suffix: Suffix, epochMiliseconds: number) => {
+    return (
+        <div />
+    );
+};
+
+const ReactTimeagoAllOptions: JSX.Element = (
+    <ReactTimeago
+        date={new Date()}
+        live
+        minPeriod={0}
+        maxPeriod={100}
+        component={() => <div />}
+        title="Timeago"
+        formatter={customFormatter}
+
+    />
+);

--- a/types/react-timeago/tsconfig.json
+++ b/types/react-timeago/tsconfig.json
@@ -1,0 +1,26 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "jsx": "react",
+        "esModuleInterop": true
+    },
+    "files": [
+        "index.d.ts",
+        "react-timeago-tests.tsx"
+    ]
+}

--- a/types/react-timeago/tslint.json
+++ b/types/react-timeago/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
This PR is to add typings for `react-timeago` package (https://github.com/nmn/react-timeago)

The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`