### PR TITLE
[jest] Restore SpyInstance interface

### DIFF
--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -726,6 +726,8 @@ declare namespace jest {
         (...args: any[]): any;
     }
 
+    interface SpyInstance<T = {}> extends MockInstance<T> {}
+
     /**
      * Wrap module with mock definitions
      *

--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -197,7 +197,7 @@ declare namespace jest {
      *   spy.mockRestore();
      * });
      */
-    function spyOn<T extends {}, M extends keyof T>(object: T, method: M, accessType?: 'get' | 'set'): MockInstance<T[M]>;
+    function spyOn<T extends {}, M extends keyof T>(object: T, method: M, accessType?: 'get' | 'set'): SpyInstance<T[M]>;
     /**
      * Indicates that the module system should never return a mocked version of
      * the specified module from require() (e.g. that it should always return the real module).

--- a/types/jest/jest-tests.ts
+++ b/types/jest/jest-tests.ts
@@ -313,6 +313,11 @@ const spy3Mock: jest.Mock<() => string> = spy3
     .mockRejectedValue("value")
     .mockRejectedValueOnce("value");
 
+let spy4: jest.SpyInstance;
+
+spy4 = jest.spyOn(spiedTarget, "returnsString");
+spy4.mockRestore();
+
 /* Snapshot serialization */
 
 const snapshotSerializerPlugin: jest.SnapshotSerializerPlugin = {


### PR DESCRIPTION
The `SpyInstance` interface was removed in #29306. The reason to remove it [was explained here](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/29296#issuecomment-425747382).

That was arguably a **breaking change** for those relying on `jest.SpyInstance` when it's used as a type in their code. For example, consider the following:

```ts
let someSpy: jest.SpyInstance; // this will break

someSpy = jest.spyOn(foo, 'someFunc');
```

Another issue related to that change was reported on https://github.com/typicode/husky/pull/374.

[A quick github search](https://github.com/search?q=%22jest.SpyInstance%22&type=Code) shows that `SpyInstance` used in a quite few places as well...

Therefore, I think it might be a good idea to restore it.

Please note that the difference between this PR and the code prior to #29306 is that:

- `SpyInstance` will be identical to `MockInstance` with no extra properties whatsoever.
- `spyOn` will now return a `SpyInstance` instead of `MockInstance`.
- `mockRestore` will continue to be declared on the `MockInstance`. The lack of that in the first place was the root cause of how all of this came about.
---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
