### PR TITLE
Add JSX Elements support to Notifications Interface

### DIFF
--- a/types/react-notification-system/index.d.ts
+++ b/types/react-notification-system/index.d.ts
@@ -18,8 +18,8 @@ declare namespace NotificationSystem {
     export type CallBackFunction = (notification: Notification) => void;
 
     export interface Notification {
-        title?: string;
-        message?: string;
+        title?: string | JSX.Element;
+        message?: string | JSX.Element;
         level?: "error" | "warning" | "info" | "success";
         position?: "tr" | "tl" | "tc" | "br" | "bl" | "bc";
         autoDismiss?: number;


### PR DESCRIPTION
Allow JSX Elements as added types for title/message properties of the Notification interface. This will allow custom html tags like spans and divs with more control over the notifications' appearance, as is possible in the js module.

For example:
```
notificationSystem.addNotification({
      title: <span data-notify="icon" className="pe-7s-gift" />,
      message: (
        <div>
          Welcome to <b>this app</b> - a great notification demo!
        </div>
      )
    });
```
