### PR TITLE
[mongodb] Allow "date" type in $currentDate

### DIFF
--- a/types/mongodb/index.d.ts
+++ b/types/mongodb/index.d.ts
@@ -866,7 +866,7 @@ export type UpdateQuery<T> = {
     $setOnInsert?: Partial<T> | { [key: string]: any };
     $unset?: { [P in keyof T]?: '' } | { [key: string]: '' };
     $rename?: { [key: string]: keyof T } | { [key: string]: string };
-    $currentDate?: { [P in keyof T]?: (true | { $type: 'timestamp' }) } | { [key: string]: (true | { $type: 'timestamp' }) };
+    $currentDate?: { [P in keyof T]?: (true | { $type: 'date' | 'timestamp' }) } | { [key: string]: (true | { $type: 'date' | 'timestamp' }) };
     $addToSet?: Partial<T> | { [key: string]: any };
     $pop?: { [P in keyof T]?: -1 | 1 } | { [key: string]: -1 | 1 };
     $pull?: Partial<T> | { [key: string]: Condition<T, keyof T> };


### PR DESCRIPTION
Small fix to allow `$currentDate: { modifiedAt: { $type: "date" } }` in update queries.

Below is related fragment from MongoDB docs:
> \<typeSpecification> can be either:
> * a boolean true to set the field value to the current date as a Date, or
> * a document { $type: "timestamp" } or { $type: "date" } which explicitly specifies the type. The operator is case-sensitive and accepts only the lowercase "timestamp" or the lowercase "date".

https://docs.mongodb.com/manual/reference/operator/update/currentDate/#up._S_currentDate