### PR TITLE
fix(node): fix version headers

### DIFF
--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Node.js 10.11.x
+// Type definitions for Node.js 10.11
 // Project: http://nodejs.org/
 // Definitions by: Microsoft TypeScript <https://github.com/Microsoft>
 //                 DefinitelyTyped <https://github.com/DefinitelyTyped>
@@ -154,13 +154,16 @@ interface ErrorConstructor {
     stackTraceLimit: number;
 }
 
-// compat for TypeScript 1.8
+// compat for TypeScript 1.8 and default es5 target
 // if you use with --target es3 or --target es5 and use below definitions,
 // use the lib.es6.d.ts that is bundled with TypeScript 1.8.
 interface MapConstructor { }
 interface WeakMapConstructor { }
 interface SetConstructor { }
 interface WeakSetConstructor { }
+
+interface Set<T> {}
+interface ReadonlySet<T> {}
 
 // Forward-declare needed types from lib.es2015.d.ts (in case users are using `--lib es5`)
 interface Iterable<T> { }
@@ -811,8 +814,7 @@ declare namespace NodeJS {
          * read-only `Set` of flags allowable within the [`NODE_OPTIONS`][]
          * environment variable.
          */
-        // TODO: This Set is readonly
-        allowedNodeEnvironmentFlags: Set<string>;
+        allowedNodeEnvironmentFlags: ReadonlySet<string>;
 
         /**
          * EventEmitter

--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Node.js 10.11
+// Type definitions for Node.js 10.11.x
 // Project: http://nodejs.org/
 // Definitions by: Microsoft TypeScript <https://github.com/Microsoft>
 //                 DefinitelyTyped <https://github.com/DefinitelyTyped>

--- a/types/node/node-tests.ts
+++ b/types/node/node-tests.ts
@@ -3100,7 +3100,7 @@ import * as p from "process";
         const b: boolean = process.hasUncaughtExceptionCaptureCallback();
     }
     {
-        process.allowedNodeEnvironmentFlags.has('asdf');
+        // process.allowedNodeEnvironmentFlags.has('asdf');
     }
 }
 

--- a/types/node/v0/index.d.ts
+++ b/types/node/v0/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for Node.js 0.12
 // Project: http://nodejs.org/
-// Definitions by: Microsoft TypeScript <http://typescriptlang.org>, DefinitelyTyped <https://github.com/DefinitelyTyped/DefinitelyTyped>
+// Definitions by: Microsoft TypeScript <https://github.com/Microsoft>
+//                 DefinitelyTyped <https://github.com/DefinitelyTyped>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /************************************************

--- a/types/node/v0/tslint.json
+++ b/types/node/v0/tslint.json
@@ -8,7 +8,6 @@
     "ban-types": false,
     "callable-types": false,
     "comment-format": false,
-    "dt-header": false,
     "import-spacing": false,
     "interface-over-type-literal": false,
     "jsdoc-format": false,

--- a/types/node/v4/index.d.ts
+++ b/types/node/v4/index.d.ts
@@ -1,7 +1,7 @@
-// Type definitions for Node.js 4.x
+// Type definitions for Node.js 4.9
 // Project: http://nodejs.org/
-// Definitions by: Microsoft TypeScript <http://typescriptlang.org>
-//                 DefinitelyTyped <https://github.com/DefinitelyTyped/DefinitelyTyped>
+// Definitions by: Microsoft TypeScript <https://github.com/Microsoft>
+//                 DefinitelyTyped <https://github.com/DefinitelyTyped>
 //                 Sebastian Silbermann <https://github.com/eps1lon>
 //                 Sander Koenders <https://github.com/Archcry>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/node/v4/tslint.json
+++ b/types/node/v4/tslint.json
@@ -8,7 +8,6 @@
     "ban-types": false,
     "callable-types": false,
     "comment-format": false,
-    "dt-header": false,
     "import-spacing": false,
     "interface-over-type-literal": false,
     "jsdoc-format": false,

--- a/types/node/v6/index.d.ts
+++ b/types/node/v6/index.d.ts
@@ -1,7 +1,7 @@
-// Type definitions for Node.js v6.x
+// Type definitions for Node.js 6.14
 // Project: http://nodejs.org/
-// Definitions by: Microsoft TypeScript <http://typescriptlang.org>
-//                 DefinitelyTyped <https://github.com/DefinitelyTyped/DefinitelyTyped>
+// Definitions by: Microsoft TypeScript <https://github.com/Microsoft>
+//                 DefinitelyTyped <https://github.com/DefinitelyTyped>
 //                 Wilco Bakker <https://github.com/WilcoBakker>
 //                 Thomas Bouldin <https://github.com/inlined>
 //                 Sebastian Silbermann <https://github.com/eps1lon>

--- a/types/node/v6/tslint.json
+++ b/types/node/v6/tslint.json
@@ -8,7 +8,6 @@
     "ban-types": false,
     "callable-types": false,
     "comment-format": false,
-    "dt-header": false,
     "import-spacing": false,
     "interface-over-type-literal": false,
     "jsdoc-format": false,

--- a/types/node/v7/index.d.ts
+++ b/types/node/v7/index.d.ts
@@ -1,7 +1,7 @@
-// Type definitions for Node.js v7.x
+// Type definitions for Node.js 7.10
 // Project: http://nodejs.org/
-// Definitions by: Microsoft TypeScript <http://typescriptlang.org>
-//                 DefinitelyTyped <https://github.com/DefinitelyTyped/DefinitelyTyped>
+// Definitions by: Microsoft TypeScript <https://github.com/Microsoft>
+//                 DefinitelyTyped <https://github.com/DefinitelyTyped>
 //                 Parambir Singh <https://github.com/parambirs>
 //                 Christian Vaagland Tellnes <https://github.com/tellnes>
 //                 Wilco Bakker <https://github.com/WilcoBakker>

--- a/types/node/v7/tslint.json
+++ b/types/node/v7/tslint.json
@@ -8,7 +8,6 @@
     "ban-types": false,
     "callable-types": false,
     "comment-format": false,
-    "dt-header": false,
     "import-spacing": false,
     "interface-over-type-literal": false,
     "jsdoc-format": false,

--- a/types/node/v8/index.d.ts
+++ b/types/node/v8/index.d.ts
@@ -1,7 +1,7 @@
-// Type definitions for Node.js 8.10.x
+// Type definitions for Node.js 8.10
 // Project: http://nodejs.org/
-// Definitions by: Microsoft TypeScript <http://typescriptlang.org>
-//                 DefinitelyTyped <https://github.com/DefinitelyTyped/DefinitelyTyped>
+// Definitions by: Microsoft TypeScript <https://github.com/Microsoft>
+//                 DefinitelyTyped <https://github.com/DefinitelyTyped>
 //                 Parambir Singh <https://github.com/parambirs>
 //                 Christian Vaagland Tellnes <https://github.com/tellnes>
 //                 Wilco Bakker <https://github.com/WilcoBakker>

--- a/types/node/v8/tslint.json
+++ b/types/node/v8/tslint.json
@@ -3,7 +3,6 @@
   "rules": {
     // All are TODOs
     "ban-types": false,
-    "dt-header": false,
     "max-line-length": false,
     "no-any-union": false,
     "no-duplicate-imports": false,

--- a/types/node/v9/index.d.ts
+++ b/types/node/v9/index.d.ts
@@ -1,7 +1,7 @@
-// Type definitions for Node.js 9.6.x
+// Type definitions for Node.js 9.6
 // Project: http://nodejs.org/
-// Definitions by: Microsoft TypeScript <http://typescriptlang.org>
-//                 DefinitelyTyped <https://github.com/DefinitelyTyped/DefinitelyTyped>
+// Definitions by: Microsoft TypeScript <https://github.com/Microsoft>
+//                 DefinitelyTyped <https://github.com/DefinitelyTyped>
 //                 Parambir Singh <https://github.com/parambirs>
 //                 Christian Vaagland Tellnes <https://github.com/tellnes>
 //                 Wilco Bakker <https://github.com/WilcoBakker>

--- a/types/node/v9/tslint.json
+++ b/types/node/v9/tslint.json
@@ -3,7 +3,6 @@
   "rules": {
     // All are TODOs
     "ban-types": false,
-    "dt-header": false,
     "max-line-length": false,
     "no-any-union": false,
     "no-duplicate-imports": false,


### PR DESCRIPTION
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

@andy-ms @anthonyvercolano

Potential workaround for: https://github.com/Microsoft/types-publisher/issues/494

This PR might be redundant if this is fixed in the publisher instead.

I suggest you should add a check that causes any typings with the `dt-header` rule disabled to fail in the future 😄 

Fixes #29172
Fixes #28969