### PR TITLE
i18next: Fix `FormatFunction`'s value type

### DIFF
--- a/types/i18next/i18next-tests.ts
+++ b/types/i18next/i18next-tests.ts
@@ -386,8 +386,9 @@ i18next
         interpolation: {
             escapeValue: false, // not needed for react!!
             formatSeparator: ',',
-            format: (value: string, format: string, lng: string) => {
+            format: (value, format, lng) => {
                 if (format === 'uppercase') return value.toUpperCase();
+                if (value instanceof Date) return value.toLocaleString();
                 return value;
             }
         }

--- a/types/i18next/index.d.ts
+++ b/types/i18next/index.d.ts
@@ -4,6 +4,7 @@
 //                 Budi Irawan <https://github.com/deerawan>
 //                 Giedrius Grabauskas <https://github.com/GiedriusGrabauskas>
 //                 Silas Rech <https://github.com/lenovouser>
+//                 Philipp Katz <https://github.com/qqilihq>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -14,7 +15,7 @@ declare namespace i18next {
 
     type FallbackLng = string | string[] | FallbackLngObjList;
 
-    type FormatFunction = (value: string, format?: string, lng?: string) => string;
+    type FormatFunction = (value: any, format?: string, lng?: string) => string;
 
     /* tslint:disable-next-line:no-empty-interface */
     interface DetectionPluginOptions {


### PR DESCRIPTION
This is not necessarily a `string`, but can be of `any` type, see:
https://www.i18next.com/translation-function/formatting#basic

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.i18next.com/translation-function/formatting#basic
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
