### PR TITLE
[react-daterange-picker] Fix onSelect prop type definitions

### DIFF
--- a/types/react-daterange-picker/index.d.ts
+++ b/types/react-daterange-picker/index.d.ts
@@ -33,7 +33,7 @@ export interface Props<T = DateRangePicker> extends React.Props<T> {
     numberOfCalendars?: number;
     onHighlightDate?(date: Date): void;
     onHighlightRange?(date: Date): void;
-    onSelect?(value: { start: moment.Moment, end: moment.Moment }): void;
+    onSelect?(value: OnSelectCallbackParam): void;
     onSelectStart?(value: momentRange.MomentRangeExtends): void;
     paginationArrowComponent?: React.ComponentClass<PaginationArrowProps> | React.SFC<PaginationArrowProps>;
     selectedLabel?: string;
@@ -63,4 +63,9 @@ export interface PaginationArrowProps<T = {}> extends React.Props<T> {
     disabled?: boolean;
     onTrigger?(): void;
     direction?: 'next' | 'previous';
+}
+
+export interface OnSelectCallbackParam {
+    start: moment.Moment;
+    end: moment.Moment;
 }

--- a/types/react-daterange-picker/index.d.ts
+++ b/types/react-daterange-picker/index.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: UNCOVER TRUTH Inc. <https://github.com/uncovertruth>
 //                 MartynasZilinskas <https://github.com/MartynasZilinskas>
 //                 Donald Ford <https://github.com/donaldtf>
+//                 Vlad Florescu <https://github.com/vladflorescu94>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -32,7 +33,7 @@ export interface Props<T = DateRangePicker> extends React.Props<T> {
     numberOfCalendars?: number;
     onHighlightDate?(date: Date): void;
     onHighlightRange?(date: Date): void;
-    onSelect?(value: Props): void;
+    onSelect?(value: { start: moment.Moment, end: moment.Moment }): void;
     onSelectStart?(value: momentRange.MomentRangeExtends): void;
     paginationArrowComponent?: React.ComponentClass<PaginationArrowProps> | React.SFC<PaginationArrowProps>;
     selectedLabel?: string;

--- a/types/react-daterange-picker/react-daterange-picker-tests.tsx
+++ b/types/react-daterange-picker/react-daterange-picker-tests.tsx
@@ -30,7 +30,7 @@ class CustomComponentClassPaginationArrow extends React.Component<ReactDateRange
 }
 
 class App extends React.Component<AppProps, any> {
-    handleSelect(value: AppProps, states: any): void {
+    handleSelect(value: ReactDateRangePicker.OnSelectCallbackParam, states: any): void {
         this.setState({ value, states });
     }
 
@@ -56,7 +56,7 @@ class App extends React.Component<AppProps, any> {
 }
 
 class DateSinglePicker extends React.Component<AppProps, any> {
-    handleSelect(value: AppProps) {
+    handleSelect(value: ReactDateRangePicker.OnSelectCallbackParam) {
         this.setState({ value });
     }
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/onefinestay/react-daterange-picker/blob/c73c92a7b21954374e19e81f17bc87c6142a292b/README.md#available-props>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
