### PR TITLE
Add typings for react-facebook-login-component package

### DIFF
--- a/types/react-facebook-login-component/index.d.ts
+++ b/types/react-facebook-login-component/index.d.ts
@@ -1,0 +1,25 @@
+// Type definitions for react-facebook-login-component 4.1
+// Project: https://github.com/kennetpostigo/react-facebook-login-component
+// Definitions by: Konstantin Lebedev <https://github.com/koss-lebedev>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.8
+
+import * as React from "react";
+
+export interface FacebookLoginInfo {
+    id: string;
+    accessToken: string;
+    name?: string;
+    email?: string;
+}
+
+export interface FacebookLoginProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+    socialId: string;
+    xfbml?: boolean;
+    version?: string;
+    fields?: string;
+    buttonText?: string;
+    responseHandler: (response: FacebookLoginInfo) => void;
+}
+
+export class FacebookLogin extends React.Component<FacebookLoginProps> {}

--- a/types/react-facebook-login-component/react-facebook-login-component-tests.tsx
+++ b/types/react-facebook-login-component/react-facebook-login-component-tests.tsx
@@ -1,0 +1,24 @@
+import { FacebookLogin, FacebookLoginInfo } from "react-facebook-login-component";
+import * as React from "react";
+
+const handler = (response: FacebookLoginInfo) => {
+    console.log(response.accessToken);
+};
+
+const ReactFacebookLoginComponent: JSX.Element = (
+    <FacebookLogin
+        socialId="1234567890000"
+        responseHandler={handler}
+    />
+);
+
+const ReactFacebookLoginComponentAllOptions: JSX.Element = (
+    <FacebookLogin
+        socialId="1234567890000"
+        responseHandler={handler}
+        xfbml
+        version="2.5"
+        fields="email,username"
+        buttonText="Sign in with Facebook"
+    />
+);

--- a/types/react-facebook-login-component/tsconfig.json
+++ b/types/react-facebook-login-component/tsconfig.json
@@ -1,0 +1,26 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "target": "es6",
+        "jsx": "react",
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "react-facebook-login-component-tests.tsx"
+    ]
+}

--- a/types/react-facebook-login-component/tslint.json
+++ b/types/react-facebook-login-component/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
This PR is to add typings for `react-facebook-login-component` package (https://github.com/kennetpostigo/react-facebook-login-component)

The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`

