### PR TITLE
[react-router-v3] Fix createHref & createPath argument

### DIFF
--- a/types/react-router/v3/index.d.ts
+++ b/types/react-router/v3/index.d.ts
@@ -11,6 +11,7 @@
 //                 Dovydas Navickas <https://github.com/DovydasNavickas>
 //                 Ross Allen <https://github.com/ssorallen>
 //                 Christian Gill <https://github.com/gillchristian>
+//                 Roman Nevolin <https://github.com/nulladdict>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 

--- a/types/react-router/v3/lib/Router.d.ts
+++ b/types/react-router/v3/lib/Router.d.ts
@@ -52,7 +52,7 @@ type GoFunction = (n: number) => void;
 type NavigateFunction = () => void;
 type ActiveFunction = (location: LocationDescriptor, indexOnly?: boolean) => boolean;
 type LeaveHookFunction = (route: any, callback: RouteHook) => void;
-type CreatePartFunction<Part> = (path: Path, query?: any) => Part;
+type CreatePartFunction<Part> = (pathOrLoc: LocationDescriptor, query?: any) => Part;
 
 export interface InjectedRouter {
     push: LocationFunction;

--- a/types/react-router/v3/react-router-tests.tsx
+++ b/types/react-router/v3/react-router-tests.tsx
@@ -192,3 +192,14 @@ if (matchedPattern) {
 }
 
 matchPattern("/foo", "/baz") === null;
+
+const CreateHref: React.SFC<WithRouterProps> = ({ router }) => (
+	<div>
+		{router.createHref({ pathname: "/foo", query: { bar: "baz" } })}
+		{router.createHref("/foo?bar=baz")}
+	</div>
+);
+
+const CreateHrefWithRouter = withRouter<{}>(CreateHref);
+
+ReactDOM.render(<CreateHrefWithRouter />, document.body);


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [Link to react-router v3 API](https://github.com/ReactTraining/react-router/blob/v3/docs/API.md#createpathpathorloc-query)

---
**tl;dt:** According to the docs, a location object could be passed into createHref & createPath functions, however current typings only allow passing string path