### PR TITLE
Type definitions for array.prototype.flatmap

### DIFF
--- a/types/array.prototype.flatmap/array.prototype.flatmap-tests.ts
+++ b/types/array.prototype.flatmap/array.prototype.flatmap-tests.ts
@@ -1,0 +1,39 @@
+import flatMap = require("array.prototype.flatmap");
+import flatMapImpl = require("array.prototype.flatmap/implementation");
+import getPolyfill = require("array.prototype.flatmap/polyfill");
+import shim = require("array.prototype.flatmap/shim");
+
+// infers type of the output array from the return type of the callback
+flatMap(["foo"], word => word.split("")); // $ExpectType string[]
+flatMapImpl(["foo"], word => word.split("")); // $ExpectType string[]
+
+// infers the type of the value argument to the callback
+flatMap([1, 2], word => word.split("")); // $ExpectError
+flatMapImpl([1, 2], word => word.split("")); // $ExpectError
+
+// the callback must return an array
+flatMap([1, 2], word => word); // $ExpectError
+flatMapImpl([1, 2], word => word); // $ExpectError
+
+// the callback accepts an index argument
+flatMap(["foo"], (_, index) => [index]); // $ExpectType number[]
+flatMapImpl(["foo"], (_, index) => [index]); // $ExpectType number[]
+
+// the callback accepts an argument that refers to the original array
+flatMap(["foo"], (_, __, input) => input); // $ExpectType string[]
+flatMapImpl(["foo"], (_, __, input) => input); // $ExpectType string[]
+
+// the third argument is used as the calling context for the callback
+flatMap(["foo"], function() { return this.foo; }, { foo: [1, 2] }); // $ExpectType number[]
+flatMapImpl(["foo"], function() { return this.foo; }, { foo: [1, 2] }); // $ExpectType number[]
+
+// assumes that value of `this` in callback is `undefined` by default (this is
+// accurate in strict mode)
+flatMap([1], function() { return [this]; }); // $ExpectType undefined[]
+flatMapImpl([1], function() { return [this]; }); // $ExpectType undefined[]
+
+// `getPolyfill` returns a flatMap implementation
+getPolyfill()(["foo"], word => word.split("")); // $ExpectType string[]
+
+// `shim` installs a flatMap implementation in `Array` prototype and returns it
+shim()(["foo"], word => word.split("")); // $ExpectType string[]

--- a/types/array.prototype.flatmap/array.prototype.flatmap-tests.ts
+++ b/types/array.prototype.flatmap/array.prototype.flatmap-tests.ts
@@ -1,4 +1,5 @@
 import flatMap = require("array.prototype.flatmap");
+import "array.prototype.flatmap/auto";
 import flatMapImpl = require("array.prototype.flatmap/implementation");
 import getPolyfill = require("array.prototype.flatmap/polyfill");
 import shim = require("array.prototype.flatmap/shim");
@@ -6,31 +7,38 @@ import shim = require("array.prototype.flatmap/shim");
 // infers type of the output array from the return type of the callback
 flatMap(["foo"], word => word.split("")); // $ExpectType string[]
 flatMapImpl(["foo"], word => word.split("")); // $ExpectType string[]
+["foo"].flatMap(word => word.split("")); // $ExpectType string[]
 
 // infers the type of the value argument to the callback
 flatMap([1, 2], word => word.split("")); // $ExpectError
 flatMapImpl([1, 2], word => word.split("")); // $ExpectError
+[1, 2].flatMap(word => word.split("")); // $ExpectError
 
 // the callback must return an array
 flatMap([1, 2], word => word); // $ExpectError
 flatMapImpl([1, 2], word => word); // $ExpectError
+[1, 2].flatMap(word => word); // $ExpectError
 
 // the callback accepts an index argument
 flatMap(["foo"], (_, index) => [index]); // $ExpectType number[]
 flatMapImpl(["foo"], (_, index) => [index]); // $ExpectType number[]
+["foo"].flatMap((_, index) => [index]); // $ExpectType number[]
 
 // the callback accepts an argument that refers to the original array
 flatMap(["foo"], (_, __, input) => input); // $ExpectType string[]
 flatMapImpl(["foo"], (_, __, input) => input); // $ExpectType string[]
+["foo"].flatMap((_, __, input) => input); // $ExpectType string[]
 
 // the third argument is used as the calling context for the callback
 flatMap(["foo"], function() { return this.foo; }, { foo: [1, 2] }); // $ExpectType number[]
 flatMapImpl(["foo"], function() { return this.foo; }, { foo: [1, 2] }); // $ExpectType number[]
+["foo"].flatMap(function() { return this.foo; }, { foo: [1, 2] }); // $ExpectType number[]
 
 // assumes that value of `this` in callback is `undefined` by default (this is
 // accurate in strict mode)
 flatMap([1], function() { return [this]; }); // $ExpectType undefined[]
 flatMapImpl([1], function() { return [this]; }); // $ExpectType undefined[]
