### PR TITLE
[bezier-js] Make last args to quadraticFromPoints optional

### DIFF
--- a/types/bezier-js/bezier-js-tests.ts
+++ b/types/bezier-js/bezier-js-tests.ts
@@ -21,6 +21,11 @@ function test() {
         startcap: cap, endcap: cap, forward: bezier, back: bezier, bbox: bbox, intersections: function (shape) { return [[0]]; }
     };
     var split: BezierJs.Split = { left: bezier, right: bezier, span: [point] };
+    var quadratic: BezierJs.Bezier = BezierJs.Bezier.quadraticFromPoints({ x: 0, y: 0 }, { x: 1, y: 1 }, { x: 2, y: 2 }, 0.5);
+    var quadratic: BezierJs.Bezier = BezierJs.Bezier.quadraticFromPoints({ x: 0, y: 0 }, { x: 1, y: 1 }, { x: 2, y: 2 });
+    var cubic: BezierJs.Bezier = BezierJs.Bezier.cubicFromPoints({ x: 0, y: 0 }, { x: 1, y: 1 }, { x: 2, y: 2 }, 0.5, 2);
+    var cubic: BezierJs.Bezier = BezierJs.Bezier.cubicFromPoints({ x: 0, y: 0 }, { x: 1, y: 1 }, { x: 2, y: 2 }, 0.5);
+    var cubic: BezierJs.Bezier = BezierJs.Bezier.cubicFromPoints({ x: 0, y: 0 }, { x: 1, y: 1 }, { x: 2, y: 2 });
 
     bezier.arcs();
     bezier.clockwise;

--- a/types/bezier-js/index.d.ts
+++ b/types/bezier-js/index.d.ts
@@ -96,8 +96,8 @@ declare namespace BezierJs {
         constructor(p1: Point, p2: Point, p3: Point, p4?: Point);
         static fromSVG(svgString: string): Bezier;
         static getABC(n: number, S: Point, B: Point, E: Point, t: number): ABC;
-        static quadraticFromPoints(p1: Point, p2: Point, p3: Point, t: number): Bezier;
-        static cubicFromPoints(S: Point, B: Point, E: Point, t: number, d1: number): Bezier;
+        static quadraticFromPoints(p1: Point, p2: Point, p3: Point, t?: number): Bezier;
+        static cubicFromPoints(S: Point, B: Point, E: Point, t?: number, d1?: number): Bezier;
         static getUtils(): typeof utils;
         getUtils(): typeof utils;
         valueOf(): string;

--- a/types/bezier-js/index.d.ts
+++ b/types/bezier-js/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for Bezier.js
 // Project: https://github.com/Pomax/bezierjs
 // Definitions by: Dan Marshall <https://github.com/danmarshall>
+//                 Simon <https://github.com/Epskampie>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare namespace BezierJs {


### PR DESCRIPTION
Also on cubicFromPoints.

As noted on the docs: https://pomax.github.io/bezierjs/
"The points p1 through p3 are required, all additional arguments are
optional."

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://pomax.github.io/bezierjs/
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.