### PR TITLE
@types/jest: relax type definition for toMatchSnapshot - allow literal values and deep objects

### DIFF
--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -664,7 +664,7 @@ declare namespace jest {
          * This ensures that a value matches the most recent snapshot with property matchers.
          * Check out [the Snapshot Testing guide](http://facebook.github.io/jest/docs/snapshot-testing.html) for more information.
          */
-        toMatchSnapshot<T extends {[P in keyof R]: Expect['any']}>(propertyMatchers: Partial<T>, snapshotName?: string): R;
+        toMatchSnapshot<T extends {[P in keyof R]: any}>(propertyMatchers: Partial<T>, snapshotName?: string): R;
         /**
          * This ensures that a value matches the most recent snapshot.
          * Check out [the Snapshot Testing guide](http://facebook.github.io/jest/docs/snapshot-testing.html) for more information.
@@ -675,7 +675,7 @@ declare namespace jest {
          * Instead of writing the snapshot value to a .snap file, it will be written into the source code automatically.
          * Check out [the Snapshot Testing guide](http://facebook.github.io/jest/docs/snapshot-testing.html) for more information.
          */
-        toMatchInlineSnapshot<T extends {[P in keyof R]: Expect['any']}>(propertyMatchers: Partial<T>, snapshot?: string): R;
+        toMatchInlineSnapshot<T extends {[P in keyof R]: any}>(propertyMatchers: Partial<T>, snapshot?: string): R;
         /**
          * This ensures that a value matches the most recent snapshot with property matchers.
          * Instead of writing the snapshot value to a .snap file, it will be written into the source code automatically.

--- a/types/jest/jest-tests.ts
+++ b/types/jest/jest-tests.ts
@@ -622,8 +622,16 @@ describe("", () => {
         expect({
             one: 1,
             two: "2",
+            three: 3,
+            four: { four: 3 },
             date: new Date(),
-        }).toMatchSnapshot({ one: expect.any(Number), date: expect.any(Date) });
+        }).toMatchSnapshot({
+            one: expect.any(Number),
+            // Leave 'two' to the auto-generated snapshot
+            three: 3,
+            four: { four: expect.any(Number) },
+            date: expect.any(Date),
+        });
 
         expect({}).toMatchInlineSnapshot();
         expect({}).toMatchInlineSnapshot("snapshot");
@@ -631,8 +639,16 @@ describe("", () => {
         expect({
             one: 1,
             two: "2",
+            three: 3,
+            four: { four: 3 },
             date: new Date(),
-        }).toMatchInlineSnapshot({ one: expect.any(Number), date: expect.any(Date) });
+        }).toMatchInlineSnapshot({
+            one: expect.any(Number),
+            // leave out two
+            three: 3,
+            four: { four: expect.any(Number) },
+            date: expect.any(Date),
+        });
 
         expect(jest.fn()).toReturn();
 


### PR DESCRIPTION
`toMatchSnapshot` allows a pretty flexible `propertyMatchers` object. It can allow literal values as well as other objects/arrays for deeper matching. 

However, the current type definition only allows for a single-level object with matchers as values. I set the values to `any` to be more flexible, but I'm open to a more strict definition that covers the updated test cases.


Template:
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - [Literal values allowed in snapshot matchers](https://github.com/facebook/jest/issues/6774)
  - [Matchers multiple levels deep are allowed](https://github.com/facebook/jest/issues/6455)
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
