### PR TITLE
@types/node: Add missing 'verbatim' option in dns.resolve

### DIFF
--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -2651,6 +2651,7 @@ declare module "dns" {
         family?: number;
         hints?: number;
         all?: boolean;
+        verbatim?: boolean;
     }
 
     interface LookupOneOptions extends LookupOptions {

--- a/types/node/node-tests.ts
+++ b/types/node/node-tests.ts
@@ -3491,6 +3491,10 @@ import * as p from "process";
         const _err: NodeJS.ErrnoException = err;
         const _address: dns.LookupAddress[] = addresses;
     });
+    dns.lookup("nodejs.org", { all: true, verbatim: true }, (err, addresses) => {
+        const _err: NodeJS.ErrnoException = err;
+        const _address: dns.LookupAddress[] = addresses;
+    });
 
     function trueOrFalse(): boolean {
         return Math.random() > 0.5 ? true : false;

--- a/types/node/v8/index.d.ts
+++ b/types/node/v8/index.d.ts
@@ -2434,6 +2434,7 @@ declare module "dns" {
         family?: number;
         hints?: number;
         all?: boolean;
+        verbatim?: boolean;
     }
 
     export interface LookupOneOptions extends LookupOptions {

--- a/types/node/v8/node-tests.ts
+++ b/types/node/v8/node-tests.ts
@@ -3075,6 +3075,10 @@ namespace dns_tests {
         const _err: NodeJS.ErrnoException = err;
         const _address: dns.LookupAddress[] = addresses;
     });
+    dns.lookup("nodejs.org", { all: true, verbatim: true }, (err, addresses) => {
+        const _err: NodeJS.ErrnoException = err;
+        const _address: dns.LookupAddress[] = addresses;
+    });
 
     function trueOrFalse(): boolean {
         return Math.random() > 0.5 ? true : false;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/api/dns.html#dns_dns_lookup_hostname_options_callback
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
