### PR TITLE
[React] Add align attribute to Td and Th

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -1697,6 +1697,7 @@ declare namespace React {
     }
 
     interface TdHTMLAttributes<T> extends HTMLAttributes<T> {
+        align?: string;
         colSpan?: number;
         headers?: string;
         rowSpan?: number;
@@ -1704,6 +1705,7 @@ declare namespace React {
     }
 
     interface ThHTMLAttributes<T> extends HTMLAttributes<T> {
+        align?: string;
         colSpan?: number;
         headers?: string;
         rowSpan?: number;

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -1697,7 +1697,7 @@ declare namespace React {
     }
 
     interface TdHTMLAttributes<T> extends HTMLAttributes<T> {
-        align?: string;
+        align?: "left" | "center" | "right" | "justify" | "char";
         colSpan?: number;
         headers?: string;
         rowSpan?: number;
@@ -1705,7 +1705,7 @@ declare namespace React {
     }
 
     interface ThHTMLAttributes<T> extends HTMLAttributes<T> {
-        align?: string;
+        align?: "left" | "center" | "right" | "justify" | "char";
         colSpan?: number;
         headers?: string;
         rowSpan?: number;


### PR DESCRIPTION
This adds the `align` attribute to the type definitions for `tr` and `th` in React. https://developer.mozilla.org/en-US/docs/Web/HTML/Element/tr#Attributes

The `align` attribute is deprecated, but it works in all major browsers and can be very useful in situations where flexbox is not available, such as in HTML emails. The CSS `text-align` property does not fully replace the functionality of the `align` attribute, as it only works on text.