### PR TITLE
Webpack: Adds maxSize as option to CacheGroupsOptions and SplitChunksOptions

### DIFF
--- a/types/webpack/index.d.ts
+++ b/types/webpack/index.d.ts
@@ -576,6 +576,8 @@ declare namespace webpack {
             priority?: number;
             /** Minimal size for the created chunk */
             minSize?: number;
+            /** Maximum size for the created chunk */
+            maxSize?: number;
             /** Minimum number of times a module has to be duplicated until it's considered for splitting */
             minChunks?: number;
             /** Maximum number of requests which are accepted for on-demand loading */
@@ -592,6 +594,8 @@ declare namespace webpack {
             chunks?: "initial" | "async" | "all" | ((chunk: compilation.Chunk) => boolean);
             /** Minimal size for the created chunk */
             minSize?: number;
+            /** Maximum size for the created chunk */
+            maxSize?: number;
             /** Minimum number of times a module has to be duplicated until it's considered for splitting */
             minChunks?: number;
             /** Maximum number of requests which are accepted for on-demand loading */

--- a/types/webpack/webpack-tests.ts
+++ b/types/webpack/webpack-tests.ts
@@ -632,14 +632,16 @@ configuration = {
     mode: "production",
     optimization: {
         splitChunks: {
-            minSize: 3000,
-            maxSize: 5000,
+            minSize: 30000,
+            maxSize: 50000,
             cacheGroups: {
                 default: false,
                 vendor: {
                     chunks: "initial",
                     test: "node_modules",
                     name: "vendor",
+                    minSize: 30000,
+                    maxSize: 50000,
                     enforce: true
                 }
             }

--- a/types/webpack/webpack-tests.ts
+++ b/types/webpack/webpack-tests.ts
@@ -632,6 +632,8 @@ configuration = {
     mode: "production",
     optimization: {
         splitChunks: {
+            minSize: 3000,
+            maxSize: 5000,
             cacheGroups: {
                 default: false,
                 vendor: {


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://webpack.js.org/plugins/split-chunks-plugin/#splitchunks-maxsize>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
