### PR TITLE
Updated file-saver index.d.ts @param disableAutoBOM

### DIFF
--- a/types/file-saver/index.d.ts
+++ b/types/file-saver/index.d.ts
@@ -10,7 +10,7 @@ declare namespace FileSaver {
      * FileSaver.js implements the saveAs() FileSaver interface in browsers that do not natively support it.
      * @param data - The actual file data blob.
      * @param filename - The optional name of the file to be downloaded. If omitted, the name used in the file data will be used. If none is provided "download" will be used.
-     * @param disableAutoBOM - Optional & defaults to `false`. Set to `true` if you don't want FileSaver.js to automatically provide Unicode text encoding hints
+     * @param disableAutoBOM - Optional & defaults to `false`. Set to `true` if you want FileSaver.js to automatically provide Unicode text encoding hints
      */
     function saveAs(data: Blob, filename?: string, disableAutoBOM?: boolean): void;
 }


### PR DESCRIPTION
Removed "don't" since it doesn't reflect the official documentation.

see -> [Pass { autoBOM: true } if you want FileSaver.js to automatically provide Unicode text encoding hints...](https://github.com/eligrey/FileSaver.js/#syntax)

If changing an existing definition:
- [ x ] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/eligrey/FileSaver.js/#syntax>>
