### PR TITLE
feathersjs/feathers: use generic type 'any' instead of 'object' for Application

### DIFF
--- a/types/feathersjs__feathers/index.d.ts
+++ b/types/feathersjs__feathers/index.d.ts
@@ -12,7 +12,7 @@
 import { EventEmitter } from 'events';
 import * as self from '@feathersjs/feathers';
 
-declare const feathers: (() => Application<object>) & typeof self;
+declare const feathers: (() => Application<any>) & typeof self;
 export default feathers;
 
 export const version: string;

--- a/types/feathersjs__feathers/index.d.ts
+++ b/types/feathersjs__feathers/index.d.ts
@@ -12,7 +12,7 @@
 import { EventEmitter } from 'events';
 import * as self from '@feathersjs/feathers';
 
-declare const feathers: (() => Application<any>) & typeof self;
+declare const feathers: (() => Application) & typeof self;
 export default feathers;
 
 export const version: string;


### PR DESCRIPTION
`object` was too restrictive. Use `any` instead.