### PR TITLE
[@types/OAuth] Fix `get > callback type` for OAuth2 class definition

### DIFF
--- a/types/oauth/index.d.ts
+++ b/types/oauth/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for oauth 0.9
 // Project: https://github.com/ciaranj/node-oauth#readme
 // Definitions by: nonAlgebraic <https://github.com/nonAlgebraic>
+//                 Eduardo AC <https://github.com/EduardoAC>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types='node' />
@@ -25,8 +26,8 @@ export type oauth2tokenCallback = (
 
 export type dataCallback = (
   err: {statusCode: number, data?: any},
-  result: string | Buffer,
-  response: IncomingMessage
+  result?: string | Buffer,
+  response?: IncomingMessage
 ) => any;
 
 export class OAuth {
@@ -285,7 +286,7 @@ export class OAuth2 {
 
   get(url: string,
     access_token: string,
-    callback: string
+    callback: dataCallback
   ): void;
 
   protected _getAccessTokenUrl(): string;

--- a/types/passport-oauth2/index.d.ts
+++ b/types/passport-oauth2/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/jaredhanson/passport-oauth2#readme
 // Definitions by: Pasi Eronen <https://github.com/pasieronen>
 //                 Wang Zishi <https://github.com/WangZishi>
+//                 Eduardo AC <https://github.com/EduardoAC>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 

--- a/types/passport-oauth2/passport-oauth2-tests.ts
+++ b/types/passport-oauth2/passport-oauth2-tests.ts
@@ -51,6 +51,8 @@ const err3 = new InternalOAuthError('Hello', {});
 
 class MyStrategy extends OAuth2Strategy {
     useProtectedProperty() {
-        this._oauth2.get('http://www.example.com/profile', 'token', 'http://www.example.com/callback');
+        this._oauth2.get('http://www.example.com/profile', 'token', err => err.statusCode);
+        this._oauth2.get('http://www.example.com/profile', 'token', (err, result) => result);
+        this._oauth2.get('http://www.example.com/profile', 'token', (err, result, response) => response);
     }
 }


### PR DESCRIPTION
Clearly we can see in the OAuth2 repository that the callback type is a function that is call on [_executeRequest](https://github.com/ciaranj/node-oauth/blob/master/lib/oauth2.js) coming from the [get](https://github.com/ciaranj/node-oauth/blob/master/lib/oauth2.js#L219) callback defition

If you follow the trace of _executeRequest and _request function types you will see that the callback function type is mistaken

I will appreciate some comments about the best tests for this change
