### PR TITLE
[@types/chai-fs] Repo has a support for chai-fs. 

### DIFF
--- a/types/chai-fs/chai-fs-tests.ts
+++ b/types/chai-fs/chai-fs-tests.ts
@@ -1,0 +1,400 @@
+import { assert, expect, use, should } from 'chai';
+import Chaifs = require('chai-fs');
+
+use(Chaifs);
+should();
+
+const name: string = 'name';
+const path: string = 'tmp/';
+const otherPath: string = 'otherPath/';
+const msg: string = 'message';
+const array: any[] = [1, 2, 3, 4];
+const data: ArrayBuffer = new ArrayBuffer(512);
+const obj: object = { 'key': 'value' };
+const schema = JSON.parse('{ "name":"John", "age":30, "city":"New York"}');
+
+// basename()
+expect(path).to.have.basename(name);
+expect(path).to.have.basename(name, msg);
+expect(path).to.not.have.basename(name);
+expect(path).to.not.have.basename(name, msg);
+
+path.should.have.basename(name);
+path.should.have.basename(name, msg);
+path.should.not.have.basename(name);
+path.should.not.have.basename(name, msg);
+
+assert.basename(path, name);
+assert.basename(path, name, msg);
+assert.notBasename(path, name);
+assert.notBasename(path, name, msg);
+
+// dirname()
+expect(path).to.have.dirname(name);
+expect(path).to.have.dirname(name, msg);
+expect(path).to.not.have.dirname(name);
+expect(path).to.not.have.dirname(name, msg);
+
+path.should.have.dirname(name);
+path.should.have.dirname(name, msg);
+path.should.not.have.dirname(name);
+path.should.not.have.dirname(name, msg);
+
+assert.dirname(path, name);
+assert.dirname(path, name, msg);
+assert.notDirname(path, name);
+assert.notDirname(path, name, msg);
+
+// extname()
+expect(path).to.have.extname(name);
+expect(path).to.have.extname(name, msg);
+expect(path).to.not.have.extname(name);
+expect(path).to.not.have.extname(name, msg);
+
+path.should.have.extname(name);
+path.should.have.extname(name, msg);
+path.should.not.have.extname(name);
+path.should.not.have.extname(name, msg);
+
+assert.extname(path, name);
+assert.extname(path, name, msg);
+assert.notExtname(path, name);
+assert.notExtname(path, name, msg);
+
+// path()
+expect(path).to.be.a.path();
+expect(path).to.be.a.path(msg);
+expect(path).to.not.be.a.path();
+expect(path).to.not.be.a.path(msg);
+
+path.should.be.a.path();
+path.should.be.a.path(msg);
+path.should.be.a.path();
+path.should.be.a.path(msg);
+path.should.not.be.a.path();
+path.should.not.be.a.path(msg);
+
+assert.pathExists(path);
+assert.pathExists(path, msg);
+assert.notPathExists(path);
+assert.notPathExists(path, msg);
+
+// directory
+expect(path).to.be.a.directory();
+expect(path).to.be.a.directory(msg);
+expect(path).to.not.be.a.directory();
+expect(path).to.not.be.a.directory(msg);
+
+path.should.be.a.directory();
+path.should.be.a.directory(msg);
+path.should.not.be.a.directory();
+path.should.not.be.a.directory(msg);
+
+assert.isDirectory(path);
+assert.isDirectory(path, msg);
+assert.notIsDirectory(path);
+assert.notIsDirectory(path, msg);
+
+// directory().and.empty
+expect(path).to.be.a.directory().and.empty;
+expect(path).to.be.a.directory(msg).and.empty;
+expect(path).to.be.a.directory().and.not.empty;
+expect(path).to.be.a.directory(msg).and.not.empty;
+
+path.should.be.a.directory().and.empty;
+path.should.be.a.directory(msg).and.empty;
+path.should.be.a.directory().and.not.empty;
+path.should.be.a.directory(msg).and.not.empty;
+
+assert.isEmptyDirectory(path);
+assert.isEmptyDirectory(path, msg);
+assert.notIsEmptyDirectory(path);
+assert.notIsEmptyDirectory(path, msg);
+
+// directory().with.contents([...])
+// #1
+expect(path).to.be.a.directory(msg).with.contents(array);
+expect(path).to.be.a.directory(msg).with.contents(array, msg);
+// #2
+expect(path).to.be.a.directory(msg).and.not.have.contents(array);
+expect(path).to.be.a.directory(msg).and.not.have.contents(array, msg);
+// #3
+expect(path).to.be.a.directory(msg).with.deep.contents(array);
+expect(path).to.be.a.directory(msg).with.deep.contents(array, msg);
+// #4
+expect(path).to.be.a.directory(msg).and.not.have.deep.contents(array);
+expect(path).to.be.a.directory(msg).and.not.have.deep.contents(array, msg);
+// #5
+expect(path).to.be.a.directory(msg).and.include.contents(array);
+expect(path).to.be.a.directory(msg).and.include.contents(array, msg);
+// #6
+expect(path).to.be.a.directory(msg).and.not.include.contents(array);
+expect(path).to.be.a.directory(msg).and.not.include.contents(array, msg);
+
+// #1
+path.should.be.a.directory(msg).with.contents(array);
+path.should.be.a.directory(msg).with.contents(array, msg);
+// #2
+path.should.be.a.directory(msg).and.not.have.contents(array);
+path.should.be.a.directory(msg).and.not.have.contents(array, msg);
+// #3
+path.should.be.a.directory(msg).with.deep.contents(array);
+path.should.be.a.directory(msg).with.deep.contents(array, msg);
+// #4
+path.should.be.a.directory(msg).and.not.have.deep.contents(array);
+path.should.be.a.directory(msg).and.not.have.deep.contents(array, msg);
+// #5
+path.should.be.a.directory(msg).and.include.contents(array);
+path.should.be.a.directory(msg).and.include.contents(array, msg);
+// #6
+path.should.be.a.directory(msg).and.not.include.contents(array);
+path.should.be.a.directory(msg).and.not.include.contents(array, msg);
+
+assert.directoryContent(path, array);
+assert.directoryContent(path, array, msg);
+assert.notDirectoryContent(path, array);
+assert.notDirectoryContent(path, array, msg);
+assert.directoryDeepContent(path, array);
+assert.directoryDeepContent(path, array, msg);
+assert.notDirectoryDeepContent(path, array);
+assert.notDirectoryDeepContent(path, array, msg);
+assert.directoryInclude(path, array);
+assert.directoryInclude(path, array, msg);
+assert.notDirectoryInclude(path, array);
+assert.notDirectoryInclude(path, array, msg);
+
+// directory().with.files([...])
+// #1
+expect(path).to.be.a.directory(msg).with.files(array);
+expect(path).to.be.a.directory(msg).with.files(array, msg);
+// #2
+expect(path).to.be.a.directory(msg).with.files(array);
+expect(path).to.be.a.directory(msg).with.files(array, msg);
+// #3
+expect(path).to.be.a.directory(msg).and.not.have.files(array);
+expect(path).to.be.a.directory(msg).and.not.have.files(array, msg);
+// #4
+expect(path).to.be.a.directory(msg).and.not.have.files(array);
+expect(path).to.be.a.directory(msg).and.not.have.files(array, msg);
+// #5
+expect(path).to.be.a.directory(msg).with.deep.files(array, msg);
+expect(path).to.be.a.directory(msg).with.deep.files(array);
+// #6
+expect(path).to.be.a.directory(msg).with.deep.files(array);
+expect(path).to.be.a.directory(msg).with.deep.files(array, msg);
+// #7
+expect(path).to.be.a.directory(msg).and.not.have.deep.files(array);
+expect(path).to.be.a.directory(msg).and.not.have.deep.files(array, msg);
+// #8
+expect(path).to.be.a.directory(msg).and.not.have.deep.files(array);
+expect(path).to.be.a.directory(msg).and.not.have.deep.files(array, msg);
+// #9
+expect(path).to.be.a.directory(msg).and.include.files(array);
+expect(path).to.be.a.directory(msg).and.include.files(array, msg);
+// #10
+expect(path).to.be.a.directory(msg).and.not.include.files(array);
+expect(path).to.be.a.directory(msg).and.not.include.files(array, msg);
+
+// #1
+path.should.be.a.directory(msg).with.files(array);
+path.should.be.a.directory(msg).with.files(array, msg);
+// #2
+path.should.be.a.directory().and.not.have.files(array);
+path.should.be.a.directory(msg).and.not.have.files(array);
+path.should.be.a.directory(msg).and.not.have.files(array, msg);
+// #3
+path.should.be.a.directory().with.deep.files(array);
+path.should.be.a.directory(msg).with.deep.files(array);
+path.should.be.a.directory(msg).with.deep.files(array, msg);
+// #4
+path.should.be.a.directory(msg).and.not.have.deep.files(array);
+path.should.be.a.directory(msg).and.not.have.deep.files(array, msg);
+// #5
+path.should.be.a.directory(msg).and.include.files(array);
+path.should.be.a.directory(msg).and.include.files(array, msg);
+// #6
+path.should.be.a.directory(msg).and.not.include.files(array);
+path.should.be.a.directory(msg).and.not.include.files(array, msg);
+
+assert.directoryFiles(path, array);
+assert.directoryFiles(path, array, msg);
+assert.notDirectoryFiles(path, array);
+assert.notDirectoryFiles(path, array, msg);
+assert.directoryDeepFiles(path, array);
+assert.directoryDeepFiles(path, array, msg);
+assert.notDirectoryDeepFiles(path, array);
+assert.notDirectoryDeepFiles(path, array, msg);
+assert.directoryIncludeFiles(path, array);
+assert.directoryIncludeFiles(path, array, msg);
+assert.notDirectoryIncludeFiles(path, array);
+assert.notDirectoryIncludeFiles(path, array, msg);
+
+// directory().with.subDirs([...])
+// #1
+expect(path).to.be.a.directory(msg).with.subDirs(array);
+expect(path).to.be.a.directory(msg).with.subDirs(array, msg);
+// #2
+expect(path).to.be.a.directory(msg).and.not.have.subDirs(array);
+expect(path).to.be.a.directory(msg).and.not.have.subDirs(array, msg);
+// #3
+expect(path).to.be.a.directory(msg).with.deep.subDirs(array);
+expect(path).to.be.a.directory(msg).with.deep.subDirs(array, msg);
+// #4
+expect(path).to.be.a.directory(msg).and.not.have.deep.subDirs(array);
+expect(path).to.be.a.directory(msg).and.not.have.deep.subDirs(array, msg);
+// #5
+expect(path).to.be.a.directory(msg).and.include.subDirs(array);
+expect(path).to.be.a.directory(msg).and.include.subDirs(array, msg);
+// #6
+expect(path).to.be.a.directory(msg).and.not.include.subDirs(array);
+expect(path).to.be.a.directory(msg).and.not.include.subDirs(array, msg);
+
+// #1
+path.should.be.a.directory(msg).with.subDirs(array);
+path.should.be.a.directory(msg).with.subDirs(array, msg);
+// #2
+path.should.be.a.directory(msg).and.not.have.subDirs(array);
+path.should.be.a.directory(msg).and.not.have.subDirs(array, msg);
+// #3
+path.should.be.a.directory(msg).with.deep.subDirs(array);
+path.should.be.a.directory(msg).with.deep.subDirs(array, msg);
+// #4
+path.should.be.a.directory(msg).and.not.have.deep.subDirs(array);
+path.should.be.a.directory(msg).and.not.have.deep.subDirs(array, msg);
+// #5
+path.should.be.a.directory(msg).and.include.subDirs(array);
+path.should.be.a.directory(msg).and.include.subDirs(array, msg);
+// #6
+path.should.be.a.directory(msg).and.not.include.subDirs(array);
+path.should.be.a.directory(msg).and.not.include.subDirs(array, msg);
+
+assert.directorySubDirs(path, array, msg);
+assert.notDirectorySubDirs(path, array, msg);
+assert.directoryDeepSubDirs(path, array, msg);
+assert.notDirectoryDeepSubDirs(path, array, msg);
+assert.directoryIncludeSubDirs(path, array, msg);
+assert.notDirectoryIncludeSubDirs(path, array, msg);
+
+// directory().and.equal(otherPath)
+// #1
+expect(path).to.be.a.directory(msg).and.equal(otherPath);
+expect(path).to.be.a.directory(msg).and.equal(otherPath, msg);
+// #2
+expect(path).to.be.a.directory(msg).and.not.equal(otherPath);
+expect(path).to.be.a.directory(msg).and.not.equal(otherPath, msg);
+// #3
+expect(path).to.be.a.directory(msg).and.deep.equal(otherPath);
+expect(path).to.be.a.directory(msg).and.deep.equal(otherPath, msg);
+// #4
+expect(path).to.be.a.directory(msg).and.not.deep.equal(otherPath);
+expect(path).to.be.a.directory(msg).and.not.deep.equal(otherPath, msg);
+
+// #1
+path.should.be.a.directory(msg).and.equal(otherPath);
+path.should.be.a.directory(msg).and.equal(otherPath, msg);
+// #2
+path.should.be.a.directory(msg).and.not.equal(otherPath);
+path.should.be.a.directory(msg).and.not.equal(otherPath, msg);
+// #3
+path.should.be.a.directory(msg).and.deep.equal(otherPath);
+path.should.be.a.directory(msg).and.deep.equal(otherPath, msg);
+// #4
+path.should.be.a.directory(msg).and.not.deep.equal(otherPath);
+path.should.be.a.directory(msg).and.not.deep.equal(otherPath, msg);
+
+assert.directoryEqual(path, otherPath, msg);
+assert.notDirectoryEqual(path, otherPath, msg);
+assert.directoryDeepEqual(path, otherPath, msg);
+assert.notDirectoryDeepEqual(path, otherPath, msg);
+
+// file()
+expect(path).to.be.a.file();
+expect(path).to.be.a.file(msg);
+expect(path).to.not.be.a.file();
+expect(path).to.not.be.a.file(msg);
+
+path.should.be.a.file();
+path.should.be.a.file(msg);
+path.should.not.be.a.file();
+path.should.not.be.a.file(msg);
+
+assert.isFile(path);
+assert.isFile(path, msg);
+assert.notIsFile(path);
+assert.notIsFile(path, msg);
+
+// file().and.empty
+expect(path).to.be.a.file(msg).and.empty;
+expect(path).to.be.a.file(msg).and.not.empty;
+
+path.should.be.a.file(msg).and.empty;
+path.should.be.a.file(msg).and.not.empty;
+
+assert.isEmptyFile(path, msg);
+assert.notIsEmptyFile(path, msg);
+
+// file().with.content(str)
+expect(path).to.be.a.file(msg).with.content(data);
+expect(path).to.be.a.file(msg).with.content(data, msg);
+expect(path).to.be.a.file(msg).and.not.have.content(data);
+expect(path).to.be.a.file(msg).and.not.have.content(data, msg);
+
+path.should.be.a.file(msg).with.content(data);
+path.should.be.a.file(msg).with.content(data, msg);
+path.should.be.a.file(msg).and.not.have.content(data);
+path.should.be.a.file(msg).and.not.have.content(data, msg);
+
+assert.fileContent(path, data);
+assert.fileContent(path, data, msg);
+assert.notFileContent(path, data);
+assert.notFileContent(path, data, msg);
+
+// file().with.contents.that.match(/xyz/)
+// expect(path).to.be.a.file(msg).with.contents.that.match(/xyz/, msg);
+// expect(path).to.be.a.file(msg).and.not.have.contents.that.match(/xyz/, msg);
+
+// path.should.be.a.file(msg).with.contents.that.match(/xyz/, msg);
+// path.should.be.a.file(msg).and.not.have.contents.that.match(/xyz/, msg);
+
+assert.fileContentMatch(path, /xyz/);
+assert.fileContentMatch(path, /xyz/, msg);
+assert.notFileContentMatch(path, /xyz/);
+assert.notFileContentMatch(path, /xyz/, msg);
+
+// file().and.equal(otherPath)
+expect(path).to.be.a.file(msg).and.equal(otherPath);
+expect(path).to.be.a.file(msg).and.equal(otherPath, msg);
+expect(path).to.be.a.file(msg).and.not.equal(otherPath);
+expect(path).to.be.a.file(msg).and.not.equal(otherPath, msg);
+
+path.should.be.a.file(msg).and.equal(otherPath);
+path.should.be.a.file(msg).and.equal(otherPath, msg);
+path.should.be.a.file(msg).and.not.equal(otherPath);
+path.should.be.a.file(msg).and.not.equal(otherPath, msg);
+
+assert.fileEqual(path, otherPath, msg);
+assert.notFileEqual(path, otherPath, msg);
+
+// file().with.json
+expect(path).to.be.a.file(msg).with.json;
+expect(path).to.be.a.file(msg).with.not.json;
+
+path.should.be.a.file(msg).with.json;
+path.should.be.a.file(msg).with.not.json;
+
+assert.jsonFile(path);
+assert.jsonFile(path, msg);
+assert.notJsonFile(path);
+assert.notJsonFile(path, msg);
+
+// file().using.json.schema(obj)
+expect(path).to.be.a.file(msg).with.json.using.schema(obj);
+expect(path).to.be.a.file(msg).with.json.not.using.schema(obj);
+
+path.should.be.a.file(msg).with.json.using.schema(obj);
+path.should.be.a.file(msg).with.json.not.using.schema(obj);
+
+assert.jsonSchemaFile(path, schema);
+assert.jsonSchemaFile(path, schema, msg);
+assert.notJsonSchemaFile(path, schema);
+assert.notJsonSchemaFile(path, schema, msg);

