### PR TITLE
[jquery] Drop type guards from isNumeric()/isPlainObject() and improve declarations of jQuery.data()/.data()/jQuery.css()

### DIFF
--- a/types/jquery/index.d.ts
+++ b/types/jquery/index.d.ts
@@ -46,7 +46,6 @@ type _Event = Event;
 interface JQueryStatic {
     /**
      * @see \`{@link https://api.jquery.com/jquery.ajax/#jQuery-ajax1 }\`
-     *
      * @deprecated Use \`{@link JQueryStatic.ajaxSetup }\`.
      */
     ajaxSettings: JQuery.AjaxSettings;
@@ -86,7 +85,6 @@ interface JQueryStatic {
          *
          * @see \`{@link https://api.jquery.com/jQuery.fx.interval/ }\`
          * @since 1.4.3
-         *
          * @deprecated Deprecated since 3.0. See \`{@link https://api.jquery.com/jQuery.fx.interval/ }\`.
          * @example ​ ````Cause all animations to run with less frames.
 ```html
@@ -226,7 +224,6 @@ $.when(
      *
      * @see \`{@link https://api.jquery.com/jQuery.support/ }\`
      * @since 1.3
-     *
      * @deprecated Deprecated since 1.9. See \`{@link https://api.jquery.com/jQuery.support/ }\`.
      */
     support: JQuery.PlainObject;
@@ -5051,7 +5048,6 @@ $p.append( jQuery.hasData( p ) + " " ); // false
      * @param hold Indicates whether the ready hold is being requested or released
      * @see \`{@link https://api.jquery.com/jQuery.holdReady/ }\`
      * @since 1.6
-     *
      * @deprecated Deprecated since 3.2. See \`{@link https://github.com/jquery/jquery/issues/3288 }\`.
      * @example ​ ````Delay the ready event until a custom plugin has loaded.
 ```html
@@ -5134,7 +5130,6 @@ $spans.eq( 3 ).text( jQuery.inArray( "Pete", arr, 2 ) );
      * @param obj Object to test whether or not it is an array.
      * @see \`{@link https://api.jquery.com/jQuery.isArray/ }\`
      * @since 1.3
-     *
      * @deprecated Deprecated since 3.2. Use \`{@link Array.isArray }\`.
      * @example ​ ````Finds out if the parameter is an array.
 ```html
@@ -5189,7 +5184,6 @@ jQuery.isEmptyObject({ foo: "bar" }); // false
      * @param obj Object to test whether or not it is a function.
      * @see \`{@link https://api.jquery.com/jQuery.isFunction/ }\`
      * @since 1.2
-     *
      * @deprecated Deprecated since 3.3. Use `typeof x === "function"`.
      * @example ​ ````Test a few parameter examples.
 ```html
@@ -5262,7 +5256,6 @@ $.isFunction(function() {});
      * @param value The value to be tested.
      * @see \`{@link https://api.jquery.com/jQuery.isNumeric/ }\`
      * @since 1.7
-     *
      * @deprecated Deprecated since 3.3. Internal. See \`{@link https://github.com/jquery/jquery/issues/2960 }\`.
      * @example ​ ````Sample return values of $.isNumeric with various inputs.
 ```html
@@ -5334,7 +5327,6 @@ jQuery.isPlainObject( "test" ) // false
      * @param obj Object to test whether or not it is a window.
      * @see \`{@link https://api.jquery.com/jQuery.isWindow/ }\`
      * @since 1.4.3
-     *
      * @deprecated Deprecated since 3.3. Internal. See \`{@link https://github.com/jquery/jquery/issues/3629 }\`.
      * @example ​ ````Finds out if the parameter is a window.
 ```html
@@ -6064,7 +6056,6 @@ $log.append( "2nd loaded jQuery version (jq162): " + jq162.fn.jquery + "<br>" );
      *
      * @see \`{@link https://api.jquery.com/jQuery.now/ }\`
      * @since 1.4.3
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Date.now }\`.
      */
     now(): number;
@@ -6241,7 +6232,6 @@ $( "<ol></ol>" )
      * @param json The JSON string to parse.
      * @see \`{@link https://api.jquery.com/jQuery.parseJSON/ }\`
      * @since 1.4.1
-     *
      * @deprecated Deprecated since 3.0. Use \`{@link JSON.parse }\`.
      * @example ​ ````Parse a JSON string.
 ```html
@@ -7052,7 +7042,6 @@ $( "#searchForm" ).submit(function( event ) {
      * @param context The object to which the context (this) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -7209,7 +7198,6 @@ $( "#test" )
      * @param context The object to which the context (this) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -7366,7 +7354,6 @@ $( "#test" )
      * @param context The object to which the context (this) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -7523,7 +7510,6 @@ $( "#test" )
      * @param context The object to which the context (this) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -7680,7 +7666,6 @@ $( "#test" )
      * @param context The object to which the context (this) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -7837,7 +7822,6 @@ $( "#test" )
      * @param context The object to which the context (this) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -7995,7 +7979,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4`
      * @since 1.6
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -8152,7 +8135,6 @@ $( "#test" )
      * @param context The object to which the context (this) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -8312,7 +8294,6 @@ $( "#test" )
      * @param context The object to which the context (this) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -8471,7 +8452,6 @@ $( "#test" )
      * @param context The object to which the context (this) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -8630,7 +8610,6 @@ $( "#test" )
      * @param context The object to which the context (this) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -8789,7 +8768,6 @@ $( "#test" )
      * @param context The object to which the context (this) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -8948,7 +8926,6 @@ $( "#test" )
      * @param context The object to which the context (this) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -9107,7 +9084,6 @@ $( "#test" )
      * @param context The object to which the context (this) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -9266,7 +9242,6 @@ $( "#test" )
      * @param context The object to which the context (this) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -9425,7 +9400,6 @@ $( "#test" )
      * @param context The object to which the context (this) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -9586,7 +9560,6 @@ $( "#test" )
      * @param context The object to which the context (this) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -9745,7 +9718,6 @@ $( "#test" )
      * @param context The object to which the context (this) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -9904,7 +9876,6 @@ $( "#test" )
      * @param context The object to which the context (this) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -10063,7 +10034,6 @@ $( "#test" )
      * @param context The object to which the context (this) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -10222,7 +10192,6 @@ $( "#test" )
      * @param context The object to which the context (this) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -10381,7 +10350,6 @@ $( "#test" )
      * @param context The object to which the context (this) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -10540,7 +10508,6 @@ $( "#test" )
      * @param context The object to which the context (this) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -10699,7 +10666,6 @@ $( "#test" )
      * @param context The object to which the context (this) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -10860,7 +10826,6 @@ $( "#test" )
      * @param context The object to which the context (this) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -11019,7 +10984,6 @@ $( "#test" )
      * @param context The object to which the context (this) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -11178,7 +11142,6 @@ $( "#test" )
      * @param context The object to which the context (this) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -11337,7 +11300,6 @@ $( "#test" )
      * @param context The object to which the context (this) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -11496,7 +11458,6 @@ $( "#test" )
      * @param context The object to which the context (this) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -11655,7 +11616,6 @@ $( "#test" )
      * @param context The object to which the context (this) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -11814,7 +11774,6 @@ $( "#test" )
      * @param context The object to which the context (this) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -11973,7 +11932,6 @@ $( "#test" )
      * @param context The object to which the context (this) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -12134,7 +12092,6 @@ $( "#test" )
      * @param context The object to which the context (this) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -12293,7 +12250,6 @@ $( "#test" )
      * @param context The object to which the context (this) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -12452,7 +12408,6 @@ $( "#test" )
      * @param context The object to which the context (this) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -12611,7 +12566,6 @@ $( "#test" )
      * @param context The object to which the context (this) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -12770,7 +12724,6 @@ $( "#test" )
      * @param context The object to which the context (this) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -12929,7 +12882,6 @@ $( "#test" )
      * @param context The object to which the context (this) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -13088,7 +13040,6 @@ $( "#test" )
      * @param context The object to which the context (this) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -13247,7 +13198,6 @@ $( "#test" )
      * @param context The object to which the context (this) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -13408,7 +13358,6 @@ $( "#test" )
      * @param context The object to which the context (this) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -13567,7 +13516,6 @@ $( "#test" )
      * @param context The object to which the context (this) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -13726,7 +13674,6 @@ $( "#test" )
      * @param context The object to which the context (this) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -13885,7 +13832,6 @@ $( "#test" )
      * @param context The object to which the context (this) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -14044,7 +13990,6 @@ $( "#test" )
      * @param context The object to which the context (this) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -14203,7 +14148,6 @@ $( "#test" )
      * @param context The object to which the context (this) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -14362,7 +14306,6 @@ $( "#test" )
      * @param context The object to which the context (this) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -14521,7 +14464,6 @@ $( "#test" )
      * @param context The object to which the context (this) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -14682,7 +14624,6 @@ $( "#test" )
      * @param context The object to which the context (this) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -14841,7 +14782,6 @@ $( "#test" )
      * @param context The object to which the context (this) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -15000,7 +14940,6 @@ $( "#test" )
      * @param context The object to which the context (this) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -15159,7 +15098,6 @@ $( "#test" )
      * @param context The object to which the context (this) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -15318,7 +15256,6 @@ $( "#test" )
      * @param context The object to which the context (this) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -15477,7 +15414,6 @@ $( "#test" )
      * @param context The object to which the context (this) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -15636,7 +15572,6 @@ $( "#test" )
      * @param context The object to which the context (this) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -15795,7 +15730,6 @@ $( "#test" )
      * @param context The object to which the context (this) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -15956,7 +15890,6 @@ $( "#test" )
      * @param context The object to which the context (this) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -16115,7 +16048,6 @@ $( "#test" )
      * @param context The object to which the context (this) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -16274,7 +16206,6 @@ $( "#test" )
      * @param context The object to which the context (this) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -16433,7 +16364,6 @@ $( "#test" )
      * @param context The object to which the context (this) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -16592,7 +16522,6 @@ $( "#test" )
      * @param context The object to which the context (this) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -16751,7 +16680,6 @@ $( "#test" )
      * @param context The object to which the context (this) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -16910,7 +16838,6 @@ $( "#test" )
      * @param context The object to which the context (this) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -17069,7 +16996,6 @@ $( "#test" )
      * @param context The object to which the context (this) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -17233,7 +17159,6 @@ $( "#test" )
      * @param additionalArguments Any number of arguments to be passed to the function referenced in the function argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -17401,7 +17326,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -17560,7 +17484,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -17719,7 +17642,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -17878,7 +17800,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -18037,7 +17958,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -18196,7 +18116,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -18355,7 +18274,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4`
      * @since 1.6
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -18514,7 +18432,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -18676,7 +18593,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -18837,7 +18753,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -18998,7 +18913,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -19159,7 +19073,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -19320,7 +19233,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -19481,7 +19393,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -19642,7 +19553,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -19803,7 +19713,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -19966,7 +19875,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -20127,7 +20035,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -20288,7 +20195,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -20449,7 +20355,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -20610,7 +20515,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -20771,7 +20675,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -20932,7 +20835,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -21093,7 +20995,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -21256,7 +21157,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -21417,7 +21317,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -21578,7 +21477,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -21739,7 +21637,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -21900,7 +21797,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -22061,7 +21957,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -22222,7 +22117,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -22383,7 +22277,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -22546,7 +22439,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -22707,7 +22599,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -22868,7 +22759,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -23029,7 +22919,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -23190,7 +23079,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -23351,7 +23239,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -23512,7 +23399,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -23673,7 +23559,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -23836,7 +23721,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -23997,7 +23881,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -24158,7 +24041,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -24319,7 +24201,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -24480,7 +24361,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -24641,7 +24521,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -24802,7 +24681,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -24963,7 +24841,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -25126,7 +25003,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -25287,7 +25163,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -25448,7 +25323,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -25609,7 +25483,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -25770,7 +25643,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -25931,7 +25803,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -26092,7 +25963,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -26253,7 +26123,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -26416,7 +26285,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -26577,7 +26445,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -26738,7 +26605,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -26899,7 +26765,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -27060,7 +26925,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -27221,7 +27085,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -27382,7 +27245,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -27543,7 +27405,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -27709,7 +27570,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -27875,7 +27735,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
      * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
 ```html
@@ -28362,7 +28221,6 @@ $.trim("    hello, how are you?    ");
      * @param obj Object to get the internal JavaScript [[Class]] of.
      * @see \`{@link https://api.jquery.com/jQuery.type/ }\`
      * @since 1.4.3
-     *
      * @deprecated Deprecated since 3.3. See \`{@link https://github.com/jquery/jquery/issues/3605 }`.
      * @example ​ ````Find out if the parameter is a RegExp.
 ```html
@@ -28392,7 +28250,6 @@ $( "b" ).append( "" + jQuery.type( /test/ ) );
      * @param array The Array of DOM elements.
      * @see \`{@link https://api.jquery.com/jQuery.unique/ }\`
      * @since 1.1.3
-     *
      * @deprecated Deprecated since 3.0. Use \`{@link JQueryStatic.uniqueSort }`.
      * @example ​ ````Removes any duplicate elements from the array of divs.
 ```html
@@ -31975,7 +31832,6 @@ $( "p" ).before( $( "b" ) );
      * @see \`{@link https://api.jquery.com/bind/ }\`
      * @since 1.0
      * @since 1.4.3
-     *
      * @deprecated Deprecated since 3.0. Use \`{@link JQuery.on }\`.
      * @example ​ ````Handle click and double-click for the paragraph.  Note: the coordinates are window relative, so in this case relative to the demo iframe.
 ```html
@@ -32199,7 +32055,6 @@ $( "div.test" ).bind({
      * @see \`{@link https://api.jquery.com/bind/ }\`
      * @since 1.0
      * @since 1.4.3
-     *
      * @deprecated Deprecated since 3.0. Use \`{@link JQuery.on }\`.
      * @example ​ ````Handle click and double-click for the paragraph.  Note: the coordinates are window relative, so in this case relative to the demo iframe.
 ```html
@@ -32418,7 +32273,6 @@ $( "div.test" ).bind({
      * @param events An object containing one or more DOM event types and functions to execute for them.
      * @see \`{@link https://api.jquery.com/bind/ }\`
      * @since 1.4
-     *
      * @deprecated Deprecated since 3.0. Use \`{@link JQuery.on }\`.
      * @example ​ ````Handle click and double-click for the paragraph.  Note: the coordinates are window relative, so in this case relative to the demo iframe.
 ```html
@@ -32637,7 +32491,6 @@ $( "div.test" ).bind({
      * @param handler A function to execute each time the event is triggered.
      * @see \`{@link https://api.jquery.com/blur/ }\`
      * @since 1.4.3
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link JQuery.on }\` or \`{@link JQuery.trigger }\`.
      * @example ​ ````To trigger the blur event on all paragraphs:
 ```html
@@ -32665,7 +32518,6 @@ $( "p" ).blur();
      * @param handler A function to execute each time the event is triggered.
      * @see \`{@link https://api.jquery.com/blur/ }\`
      * @since 1.0
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link JQuery.on }\` or \`{@link JQuery.trigger }\`.
      * @example ​ ````To trigger the blur event on all paragraphs:
 ```html
@@ -32693,7 +32545,6 @@ $( "p" ).blur();
      * @param handler A function to execute each time the event is triggered.
      * @see \`{@link https://api.jquery.com/change/ }\`
      * @since 1.4.3
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link JQuery.on }\` or \`{@link JQuery.trigger }\`.
      * @example ​ ````Attaches a change event to the select that gets the text for each selected option and writes them in the div.  It then triggers the event for the initial text draw.
 ```html
@@ -32763,7 +32614,6 @@ $( "input[type='text']" ).change(function() {
      * @param handler A function to execute each time the event is triggered.
      * @see \`{@link https://api.jquery.com/change/ }\`
      * @since 1.0
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link JQuery.on }\` or \`{@link JQuery.trigger }\`.
      * @example ​ ````Attaches a change event to the select that gets the text for each selected option and writes them in the div.  It then triggers the event for the initial text draw.
 ```html
@@ -33070,7 +32920,6 @@ $( "#stop" ).click(function() {
      * @param handler A function to execute each time the event is triggered.
      * @see \`{@link https://api.jquery.com/click/ }\`
      * @since 1.4.3
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link JQuery.on }\` or \`{@link JQuery.trigger }\`.
      * @example ​ ````Hide paragraphs on a page when they are clicked:
 ```html
@@ -33131,7 +32980,6 @@ $( "p" ).click();
      * @param handler A function to execute each time the event is triggered.
      * @see \`{@link https://api.jquery.com/click/ }\`
      * @since 1.0
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link JQuery.on }\` or \`{@link JQuery.trigger }\`.
      * @example ​ ````Hide paragraphs on a page when they are clicked:
 ```html
@@ -33434,7 +33282,6 @@ $( "#frameDemo" ).contents().find( "a" ).css( "background-color", "#BADA55" );
      * @param handler A function to execute each time the event is triggered.
      * @see \`{@link https://api.jquery.com/contextmenu/ }\`
      * @since 1.4.3
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link JQuery.on }\` or \`{@link JQuery.trigger }\`.
      * @example ​ ````To show a &quot;Hello World!&quot; alert box when the contextmenu event is triggered on a paragraph on the page:
 ```html
@@ -33499,7 +33346,6 @@ div.contextmenu(function() {
      * @param handler A function to execute each time the event is triggered.
      * @see \`{@link https://api.jquery.com/contextmenu/ }\`
      * @since 1.0
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link JQuery.on }\` or \`{@link JQuery.trigger }\`.
      * @example ​ ````To show a &quot;Hello World!&quot; alert box when the contextmenu event is triggered on a paragraph on the page:
 ```html
@@ -35194,7 +35040,6 @@ $( "button" ).click(function() {
      * @param handler A function to execute each time the event is triggered.
      * @see \`{@link https://api.jquery.com/dblclick/ }\`
      * @since 1.4.3
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link JQuery.on }\` or \`{@link JQuery.trigger }\`.
      * @example ​ ````To bind a &quot;Hello World!&quot; alert box to the dblclick event on every paragraph on the page:
 ```html
@@ -35259,7 +35104,6 @@ divdbl.dblclick(function() {
      * @param handler A function to execute each time the event is triggered.
      * @see \`{@link https://api.jquery.com/dblclick/ }\`
      * @since 1.0
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link JQuery.on }\` or \`{@link JQuery.trigger }\`.
      * @example ​ ````To bind a &quot;Hello World!&quot; alert box to the dblclick event on every paragraph on the page:
 ```html
@@ -35377,7 +35221,6 @@ $( "button" ).click(function() {
      * @param handler A function to execute each time the event is triggered.
      * @see \`{@link https://api.jquery.com/delegate/ }\`
      * @since 1.4.2
-     *
      * @deprecated Deprecated since 3.0. Use \`{@link JQuery.on }\`.
      * @example ​ ````Click a paragraph to add another. Note that .delegate() attaches a click event handler to all paragraphs - even new ones.
 ```html
@@ -35528,7 +35371,6 @@ $( "button" ).click(function() {
      * @param handler A function to execute each time the event is triggered.
      * @see \`{@link https://api.jquery.com/delegate/ }\`
      * @since 1.4.2
-     *
      * @deprecated Deprecated since 3.0. Use \`{@link JQuery.on }\`.
      * @example ​ ````Click a paragraph to add another. Note that .delegate() attaches a click event handler to all paragraphs - even new ones.
 ```html
@@ -35676,7 +35518,6 @@ $( "button" ).click(function() {
      * @param events A plain object of one or more event types and functions to execute for them.
      * @see \`{@link https://api.jquery.com/delegate/ }\`
      * @since 1.4.3
-     *
      * @deprecated Deprecated since 3.0. Use \`{@link JQuery.on }\`.
      * @example ​ ````Click a paragraph to add another. Note that .delegate() attaches a click event handler to all paragraphs - even new ones.
 ```html
@@ -37860,7 +37701,6 @@ $( "p span" ).first().addClass( "highlight" );
      * @param handler A function to execute each time the event is triggered.
      * @see \`{@link https://api.jquery.com/focus/ }\`
      * @since 1.4.3
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link JQuery.on }\` or \`{@link JQuery.trigger }\`.
      * @example ​ ````Fire focus.
 ```html
@@ -37936,7 +37776,6 @@ $( document ).ready(function() {
      * @param handler A function to execute each time the event is triggered.
      * @see \`{@link https://api.jquery.com/focus/ }\`
      * @since 1.0
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link JQuery.on }\` or \`{@link JQuery.trigger }\`.
      * @example ​ ````Fire focus.
 ```html
@@ -38012,7 +37851,6 @@ $( document ).ready(function() {
      * @param handler A function to execute each time the event is triggered.
      * @see \`{@link https://api.jquery.com/focusin/ }\`
      * @since 1.4.3
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link JQuery.on }\` or \`{@link JQuery.trigger }\`.
      * @example ​ ````Watch for a focus to occur within the paragraphs on the page.
 ```html
@@ -38050,7 +37888,6 @@ $( "p" ).focusin(function() {
      * @param handler A function to execute each time the event is triggered.
      * @see \`{@link https://api.jquery.com/focusin/ }\`
      * @since 1.4
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link JQuery.on }\` or \`{@link JQuery.trigger }\`.
      * @example ​ ````Watch for a focus to occur within the paragraphs on the page.
 ```html
@@ -38088,7 +37925,6 @@ $( "p" ).focusin(function() {
      * @param handler A function to execute each time the event is triggered.
      * @see \`{@link https://api.jquery.com/focusout/ }\`
      * @since 1.4.3
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link JQuery.on }\` or \`{@link JQuery.trigger }\`.
      * @example ​ ````Watch for a loss of focus to occur inside paragraphs and note the difference between the focusout count and the blur count. (The blur count does not change because those events do not bubble.)
 ```html
@@ -38147,7 +37983,6 @@ $( "p" )
      * @param handler A function to execute each time the event is triggered.
      * @see \`{@link https://api.jquery.com/focusout/ }\`
      * @since 1.4
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link JQuery.on }\` or \`{@link JQuery.trigger }\`.
      * @example ​ ````Watch for a loss of focus to occur inside paragraphs and note the difference between the focusout count and the blur count. (The blur count does not change because those events do not bubble.)
 ```html
@@ -40233,7 +40068,6 @@ $( "li" ).click(function() {
      * @param handler A function to execute each time the event is triggered.
      * @see \`{@link https://api.jquery.com/keydown/ }\`
      * @since 1.4.3
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link JQuery.on }\` or \`{@link JQuery.trigger }\`.
      * @example ​ ````Show the event object for the keydown handler when a key is pressed in the input.
 ```html
@@ -40303,7 +40137,6 @@ $( "#other" ).click(function() {
      * @param handler A function to execute each time the event is triggered.
      * @see \`{@link https://api.jquery.com/keydown/ }\`
      * @since 1.0
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link JQuery.on }\` or \`{@link JQuery.trigger }\`.
      * @example ​ ````Show the event object for the keydown handler when a key is pressed in the input.
 ```html
@@ -40373,7 +40206,6 @@ $( "#other" ).click(function() {
      * @param handler A function to execute each time the event is triggered.
      * @see \`{@link https://api.jquery.com/keypress/ }\`
      * @since 1.4.3
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link JQuery.on }\` or \`{@link JQuery.trigger }\`.
      * @example ​ ````Show the event object when a key is pressed in the input. Note: This demo relies on a simple $.print() plugin (https://api.jquery.com/resources/events.js) for the event object&#39;s output.
 ```html
@@ -40443,7 +40275,6 @@ $( "#other" ).click(function() {
      * @param handler A function to execute each time the event is triggered.
      * @see \`{@link https://api.jquery.com/keypress/ }\`
      * @since 1.0
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link JQuery.on }\` or \`{@link JQuery.trigger }\`.
      * @example ​ ````Show the event object when a key is pressed in the input. Note: This demo relies on a simple $.print() plugin (https://api.jquery.com/resources/events.js) for the event object&#39;s output.
 ```html
@@ -40513,7 +40344,6 @@ $( "#other" ).click(function() {
      * @param handler A function to execute each time the event is triggered.
      * @see \`{@link https://api.jquery.com/keyup/ }\`
      * @since 1.4.3
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link JQuery.on }\` or \`{@link JQuery.trigger }\`.
      * @example ​ ````Show the event object for the keyup handler (using a simple $.print plugin) when a key is released in the input.
 ```html
@@ -40584,7 +40414,6 @@ $( "#other").click(function() {
      * @param handler A function to execute each time the event is triggered.
      * @see \`{@link https://api.jquery.com/keyup/ }\`
      * @since 1.0
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link JQuery.on }\` or \`{@link JQuery.trigger }\`.
      * @example ​ ````Show the event object for the keyup handler (using a simple $.print plugin) when a key is released in the input.
 ```html
@@ -41078,7 +40907,6 @@ $( "input" ).click(function() {
      * @param handler A function to execute each time the event is triggered.
      * @see \`{@link https://api.jquery.com/mousedown/ }\`
      * @since 1.4.3
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link JQuery.on }\` or \`{@link JQuery.trigger }\`.
      * @example ​ ````Show texts when mouseup and mousedown event triggering.
 ```html
@@ -41114,7 +40942,6 @@ $( "p" )
      * @param handler A function to execute each time the event is triggered.
      * @see \`{@link https://api.jquery.com/mousedown/ }\`
      * @since 1.0
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link JQuery.on }\` or \`{@link JQuery.trigger }\`.
      * @example ​ ````Show texts when mouseup and mousedown event triggering.
 ```html
@@ -41150,7 +40977,6 @@ $( "p" )
      * @param handler A function to execute each time the event is triggered.
      * @see \`{@link https://api.jquery.com/mouseenter/ }\`
      * @since 1.4.3
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link JQuery.on }\` or \`{@link JQuery.trigger }\`.
      * @example ​ ````Show texts when mouseenter and mouseout event triggering.
     mouseover fires when the pointer moves into the child element as well, while mouseenter fires only when the pointer moves into the bound element.
@@ -41229,7 +41055,6 @@ $( "div.enterleave" )
      * @param handler A function to execute each time the event is triggered.
      * @see \`{@link https://api.jquery.com/mouseenter/ }\`
      * @since 1.0
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link JQuery.on }\` or \`{@link JQuery.trigger }\`.
      * @example ​ ````Show texts when mouseenter and mouseout event triggering.
     mouseover fires when the pointer moves into the child element as well, while mouseenter fires only when the pointer moves into the bound element.
@@ -41308,7 +41133,6 @@ $( "div.enterleave" )
      * @param handler A function to execute each time the event is triggered.
      * @see \`{@link https://api.jquery.com/mouseleave/ }\`
      * @since 1.4.3
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link JQuery.on }\` or \`{@link JQuery.trigger }\`.
      * @example ​ ````Show number of times mouseout and mouseleave events are triggered. mouseout fires when the pointer moves out of child element as well, while mouseleave fires only when the pointer moves out of the bound element.
 ```html
@@ -41385,7 +41209,6 @@ $( "div.enterleave" )
      * @param handler A function to execute each time the event is triggered.
      * @see \`{@link https://api.jquery.com/mouseleave/ }\`
      * @since 1.0
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link JQuery.on }\` or \`{@link JQuery.trigger }\`.
      * @example ​ ````Show number of times mouseout and mouseleave events are triggered. mouseout fires when the pointer moves out of child element as well, while mouseleave fires only when the pointer moves out of the bound element.
 ```html
@@ -41462,7 +41285,6 @@ $( "div.enterleave" )
      * @param handler A function to execute each time the event is triggered.
      * @see \`{@link https://api.jquery.com/mousemove/ }\`
      * @since 1.4.3
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link JQuery.on }\` or \`{@link JQuery.trigger }\`.
      * @example ​ ````Show the mouse coordinates when the mouse is moved over the yellow div.  Coordinates are relative to the window, which in this case is the iframe.
 ```html
@@ -41524,7 +41346,6 @@ $( "div" ).mousemove(function( event ) {
      * @param handler A function to execute each time the event is triggered.
      * @see \`{@link https://api.jquery.com/mousemove/ }\`
      * @since 1.0
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link JQuery.on }\` or \`{@link JQuery.trigger }\`.
      * @example ​ ````Show the mouse coordinates when the mouse is moved over the yellow div.  Coordinates are relative to the window, which in this case is the iframe.
 ```html
@@ -41586,7 +41407,6 @@ $( "div" ).mousemove(function( event ) {
      * @param handler A function to execute each time the event is triggered.
      * @see \`{@link https://api.jquery.com/mouseout/ }\`
      * @since 1.4.3
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link JQuery.on }\` or \`{@link JQuery.trigger }\`.
      * @example ​ ````Show the number of times mouseout and mouseleave events are triggered.
   mouseout fires when the pointer moves out of the child element as well, while mouseleave fires only when the pointer moves out of the bound element.
@@ -41665,7 +41485,6 @@ $( "div.enterleave" )
      * @param handler A function to execute each time the event is triggered.
      * @see \`{@link https://api.jquery.com/mouseout/ }\`
      * @since 1.0
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link JQuery.on }\` or \`{@link JQuery.trigger }\`.
      * @example ​ ````Show the number of times mouseout and mouseleave events are triggered.
   mouseout fires when the pointer moves out of the child element as well, while mouseleave fires only when the pointer moves out of the bound element.
@@ -41744,7 +41563,6 @@ $( "div.enterleave" )
      * @param handler A function to execute each time the event is triggered.
      * @see \`{@link https://api.jquery.com/mouseover/ }\`
      * @since 1.4.3
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link JQuery.on }\` or \`{@link JQuery.trigger }\`.
      * @example ​ ````Show the number of times mouseover and mouseenter events are triggered.
 mouseover fires when the pointer moves into the child element as well, while mouseenter fires only when the pointer moves into the bound element.
@@ -41823,7 +41641,6 @@ $( "div.enterleave" )
      * @param handler A function to execute each time the event is triggered.
      * @see \`{@link https://api.jquery.com/mouseover/ }\`
      * @since 1.0
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link JQuery.on }\` or \`{@link JQuery.trigger }\`.
      * @example ​ ````Show the number of times mouseover and mouseenter events are triggered.
 mouseover fires when the pointer moves into the child element as well, while mouseenter fires only when the pointer moves into the bound element.
@@ -41902,7 +41719,6 @@ $( "div.enterleave" )
      * @param handler A function to execute each time the event is triggered.
      * @see \`{@link https://api.jquery.com/mouseup/ }\`
      * @since 1.4.3
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link JQuery.on }\` or \`{@link JQuery.trigger }\`.
      * @example ​ ````Show texts when mouseup and mousedown event triggering.
 ```html
@@ -41938,7 +41754,6 @@ $( "p" )
      * @param handler A function to execute each time the event is triggered.
      * @see \`{@link https://api.jquery.com/mouseup/ }\`
      * @since 1.0
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link JQuery.on }\` or \`{@link JQuery.trigger }\`.
      * @example ​ ````Show texts when mouseup and mousedown event triggering.
 ```html
@@ -49967,7 +49782,6 @@ $( "#stop" ).click(function() {
      * @param handler A function to execute after the DOM is ready.
      * @see \`{@link https://api.jquery.com/ready/ }\`
      * @since 1.0
-     *
      * @deprecated Deprecated since 3.0. Use `jQuery(function() { })`.
      * @example ​ ````Display a message when the DOM is loaded.
 ```html
@@ -50507,7 +50321,6 @@ $( "button" ).on( "click", function() {
      * @param handler A function to execute each time the event is triggered.
      * @see \`{@link https://api.jquery.com/resize/ }\`
      * @since 1.4.3
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link JQuery.on }\` or \`{@link JQuery.trigger }\`.
      * @example ​ ````To see the window width while (or after) it is resized, try:
 ```html
@@ -50537,7 +50350,6 @@ $( window ).resize(function() {
      * @param handler A function to execute each time the event is triggered.
      * @see \`{@link https://api.jquery.com/resize/ }\`
      * @since 1.0
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link JQuery.on }\` or \`{@link JQuery.trigger }\`.
      * @example ​ ````To see the window width while (or after) it is resized, try:
 ```html
@@ -50567,7 +50379,6 @@ $( window ).resize(function() {
      * @param handler A function to execute each time the event is triggered.
      * @see \`{@link https://api.jquery.com/scroll/ }\`
      * @since 1.4.3
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link JQuery.on }\` or \`{@link JQuery.trigger }\`.
      * @example ​ ````To do something when your page is scrolled:
 ```html
@@ -50615,7 +50426,6 @@ $( window ).scroll(function() {
      * @param handler A function to execute each time the event is triggered.
      * @see \`{@link https://api.jquery.com/scroll/ }\`
      * @since 1.0
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link JQuery.on }\` or \`{@link JQuery.trigger }\`.
      * @example ​ ````To do something when your page is scrolled:
 ```html
@@ -50954,7 +50764,6 @@ $( "div.demo" ).scrollTop( 300 );
      * @param handler A function to execute each time the event is triggered.
      * @see \`{@link https://api.jquery.com/select/ }\`
      * @since 1.4.3
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link JQuery.on }\` or \`{@link JQuery.trigger }\`.
      * @example ​ ````To do something when text in input boxes is selected:
 ```html
@@ -51014,7 +50823,6 @@ $( "input" ).select();
      * @param handler A function to execute each time the event is triggered.
      * @see \`{@link https://api.jquery.com/select/ }\`
      * @since 1.0
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link JQuery.on }\` or \`{@link JQuery.trigger }\`.
      * @example ​ ````To do something when text in input boxes is selected:
 ```html
@@ -52932,7 +52740,6 @@ $( "#toggle" ).on( "click", function() {
      * @param handler A function to execute each time the event is triggered.
      * @see \`{@link https://api.jquery.com/submit/ }\`
      * @since 1.4.3
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link JQuery.on }\` or \`{@link JQuery.trigger }\`.
      * @example ​ ````If you&#39;d like to prevent forms from being submitted unless a flag variable is set, try:
 ```html
@@ -53025,7 +52832,6 @@ $( "form:first" ).submit();
      * @param handler A function to execute each time the event is triggered.
      * @see \`{@link https://api.jquery.com/submit/ }\`
      * @since 1.0
-     *
      * @deprecated Deprecated since 3.3. Use \`{@link JQuery.on }\` or \`{@link JQuery.trigger }\`.
      * @example ​ ````If you&#39;d like to prevent forms from being submitted unless a flag variable is set, try:
 ```html
@@ -53722,7 +53528,6 @@ $( "a" ).on( "click", function( event ) {
      * @param state A boolean value to determine whether the class should be added or removed.
      * @see \`{@link https://api.jquery.com/toggleClass/ }\`
      * @since 1.4
-     *
      * @deprecated Deprecated since 3.0. See \`{@link https://github.com/jquery/jquery/pull/2618 }\`.
      * @example ​ ````Toggle the class &#39;highlight&#39; when a paragraph is clicked.
 ```html
@@ -54087,7 +53892,6 @@ $( "input" ).focus(function() {
      * @see \`{@link https://api.jquery.com/unbind/ }\`
      * @since 1.0
      * @since 1.4.3
-     *
      * @deprecated Deprecated since 3.0. Use \`{@link JQuery.off }\`.
      * @example ​ ````Can bind and unbind events to the colored button.
 ```html
@@ -54198,7 +54002,6 @@ $( "p" ).unbind( "click", foo ); // ... foo will no longer be called.
      *              A jQuery.Event object.
      * @see \`{@link https://api.jquery.com/unbind/ }\`
      * @since 1.0
-     *
      * @deprecated Deprecated since 3.0. Use \`{@link JQuery.off }\`.
      * @example ​ ````Can bind and unbind events to the colored button.
 ```html
@@ -54311,7 +54114,6 @@ $( "p" ).unbind( "click", foo ); // ... foo will no longer be called.
      * @param handler A function to execute each time the event is triggered.
      * @see \`{@link https://api.jquery.com/undelegate/ }\`
      * @since 1.4.2
-     *
      * @deprecated Deprecated since 3.0. Use \`{@link JQuery.off }\`.
      * @example ​ ````Can bind and unbind events to the colored button.
 ```html
@@ -54454,7 +54256,6 @@ $( "form" ).undelegate( ".whatever" );
      * @see \`{@link https://api.jquery.com/undelegate/ }\`
      * @since 1.4.2
      * @since 1.4.3
-     *
      * @deprecated Deprecated since 3.0. Use \`{@link JQuery.off }\`.
      * @example ​ ````Can bind and unbind events to the colored button.
 ```html
@@ -54595,7 +54396,6 @@ $( "form" ).undelegate( ".whatever" );
      * @see \`{@link https://api.jquery.com/undelegate/ }\`
      * @since 1.4.2
      * @since 1.6
-     *
      * @deprecated Deprecated since 3.0. Use \`{@link JQuery.off }\`.
      * @example ​ ````Can bind and unbind events to the colored button.
 ```html
@@ -57589,7 +57389,6 @@ obj.done(function( name ) {
          * @see \`{@link https://api.jquery.com/deferred.pipe/ }\`
          * @since 1.6
          * @since 1.7
-         *
          * @deprecated Deprecated since 1.8. Use \`{@link then JQuery.PromiseBase.then }\`.
          * @example ​ ````Filter resolve value:
 ```html
@@ -57702,7 +57501,6 @@ chained.done(function( data ) {
          * @see \`{@link https://api.jquery.com/deferred.pipe/ }\`
          * @since 1.6
          * @since 1.7
-         *
          * @deprecated Deprecated since 1.8. Use \`{@link then JQuery.PromiseBase.then }\`.
          * @example ​ ````Filter resolve value:
 ```html
@@ -57808,7 +57606,6 @@ chained.done(function( data ) {
          * @see \`{@link https://api.jquery.com/deferred.pipe/ }\`
          * @since 1.6
          * @since 1.7
-         *
          * @deprecated Deprecated since 1.8. Use \`{@link then JQuery.PromiseBase.then }\`.
          * @example ​ ````Filter resolve value:
 ```html
@@ -57914,7 +57711,6 @@ chained.done(function( data ) {
          * @see \`{@link https://api.jquery.com/deferred.pipe/ }\`
          * @since 1.6
          * @since 1.7
-         *
          * @deprecated Deprecated since 1.8. Use \`{@link then JQuery.PromiseBase.then }\`.
          * @example ​ ````Filter resolve value:
 ```html
@@ -58013,7 +57809,6 @@ chained.done(function( data ) {
          * @see \`{@link https://api.jquery.com/deferred.pipe/ }\`
          * @since 1.6
          * @since 1.7
-         *
          * @deprecated Deprecated since 1.8. Use \`{@link then JQuery.PromiseBase.then }\`.
          * @example ​ ````Filter resolve value:
 ```html
@@ -58119,7 +57914,6 @@ chained.done(function( data ) {
          * @see \`{@link https://api.jquery.com/deferred.pipe/ }\`
          * @since 1.6
          * @since 1.7
-         *
          * @deprecated Deprecated since 1.8. Use \`{@link then JQuery.PromiseBase.then }\`.
          * @example ​ ````Filter resolve value:
 ```html
@@ -58218,7 +58012,6 @@ chained.done(function( data ) {
          * @see \`{@link https://api.jquery.com/deferred.pipe/ }\`
          * @since 1.6
          * @since 1.7
-         *
          * @deprecated Deprecated since 1.8. Use \`{@link then JQuery.PromiseBase.then }\`.
          * @example ​ ````Filter resolve value:
 ```html
@@ -59729,7 +59522,6 @@ obj.done(function( name ) {
          * @see \`{@link https://api.jquery.com/deferred.pipe/ }\`
          * @since 1.6
          * @since 1.7
-         *
          * @deprecated Deprecated since 1.8. Use \`{@link JQuery.Deferred.then }\`.
          * @example ​ ````Filter resolve value:
 ```html
@@ -59842,7 +59634,6 @@ chained.done(function( data ) {
          * @see \`{@link https://api.jquery.com/deferred.pipe/ }\`
          * @since 1.6
          * @since 1.7
-         *
          * @deprecated Deprecated since 1.8. Use \`{@link JQuery.Deferred.then }\`.
          * @example ​ ````Filter resolve value:
 ```html
@@ -59948,7 +59739,6 @@ chained.done(function( data ) {
          * @see \`{@link https://api.jquery.com/deferred.pipe/ }\`
          * @since 1.6
          * @since 1.7
-         *
          * @deprecated Deprecated since 1.8. Use \`{@link JQuery.Deferred.then }\`.
          * @example ​ ````Filter resolve value:
 ```html
@@ -60054,7 +59844,6 @@ chained.done(function( data ) {
          * @see \`{@link https://api.jquery.com/deferred.pipe/ }\`
          * @since 1.6
          * @since 1.7
-         *
          * @deprecated Deprecated since 1.8. Use \`{@link JQuery.Deferred.then }\`.
          * @example ​ ````Filter resolve value:
 ```html
@@ -60153,7 +59942,6 @@ chained.done(function( data ) {
          * @see \`{@link https://api.jquery.com/deferred.pipe/ }\`
          * @since 1.6
          * @since 1.7
-         *
          * @deprecated Deprecated since 1.8. Use \`{@link JQuery.Deferred.then }\`.
          * @example ​ ````Filter resolve value:
 ```html
@@ -60259,7 +60047,6 @@ chained.done(function( data ) {
          * @see \`{@link https://api.jquery.com/deferred.pipe/ }\`
          * @since 1.6
          * @since 1.7
-         *
          * @deprecated Deprecated since 1.8. Use \`{@link JQuery.Deferred.then }\`.
          * @example ​ ````Filter resolve value:
 ```html
@@ -60358,7 +60145,6 @@ chained.done(function( data ) {
          * @see \`{@link https://api.jquery.com/deferred.pipe/ }\`
          * @since 1.6
          * @since 1.7
-         *
          * @deprecated Deprecated since 1.8. Use \`{@link JQuery.Deferred.then }\`.
          * @example ​ ````Filter resolve value:
 ```html

--- a/types/jquery/index.d.ts
+++ b/types/jquery/index.d.ts
@@ -5301,7 +5301,7 @@ $.isNumeric( undefined )
 </html>
 ```
      */
-    isNumeric(value: any): value is number;
+    isNumeric(value: any): boolean;
     /**
      * Check to see if an object is a plain object (created using "{}" or "new Object").
      *

--- a/types/jquery/index.d.ts
+++ b/types/jquery/index.d.ts
@@ -7078,12 +7078,16 @@ $( "#searchForm" ).submit(function( event ) {
      */
     post(url_settings?: string | JQuery.UrlAjaxSettings): JQuery.jqXHR;
 
+    // region proxy
     // #region proxy
 
+    // region (fn, null | undefined)
     // #region (fn, null | undefined)
 
+    // region 0 to 7 additional arguments
     // #region 0 to 7 additional arguments
 
+    // region 0 parameters
     // #region 0 parameters
 
     /**
@@ -8336,6 +8340,7 @@ $( "#test" )
 
     // #endregion
 
+    // region 1 parameters
     // #region 1 parameters
 
     /**
@@ -9602,6 +9607,7 @@ $( "#test" )
 
     // #endregion
 
+    // region 2 parameters
     // #region 2 parameters
 
     /**
@@ -10868,6 +10874,7 @@ $( "#test" )
 
     // #endregion
 
+    // region 3 parameters
     // #region 3 parameters
 
     /**
@@ -12134,6 +12141,7 @@ $( "#test" )
 
     // #endregion
 
+    // region 4 parameters
     // #region 4 parameters
 
     /**
@@ -13400,6 +13408,7 @@ $( "#test" )
 
     // #endregion
 
+    // region 5 parameters
     // #region 5 parameters
 
     /**
@@ -14666,6 +14675,7 @@ $( "#test" )
 
     // #endregion
 
+    // region 6 parameters
     // #region 6 parameters
 
     /**
@@ -15932,6 +15942,7 @@ $( "#test" )
 
     // #endregion
 
+    // region 7+ parameters
     // #region 7+ parameters
 
     /**
@@ -17200,6 +17211,7 @@ $( "#test" )
 
     // #endregion
 
+    // region 8+ additional arguments
     // #region 8+ additional arguments
 
     /**
@@ -17363,10 +17375,13 @@ $( "#test" )
 
     // #endregion
 
+    // region (fn, context)
     // #region (fn, context)
 
+    // region 0 to 7 additional arguments
     // #region 0 to 7 additional arguments
 
+    // region 0 parameters
     // #region 0 parameters
 
     /**
@@ -18634,6 +18649,7 @@ $( "#test" )
 
     // #endregion
 
+    // region 1 parameters
     // #region 1 parameters
 
     /**
@@ -19916,6 +19932,7 @@ $( "#test" )
 
     // #endregion
 
+    // region 2 parameters
     // #region 2 parameters
 
     /**
@@ -21198,6 +21215,7 @@ $( "#test" )
 
     // #endregion
 
+    // region 3 parameters
     // #region 3 parameters
 
     /**
@@ -22480,6 +22498,7 @@ $( "#test" )
 
     // #endregion
 
+    // region 4 parameters
     // #region 4 parameters
 
     /**
@@ -23762,6 +23781,7 @@ $( "#test" )
 
     // #endregion
 
+    // region 5 parameters
     // #region 5 parameters
 
     /**
@@ -25044,6 +25064,7 @@ $( "#test" )
 
     // #endregion
 
+    // region 6 parameters
     // #region 6 parameters
 
     /**
@@ -26326,6 +26347,7 @@ $( "#test" )
 
     // #endregion
 
+    // region 7+ parameters
     // #region 7+ parameters
 
     /**
@@ -27610,6 +27632,7 @@ $( "#test" )
 
     // #endregion
 
+    // region 8+ additional arguments
     // #region 8+ additional arguments
 
     /**
@@ -27775,6 +27798,7 @@ $( "#test" )
 
     // #endregion
 
+    // region (context, name)
     // #region (context, name)
 
     /**
@@ -55642,6 +55666,7 @@ $( "p" ).wrapInner( $( "<span class='red'></span>" ) );
     [n: number]: TElement;
 }
 
+// region ES5 compatibility
 // #region ES5 compatibility
 
 // tslint:disable-next-line:no-empty-interface
@@ -55690,6 +55715,7 @@ declare namespace JQuery {
         [key: string]: T;
     }
 
+    // region Ajax
     // #region Ajax
 
     interface AjaxSettings<TContext = any> extends Ajax.AjaxSettingsBase<TContext> {
@@ -55995,6 +56021,7 @@ declare namespace JQuery {
         }
 
         type StatusCodeCallbacks<TContext> = {
+            // region Success Status Codes
             // #region Success Status Codes
 
             // jQuery treats 2xx and 304 status codes as a success
@@ -56103,6 +56130,7 @@ declare namespace JQuery {
 
             // #endregion
 
+            // region Error Status Codes
             // #region Error Status Codes
 
             300?: ErrorCallback<TContext>;
@@ -56459,6 +56487,7 @@ declare namespace JQuery {
 
     // #endregion
 
+    // region Callbacks
     // #region Callbacks
 
     // tslint:disable-next-line:ban-types
@@ -57023,6 +57052,7 @@ callbacks.fire( "world" );
 
     // #endregion
 
+    // region CSS
     // #region CSS
 
     interface CSSHook<TElement> {
@@ -57032,6 +57062,7 @@ callbacks.fire( "world" );
 
     // #endregion
 
+    // region Deferred
     // #region Deferred
 
     /**
@@ -57434,6 +57465,7 @@ obj.done(function( name ) {
          */
         state(): 'pending' | 'resolved' | 'rejected';
 
+        // region pipe
         // #region pipe
 
         /**
@@ -58160,6 +58192,7 @@ chained.done(function( data ) {
 
         // #endregion
 
+        // region then
         // #region then
 
         /**
@@ -59567,6 +59600,7 @@ obj.done(function( name ) {
          */
         state(): 'pending' | 'resolved' | 'rejected';
 
+        // region pipe
         // #region pipe
 
         /**
@@ -60293,6 +60327,7 @@ chained.done(function( data ) {
 
         // #endregion
 
+        // region then
         // #region then
 
         /**
@@ -61292,6 +61327,7 @@ $.get( "test.php" )
 
     // #endregion
 
+    // region Effects
     // #region Effects
 
     type Duration = number | 'fast' | 'slow';
@@ -61396,8 +61432,10 @@ $.get( "test.php" )
 
     // #endregion
 
+    // region Events
     // #region Events
 
+    // region Event
     // #region Event
 
     // This should be a class but doesn't work correctly under the JQuery namespace. Event should be an inner class of jQuery.
@@ -62175,6 +62213,7 @@ $( "ul" ).click( handler ).find( "ul" ).hide();
     }
 }
 
+// region Legacy types
 // #region Legacy types
 
 // tslint:disable-next-line:no-empty-interface

--- a/types/jquery/index.d.ts
+++ b/types/jquery/index.d.ts
@@ -5327,7 +5327,7 @@ jQuery.isPlainObject( "test" ) // false
 </html>
 ```
      */
-    isPlainObject(obj: any): obj is JQuery.PlainObject;
+    isPlainObject(obj: any): boolean;
     /**
      * Determine whether the argument is a window.
      *
@@ -55826,6 +55826,9 @@ declare namespace JQuery {
      * object is, in other words, an Object object. It is designated "plain" in jQuery documentation to
      * distinguish it from other kinds of JavaScript objects: for example, null, user-defined arrays, and
      * host objects such as document, all of which have a typeof value of "object."
+     *
+     * **Note**: The type declaration of PlainObject is imprecise. It includes host objects and user-defined
+     *           arrays which do not match jQuery's definition.
      */
     interface PlainObject<T = any> {
         [key: string]: T;

--- a/types/jquery/index.d.ts
+++ b/types/jquery/index.d.ts
@@ -7082,7 +7082,7 @@ $( "#searchForm" ).submit(function( event ) {
 
     // #region (fn, null | undefined)
 
-    // #region 0 to 7 arguments
+    // #region 0 to 7 additional arguments
 
     // #region 0 parameters
 
@@ -7090,7 +7090,7 @@ $( "#searchForm" ).submit(function( event ) {
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
@@ -7246,7 +7246,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
@@ -7402,7 +7402,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
@@ -7558,7 +7558,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
@@ -7714,7 +7714,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
@@ -7870,7 +7870,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
@@ -8026,7 +8026,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4`
      * @since 1.6
@@ -8183,7 +8183,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
@@ -8342,7 +8342,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
@@ -8500,7 +8500,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
@@ -8658,7 +8658,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
@@ -8816,7 +8816,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
@@ -8974,7 +8974,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
@@ -9132,7 +9132,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
@@ -9290,7 +9290,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
@@ -9448,7 +9448,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
@@ -9608,7 +9608,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
@@ -9766,7 +9766,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
@@ -9924,7 +9924,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
@@ -10082,7 +10082,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
@@ -10240,7 +10240,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
@@ -10398,7 +10398,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
@@ -10556,7 +10556,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
@@ -10714,7 +10714,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
@@ -10874,7 +10874,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
@@ -11032,7 +11032,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
@@ -11190,7 +11190,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
@@ -11348,7 +11348,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
@@ -11506,7 +11506,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
@@ -11664,7 +11664,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
@@ -11822,7 +11822,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
@@ -11980,7 +11980,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
@@ -12140,7 +12140,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
@@ -12298,7 +12298,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
@@ -12456,7 +12456,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
@@ -12614,7 +12614,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
@@ -12772,7 +12772,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
@@ -12930,7 +12930,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
@@ -13088,7 +13088,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
@@ -13246,7 +13246,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
@@ -13406,7 +13406,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
@@ -13564,7 +13564,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
@@ -13722,7 +13722,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
@@ -13880,7 +13880,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
@@ -14038,7 +14038,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
@@ -14196,7 +14196,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
@@ -14354,7 +14354,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
@@ -14512,7 +14512,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
@@ -14672,7 +14672,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
@@ -14830,7 +14830,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
@@ -14988,7 +14988,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
@@ -15146,7 +15146,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
@@ -15304,7 +15304,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
@@ -15462,7 +15462,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
@@ -15620,7 +15620,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
@@ -15778,7 +15778,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
@@ -15938,7 +15938,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
@@ -16096,7 +16096,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
@@ -16254,7 +16254,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
@@ -16412,7 +16412,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
@@ -16570,7 +16570,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
@@ -16728,7 +16728,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
@@ -16886,7 +16886,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
@@ -17044,7 +17044,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated Deprecated since 3.3. Use \`{@link Function.bind }\`.
@@ -17200,13 +17200,13 @@ $( "#test" )
 
     // #endregion
 
-    // #region 8+ arguments
+    // #region 8+ additional arguments
 
     /**
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @param additionalArguments Any number of arguments to be passed to the function referenced in the function argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
@@ -17365,7 +17365,7 @@ $( "#test" )
 
     // #region (fn, context)
 
-    // #region 0 to 7 arguments
+    // #region 0 to 7 additional arguments
 
     // #region 0 parameters
 
@@ -17373,7 +17373,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -17531,7 +17531,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -17689,7 +17689,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -17847,7 +17847,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -18005,7 +18005,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -18163,7 +18163,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -18321,7 +18321,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4`
      * @since 1.6
@@ -18479,7 +18479,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -18640,7 +18640,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -18800,7 +18800,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -18960,7 +18960,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -19120,7 +19120,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -19280,7 +19280,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -19440,7 +19440,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -19600,7 +19600,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -19760,7 +19760,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -19922,7 +19922,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -20082,7 +20082,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -20242,7 +20242,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -20402,7 +20402,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -20562,7 +20562,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -20722,7 +20722,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -20882,7 +20882,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -21042,7 +21042,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -21204,7 +21204,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -21364,7 +21364,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -21524,7 +21524,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -21684,7 +21684,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -21844,7 +21844,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -22004,7 +22004,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -22164,7 +22164,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -22324,7 +22324,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -22486,7 +22486,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -22646,7 +22646,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -22806,7 +22806,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -22966,7 +22966,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -23126,7 +23126,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -23286,7 +23286,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -23446,7 +23446,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -23606,7 +23606,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -23768,7 +23768,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -23928,7 +23928,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -24088,7 +24088,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -24248,7 +24248,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -24408,7 +24408,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -24568,7 +24568,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -24728,7 +24728,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -24888,7 +24888,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -25050,7 +25050,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -25210,7 +25210,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -25370,7 +25370,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -25530,7 +25530,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -25690,7 +25690,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -25850,7 +25850,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -26010,7 +26010,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -26170,7 +26170,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -26332,7 +26332,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -26492,7 +26492,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -26652,7 +26652,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -26812,7 +26812,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -26972,7 +26972,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -27132,7 +27132,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -27292,7 +27292,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -27452,7 +27452,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -27610,13 +27610,13 @@ $( "#test" )
 
     // #endregion
 
-    // #region 8+ arguments
+    // #region 8+ additional arguments
 
     /**
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param fn The function whose context will be changed.
-     * @param context The object to which the context (this) of the function should be set.
+     * @param context The object to which the context (`this`) of the function should be set.
      * @param additionalArguments Any number of arguments to be passed to the function referenced in the function argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4

--- a/types/jquery/index.d.ts
+++ b/types/jquery/index.d.ts
@@ -2662,6 +2662,12 @@ $( "div" ).find( "." + $.escapeSelector( ".box" ) );
      *
      * @param deep If true, the merge becomes recursive (aka. deep copy). Passing false for this argument is not supported.
      * @param target The object to extend. It will receive the new properties.
+     * @param object1 An object containing additional properties to merge in.
+     * @param object2 An object containing additional properties to merge in.
+     * @param object3 An object containing additional properties to merge in.
+     * @param object4 An object containing additional properties to merge in.
+     * @param object5 An object containing additional properties to merge in.
+     * @param object6 An object containing additional properties to merge in.
      * @see \`{@link https://api.jquery.com/jQuery.extend/ }\`
      * @since 1.1.4
      * @example ​ ````Merge two objects, modifying the first.
@@ -2765,6 +2771,11 @@ $( "#log" ).append( "<div><b>settings -- </b>" + JSON.stringify( settings ) + "<
      *
      * @param deep If true, the merge becomes recursive (aka. deep copy). Passing false for this argument is not supported.
      * @param target The object to extend. It will receive the new properties.
+     * @param object1 An object containing additional properties to merge in.
+     * @param object2 An object containing additional properties to merge in.
+     * @param object3 An object containing additional properties to merge in.
+     * @param object4 An object containing additional properties to merge in.
+     * @param object5 An object containing additional properties to merge in.
      * @see \`{@link https://api.jquery.com/jQuery.extend/ }\`
      * @since 1.1.4
      * @example ​ ````Merge two objects, modifying the first.
@@ -2868,6 +2879,10 @@ $( "#log" ).append( "<div><b>settings -- </b>" + JSON.stringify( settings ) + "<
      *
      * @param deep If true, the merge becomes recursive (aka. deep copy). Passing false for this argument is not supported.
      * @param target The object to extend. It will receive the new properties.
+     * @param object1 An object containing additional properties to merge in.
+     * @param object2 An object containing additional properties to merge in.
+     * @param object3 An object containing additional properties to merge in.
+     * @param object4 An object containing additional properties to merge in.
      * @see \`{@link https://api.jquery.com/jQuery.extend/ }\`
      * @since 1.1.4
      * @example ​ ````Merge two objects, modifying the first.
@@ -2971,6 +2986,9 @@ $( "#log" ).append( "<div><b>settings -- </b>" + JSON.stringify( settings ) + "<
      *
      * @param deep If true, the merge becomes recursive (aka. deep copy). Passing false for this argument is not supported.
      * @param target The object to extend. It will receive the new properties.
+     * @param object1 An object containing additional properties to merge in.
+     * @param object2 An object containing additional properties to merge in.
+     * @param object3 An object containing additional properties to merge in.
      * @see \`{@link https://api.jquery.com/jQuery.extend/ }\`
      * @since 1.1.4
      * @example ​ ````Merge two objects, modifying the first.
@@ -3074,6 +3092,8 @@ $( "#log" ).append( "<div><b>settings -- </b>" + JSON.stringify( settings ) + "<
      *
      * @param deep If true, the merge becomes recursive (aka. deep copy). Passing false for this argument is not supported.
      * @param target The object to extend. It will receive the new properties.
+     * @param object1 An object containing additional properties to merge in.
+     * @param object2 An object containing additional properties to merge in.
      * @see \`{@link https://api.jquery.com/jQuery.extend/ }\`
      * @since 1.1.4
      * @example ​ ````Merge two objects, modifying the first.
@@ -3177,6 +3197,7 @@ $( "#log" ).append( "<div><b>settings -- </b>" + JSON.stringify( settings ) + "<
      *
      * @param deep If true, the merge becomes recursive (aka. deep copy). Passing false for this argument is not supported.
      * @param target The object to extend. It will receive the new properties.
+     * @param object1 An object containing additional properties to merge in.
      * @see \`{@link https://api.jquery.com/jQuery.extend/ }\`
      * @since 1.1.4
      * @example ​ ````Merge two objects, modifying the first.
@@ -3280,6 +3301,8 @@ $( "#log" ).append( "<div><b>settings -- </b>" + JSON.stringify( settings ) + "<
      *
      * @param deep If true, the merge becomes recursive (aka. deep copy). Passing false for this argument is not supported.
      * @param target The object to extend. It will receive the new properties.
+     * @param object1 An object containing additional properties to merge in.
+     * @param objectN Additional objects containing properties to merge in.
      * @see \`{@link https://api.jquery.com/jQuery.extend/ }\`
      * @since 1.1.4
      * @example ​ ````Merge two objects, modifying the first.
@@ -3377,12 +3400,18 @@ $( "#log" ).append( "<div><b>settings -- </b>" + JSON.stringify( settings ) + "<
 </html>
 ```
      */
-    extend(deep: true, target: any, object1: any, ...objects: any[]): any;
+    extend(deep: true, target: any, object1: any, ...objectN: any[]): any;
     /**
      * Merge the contents of two or more objects together into the first object.
      *
      * @param target An object that will receive the new properties if additional objects are passed in or that will
      *               extend the jQuery namespace if it is the sole argument.
+     * @param object1 An object containing additional properties to merge in.
+     * @param object2 An object containing additional properties to merge in.
+     * @param object3 An object containing additional properties to merge in.
+     * @param object4 An object containing additional properties to merge in.
+     * @param object5 An object containing additional properties to merge in.
+     * @param object6 An object containing additional properties to merge in.
      * @see \`{@link https://api.jquery.com/jQuery.extend/ }\`
      * @since 1.0
      * @example ​ ````Merge two objects, modifying the first.
@@ -3486,6 +3515,11 @@ $( "#log" ).append( "<div><b>settings -- </b>" + JSON.stringify( settings ) + "<
      *
      * @param target An object that will receive the new properties if additional objects are passed in or that will
      *               extend the jQuery namespace if it is the sole argument.
+     * @param object1 An object containing additional properties to merge in.
+     * @param object2 An object containing additional properties to merge in.
+     * @param object3 An object containing additional properties to merge in.
+     * @param object4 An object containing additional properties to merge in.
+     * @param object5 An object containing additional properties to merge in.
      * @see \`{@link https://api.jquery.com/jQuery.extend/ }\`
      * @since 1.0
      * @example ​ ````Merge two objects, modifying the first.
@@ -3589,6 +3623,10 @@ $( "#log" ).append( "<div><b>settings -- </b>" + JSON.stringify( settings ) + "<
      *
      * @param target An object that will receive the new properties if additional objects are passed in or that will
      *               extend the jQuery namespace if it is the sole argument.
+     * @param object1 An object containing additional properties to merge in.
+     * @param object2 An object containing additional properties to merge in.
+     * @param object3 An object containing additional properties to merge in.
+     * @param object4 An object containing additional properties to merge in.
      * @see \`{@link https://api.jquery.com/jQuery.extend/ }\`
      * @since 1.0
      * @example ​ ````Merge two objects, modifying the first.
@@ -3692,6 +3730,9 @@ $( "#log" ).append( "<div><b>settings -- </b>" + JSON.stringify( settings ) + "<
      *
      * @param target An object that will receive the new properties if additional objects are passed in or that will
      *               extend the jQuery namespace if it is the sole argument.
+     * @param object1 An object containing additional properties to merge in.
+     * @param object2 An object containing additional properties to merge in.
+     * @param object3 An object containing additional properties to merge in.
      * @see \`{@link https://api.jquery.com/jQuery.extend/ }\`
      * @since 1.0
      * @example ​ ````Merge two objects, modifying the first.
@@ -3795,6 +3836,8 @@ $( "#log" ).append( "<div><b>settings -- </b>" + JSON.stringify( settings ) + "<
      *
      * @param target An object that will receive the new properties if additional objects are passed in or that will
      *               extend the jQuery namespace if it is the sole argument.
+     * @param object1 An object containing additional properties to merge in.
+     * @param object2 An object containing additional properties to merge in.
      * @see \`{@link https://api.jquery.com/jQuery.extend/ }\`
      * @since 1.0
      * @example ​ ````Merge two objects, modifying the first.
@@ -3898,6 +3941,7 @@ $( "#log" ).append( "<div><b>settings -- </b>" + JSON.stringify( settings ) + "<
      *
      * @param target An object that will receive the new properties if additional objects are passed in or that will
      *               extend the jQuery namespace if it is the sole argument.
+     * @param object1 An object containing additional properties to merge in.
      * @see \`{@link https://api.jquery.com/jQuery.extend/ }\`
      * @since 1.0
      * @example ​ ````Merge two objects, modifying the first.
@@ -4001,6 +4045,8 @@ $( "#log" ).append( "<div><b>settings -- </b>" + JSON.stringify( settings ) + "<
      *
      * @param target An object that will receive the new properties if additional objects are passed in or that will
      *               extend the jQuery namespace if it is the sole argument.
+     * @param object1 An object containing additional properties to merge in.
+     * @param objectN Additional objects containing properties to merge in.
      * @see \`{@link https://api.jquery.com/jQuery.extend/ }\`
      * @since 1.0
      * @example ​ ````Merge two objects, modifying the first.
@@ -4098,7 +4144,7 @@ $( "#log" ).append( "<div><b>settings -- </b>" + JSON.stringify( settings ) + "<
 </html>
 ```
      */
-    extend(target: any, object1: any, ...objects: any[]): any;
+    extend(target: any, object1: any, ...objectN: any[]): any;
     /**
      * Load data from the server using a HTTP GET request.
      *

--- a/types/jquery/index.d.ts
+++ b/types/jquery/index.d.ts
@@ -2022,7 +2022,7 @@ $.contains( document.body, document.documentElement ); // false
 ```
      */
     contains(container: Element, contained: Element): boolean;
-    css(elem: Element, unknown: any): any;
+    css(elem: Element, name: string): any;
     /**
      * Store arbitrary data associated with the specified element. Returns the value that was set.
      *

--- a/types/jquery/index.d.ts
+++ b/types/jquery/index.d.ts
@@ -45,7 +45,7 @@ type _Event = Event;
 
 interface JQueryStatic {
     /**
-     * @see \`{@link http://api.jquery.com/jquery.ajax/#jQuery-ajax1 }\`
+     * @see \`{@link https://api.jquery.com/jquery.ajax/#jQuery-ajax1 }\`
      *
      * @deprecated Use \`{@link JQueryStatic.ajaxSetup }\`.
      */
@@ -55884,7 +55884,7 @@ declare namespace JQuery {
         }
 
         /**
-         * @see \`{@link http://api.jquery.com/jquery.ajax/#jQuery-ajax-settings }\`
+         * @see \`{@link https://api.jquery.com/jquery.ajax/#jQuery-ajax-settings }\`
          */
         interface AjaxSettingsBase<TContext> {
             /**
@@ -56573,7 +56573,7 @@ declare namespace JQuery {
     }
 
     /**
-     * @see \`{@link http://api.jquery.com/jquery.ajax/#jqXHR }\`
+     * @see \`{@link https://api.jquery.com/jquery.ajax/#jqXHR }\`
      */
     interface jqXHR<TResolve = any> extends Promise3<TResolve, jqXHR<TResolve>, never,
         Ajax.SuccessTextStatus, Ajax.ErrorTextStatus, never,
@@ -57225,7 +57225,7 @@ callbacks.fire( "world" );
      * This object provides a subset of the methods of the Deferred object (then, done, fail, always,
      * pipe, progress, state and promise) to prevent users from changing the state of the Deferred.
      *
-     * @see \`{@link http://api.jquery.com/Types/#Promise }\`
+     * @see \`{@link https://api.jquery.com/Types/#Promise }\`
      */
     interface PromiseBase<TR, TJ, TN,
         UR, UJ, UN,
@@ -59280,7 +59280,7 @@ $.get( "test.php" )
      * This object provides a subset of the methods of the Deferred object (then, done, fail, always,
      * pipe, progress, state and promise) to prevent users from changing the state of the Deferred.
      *
-     * @see \`{@link http://api.jquery.com/Types/#Promise }\`
+     * @see \`{@link https://api.jquery.com/Types/#Promise }\`
      */
     interface Promise3<TR, TJ, TN,
         UR, UJ, UN,
@@ -59293,7 +59293,7 @@ $.get( "test.php" )
      * This object provides a subset of the methods of the Deferred object (then, done, fail, always,
      * pipe, progress, state and promise) to prevent users from changing the state of the Deferred.
      *
-     * @see \`{@link http://api.jquery.com/Types/#Promise }\`
+     * @see \`{@link https://api.jquery.com/Types/#Promise }\`
      */
     interface Promise2<TR, TJ, TN,
         UR, UJ, UN> extends PromiseBase<TR, TJ, TN,
@@ -59305,7 +59305,7 @@ $.get( "test.php" )
      * This object provides a subset of the methods of the Deferred object (then, done, fail, always,
      * pipe, progress, state and promise) to prevent users from changing the state of the Deferred.
      *
-     * @see \`{@link http://api.jquery.com/Types/#Promise }\`
+     * @see \`{@link https://api.jquery.com/Types/#Promise }\`
      */
     interface Promise<TR, TJ = any, TN = any> extends PromiseBase<TR, TJ, TN,
         TR, TJ, TN,

--- a/types/jquery/index.d.ts
+++ b/types/jquery/index.d.ts
@@ -2024,121 +2024,11 @@ $.contains( document.body, document.documentElement ); // false
     contains(container: Element, contained: Element): boolean;
     css(elem: Element, unknown: any): any;
     /**
-     * Returns value at named data store for the element, as set by jQuery.data(element, name, value), or
-     * the full data store for the element.
-     *
-     * @param element The DOM element to query for the data.
-     * @param key Name of the data stored.
-     * @see \`{@link https://api.jquery.com/jQuery.data/ }\`
-     * @since 1.2.3
-     * @example ​ ````Store then retrieve a value from the div element.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.data demo</title>
-  <style>
-  div {
-    color: blue;
-  }
-  span {
-    color: red;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<div>
-  The values stored were
-  <span></span>
-  and
-  <span></span>
-</div>
-​
-<script>
-var div = $( "div" )[ 0 ];
-jQuery.data( div, "test", {
-  first: 16,
-  last: "pizza!"
-});
-$( "span:first" ).text( jQuery.data( div, "test" ).first );
-$( "span:last" ).text( jQuery.data( div, "test" ).last );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Get the data named &quot;blah&quot; stored at for an element.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.data demo</title>
-  <style>
-  div {
-    margin: 5px;
-    background: yellow;
-  }
-  button {
-    margin: 5px;
-    font-size: 14px;
-  }
-  p {
-    margin: 5px;
-    color: blue;
-  }
-  span {
-    color: red;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<div>A div</div>
-<button>Get "blah" from the div</button>
-<button>Set "blah" to "hello"</button>
-<button>Set "blah" to 86</button>
-<button>Remove "blah" from the div</button>
-<p>The "blah" value of this div is <span>?</span></p>
-​
-<script>
-$( "button" ).click( function() {
-  var value,
-    div = $( "div" )[ 0 ];
-  switch ( $( "button" ).index( this ) ) {
-  case 0 :
-    value = jQuery.data( div, "blah" );
-    break;
-  case 1 :
-    jQuery.data( div, "blah", "hello" );
-    value = "Stored!";
-    break;
-  case 2 :
-    jQuery.data( div, "blah", 86 );
-    value = "Stored!";
-    break;
-  case 3 :
-    jQuery.removeData( div, "blah" );
-    value = "Removed!";
-    break;
-  }
-  $( "span" ).text( "" + value );
-});
-</script>
-</body>
-</html>
-```
-     */
-    data(element: Element, key: string, undefined: undefined): any; // tslint:disable-line:unified-signatures
-    /**
      * Store arbitrary data associated with the specified element. Returns the value that was set.
      *
      * @param element The DOM element to associate with the data.
      * @param key A string naming the piece of data to set.
-     * @param value The new data value; this can be any Javascript type except undefined.
+     * @param value The new data value; this can be any Javascript type except `undefined`.
      * @see \`{@link https://api.jquery.com/jQuery.data/ }\`
      * @since 1.2.3
      * @example ​ ````Store then retrieve a value from the div element.
@@ -2242,9 +2132,124 @@ $( "button" ).click( function() {
 </html>
 ```
      */
-    data<T>(element: Element, key: string, value: T): T;
+    data<T extends string | number | boolean | symbol | object | null>(element: Element, key: string, value: T): T;
     /**
-     * Returns value at named data store for the element, as set by jQuery.data(element, name, value), or
+     * Returns value at named data store for the element, as set by `jQuery.data(element, name, value)`, or
+     * the full data store for the element.
+     *
+     * @param element The DOM element to query for the data.
+     * @param key Name of the data stored.
+     * @param value `undefined` is not recognized as a data value. Calls such as `jQuery.data( el, "name", undefined )`
+     *              will return the corresponding data for "name", and is therefore the same as `jQuery.data( el, "name" )`
+     * @see \`{@link https://api.jquery.com/jQuery.data/ }\`
+     * @since 1.2.3
+     * @example ​ ````Store then retrieve a value from the div element.
+```html
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>jQuery.data demo</title>
+  <style>
+  div {
+    color: blue;
+  }
+  span {
+    color: red;
+  }
+  </style>
+  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
+</head>
+<body>
+​
+<div>
+  The values stored were
+  <span></span>
+  and
+  <span></span>
+</div>
+​
+<script>
+var div = $( "div" )[ 0 ];
+jQuery.data( div, "test", {
+  first: 16,
+  last: "pizza!"
+});
+$( "span:first" ).text( jQuery.data( div, "test" ).first );
+$( "span:last" ).text( jQuery.data( div, "test" ).last );
+</script>
+</body>
+</html>
+```
+     * @example ​ ````Get the data named &quot;blah&quot; stored at for an element.
+```html
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>jQuery.data demo</title>
+  <style>
+  div {
+    margin: 5px;
+    background: yellow;
+  }
+  button {
+    margin: 5px;
+    font-size: 14px;
+  }
+  p {
+    margin: 5px;
+    color: blue;
+  }
+  span {
+    color: red;
+  }
+  </style>
+  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
+</head>
+<body>
+​
+<div>A div</div>
+<button>Get "blah" from the div</button>
+<button>Set "blah" to "hello"</button>
+<button>Set "blah" to 86</button>
+<button>Remove "blah" from the div</button>
+<p>The "blah" value of this div is <span>?</span></p>
+​
+<script>
+$( "button" ).click( function() {
+  var value,
+    div = $( "div" )[ 0 ];
+  switch ( $( "button" ).index( this ) ) {
+  case 0 :
+    value = jQuery.data( div, "blah" );
+    break;
+  case 1 :
+    jQuery.data( div, "blah", "hello" );
+    value = "Stored!";
+    break;
+  case 2 :
+    jQuery.data( div, "blah", 86 );
+    value = "Stored!";
+    break;
+  case 3 :
+    jQuery.removeData( div, "blah" );
+    value = "Removed!";
+    break;
+  }
+  $( "span" ).text( "" + value );
+});
+</script>
+</body>
+</html>
+```
+     */
+    // `unified-signatures` is disabled so that behavior when passing `undefined` to `value` can be documented. Unifying the signatures
+    // results in potential confusion for users from an unexpected parameter.
+    // tslint:disable-next-line:unified-signatures
+    data(element: Element, key: string, value: undefined): any;
+    /**
+     * Returns value at named data store for the element, as set by `jQuery.data(element, name, value)`, or
      * the full data store for the element.
      *
      * @param element The DOM element to query for the data.
@@ -34552,116 +34557,10 @@ $( "div" ).on( "click", function() {
      */
     css(propertyNames: string[]): JQuery.PlainObject<string>;
     /**
-     * Return the value at the named data store for the first element in the jQuery collection, as set by
-     * data(name, value) or by an HTML5 data-* attribute.
-     *
-     * @param key Name of the data stored.
-     * @see \`{@link https://api.jquery.com/data/ }\`
-     * @since 1.2.3
-     * @example ​ ````Store then retrieve a value from the div element.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>data demo</title>
-  <style>
-  div {
-    color: blue;
-  }
-  span {
-    color: red;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<div>
-  The values stored were
-  <span></span>
-  and
-  <span></span>
-</div>
-​
-<script>
-$( "div" ).data( "test", { first: 16, last: "pizza!" } );
-$( "span:first" ).text( $( "div" ).data( "test" ).first );
-$( "span:last" ).text( $( "div" ).data( "test" ).last );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Get the data named &quot;blah&quot; stored at for an element.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>data demo</title>
-  <style>
-  div {
-    margin: 5px;
-    background: yellow;
-  }
-  button {
-    margin: 5px;
-    font-size: 14px;
-  }
-  p {
-    margin: 5px;
-    color: blue;
-  }
-  span {
-    color: red;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<div>A div</div>
-<button>Get "blah" from the div</button>
-<button>Set "blah" to "hello"</button>
-<button>Set "blah" to 86</button>
-<button>Remove "blah" from the div</button>
-<p>The "blah" value of this div is <span>?</span></p>
-​
-<script>
-$( "button" ).click(function() {
-  var value;
-​
-  switch ( $( "button" ).index( this ) ) {
-    case 0 :
-      value = $( "div" ).data( "blah" );
-      break;
-    case 1 :
-      $( "div" ).data( "blah", "hello" );
-      value = "Stored!";
-      break;
-    case 2 :
-      $( "div" ).data( "blah", 86 );
-      value = "Stored!";
-      break;
-    case 3 :
-      $( "div" ).removeData( "blah" );
-      value = "Removed!";
-      break;
-  }
-​
-  $( "span" ).text( "" + value );
-});
-</script>
-</body>
-</html>
-```
-     */
-    data(key: string, undefined: undefined): any; // tslint:disable-line:unified-signatures
-    /**
      * Store arbitrary data associated with the matched elements.
      *
      * @param key A string naming the piece of data to set.
-     * @param value The new data value; this can be any Javascript type except undefined.
+     * @param value The new data value; this can be any Javascript type except `undefined`.
      * @see \`{@link https://api.jquery.com/data/ }\`
      * @since 1.2.3
      * @example ​ ````Store then retrieve a value from the div element.
@@ -34762,7 +34661,7 @@ $( "button" ).click(function() {
 </html>
 ```
      */
-    data(key: string, value: any): this;
+    data(key: string, value: string | number | boolean | symbol | object | null): this;
     /**
      * Store arbitrary data associated with the matched elements.
      *
@@ -34868,6 +34767,117 @@ $( "button" ).click(function() {
 ```
      */
     data(obj: JQuery.PlainObject): this;
+    /**
+     * Return the value at the named data store for the first element in the jQuery collection, as set by
+     * data(name, value) or by an HTML5 data-* attribute.
+     *
+     * @param key Name of the data stored.
+     * @param value `undefined` is not recognized as a data value. Calls such as `.data( "name", undefined )`
+     *              will return the jQuery object that it was called on, allowing for chaining.
+     * @see \`{@link https://api.jquery.com/data/ }\`
+     * @since 1.2.3
+     * @example ​ ````Store then retrieve a value from the div element.
+```html
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>data demo</title>
+  <style>
+  div {
+    color: blue;
+  }
+  span {
+    color: red;
+  }
+  </style>
+  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
+</head>
+<body>
+​
+<div>
+  The values stored were
+  <span></span>
+  and
+  <span></span>
+</div>
+​
+<script>
+$( "div" ).data( "test", { first: 16, last: "pizza!" } );
+$( "span:first" ).text( $( "div" ).data( "test" ).first );
+$( "span:last" ).text( $( "div" ).data( "test" ).last );
+</script>
+</body>
+</html>
+```
+     * @example ​ ````Get the data named &quot;blah&quot; stored at for an element.
+```html
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>data demo</title>
+  <style>
+  div {
+    margin: 5px;
+    background: yellow;
+  }
+  button {
+    margin: 5px;
+    font-size: 14px;
+  }
+  p {
+    margin: 5px;
+    color: blue;
+  }
+  span {
+    color: red;
+  }
+  </style>
+  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
+</head>
+<body>
+​
+<div>A div</div>
+<button>Get "blah" from the div</button>
+<button>Set "blah" to "hello"</button>
+<button>Set "blah" to 86</button>
+<button>Remove "blah" from the div</button>
+<p>The "blah" value of this div is <span>?</span></p>
+​
+<script>
+$( "button" ).click(function() {
+  var value;
+​
+  switch ( $( "button" ).index( this ) ) {
+    case 0 :
+      value = $( "div" ).data( "blah" );
+      break;
+    case 1 :
+      $( "div" ).data( "blah", "hello" );
+      value = "Stored!";
+      break;
+    case 2 :
+      $( "div" ).data( "blah", 86 );
+      value = "Stored!";
+      break;
+    case 3 :
+      $( "div" ).removeData( "blah" );
+      value = "Removed!";
+      break;
+  }
+​
+  $( "span" ).text( "" + value );
+});
+</script>
+</body>
+</html>
+```
+     */
+    // `unified-signatures` is disabled so that behavior when passing `undefined` to `value` can be documented. Unifying the signatures
+    // results in potential confusion for users from an unexpected parameter.
+    // tslint:disable-next-line:unified-signatures
+    data(key: string, value: undefined): any;
     /**
      * Return the value at the named data store for the first element in the jQuery collection, as set by
      * data(name, value) or by an HTML5 data-* attribute.

--- a/types/jquery/index.d.ts
+++ b/types/jquery/index.d.ts
@@ -28804,7 +28804,7 @@ interface JQuery<TElement = HTMLElement> extends Iterable<TElement> {
     /**
      * A string containing the jQuery version number.
      *
-     * @see \`{@link https://api.jquery.com/jquery/ }\`
+     * @see \`{@link https://api.jquery.com/jquery-2/#jquery1 }\`
      * @since 1.0
      * @example ​ ````Determine if an object is a jQuery object
 ```html

--- a/types/jquery/jquery-tests.ts
+++ b/types/jquery/jquery-tests.ts
@@ -336,11 +336,15 @@ function JQueryStatic() {
     }
 
     function data() {
-        // $ExpectType any
-        $.data(new HTMLElement(), 'myKey', undefined);
+        const value: string | undefined = {} as any;
+        // $ExpectError
+        $.data(new HTMLElement(), 'myKey', value);
 
         // $ExpectType "myValue"
         $.data(new HTMLElement(), 'myKey', 'myValue');
+
+        // $ExpectType any
+        $.data(new HTMLElement(), 'myKey', undefined);
 
         // $ExpectType any
         $.data(new HTMLElement(), 'myKey');
@@ -2937,8 +2941,9 @@ function JQuery() {
 
     function data() {
         function data() {
-            // $ExpectType any
-            $('p').data('myData', undefined);
+            const value: string | undefined = {} as any;
+            // $ExpectError
+            $('p').data('myData', value);
 
             // $ExpectType JQuery<HTMLElement>
             $('p').data('myData', {});
@@ -2948,6 +2953,9 @@ function JQuery() {
                 myData1: {},
                 myData2: false
             });
+
+            // $ExpectType any
+            $('p').data('myData', undefined);
 
             // $ExpectType any
             $('p').data('myData');

--- a/types/jquery/jquery-tests.ts
+++ b/types/jquery/jquery-tests.ts
@@ -332,7 +332,7 @@ function JQueryStatic() {
 
     function css() {
         // $ExpectType any
-        $.css(new HTMLElement(), {});
+        $.css(new HTMLElement(), 'borderRadius');
     }
 
     function data() {

--- a/types/jquery/jquery-tests.ts
+++ b/types/jquery/jquery-tests.ts
@@ -706,15 +706,17 @@ function JQueryStatic() {
     }
 
     function isNumeric() {
-        function type_guard(obj: boolean | number) {
-            if ($.isNumeric(obj)) {
-                // $ExpectType number
-                obj;
-            } else {
-                // $ExpectType boolean
-                obj;
-            }
-        }
+        // $ExpectType boolean
+        $.isNumeric(123);   // true
+
+        // $ExpectType boolean
+        $.isNumeric(0 / 0); // false
+
+        // $ExpectType boolean
+        $.isNumeric('123'); // true
+
+        // $ExpectType boolean
+        $.isNumeric('1s3'); // false
     }
 
     function isPlainObject() {

--- a/types/jquery/jquery-tests.ts
+++ b/types/jquery/jquery-tests.ts
@@ -720,12 +720,17 @@ function JQueryStatic() {
     }
 
     function isPlainObject() {
-        function type_guard(obj: object) {
-            if ($.isPlainObject(obj)) {
-                // $ExpectType PlainObject<any>
-                obj;
-            }
-        }
+        // $ExpectType boolean
+        $.isPlainObject({});                    // true
+
+        // $ExpectType boolean
+        $.isPlainObject(new Object());          // true
+
+        // $ExpectType boolean
+        $.isPlainObject(document);              // false
+
+        // $ExpectType boolean
+        $.isPlainObject(Object.create(null));   // true
     }
 
     function isWindow() {

--- a/types/jquery/test/longdesc-tests.ts
+++ b/types/jquery/test/longdesc-tests.ts
@@ -1291,7 +1291,7 @@ function longdesc() {
             if (borderRadius && borderRadius !== 'borderRadius') {
                 $.cssHooks.borderRadius = {
                     get: function(elem, computed, extra) {
-                        return $.css(elem, borderRadius);
+                        return $.css(elem, borderRadius!);
                     },
                     set: function(elem, value) {
                         (<any> elem.style)[borderRadius!] = value;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- ~~Increase the version number in the header if appropriate.~~
- ~~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.~~

---

#### Summary of changes

##### [`isNumeric`](https://api.jquery.com/jQuery.isNumeric/) can not be a user defined type guard. (577ca4af0f54c0cea1fd3f2b21f29230609d2d50)

`isNumeric` can return true for strings in addition to numbers, but only for a subset of either. It'll return `false` for `NaN` (which TypeScript treats as a number) and for strings which cannot be parsed as a number.

##### [`isPlainObject`](https://api.jquery.com/jquery.isplainobject/) can not be a user defined type guard. (6258aa2cb2868b8606d82aabd34acf940fc03470)

Due to the imprecise way with how [`PlainObject`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/5dc1165fb11875022d76f32554ca96c01804d8a1/types/jquery/index.d.ts#L5899) is declared, `isPlainObject` can not be a user defined type guard.

##### Improve declarations of [`jQuery.data()`](https://api.jquery.com/jquery.data/)/[`.data()`](https://api.jquery.com/data/) to catch unintentionally passing `undefined` as a value. (a05dc4290b75d52b6c68c3ca19038f615cada2b6)

Passing `undefined` to `.data()` calls the getter overload instead of the setter. The declarations correctly handled the case where value is _only_ of type `undefined`. However, the more likely scenario is that a value that is _possibly_ undefined is passed instead. Previously, this would resolve exclusively to the setter overload (which is incorrect if the value is actually undefined). It is now an error to call `.data()` with a value that is possibly undefined.

##### Improve declaration of [`css()`](https://api.jquery.com/jQuery.cssHooks/#defining-complete-csshook). (acf60379580e8bf0beec82844ba5b5ba6e931a19)

The 2nd parameter is now of type `string` (previously `any`).

---

The rest of the changes are documentation improvements.