### PR TITLE
[@types/firefox-webext-browser] tab changeInfo attention flag is optional

### DIFF
--- a/types/firefox-webext-browser/index.d.ts
+++ b/types/firefox-webext-browser/index.d.ts
@@ -6915,7 +6915,7 @@ declare namespace browser.tabs {
 
     type _TabsOnUpdatedEvent<T = (tabId: number, changeInfo: {
         /** The tab's new attention state. */
-        attention: boolean;
+        attention?: boolean;
         /** The tab's new audible state. */
         audible?: boolean;
         /** True while the tab is not loaded with content. */


### PR DESCRIPTION
As stated in the MDN the boolean attention flag in the `changeInfo` object is optional (see link below).

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
Not sure how this could be tested (or if it should).
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/tabs/onUpdated#changeInfo
- [x] Increase the version number in the header if appropriate.
Not appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
No substantial changes.