--- a/types/chai-fs/chai-fs-tests.ts
+++ b/types/chai-fs/chai-fs-tests.ts
@@ -4,13 +4,13 @@ import Chaifs = require('chai-fs');
 use(Chaifs);
 should();
 
-const name: string = 'name';
-const path: string = 'tmp/';
-const otherPath: string = 'otherPath/';
-const msg: string = 'message';
+const name = 'name';
+const path = 'tmp/';
+const otherPath = 'otherPath/';
+const msg = 'message';
 const array: any[] = [1, 2, 3, 4];
 const data: ArrayBuffer = new ArrayBuffer(512);
-const obj: object = { 'key': 'value' };
+const obj: object = { key: 'value' };
 const schema = JSON.parse('{ "name":"John", "age":30, "city":"New York"}');
 
 // basename()

--- a/types/chai-fs/index.d.ts
+++ b/types/chai-fs/index.d.ts
@@ -1,0 +1,231 @@
+// Type definitions for chai-fs 2.0
+// Project: https://github.com/chaijs/chai-fs
+// Definitions by: Dimitar Danailov <https://github.com/Nemo157>
+//
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.0.1
+
+/// <reference types="node" />
+/// <reference types="chai" />
+
+declare global {
+    namespace Chai {
+
+        interface TypeComparison {
+            path(msg?: string): Assertion;
+            directory(msg?: string): Assertion;
+            file(msg?: string): Assertion;
+        }
+
+        interface Deep {
+            contents(array: any[], msg?: string): Assertion;
+            files(array: any[], msg?: string): Assertion;
+            subDirs(array: any[], msg?: string): Assertion;
+        }
+
+        interface Include {
+            contents(array: any[], msg?: string): Assertion;
+            files(array: any[], msg?: string): Assertion;
+            subDirs(array: any[], msg?: string): Assertion;
+        }
+
+        interface LanguageChains {
+            json: Assertion;
+            using: Assertion;
+        }
+
+        interface Assertion extends LanguageChains, NumericComparison, TypeComparison {
+            // Basename
+            basename(name: string, msg?: string): Assertion;
+            basename(path: string, name: string, msg?: string): Assertion;
+            notBasename(path: string, name: string, msg?: string): Assertion;
+
+            // Dirname
+            dirname(name: string, msg?: string): Assertion;
+            notDirname(path: string, name: string, msg?: string): Assertion;
+
+            // Еxtname
+            extname(name: string, msg?: string): Assertion;
+            extname(path: string, name: string, msg?: string): Assertion;
+            notExtname(path: string, name: string, msg?: string): Assertion;
+
+            // Path
+            pathExists(path: string, msg?: string): Assertion;
+            notPathExists(path: string, msg?: string): Assertion;
+
+            // Directory
+            isDirectory(path: string, msg?: string): Assertion;
+            notIsDirectory(path: string, msg?: string): Assertion;
+
+            // directory().and.empty
+            isEmptyDirectory(path: string, msg?: string): Assertion;
+            notIsEmptyDirectory(path: string, msg?: string): Assertion;
+
+            // directory().with.contents([...])
+            contents(array: any[], msg?: string): Assertion;
+            directoryContent(path: string, array: any[], msg?: string): Assertion;
+            notDirectoryContent(path: string, array: any[], msg?: string): Assertion;
+            directoryDeepContent(path: string, array: any[], msg?: string): Assertion;
+            notDirectoryDeepContent(path: string, array: any[], msg?: string): Assertion;
+            directoryInclude(path: string, array: any[], msg?: string): Assertion;
+            notDirectoryInclude(path: string, array: any[], msg?: string): Assertion;
+
+            // directory().with.files([...])
+            files(array: any[], msg?: string): Assertion;
+            directoryFiles(path: string, array: any[], msg?: string): Assertion;
+            notDirectoryFiles(path: string, array: any[], msg?: string): Assertion;
+            directoryDeepFiles(path: string, array: any[], msg?: string): Assertion;
+            notDirectoryDeepFiles(path: string, array: any[], msg?: string): Assertion;
+            directoryIncludeFiles(path: string, array: any[], msg?: string): Assertion;
+            notDirectoryIncludeFiles(path: string, array: any[], msg?: string): Assertion;
+
+            // directory().with.subDirs([...])
+            subDirs(array: any[], msg? :string): Assertion;
+            directorySubDirs(path: string, array: any[], msg?: string): Assertion;
+            notDirectorySubDirs(path: string, array: any[], msg?: string): Assertion;
+            directoryDeepSubDirs(path: string, array: any[], msg?: string): Assertion;
+            notDirectoryDeepSubDirs(path: string, array: any[], msg?: string): Assertion;
+            directoryIncludeSubDirs(path: string, array: any[], msg?: string): Assertion;
+            notDirectoryIncludeSubDirs(path: string, array: any[], msg?: string): Assertion;
+
+            // directory().and.equal(otherPath)
+            directoryEqual(path: string, otherPath: string, msg?: string): Assertion;
+            notDirectoryEqual(path: string, otherPath: string, msg?: string): Assertion;
+            directoryDeepEqual(path: string, otherPath: string, msg?: string): Assertion;
+            notDirectoryDeepEqual(path: string, otherPath: string, msg?: string): Assertion;
+
+            // file
+            isFile(path: string, msg?: string): Assertion;
+            notIsFile(path: string, msg?: string): Assertion;
+
+            // file().and.empty
+            isEmptyFile(path: string, msg?: string): Assertion;
+            notIsEmptyFile(path: string, msg?: string): Assertion;
+
+            // file().with.content(str)
+            content(data: any, msg?: string): Assertion;
+            fileContent(path: string, data: any, msg?: string): Assertion;
+            notFileContent(path: string, data: any, msg?: string): Assertion;
+
+            // file().with.contents.that.match(/xyz/)
+            fileContentMatch(path: string, regExp: RegExp, msg?: string): Assertion;
+            notFileContentMatch(path: string, regExp: RegExp, msg?: string): Assertion;
+
+            // file().and.equal(otherPath)
+            fileEqual(path: string, otherPath: string, msg?: string): Assertion;
+            notFileEqual(path: string, otherPath: string, msg?: string): Assertion;
+
+            // file().with.json
+            jsonFile(path: string, msg?: string): Assertion;
+            notJsonFile(path: string, msg?: string): Assertion;
+
+            //file().using.json.schema(obj)
+            jsonSchemaFile(path: string, schema: any, msg?: string): Assertion;
+            notJsonSchemaFile(path: string, schema: any, msg?: string): Assertion;
+            schema(obj: object): Assertion;
+        }
+
+        export interface Assert {
+
+            // Basename
+            basename(name: string, msg?: string): void;
+            basename(path: string, name: string, msg: string): void;
+            notBasename(path: string, name: string, msg?: string): void;
+
+            // Dirname
+            dirname(name: string, msg?: string): void;
+            dirname(path: string, name: string, msg?: string): void;
+            notDirname(path: string, name: string, msg?: string): void;
+
+            // Еxtname
+            extname(name: string, msg?: string): void;
+            extname(path: string, name: string, msg?: string): void;
+            notExtname(path: string, name: string, msg?: string): void;
+
+            // Path
+            path(msg?: string): void;
+            pathExists(path: string, msg?: string): void;
+            notPathExists(path: string, msg?: string): void;
+
+            // Directory
+            directory(msg?: string): void;
+            isDirectory(path: string, msg?: string): void;
+            notIsDirectory(path: string, msg?: string): void;
+
+            // directory().and.empty
+            isEmptyDirectory(path: string, msg?: string): void;
+            notIsEmptyDirectory(path: string, msg?: string): void;
+
+            // directory().with.contents([...])
+            contents(array: any[], msg?: string): void;
+            directoryContent(path: string, array: any[], msg?: string): void;
+            notDirectoryContent(path: string, array: any[], msg?: string): void;
+            directoryDeepContent(path: string, array: any[], msg?: string): void;
+            notDirectoryDeepContent(path: string, array: any[], msg?: string): void;
+            directoryInclude(path: string, array: any[], msg?: string): void;
+            notDirectoryInclude(path: string, array: any[], msg?: string): void;
+
+            // directory().with.files([...])
+            files(array: any[], msg?: string): void;
+            directoryFiles(path: string, array: any[], msg?: string): void;
+            notDirectoryFiles(path: string, array: any[], msg?: string): void;
+            directoryDeepFiles(path: string, array: any[], msg?: string): void;
+            notDirectoryDeepFiles(path: string, array: any[], msg?: string): void;
+            directoryIncludeFiles(path: string, array: any[], msg?: string): void;
+            notDirectoryIncludeFiles(path: string, array: any[], msg?: string): void;
+
+            // directory().with.subDirs([...])
+            subDirs(array: any[], msg? :string): void;
+            directorySubDirs(path: string, array: any[], msg?: string): void;
+            notDirectorySubDirs(path: string, array: any[], msg?: string): void;
+            directoryDeepSubDirs(path: string, array: any[], msg?: string): void;
+            notDirectoryDeepSubDirs(path: string, array: any[], msg?: string): void;
+            directoryIncludeSubDirs(path: string, array: any[], msg?: string): void;
+            notDirectoryIncludeSubDirs(path: string, array: any[], msg?: string): void;
+
+            // directory().and.equal(otherPath)
+            directoryEqual(path: string, otherPath: string, msg?: string): void;
+            notDirectoryEqual(path: string, otherPath: string, msg?: string): void;
+            directoryDeepEqual(path: string, otherPath: string, msg?: string): void;
+            notDirectoryDeepEqual(path: string, otherPath: string, msg?: string): void;
+
+            // file
+            file(msg?: string): void;
+            isFile(path: string, msg?: string): void;
+            notIsFile(path: string, msg?: string): void;
+
+            // file().and.empty
+            isEmptyFile(path: string, msg?: string): void;
+            notIsEmptyFile(path: string, msg?: string): void;
+
+            // file().with.content(str)
+            fileContent(path: string, data: any, msg?: string): void;
+            notFileContent(path: string, data: any, msg?: string): void;
+
+            // file().with.contents.that.match(/xyz/)
+            fileContentMatch(path: string, regExp: RegExp, msg?: string): void;
+            notFileContentMatch(path: string, regExp: RegExp, msg?: string): void;
+
+            // file().and.equal(otherPath)
+            fileEqual(path: string, otherPath: string, msg?: string): void;
+            notFileEqual(path: string, otherPath: string, msg?: string): void;
+
+            // file().with.json
+            jsonFile(path: string, msg?: string): void;
+            notJsonFile(path: string, msg?: string): void;
+
+            //file().using.json.schema(obj)
+            jsonSchemaFile(path: string, schema: any, msg?: string): void;
+            notJsonSchemaFile(path: string, schema: any, msg?: string): void;
+            schema(obj: object): void;
+        }
+    }
+}
+
+
+declare function chaiFs(chai: any, utils: any): void;
+export = chaiFs;
+
+interface Object {
+    should: Chai.Assertion;
+}

