### PR TITLE
Revert "[react-dom] there is no type named `Text`"

### DIFF
--- a/types/react-dom/index.d.ts
+++ b/types/react-dom/index.d.ts
@@ -5,7 +5,6 @@
 //                 Microsoft <https://microsoft.com>
 //                 MartynasZilinskas <https://github.com/MartynasZilinskas>
 //                 Josh Rutherford <https://github.com/theruther4d>
-//                 JounQin <https://github.com/JounQin>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -17,7 +16,7 @@ import {
     DOMAttributes, DOMElement, ReactNode, ReactPortal
 } from 'react';
 
-export function findDOMNode(instance: ReactInstance): Element | string | null;
+export function findDOMNode(instance: ReactInstance): Element | null | Text;
 export function unmountComponentAtNode(container: Element): boolean;
 
 export function createPortal(children: ReactNode, container: Element, key?: null | string): ReactPortal;


### PR DESCRIPTION
Commit 96205f1 introduced a breaking change to `react-dom`. `ReactDOM.findDOMNode`’s return type was changed from a `Text` element to a plain `string`. The original return type was correct.

Context is [here](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/28936#issuecomment-427449252), and I’ve copied over the relevant bits:

> The return type for `ReactDOM.findDOMNode` is either `null`, an `Element`, or a `Text` _element_:
>
> https://github.com/facebook/react/blob/0dc0ddc/packages/react-dom/src/client/ReactDOM.js#L591-L593
>
> `string` is not equivalent to a `Text` element.

----

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/facebook/react/blob/0dc0ddc/packages/react-dom/src/client/ReactDOM.js#L591-L593
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

