### PR TITLE
[detox] Fix types according to example snippets

### DIFF
--- a/types/detox/detox-tests.ts
+++ b/types/detox/detox-tests.ts
@@ -15,8 +15,13 @@ describe('Test', () => {
     test('Test', async () => {
         await element(by.id('element')).replaceText('text');
         await element(by.id('element')).tap();
+        await element(by.id('element')).scroll(50, 'down');
+        await element(by.id('scrollView')).scrollTo('bottom');
         await expect(element(by.id('element')).atIndex(0)).toNotExist();
+        await element(by.id('scrollView')).swipe('down', 'fast');
+        await element(by.type('UIPickerView')).setColumnToValue(1, "6");
 
         await waitFor(element(by.id('element'))).toBeVisible().withTimeout(2000);
+        await waitFor(element(by.text('Text5'))).toBeVisible().whileElement(by.id('ScrollView630')).scroll(50, 'down');
     });
 });

--- a/types/detox/index.d.ts
+++ b/types/detox/index.d.ts
@@ -274,7 +274,7 @@ declare namespace Detox {
          * @param element
          * @example await waitFor(element(by.text('Text5'))).toBeVisible().whileElement(by.id('ScrollView630')).scroll(50, 'down');
          */
-        whileElement(by: Matchers): Element;
+        whileElement(by: Matchers): DetoxAny;
     }
     interface Actions<R> {
         /**
@@ -325,14 +325,14 @@ declare namespace Detox {
          * await element(by.id('scrollView')).scroll(100, 'down');
          * await element(by.id('scrollView')).scroll(100, 'up');
          */
-        scroll(pixels: number, direction: Direction): Actions<Promise<R>>;
+        scroll(pixels: number, direction: Direction): Promise<Actions<R>>;
         /**
          * Scroll to edge.
          * @param edge
          * @example await element(by.id('scrollView')).scrollTo('bottom');
          * await element(by.id('scrollView')).scrollTo('top');
          */
-        scrollTo(edge: Direction): Actions<Promise<R>>;
+        scrollTo(edge: Direction): Promise<Actions<R>>;
         /**
          *
          * @param direction
@@ -342,7 +342,7 @@ declare namespace Detox {
          * await element(by.id('scrollView')).swipe('down', 'fast');
          * await element(by.id('scrollView')).swipe('down', 'fast', 0.5);
          */
-        swipe(direction: Direction, speed?: Speed, percentage?: number): Actions<Promise<R>>;
+        swipe(direction: Direction, speed?: Speed, percentage?: number): Promise<Actions<R>>;
         /**
          * (iOS Only) column - number of datepicker column (starts from 0) value - string value in setted column (must be correct)
          * @param column
@@ -351,7 +351,7 @@ declare namespace Detox {
          * await element(by.type('UIPickerView')).setColumnToValue(1,"6");
          * await element(by.type('UIPickerView')).setColumnToValue(2,"34");
          */
-        setColumnToValue(column: number, value: string): Actions<Promise<R>>;
+        setColumnToValue(column: number, value: string): Promise<Actions<R>>;
     }
 
     type Direction = "left" | "right" | "top" | "bottom" | "up" | "down";


### PR DESCRIPTION
Some of the Detox types were broken when testing on the example snippets included in the docstrings. These changes fix the tslint errors for the newly added tests.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: The test snippets are taken from type definition docstring examples. They are also available in the Detox documentation at https://github.com/wix/Detox/blob/master/docs/APIRef.ActionsOnElement.md and https://github.com/wix/Detox/blob/master/docs/APIRef.waitFor.md
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.