### PR TITLE
webauthn: Mark `rpId` and `allowCredentials` as optional for `PublicKeyCredentialRequestOptions`.

### DIFF
--- a/types/webappsec-credential-management/index.d.ts
+++ b/types/webappsec-credential-management/index.d.ts
@@ -392,8 +392,8 @@ type UserVerificationRequirement = "required" | "preferred" | "discouraged";
 interface PublicKeyCredentialRequestOptions {
     challenge: BufferSource;
     timeout: number;
-    rpId: string;
-    allowCredentials: PublicKeyCredentialDescriptor[];
+    rpId?: string;
+    allowCredentials?: PublicKeyCredentialDescriptor[];
     userVerification?: UserVerificationRequirement;
     extensions?: any;
 }


### PR DESCRIPTION
As documented at
https://w3c.github.io/webauthn/#dictdef-publickeycredentialrequestoptions
(already linked in the comment for the interface), the the `rpId` and and
`allowCredentials` fields are optional.
