### PR TITLE
[@types/proton-native] Fix Type RadioButtonProps and GridChildrenProps

### DIFF
--- a/types/proton-native/index.d.ts
+++ b/types/proton-native/index.d.ts
@@ -422,6 +422,13 @@ export interface GridChildrenProps {
      * What row the component resides in.
      */
     row?: number;
+    /**
+     * How many rows/columns the component takes off.
+     */
+    span?: {
+        x: number;
+        y: number;
+  };
 }
 
 export interface GridProps {

--- a/types/proton-native/index.d.ts
+++ b/types/proton-native/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for proton-native 1.1
 // Project: https://github.com/kusti8/proton-native
 // Definitions by: Nguyen Xuan Khanh <https://github.com/khanhas>
+//                 Lukas Tetzlaff <https://github.com/ltetzlaff>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -608,7 +609,7 @@ export interface RadioButtonsProps extends GridChildrenProps, Label, Stretchy {
     /**
      * Called when a RadioButton is selected. The number selected is passed as an argument.
      */
-    onSelect?: (selected: boolean) => void;
+    onSelect?: (selected: number) => void;
     /**
      * What RadioButton is selected, zero-indexed. -1 means nothing is selected.
      */

--- a/types/proton-native/test/index.tsx
+++ b/types/proton-native/test/index.tsx
@@ -48,7 +48,7 @@ class RadioTest extends React.Component {
       return (
         <App>
             <Window title="Example" size={{w: 500, h: 500}}>
-                <RadioButtons enabled={true}>
+                <RadioButtons onSelect={selected => selected.toFixed()} enabled={true}>
                     <RadioButtons.Item>Option 1</RadioButtons.Item>
                     <RadioButtons.Item>Option 2</RadioButtons.Item>
                 </RadioButtons>
@@ -117,6 +117,14 @@ class GridTest extends React.Component {
                         column={1}
                     >
                         <Form><ColorButton label={"Test"}/></Form>
+                    </Box>
+                    <Box
+                        align={{h: false, v: false}}
+                        row={2}
+                        column={0}
+                        span={{x: 2, y: 1}}
+                    >
+                        <Form><ColorButton label={"Spans Two Columns"}/></Form>
                     </Box>
                 </Grid>
                 </Window>


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
  - https://proton-native.js.org/#/component_APIs/grid_components?id=span
  - https://proton-native.js.org/#/component_APIs/radio_buttons
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
