### PR TITLE
fix(ember-data): update value types for BelongsToReference, HasManyReference

### DIFF
--- a/types/ember-data/index.d.ts
+++ b/types/ember-data/index.d.ts
@@ -747,7 +747,7 @@ export namespace DS {
          * relationship is not yet loaded. If the relationship is not loaded
          * it will always return `null`.
          */
-        value(objectOrPromise: {} | RSVP.Promise<any>): Model;
+        value(): Model | null;
         /**
          * Loads a record in a belongs to relationship if it is not already
          * loaded. If the relationship is already loaded this method does not
@@ -799,7 +799,7 @@ export namespace DS {
          * relationship is not yet loaded. If the relationship is not loaded
          * it will always return `null`.
          */
-        value(): ManyArray<T>;
+        value(): ManyArray<T> | null;
         /**
          * Loads the relationship if it is not already loaded.  If the
          * relationship is already loaded this method does not trigger a new

--- a/types/ember-data/test/belongs-to.ts
+++ b/types/ember-data/test/belongs-to.ts
@@ -27,3 +27,6 @@ folder.get('parent').then(parent => {
 folder.set('parent', folder);
 folder.set('parent', folder.get('parent'));
 folder.set('parent', store.findRecord('folder', 3));
+
+// $ExpectType Model | null
+folder.belongsTo('parent').value();

--- a/types/ember-data/test/has-many.ts
+++ b/types/ember-data/test/has-many.ts
@@ -59,3 +59,6 @@ declare module 'ember-data/types/registries/model' {
 class Polymorphic extends DS.Model {
     paymentMethods = DS.hasMany('payment-method', { polymorphic: true });
 }
+
+// $ExpectType ManyArray<any> | null
+blogPost.hasMany('commentsAsync').value();


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://emberjs.com/api/ember-data/3.4/classes/DS.BelongsToReference/methods/value?anchor=value and https://emberjs.com/api/ember-data/3.4/classes/DS.HasManyReference/methods/value?anchor=value

This PR changes three things:
* [`BelongsToReference.value()`](https://emberjs.com/api/ember-data/3.4/classes/DS.BelongsToReference/methods/value?anchor=value) accepts no arguments. 
* [`BelongsToReference.value()`](https://emberjs.com/api/ember-data/3.4/classes/DS.BelongsToReference/methods/value?anchor=value) returns `null` in some cases
* [`HasManyReference.value()`](https://emberjs.com/api/ember-data/3.4/classes/DS.HasManyReference/methods/value?anchor=value) returns `null` in some cases
