### PR TITLE
Fix `FieldDefinitionNode.arguments` for graphql

### DIFF
--- a/types/graphql/index.d.ts
+++ b/types/graphql/index.d.ts
@@ -15,6 +15,7 @@
 //                 Divyendu Singh <https://github.com/divyenduz>
 //                 Brad Zacher <https://github.com/bradzacher>
 //                 Curtis Layne <https://github.com/clayne11>
+//                 Kevin Sullivan <https://github.com/awfulaxolotl>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 

--- a/types/graphql/language/ast.d.ts
+++ b/types/graphql/language/ast.d.ts
@@ -424,7 +424,7 @@ export interface FieldDefinitionNode {
     readonly loc?: Location;
     readonly description?: StringValueNode;
     readonly name: NameNode;
-    readonly arguments?: ReadonlyArray<InputValueDefinitionNode>;
+    readonly arguments: ReadonlyArray<InputValueDefinitionNode>;
     readonly type: TypeNode;
     readonly directives?: ReadonlyArray<DirectiveNode>;
 }


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/graphql/graphql-js/blob/787422956c9554d12d063a41fe35705335ec6290/src/language/printer.js#L139
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
