### PR TITLE
[cassandra-driver] ResultSet.first can return null, add 3.5.0's noCompact, bump version

### DIFF
--- a/types/cassandra-driver/index.d.ts
+++ b/types/cassandra-driver/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for cassandra-driver v3.4.1
+// Type definitions for cassandra-driver v3.5.0
 // Project: https://github.com/datastax/nodejs-driver
 // Definitions by: Marc Fisher <https://github.com/Svjard>
 //                 Christian D <https://github.com/pc-jedi>
@@ -413,7 +413,7 @@ export namespace types {
     pageState: string;
     nextPage: Function;
 
-    first(): Row;
+    first(): Row | null;
     getPageState(): string;
     getColumns(): Array<{ [key: string]: string; }>;
     wasApplied(): boolean;
@@ -526,7 +526,8 @@ export interface ClientOptions {
   protocolOptions?: {
     port?: number,
     maxSchemaAgreementWaitSeconds?: number,
-    maxVersion?: number
+    maxVersion?: number,
+    noCompact?: boolean
   },
   socketOptions?: {
     connectTimeout?: number,


### PR DESCRIPTION
this might be a build breaking change for some users of "first" in strict null checking mode, albeit one with an easy fix:
if you are sure that having zero returned rows is impossible, just add an exclamation mark to ignore the null check like this: r.first().!get(0) or just perform a proper check..

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [X] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
