### PR TITLE
React-native: SwitchProps updates to match source code

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -8087,16 +8087,25 @@ export interface SwitchPropsIOS extends ViewProps {
 
     /**
      * Color of the foreground switch grip.
+     *
+     * @deprecated
      */
     thumbTintColor?: string;
 
     /**
      * Background color when the switch is turned off.
+     *
+     * @deprecated
      */
     tintColor?: string;
 }
 
 export interface SwitchProps extends SwitchPropsIOS {
+    /**
+     * Color of the foreground switch grip.
+     */
+    thumbColor?: string;
+
     /**
      * Custom colors for the switch track
      *

--- a/types/react-native/test/index.tsx
+++ b/types/react-native/test/index.tsx
@@ -813,3 +813,7 @@ const NativeBridgedComponent = requireNativeComponent("NativeBridgedComponent", 
 const SwitchColorTest = () => (
     <Switch trackColor={{ true: 'pink', false: 'red'}} />
 )
+
+const SwitchThumbColorTest = () => (
+    <Switch thumbColor={'red'} />
+)


### PR DESCRIPTION
https://facebook.github.io/react-native/docs/next/switch
https://github.com/facebook/react-native/blob/0.57-stable/Libraries/Components/Switch/Switch.js

This PR is made to correctly represent the changes made to the source code. 
Documentation for 0.57 does not correspond correctly to the changes made to the source code in update 0.57. 

A PR is made to update the documentation:
https://github.com/facebook/react-native-website/pull/605

Changes:
thumbTintColor and tintColor is marked deprecated (line 107 in source code)
thumbColor is added as a prop (line 95 in source code)