### PR TITLE
Add typings for react-google-login-component

### DIFF
--- a/types/react-google-login-component/index.d.ts
+++ b/types/react-google-login-component/index.d.ts
@@ -1,0 +1,24 @@
+// Type definitions for react-google-login-component 0.9
+// Project: https://github.com/kennetpostigo/react-google-login-component
+// Definitions by: Konstantin Lebedev <https://github.com/koss-lebedev>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.8
+
+import * as React from "react";
+
+export interface GoogleLoginInfo {
+    getAuthResponse: () => {
+        access_token: string;
+    };
+}
+
+export interface GoogleLoginProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+    socialId: string;
+    scope?: string;
+    fetchBasicProfile?: boolean;
+    buttonText?: string;
+    prompt?: string;
+    responseHandler: (response: GoogleLoginInfo) => void;
+}
+
+export class GoogleLogin extends React.Component<GoogleLoginProps> {}

--- a/types/react-google-login-component/react-google-login-component-tests.tsx
+++ b/types/react-google-login-component/react-google-login-component-tests.tsx
@@ -1,0 +1,24 @@
+import { GoogleLogin, GoogleLoginInfo } from "react-google-login-component";
+import * as React from "react";
+
+const handler = (response: GoogleLoginInfo) => {
+    console.log(response.getAuthResponse().access_token);
+};
+
+const ReactGoogleLoginComponent: JSX.Element = (
+    <GoogleLogin
+        socialId="1234567890000"
+        responseHandler={handler}
+    />
+);
+
+const ReactGoogleLoginComponentAllOptions: JSX.Element = (
+    <GoogleLogin
+        socialId="1234567890000"
+        responseHandler={handler}
+        scope="profile"
+        fetchBasicProfile
+        prompt="select_account"
+        buttonText="Sign in with Google"
+    />
+);

--- a/types/react-google-login-component/tsconfig.json
+++ b/types/react-google-login-component/tsconfig.json
@@ -1,0 +1,26 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "target": "es6",
+        "jsx": "react",
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "react-google-login-component-tests.tsx"
+    ]
+}

--- a/types/react-google-login-component/tslint.json
+++ b/types/react-google-login-component/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
This PR is to add typings for `react-google-login-component` package (https://github.com/kennetpostigo/react-google-login-component)

The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`