### PR TITLE
[@types/react-table] SortFunction signature should match Array.sort

### DIFF
--- a/types/react-table/index.d.ts
+++ b/types/react-table/index.d.ts
@@ -27,7 +27,7 @@ export type SortedChangeFunction = (newSorted: SortingRule[], column: any, addit
 export type FilteredChangeFunction = (newFiltering: Filter[], column: any, value: any) => void;
 export type ExpandedChangeFunction = (column: any, event: any, isTouch: boolean) => void;
 export type ResizedChangeFunction = (newResized: Resize[], event: any) => void;
-export type SortFunction = (a: any, b: any, desc: any) => -1 | 0 | 1;
+export type SortFunction = (a: any, b: any, desc: any) => number;
 
 export interface Resize {
     id: string;


### PR DESCRIPTION
-1 and 1 aren't the only numbers allowed. Any number less than or greater than 0 will sort the item properly.
This enables shortcuts like (a, b) => a - b;
Restricting the signature to -1 | 0 | 1 is a mistake.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)