### PR TITLE
create AposConstructor Type, add beforeConstruct in ModuleOptions

### DIFF
--- a/types/apostrophe/index.d.ts
+++ b/types/apostrophe/index.d.ts
@@ -21,8 +21,15 @@ declare namespace apostrophe {
     // Pass in custom modules as first argument
     // second argument is additional custom options e.g. restApi exposed by apostrophe-headless
     interface AposConstructor<M = {}, O = {}> {
-        shortName: string;
+        afterInit?: () => void;
+        afterListen?: () => void;
+        initFailed?: (error: any) => void;
+        baseUrl?: string;
         modules: { [K in AposCoreModules & M]?: AposModuleOptions | O };
+        prefix?: string;
+        root?: string;
+        rootDir?: string;
+        shortName: string;
     }
 
     const ui: {

--- a/types/apostrophe/index.d.ts
+++ b/types/apostrophe/index.d.ts
@@ -7,13 +7,23 @@
 export = apostrophe;
 export as namespace apos;
 
-declare function apostrophe(options: any, ...args: any[]): any;
+declare function apostrophe(
+    options: apostrophe.AposConstructor,
+    ...args: any[]
+): any;
 
 declare namespace apostrophe {
     const moogBundle: {
         directory: string;
         modules: string[];
     };
+
+    // Pass in custom modules as first argument
+    // second argument is additional custom options e.g. restApi exposed by apostrophe-headless
+    interface AposConstructor<M = {}, O = {}> {
+        shortName: string;
+        modules: { [K in AposCoreModules & M]?: AposModuleOptions | O };
+    }
 
     const ui: {
         globalBusy: (state: any) => any;
@@ -290,6 +300,7 @@ declare namespace apostrophe {
             label: string;
             fields: string[];
         }[];
+        beforeConstruct?: (self: any, options: any) => any;
         defer?: boolean;
         filters?: {
             projection?: {


### PR DESCRIPTION
Please fill in this template.

- [ ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