+[1].flatMap(function() { return [this]; }); // $ExpectType undefined[]
 
 // `getPolyfill` returns a flatMap implementation
 getPolyfill()(["foo"], word => word.split("")); // $ExpectType string[]

--- a/types/array.prototype.flatmap/auto.d.ts
+++ b/types/array.prototype.flatmap/auto.d.ts
@@ -1,2 +1,6 @@
-declare const noExports: {};
-export default noExports;
+interface Array<T> {
+    flatMap<U, R extends object | undefined = undefined>(
+        fn: (this: R, x: T, index: number, array: this) => U[],
+        thisArg?: R
+    ): U[];
+}

--- a/types/array.prototype.flatmap/auto.d.ts
+++ b/types/array.prototype.flatmap/auto.d.ts
@@ -1,0 +1,2 @@
+declare const noExports: {};
+export default noExports;

--- a/types/array.prototype.flatmap/implementation.d.ts
+++ b/types/array.prototype.flatmap/implementation.d.ts
@@ -1,0 +1,7 @@
+// This is the same type as the callable signature in `FlatMap` in `index.d.ts`.
+declare function flatMap<A, B, T extends object | undefined = undefined>(
+    xs: ReadonlyArray<A>,
+    fn: (this: T, x: A, index: number, array: A[]) => B[],
+        thisArg?: T
+): B[];
+export = flatMap;

--- a/types/array.prototype.flatmap/implementation.d.ts
+++ b/types/array.prototype.flatmap/implementation.d.ts
@@ -2,6 +2,6 @@
 declare function flatMap<A, B, T extends object | undefined = undefined>(
     xs: ReadonlyArray<A>,
     fn: (this: T, x: A, index: number, array: A[]) => B[],
-        thisArg?: T
+    thisArg?: T
 ): B[];
 export = flatMap;

--- a/types/array.prototype.flatmap/index.d.ts
+++ b/types/array.prototype.flatmap/index.d.ts
@@ -1,0 +1,21 @@
+// Type definitions for array.prototype.flatmap 1.2
+// Project: https://github.com/es-shims/Array.prototype.flatMap#readme
+// Definitions by: Jesse Hallett <https://github.com/hallettj>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
+
+import flatMapImpl = require("./implementation");
+
+interface FlatMap {
+    <A, B, T extends object | undefined = undefined>(
+        xs: ReadonlyArray<A>,
+        fn: (this: T, x: A, index: number, array: A[]) => B[],
+            thisArg?: T
+    ): B[];
+    getPolyfill(): typeof flatMapImpl;
+    implementation: typeof flatMapImpl;
+    shim(): typeof flatMapImpl;
+}
+
+declare const flatMap: FlatMap;
+export = flatMap;

--- a/types/array.prototype.flatmap/index.d.ts
+++ b/types/array.prototype.flatmap/index.d.ts
@@ -10,7 +10,7 @@ interface FlatMap {
     <A, B, T extends object | undefined = undefined>(
         xs: ReadonlyArray<A>,
         fn: (this: T, x: A, index: number, array: A[]) => B[],
-            thisArg?: T
+        thisArg?: T
     ): B[];
     getPolyfill(): typeof flatMapImpl;
     implementation: typeof flatMapImpl;

--- a/types/array.prototype.flatmap/polyfill.d.ts
+++ b/types/array.prototype.flatmap/polyfill.d.ts
@@ -1,0 +1,4 @@
+import flatMap = require("./implementation");
+
+declare function getPolyfill(): typeof flatMap;
+export = getPolyfill;

--- a/types/array.prototype.flatmap/shim.d.ts
+++ b/types/array.prototype.flatmap/shim.d.ts
@@ -1,0 +1,4 @@
+import flatMap = require("./implementation");
+
+declare function shim(): typeof flatMap;
+export = shim;

--- a/types/array.prototype.flatmap/tsconfig.json
+++ b/types/array.prototype.flatmap/tsconfig.json
@@ -1,0 +1,27 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "array.prototype.flatmap-tests.ts",
+        "auto.d.ts",
+        "implementation.d.ts",
+        "index.d.ts",
+        "polyfill.d.ts",
+        "shim.d.ts"
+    ]
+}

--- a/types/array.prototype.flatmap/tslint.json
+++ b/types/array.prototype.flatmap/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [✔] Use a meaningful title for the pull request. Include the name of the package modified.
- [✔] Test the change in your own code. (Compile and run.)
- [✔] Add or edit tests to reflect the change. (Run with `npm test`.)
- [✔] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [✔] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [✔] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [✔] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [✔] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [✔] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [✔] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

Notes:

The modules in array.prototype.flatmap set their export values to functions, so I had to use the `export = ...` construct in declaration files to accurately describe the behavior of the package, and use `import ... = require("...")` to import non-module values.

One module, described by `auto.d.ts`, does not export anything. Importing the `/auto` module has the side-effect of installing a `flatMap` method on the `Array` prototype if necessary. The linter objected to an empty declaration file; so I declared a phony empty object default export. I don't know if that is the best solution.