### PR TITLE
touch: Add closeAfter option

### DIFF
--- a/types/touch/index.d.ts
+++ b/types/touch/index.d.ts
@@ -18,6 +18,7 @@ declare namespace touch {
         mtime?: boolean | Date;
         ref?: string;
         nocreate?: boolean;
+        closeAfter?: boolean;
     }
 
     function sync(filename: string, options?: Options): void;

--- a/types/touch/touch-tests.ts
+++ b/types/touch/touch-tests.ts
@@ -25,6 +25,8 @@ opts.ref = strVal;
 
 opts.nocreate = boolVal;
 
+opts.closeAfter = boolVal;
+
 let str: string;
 // touch API tests
 touch(strVal, (e) => console.log(e));


### PR DESCRIPTION
The `closeAfter` option exists in the [source](https://github.com/isaacs/node-touch/blob/master/index.js) but was missing from the typings.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/isaacs/node-touch/blob/master/index.js#L76
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.