### PR TITLE
Fix wu.enumerate() definition error in 'wu' package

### DIFF
--- a/types/wu/index.d.ts
+++ b/types/wu/index.d.ts
@@ -27,7 +27,7 @@ declare namespace wu {
 	function cycle<T>(iter: Iterable<T>): Iterable<T>;
 	function chunk<T>(n: number, iter: Iterable<T>): WuIterable<T[]>;
 	function concatMap<T, U>(fn: (t: T) => Iterable<U>, iter: Iterable<T>): WuIterable<U>;
-	function enumerate<T>(iter: Iterable<T>): Iterable<[number, T]>;
+	function enumerate<T>(iter: Iterable<T>): Iterable<[T, number]>;
 	function every<T>(fn: Filter<T>, iter: Iterable<T>): boolean;
 	function filter<T>(fn: Filter<T>, iter: Iterable<T>): WuIterable<T>;
 	function find<T>(fn: Filter<T>, iter: Iterable<T>): T | undefined;
@@ -76,7 +76,7 @@ declare namespace wu {
 		cycle(): Iterable<T>;
 		chunk(n: number): WuIterable<T[]>;
 		concatMap<U>(fn: (t: T) => Iterable<U>): WuIterable<U>;
-		enumerate(): Iterable<[number, T]>;
+		enumerate(): Iterable<[T, number]>;
 		every(fn: Filter<T>): boolean;
 		filter(fn: Filter<T>): WuIterable<T>;
 		find(fn: Filter<T>): T | undefined;

--- a/types/wu/index.d.ts
+++ b/types/wu/index.d.ts
@@ -24,10 +24,10 @@ declare namespace wu {
 	function asyncEach(fn: Consumer<any>, maxBlock?: number, timeout?: number): void;
 	function drop<T>(n: number, iter: Iterable<T>): WuIterable<T>;
 	function dropWhile<T>(fn: Filter<T>, iter: Iterable<T>): WuIterable<T>;
-	function cycle<T>(iter: Iterable<T>): Iterable<T>;
+	function cycle<T>(iter: Iterable<T>): WuIterable<T>;
 	function chunk<T>(n: number, iter: Iterable<T>): WuIterable<T[]>;
 	function concatMap<T, U>(fn: (t: T) => Iterable<U>, iter: Iterable<T>): WuIterable<U>;
-	function enumerate<T>(iter: Iterable<T>): Iterable<[T, number]>;
+	function enumerate<T>(iter: Iterable<T>): WuIterable<[T, number]>;
 	function every<T>(fn: Filter<T>, iter: Iterable<T>): boolean;
 	function filter<T>(fn: Filter<T>, iter: Iterable<T>): WuIterable<T>;
 	function find<T>(fn: Filter<T>, iter: Iterable<T>): T | undefined;
@@ -73,10 +73,10 @@ declare namespace wu {
 		asyncEach(fn: Consumer<any>, maxBlock?: number, timeout?: number): any;
 		drop(n: number): WuIterable<T>;
 		dropWhile(fn: Filter<T>): WuIterable<T>;
-		cycle(): Iterable<T>;
+		cycle(): WuIterable<T>;
 		chunk(n: number): WuIterable<T[]>;
 		concatMap<U>(fn: (t: T) => Iterable<U>): WuIterable<U>;
-		enumerate(): Iterable<[T, number]>;
+		enumerate(): WuIterable<[T, number]>;
 		every(fn: Filter<T>): boolean;
 		filter(fn: Filter<T>): WuIterable<T>;
 		find(fn: Filter<T>): T | undefined;


### PR DESCRIPTION
The type definitions for wu.enumerate() had a mistake: the definitions had the tuple's types in the wrong order. The documentation and even the wu-tests.js file show the returned tuple having the index number second, not first. I tested to make sure this was right.

There was also an issue that the wu.enumerate() and wu.cycle() methods were marked as returning `Iterable` instead of `WuIterable` as every other method in wu returns. (I checked to make sure they do return this in practice.)
____

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://fitzgen.github.io/wu.js/#enumerate
