### PR TITLE
Add `in()`, `out()` & `command()` definitions for gm package

### DIFF
--- a/types/gm/gm-tests.ts
+++ b/types/gm/gm-tests.ts
@@ -63,6 +63,9 @@ declare const quality: number;
 declare const align: string;
 declare const depth: number;
 declare const defineValue: string;
+declare const customCommand: string;
+declare const customInArguments: string[];
+declare const customOutArguments: string[];
 let readStream: stream.PassThrough;
 
 gm(src)
@@ -95,6 +98,7 @@ gm(src)
 	.colorMap(type)
 	.colors(numColors)
 	.colorspace(type)
+	.command(customCommand)
 	.compose(operator)
 	.compress(type)
 	.contrast(multiplier)
@@ -147,6 +151,7 @@ gm(src)
 	.iconGeometry(geometry)
 	.implode()
 	.implode(factor)
+	.in(...customInArguments)
 	.intent(type)
 	.interlace(type)
 	.label(name)
@@ -192,6 +197,7 @@ gm(src)
 	.operator(channel, operator, factor)
 	.operator(channel, operator, factor, usePercent)
 	.orderedDither(channel, NxN)
+	.out(...customOutArguments)
 	.outputDirectory(dest)
 	.page(width, height)
 	.page(width, height, options)

--- a/types/gm/index.d.ts
+++ b/types/gm/index.d.ts
@@ -1,6 +1,8 @@
 // Type definitions for gm 1.18
 // Project: https://github.com/aheckmann/gm
-// Definitions by: Joel Spadin <https://github.com/ChaosinaCan>, Maarten van Vliet <https://github.com/maartenvanvliet>
+// Definitions by:  Joel Spadin <https://github.com/ChaosinaCan>
+//                  Maarten van Vliet <https://github.com/maartenvanvliet>
+//                  Vaclav Mlejnsky <https://github.com/mlejva>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node"/>
@@ -115,6 +117,7 @@ declare namespace m {
         colorMap(type: 'shared' | 'private' | string): State;
         colors(colors: number): State;
         colorspace(space: ColorSpace | string): State;
+        command(customCommand: string): State;
         compose(operator: ComposeOperator | string): State;
         compress(type: CompressionType | string): State;
         contrast(multiplier: number): State;
@@ -157,6 +160,7 @@ declare namespace m {
         highlightStyle(style: HighlightStyle | string): State;
         iconGeometry(geometry: string): State;
         implode(factor?: number): State;
+        in(...customArguments: string[]): State;
         intent(type: IntentType | string): State;
         interlace(type: InterlaceType | string): State;
         label(name: string): State;
@@ -190,6 +194,7 @@ declare namespace m {
         opaque(color: string): State;
         operator(channel: string, operator: ChannelOperator | string, rvalue: number, percent?: boolean): State;
         orderedDither(channelType: ChannelType | string, NxN: string): State;
+        out(...customArguments: string[]): State;
         outputDirectory(directory: string): State;
         page(width: number, height: number, arg?: '%' | '!' | '<' | '>' |string): State;
         pause(seconds: number): State;


### PR DESCRIPTION
Definitions for [gm](https://github.com/aheckmann/gm) package are missing 3 methods - `command()`, `in()` and `out()`.
Usage of these methods is described [here](https://github.com/aheckmann/gm#custom-arguments).

Basically methods `in()` and `out()` take arbitrary number of string parameters and are used if GM doesn't provide an interface to specify certain arguments. Method `command()` takes a single string parameter and is used when GM doesn't implement an option to call certain method.


Also, this should resolve #24795

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/aheckmann/gm#custom-arguments>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.