### PR TITLE
Plotly.js add missing properties

### DIFF
--- a/types/plotly.js/index.d.ts
+++ b/types/plotly.js/index.d.ts
@@ -155,7 +155,7 @@ export interface PlotlyHTMLElement extends HTMLElement {
 	on(event: 'plotly_afterexport' | 'plotly_afterplot' | 'plotly_animated' | 'plotly_animationinterrupted' | 'plotly_autosize' |
 		'plotly_beforeexport' | 'plotly_deselect' | 'plotly_doubleclick' | 'plotly_framework' | 'plotly_redraw' |
 		'plotly_transitioning' | 'plotly_transitioninterrupted', callback: () => void): void;
-    removeAllListeners: (handler: string) => void;
+	removeAllListeners: (handler: string) => void;
 }
 
 export interface ToImgopts {
@@ -339,7 +339,7 @@ export interface LayoutAxis extends Axis {
 	position: number;
 	rangeslider: Partial<RangeSlider>;
 	rangeselector: Partial<RangeSelector>;
-    automargin: boolean
+	automargin: boolean;
 }
 
 export interface SceneAxis extends Axis {

--- a/types/plotly.js/index.d.ts
+++ b/types/plotly.js/index.d.ts
@@ -339,6 +339,7 @@ export interface LayoutAxis extends Axis {
 	position: number;
 	rangeslider: Partial<RangeSlider>;
 	rangeselector: Partial<RangeSelector>;
+    automargin: boolean
 }
 
 export interface SceneAxis extends Axis {

--- a/types/plotly.js/index.d.ts
+++ b/types/plotly.js/index.d.ts
@@ -155,6 +155,7 @@ export interface PlotlyHTMLElement extends HTMLElement {
 	on(event: 'plotly_afterexport' | 'plotly_afterplot' | 'plotly_animated' | 'plotly_animationinterrupted' | 'plotly_autosize' |
 		'plotly_beforeexport' | 'plotly_deselect' | 'plotly_doubleclick' | 'plotly_framework' | 'plotly_redraw' |
 		'plotly_transitioning' | 'plotly_transitioninterrupted', callback: () => void): void;
+    removeAllListeners: (handler: string) => void;
 }
 
 export interface ToImgopts {

--- a/types/plotly.js/index.d.ts
+++ b/types/plotly.js/index.d.ts
@@ -550,6 +550,54 @@ export interface Transform {
 	value: any;
 	order: 'ascending' | 'descending';
 }
+
+export interface ColorBar {
+	thicknessmode: 'fraction' | 'pixels';
+	thickness: number;
+	lenmode: 'fraction' | 'pixels';
+	len: number;
+	x: number;
+	xanchor: 'left' | 'center' | 'right';
+	xpad: number;
+	y: number;
+	yanchor: 'top' | 'middle' | 'bottom';
+	ypad: number;
+	outlinecolor: Color;
+	outlinewidth: number;
+	bordercolor: Color;
+	borderwidth: Color;
+	bgcolor: Color;
+	tickmode: 'auto' | 'linear' | 'array';
+	nticks: number;
+	tick0: number | string;
+	dtick: number | string;
+	tickvals: Datum[] | Datum[][] | Datum[][][] | TypedArray;
+	ticktext: Datum[] | Datum[][] | Datum[][][] | TypedArray;
+	ticks: 'outside' | 'inside' | '';
+	ticklen: number;
+	tickwidth: number;
+	tickcolor: Color;
+	showticklabels: boolean;
+	tickfont: Font;
+	tickangle: number;
+	tickformat: string;
+	tickformatstops: {
+		dtickrange: any[];
+		value: string;
+	};
+	tickprefix: string;
+	showtickprefix: 'all' | 'first' | 'last' | 'none';
+	ticksuffix: string;
+	showticksuffix: 'all' | 'first' | 'last' | 'none';
+	separatethousands: boolean;
+	exponentformat: 'none' | 'e' | 'E' | 'power' | 'SI' | 'B';
+	showexponent: 'all' | 'first' | 'last' | 'none';
+	title: string;
+	titlefont: Font;
+	titleside: 'right' | 'top' | 'bottom';
+	tickvalssrc: any;
+	ticktextsrc: any;
+}
 /**
  * Any combination of "x", "y", "z", "text", "name" joined with a "+" OR "all" or "none" or "skip".
  * examples: "x", "y", "x+y", "x+y+z", "all"
@@ -574,53 +622,7 @@ export interface PlotMarker {
 	showscale: boolean;
 	line: Partial<ScatterMarkerLine>;
 	width: number;
-	colorbar: Partial<{
-		thicknessmode: 'fraction' | 'pixels',
-		thickness: number,
-		lenmode: 'fraction' | 'pixels',
-		len: number,
-		x: number,
-		xanchor: 'left' | 'center' | 'right',
-		xpad: number,
-		y: number,
-		yanchor: 'top' | 'middle' | 'bottom',
-		ypad: number,
-		outlinecolor: Color,
-		outlinewidth: number,
-		bordercolor: Color,
-		borderwidth: Color,
-		bgcolor: Color,
-		tickmode: 'auto' | 'linear' | 'array',
-		nticks: number,
-		tick0: number | string,
-		dtick: number | string,
-		tickvals: Datum[] | Datum[][] | Datum[][][] | TypedArray,
-		ticktext: Datum[] | Datum[][] | Datum[][][] | TypedArray,
-		ticks: 'outside' | 'inside' | '',
-		ticklen: number,
-		tickwidth: number,
-		tickcolor: Color,
-		showticklabels: boolean,
-		tickfont: Font,
-		tickangle: number,
-		tickformat: string,
-		tickformatstops: {
-			dtickrange: any[],
-			value: string,
-		},
-		tickprefix: string,
-		showtickprefix: 'all' | 'first' | 'last' | 'none',
-		ticksuffix: string,
-		showticksuffix: 'all' | 'first' | 'last' | 'none',
-		separatethousands: boolean,
-		exponentformat: 'none' | 'e' | 'E' | 'power' | 'SI' | 'B',
-		showexponent: 'all' | 'first' | 'last' | 'none',
-		title: string,
-		titlefont: Font,
-		titleside: 'right' | 'top' | 'bottom',
-		tickvalssrc: any,
-		ticktextsrc: any,
-	}>;
+	colorbar: Partial<ColorBar>;
 	gradient: {
 		type: 'radial' | 'horizontal' | 'vertical' | 'none',
 		color: Color,

--- a/types/plotly.js/index.d.ts
+++ b/types/plotly.js/index.d.ts
@@ -574,7 +574,7 @@ export interface PlotMarker {
 	showscale: boolean;
 	line: Partial<ScatterMarkerLine>;
 	width: number;
-	colorbar: {
+	colorbar: Partial<{
 		thicknessmode: 'fraction' | 'pixels',
 		thickness: number,
 		lenmode: 'fraction' | 'pixels',
@@ -620,7 +620,7 @@ export interface PlotMarker {
 		titleside: 'right' | 'top' | 'bottom',
 		tickvalssrc: any,
 		ticktextsrc: any,
-	};
+	}>;
 	gradient: {
 		type: 'radial' | 'horizontal' | 'vertical' | 'none',
 		color: Color,

--- a/types/plotly.js/test/index-tests.ts
+++ b/types/plotly.js/test/index-tests.ts
@@ -546,5 +546,6 @@ function rand() {
 	myPlot.on('plotly_transitioninterrupted', () => {
 		console.log('transition interrupted');
 	});
+
+	myPlot.removeAllListeners('plotly_restyle');
 })();
-//////////////////////////////////////////////////////////////////////


### PR DESCRIPTION

Three changes have been made:

1. Added definition for function `removeAllListeners`, this is a helpful function that is not documented in the official docs but exists and it is mentioned here: 
https://github.com/plotly/plotly.js/issues/107#issuecomment-279716312

2. The `automargin` property has been added to the Axis type, this property is part of the Axis object as detailed in the official docs:
https://plot.ly/javascript/reference/#layout-xaxis-automargin

3. All the properties for the `colorbar` in `ScatterMaker` are now optional. As detailed in the official documentation, all of this values have defaults:
https://plot.ly/javascript/reference/#scatter-marker-colorbar