--- a/types/chai-fs/index.d.ts
+++ b/types/chai-fs/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/chaijs/chai-fs
 // Definitions by: Dimitar Danailov <https://github.com/Nemo157>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.0.2
+// TypeScript Version: 2.2
 
 /// <reference types="node" />
 /// <reference types="chai" />

--- a/types/chai-fs/index.d.ts
+++ b/types/chai-fs/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/chaijs/chai-fs
 // Definitions by: Dimitar Danailov <https://github.com/Nemo157>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.0.0
+// TypeScript Version: v2.0.2
 
 /// <reference types="node" />
 /// <reference types="chai" />

--- a/types/chai-fs/index.d.ts
+++ b/types/chai-fs/index.d.ts
@@ -1,9 +1,8 @@
 // Type definitions for chai-fs 2.0
 // Project: https://github.com/chaijs/chai-fs
 // Definitions by: Dimitar Danailov <https://github.com/Nemo157>
-//
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.0.1
+// TypeScript Version: 2.0.0
 
 /// <reference types="node" />
 /// <reference types="chai" />

--- a/types/chai-fs/index.d.ts
+++ b/types/chai-fs/index.d.ts
@@ -9,7 +9,6 @@
 
 declare global {
     namespace Chai {
-
         interface TypeComparison {
             path(msg?: string): Assertion;
             directory(msg?: string): Assertion;
@@ -35,8 +34,7 @@ declare global {
 
         interface Assertion extends LanguageChains, NumericComparison, TypeComparison {
             // Basename
-            basename(name: string, msg?: string): Assertion;
-            basename(path: string, name: string, msg?: string): Assertion;
+            basename(path?: string, name?: string, msg?: string): Assertion;
             notBasename(path: string, name: string, msg?: string): Assertion;
 
             // Dirname
@@ -44,8 +42,7 @@ declare global {
             notDirname(path: string, name: string, msg?: string): Assertion;
 
             // Еxtname
-            extname(name: string, msg?: string): Assertion;
-            extname(path: string, name: string, msg?: string): Assertion;
+            extname(path: string, name?: string, msg?: string): Assertion;
             notExtname(path: string, name: string, msg?: string): Assertion;
 
             // Path
@@ -79,7 +76,7 @@ declare global {
             notDirectoryIncludeFiles(path: string, array: any[], msg?: string): Assertion;
 
             // directory().with.subDirs([...])
-            subDirs(array: any[], msg? :string): Assertion;
+            subDirs(array: any[], msg?: string): Assertion;
             directorySubDirs(path: string, array: any[], msg?: string): Assertion;
             notDirectorySubDirs(path: string, array: any[], msg?: string): Assertion;
             directoryDeepSubDirs(path: string, array: any[], msg?: string): Assertion;
@@ -118,26 +115,22 @@ declare global {
             jsonFile(path: string, msg?: string): Assertion;
             notJsonFile(path: string, msg?: string): Assertion;
 
-            //file().using.json.schema(obj)
+            // file().using.json.schema(obj)
             jsonSchemaFile(path: string, schema: any, msg?: string): Assertion;
             notJsonSchemaFile(path: string, schema: any, msg?: string): Assertion;
             schema(obj: object): Assertion;
         }
 
-        export interface Assert {
-
+        interface Assert {
             // Basename
-            basename(name: string, msg?: string): void;
-            basename(path: string, name: string, msg: string): void;
+            basename(path: string, name: string, msg?: string): void;
             notBasename(path: string, name: string, msg?: string): void;
 
             // Dirname
-            dirname(name: string, msg?: string): void;
-            dirname(path: string, name: string, msg?: string): void;
+            dirname(path: string, name?: string, msg?: string): void;
             notDirname(path: string, name: string, msg?: string): void;
 
             // Еxtname
-            extname(name: string, msg?: string): void;
             extname(path: string, name: string, msg?: string): void;
             notExtname(path: string, name: string, msg?: string): void;
 
@@ -174,7 +167,7 @@ declare global {
             notDirectoryIncludeFiles(path: string, array: any[], msg?: string): void;
 
             // directory().with.subDirs([...])
-            subDirs(array: any[], msg? :string): void;
+            subDirs(array: any[], msg?: string): void;
             directorySubDirs(path: string, array: any[], msg?: string): void;
             notDirectorySubDirs(path: string, array: any[], msg?: string): void;
             directoryDeepSubDirs(path: string, array: any[], msg?: string): void;
@@ -213,14 +206,13 @@ declare global {
             jsonFile(path: string, msg?: string): void;
             notJsonFile(path: string, msg?: string): void;
 
-            //file().using.json.schema(obj)
+            // file().using.json.schema(obj)
             jsonSchemaFile(path: string, schema: any, msg?: string): void;
             notJsonSchemaFile(path: string, schema: any, msg?: string): void;
             schema(obj: object): void;
         }
     }
 }
-
 
 declare function chaiFs(chai: any, utils: any): void;
 export = chaiFs;

--- a/types/chai-fs/index.d.ts
+++ b/types/chai-fs/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/chaijs/chai-fs
 // Definitions by: Dimitar Danailov <https://github.com/Nemo157>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: v2.0.2
+// TypeScript Version: 2.0.2
 
 /// <reference types="node" />
 /// <reference types="chai" />

--- a/types/chai-fs/tsconfig.json
+++ b/types/chai-fs/tsconfig.json
@@ -6,7 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
-        "strictNullChecks": false,
+        "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/chai-fs/tsconfig.json
+++ b/types/chai-fs/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": false,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "chai-fs-tests.ts"
+    ]
+}

--- a/types/chai-fs/tslint.json
+++ b/types/chai-fs/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
My pull request covers: https://github.com/chaijs/chai-fs definitions. 

My pull request doesn't covers these combinations:
```
expect(path).to.be.a.file(msg).with.contents.that.match(/xyz/, msg);
expect(path).to.be.a.file(msg).and.not.have.contents.that.match(/xyz/, msg);

path.should.be.a.file(msg).with.contents.that.match(/xyz/, msg);
path.should.be.a.file(msg).and.not.have.contents.that.match(/xyz/, msg);
```

Example: 
<img width="600" alt="screenshot 2018-10-04 at 10 06 06" src="https://user-images.githubusercontent.com/2182018/46458254-d15bc980-c7bd-11e8-98bb-a6a38e385fef.png">

@jedmao, @Bartvds, @AGBrown, @olivr70, @mwistrand, @joshuakgoldberg, @shaunluttin, @Naktibalda, @micksatana, @ErikSchierboom

Guys: Do you have an idea how to resolve this issue ? 
