### PR TITLE
fix(node-redis-pubsub): messages should be parameterized

### DIFF
--- a/types/node-redis-pubsub/index.d.ts
+++ b/types/node-redis-pubsub/index.d.ts
@@ -1,29 +1,37 @@
 // Type definitions for node-redis-pubsub 3.0
 // Project: https://github.com/louischatriot/node-redis-pubsub#readme
 // Definitions by: Rene Keijzer <https://github.com/renekeijzer>
+//                 Martin Loeper <https://github.com/MartinLoeper>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
-import * as redis from "redis";
+import { Callback, RedisClient } from "redis";
 
-declare function NRP(options: object): NRP.NodeRedisPubSub;
+declare function NRP(options?: NRP.RedisPubsubOptions): NRP.NodeRedisPubSub;
 declare namespace NRP {
-    function initClient(options: object): NodeRedisPubSub;
+    interface RedisPubsubOptions {
+        port?: number;
+        scope?: string;
+        emitter?: RedisClient;
+        receiver?: RedisClient;
+        auth?: string;
+    }
+    function initClient(options?: RedisPubsubOptions): NodeRedisPubSub;
     class NodeRedisPubSub {
-        constructor(options: object);
-        getRedisClient(): redis.RedisClient;
-        on(
+        constructor(options?: RedisPubsubOptions);
+        getRedisClient(): RedisClient;
+        on<T>(
             channel: string,
-            handler: (data: string, channel: string) => void,
-            callback?: () => void
-        ): () => void;
-        subscribe(
+            handler: (message: T, channel: string) => void,
+            callback?: () => void,
+        ): () => Callback<any>;
+        subscribe<T>(
             channel: string,
-            handler: (data: string, channel: string) => void,
-            callback?: () => void
-        ): () => void;
-        emit(channel: string, message: string): void;
-        publish(channel: string, message: string): void;
+            handler: (message: T, channel: string) => void,
+            callback?: () => void,
+        ): () => Callback<any>;
+        emit<T>(channel: string, message: T): boolean;
+        publish<T>(channel: string, message: T): boolean;
         quit(): void;
         end(): void;
     }

--- a/types/node-redis-pubsub/node-redis-pubsub-tests.ts
+++ b/types/node-redis-pubsub/node-redis-pubsub-tests.ts
@@ -6,14 +6,14 @@ const options = {
 };
 const nrp: NRP.NodeRedisPubSub = NRP(options);
 
-nrp.on("message:*", (data, channel) => {});
+nrp.on<string>("message:*", (data, channel) => {});
 
-nrp.subscribe("message:*", (data, channel) => {});
+nrp.subscribe<string>("message:*", (data, channel) => {});
 
 const redis: RedisClient = nrp.getRedisClient();
 
-nrp.emit("message:test", "hello world");
-nrp.publish("message:test2", "hello world2");
+nrp.emit<string>("message:test", "hello world");
+nrp.publish<string>("message:test2", "hello world2");
 
 nrp.quit();
 nrp.end();


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/louischatriot/node-redis-pubsub/blob/master/lib/node-redis-pubsub.js
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

Note:
- I do not know which version number to increase
- I am not sure if substituting the type parameter with any as tslint says is the right way to go
