### PR TITLE
hls.js  Fix typo for startFragPrefetch config

### DIFF
--- a/types/hls.js/hls.js-tests.ts
+++ b/types/hls.js/hls.js-tests.ts
@@ -23,7 +23,7 @@ class pLoader extends Hls.DefaultConfig.loader {
 
 if (Hls.isSupported()) {
     const video = <HTMLVideoElement> document.getElementById('video');
-    const hls = new Hls({ pLoader });
+    const hls = new Hls({ pLoader, startFragPrefetch: true });
     const version: string = Hls.version;
     hls.loadSource('http://www.streambox.fr/playlists/test_001/stream.m3u8');
     hls.attachMedia(video);

--- a/types/hls.js/index.d.ts
+++ b/types/hls.js/index.d.ts
@@ -567,7 +567,7 @@ declare namespace Hls {
          * (default: false)
          * Start prefetching start fragment although media not attached yet. Max number of append retries.
          */
-        startFragPrefech: boolean;
+        startFragPrefetch: boolean;
         /**
          * (default: 3)
          * Max number of sourceBuffer.appendBuffer() retry upon error. Such error could happen in loop with UHD streams, when internal buffer is full. (Quota Exceeding Error will be triggered).


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/video-dev/hls.js/blob/master/docs/API.md#startfragprefetch>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

Fix for issue https://github.com/DefinitelyTyped/DefinitelyTyped/issues/29444