### PR TITLE
[redis] change increase-by-float commands to reply a string

### DIFF
--- a/types/redis/index.d.ts
+++ b/types/redis/index.d.ts
@@ -1,5 +1,5 @@
 // Type definitions for redis 2.8
-// Project: https://github.com/mranney/node_redis
+// Project: https://github.com/NodeRedis/node_redis
 // Definitions by: Carlos Ballesteros Velasco <https://github.com/soywiz>
 //                 Peter Harris <https://github.com/CodeAnimal>
 //                 TANAKA Koichi <https://github.com/MugeSo>
@@ -7,6 +7,7 @@
 //                 Junyoung Choi <https://github.com/Rokt33r>
 //                 James Garbutt <https://github.com/43081j>
 //                 Bartek Szczepański <https://github.com/barnski>
+//                 Pirasis Leelatanon <https://github.com/1pete>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 // Imported from: https://github.com/types/npm-redis
@@ -488,8 +489,8 @@ export interface Commands<R> {
     /**
      * Increment the float value of a hash field by the given amount.
      */
-    hincrbyfloat(key: string, field: string, increment: number, cb?: Callback<number>): R;
-    HINCRBYFLOAT(key: string, field: string, increment: number, cb?: Callback<number>): R;
+    hincrbyfloat(key: string, field: string, increment: number, cb?: Callback<string>): R;
+    HINCRBYFLOAT(key: string, field: string, increment: number, cb?: Callback<string>): R;
 
     /**
      * Get all the fields of a hash.
@@ -548,8 +549,8 @@ export interface Commands<R> {
     /**
      * Increment the float value of a key by the given amount.
      */
-    incrbyfloat(key: string, increment: number, cb?: Callback<number>): R;
-    INCRBYFLOAT(key: string, increment: number, cb?: Callback<number>): R;
+    incrbyfloat(key: string, increment: number, cb?: Callback<string>): R;
+    INCRBYFLOAT(key: string, increment: number, cb?: Callback<string>): R;
 
     /**
      * Find all keys matching the given pattern.

--- a/types/redis/redis-tests.ts
+++ b/types/redis/redis-tests.ts
@@ -125,3 +125,9 @@ client.addCommand('my other command');
 // redis.print as callback
 client.set(str, str, redis.print);
 client.get(str, redis.print);
+
+// increase-by-float reply a string
+client.incrbyfloat('a', 1.5, (error, value) => value.startsWith('1'));
+client.INCRBYFLOAT('a', 1.5, (error, value) => value.startsWith('1'));
+client.hincrbyfloat('a', 'b', 1.5, (error, value) => value.startsWith('1'));
+client.HINCRBYFLOAT('a', 'b', 1.5, (error, value) => value.startsWith('1'));


### PR DESCRIPTION
in redis, normal increase/decrease commands reply an integer which type is `number`
e.g. https://redis.io/commands/incrby

but for increase-by-float commands, they reply a string
https://redis.io/commands/incrbyfloat
https://redis.io/commands/hincrbyfloat