### PR TITLE
[react-native-video] add seekableDuration to onProgress callback data

### DIFF
--- a/types/react-native-video/index.d.ts
+++ b/types/react-native-video/index.d.ts
@@ -75,6 +75,7 @@ export interface VideoProperties extends ViewProps {
     onProgress?(data: {
         currentTime: number;
         playableDuration: number;
+        seekableDuration: number;
     }): void;
     onSeek?(): void;
     onEnd?(): void;

--- a/types/react-native-video/react-native-video-tests.tsx
+++ b/types/react-native-video/react-native-video-tests.tsx
@@ -54,8 +54,9 @@ class VideoTest extends React.Component {
     onProgress = (data: {
         currentTime: number,
         playableDuration: number,
+        seekableDuration: number
     }): void => {
-        console.log(data.currentTime, data.playableDuration);
+        console.log(data.currentTime, data.playableDuration, data.seekableDuration);
     }
 }
 


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).


- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/react-native-community/react-native-video#onprogress
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

seekableDuration was missing. So i added it.
