### PR TITLE
allow GraphQLNonNull usage with and without new

### DIFF
--- a/types/graphql/index.d.ts
+++ b/types/graphql/index.d.ts
@@ -15,6 +15,7 @@
 //                 Divyendu Singh <https://github.com/divyenduz>
 //                 Brad Zacher <https://github.com/bradzacher>
 //                 Curtis Layne <https://github.com/clayne11>
+//                 Jonathan Cardoso <https://github.com/JCMais>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 

--- a/types/graphql/type/definition.d.ts
+++ b/types/graphql/type/definition.d.ts
@@ -194,7 +194,7 @@ interface GraphQLNonNullI<T extends GraphQLNullableType> {
   new (type: T): GraphQLNonNull<T>;
 }
 
-declare const GraphQLNonNull: GraphQLNonNullI<any>;
+declare const GraphQLNonNull: GraphQLNonNullI<GraphQLNullableType>;
 
 export type GraphQLWrappingType = GraphQLList<any> | GraphQLNonNull<any>;
 

--- a/types/graphql/type/definition.d.ts
+++ b/types/graphql/type/definition.d.ts
@@ -154,13 +154,20 @@ export function assertAbstractType(type: any): GraphQLAbstractType;
  *     })
  *
  */
-export class GraphQLList<T extends GraphQLType> {
+interface GraphQLList<T extends GraphQLType> {
     readonly ofType: T;
-    constructor(ofType: T);
     toString(): string;
     toJSON(): string;
     inspect(): string;
 }
+
+
+interface _GraphQLList<T extends GraphQLType> {
+    (type: T): GraphQLList<T>;
+    new (type: T): GraphQLList<T>;
+}
+
+export const GraphQLList: _GraphQLList<GraphQLType>;
 
 /**
  * Non-Null Modifier
@@ -183,18 +190,18 @@ export class GraphQLList<T extends GraphQLType> {
  * Note: the enforcement of non-nullability occurs within the executor.
  */
 interface GraphQLNonNull<T extends GraphQLNullableType> {
-  readonly ofType: T;
-  toString(): string;
-  toJSON(): string;
-  inspect(): string;
+    readonly ofType: T;
+    toString(): string;
+    toJSON(): string;
+    inspect(): string;
 }
 
-interface GraphQLNonNullI<T extends GraphQLNullableType> {
-  (type: T): GraphQLNonNull<T>;
-  new (type: T): GraphQLNonNull<T>;
+interface _GraphQLNonNull<T extends GraphQLNullableType> {
+    (type: T): GraphQLNonNull<T>;
+    new (type: T): GraphQLNonNull<T>;
 }
 
-declare const GraphQLNonNull: GraphQLNonNullI<GraphQLNullableType>;
+export const GraphQLNonNull: _GraphQLNonNull<GraphQLNullableType>;
 
 export type GraphQLWrappingType = GraphQLList<any> | GraphQLNonNull<any>;
 

--- a/types/graphql/type/definition.d.ts
+++ b/types/graphql/type/definition.d.ts
@@ -182,13 +182,19 @@ export class GraphQLList<T extends GraphQLType> {
  *
  * Note: the enforcement of non-nullability occurs within the executor.
  */
-export class GraphQLNonNull<T extends GraphQLNullableType> {
-    readonly ofType: T;
-    constructor(ofType: T);
-    toString(): string;
-    toJSON(): string;
-    inspect(): string;
+interface GraphQLNonNull<T extends GraphQLNullableType> {
+  readonly ofType: T;
+  toString(): string;
+  toJSON(): string;
+  inspect(): string;
 }
+
+interface GraphQLNonNullI<T extends GraphQLNullableType> {
+  (type: T): GraphQLNonNull<T>;
+  new (type: T): GraphQLNonNull<T>;
+}
+
+declare const GraphQLNonNull: GraphQLNonNullI<any>;
 
 export type GraphQLWrappingType = GraphQLList<any> | GraphQLNonNull<any>;
 


### PR DESCRIPTION
I think this solves https://github.com/DefinitelyTyped/DefinitelyTyped/issues/28750

I ran it locally and tested, seems to be working fine.

before:
![image](https://user-images.githubusercontent.com/1041647/46566384-b8553480-c8f3-11e8-80c6-f5366199c2be.png)

after:
![image](https://user-images.githubusercontent.com/1041647/46566391-d9b62080-c8f3-11e8-8472-ebf205103e72.png)

still works with `new`:
![image](https://user-images.githubusercontent.com/1041647/46566411-1d108f00-c8f4-11e8-8ef0-2677edf315d4.png)


This does not follow the best practices in the Readme, so I don't know if this is going to be approved or not. If it's ok to do it that way, I will do the same changes to `GraphQLList`