### PR TITLE
fix(node): revert remaining common var to const globals

### DIFF
--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -174,7 +174,7 @@ interface SymbolConstructor {
     readonly iterator: symbol;
     readonly asyncIterator: symbol;
 }
-// declare const Symbol: SymbolConstructor;
+declare var Symbol: SymbolConstructor;
 interface SharedArrayBuffer {
     readonly byteLength: number;
     slice(begin?: number, end?: number): SharedArrayBuffer;
@@ -194,11 +194,11 @@ interface String {
  *                                               *
  ------------------------------------------------*/
 declare var process: NodeJS.Process;
-declare const global: NodeJS.Global;
+declare var global: NodeJS.Global;
 declare var console: Console;
 
-declare const __filename: string;
-declare const __dirname: string;
+declare var __filename: string;
+declare var __dirname: string;
 
 declare function setTimeout(callback: (...args: any[]) => void, ms: number, ...args: any[]): NodeJS.Timer;
 declare namespace setTimeout {
@@ -256,7 +256,7 @@ interface NodeModule {
 declare var module: NodeModule;
 
 // Same as module.exports
-declare const exports: any;
+declare var exports: any;
 declare const SlowBuffer: {
     new(str: string, encoding?: string): Buffer;
     new(size: number): Buffer;


### PR DESCRIPTION
If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: Does not apply.
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

Revert the remaining var to const changes from a previous PR.

Unfortunately too many other typings are loaded at the same time as with node that declare the same globals as node.

At some point some of these may be removed from all typings and instead only be loaded from libs, but until then we need to restore compatibility. 

Also reverting the commented out `Symbol` declaration, while all libs define this it broke some projects for some reason.