### PR TITLE
Enhance typings of easy-table

### DIFF
--- a/types/easy-table/easy-table-tests.ts
+++ b/types/easy-table/easy-table-tests.ts
@@ -83,11 +83,13 @@ function totalling() {
 
 function other_samples() {
 	var t = new Table();
+	var columns = Object.freeze(t.columns());
 
 	data.forEach(product => {
 		t.cell('Product Id', product.id)
 		t.cell('Description', product.desc)
 		t.cell('Price, USD', product.price, Table.number(2))
+		t.pushDelimeter(columns)
 		t.newRow()
 	})
 

--- a/types/easy-table/index.d.ts
+++ b/types/easy-table/index.d.ts
@@ -53,7 +53,7 @@ declare class EasyTable {
      *
      * @returns {Table} `this`
      */
-    public newRow(): EasyTable;
+    public newRow(): this;
 
     /**
      * Write cell in the current row
@@ -63,7 +63,7 @@ declare class EasyTable {
      * @param {Function} [printer]  - Printer function to format the value
      * @returns {Table} `this`
      */
-    public cell<T>(col: string, val: T, printer?: CellPrinter<T>): EasyTable;
+    public cell<T>(col: string, val: T, printer?: CellPrinter<T>): this;
 
     /**
      * Get list of columns in printing order
@@ -92,7 +92,7 @@ declare class EasyTable {
      * @param {String[]} [cols]
      * @returns {Table} `this`
      */
-    public pushDelimeter(cols?: string[]): EasyTable;
+    public pushDelimeter(cols?: ReadonlyArray<string>): this;
 
     /**
      * Compute all totals and yield the results to `cb`
@@ -115,14 +115,14 @@ declare class EasyTable {
      * @param {Function|string[]} [cmp] - Either compare function or a list of columns to sort on
      * @returns {Table} `this`
      */
-    public sort(cmp?: string[]): EasyTable;
+    public sort(cmp?: ReadonlyArray<string>): this;
     /**
      * Sort the table
      *
      * @param {Function|string[]} [cmp] - Either compare function or a list of columns to sort on
      * @returns {Table} `this`
      */
-    public sort<T>(cmp?: CompareFunction<T>): EasyTable;
+    public sort<T>(cmp?: CompareFunction<T>): this;
 
     /**
      * Add a total for the column
@@ -131,7 +131,7 @@ declare class EasyTable {
      * @param {Object} [opts]
      * @returns {Table} `this`
      */
-    public total<T>(col: string, opts?: TotalOptions<T>): EasyTable;
+    public total<T>(col: string, opts?: TotalOptions<T>): this;
     /**
      * Predefined helpers for totals
      */


### PR DESCRIPTION
The guidelines state that ReadonlyArray<T> should be used in parameters if the contents are not modified. Also, the return types now reflect that `this` is returned.

- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/eldargab/easy-table/blob/master/table.js
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
