### PR TITLE
Add typings for react-sticky-box package

### DIFF
--- a/types/react-sticky-box/index.d.ts
+++ b/types/react-sticky-box/index.d.ts
@@ -1,0 +1,22 @@
+// Type definitions for react-sticky-box 0.7
+// Project: https://github.com/codecks-io/react-sticky-box
+// Definitions by: Konstantin Lebedev <https://github.com/koss-lebedev>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.8
+
+import * as React from "react";
+
+declare namespace ReactStickyBox {
+  type StickyBoxMode = 'relative' | 'stickyBottom' | 'stickyTop';
+
+  interface StickyBoxProps {
+    bottom?: boolean;
+    offsetTop?: number;
+    offsetBottom?: number;
+    onChangeMode?: (oldMode: StickyBoxMode, newMode: StickyBoxMode) => void;
+  }
+}
+
+declare const ReactStickyBox: React.ComponentClass<ReactStickyBox.StickyBoxProps>;
+
+export = ReactStickyBox;

--- a/types/react-sticky-box/react-sticky-box-tests.tsx
+++ b/types/react-sticky-box/react-sticky-box-tests.tsx
@@ -1,0 +1,19 @@
+import ReactStickyBox, { StickyBoxMode } from "react-sticky-box";
+import * as React from "react";
+
+const ReactStickyBoxRequiredOptions: JSX.Element = (
+    <ReactStickyBox />
+);
+
+const changeHandler = (oldMode: StickyBoxMode, newMode: StickyBoxMode) => {
+    console.log(`Changing from ${oldMode} to ${newMode}`);
+};
+
+const ReactStickyBoxAllOptions: JSX.Element = (
+    <ReactStickyBox
+        bottom
+        offsetBottom={20}
+        offsetTop={10}
+        onChangeMode={changeHandler}
+    />
+);

--- a/types/react-sticky-box/tsconfig.json
+++ b/types/react-sticky-box/tsconfig.json
@@ -1,0 +1,26 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "jsx": "react",
+        "esModuleInterop": true
+    },
+    "files": [
+        "index.d.ts",
+        "react-sticky-box-tests.tsx"
+    ]
+}

--- a/types/react-sticky-box/tslint.json
+++ b/types/react-sticky-box/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
This PR is to add typings for `react-sticky-box` package (https://github.com/codecks-io/react-sticky-box)

The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`