### PR TITLE
[jquery] Documentation improvements. Add `jQuery.cleanData` and overloads for `jQuery.getScript` and Data APIs.

### DIFF
--- a/types/jquery/index.d.ts
+++ b/types/jquery/index.d.ts
@@ -388,6 +388,7 @@ $.ajax({ data: myData });
      * @deprecated ​ Deprecated since 3.3. Internal. See \`{@link https://github.com/jquery/jquery/issues/3384 }\`.
      */
     camelCase(value: string): string;
+    cleanData(elems: ArrayLike<Element | Document | Window | JQuery.PlainObject>): void;
     /**
      * Check to see if a DOM element is a descendant of another DOM element.
      *

--- a/types/jquery/index.d.ts
+++ b/types/jquery/index.d.ts
@@ -32288,6 +32288,7 @@ $( document ).on( "mousemove", function( event ) {
   $( "#log" ).text( "pageX: " + event.pageX + ", pageY: " + event.pageY );
 });
 </script>
+​
 </body>
 </html>
 ```
@@ -32324,6 +32325,7 @@ $( document ).on( "mousemove", function( event ) {
   $( "#log" ).text( "pageX: " + event.pageX + ", pageY: " + event.pageY );
 });
 </script>
+​
 </body>
 </html>
 ```
@@ -32403,6 +32405,7 @@ $( "#checkMetaKey" ).click(function( event ) {
   $( "#display" ).text( event.metaKey );
 });
 </script>
+​
 </body>
 </html>
 ```
@@ -32441,6 +32444,7 @@ $( "button" ).click(function( event ) {
   $( "p" ).trigger( "test.something" );
 });
 </script>
+​
 </body>
 </html>
 ```
@@ -32473,6 +32477,7 @@ $( "button" ).click(function( event ) {
   $( "p" ).html( event.result );
 });
 </script>
+​
 </body>
 </html>
 ```
@@ -32517,6 +32522,7 @@ $( "div" ).click(function( event ) {
   last = event.timeStamp;
 });
 </script>
+​
 </body>
 </html>
 ```
@@ -32528,23 +32534,10 @@ $( "div" ).click(function( event ) {
          * @see \`{@link https://api.jquery.com/event.type/ }\`
          * @since 1.0
          * @example ​ ````On all anchor clicks, alert the event type.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>event.type demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $( "a" ).click(function( event ) {
   alert( event.type ); // "click"
 });
-</script>
-</body>
-</html>
 ```
          */
         type: string;
@@ -32572,6 +32565,7 @@ $( "#whichkey" ).on( "keydown", function( event ) {
   $( "#log" ).html( event.type + ": " +  event.which );
 });
 </script>
+​
 </body>
 </html>
 ```
@@ -32594,6 +32588,7 @@ $( "#whichkey" ).on( "mousedown", function( event ) {
   $( "#log" ).html( event.type + ": " +  event.which );
 });
 </script>
+​
 </body>
 </html>
 ```
@@ -32605,25 +32600,12 @@ $( "#whichkey" ).on( "mousedown", function( event ) {
          * @see \`{@link https://api.jquery.com/event.isDefaultPrevented/ }\`
          * @since 1.3
          * @example ​ ````Checks whether event.preventDefault() was called.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>event.isDefaultPrevented demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $( "a" ).click(function( event ) {
   alert( event.isDefaultPrevented() ); // false
   event.preventDefault();
   alert( event.isDefaultPrevented() ); // true
 });
-</script>
-</body>
-</html>
 ```
          */
         isDefaultPrevented(): boolean;
@@ -32663,6 +32645,7 @@ $( "button" ).click(function( event ) {
   immediatePropStopped( event );
 });
 </script>
+​
 </body>
 </html>
 ```
@@ -32704,6 +32687,7 @@ $( "button" ).click(function(event) {
   propStopped( event );
 });
 </script>
+​
 </body>
 </html>
 ```
@@ -32736,6 +32720,7 @@ $( "a" ).click(function( event ) {
     .appendTo( "#log" );
 });
 </script>
+​
 </body>
 </html>
 ```
@@ -32785,6 +32770,7 @@ $( "div" ).click(function( event ) {
   $( this ).css( "background-color", "#f00" );
 });
 </script>
+​
 </body>
 </html>
 ```
@@ -32796,24 +32782,11 @@ $( "div" ).click(function( event ) {
          * @see \`{@link https://api.jquery.com/event.stopPropagation/ }\`
          * @since 1.0
          * @example ​ ````Kill the bubbling on the click event.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>event.stopPropagation demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $( "p" ).click(function( event ) {
   event.stopPropagation();
   // Do something
 });
-</script>
-</body>
-</html>
 ```
          */
         stopPropagation(): void;
@@ -32828,23 +32801,10 @@ $( "p" ).click(function( event ) {
          * @see \`{@link https://api.jquery.com/event.currentTarget/ }\`
          * @since 1.3
          * @example ​ ````Alert that currentTarget matches the `this` keyword.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>event.currentTarget demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $( "p" ).click(function( event ) {
   alert( event.currentTarget === this ); // true
 });
-</script>
-</body>
-</html>
 ```
          */
         currentTarget: TTarget;
@@ -32886,6 +32846,7 @@ for ( var i = 0; i < 5; i++ ) {
   });
 }
 </script>
+​
 </body>
 </html>
 ```
@@ -32897,23 +32858,10 @@ for ( var i = 0; i < 5; i++ ) {
          * @see \`{@link https://api.jquery.com/event.delegateTarget/ }\`
          * @since 1.7
          * @example ​ ````When a button in any box class is clicked, change the box&#39;s background color to red.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>event.delegateTarget demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $( ".box" ).on( "click", "button", function( event ) {
   $( event.delegateTarget ).css( "background-color", "red" );
 });
-</script>
-</body>
-</html>
 ```
          */
         delegateTarget: TTarget;
@@ -32924,23 +32872,10 @@ $( ".box" ).on( "click", "button", function( event ) {
          * @see \`{@link https://api.jquery.com/event.relatedTarget/ }\`
          * @since 1.1.4
          * @example ​ ````On mouseout of anchors, alert the element type being entered.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>event.relatedTarget demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $( "a" ).mouseout(function( event ) {
   alert( event.relatedTarget.nodeName ); // "DIV"
 });
-</script>
-</body>
-</html>
 ```
          */
         relatedTarget: TTarget | null;
@@ -32979,6 +32914,7 @@ $( "body" ).click(function( event ) {
   $( "#log" ).html( "clicked: " + event.target.nodeName );
 });
 </script>
+​
 </body>
 </html>
 ```
@@ -33017,6 +32953,7 @@ function handler( event ) {
 }
 $( "ul" ).click( handler ).find( "ul" ).hide();
 </script>
+​
 </body>
 </html>
 ```

--- a/types/jquery/index.d.ts
+++ b/types/jquery/index.d.ts
@@ -83,97 +83,7 @@ interface JQueryStatic {
     expr: JQuery.Selectors;
     // Set to HTMLElement to minimize breaks but should probably be Element.
     readonly fn: JQuery;
-    fx: {
-        /**
-         * The rate (in milliseconds) at which animations fire.
-         *
-         * @see \`{@link https://api.jquery.com/jQuery.fx.interval/ }\`
-         * @since 1.4.3
-         * @deprecated ​ Deprecated since 3.0. See \`{@link https://api.jquery.com/jQuery.fx.interval/ }\`.
-         *
-         * **Cause**: As of jQuery 3.0 the `jQuery.fx.interval` property can be used to change the animation interval only on browsers that do not support the `window.requestAnimationFrame()` method. That is currently only Internet Explorer 9 and the Android Browser. Once support is dropped for these browsers, the property will serve no purpose and it will be removed.
-         *
-         * **Solution**: Find and remove code that changes or uses `jQuery.fx.interval`. If the value is being used by code in your page or a plugin, the code may be making assumptions that are no longer valid. The default value of `jQuery.fx.interval` is `13` (milliseconds), which could be used instead of accessing this property.
-         * @example ​ ````Cause all animations to run with less frames.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.fx.interval demo</title>
-  <style>
-  div {
-    width: 50px;
-    height: 30px;
-    margin: 5px;
-    float: left;
-    background: green;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><input type="button" value="Run"></p>
-<div></div>
-​
-<script>
-jQuery.fx.interval = 100;
-$( "input" ).click(function() {
-  $( "div" ).toggle( 3000 );
-});
-</script>
-</body>
-</html>
-```
-         */
-        interval: number;
-        /**
-         * Globally disable all animations.
-         *
-         * @see \`{@link https://api.jquery.com/jQuery.fx.off/ }\`
-         * @since 1.3
-         * @example ​ ````Toggle animation on and off
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.fx.off demo</title>
-  <style>
-  div {
-    width: 50px;
-    height: 30px;
-    margin: 5px;
-    float: left;
-    background: green;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<input type="button" value="Run">
-<button>Toggle fx</button>
-<div></div>
-​
-<script>
-var toggleFx = function() {
-  $.fx.off = !$.fx.off;
-};
-toggleFx();
-$( "button" ).click( toggleFx );
-$( "input" ).click(function() {
-  $( "div" ).toggle( "slow" );
-});
-</script>
-</body>
-</html>
-```
-         */
-        off: boolean;
-        step: JQuery.PlainObject<JQuery.AnimationHook<Node>>;
-    };
+    fx: JQuery.Effects;
     /**
      * A Promise-like object (or "thenable") that resolves when the document is ready.
      *
@@ -61667,6 +61577,98 @@ $.get( "test.php" )
 
     // region Effects
     // #region Effects
+
+    interface Effects {
+        /**
+         * The rate (in milliseconds) at which animations fire.
+         *
+         * @see \`{@link https://api.jquery.com/jQuery.fx.interval/ }\`
+         * @since 1.4.3
+         * @deprecated ​ Deprecated since 3.0. See \`{@link https://api.jquery.com/jQuery.fx.interval/ }\`.
+         *
+         * **Cause**: As of jQuery 3.0 the `jQuery.fx.interval` property can be used to change the animation interval only on browsers that do not support the `window.requestAnimationFrame()` method. That is currently only Internet Explorer 9 and the Android Browser. Once support is dropped for these browsers, the property will serve no purpose and it will be removed.
+         *
+         * **Solution**: Find and remove code that changes or uses `jQuery.fx.interval`. If the value is being used by code in your page or a plugin, the code may be making assumptions that are no longer valid. The default value of `jQuery.fx.interval` is `13` (milliseconds), which could be used instead of accessing this property.
+         * @example ​ ````Cause all animations to run with less frames.
+```html
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>jQuery.fx.interval demo</title>
+  <style>
+  div {
+    width: 50px;
+    height: 30px;
+    margin: 5px;
+    float: left;
+    background: green;
+  }
+  </style>
+  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
+</head>
+<body>
+​
+<p><input type="button" value="Run"></p>
+<div></div>
+​
+<script>
+jQuery.fx.interval = 100;
+$( "input" ).click(function() {
+  $( "div" ).toggle( 3000 );
+});
+</script>
+</body>
+</html>
+```
+        */
+        interval: number;
+        /**
+         * Globally disable all animations.
+         *
+         * @see \`{@link https://api.jquery.com/jQuery.fx.off/ }\`
+         * @since 1.3
+         * @example ​ ````Toggle animation on and off
+```html
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>jQuery.fx.off demo</title>
+  <style>
+  div {
+    width: 50px;
+    height: 30px;
+    margin: 5px;
+    float: left;
+    background: green;
+  }
+  </style>
+  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
+</head>
+<body>
+​
+<input type="button" value="Run">
+<button>Toggle fx</button>
+<div></div>
+​
+<script>
+var toggleFx = function() {
+  $.fx.off = !$.fx.off;
+};
+toggleFx();
+$( "button" ).click( toggleFx );
+$( "input" ).click(function() {
+  $( "div" ).toggle( "slow" );
+});
+</script>
+</body>
+</html>
+```
+        */
+        off: boolean;
+        step: PlainObject<AnimationHook<Node>>;
+    }
 
     type Duration = number | 'fast' | 'slow';
     // TODO: Is the first element always a string or is that specific to the 'fx' queue?

--- a/types/jquery/index.d.ts
+++ b/types/jquery/index.d.ts
@@ -82,36 +82,13 @@ interface JQueryStatic {
      * @see \`{@link https://api.jquery.com/jQuery.ready/ }\`
      * @since 1.8
      * @example ​ ````Listen for document ready using jQuery.when.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.ready demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $.when( $.ready ).then(function() {
   // Document is ready.
 });
-</script>
-</body>
-</html>
 ```
      * @example ​ ````Typical usage involving another promise, using jQuery.when.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.ready demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $.when(
   $.getJSON( "ajax/test.json" ),
   $.ready
@@ -119,9 +96,6 @@ $.when(
   // Document is ready.
   // Value of test.json is passed as `data`.
 });
-</script>
-</body>
-</html>
 ```
      */
     ready: JQuery.Thenable<JQueryStatic>;
@@ -152,124 +126,12 @@ $.when(
      * @see \`{@link https://api.jquery.com/jQuery/ }\`
      * @since 1.0
      * @since 1.4
-     * @example ​ ````Find all p elements that are children of a div element and apply a border to them.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p>one</p>
-<div><p>two</p></div>
-<p>three</p>
-​
-<script>
-$( "div > p" ).css( "border", "1px solid gray" );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Find all inputs of type radio within the first form in the document.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "input:radio", document.forms[ 0 ] );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Find all div elements within an XML document from an Ajax response.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "div", xml.responseXML );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Set the background color of the page to black.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( document.body ).css( "background", "black" );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Hide all the input elements within a form.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( myForm.elements ).hide();
-</script>
-</body>
-</html>
-```
      * @example ​ ````Create a div element (and all of its contents) dynamically and append it to the body element. Internally, an element is created and its innerHTML property set to the given markup.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $( "<div><p>Hello</p></div>" ).appendTo( "body" )
-</script>
-</body>
-</html>
 ```
      * @example ​ ````Create some DOM elements.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $( "<div/>", {
   "class": "test",
   text: "Click me!",
@@ -278,47 +140,6 @@ $( "<div/>", {
   }
 })
   .appendTo( "body" );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Execute the function when the DOM is ready to be used.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$(function() {
-  // Document is ready
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Use both the shortcut for $(document).ready() and the argument to write failsafe jQuery code using the $ alias, without relying on the global alias.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-jQuery(function( $ ) {
-  // Your code using failsafe $ alias here...
-});
-</script>
-</body>
-</html>
 ```
      */
     // tslint:disable-next-line:no-unnecessary-generics
@@ -352,151 +173,12 @@ $( "div > p" ).css( "border", "1px solid gray" );
 </html>
 ```
      * @example ​ ````Find all inputs of type radio within the first form in the document.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $( "input:radio", document.forms[ 0 ] );
-</script>
-</body>
-</html>
 ```
      * @example ​ ````Find all div elements within an XML document from an Ajax response.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $( "div", xml.responseXML );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Set the background color of the page to black.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( document.body ).css( "background", "black" );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Hide all the input elements within a form.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( myForm.elements ).hide();
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Create a div element (and all of its contents) dynamically and append it to the body element. Internally, an element is created and its innerHTML property set to the given markup.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "<div><p>Hello</p></div>" ).appendTo( "body" )
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Create some DOM elements.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "<div/>", {
-  "class": "test",
-  text: "Click me!",
-  click: function() {
-    $( this ).toggleClass( "test" );
-  }
-})
-  .appendTo( "body" );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Execute the function when the DOM is ready to be used.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$(function() {
-  // Document is ready
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Use both the shortcut for $(document).ready() and the argument to write failsafe jQuery code using the $ alias, without relying on the global alias.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-jQuery(function( $ ) {
-  // Your code using failsafe $ alias here...
-});
-</script>
-</body>
-</html>
 ```
      */
     // tslint:disable-next-line:no-unnecessary-generics
@@ -508,173 +190,9 @@ jQuery(function( $ ) {
      * @param element A DOM element to wrap in a jQuery object.
      * @see \`{@link https://api.jquery.com/jQuery/ }\`
      * @since 1.0
-     * @example ​ ````Find all p elements that are children of a div element and apply a border to them.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p>one</p>
-<div><p>two</p></div>
-<p>three</p>
-​
-<script>
-$( "div > p" ).css( "border", "1px solid gray" );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Find all inputs of type radio within the first form in the document.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "input:radio", document.forms[ 0 ] );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Find all div elements within an XML document from an Ajax response.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "div", xml.responseXML );
-</script>
-</body>
-</html>
-```
      * @example ​ ````Set the background color of the page to black.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $( document.body ).css( "background", "black" );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Hide all the input elements within a form.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( myForm.elements ).hide();
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Create a div element (and all of its contents) dynamically and append it to the body element. Internally, an element is created and its innerHTML property set to the given markup.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "<div><p>Hello</p></div>" ).appendTo( "body" )
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Create some DOM elements.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "<div/>", {
-  "class": "test",
-  text: "Click me!",
-  click: function() {
-    $( this ).toggleClass( "test" );
-  }
-})
-  .appendTo( "body" );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Execute the function when the DOM is ready to be used.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$(function() {
-  // Document is ready
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Use both the shortcut for $(document).ready() and the argument to write failsafe jQuery code using the $ alias, without relying on the global alias.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-jQuery(function( $ ) {
-  // Your code using failsafe $ alias here...
-});
-</script>
-</body>
-</html>
 ```
      */
     // Using a unified signature is not possible due to a TypeScript 2.4 bug (DefinitelyTyped#27810)
@@ -687,173 +205,9 @@ jQuery(function( $ ) {
      * @param elementArray An array containing a set of DOM elements to wrap in a jQuery object.
      * @see \`{@link https://api.jquery.com/jQuery/ }\`
      * @since 1.0
-     * @example ​ ````Find all p elements that are children of a div element and apply a border to them.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p>one</p>
-<div><p>two</p></div>
-<p>three</p>
-​
-<script>
-$( "div > p" ).css( "border", "1px solid gray" );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Find all inputs of type radio within the first form in the document.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "input:radio", document.forms[ 0 ] );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Find all div elements within an XML document from an Ajax response.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "div", xml.responseXML );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Set the background color of the page to black.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( document.body ).css( "background", "black" );
-</script>
-</body>
-</html>
-```
      * @example ​ ````Hide all the input elements within a form.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $( myForm.elements ).hide();
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Create a div element (and all of its contents) dynamically and append it to the body element. Internally, an element is created and its innerHTML property set to the given markup.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "<div><p>Hello</p></div>" ).appendTo( "body" )
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Create some DOM elements.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "<div/>", {
-  "class": "test",
-  text: "Click me!",
-  click: function() {
-    $( this ).toggleClass( "test" );
-  }
-})
-  .appendTo( "body" );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Execute the function when the DOM is ready to be used.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$(function() {
-  // Document is ready
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Use both the shortcut for $(document).ready() and the argument to write failsafe jQuery code using the $ alias, without relying on the global alias.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-jQuery(function( $ ) {
-  // Your code using failsafe $ alias here...
-});
-</script>
-</body>
-</html>
 ```
      */
     // Using a unified signature is not possible due to a TypeScript 2.4 bug (DefinitelyTyped#27810)
@@ -866,174 +220,6 @@ jQuery(function( $ ) {
      * @param selection An existing jQuery object to clone.
      * @see \`{@link https://api.jquery.com/jQuery/ }\`
      * @since 1.0
-     * @example ​ ````Find all p elements that are children of a div element and apply a border to them.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p>one</p>
-<div><p>two</p></div>
-<p>three</p>
-​
-<script>
-$( "div > p" ).css( "border", "1px solid gray" );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Find all inputs of type radio within the first form in the document.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "input:radio", document.forms[ 0 ] );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Find all div elements within an XML document from an Ajax response.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "div", xml.responseXML );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Set the background color of the page to black.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( document.body ).css( "background", "black" );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Hide all the input elements within a form.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( myForm.elements ).hide();
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Create a div element (and all of its contents) dynamically and append it to the body element. Internally, an element is created and its innerHTML property set to the given markup.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "<div><p>Hello</p></div>" ).appendTo( "body" )
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Create some DOM elements.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "<div/>", {
-  "class": "test",
-  text: "Click me!",
-  click: function() {
-    $( this ).toggleClass( "test" );
-  }
-})
-  .appendTo( "body" );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Execute the function when the DOM is ready to be used.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$(function() {
-  // Document is ready
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Use both the shortcut for $(document).ready() and the argument to write failsafe jQuery code using the $ alias, without relying on the global alias.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-jQuery(function( $ ) {
-  // Your code using failsafe $ alias here...
-});
-</script>
-</body>
-</html>
-```
      */
     <T>(selection: JQuery<T>): JQuery<T>;
     /**
@@ -1042,173 +228,17 @@ jQuery(function( $ ) {
      * @param callback The function to execute when the DOM is ready.
      * @see \`{@link https://api.jquery.com/jQuery/ }\`
      * @since 1.0
-     * @example ​ ````Find all p elements that are children of a div element and apply a border to them.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p>one</p>
-<div><p>two</p></div>
-<p>three</p>
-​
-<script>
-$( "div > p" ).css( "border", "1px solid gray" );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Find all inputs of type radio within the first form in the document.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "input:radio", document.forms[ 0 ] );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Find all div elements within an XML document from an Ajax response.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "div", xml.responseXML );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Set the background color of the page to black.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( document.body ).css( "background", "black" );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Hide all the input elements within a form.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( myForm.elements ).hide();
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Create a div element (and all of its contents) dynamically and append it to the body element. Internally, an element is created and its innerHTML property set to the given markup.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "<div><p>Hello</p></div>" ).appendTo( "body" )
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Create some DOM elements.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "<div/>", {
-  "class": "test",
-  text: "Click me!",
-  click: function() {
-    $( this ).toggleClass( "test" );
-  }
-})
-  .appendTo( "body" );
-</script>
-</body>
-</html>
-```
      * @example ​ ````Execute the function when the DOM is ready to be used.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $(function() {
   // Document is ready
 });
-</script>
-</body>
-</html>
 ```
      * @example ​ ````Use both the shortcut for $(document).ready() and the argument to write failsafe jQuery code using the $ alias, without relying on the global alias.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 jQuery(function( $ ) {
   // Your code using failsafe $ alias here...
 });
-</script>
-</body>
-</html>
 ```
      */
     // tslint:disable-next-line:no-unnecessary-generics unified-signatures
@@ -1219,174 +249,6 @@ jQuery(function( $ ) {
      * @param object A plain object to wrap in a jQuery object.
      * @see \`{@link https://api.jquery.com/jQuery/ }\`
      * @since 1.0
-     * @example ​ ````Find all p elements that are children of a div element and apply a border to them.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p>one</p>
-<div><p>two</p></div>
-<p>three</p>
-​
-<script>
-$( "div > p" ).css( "border", "1px solid gray" );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Find all inputs of type radio within the first form in the document.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "input:radio", document.forms[ 0 ] );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Find all div elements within an XML document from an Ajax response.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "div", xml.responseXML );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Set the background color of the page to black.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( document.body ).css( "background", "black" );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Hide all the input elements within a form.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( myForm.elements ).hide();
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Create a div element (and all of its contents) dynamically and append it to the body element. Internally, an element is created and its innerHTML property set to the given markup.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "<div><p>Hello</p></div>" ).appendTo( "body" )
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Create some DOM elements.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "<div/>", {
-  "class": "test",
-  text: "Click me!",
-  click: function() {
-    $( this ).toggleClass( "test" );
-  }
-})
-  .appendTo( "body" );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Execute the function when the DOM is ready to be used.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$(function() {
-  // Document is ready
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Use both the shortcut for $(document).ready() and the argument to write failsafe jQuery code using the $ alias, without relying on the global alias.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-jQuery(function( $ ) {
-  // Your code using failsafe $ alias here...
-});
-</script>
-</body>
-</html>
-```
      */
     <T extends JQuery.PlainObject>(object: T): JQuery<T>;
     /**
@@ -1394,174 +256,6 @@ jQuery(function( $ ) {
      *
      * @see \`{@link https://api.jquery.com/jQuery/ }\`
      * @since 1.4
-     * @example ​ ````Find all p elements that are children of a div element and apply a border to them.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p>one</p>
-<div><p>two</p></div>
-<p>three</p>
-​
-<script>
-$( "div > p" ).css( "border", "1px solid gray" );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Find all inputs of type radio within the first form in the document.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "input:radio", document.forms[ 0 ] );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Find all div elements within an XML document from an Ajax response.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "div", xml.responseXML );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Set the background color of the page to black.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( document.body ).css( "background", "black" );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Hide all the input elements within a form.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( myForm.elements ).hide();
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Create a div element (and all of its contents) dynamically and append it to the body element. Internally, an element is created and its innerHTML property set to the given markup.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "<div><p>Hello</p></div>" ).appendTo( "body" )
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Create some DOM elements.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "<div/>", {
-  "class": "test",
-  text: "Click me!",
-  click: function() {
-    $( this ).toggleClass( "test" );
-  }
-})
-  .appendTo( "body" );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Execute the function when the DOM is ready to be used.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$(function() {
-  // Document is ready
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Use both the shortcut for $(document).ready() and the argument to write failsafe jQuery code using the $ alias, without relying on the global alias.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-jQuery(function( $ ) {
-  // Your code using failsafe $ alias here...
-});
-</script>
-</body>
-</html>
-```
      */
     // tslint:disable-next-line:no-unnecessary-generics
     <TElement = HTMLElement>(): JQuery<TElement>;
@@ -1573,130 +267,6 @@ jQuery(function( $ ) {
      *                 be set for any option with $.ajaxSetup(). See jQuery.ajax( settings ) below for a complete list of all settings.
      * @see \`{@link https://api.jquery.com/jQuery.ajax/ }\`
      * @since 1.5
-     * @example ​ ````Save some data to the server and notify the user once it&#39;s complete.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.ajax demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$.ajax({
-  method: "POST",
-  url: "some.php",
-  data: { name: "John", location: "Boston" }
-})
-  .done(function( msg ) {
-    alert( "Data Saved: " + msg );
-  });
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Retrieve the latest version of an HTML page.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.ajax demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$.ajax({
-  url: "test.html",
-  cache: false
-})
-  .done(function( html ) {
-    $( "#results" ).append( html );
-  });
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Send an xml document as data to the server. By setting the processData
-    option to false, the automatic conversion of data to strings is prevented.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.ajax demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-var xmlDocument = [create xml document];
-var xmlRequest = $.ajax({
-  url: "page.php",
-  processData: false,
-  data: xmlDocument
-});
-​
-xmlRequest.done( handleResponse );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Send an id as data to the server, save some data to the server, and notify the user once it&#39;s complete. If the request fails, alert the user.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.ajax demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-var menuId = $( "ul.nav" ).first().attr( "id" );
-var request = $.ajax({
-  url: "script.php",
-  method: "POST",
-  data: { id : menuId },
-  dataType: "html"
-});
-​
-request.done(function( msg ) {
-  $( "#log" ).html( msg );
-});
-​
-request.fail(function( jqXHR, textStatus ) {
-  alert( "Request failed: " + textStatus );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Load and execute a JavaScript file.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.ajax demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$.ajax({
-  method: "GET",
-  url: "test.js",
-  dataType: "script"
-});
-</script>
-</body>
-</html>
-```
      */
     ajax(url: string, settings?: JQuery.AjaxSettings): JQuery.jqXHR;
     /**
@@ -1707,17 +277,7 @@ $.ajax({
      * @see \`{@link https://api.jquery.com/jQuery.ajax/ }\`
      * @since 1.0
      * @example ​ ````Save some data to the server and notify the user once it&#39;s complete.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.ajax demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $.ajax({
   method: "POST",
   url: "some.php",
@@ -1726,22 +286,9 @@ $.ajax({
   .done(function( msg ) {
     alert( "Data Saved: " + msg );
   });
-</script>
-</body>
-</html>
 ```
      * @example ​ ````Retrieve the latest version of an HTML page.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.ajax demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $.ajax({
   url: "test.html",
   cache: false
@@ -1749,23 +296,10 @@ $.ajax({
   .done(function( html ) {
     $( "#results" ).append( html );
   });
-</script>
-</body>
-</html>
 ```
      * @example ​ ````Send an xml document as data to the server. By setting the processData
     option to false, the automatic conversion of data to strings is prevented.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.ajax demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 var xmlDocument = [create xml document];
 var xmlRequest = $.ajax({
   url: "page.php",
@@ -1774,22 +308,9 @@ var xmlRequest = $.ajax({
 });
 ​
 xmlRequest.done( handleResponse );
-</script>
-</body>
-</html>
 ```
      * @example ​ ````Send an id as data to the server, save some data to the server, and notify the user once it&#39;s complete. If the request fails, alert the user.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.ajax demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 var menuId = $( "ul.nav" ).first().attr( "id" );
 var request = $.ajax({
   url: "script.php",
@@ -1805,30 +326,14 @@ request.done(function( msg ) {
 request.fail(function( jqXHR, textStatus ) {
   alert( "Request failed: " + textStatus );
 });
-</script>
-</body>
-</html>
 ```
      * @example ​ ````Load and execute a JavaScript file.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.ajax demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $.ajax({
   method: "GET",
   url: "test.js",
   dataType: "script"
 });
-</script>
-</body>
-</html>
 ```
      */
     ajax(settings?: JQuery.AjaxSettings): JQuery.jqXHR;
@@ -1859,26 +364,13 @@ $.ajax({
      * @see \`{@link https://api.jquery.com/jQuery.ajaxSetup/ }\`
      * @since 1.1
      * @example ​ ````Sets the defaults for Ajax requests to the url &quot;/xmlhttp/&quot;, disables global handlers and uses POST instead of GET. The following Ajax requests then sends some data without having to set anything else.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.ajaxSetup demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $.ajaxSetup({
   url: "/xmlhttp/",
   global: false,
   type: "POST"
 });
 $.ajax({ data: myData });
-</script>
-</body>
-</html>
 ```
      */
     ajaxSetup(options: JQuery.AjaxSettings): JQuery.AjaxSettings;
@@ -1904,22 +396,9 @@ $.ajax({ data: myData });
      * @see \`{@link https://api.jquery.com/jQuery.contains/ }\`
      * @since 1.4
      * @example ​ ````Check if an element is a descendant of another.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.contains demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $.contains( document.documentElement, document.body ); // true
 $.contains( document.body, document.documentElement ); // false
-</script>
-</body>
-</html>
 ```
      */
     contains(container: Element, contained: Element): boolean;
@@ -1932,44 +411,6 @@ $.contains( document.body, document.documentElement ); // false
      * @param value The new data value; this can be any Javascript type except `undefined`.
      * @see \`{@link https://api.jquery.com/jQuery.data/ }\`
      * @since 1.2.3
-     * @example ​ ````Store then retrieve a value from the div element.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.data demo</title>
-  <style>
-  div {
-    color: blue;
-  }
-  span {
-    color: red;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<div>
-  The values stored were
-  <span></span>
-  and
-  <span></span>
-</div>
-​
-<script>
-var div = $( "div" )[ 0 ];
-jQuery.data( div, "test", {
-  first: 16,
-  last: "pizza!"
-});
-$( "span:first" ).text( jQuery.data( div, "test" ).first );
-$( "span:last" ).text( jQuery.data( div, "test" ).last );
-</script>
-</body>
-</html>
-```
      * @example ​ ````Get the data named &quot;blah&quot; stored at for an element.
 ```html
 <!doctype html>
@@ -2029,6 +470,7 @@ $( "button" ).click( function() {
   $( "span" ).text( "" + value );
 });
 </script>
+​
 </body>
 </html>
 ```
@@ -2044,106 +486,6 @@ $( "button" ).click( function() {
      *              will return the corresponding data for "name", and is therefore the same as `jQuery.data( el, "name" )`
      * @see \`{@link https://api.jquery.com/jQuery.data/ }\`
      * @since 1.2.3
-     * @example ​ ````Store then retrieve a value from the div element.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.data demo</title>
-  <style>
-  div {
-    color: blue;
-  }
-  span {
-    color: red;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<div>
-  The values stored were
-  <span></span>
-  and
-  <span></span>
-</div>
-​
-<script>
-var div = $( "div" )[ 0 ];
-jQuery.data( div, "test", {
-  first: 16,
-  last: "pizza!"
-});
-$( "span:first" ).text( jQuery.data( div, "test" ).first );
-$( "span:last" ).text( jQuery.data( div, "test" ).last );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Get the data named &quot;blah&quot; stored at for an element.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.data demo</title>
-  <style>
-  div {
-    margin: 5px;
-    background: yellow;
-  }
-  button {
-    margin: 5px;
-    font-size: 14px;
-  }
-  p {
-    margin: 5px;
-    color: blue;
-  }
-  span {
-    color: red;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<div>A div</div>
-<button>Get "blah" from the div</button>
-<button>Set "blah" to "hello"</button>
-<button>Set "blah" to 86</button>
-<button>Remove "blah" from the div</button>
-<p>The "blah" value of this div is <span>?</span></p>
-​
-<script>
-$( "button" ).click( function() {
-  var value,
-    div = $( "div" )[ 0 ];
-  switch ( $( "button" ).index( this ) ) {
-  case 0 :
-    value = jQuery.data( div, "blah" );
-    break;
-  case 1 :
-    jQuery.data( div, "blah", "hello" );
-    value = "Stored!";
-    break;
-  case 2 :
-    jQuery.data( div, "blah", 86 );
-    value = "Stored!";
-    break;
-  case 3 :
-    jQuery.removeData( div, "blah" );
-    value = "Removed!";
-    break;
-  }
-  $( "span" ).text( "" + value );
-});
-</script>
-</body>
-</html>
-```
      */
     // `unified-signatures` is disabled so that behavior when passing `undefined` to `value` can be documented. Unifying the signatures
     // results in potential confusion for users from an unexpected parameter.
@@ -2193,68 +535,7 @@ jQuery.data( div, "test", {
 $( "span:first" ).text( jQuery.data( div, "test" ).first );
 $( "span:last" ).text( jQuery.data( div, "test" ).last );
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Get the data named &quot;blah&quot; stored at for an element.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.data demo</title>
-  <style>
-  div {
-    margin: 5px;
-    background: yellow;
-  }
-  button {
-    margin: 5px;
-    font-size: 14px;
-  }
-  p {
-    margin: 5px;
-    color: blue;
-  }
-  span {
-    color: red;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-<div>A div</div>
-<button>Get "blah" from the div</button>
-<button>Set "blah" to "hello"</button>
-<button>Set "blah" to 86</button>
-<button>Remove "blah" from the div</button>
-<p>The "blah" value of this div is <span>?</span></p>
-​
-<script>
-$( "button" ).click( function() {
-  var value,
-    div = $( "div" )[ 0 ];
-  switch ( $( "button" ).index( this ) ) {
-  case 0 :
-    value = jQuery.data( div, "blah" );
-    break;
-  case 1 :
-    jQuery.data( div, "blah", "hello" );
-    value = "Stored!";
-    break;
-  case 2 :
-    jQuery.data( div, "blah", 86 );
-    value = "Stored!";
-    break;
-  case 3 :
-    jQuery.removeData( div, "blah" );
-    value = "Removed!";
-    break;
-  }
-  $( "span" ).text( "" + value );
-});
-</script>
 </body>
 </html>
 ```
@@ -2307,6 +588,7 @@ $( "button" ).click(function() {
     .animate({ left:'10px', top:'30px' }, 700 );
 });
 </script>
+​
 </body>
 </html>
 ```
@@ -2361,46 +643,15 @@ jQuery.each( obj, function( i, val ) {
   $( "#" + i ).append( document.createTextNode( " - " + val ) );
 });
 </script>
+​
 </body>
 </html>
 ```
      * @example ​ ````Iterates over items in an array, accessing both the current item and its index.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.each demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $.each( [ "a", "b", "c" ], function( i, l ){
   alert( "Index #" + i + ": " + l );
 });
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Iterates over the properties in an object, accessing both the current item and its key.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.each demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$.each({ name: "John", lang: "JS" }, function( k, v ) {
-  alert( "Key: " + k + ", Value: " + v );
-});
-</script>
-</body>
-</html>
 ```
      */
     each<T>(array: ArrayLike<T>, callback: (this: T, indexInArray: number, value: T) => false | any): ArrayLike<T>;
@@ -2453,46 +704,15 @@ jQuery.each( obj, function( i, val ) {
   $( "#" + i ).append( document.createTextNode( " - " + val ) );
 });
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Iterates over items in an array, accessing both the current item and its index.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.each demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$.each( [ "a", "b", "c" ], function( i, l ){
-  alert( "Index #" + i + ": " + l );
-});
-</script>
+​
 </body>
 </html>
 ```
      * @example ​ ````Iterates over the properties in an object, accessing both the current item and its key.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.each demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $.each({ name: "John", lang: "JS" }, function( k, v ) {
   alert( "Key: " + k + ", Value: " + v );
 });
-</script>
-</body>
-</html>
 ```
      */
     each<T, K extends keyof T>(obj: T, callback: (this: T[K], propertyName: K, valueOfProperty: T[K]) => false | any): T;
@@ -2503,21 +723,8 @@ $.each({ name: "John", lang: "JS" }, function( k, v ) {
      * @see \`{@link https://api.jquery.com/jQuery.error/ }\`
      * @since 1.4.1
      * @example ​ ````Override jQuery.error for display in Firebug.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.error demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 jQuery.error = console.error;
-</script>
-</body>
-</html>
 ```
      */
     error(message: string): any;
@@ -2528,38 +735,12 @@ jQuery.error = console.error;
      * @see \`{@link https://api.jquery.com/jQuery.escapeSelector/ }\`
      * @since 3.0
      * @example ​ ````Escape an ID containing a hash.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.escapeSelector demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $.escapeSelector( "#target" ); // "\#target"
-</script>
-</body>
-</html>
 ```
      * @example ​ ````Select all the elements having a class name of .box inside a div.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.escapeSelector demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $( "div" ).find( "." + $.escapeSelector( ".box" ) );
-</script>
-</body>
-</html>
 ```
      */
     escapeSelector(selector: JQuery.Selector): JQuery.Selector;
@@ -2576,39 +757,6 @@ $( "div" ).find( "." + $.escapeSelector( ".box" ) );
      * @param object6 An object containing additional properties to merge in.
      * @see \`{@link https://api.jquery.com/jQuery.extend/ }\`
      * @since 1.1.4
-     * @example ​ ````Merge two objects, modifying the first.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.extend demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<div id="log"></div>
-​
-<script>
-var object1 = {
-  apple: 0,
-  banana: { weight: 52, price: 100 },
-  cherry: 97
-};
-var object2 = {
-  banana: { price: 200 },
-  durian: 100
-};
-​
-// Merge object2 into object1
-$.extend( object1, object2 );
-​
-// Assuming JSON.stringify - not available in IE<8
-$( "#log" ).append( JSON.stringify( object1 ) );
-</script>
-</body>
-</html>
-```
      * @example ​ ````Merge two objects recursively, modifying the first.
 ```html
 <!doctype html>
@@ -2639,34 +787,7 @@ $.extend( true, object1, object2 );
 // Assuming JSON.stringify - not available in IE<8
 $( "#log" ).append( JSON.stringify( object1 ) );
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Merge defaults and options, without modifying the defaults. This is a common plugin development pattern.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.extend demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-<div id="log"></div>
-​
-<script>
-var defaults = { validate: false, limit: 5, name: "foo" };
-var options = { validate: true, name: "bar" };
-​
-// Merge defaults and options, without modifying defaults
-var settings = $.extend( {}, defaults, options );
-​
-// Assuming JSON.stringify - not available in IE<8
-$( "#log" ).append( "<div><b>defaults -- </b>" + JSON.stringify( defaults ) + "</div>" );
-$( "#log" ).append( "<div><b>options -- </b>" + JSON.stringify( options ) + "</div>" );
-$( "#log" ).append( "<div><b>settings -- </b>" + JSON.stringify( settings ) + "</div>" );
-</script>
 </body>
 </html>
 ```
@@ -2684,39 +805,6 @@ $( "#log" ).append( "<div><b>settings -- </b>" + JSON.stringify( settings ) + "<
      * @param object5 An object containing additional properties to merge in.
      * @see \`{@link https://api.jquery.com/jQuery.extend/ }\`
      * @since 1.1.4
-     * @example ​ ````Merge two objects, modifying the first.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.extend demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<div id="log"></div>
-​
-<script>
-var object1 = {
-  apple: 0,
-  banana: { weight: 52, price: 100 },
-  cherry: 97
-};
-var object2 = {
-  banana: { price: 200 },
-  durian: 100
-};
-​
-// Merge object2 into object1
-$.extend( object1, object2 );
-​
-// Assuming JSON.stringify - not available in IE<8
-$( "#log" ).append( JSON.stringify( object1 ) );
-</script>
-</body>
-</html>
-```
      * @example ​ ````Merge two objects recursively, modifying the first.
 ```html
 <!doctype html>
@@ -2747,34 +835,7 @@ $.extend( true, object1, object2 );
 // Assuming JSON.stringify - not available in IE<8
 $( "#log" ).append( JSON.stringify( object1 ) );
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Merge defaults and options, without modifying the defaults. This is a common plugin development pattern.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.extend demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-<div id="log"></div>
-​
-<script>
-var defaults = { validate: false, limit: 5, name: "foo" };
-var options = { validate: true, name: "bar" };
-​
-// Merge defaults and options, without modifying defaults
-var settings = $.extend( {}, defaults, options );
-​
-// Assuming JSON.stringify - not available in IE<8
-$( "#log" ).append( "<div><b>defaults -- </b>" + JSON.stringify( defaults ) + "</div>" );
-$( "#log" ).append( "<div><b>options -- </b>" + JSON.stringify( options ) + "</div>" );
-$( "#log" ).append( "<div><b>settings -- </b>" + JSON.stringify( settings ) + "</div>" );
-</script>
 </body>
 </html>
 ```
@@ -2791,39 +852,6 @@ $( "#log" ).append( "<div><b>settings -- </b>" + JSON.stringify( settings ) + "<
      * @param object4 An object containing additional properties to merge in.
      * @see \`{@link https://api.jquery.com/jQuery.extend/ }\`
      * @since 1.1.4
-     * @example ​ ````Merge two objects, modifying the first.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.extend demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<div id="log"></div>
-​
-<script>
-var object1 = {
-  apple: 0,
-  banana: { weight: 52, price: 100 },
-  cherry: 97
-};
-var object2 = {
-  banana: { price: 200 },
-  durian: 100
-};
-​
-// Merge object2 into object1
-$.extend( object1, object2 );
-​
-// Assuming JSON.stringify - not available in IE<8
-$( "#log" ).append( JSON.stringify( object1 ) );
-</script>
-</body>
-</html>
-```
      * @example ​ ````Merge two objects recursively, modifying the first.
 ```html
 <!doctype html>
@@ -2854,34 +882,7 @@ $.extend( true, object1, object2 );
 // Assuming JSON.stringify - not available in IE<8
 $( "#log" ).append( JSON.stringify( object1 ) );
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Merge defaults and options, without modifying the defaults. This is a common plugin development pattern.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.extend demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-<div id="log"></div>
-​
-<script>
-var defaults = { validate: false, limit: 5, name: "foo" };
-var options = { validate: true, name: "bar" };
-​
-// Merge defaults and options, without modifying defaults
-var settings = $.extend( {}, defaults, options );
-​
-// Assuming JSON.stringify - not available in IE<8
-$( "#log" ).append( "<div><b>defaults -- </b>" + JSON.stringify( defaults ) + "</div>" );
-$( "#log" ).append( "<div><b>options -- </b>" + JSON.stringify( options ) + "</div>" );
-$( "#log" ).append( "<div><b>settings -- </b>" + JSON.stringify( settings ) + "</div>" );
-</script>
 </body>
 </html>
 ```
@@ -2897,39 +898,6 @@ $( "#log" ).append( "<div><b>settings -- </b>" + JSON.stringify( settings ) + "<
      * @param object3 An object containing additional properties to merge in.
      * @see \`{@link https://api.jquery.com/jQuery.extend/ }\`
      * @since 1.1.4
-     * @example ​ ````Merge two objects, modifying the first.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.extend demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<div id="log"></div>
-​
-<script>
-var object1 = {
-  apple: 0,
-  banana: { weight: 52, price: 100 },
-  cherry: 97
-};
-var object2 = {
-  banana: { price: 200 },
-  durian: 100
-};
-​
-// Merge object2 into object1
-$.extend( object1, object2 );
-​
-// Assuming JSON.stringify - not available in IE<8
-$( "#log" ).append( JSON.stringify( object1 ) );
-</script>
-</body>
-</html>
-```
      * @example ​ ````Merge two objects recursively, modifying the first.
 ```html
 <!doctype html>
@@ -2960,34 +928,7 @@ $.extend( true, object1, object2 );
 // Assuming JSON.stringify - not available in IE<8
 $( "#log" ).append( JSON.stringify( object1 ) );
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Merge defaults and options, without modifying the defaults. This is a common plugin development pattern.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.extend demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-<div id="log"></div>
-​
-<script>
-var defaults = { validate: false, limit: 5, name: "foo" };
-var options = { validate: true, name: "bar" };
-​
-// Merge defaults and options, without modifying defaults
-var settings = $.extend( {}, defaults, options );
-​
-// Assuming JSON.stringify - not available in IE<8
-$( "#log" ).append( "<div><b>defaults -- </b>" + JSON.stringify( defaults ) + "</div>" );
-$( "#log" ).append( "<div><b>options -- </b>" + JSON.stringify( options ) + "</div>" );
-$( "#log" ).append( "<div><b>settings -- </b>" + JSON.stringify( settings ) + "</div>" );
-</script>
 </body>
 </html>
 ```
@@ -3002,39 +943,6 @@ $( "#log" ).append( "<div><b>settings -- </b>" + JSON.stringify( settings ) + "<
      * @param object2 An object containing additional properties to merge in.
      * @see \`{@link https://api.jquery.com/jQuery.extend/ }\`
      * @since 1.1.4
-     * @example ​ ````Merge two objects, modifying the first.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.extend demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<div id="log"></div>
-​
-<script>
-var object1 = {
-  apple: 0,
-  banana: { weight: 52, price: 100 },
-  cherry: 97
-};
-var object2 = {
-  banana: { price: 200 },
-  durian: 100
-};
-​
-// Merge object2 into object1
-$.extend( object1, object2 );
-​
-// Assuming JSON.stringify - not available in IE<8
-$( "#log" ).append( JSON.stringify( object1 ) );
-</script>
-</body>
-</html>
-```
      * @example ​ ````Merge two objects recursively, modifying the first.
 ```html
 <!doctype html>
@@ -3065,34 +973,7 @@ $.extend( true, object1, object2 );
 // Assuming JSON.stringify - not available in IE<8
 $( "#log" ).append( JSON.stringify( object1 ) );
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Merge defaults and options, without modifying the defaults. This is a common plugin development pattern.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.extend demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-<div id="log"></div>
-​
-<script>
-var defaults = { validate: false, limit: 5, name: "foo" };
-var options = { validate: true, name: "bar" };
-​
-// Merge defaults and options, without modifying defaults
-var settings = $.extend( {}, defaults, options );
-​
-// Assuming JSON.stringify - not available in IE<8
-$( "#log" ).append( "<div><b>defaults -- </b>" + JSON.stringify( defaults ) + "</div>" );
-$( "#log" ).append( "<div><b>options -- </b>" + JSON.stringify( options ) + "</div>" );
-$( "#log" ).append( "<div><b>settings -- </b>" + JSON.stringify( settings ) + "</div>" );
-</script>
 </body>
 </html>
 ```
@@ -3106,39 +987,6 @@ $( "#log" ).append( "<div><b>settings -- </b>" + JSON.stringify( settings ) + "<
      * @param object1 An object containing additional properties to merge in.
      * @see \`{@link https://api.jquery.com/jQuery.extend/ }\`
      * @since 1.1.4
-     * @example ​ ````Merge two objects, modifying the first.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.extend demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<div id="log"></div>
-​
-<script>
-var object1 = {
-  apple: 0,
-  banana: { weight: 52, price: 100 },
-  cherry: 97
-};
-var object2 = {
-  banana: { price: 200 },
-  durian: 100
-};
-​
-// Merge object2 into object1
-$.extend( object1, object2 );
-​
-// Assuming JSON.stringify - not available in IE<8
-$( "#log" ).append( JSON.stringify( object1 ) );
-</script>
-</body>
-</html>
-```
      * @example ​ ````Merge two objects recursively, modifying the first.
 ```html
 <!doctype html>
@@ -3169,34 +1017,7 @@ $.extend( true, object1, object2 );
 // Assuming JSON.stringify - not available in IE<8
 $( "#log" ).append( JSON.stringify( object1 ) );
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Merge defaults and options, without modifying the defaults. This is a common plugin development pattern.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.extend demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-<div id="log"></div>
-​
-<script>
-var defaults = { validate: false, limit: 5, name: "foo" };
-var options = { validate: true, name: "bar" };
-​
-// Merge defaults and options, without modifying defaults
-var settings = $.extend( {}, defaults, options );
-​
-// Assuming JSON.stringify - not available in IE<8
-$( "#log" ).append( "<div><b>defaults -- </b>" + JSON.stringify( defaults ) + "</div>" );
-$( "#log" ).append( "<div><b>options -- </b>" + JSON.stringify( options ) + "</div>" );
-$( "#log" ).append( "<div><b>settings -- </b>" + JSON.stringify( settings ) + "</div>" );
-</script>
 </body>
 </html>
 ```
@@ -3211,39 +1032,6 @@ $( "#log" ).append( "<div><b>settings -- </b>" + JSON.stringify( settings ) + "<
      * @param objectN Additional objects containing properties to merge in.
      * @see \`{@link https://api.jquery.com/jQuery.extend/ }\`
      * @since 1.1.4
-     * @example ​ ````Merge two objects, modifying the first.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.extend demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<div id="log"></div>
-​
-<script>
-var object1 = {
-  apple: 0,
-  banana: { weight: 52, price: 100 },
-  cherry: 97
-};
-var object2 = {
-  banana: { price: 200 },
-  durian: 100
-};
-​
-// Merge object2 into object1
-$.extend( object1, object2 );
-​
-// Assuming JSON.stringify - not available in IE<8
-$( "#log" ).append( JSON.stringify( object1 ) );
-</script>
-</body>
-</html>
-```
      * @example ​ ````Merge two objects recursively, modifying the first.
 ```html
 <!doctype html>
@@ -3274,34 +1062,7 @@ $.extend( true, object1, object2 );
 // Assuming JSON.stringify - not available in IE<8
 $( "#log" ).append( JSON.stringify( object1 ) );
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Merge defaults and options, without modifying the defaults. This is a common plugin development pattern.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.extend demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-<div id="log"></div>
-​
-<script>
-var defaults = { validate: false, limit: 5, name: "foo" };
-var options = { validate: true, name: "bar" };
-​
-// Merge defaults and options, without modifying defaults
-var settings = $.extend( {}, defaults, options );
-​
-// Assuming JSON.stringify - not available in IE<8
-$( "#log" ).append( "<div><b>defaults -- </b>" + JSON.stringify( defaults ) + "</div>" );
-$( "#log" ).append( "<div><b>options -- </b>" + JSON.stringify( options ) + "</div>" );
-$( "#log" ).append( "<div><b>settings -- </b>" + JSON.stringify( settings ) + "</div>" );
-</script>
 </body>
 </html>
 ```
@@ -3350,39 +1111,7 @@ $.extend( object1, object2 );
 // Assuming JSON.stringify - not available in IE<8
 $( "#log" ).append( JSON.stringify( object1 ) );
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Merge two objects recursively, modifying the first.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.extend demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-<div id="log"></div>
-​
-<script>
-var object1 = {
-  apple: 0,
-  banana: { weight: 52, price: 100 },
-  cherry: 97
-};
-var object2 = {
-  banana: { price: 200 },
-  durian: 100
-};
-​
-// Merge object2 into object1, recursively
-$.extend( true, object1, object2 );
-​
-// Assuming JSON.stringify - not available in IE<8
-$( "#log" ).append( JSON.stringify( object1 ) );
-</script>
 </body>
 </html>
 ```
@@ -3411,6 +1140,7 @@ $( "#log" ).append( "<div><b>defaults -- </b>" + JSON.stringify( defaults ) + "<
 $( "#log" ).append( "<div><b>options -- </b>" + JSON.stringify( options ) + "</div>" );
 $( "#log" ).append( "<div><b>settings -- </b>" + JSON.stringify( settings ) + "</div>" );
 </script>
+​
 </body>
 </html>
 ```
@@ -3458,39 +1188,7 @@ $.extend( object1, object2 );
 // Assuming JSON.stringify - not available in IE<8
 $( "#log" ).append( JSON.stringify( object1 ) );
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Merge two objects recursively, modifying the first.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.extend demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-<div id="log"></div>
-​
-<script>
-var object1 = {
-  apple: 0,
-  banana: { weight: 52, price: 100 },
-  cherry: 97
-};
-var object2 = {
-  banana: { price: 200 },
-  durian: 100
-};
-​
-// Merge object2 into object1, recursively
-$.extend( true, object1, object2 );
-​
-// Assuming JSON.stringify - not available in IE<8
-$( "#log" ).append( JSON.stringify( object1 ) );
-</script>
 </body>
 </html>
 ```
@@ -3519,6 +1217,7 @@ $( "#log" ).append( "<div><b>defaults -- </b>" + JSON.stringify( defaults ) + "<
 $( "#log" ).append( "<div><b>options -- </b>" + JSON.stringify( options ) + "</div>" );
 $( "#log" ).append( "<div><b>settings -- </b>" + JSON.stringify( settings ) + "</div>" );
 </script>
+​
 </body>
 </html>
 ```
@@ -3565,39 +1264,7 @@ $.extend( object1, object2 );
 // Assuming JSON.stringify - not available in IE<8
 $( "#log" ).append( JSON.stringify( object1 ) );
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Merge two objects recursively, modifying the first.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.extend demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-<div id="log"></div>
-​
-<script>
-var object1 = {
-  apple: 0,
-  banana: { weight: 52, price: 100 },
-  cherry: 97
-};
-var object2 = {
-  banana: { price: 200 },
-  durian: 100
-};
-​
-// Merge object2 into object1, recursively
-$.extend( true, object1, object2 );
-​
-// Assuming JSON.stringify - not available in IE<8
-$( "#log" ).append( JSON.stringify( object1 ) );
-</script>
 </body>
 </html>
 ```
@@ -3626,6 +1293,7 @@ $( "#log" ).append( "<div><b>defaults -- </b>" + JSON.stringify( defaults ) + "<
 $( "#log" ).append( "<div><b>options -- </b>" + JSON.stringify( options ) + "</div>" );
 $( "#log" ).append( "<div><b>settings -- </b>" + JSON.stringify( settings ) + "</div>" );
 </script>
+​
 </body>
 </html>
 ```
@@ -3671,39 +1339,7 @@ $.extend( object1, object2 );
 // Assuming JSON.stringify - not available in IE<8
 $( "#log" ).append( JSON.stringify( object1 ) );
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Merge two objects recursively, modifying the first.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.extend demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-<div id="log"></div>
-​
-<script>
-var object1 = {
-  apple: 0,
-  banana: { weight: 52, price: 100 },
-  cherry: 97
-};
-var object2 = {
-  banana: { price: 200 },
-  durian: 100
-};
-​
-// Merge object2 into object1, recursively
-$.extend( true, object1, object2 );
-​
-// Assuming JSON.stringify - not available in IE<8
-$( "#log" ).append( JSON.stringify( object1 ) );
-</script>
 </body>
 </html>
 ```
@@ -3732,6 +1368,7 @@ $( "#log" ).append( "<div><b>defaults -- </b>" + JSON.stringify( defaults ) + "<
 $( "#log" ).append( "<div><b>options -- </b>" + JSON.stringify( options ) + "</div>" );
 $( "#log" ).append( "<div><b>settings -- </b>" + JSON.stringify( settings ) + "</div>" );
 </script>
+​
 </body>
 </html>
 ```
@@ -3776,39 +1413,7 @@ $.extend( object1, object2 );
 // Assuming JSON.stringify - not available in IE<8
 $( "#log" ).append( JSON.stringify( object1 ) );
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Merge two objects recursively, modifying the first.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.extend demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-<div id="log"></div>
-​
-<script>
-var object1 = {
-  apple: 0,
-  banana: { weight: 52, price: 100 },
-  cherry: 97
-};
-var object2 = {
-  banana: { price: 200 },
-  durian: 100
-};
-​
-// Merge object2 into object1, recursively
-$.extend( true, object1, object2 );
-​
-// Assuming JSON.stringify - not available in IE<8
-$( "#log" ).append( JSON.stringify( object1 ) );
-</script>
 </body>
 </html>
 ```
@@ -3837,6 +1442,7 @@ $( "#log" ).append( "<div><b>defaults -- </b>" + JSON.stringify( defaults ) + "<
 $( "#log" ).append( "<div><b>options -- </b>" + JSON.stringify( options ) + "</div>" );
 $( "#log" ).append( "<div><b>settings -- </b>" + JSON.stringify( settings ) + "</div>" );
 </script>
+​
 </body>
 </html>
 ```
@@ -3880,39 +1486,7 @@ $.extend( object1, object2 );
 // Assuming JSON.stringify - not available in IE<8
 $( "#log" ).append( JSON.stringify( object1 ) );
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Merge two objects recursively, modifying the first.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.extend demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-<div id="log"></div>
-​
-<script>
-var object1 = {
-  apple: 0,
-  banana: { weight: 52, price: 100 },
-  cherry: 97
-};
-var object2 = {
-  banana: { price: 200 },
-  durian: 100
-};
-​
-// Merge object2 into object1, recursively
-$.extend( true, object1, object2 );
-​
-// Assuming JSON.stringify - not available in IE<8
-$( "#log" ).append( JSON.stringify( object1 ) );
-</script>
 </body>
 </html>
 ```
@@ -3941,6 +1515,7 @@ $( "#log" ).append( "<div><b>defaults -- </b>" + JSON.stringify( defaults ) + "<
 $( "#log" ).append( "<div><b>options -- </b>" + JSON.stringify( options ) + "</div>" );
 $( "#log" ).append( "<div><b>settings -- </b>" + JSON.stringify( settings ) + "</div>" );
 </script>
+​
 </body>
 </html>
 ```
@@ -3985,39 +1560,7 @@ $.extend( object1, object2 );
 // Assuming JSON.stringify - not available in IE<8
 $( "#log" ).append( JSON.stringify( object1 ) );
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Merge two objects recursively, modifying the first.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.extend demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-<div id="log"></div>
-​
-<script>
-var object1 = {
-  apple: 0,
-  banana: { weight: 52, price: 100 },
-  cherry: 97
-};
-var object2 = {
-  banana: { price: 200 },
-  durian: 100
-};
-​
-// Merge object2 into object1, recursively
-$.extend( true, object1, object2 );
-​
-// Assuming JSON.stringify - not available in IE<8
-$( "#log" ).append( JSON.stringify( object1 ) );
-</script>
 </body>
 </html>
 ```
@@ -4046,6 +1589,7 @@ $( "#log" ).append( "<div><b>defaults -- </b>" + JSON.stringify( defaults ) + "<
 $( "#log" ).append( "<div><b>options -- </b>" + JSON.stringify( options ) + "</div>" );
 $( "#log" ).append( "<div><b>settings -- </b>" + JSON.stringify( settings ) + "</div>" );
 </script>
+​
 </body>
 </html>
 ```
@@ -4061,117 +1605,6 @@ $( "#log" ).append( "<div><b>settings -- </b>" + JSON.stringify( settings ) + "<
      * @param dataType The type of data expected from the server. Default: Intelligent Guess (xml, json, script, text, html).
      * @see \`{@link https://api.jquery.com/jQuery.get/ }\`
      * @since 1.0
-     * @example ​ ````Request the test.php page, but ignore the return results.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.get demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$.get( "test.php" );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Request the test.php page and send some additional data along (while still ignoring the return results).
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.get demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$.get( "test.php", { name: "John", time: "2pm" } );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Pass arrays of data to the server (while still ignoring the return results).
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.get demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$.get( "test.php", { "choices[]": ["Jon", "Susan"] } );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Alert the results from requesting test.php (HTML or XML, depending on what was returned).
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.get demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$.get( "test.php", function( data ) {
-  alert( "Data Loaded: " + data );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Alert the results from requesting test.cgi with an additional payload of data (HTML or XML, depending on what was returned).
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.get demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$.get( "test.cgi", { name: "John", time: "2pm" } )
-  .done(function( data ) {
-    alert( "Data Loaded: " + data );
-  });
-</script>
-</body>
-</html>
-```
-     * @example ​ ```` Get the test.php page contents, which has been returned in json format (&lt;?php echo json_encode( array( &quot;name&quot;=&gt;&quot;John&quot;,&quot;time&quot;=&gt;&quot;2pm&quot; ) ); ?&gt;), and add it to the page.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.get demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$.get( "test.php", function( data ) {
-  $( "body" )
-    .append( "Name: " + data.name ) // John
-    .append( "Time: " + data.time ); //  2pm
-}, "json" );
-</script>
-</body>
-</html>
-```
      */
     get(url: string,
         data: JQuery.PlainObject | string,
@@ -4186,116 +1619,13 @@ $.get( "test.php", function( data ) {
      * @param dataType The type of data expected from the server. Default: Intelligent Guess (xml, json, script, text, html).
      * @see \`{@link https://api.jquery.com/jQuery.get/ }\`
      * @since 1.0
-     * @example ​ ````Request the test.php page, but ignore the return results.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.get demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$.get( "test.php" );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Request the test.php page and send some additional data along (while still ignoring the return results).
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.get demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$.get( "test.php", { name: "John", time: "2pm" } );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Pass arrays of data to the server (while still ignoring the return results).
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.get demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$.get( "test.php", { "choices[]": ["Jon", "Susan"] } );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Alert the results from requesting test.php (HTML or XML, depending on what was returned).
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.get demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$.get( "test.php", function( data ) {
-  alert( "Data Loaded: " + data );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Alert the results from requesting test.cgi with an additional payload of data (HTML or XML, depending on what was returned).
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.get demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$.get( "test.cgi", { name: "John", time: "2pm" } )
-  .done(function( data ) {
-    alert( "Data Loaded: " + data );
-  });
-</script>
-</body>
-</html>
-```
-     * @example ​ ```` Get the test.php page contents, which has been returned in json format (&lt;?php echo json_encode( array( &quot;name&quot;=&gt;&quot;John&quot;,&quot;time&quot;=&gt;&quot;2pm&quot; ) ); ?&gt;), and add it to the page.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.get demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+     * @example ​ ````Get the test.php page contents, which has been returned in json format (&lt;?php echo json_encode( array( &quot;name&quot;=&gt;&quot;John&quot;,&quot;time&quot;=&gt;&quot;2pm&quot; ) ); ?&gt;), and add it to the page.
+```javascript
 $.get( "test.php", function( data ) {
   $( "body" )
     .append( "Name: " + data.name ) // John
     .append( "Time: " + data.time ); //  2pm
 }, "json" );
-</script>
-</body>
-</html>
 ```
      */
     get(url: string,
@@ -4310,116 +1640,26 @@ $.get( "test.php", function( data ) {
      *                     A plain object or string that is sent to the server with the request.
      * @see \`{@link https://api.jquery.com/jQuery.get/ }\`
      * @since 1.0
-     * @example ​ ````Request the test.php page, but ignore the return results.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.get demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$.get( "test.php" );
-</script>
-</body>
-</html>
-```
      * @example ​ ````Request the test.php page and send some additional data along (while still ignoring the return results).
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.get demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $.get( "test.php", { name: "John", time: "2pm" } );
-</script>
-</body>
-</html>
 ```
      * @example ​ ````Pass arrays of data to the server (while still ignoring the return results).
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.get demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $.get( "test.php", { "choices[]": ["Jon", "Susan"] } );
-</script>
-</body>
-</html>
 ```
      * @example ​ ````Alert the results from requesting test.php (HTML or XML, depending on what was returned).
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.get demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $.get( "test.php", function( data ) {
   alert( "Data Loaded: " + data );
 });
-</script>
-</body>
-</html>
 ```
      * @example ​ ````Alert the results from requesting test.cgi with an additional payload of data (HTML or XML, depending on what was returned).
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.get demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $.get( "test.cgi", { name: "John", time: "2pm" } )
   .done(function( data ) {
     alert( "Data Loaded: " + data );
   });
-</script>
-</body>
-</html>
-```
-     * @example ​ ```` Get the test.php page contents, which has been returned in json format (&lt;?php echo json_encode( array( &quot;name&quot;=&gt;&quot;John&quot;,&quot;time&quot;=&gt;&quot;2pm&quot; ) ); ?&gt;), and add it to the page.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.get demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$.get( "test.php", function( data ) {
-  $( "body" )
-    .append( "Name: " + data.name ) // John
-    .append( "Time: " + data.time ); //  2pm
-}, "json" );
-</script>
-</body>
-</html>
 ```
      */
     get(url: string,
@@ -4436,115 +1676,8 @@ $.get( "test.php", function( data ) {
      * @since 1.12
      * @since 2.2
      * @example ​ ````Request the test.php page, but ignore the return results.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.get demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $.get( "test.php" );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Request the test.php page and send some additional data along (while still ignoring the return results).
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.get demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$.get( "test.php", { name: "John", time: "2pm" } );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Pass arrays of data to the server (while still ignoring the return results).
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.get demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$.get( "test.php", { "choices[]": ["Jon", "Susan"] } );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Alert the results from requesting test.php (HTML or XML, depending on what was returned).
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.get demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$.get( "test.php", function( data ) {
-  alert( "Data Loaded: " + data );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Alert the results from requesting test.cgi with an additional payload of data (HTML or XML, depending on what was returned).
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.get demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$.get( "test.cgi", { name: "John", time: "2pm" } )
-  .done(function( data ) {
-    alert( "Data Loaded: " + data );
-  });
-</script>
-</body>
-</html>
-```
-     * @example ​ ```` Get the test.php page contents, which has been returned in json format (&lt;?php echo json_encode( array( &quot;name&quot;=&gt;&quot;John&quot;,&quot;time&quot;=&gt;&quot;2pm&quot; ) ); ?&gt;), and add it to the page.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.get demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$.get( "test.php", function( data ) {
-  $( "body" )
-    .append( "Name: " + data.name ) // John
-    .append( "Time: " + data.time ); //  2pm
-}, "json" );
-</script>
-</body>
-</html>
 ```
      */
     get(url_settings?: string | JQuery.UrlAjaxSettings): JQuery.jqXHR;
@@ -4556,90 +1689,6 @@ $.get( "test.php", function( data ) {
      * @param success A callback function that is executed if the request succeeds.
      * @see \`{@link https://api.jquery.com/jQuery.getJSON/ }\`
      * @since 1.0
-     * @example ​ ````Loads the four most recent pictures of Mount Rainier from the Flickr JSONP API.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.getJSON demo</title>
-  <style>
-  img {
-    height: 100px;
-    float: left;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<div id="images"></div>
-​
-<script>
-(function() {
-  var flickerAPI = "https://api.flickr.com/services/feeds/photos_public.gne?jsoncallback=?";
-  $.getJSON( flickerAPI, {
-    tags: "mount rainier",
-    tagmode: "any",
-    format: "json"
-  })
-    .done(function( data ) {
-      $.each( data.items, function( i, item ) {
-        $( "<img>" ).attr( "src", item.media.m ).appendTo( "#images" );
-        if ( i === 3 ) {
-          return false;
-        }
-      });
-    });
-})();
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Load the JSON data from test.js and access a name from the returned JSON data.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.getJSON demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$.getJSON( "test.js", function( json ) {
-  console.log( "JSON Data: " + json.users[ 3 ].name );
- });
- </script>
-</body>
-</html>
-```
-     * @example ​ ````Load the JSON data from test.js, passing along additional data, and access a name from the returned JSON data.
-      If an error occurs, log an error message instead.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.getJSON demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$.getJSON( "test.js", { name: "John", time: "2pm" } )
-  .done(function( json ) {
-    console.log( "JSON Data: " + json.users[ 3 ].name );
-  })
-  .fail(function( jqxhr, textStatus, error ) {
-    var err = textStatus + ", " + error;
-    console.log( "Request Failed: " + err );
-});
-</script>
-</body>
-</html>
-```
      */
     getJSON(url: string,
             data: JQuery.PlainObject | string,
@@ -4689,41 +1738,19 @@ $.getJSON( "test.js", { name: "John", time: "2pm" } )
     });
 })();
 </script>
+​
 </body>
 </html>
 ```
      * @example ​ ````Load the JSON data from test.js and access a name from the returned JSON data.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.getJSON demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $.getJSON( "test.js", function( json ) {
   console.log( "JSON Data: " + json.users[ 3 ].name );
  });
- </script>
-</body>
-</html>
-```
+ ```
      * @example ​ ````Load the JSON data from test.js, passing along additional data, and access a name from the returned JSON data.
       If an error occurs, log an error message instead.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.getJSON demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $.getJSON( "test.js", { name: "John", time: "2pm" } )
   .done(function( json ) {
     console.log( "JSON Data: " + json.users[ 3 ].name );
@@ -4732,9 +1759,6 @@ $.getJSON( "test.js", { name: "John", time: "2pm" } )
     var err = textStatus + ", " + error;
     console.log( "Request Failed: " + err );
 });
-</script>
-</body>
-</html>
 ```
      */
     getJSON(url: string,
@@ -4747,17 +1771,7 @@ $.getJSON( "test.js", { name: "John", time: "2pm" } )
      * @see \`{@link https://api.jquery.com/jQuery.getScript/ }\`
      * @since 1.0
      * @example ​ ````Define a $.cachedScript() method that allows fetching a cached script:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.getScript demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 jQuery.cachedScript = function( url, options ) {
 ​
   // Allow user to set any option except for dataType, cache, and url
@@ -4776,9 +1790,6 @@ jQuery.cachedScript = function( url, options ) {
 $.cachedScript( "ajax/test.js" ).done(function( script, textStatus ) {
   console.log( textStatus );
 });
-</script>
-</body>
-</html>
 ```
      * @example ​ ````Load the official jQuery Color Animation plugin dynamically and bind some color animations to occur once the new functionality is loaded.
 ```html
@@ -4821,6 +1832,7 @@ $.getScript( url, function() {
   });
 });
 </script>
+​
 </body>
 </html>
 ```
@@ -4834,25 +1846,12 @@ $.getScript( url, function() {
      * @see \`{@link https://api.jquery.com/jQuery.globalEval/ }\`
      * @since 1.0.4
      * @example ​ ````Execute a script in the global context.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.globalEval demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 function test() {
   jQuery.globalEval( "var newVar = true;" )
 }
 test();
 // newVar === true
-</script>
-</body>
-</html>
 ```
      */
     globalEval(code: string): void;
@@ -4909,46 +1908,21 @@ arr = jQuery.grep(arr, function( a ) {
 ​
 $( "span" ).text( arr.join( ", " ) );
 </script>
+​
 </body>
 </html>
 ```
      * @example ​ ````Filter an array of numbers to include only numbers bigger then zero.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.grep demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $.grep( [ 0, 1, 2 ], function( n, i ) {
   return n > 0;
 });
-</script>
-</body>
-</html>
 ```
      * @example ​ ````Filter an array of numbers to include numbers that are not bigger than zero.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.grep demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $.grep( [ 0, 1, 2 ], function( n, i ) {
     return n > 0;
 }, true );
-</script>
-</body>
-</html>
 ```
      */
     grep<T>(array: ArrayLike<T>,
@@ -4989,6 +1963,7 @@ $p.append( jQuery.hasData( p ) + " " ); // true
 $p.off( "click" );
 $p.append( jQuery.hasData( p ) + " " ); // false
 </script>
+​
 </body>
 </html>
 ```
@@ -5006,24 +1981,11 @@ $p.append( jQuery.hasData( p ) + " " ); // false
      *
      * **Solution**: Rewrite the page so that it does not require all jQuery ready handlers to be delayed. This might be accomplished, for example, by late-loading only the code that requires the delay when it is safe to run. Due to the complexity of this method, jQuery Migrate does not attempt to fill the functionality. If the underlying version of jQuery used with jQuery Migrate no longer contains `jQuery.holdReady()` the code will fail shortly after this warning appears.
      * @example ​ ````Delay the ready event until a custom plugin has loaded.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.holdReady demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $.holdReady( true );
 $.getScript( "myplugin.js", function() {
   $.holdReady( false );
 });
-</script>
-</body>
-</html>
 ```
      */
     holdReady(hold: boolean): void;
@@ -5075,6 +2037,7 @@ $spans.eq( 1 ).text( jQuery.inArray( 4, arr ) );
 $spans.eq( 2 ).text( jQuery.inArray( "Karl", arr ) );
 $spans.eq( 3 ).text( jQuery.inArray( "Pete", arr, 2 ) );
 </script>
+​
 </body>
 </html>
 ```
@@ -5103,6 +2066,7 @@ Is [] an Array? <b></b>
 <script>
 $( "b" ).append( "" + $.isArray([]) );
 </script>
+​
 </body>
 </html>
 ```
@@ -5115,22 +2079,9 @@ $( "b" ).append( "" + $.isArray([]) );
      * @see \`{@link https://api.jquery.com/jQuery.isEmptyObject/ }\`
      * @since 1.4
      * @example ​ ````Check an object to see if it&#39;s empty.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.isEmptyObject demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 jQuery.isEmptyObject({}); // true
 jQuery.isEmptyObject({ foo: "bar" }); // false
-</script>
-</body>
-</html>
 ```
      */
     isEmptyObject(obj: any): boolean;
@@ -5183,25 +2134,13 @@ jQuery.each( objs, function( i ) {
   $( "span" ).eq( i ).text( isFunc );
 });
 </script>
+​
 </body>
 </html>
 ```
      * @example ​ ````Finds out if the parameter is a function.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.isFunction demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $.isFunction(function() {});
-</script>
-</body>
-</html>
 ```
      */
     // tslint:disable-next-line:ban-types
@@ -5214,17 +2153,7 @@ $.isFunction(function() {});
      * @since 1.7
      * @deprecated ​ Deprecated since 3.3. Internal. See \`{@link https://github.com/jquery/jquery/issues/2960 }\`.
      * @example ​ ````Sample return values of $.isNumeric with various inputs.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.isNumeric demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 // true (numeric)
 $.isNumeric( "-10" )
 $.isNumeric( "0" )
@@ -5245,9 +2174,6 @@ $.isNumeric( null )
 $.isNumeric( true )
 $.isNumeric( Infinity )
 $.isNumeric( undefined )
-</script>
-</body>
-</html>
 ```
      */
     isNumeric(value: any): boolean;
@@ -5258,22 +2184,9 @@ $.isNumeric( undefined )
      * @see \`{@link https://api.jquery.com/jQuery.isPlainObject/ }\`
      * @since 1.4
      * @example ​ ````Check an object to see if it&#39;s a plain object.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.isPlainObject demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 jQuery.isPlainObject({}) // true
 jQuery.isPlainObject( "test" ) // false
-</script>
-</body>
-</html>
 ```
      */
     isPlainObject(obj: any): boolean;
@@ -5285,11 +2198,9 @@ jQuery.isPlainObject( "test" ) // false
      * @since 1.4.3
      * @deprecated ​ Deprecated since 3.3. Internal. See \`{@link https://github.com/jquery/jquery/issues/3629 }\`.
      *
-     * **Cause**: This method returns `true` if its argument is thought to be a `window` element. It was
-     * created for internal use and is not a reliable way of detecting `window` for public needs.
+     * **Cause**: This method returns `true` if its argument is thought to be a `window` element. It was created for internal use and is not a reliable way of detecting `window` for public needs.
      *
-     * **Solution**: Remove any use of `jQuery.isWindow()` from code. If it is truly needed it can be
-     * replaced with a check for `obj != null && obj === obj.window` which was the test used inside this method.
+     * **Solution**: Remove any use of `jQuery.isWindow()` from code. If it is truly needed it can be replaced with a check for `obj != null && obj === obj.window` which was the test used inside this method.
      * @example ​ ````Finds out if the parameter is a window.
 ```html
 <!doctype html>
@@ -5306,6 +2217,7 @@ Is 'window' a window? <b></b>
 <script>
 $( "b" ).append( "" + $.isWindow( window ) );
 </script>
+​
 </body>
 </html>
 ```
@@ -5318,22 +2230,9 @@ $( "b" ).append( "" + $.isWindow( window ) );
      * @see \`{@link https://api.jquery.com/jQuery.isXMLDoc/ }\`
      * @since 1.1.4
      * @example ​ ````Check an object to see if it&#39;s in an XML document.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.isXMLDoc demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 jQuery.isXMLDoc( document ) // false
 jQuery.isXMLDoc( document.body ) // false
-</script>
-</body>
-</html>
 ```
      */
     isXMLDoc(node: Node): boolean;
@@ -5373,26 +2272,14 @@ var arr = jQuery.makeArray( elems );
 arr.reverse();
 $( arr ).appendTo( document.body );
 </script>
+​
 </body>
 </html>
 ```
      * @example ​ ````Turn a jQuery object into an array
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.makeArray demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 var obj = $( "li" );
 var arr = $.makeArray( obj );
-</script>
-</body>
-</html>
 ```
      */
     makeArray<T>(obj: ArrayLike<T>): T[];
@@ -5446,163 +2333,46 @@ arr = jQuery.map( arr, function( a ) {
 });
 $( "span" ).text( arr.join( ", " ) );
 </script>
+​
 </body>
 </html>
 ```
      * @example ​ ````Map the original array to a new one and add 4 to each value.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.map demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $.map( [ 0, 1, 2 ], function( n ) {
   return n + 4;
 });
-</script>
-</body>
-</html>
 ```
      * @example ​ ````Map the original array to a new one, adding 1 to each value if it is bigger then zero and removing it if not.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.map demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $.map( [ 0, 1, 2 ], function( n ) {
   return n > 0 ? n + 1 : null;
 });
-</script>
-</body>
-</html>
 ```
      * @example ​ ````Map the original array to a new one; each element is added with its original value and the value plus one.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.map demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $.map( [ 0, 1, 2 ], function( n ) {
     return [ n, n + 1 ];
 });
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Map the original object to a new array and double each value.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.map demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-var dimensions = { width: 10, height: 15, length: 20 };
-dimensions = $.map( dimensions, function( value, index ) {
-  return value * 2;
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Map an object&#39;s keys to an array.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.map demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-var dimensions = { width: 10, height: 15, length: 20 };
-var keys = $.map( dimensions, function( value, key ) {
-  return key;
-});
-</script>
-</body>
-</html>
 ```
      * @example ​ ````Map the original array to a new one; each element is squared.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.map demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $.map( [ 0, 1, 2, 3 ], function( a ) {
   return a * a;
 });
-</script>
-</body>
-</html>
 ```
      * @example ​ ````Map the original array to a new one, removing numbers less than 50 by returning null and subtracting 45 from the rest.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.map demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $.map( [ 0, 1, 52, 97 ], function( a ) {
   return (a > 50 ? a - 45 : null);
 });
-</script>
-</body>
-</html>
 ```
      * @example ​ ````Augment the resulting array by returning an array inside the function.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.map demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 var array = [ 0, 1, 52, 97 ];
 array = $.map( array, function( a, index ) {
   return [ a - 45, index ];
 });
-</script>
-</body>
-</html>
 ```
      */
     map<T, TReturn>(array: T[], callback: (this: Window, elementOfArray: T, indexInArray: number) => JQuery.TypeOrArray<TReturn> | null | undefined): TReturn[];
@@ -5616,204 +2386,19 @@ array = $.map( array, function( a, index ) {
      *                 to the global (window) object.
      * @see \`{@link https://api.jquery.com/jQuery.map/ }\`
      * @since 1.6
-     * @example ​ ````Use $.map() to change the values of an array.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.map demo</title>
-  <style>
-  div {
-    color: blue;
-  }
-  p {
-    color: green;
-    margin: 0;
-  }
-  span {
-    color: red;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<div></div>
-<p></p>
-<span></span>
-​
-<script>
-var arr = [ "a", "b", "c", "d", "e" ];
-$( "div" ).text( arr.join( ", " ) );
-​
-arr = jQuery.map( arr, function( n, i ) {
-  return ( n.toUpperCase() + i );
-});
-$( "p" ).text( arr.join( ", " ) );
-​
-arr = jQuery.map( arr, function( a ) {
-  return a + a;
-});
-$( "span" ).text( arr.join( ", " ) );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Map the original array to a new one and add 4 to each value.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.map demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$.map( [ 0, 1, 2 ], function( n ) {
-  return n + 4;
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Map the original array to a new one, adding 1 to each value if it is bigger then zero and removing it if not.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.map demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$.map( [ 0, 1, 2 ], function( n ) {
-  return n > 0 ? n + 1 : null;
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Map the original array to a new one; each element is added with its original value and the value plus one.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.map demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$.map( [ 0, 1, 2 ], function( n ) {
-    return [ n, n + 1 ];
-});
-</script>
-</body>
-</html>
-```
      * @example ​ ````Map the original object to a new array and double each value.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.map demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 var dimensions = { width: 10, height: 15, length: 20 };
 dimensions = $.map( dimensions, function( value, index ) {
   return value * 2;
 });
-</script>
-</body>
-</html>
 ```
      * @example ​ ````Map an object&#39;s keys to an array.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.map demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 var dimensions = { width: 10, height: 15, length: 20 };
 var keys = $.map( dimensions, function( value, key ) {
   return key;
 });
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Map the original array to a new one; each element is squared.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.map demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$.map( [ 0, 1, 2, 3 ], function( a ) {
-  return a * a;
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Map the original array to a new one, removing numbers less than 50 by returning null and subtracting 45 from the rest.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.map demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$.map( [ 0, 1, 52, 97 ], function( a ) {
-  return (a > 50 ? a - 45 : null);
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Augment the resulting array by returning an array inside the function.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.map demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-var array = [ 0, 1, 52, 97 ];
-array = $.map( array, function( a, index ) {
-  return [ a - 45, index ];
-});
-</script>
-</body>
-</html>
 ```
      */
     map<T, K extends keyof T, TReturn>(obj: T, callback: (this: Window, propertyOfObject: T[K], key: K) => JQuery.TypeOrArray<TReturn> | null | undefined): TReturn[];
@@ -5825,57 +2410,18 @@ array = $.map( array, function( a, index ) {
      * @see \`{@link https://api.jquery.com/jQuery.merge/ }\`
      * @since 1.0
      * @example ​ ````Merges two arrays, altering the first argument.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.merge demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $.merge( [ 0, 1, 2 ], [ 2, 3, 4 ] )
-</script>
-</body>
-</html>
 ```
      * @example ​ ````Merges two arrays, altering the first argument.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.merge demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $.merge( [ 3, 2, 1 ], [ 4, 3, 2 ] )
-</script>
-</body>
-</html>
 ```
      * @example ​ ````Merges two arrays, but uses a copy, so the original isn&#39;t altered.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.merge demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 var first = [ "a", "b", "c" ];
 var second = [ "d", "e", "f" ];
 $.merge( $.merge( [], first ), second );
-</script>
-</body>
-</html>
 ```
      */
     merge<T, U>(first: ArrayLike<T>, second: ArrayLike<U>): Array<T | U>;
@@ -5886,38 +2432,15 @@ $.merge( $.merge( [], first ), second );
      * @see \`{@link https://api.jquery.com/jQuery.noConflict/ }\`
      * @since 1.0
      * @example ​ ````Map the original object that was referenced by $ back to $.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.noConflict demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 jQuery.noConflict();
 // Do something with jQuery
 jQuery( "div p" ).hide();
 // Do something with another library's $()
 $( "content" ).style.display = "none";
-</script>
-</body>
-</html>
 ```
      * @example ​ ````Revert the $ alias and then create and execute a function to provide the $ as a jQuery alias inside the function&#39;s scope. Inside the function the original $ object is not available. This works well for most plugins that don&#39;t rely on any other library.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.noConflict demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 jQuery.noConflict();
 (function( $ ) {
   $(function() {
@@ -5926,22 +2449,9 @@ jQuery.noConflict();
 })(jQuery);
 ​
 // Other code using $ as an alias to the other library
-</script>
-</body>
-</html>
 ```
      * @example ​ ````Create a different alias instead of jQuery to use in the rest of the script.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.noConflict demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 var j = jQuery.noConflict();
 ​
 // Do something with jQuery
@@ -5949,27 +2459,11 @@ j( "div p" ).hide();
 ​
 // Do something with another library's $()
 $( "content" ).style.display = "none";
-</script>
-</body>
-</html>
 ```
      * @example ​ ````Completely move jQuery to a new namespace in another object.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.noConflict demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 var dom = {};
 dom.query = jQuery.noConflict( true );
-</script>
-</body>
-</html>
 ```
      * @example ​ ````Load two versions of jQuery (not recommended). Then, restore jQuery&#39;s globally scoped variables to the first loaded jQuery.
 ```html
@@ -6001,6 +2495,7 @@ $log.append( "<h3>After $.noConflict(true)</h3>" );
 $log.append( "1st loaded jQuery version ($): " + $.fn.jquery + "<br>" );
 $log.append( "2nd loaded jQuery version (jq162): " + jq162.fn.jquery + "<br>" );
 </script>
+​
 </body>
 </html>
 ```
@@ -6062,6 +2557,7 @@ var params = { width:1680, height:1050 };
 var str = jQuery.param( params );
 $( "#results" ).text( str );
 </script>
+​
 </body>
 </html>
 ```
@@ -6095,6 +2591,7 @@ $.param({ a: { b: 1, c: 2 }, d: [ 3, 4, { e: 5 } ] });
 $.param({ a: { b: 1, c: 2 }, d: [ 3, 4, { e: 5 } ] });
 // "a[b]=1&a[c]=2&d[]=3&d[]=4&d[2][e]=5"
 </script>
+​
 </body>
 </html>
 ```
@@ -6108,44 +2605,6 @@ $.param({ a: { b: 1, c: 2 }, d: [ 3, 4, { e: 5 } ] });
      * @param keepScripts A Boolean indicating whether to include scripts passed in the HTML string
      * @see \`{@link https://api.jquery.com/jQuery.parseHTML/ }\`
      * @since 1.8
-     * @example ​ ````Create an array of DOM nodes using an HTML string and insert it into a div.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.parseHTML demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<div id="log">
-  <h3>Content:</h3>
-</div>
-​
-<script>
-var $log = $( "#log" ),
-  str = "hello, <b>my name is</b> jQuery.",
-  html = $.parseHTML( str ),
-  nodeNames = [];
-​
-// Append the parsed HTML
-$log.append( html );
-​
-// Gather the parsed HTML's node names
-$.each( html, function( i, el ) {
-  nodeNames[ i ] = "<li>" + el.nodeName + "</li>";
-});
-​
-// Insert the node names
-$log.append( "<h3>Node Names:</h3>" );
-$( "<ol></ol>" )
-  .append( nodeNames.join( "" ) )
-  .appendTo( $log );
-</script>
-</body>
-</html>
-```
      */
     parseHTML(data: string, context: Document | null | undefined, keepScripts: boolean): JQuery.Node[];
     /**
@@ -6191,6 +2650,7 @@ $( "<ol></ol>" )
   .append( nodeNames.join( "" ) )
   .appendTo( $log );
 </script>
+​
 </body>
 </html>
 ```
@@ -6208,22 +2668,9 @@ $( "<ol></ol>" )
      *
      * **Solution**: Replace any use of `jQuery.parseJSON` with `JSON.parse`.
      * @example ​ ````Parse a JSON string.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.parseJSON demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 var obj = jQuery.parseJSON( '{ "name": "John" }' );
 alert( obj.name === "John" );
-</script>
-</body>
-</html>
 ```
      */
     parseJSON(json: string): any;
@@ -6262,6 +2709,7 @@ $title.text( "XML Title" );
 // Append "XML Title" to #anotherElement
 $( "#anotherElement" ).append( $title.text() );
 </script>
+​
 </body>
 </html>
 ```
@@ -6277,175 +2725,12 @@ $( "#anotherElement" ).append( $title.text() );
      * @param dataType The type of data expected from the server. Default: Intelligent Guess (xml, json, script, text, html).
      * @see \`{@link https://api.jquery.com/jQuery.post/ }\`
      * @since 1.0
-     * @example ​ ````Request the test.php page, but ignore the return results.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.post demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$.post( "test.php" );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Request the test.php page and send some additional data along (while still ignoring the return results).
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.post demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$.post( "test.php", { name: "John", time: "2pm" } );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Pass arrays of data to the server (while still ignoring the return results).
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.post demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$.post( "test.php", { 'choices[]': [ "Jon", "Susan" ] } );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Send form data using Ajax requests
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.post demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$.post( "test.php", $( "#testform" ).serialize() );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Alert the results from requesting test.php (HTML or XML, depending on what was returned).
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.post demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$.post( "test.php", function( data ) {
-  alert( "Data Loaded: " + data );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Alert the results from requesting test.php with an additional payload of data (HTML or XML, depending on what was returned).
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.post demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$.post( "test.php", { name: "John", time: "2pm" })
-  .done(function( data ) {
-    alert( "Data Loaded: " + data );
-  });
-</script>
-</body>
-</html>
-```
      * @example ​ ````Post to the test.php page and get content which has been returned in json format (&lt;?php echo json_encode(array(&quot;name&quot;=&gt;&quot;John&quot;,&quot;time&quot;=&gt;&quot;2pm&quot;)); ?&gt;).
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.post demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $.post( "test.php", { func: "getNameAndTime" }, function( data ) {
   console.log( data.name ); // John
   console.log( data.time ); // 2pm
 }, "json");
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Post a form using Ajax and put results in a div
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.post demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<form action="/" id="searchForm">
-  <input type="text" name="s" placeholder="Search...">
-  <input type="submit" value="Search">
-</form>
-<!-- the result of the search will be rendered inside this div -->
-<div id="result"></div>
-​
-<script>
-// Attach a submit handler to the form
-$( "#searchForm" ).submit(function( event ) {
-​
-  // Stop form from submitting normally
-  event.preventDefault();
-​
-  // Get some values from elements on the page:
-  var $form = $( this ),
-    term = $form.find( "input[name='s']" ).val(),
-    url = $form.attr( "action" );
-​
-  // Send the data using post
-  var posting = $.post( url, { s: term } );
-​
-  // Put the results in a div
-  posting.done(function( data ) {
-    var content = $( data ).find( "#content" );
-    $( "#result" ).empty().append( content );
-  });
-});
-</script>
-</body>
-</html>
 ```
      */
     post(url: string,
@@ -6461,176 +2746,6 @@ $( "#searchForm" ).submit(function( event ) {
      * @param dataType The type of data expected from the server. Default: Intelligent Guess (xml, json, script, text, html).
      * @see \`{@link https://api.jquery.com/jQuery.post/ }\`
      * @since 1.0
-     * @example ​ ````Request the test.php page, but ignore the return results.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.post demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$.post( "test.php" );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Request the test.php page and send some additional data along (while still ignoring the return results).
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.post demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$.post( "test.php", { name: "John", time: "2pm" } );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Pass arrays of data to the server (while still ignoring the return results).
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.post demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$.post( "test.php", { 'choices[]': [ "Jon", "Susan" ] } );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Send form data using Ajax requests
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.post demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$.post( "test.php", $( "#testform" ).serialize() );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Alert the results from requesting test.php (HTML or XML, depending on what was returned).
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.post demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$.post( "test.php", function( data ) {
-  alert( "Data Loaded: " + data );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Alert the results from requesting test.php with an additional payload of data (HTML or XML, depending on what was returned).
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.post demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$.post( "test.php", { name: "John", time: "2pm" })
-  .done(function( data ) {
-    alert( "Data Loaded: " + data );
-  });
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Post to the test.php page and get content which has been returned in json format (&lt;?php echo json_encode(array(&quot;name&quot;=&gt;&quot;John&quot;,&quot;time&quot;=&gt;&quot;2pm&quot;)); ?&gt;).
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.post demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$.post( "test.php", { func: "getNameAndTime" }, function( data ) {
-  console.log( data.name ); // John
-  console.log( data.time ); // 2pm
-}, "json");
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Post a form using Ajax and put results in a div
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.post demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<form action="/" id="searchForm">
-  <input type="text" name="s" placeholder="Search...">
-  <input type="submit" value="Search">
-</form>
-<!-- the result of the search will be rendered inside this div -->
-<div id="result"></div>
-​
-<script>
-// Attach a submit handler to the form
-$( "#searchForm" ).submit(function( event ) {
-​
-  // Stop form from submitting normally
-  event.preventDefault();
-​
-  // Get some values from elements on the page:
-  var $form = $( this ),
-    term = $form.find( "input[name='s']" ).val(),
-    url = $form.attr( "action" );
-​
-  // Send the data using post
-  var posting = $.post( url, { s: term } );
-​
-  // Put the results in a div
-  posting.done(function( data ) {
-    var content = $( data ).find( "#content" );
-    $( "#result" ).empty().append( content );
-  });
-});
-</script>
-</body>
-</html>
-```
      */
     post(url: string,
          success: JQuery.jqXHR.DoneCallback | null,
@@ -6644,132 +2759,30 @@ $( "#searchForm" ).submit(function( event ) {
      *                     A plain object or string that is sent to the server with the request.
      * @see \`{@link https://api.jquery.com/jQuery.post/ }\`
      * @since 1.0
-     * @example ​ ````Request the test.php page, but ignore the return results.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.post demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$.post( "test.php" );
-</script>
-</body>
-</html>
-```
      * @example ​ ````Request the test.php page and send some additional data along (while still ignoring the return results).
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.post demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $.post( "test.php", { name: "John", time: "2pm" } );
-</script>
-</body>
-</html>
 ```
      * @example ​ ````Pass arrays of data to the server (while still ignoring the return results).
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.post demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $.post( "test.php", { 'choices[]': [ "Jon", "Susan" ] } );
-</script>
-</body>
-</html>
 ```
      * @example ​ ````Send form data using Ajax requests
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.post demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $.post( "test.php", $( "#testform" ).serialize() );
-</script>
-</body>
-</html>
 ```
      * @example ​ ````Alert the results from requesting test.php (HTML or XML, depending on what was returned).
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.post demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $.post( "test.php", function( data ) {
   alert( "Data Loaded: " + data );
 });
-</script>
-</body>
-</html>
 ```
      * @example ​ ````Alert the results from requesting test.php with an additional payload of data (HTML or XML, depending on what was returned).
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.post demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $.post( "test.php", { name: "John", time: "2pm" })
   .done(function( data ) {
     alert( "Data Loaded: " + data );
   });
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Post to the test.php page and get content which has been returned in json format (&lt;?php echo json_encode(array(&quot;name&quot;=&gt;&quot;John&quot;,&quot;time&quot;=&gt;&quot;2pm&quot;)); ?&gt;).
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.post demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$.post( "test.php", { func: "getNameAndTime" }, function( data ) {
-  console.log( data.name ); // John
-  console.log( data.time ); // 2pm
-}, "json");
-</script>
-</body>
-</html>
 ```
      * @example ​ ````Post a form using Ajax and put results in a div
 ```html
@@ -6811,6 +2824,7 @@ $( "#searchForm" ).submit(function( event ) {
   });
 });
 </script>
+​
 </body>
 </html>
 ```
@@ -6829,174 +2843,8 @@ $( "#searchForm" ).submit(function( event ) {
      * @since 1.12
      * @since 2.2
      * @example ​ ````Request the test.php page, but ignore the return results.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.post demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $.post( "test.php" );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Request the test.php page and send some additional data along (while still ignoring the return results).
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.post demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$.post( "test.php", { name: "John", time: "2pm" } );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Pass arrays of data to the server (while still ignoring the return results).
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.post demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$.post( "test.php", { 'choices[]': [ "Jon", "Susan" ] } );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Send form data using Ajax requests
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.post demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$.post( "test.php", $( "#testform" ).serialize() );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Alert the results from requesting test.php (HTML or XML, depending on what was returned).
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.post demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$.post( "test.php", function( data ) {
-  alert( "Data Loaded: " + data );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Alert the results from requesting test.php with an additional payload of data (HTML or XML, depending on what was returned).
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.post demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$.post( "test.php", { name: "John", time: "2pm" })
-  .done(function( data ) {
-    alert( "Data Loaded: " + data );
-  });
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Post to the test.php page and get content which has been returned in json format (&lt;?php echo json_encode(array(&quot;name&quot;=&gt;&quot;John&quot;,&quot;time&quot;=&gt;&quot;2pm&quot;)); ?&gt;).
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.post demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$.post( "test.php", { func: "getNameAndTime" }, function( data ) {
-  console.log( data.name ); // John
-  console.log( data.time ); // 2pm
-}, "json");
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Post a form using Ajax and put results in a div
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.post demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<form action="/" id="searchForm">
-  <input type="text" name="s" placeholder="Search...">
-  <input type="submit" value="Search">
-</form>
-<!-- the result of the search will be rendered inside this div -->
-<div id="result"></div>
-​
-<script>
-// Attach a submit handler to the form
-$( "#searchForm" ).submit(function( event ) {
-​
-  // Stop form from submitting normally
-  event.preventDefault();
-​
-  // Get some values from elements on the page:
-  var $form = $( this ),
-    term = $form.find( "input[name='s']" ).val(),
-    url = $form.attr( "action" );
-​
-  // Send the data using post
-  var posting = $.post( url, { s: term } );
-​
-  // Put the results in a div
-  posting.done(function( data ) {
-    var content = $( data ).find( "#content" );
-    $( "#result" ).empty().append( content );
-  });
-});
-</script>
-</body>
-</html>
 ```
      */
     post(url_settings?: string | JQuery.UrlAjaxSettings): JQuery.jqXHR;
@@ -7021,149 +2869,6 @@ $( "#searchForm" ).submit(function( event ) {
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
-     * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  type: "zombie",
-  test: function( event ) {
-    // Without proxy, `this` would refer to the event target
-    // use event.target to reference that element.
-    var element = event.target;
-    $( element ).css( "background-color", "red" );
-​
-    // With proxy, `this` refers to the me object encapsulating
-    // this function.
-    $( "#log" ).append( "Hello " + this.type + "<br>" );
-    $( "#test" ).off( "click", this.test );
-  }
-};
-​
-var you = {
-  type: "person",
-  test: function( event ) {
-    $( "#log" ).append( this.type + " " );
-  }
-};
-​
-// Execute you.test() in the context of the `you` object
-// no matter where it is called
-// i.e. the `this` keyword will refer to `you`
-var youClick = $.proxy( you.test, you );
-​
-// attach click handlers to #test
-$( "#test" )
-  // this === "zombie"; handler unbound after first click
-  .on( "click", $.proxy( me.test, me ) )
-​
-  // this === "person"
-  .on( "click", youClick )
-​
-  // this === "zombie"
-  .on( "click", $.proxy( you.test, me ) )
-​
-  // this === "<button> element"
-  .on( "click", you.test );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Change the context of a function bound to the click handler,
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  // I'm a dog
-  type: "dog",
-​
-  // Note that event comes *after* one and two
-  test: function( one, two, event ) {
-    $( "#log" )
-​
-      // `one` maps to `you`, the 1st additional
-      // argument in the $.proxy function call
-      .append( "<h3>Hello " + one.type + ":</h3>" )
-​
-      // The `this` keyword refers to `me`
-      // (the 2nd, context, argument of $.proxy)
-      .append( "I am a " + this.type + ", " )
-​
-      // `two` maps to `they`, the 2nd additional
-      // argument in the $.proxy function call
-      .append( "and they are " + two.type + ".<br>" )
-​
-      // The event type is "click"
-      .append( "Thanks for " + event.type + "ing." )
-​
-      // The clicked element is `event.target`,
-      // and its type is "button"
-      .append( "the " + event.target.type + "." );
-  }
-};
-​
-var you = { type: "cat" };
-var they = { type: "fish" };
-​
-// Set up handler to execute me.test() in the context
-// of `me`, with `you` and `they` as additional arguments
-var proxy = $.proxy( me.test, me, you, they );
-​
-$( "#test" )
-  .on( "click", proxy );
-</script>
-</body>
-</html>
-```
      */
     proxy<TReturn,
         A, B, C, D, E, F, G>(fn: (a: A, b: B, c: C, d: D, e: E, f: F, g: G) => TReturn,
@@ -7177,149 +2882,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
-     * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  type: "zombie",
-  test: function( event ) {
-    // Without proxy, `this` would refer to the event target
-    // use event.target to reference that element.
-    var element = event.target;
-    $( element ).css( "background-color", "red" );
-​
-    // With proxy, `this` refers to the me object encapsulating
-    // this function.
-    $( "#log" ).append( "Hello " + this.type + "<br>" );
-    $( "#test" ).off( "click", this.test );
-  }
-};
-​
-var you = {
-  type: "person",
-  test: function( event ) {
-    $( "#log" ).append( this.type + " " );
-  }
-};
-​
-// Execute you.test() in the context of the `you` object
-// no matter where it is called
-// i.e. the `this` keyword will refer to `you`
-var youClick = $.proxy( you.test, you );
-​
-// attach click handlers to #test
-$( "#test" )
-  // this === "zombie"; handler unbound after first click
-  .on( "click", $.proxy( me.test, me ) )
-​
-  // this === "person"
-  .on( "click", youClick )
-​
-  // this === "zombie"
-  .on( "click", $.proxy( you.test, me ) )
-​
-  // this === "<button> element"
-  .on( "click", you.test );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Change the context of a function bound to the click handler,
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  // I'm a dog
-  type: "dog",
-​
-  // Note that event comes *after* one and two
-  test: function( one, two, event ) {
-    $( "#log" )
-​
-      // `one` maps to `you`, the 1st additional
-      // argument in the $.proxy function call
-      .append( "<h3>Hello " + one.type + ":</h3>" )
-​
-      // The `this` keyword refers to `me`
-      // (the 2nd, context, argument of $.proxy)
-      .append( "I am a " + this.type + ", " )
-​
-      // `two` maps to `they`, the 2nd additional
-      // argument in the $.proxy function call
-      .append( "and they are " + two.type + ".<br>" )
-​
-      // The event type is "click"
-      .append( "Thanks for " + event.type + "ing." )
-​
-      // The clicked element is `event.target`,
-      // and its type is "button"
-      .append( "the " + event.target.type + "." );
-  }
-};
-​
-var you = { type: "cat" };
-var they = { type: "fish" };
-​
-// Set up handler to execute me.test() in the context
-// of `me`, with `you` and `they` as additional arguments
-var proxy = $.proxy( me.test, me, you, they );
-​
-$( "#test" )
-  .on( "click", proxy );
-</script>
-</body>
-</html>
-```
      */
     proxy<TReturn,
         A, B, C, D, E, F>(fn: (a: A, b: B, c: C, d: D, e: E, f: F) => TReturn,
@@ -7333,149 +2895,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
-     * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  type: "zombie",
-  test: function( event ) {
-    // Without proxy, `this` would refer to the event target
-    // use event.target to reference that element.
-    var element = event.target;
-    $( element ).css( "background-color", "red" );
-​
-    // With proxy, `this` refers to the me object encapsulating
-    // this function.
-    $( "#log" ).append( "Hello " + this.type + "<br>" );
-    $( "#test" ).off( "click", this.test );
-  }
-};
-​
-var you = {
-  type: "person",
-  test: function( event ) {
-    $( "#log" ).append( this.type + " " );
-  }
-};
-​
-// Execute you.test() in the context of the `you` object
-// no matter where it is called
-// i.e. the `this` keyword will refer to `you`
-var youClick = $.proxy( you.test, you );
-​
-// attach click handlers to #test
-$( "#test" )
-  // this === "zombie"; handler unbound after first click
-  .on( "click", $.proxy( me.test, me ) )
-​
-  // this === "person"
-  .on( "click", youClick )
-​
-  // this === "zombie"
-  .on( "click", $.proxy( you.test, me ) )
-​
-  // this === "<button> element"
-  .on( "click", you.test );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Change the context of a function bound to the click handler,
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  // I'm a dog
-  type: "dog",
-​
-  // Note that event comes *after* one and two
-  test: function( one, two, event ) {
-    $( "#log" )
-​
-      // `one` maps to `you`, the 1st additional
-      // argument in the $.proxy function call
-      .append( "<h3>Hello " + one.type + ":</h3>" )
-​
-      // The `this` keyword refers to `me`
-      // (the 2nd, context, argument of $.proxy)
-      .append( "I am a " + this.type + ", " )
-​
-      // `two` maps to `they`, the 2nd additional
-      // argument in the $.proxy function call
-      .append( "and they are " + two.type + ".<br>" )
-​
-      // The event type is "click"
-      .append( "Thanks for " + event.type + "ing." )
-​
-      // The clicked element is `event.target`,
-      // and its type is "button"
-      .append( "the " + event.target.type + "." );
-  }
-};
-​
-var you = { type: "cat" };
-var they = { type: "fish" };
-​
-// Set up handler to execute me.test() in the context
-// of `me`, with `you` and `they` as additional arguments
-var proxy = $.proxy( me.test, me, you, they );
-​
-$( "#test" )
-  .on( "click", proxy );
-</script>
-</body>
-</html>
-```
      */
     proxy<TReturn,
         A, B, C, D, E>(fn: (a: A, b: B, c: C, d: D, e: E) => TReturn,
@@ -7489,149 +2908,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
-     * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  type: "zombie",
-  test: function( event ) {
-    // Without proxy, `this` would refer to the event target
-    // use event.target to reference that element.
-    var element = event.target;
-    $( element ).css( "background-color", "red" );
-​
-    // With proxy, `this` refers to the me object encapsulating
-    // this function.
-    $( "#log" ).append( "Hello " + this.type + "<br>" );
-    $( "#test" ).off( "click", this.test );
-  }
-};
-​
-var you = {
-  type: "person",
-  test: function( event ) {
-    $( "#log" ).append( this.type + " " );
-  }
-};
-​
-// Execute you.test() in the context of the `you` object
-// no matter where it is called
-// i.e. the `this` keyword will refer to `you`
-var youClick = $.proxy( you.test, you );
-​
-// attach click handlers to #test
-$( "#test" )
-  // this === "zombie"; handler unbound after first click
-  .on( "click", $.proxy( me.test, me ) )
-​
-  // this === "person"
-  .on( "click", youClick )
-​
-  // this === "zombie"
-  .on( "click", $.proxy( you.test, me ) )
-​
-  // this === "<button> element"
-  .on( "click", you.test );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Change the context of a function bound to the click handler,
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  // I'm a dog
-  type: "dog",
-​
-  // Note that event comes *after* one and two
-  test: function( one, two, event ) {
-    $( "#log" )
-​
-      // `one` maps to `you`, the 1st additional
-      // argument in the $.proxy function call
-      .append( "<h3>Hello " + one.type + ":</h3>" )
-​
-      // The `this` keyword refers to `me`
-      // (the 2nd, context, argument of $.proxy)
-      .append( "I am a " + this.type + ", " )
-​
-      // `two` maps to `they`, the 2nd additional
-      // argument in the $.proxy function call
-      .append( "and they are " + two.type + ".<br>" )
-​
-      // The event type is "click"
-      .append( "Thanks for " + event.type + "ing." )
-​
-      // The clicked element is `event.target`,
-      // and its type is "button"
-      .append( "the " + event.target.type + "." );
-  }
-};
-​
-var you = { type: "cat" };
-var they = { type: "fish" };
-​
-// Set up handler to execute me.test() in the context
-// of `me`, with `you` and `they` as additional arguments
-var proxy = $.proxy( me.test, me, you, they );
-​
-$( "#test" )
-  .on( "click", proxy );
-</script>
-</body>
-</html>
-```
      */
     proxy<TReturn,
         A, B, C, D>(fn: (a: A, b: B, c: C, d: D) => TReturn,
@@ -7645,149 +2921,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
-     * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  type: "zombie",
-  test: function( event ) {
-    // Without proxy, `this` would refer to the event target
-    // use event.target to reference that element.
-    var element = event.target;
-    $( element ).css( "background-color", "red" );
-​
-    // With proxy, `this` refers to the me object encapsulating
-    // this function.
-    $( "#log" ).append( "Hello " + this.type + "<br>" );
-    $( "#test" ).off( "click", this.test );
-  }
-};
-​
-var you = {
-  type: "person",
-  test: function( event ) {
-    $( "#log" ).append( this.type + " " );
-  }
-};
-​
-// Execute you.test() in the context of the `you` object
-// no matter where it is called
-// i.e. the `this` keyword will refer to `you`
-var youClick = $.proxy( you.test, you );
-​
-// attach click handlers to #test
-$( "#test" )
-  // this === "zombie"; handler unbound after first click
-  .on( "click", $.proxy( me.test, me ) )
-​
-  // this === "person"
-  .on( "click", youClick )
-​
-  // this === "zombie"
-  .on( "click", $.proxy( you.test, me ) )
-​
-  // this === "<button> element"
-  .on( "click", you.test );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Change the context of a function bound to the click handler,
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  // I'm a dog
-  type: "dog",
-​
-  // Note that event comes *after* one and two
-  test: function( one, two, event ) {
-    $( "#log" )
-​
-      // `one` maps to `you`, the 1st additional
-      // argument in the $.proxy function call
-      .append( "<h3>Hello " + one.type + ":</h3>" )
-​
-      // The `this` keyword refers to `me`
-      // (the 2nd, context, argument of $.proxy)
-      .append( "I am a " + this.type + ", " )
-​
-      // `two` maps to `they`, the 2nd additional
-      // argument in the $.proxy function call
-      .append( "and they are " + two.type + ".<br>" )
-​
-      // The event type is "click"
-      .append( "Thanks for " + event.type + "ing." )
-​
-      // The clicked element is `event.target`,
-      // and its type is "button"
-      .append( "the " + event.target.type + "." );
-  }
-};
-​
-var you = { type: "cat" };
-var they = { type: "fish" };
-​
-// Set up handler to execute me.test() in the context
-// of `me`, with `you` and `they` as additional arguments
-var proxy = $.proxy( me.test, me, you, they );
-​
-$( "#test" )
-  .on( "click", proxy );
-</script>
-</body>
-</html>
-```
      */
     proxy<TReturn,
         A, B, C>(fn: (a: A, b: B, c: C) => TReturn,
@@ -7801,149 +2934,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
-     * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  type: "zombie",
-  test: function( event ) {
-    // Without proxy, `this` would refer to the event target
-    // use event.target to reference that element.
-    var element = event.target;
-    $( element ).css( "background-color", "red" );
-​
-    // With proxy, `this` refers to the me object encapsulating
-    // this function.
-    $( "#log" ).append( "Hello " + this.type + "<br>" );
-    $( "#test" ).off( "click", this.test );
-  }
-};
-​
-var you = {
-  type: "person",
-  test: function( event ) {
-    $( "#log" ).append( this.type + " " );
-  }
-};
-​
-// Execute you.test() in the context of the `you` object
-// no matter where it is called
-// i.e. the `this` keyword will refer to `you`
-var youClick = $.proxy( you.test, you );
-​
-// attach click handlers to #test
-$( "#test" )
-  // this === "zombie"; handler unbound after first click
-  .on( "click", $.proxy( me.test, me ) )
-​
-  // this === "person"
-  .on( "click", youClick )
-​
-  // this === "zombie"
-  .on( "click", $.proxy( you.test, me ) )
-​
-  // this === "<button> element"
-  .on( "click", you.test );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Change the context of a function bound to the click handler,
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  // I'm a dog
-  type: "dog",
-​
-  // Note that event comes *after* one and two
-  test: function( one, two, event ) {
-    $( "#log" )
-​
-      // `one` maps to `you`, the 1st additional
-      // argument in the $.proxy function call
-      .append( "<h3>Hello " + one.type + ":</h3>" )
-​
-      // The `this` keyword refers to `me`
-      // (the 2nd, context, argument of $.proxy)
-      .append( "I am a " + this.type + ", " )
-​
-      // `two` maps to `they`, the 2nd additional
-      // argument in the $.proxy function call
-      .append( "and they are " + two.type + ".<br>" )
-​
-      // The event type is "click"
-      .append( "Thanks for " + event.type + "ing." )
-​
-      // The clicked element is `event.target`,
-      // and its type is "button"
-      .append( "the " + event.target.type + "." );
-  }
-};
-​
-var you = { type: "cat" };
-var they = { type: "fish" };
-​
-// Set up handler to execute me.test() in the context
-// of `me`, with `you` and `they` as additional arguments
-var proxy = $.proxy( me.test, me, you, they );
-​
-$( "#test" )
-  .on( "click", proxy );
-</script>
-</body>
-</html>
-```
      */
     proxy<TReturn,
         A, B>(fn: (a: A, b: B) => TReturn,
@@ -7958,149 +2948,6 @@ $( "#test" )
      * @since 1.4`
      * @since 1.6
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
-     * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  type: "zombie",
-  test: function( event ) {
-    // Without proxy, `this` would refer to the event target
-    // use event.target to reference that element.
-    var element = event.target;
-    $( element ).css( "background-color", "red" );
-​
-    // With proxy, `this` refers to the me object encapsulating
-    // this function.
-    $( "#log" ).append( "Hello " + this.type + "<br>" );
-    $( "#test" ).off( "click", this.test );
-  }
-};
-​
-var you = {
-  type: "person",
-  test: function( event ) {
-    $( "#log" ).append( this.type + " " );
-  }
-};
-​
-// Execute you.test() in the context of the `you` object
-// no matter where it is called
-// i.e. the `this` keyword will refer to `you`
-var youClick = $.proxy( you.test, you );
-​
-// attach click handlers to #test
-$( "#test" )
-  // this === "zombie"; handler unbound after first click
-  .on( "click", $.proxy( me.test, me ) )
-​
-  // this === "person"
-  .on( "click", youClick )
-​
-  // this === "zombie"
-  .on( "click", $.proxy( you.test, me ) )
-​
-  // this === "<button> element"
-  .on( "click", you.test );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Change the context of a function bound to the click handler,
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  // I'm a dog
-  type: "dog",
-​
-  // Note that event comes *after* one and two
-  test: function( one, two, event ) {
-    $( "#log" )
-​
-      // `one` maps to `you`, the 1st additional
-      // argument in the $.proxy function call
-      .append( "<h3>Hello " + one.type + ":</h3>" )
-​
-      // The `this` keyword refers to `me`
-      // (the 2nd, context, argument of $.proxy)
-      .append( "I am a " + this.type + ", " )
-​
-      // `two` maps to `they`, the 2nd additional
-      // argument in the $.proxy function call
-      .append( "and they are " + two.type + ".<br>" )
-​
-      // The event type is "click"
-      .append( "Thanks for " + event.type + "ing." )
-​
-      // The clicked element is `event.target`,
-      // and its type is "button"
-      .append( "the " + event.target.type + "." );
-  }
-};
-​
-var you = { type: "cat" };
-var they = { type: "fish" };
-​
-// Set up handler to execute me.test() in the context
-// of `me`, with `you` and `they` as additional arguments
-var proxy = $.proxy( me.test, me, you, they );
-​
-$( "#test" )
-  .on( "click", proxy );
-</script>
-</body>
-</html>
-```
      */
     proxy<TReturn,
         A>(fn: (a: A) => TReturn,
@@ -8114,149 +2961,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
-     * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  type: "zombie",
-  test: function( event ) {
-    // Without proxy, `this` would refer to the event target
-    // use event.target to reference that element.
-    var element = event.target;
-    $( element ).css( "background-color", "red" );
-​
-    // With proxy, `this` refers to the me object encapsulating
-    // this function.
-    $( "#log" ).append( "Hello " + this.type + "<br>" );
-    $( "#test" ).off( "click", this.test );
-  }
-};
-​
-var you = {
-  type: "person",
-  test: function( event ) {
-    $( "#log" ).append( this.type + " " );
-  }
-};
-​
-// Execute you.test() in the context of the `you` object
-// no matter where it is called
-// i.e. the `this` keyword will refer to `you`
-var youClick = $.proxy( you.test, you );
-​
-// attach click handlers to #test
-$( "#test" )
-  // this === "zombie"; handler unbound after first click
-  .on( "click", $.proxy( me.test, me ) )
-​
-  // this === "person"
-  .on( "click", youClick )
-​
-  // this === "zombie"
-  .on( "click", $.proxy( you.test, me ) )
-​
-  // this === "<button> element"
-  .on( "click", you.test );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Change the context of a function bound to the click handler,
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  // I'm a dog
-  type: "dog",
-​
-  // Note that event comes *after* one and two
-  test: function( one, two, event ) {
-    $( "#log" )
-​
-      // `one` maps to `you`, the 1st additional
-      // argument in the $.proxy function call
-      .append( "<h3>Hello " + one.type + ":</h3>" )
-​
-      // The `this` keyword refers to `me`
-      // (the 2nd, context, argument of $.proxy)
-      .append( "I am a " + this.type + ", " )
-​
-      // `two` maps to `they`, the 2nd additional
-      // argument in the $.proxy function call
-      .append( "and they are " + two.type + ".<br>" )
-​
-      // The event type is "click"
-      .append( "Thanks for " + event.type + "ing." )
-​
-      // The clicked element is `event.target`,
-      // and its type is "button"
-      .append( "the " + event.target.type + "." );
-  }
-};
-​
-var you = { type: "cat" };
-var they = { type: "fish" };
-​
-// Set up handler to execute me.test() in the context
-// of `me`, with `you` and `they` as additional arguments
-var proxy = $.proxy( me.test, me, you, they );
-​
-$( "#test" )
-  .on( "click", proxy );
-</script>
-</body>
-</html>
-```
      */
     proxy<TReturn>(fn: () => TReturn,
                    context: null | undefined): () => TReturn;
@@ -8274,149 +2978,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
-     * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  type: "zombie",
-  test: function( event ) {
-    // Without proxy, `this` would refer to the event target
-    // use event.target to reference that element.
-    var element = event.target;
-    $( element ).css( "background-color", "red" );
-​
-    // With proxy, `this` refers to the me object encapsulating
-    // this function.
-    $( "#log" ).append( "Hello " + this.type + "<br>" );
-    $( "#test" ).off( "click", this.test );
-  }
-};
-​
-var you = {
-  type: "person",
-  test: function( event ) {
-    $( "#log" ).append( this.type + " " );
-  }
-};
-​
-// Execute you.test() in the context of the `you` object
-// no matter where it is called
-// i.e. the `this` keyword will refer to `you`
-var youClick = $.proxy( you.test, you );
-​
-// attach click handlers to #test
-$( "#test" )
-  // this === "zombie"; handler unbound after first click
-  .on( "click", $.proxy( me.test, me ) )
-​
-  // this === "person"
-  .on( "click", youClick )
-​
-  // this === "zombie"
-  .on( "click", $.proxy( you.test, me ) )
-​
-  // this === "<button> element"
-  .on( "click", you.test );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Change the context of a function bound to the click handler,
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  // I'm a dog
-  type: "dog",
-​
-  // Note that event comes *after* one and two
-  test: function( one, two, event ) {
-    $( "#log" )
-​
-      // `one` maps to `you`, the 1st additional
-      // argument in the $.proxy function call
-      .append( "<h3>Hello " + one.type + ":</h3>" )
-​
-      // The `this` keyword refers to `me`
-      // (the 2nd, context, argument of $.proxy)
-      .append( "I am a " + this.type + ", " )
-​
-      // `two` maps to `they`, the 2nd additional
-      // argument in the $.proxy function call
-      .append( "and they are " + two.type + ".<br>" )
-​
-      // The event type is "click"
-      .append( "Thanks for " + event.type + "ing." )
-​
-      // The clicked element is `event.target`,
-      // and its type is "button"
-      .append( "the " + event.target.type + "." );
-  }
-};
-​
-var you = { type: "cat" };
-var they = { type: "fish" };
-​
-// Set up handler to execute me.test() in the context
-// of `me`, with `you` and `they` as additional arguments
-var proxy = $.proxy( me.test, me, you, they );
-​
-$( "#test" )
-  .on( "click", proxy );
-</script>
-</body>
-</html>
-```
      */
     proxy<TReturn,
         A, B, C, D, E, F, G,
@@ -8432,149 +2993,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
-     * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  type: "zombie",
-  test: function( event ) {
-    // Without proxy, `this` would refer to the event target
-    // use event.target to reference that element.
-    var element = event.target;
-    $( element ).css( "background-color", "red" );
-​
-    // With proxy, `this` refers to the me object encapsulating
-    // this function.
-    $( "#log" ).append( "Hello " + this.type + "<br>" );
-    $( "#test" ).off( "click", this.test );
-  }
-};
-​
-var you = {
-  type: "person",
-  test: function( event ) {
-    $( "#log" ).append( this.type + " " );
-  }
-};
-​
-// Execute you.test() in the context of the `you` object
-// no matter where it is called
-// i.e. the `this` keyword will refer to `you`
-var youClick = $.proxy( you.test, you );
-​
-// attach click handlers to #test
-$( "#test" )
-  // this === "zombie"; handler unbound after first click
-  .on( "click", $.proxy( me.test, me ) )
-​
-  // this === "person"
-  .on( "click", youClick )
-​
-  // this === "zombie"
-  .on( "click", $.proxy( you.test, me ) )
-​
-  // this === "<button> element"
-  .on( "click", you.test );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Change the context of a function bound to the click handler,
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  // I'm a dog
-  type: "dog",
-​
-  // Note that event comes *after* one and two
-  test: function( one, two, event ) {
-    $( "#log" )
-​
-      // `one` maps to `you`, the 1st additional
-      // argument in the $.proxy function call
-      .append( "<h3>Hello " + one.type + ":</h3>" )
-​
-      // The `this` keyword refers to `me`
-      // (the 2nd, context, argument of $.proxy)
-      .append( "I am a " + this.type + ", " )
-​
-      // `two` maps to `they`, the 2nd additional
-      // argument in the $.proxy function call
-      .append( "and they are " + two.type + ".<br>" )
-​
-      // The event type is "click"
-      .append( "Thanks for " + event.type + "ing." )
-​
-      // The clicked element is `event.target`,
-      // and its type is "button"
-      .append( "the " + event.target.type + "." );
-  }
-};
-​
-var you = { type: "cat" };
-var they = { type: "fish" };
-​
-// Set up handler to execute me.test() in the context
-// of `me`, with `you` and `they` as additional arguments
-var proxy = $.proxy( me.test, me, you, they );
-​
-$( "#test" )
-  .on( "click", proxy );
-</script>
-</body>
-</html>
-```
      */
     proxy<TReturn,
         A, B, C, D, E, F,
@@ -8590,149 +3008,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
-     * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  type: "zombie",
-  test: function( event ) {
-    // Without proxy, `this` would refer to the event target
-    // use event.target to reference that element.
-    var element = event.target;
-    $( element ).css( "background-color", "red" );
-​
-    // With proxy, `this` refers to the me object encapsulating
-    // this function.
-    $( "#log" ).append( "Hello " + this.type + "<br>" );
-    $( "#test" ).off( "click", this.test );
-  }
-};
-​
-var you = {
-  type: "person",
-  test: function( event ) {
-    $( "#log" ).append( this.type + " " );
-  }
-};
-​
-// Execute you.test() in the context of the `you` object
-// no matter where it is called
-// i.e. the `this` keyword will refer to `you`
-var youClick = $.proxy( you.test, you );
-​
-// attach click handlers to #test
-$( "#test" )
-  // this === "zombie"; handler unbound after first click
-  .on( "click", $.proxy( me.test, me ) )
-​
-  // this === "person"
-  .on( "click", youClick )
-​
-  // this === "zombie"
-  .on( "click", $.proxy( you.test, me ) )
-​
-  // this === "<button> element"
-  .on( "click", you.test );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Change the context of a function bound to the click handler,
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  // I'm a dog
-  type: "dog",
-​
-  // Note that event comes *after* one and two
-  test: function( one, two, event ) {
-    $( "#log" )
-​
-      // `one` maps to `you`, the 1st additional
-      // argument in the $.proxy function call
-      .append( "<h3>Hello " + one.type + ":</h3>" )
-​
-      // The `this` keyword refers to `me`
-      // (the 2nd, context, argument of $.proxy)
-      .append( "I am a " + this.type + ", " )
-​
-      // `two` maps to `they`, the 2nd additional
-      // argument in the $.proxy function call
-      .append( "and they are " + two.type + ".<br>" )
-​
-      // The event type is "click"
-      .append( "Thanks for " + event.type + "ing." )
-​
-      // The clicked element is `event.target`,
-      // and its type is "button"
-      .append( "the " + event.target.type + "." );
-  }
-};
-​
-var you = { type: "cat" };
-var they = { type: "fish" };
-​
-// Set up handler to execute me.test() in the context
-// of `me`, with `you` and `they` as additional arguments
-var proxy = $.proxy( me.test, me, you, they );
-​
-$( "#test" )
-  .on( "click", proxy );
-</script>
-</body>
-</html>
-```
      */
     proxy<TReturn,
         A, B, C, D, E,
@@ -8748,149 +3023,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
-     * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  type: "zombie",
-  test: function( event ) {
-    // Without proxy, `this` would refer to the event target
-    // use event.target to reference that element.
-    var element = event.target;
-    $( element ).css( "background-color", "red" );
-​
-    // With proxy, `this` refers to the me object encapsulating
-    // this function.
-    $( "#log" ).append( "Hello " + this.type + "<br>" );
-    $( "#test" ).off( "click", this.test );
-  }
-};
-​
-var you = {
-  type: "person",
-  test: function( event ) {
-    $( "#log" ).append( this.type + " " );
-  }
-};
-​
-// Execute you.test() in the context of the `you` object
-// no matter where it is called
-// i.e. the `this` keyword will refer to `you`
-var youClick = $.proxy( you.test, you );
-​
-// attach click handlers to #test
-$( "#test" )
-  // this === "zombie"; handler unbound after first click
-  .on( "click", $.proxy( me.test, me ) )
-​
-  // this === "person"
-  .on( "click", youClick )
-​
-  // this === "zombie"
-  .on( "click", $.proxy( you.test, me ) )
-​
-  // this === "<button> element"
-  .on( "click", you.test );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Change the context of a function bound to the click handler,
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  // I'm a dog
-  type: "dog",
-​
-  // Note that event comes *after* one and two
-  test: function( one, two, event ) {
-    $( "#log" )
-​
-      // `one` maps to `you`, the 1st additional
-      // argument in the $.proxy function call
-      .append( "<h3>Hello " + one.type + ":</h3>" )
-​
-      // The `this` keyword refers to `me`
-      // (the 2nd, context, argument of $.proxy)
-      .append( "I am a " + this.type + ", " )
-​
-      // `two` maps to `they`, the 2nd additional
-      // argument in the $.proxy function call
-      .append( "and they are " + two.type + ".<br>" )
-​
-      // The event type is "click"
-      .append( "Thanks for " + event.type + "ing." )
-​
-      // The clicked element is `event.target`,
-      // and its type is "button"
-      .append( "the " + event.target.type + "." );
-  }
-};
-​
-var you = { type: "cat" };
-var they = { type: "fish" };
-​
-// Set up handler to execute me.test() in the context
-// of `me`, with `you` and `they` as additional arguments
-var proxy = $.proxy( me.test, me, you, they );
-​
-$( "#test" )
-  .on( "click", proxy );
-</script>
-</body>
-</html>
-```
      */
     proxy<TReturn,
         A, B, C, D,
@@ -8906,149 +3038,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
-     * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  type: "zombie",
-  test: function( event ) {
-    // Without proxy, `this` would refer to the event target
-    // use event.target to reference that element.
-    var element = event.target;
-    $( element ).css( "background-color", "red" );
-​
-    // With proxy, `this` refers to the me object encapsulating
-    // this function.
-    $( "#log" ).append( "Hello " + this.type + "<br>" );
-    $( "#test" ).off( "click", this.test );
-  }
-};
-​
-var you = {
-  type: "person",
-  test: function( event ) {
-    $( "#log" ).append( this.type + " " );
-  }
-};
-​
-// Execute you.test() in the context of the `you` object
-// no matter where it is called
-// i.e. the `this` keyword will refer to `you`
-var youClick = $.proxy( you.test, you );
-​
-// attach click handlers to #test
-$( "#test" )
-  // this === "zombie"; handler unbound after first click
-  .on( "click", $.proxy( me.test, me ) )
-​
-  // this === "person"
-  .on( "click", youClick )
-​
-  // this === "zombie"
-  .on( "click", $.proxy( you.test, me ) )
-​
-  // this === "<button> element"
-  .on( "click", you.test );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Change the context of a function bound to the click handler,
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  // I'm a dog
-  type: "dog",
-​
-  // Note that event comes *after* one and two
-  test: function( one, two, event ) {
-    $( "#log" )
-​
-      // `one` maps to `you`, the 1st additional
-      // argument in the $.proxy function call
-      .append( "<h3>Hello " + one.type + ":</h3>" )
-​
-      // The `this` keyword refers to `me`
-      // (the 2nd, context, argument of $.proxy)
-      .append( "I am a " + this.type + ", " )
-​
-      // `two` maps to `they`, the 2nd additional
-      // argument in the $.proxy function call
-      .append( "and they are " + two.type + ".<br>" )
-​
-      // The event type is "click"
-      .append( "Thanks for " + event.type + "ing." )
-​
-      // The clicked element is `event.target`,
-      // and its type is "button"
-      .append( "the " + event.target.type + "." );
-  }
-};
-​
-var you = { type: "cat" };
-var they = { type: "fish" };
-​
-// Set up handler to execute me.test() in the context
-// of `me`, with `you` and `they` as additional arguments
-var proxy = $.proxy( me.test, me, you, they );
-​
-$( "#test" )
-  .on( "click", proxy );
-</script>
-</body>
-</html>
-```
      */
     proxy<TReturn,
         A, B, C,
@@ -9064,149 +3053,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
-     * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  type: "zombie",
-  test: function( event ) {
-    // Without proxy, `this` would refer to the event target
-    // use event.target to reference that element.
-    var element = event.target;
-    $( element ).css( "background-color", "red" );
-​
-    // With proxy, `this` refers to the me object encapsulating
-    // this function.
-    $( "#log" ).append( "Hello " + this.type + "<br>" );
-    $( "#test" ).off( "click", this.test );
-  }
-};
-​
-var you = {
-  type: "person",
-  test: function( event ) {
-    $( "#log" ).append( this.type + " " );
-  }
-};
-​
-// Execute you.test() in the context of the `you` object
-// no matter where it is called
-// i.e. the `this` keyword will refer to `you`
-var youClick = $.proxy( you.test, you );
-​
-// attach click handlers to #test
-$( "#test" )
-  // this === "zombie"; handler unbound after first click
-  .on( "click", $.proxy( me.test, me ) )
-​
-  // this === "person"
-  .on( "click", youClick )
-​
-  // this === "zombie"
-  .on( "click", $.proxy( you.test, me ) )
-​
-  // this === "<button> element"
-  .on( "click", you.test );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Change the context of a function bound to the click handler,
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  // I'm a dog
-  type: "dog",
-​
-  // Note that event comes *after* one and two
-  test: function( one, two, event ) {
-    $( "#log" )
-​
-      // `one` maps to `you`, the 1st additional
-      // argument in the $.proxy function call
-      .append( "<h3>Hello " + one.type + ":</h3>" )
-​
-      // The `this` keyword refers to `me`
-      // (the 2nd, context, argument of $.proxy)
-      .append( "I am a " + this.type + ", " )
-​
-      // `two` maps to `they`, the 2nd additional
-      // argument in the $.proxy function call
-      .append( "and they are " + two.type + ".<br>" )
-​
-      // The event type is "click"
-      .append( "Thanks for " + event.type + "ing." )
-​
-      // The clicked element is `event.target`,
-      // and its type is "button"
-      .append( "the " + event.target.type + "." );
-  }
-};
-​
-var you = { type: "cat" };
-var they = { type: "fish" };
-​
-// Set up handler to execute me.test() in the context
-// of `me`, with `you` and `they` as additional arguments
-var proxy = $.proxy( me.test, me, you, they );
-​
-$( "#test" )
-  .on( "click", proxy );
-</script>
-</body>
-</html>
-```
      */
     proxy<TReturn,
         A, B,
@@ -9222,149 +3068,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
-     * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  type: "zombie",
-  test: function( event ) {
-    // Without proxy, `this` would refer to the event target
-    // use event.target to reference that element.
-    var element = event.target;
-    $( element ).css( "background-color", "red" );
-​
-    // With proxy, `this` refers to the me object encapsulating
-    // this function.
-    $( "#log" ).append( "Hello " + this.type + "<br>" );
-    $( "#test" ).off( "click", this.test );
-  }
-};
-​
-var you = {
-  type: "person",
-  test: function( event ) {
-    $( "#log" ).append( this.type + " " );
-  }
-};
-​
-// Execute you.test() in the context of the `you` object
-// no matter where it is called
-// i.e. the `this` keyword will refer to `you`
-var youClick = $.proxy( you.test, you );
-​
-// attach click handlers to #test
-$( "#test" )
-  // this === "zombie"; handler unbound after first click
-  .on( "click", $.proxy( me.test, me ) )
-​
-  // this === "person"
-  .on( "click", youClick )
-​
-  // this === "zombie"
-  .on( "click", $.proxy( you.test, me ) )
-​
-  // this === "<button> element"
-  .on( "click", you.test );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Change the context of a function bound to the click handler,
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  // I'm a dog
-  type: "dog",
-​
-  // Note that event comes *after* one and two
-  test: function( one, two, event ) {
-    $( "#log" )
-​
-      // `one` maps to `you`, the 1st additional
-      // argument in the $.proxy function call
-      .append( "<h3>Hello " + one.type + ":</h3>" )
-​
-      // The `this` keyword refers to `me`
-      // (the 2nd, context, argument of $.proxy)
-      .append( "I am a " + this.type + ", " )
-​
-      // `two` maps to `they`, the 2nd additional
-      // argument in the $.proxy function call
-      .append( "and they are " + two.type + ".<br>" )
-​
-      // The event type is "click"
-      .append( "Thanks for " + event.type + "ing." )
-​
-      // The clicked element is `event.target`,
-      // and its type is "button"
-      .append( "the " + event.target.type + "." );
-  }
-};
-​
-var you = { type: "cat" };
-var they = { type: "fish" };
-​
-// Set up handler to execute me.test() in the context
-// of `me`, with `you` and `they` as additional arguments
-var proxy = $.proxy( me.test, me, you, they );
-​
-$( "#test" )
-  .on( "click", proxy );
-</script>
-</body>
-</html>
-```
      */
     proxy<TReturn,
         A,
@@ -9380,149 +3083,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
-     * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  type: "zombie",
-  test: function( event ) {
-    // Without proxy, `this` would refer to the event target
-    // use event.target to reference that element.
-    var element = event.target;
-    $( element ).css( "background-color", "red" );
-​
-    // With proxy, `this` refers to the me object encapsulating
-    // this function.
-    $( "#log" ).append( "Hello " + this.type + "<br>" );
-    $( "#test" ).off( "click", this.test );
-  }
-};
-​
-var you = {
-  type: "person",
-  test: function( event ) {
-    $( "#log" ).append( this.type + " " );
-  }
-};
-​
-// Execute you.test() in the context of the `you` object
-// no matter where it is called
-// i.e. the `this` keyword will refer to `you`
-var youClick = $.proxy( you.test, you );
-​
-// attach click handlers to #test
-$( "#test" )
-  // this === "zombie"; handler unbound after first click
-  .on( "click", $.proxy( me.test, me ) )
-​
-  // this === "person"
-  .on( "click", youClick )
-​
-  // this === "zombie"
-  .on( "click", $.proxy( you.test, me ) )
-​
-  // this === "<button> element"
-  .on( "click", you.test );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Change the context of a function bound to the click handler,
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  // I'm a dog
-  type: "dog",
-​
-  // Note that event comes *after* one and two
-  test: function( one, two, event ) {
-    $( "#log" )
-​
-      // `one` maps to `you`, the 1st additional
-      // argument in the $.proxy function call
-      .append( "<h3>Hello " + one.type + ":</h3>" )
-​
-      // The `this` keyword refers to `me`
-      // (the 2nd, context, argument of $.proxy)
-      .append( "I am a " + this.type + ", " )
-​
-      // `two` maps to `they`, the 2nd additional
-      // argument in the $.proxy function call
-      .append( "and they are " + two.type + ".<br>" )
-​
-      // The event type is "click"
-      .append( "Thanks for " + event.type + "ing." )
-​
-      // The clicked element is `event.target`,
-      // and its type is "button"
-      .append( "the " + event.target.type + "." );
-  }
-};
-​
-var you = { type: "cat" };
-var they = { type: "fish" };
-​
-// Set up handler to execute me.test() in the context
-// of `me`, with `you` and `they` as additional arguments
-var proxy = $.proxy( me.test, me, you, they );
-​
-$( "#test" )
-  .on( "click", proxy );
-</script>
-</body>
-</html>
-```
      */
     proxy<TReturn,
         T>(fn: (t: T) => TReturn,
@@ -9541,149 +3101,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
-     * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  type: "zombie",
-  test: function( event ) {
-    // Without proxy, `this` would refer to the event target
-    // use event.target to reference that element.
-    var element = event.target;
-    $( element ).css( "background-color", "red" );
-​
-    // With proxy, `this` refers to the me object encapsulating
-    // this function.
-    $( "#log" ).append( "Hello " + this.type + "<br>" );
-    $( "#test" ).off( "click", this.test );
-  }
-};
-​
-var you = {
-  type: "person",
-  test: function( event ) {
-    $( "#log" ).append( this.type + " " );
-  }
-};
-​
-// Execute you.test() in the context of the `you` object
-// no matter where it is called
-// i.e. the `this` keyword will refer to `you`
-var youClick = $.proxy( you.test, you );
-​
-// attach click handlers to #test
-$( "#test" )
-  // this === "zombie"; handler unbound after first click
-  .on( "click", $.proxy( me.test, me ) )
-​
-  // this === "person"
-  .on( "click", youClick )
-​
-  // this === "zombie"
-  .on( "click", $.proxy( you.test, me ) )
-​
-  // this === "<button> element"
-  .on( "click", you.test );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Change the context of a function bound to the click handler,
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  // I'm a dog
-  type: "dog",
-​
-  // Note that event comes *after* one and two
-  test: function( one, two, event ) {
-    $( "#log" )
-​
-      // `one` maps to `you`, the 1st additional
-      // argument in the $.proxy function call
-      .append( "<h3>Hello " + one.type + ":</h3>" )
-​
-      // The `this` keyword refers to `me`
-      // (the 2nd, context, argument of $.proxy)
-      .append( "I am a " + this.type + ", " )
-​
-      // `two` maps to `they`, the 2nd additional
-      // argument in the $.proxy function call
-      .append( "and they are " + two.type + ".<br>" )
-​
-      // The event type is "click"
-      .append( "Thanks for " + event.type + "ing." )
-​
-      // The clicked element is `event.target`,
-      // and its type is "button"
-      .append( "the " + event.target.type + "." );
-  }
-};
-​
-var you = { type: "cat" };
-var they = { type: "fish" };
-​
-// Set up handler to execute me.test() in the context
-// of `me`, with `you` and `they` as additional arguments
-var proxy = $.proxy( me.test, me, you, they );
-​
-$( "#test" )
-  .on( "click", proxy );
-</script>
-</body>
-</html>
-```
      */
     proxy<TReturn,
         A, B, C, D, E, F, G,
@@ -9699,149 +3116,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
-     * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  type: "zombie",
-  test: function( event ) {
-    // Without proxy, `this` would refer to the event target
-    // use event.target to reference that element.
-    var element = event.target;
-    $( element ).css( "background-color", "red" );
-​
-    // With proxy, `this` refers to the me object encapsulating
-    // this function.
-    $( "#log" ).append( "Hello " + this.type + "<br>" );
-    $( "#test" ).off( "click", this.test );
-  }
-};
-​
-var you = {
-  type: "person",
-  test: function( event ) {
-    $( "#log" ).append( this.type + " " );
-  }
-};
-​
-// Execute you.test() in the context of the `you` object
-// no matter where it is called
-// i.e. the `this` keyword will refer to `you`
-var youClick = $.proxy( you.test, you );
-​
-// attach click handlers to #test
-$( "#test" )
-  // this === "zombie"; handler unbound after first click
-  .on( "click", $.proxy( me.test, me ) )
-​
-  // this === "person"
-  .on( "click", youClick )
-​
-  // this === "zombie"
-  .on( "click", $.proxy( you.test, me ) )
-​
-  // this === "<button> element"
-  .on( "click", you.test );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Change the context of a function bound to the click handler,
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  // I'm a dog
-  type: "dog",
-​
-  // Note that event comes *after* one and two
-  test: function( one, two, event ) {
-    $( "#log" )
-​
-      // `one` maps to `you`, the 1st additional
-      // argument in the $.proxy function call
-      .append( "<h3>Hello " + one.type + ":</h3>" )
-​
-      // The `this` keyword refers to `me`
-      // (the 2nd, context, argument of $.proxy)
-      .append( "I am a " + this.type + ", " )
-​
-      // `two` maps to `they`, the 2nd additional
-      // argument in the $.proxy function call
-      .append( "and they are " + two.type + ".<br>" )
-​
-      // The event type is "click"
-      .append( "Thanks for " + event.type + "ing." )
-​
-      // The clicked element is `event.target`,
-      // and its type is "button"
-      .append( "the " + event.target.type + "." );
-  }
-};
-​
-var you = { type: "cat" };
-var they = { type: "fish" };
-​
-// Set up handler to execute me.test() in the context
-// of `me`, with `you` and `they` as additional arguments
-var proxy = $.proxy( me.test, me, you, they );
-​
-$( "#test" )
-  .on( "click", proxy );
-</script>
-</body>
-</html>
-```
      */
     proxy<TReturn,
         A, B, C, D, E, F,
@@ -9857,149 +3131,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
-     * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  type: "zombie",
-  test: function( event ) {
-    // Without proxy, `this` would refer to the event target
-    // use event.target to reference that element.
-    var element = event.target;
-    $( element ).css( "background-color", "red" );
-​
-    // With proxy, `this` refers to the me object encapsulating
-    // this function.
-    $( "#log" ).append( "Hello " + this.type + "<br>" );
-    $( "#test" ).off( "click", this.test );
-  }
-};
-​
-var you = {
-  type: "person",
-  test: function( event ) {
-    $( "#log" ).append( this.type + " " );
-  }
-};
-​
-// Execute you.test() in the context of the `you` object
-// no matter where it is called
-// i.e. the `this` keyword will refer to `you`
-var youClick = $.proxy( you.test, you );
-​
-// attach click handlers to #test
-$( "#test" )
-  // this === "zombie"; handler unbound after first click
-  .on( "click", $.proxy( me.test, me ) )
-​
-  // this === "person"
-  .on( "click", youClick )
-​
-  // this === "zombie"
-  .on( "click", $.proxy( you.test, me ) )
-​
-  // this === "<button> element"
-  .on( "click", you.test );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Change the context of a function bound to the click handler,
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  // I'm a dog
-  type: "dog",
-​
-  // Note that event comes *after* one and two
-  test: function( one, two, event ) {
-    $( "#log" )
-​
-      // `one` maps to `you`, the 1st additional
-      // argument in the $.proxy function call
-      .append( "<h3>Hello " + one.type + ":</h3>" )
-​
-      // The `this` keyword refers to `me`
-      // (the 2nd, context, argument of $.proxy)
-      .append( "I am a " + this.type + ", " )
-​
-      // `two` maps to `they`, the 2nd additional
-      // argument in the $.proxy function call
-      .append( "and they are " + two.type + ".<br>" )
-​
-      // The event type is "click"
-      .append( "Thanks for " + event.type + "ing." )
-​
-      // The clicked element is `event.target`,
-      // and its type is "button"
-      .append( "the " + event.target.type + "." );
-  }
-};
-​
-var you = { type: "cat" };
-var they = { type: "fish" };
-​
-// Set up handler to execute me.test() in the context
-// of `me`, with `you` and `they` as additional arguments
-var proxy = $.proxy( me.test, me, you, they );
-​
-$( "#test" )
-  .on( "click", proxy );
-</script>
-</body>
-</html>
-```
      */
     proxy<TReturn,
         A, B, C, D, E,
@@ -10015,149 +3146,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
-     * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  type: "zombie",
-  test: function( event ) {
-    // Without proxy, `this` would refer to the event target
-    // use event.target to reference that element.
-    var element = event.target;
-    $( element ).css( "background-color", "red" );
-​
-    // With proxy, `this` refers to the me object encapsulating
-    // this function.
-    $( "#log" ).append( "Hello " + this.type + "<br>" );
-    $( "#test" ).off( "click", this.test );
-  }
-};
-​
-var you = {
-  type: "person",
-  test: function( event ) {
-    $( "#log" ).append( this.type + " " );
-  }
-};
-​
-// Execute you.test() in the context of the `you` object
-// no matter where it is called
-// i.e. the `this` keyword will refer to `you`
-var youClick = $.proxy( you.test, you );
-​
-// attach click handlers to #test
-$( "#test" )
-  // this === "zombie"; handler unbound after first click
-  .on( "click", $.proxy( me.test, me ) )
-​
-  // this === "person"
-  .on( "click", youClick )
-​
-  // this === "zombie"
-  .on( "click", $.proxy( you.test, me ) )
-​
-  // this === "<button> element"
-  .on( "click", you.test );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Change the context of a function bound to the click handler,
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  // I'm a dog
-  type: "dog",
-​
-  // Note that event comes *after* one and two
-  test: function( one, two, event ) {
-    $( "#log" )
-​
-      // `one` maps to `you`, the 1st additional
-      // argument in the $.proxy function call
-      .append( "<h3>Hello " + one.type + ":</h3>" )
-​
-      // The `this` keyword refers to `me`
-      // (the 2nd, context, argument of $.proxy)
-      .append( "I am a " + this.type + ", " )
-​
-      // `two` maps to `they`, the 2nd additional
-      // argument in the $.proxy function call
-      .append( "and they are " + two.type + ".<br>" )
-​
-      // The event type is "click"
-      .append( "Thanks for " + event.type + "ing." )
-​
-      // The clicked element is `event.target`,
-      // and its type is "button"
-      .append( "the " + event.target.type + "." );
-  }
-};
-​
-var you = { type: "cat" };
-var they = { type: "fish" };
-​
-// Set up handler to execute me.test() in the context
-// of `me`, with `you` and `they` as additional arguments
-var proxy = $.proxy( me.test, me, you, they );
-​
-$( "#test" )
-  .on( "click", proxy );
-</script>
-</body>
-</html>
-```
      */
     proxy<TReturn,
         A, B, C, D,
@@ -10173,149 +3161,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
-     * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  type: "zombie",
-  test: function( event ) {
-    // Without proxy, `this` would refer to the event target
-    // use event.target to reference that element.
-    var element = event.target;
-    $( element ).css( "background-color", "red" );
-​
-    // With proxy, `this` refers to the me object encapsulating
-    // this function.
-    $( "#log" ).append( "Hello " + this.type + "<br>" );
-    $( "#test" ).off( "click", this.test );
-  }
-};
-​
-var you = {
-  type: "person",
-  test: function( event ) {
-    $( "#log" ).append( this.type + " " );
-  }
-};
-​
-// Execute you.test() in the context of the `you` object
-// no matter where it is called
-// i.e. the `this` keyword will refer to `you`
-var youClick = $.proxy( you.test, you );
-​
-// attach click handlers to #test
-$( "#test" )
-  // this === "zombie"; handler unbound after first click
-  .on( "click", $.proxy( me.test, me ) )
-​
-  // this === "person"
-  .on( "click", youClick )
-​
-  // this === "zombie"
-  .on( "click", $.proxy( you.test, me ) )
-​
-  // this === "<button> element"
-  .on( "click", you.test );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Change the context of a function bound to the click handler,
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  // I'm a dog
-  type: "dog",
-​
-  // Note that event comes *after* one and two
-  test: function( one, two, event ) {
-    $( "#log" )
-​
-      // `one` maps to `you`, the 1st additional
-      // argument in the $.proxy function call
-      .append( "<h3>Hello " + one.type + ":</h3>" )
-​
-      // The `this` keyword refers to `me`
-      // (the 2nd, context, argument of $.proxy)
-      .append( "I am a " + this.type + ", " )
-​
-      // `two` maps to `they`, the 2nd additional
-      // argument in the $.proxy function call
-      .append( "and they are " + two.type + ".<br>" )
-​
-      // The event type is "click"
-      .append( "Thanks for " + event.type + "ing." )
-​
-      // The clicked element is `event.target`,
-      // and its type is "button"
-      .append( "the " + event.target.type + "." );
-  }
-};
-​
-var you = { type: "cat" };
-var they = { type: "fish" };
-​
-// Set up handler to execute me.test() in the context
-// of `me`, with `you` and `they` as additional arguments
-var proxy = $.proxy( me.test, me, you, they );
-​
-$( "#test" )
-  .on( "click", proxy );
-</script>
-</body>
-</html>
-```
      */
     proxy<TReturn,
         A, B, C,
@@ -10331,149 +3176,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
-     * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  type: "zombie",
-  test: function( event ) {
-    // Without proxy, `this` would refer to the event target
-    // use event.target to reference that element.
-    var element = event.target;
-    $( element ).css( "background-color", "red" );
-​
-    // With proxy, `this` refers to the me object encapsulating
-    // this function.
-    $( "#log" ).append( "Hello " + this.type + "<br>" );
-    $( "#test" ).off( "click", this.test );
-  }
-};
-​
-var you = {
-  type: "person",
-  test: function( event ) {
-    $( "#log" ).append( this.type + " " );
-  }
-};
-​
-// Execute you.test() in the context of the `you` object
-// no matter where it is called
-// i.e. the `this` keyword will refer to `you`
-var youClick = $.proxy( you.test, you );
-​
-// attach click handlers to #test
-$( "#test" )
-  // this === "zombie"; handler unbound after first click
-  .on( "click", $.proxy( me.test, me ) )
-​
-  // this === "person"
-  .on( "click", youClick )
-​
-  // this === "zombie"
-  .on( "click", $.proxy( you.test, me ) )
-​
-  // this === "<button> element"
-  .on( "click", you.test );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Change the context of a function bound to the click handler,
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  // I'm a dog
-  type: "dog",
-​
-  // Note that event comes *after* one and two
-  test: function( one, two, event ) {
-    $( "#log" )
-​
-      // `one` maps to `you`, the 1st additional
-      // argument in the $.proxy function call
-      .append( "<h3>Hello " + one.type + ":</h3>" )
-​
-      // The `this` keyword refers to `me`
-      // (the 2nd, context, argument of $.proxy)
-      .append( "I am a " + this.type + ", " )
-​
-      // `two` maps to `they`, the 2nd additional
-      // argument in the $.proxy function call
-      .append( "and they are " + two.type + ".<br>" )
-​
-      // The event type is "click"
-      .append( "Thanks for " + event.type + "ing." )
-​
-      // The clicked element is `event.target`,
-      // and its type is "button"
-      .append( "the " + event.target.type + "." );
-  }
-};
-​
-var you = { type: "cat" };
-var they = { type: "fish" };
-​
-// Set up handler to execute me.test() in the context
-// of `me`, with `you` and `they` as additional arguments
-var proxy = $.proxy( me.test, me, you, they );
-​
-$( "#test" )
-  .on( "click", proxy );
-</script>
-</body>
-</html>
-```
      */
     proxy<TReturn,
         A, B,
@@ -10489,149 +3191,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
-     * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  type: "zombie",
-  test: function( event ) {
-    // Without proxy, `this` would refer to the event target
-    // use event.target to reference that element.
-    var element = event.target;
-    $( element ).css( "background-color", "red" );
-​
-    // With proxy, `this` refers to the me object encapsulating
-    // this function.
-    $( "#log" ).append( "Hello " + this.type + "<br>" );
-    $( "#test" ).off( "click", this.test );
-  }
-};
-​
-var you = {
-  type: "person",
-  test: function( event ) {
-    $( "#log" ).append( this.type + " " );
-  }
-};
-​
-// Execute you.test() in the context of the `you` object
-// no matter where it is called
-// i.e. the `this` keyword will refer to `you`
-var youClick = $.proxy( you.test, you );
-​
-// attach click handlers to #test
-$( "#test" )
-  // this === "zombie"; handler unbound after first click
-  .on( "click", $.proxy( me.test, me ) )
-​
-  // this === "person"
-  .on( "click", youClick )
-​
-  // this === "zombie"
-  .on( "click", $.proxy( you.test, me ) )
-​
-  // this === "<button> element"
-  .on( "click", you.test );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Change the context of a function bound to the click handler,
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  // I'm a dog
-  type: "dog",
-​
-  // Note that event comes *after* one and two
-  test: function( one, two, event ) {
-    $( "#log" )
-​
-      // `one` maps to `you`, the 1st additional
-      // argument in the $.proxy function call
-      .append( "<h3>Hello " + one.type + ":</h3>" )
-​
-      // The `this` keyword refers to `me`
-      // (the 2nd, context, argument of $.proxy)
-      .append( "I am a " + this.type + ", " )
-​
-      // `two` maps to `they`, the 2nd additional
-      // argument in the $.proxy function call
-      .append( "and they are " + two.type + ".<br>" )
-​
-      // The event type is "click"
-      .append( "Thanks for " + event.type + "ing." )
-​
-      // The clicked element is `event.target`,
-      // and its type is "button"
-      .append( "the " + event.target.type + "." );
-  }
-};
-​
-var you = { type: "cat" };
-var they = { type: "fish" };
-​
-// Set up handler to execute me.test() in the context
-// of `me`, with `you` and `they` as additional arguments
-var proxy = $.proxy( me.test, me, you, they );
-​
-$( "#test" )
-  .on( "click", proxy );
-</script>
-</body>
-</html>
-```
      */
     proxy<TReturn,
         A,
@@ -10647,149 +3206,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
-     * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  type: "zombie",
-  test: function( event ) {
-    // Without proxy, `this` would refer to the event target
-    // use event.target to reference that element.
-    var element = event.target;
-    $( element ).css( "background-color", "red" );
-​
-    // With proxy, `this` refers to the me object encapsulating
-    // this function.
-    $( "#log" ).append( "Hello " + this.type + "<br>" );
-    $( "#test" ).off( "click", this.test );
-  }
-};
-​
-var you = {
-  type: "person",
-  test: function( event ) {
-    $( "#log" ).append( this.type + " " );
-  }
-};
-​
-// Execute you.test() in the context of the `you` object
-// no matter where it is called
-// i.e. the `this` keyword will refer to `you`
-var youClick = $.proxy( you.test, you );
-​
-// attach click handlers to #test
-$( "#test" )
-  // this === "zombie"; handler unbound after first click
-  .on( "click", $.proxy( me.test, me ) )
-​
-  // this === "person"
-  .on( "click", youClick )
-​
-  // this === "zombie"
-  .on( "click", $.proxy( you.test, me ) )
-​
-  // this === "<button> element"
-  .on( "click", you.test );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Change the context of a function bound to the click handler,
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  // I'm a dog
-  type: "dog",
-​
-  // Note that event comes *after* one and two
-  test: function( one, two, event ) {
-    $( "#log" )
-​
-      // `one` maps to `you`, the 1st additional
-      // argument in the $.proxy function call
-      .append( "<h3>Hello " + one.type + ":</h3>" )
-​
-      // The `this` keyword refers to `me`
-      // (the 2nd, context, argument of $.proxy)
-      .append( "I am a " + this.type + ", " )
-​
-      // `two` maps to `they`, the 2nd additional
-      // argument in the $.proxy function call
-      .append( "and they are " + two.type + ".<br>" )
-​
-      // The event type is "click"
-      .append( "Thanks for " + event.type + "ing." )
-​
-      // The clicked element is `event.target`,
-      // and its type is "button"
-      .append( "the " + event.target.type + "." );
-  }
-};
-​
-var you = { type: "cat" };
-var they = { type: "fish" };
-​
-// Set up handler to execute me.test() in the context
-// of `me`, with `you` and `they` as additional arguments
-var proxy = $.proxy( me.test, me, you, they );
-​
-$( "#test" )
-  .on( "click", proxy );
-</script>
-</body>
-</html>
-```
      */
     proxy<TReturn,
         T, U>(fn: (t: T, u: U) => TReturn,
@@ -10808,149 +3224,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
-     * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  type: "zombie",
-  test: function( event ) {
-    // Without proxy, `this` would refer to the event target
-    // use event.target to reference that element.
-    var element = event.target;
-    $( element ).css( "background-color", "red" );
-​
-    // With proxy, `this` refers to the me object encapsulating
-    // this function.
-    $( "#log" ).append( "Hello " + this.type + "<br>" );
-    $( "#test" ).off( "click", this.test );
-  }
-};
-​
-var you = {
-  type: "person",
-  test: function( event ) {
-    $( "#log" ).append( this.type + " " );
-  }
-};
-​
-// Execute you.test() in the context of the `you` object
-// no matter where it is called
-// i.e. the `this` keyword will refer to `you`
-var youClick = $.proxy( you.test, you );
-​
-// attach click handlers to #test
-$( "#test" )
-  // this === "zombie"; handler unbound after first click
-  .on( "click", $.proxy( me.test, me ) )
-​
-  // this === "person"
-  .on( "click", youClick )
-​
-  // this === "zombie"
-  .on( "click", $.proxy( you.test, me ) )
-​
-  // this === "<button> element"
-  .on( "click", you.test );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Change the context of a function bound to the click handler,
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  // I'm a dog
-  type: "dog",
-​
-  // Note that event comes *after* one and two
-  test: function( one, two, event ) {
-    $( "#log" )
-​
-      // `one` maps to `you`, the 1st additional
-      // argument in the $.proxy function call
-      .append( "<h3>Hello " + one.type + ":</h3>" )
-​
-      // The `this` keyword refers to `me`
-      // (the 2nd, context, argument of $.proxy)
-      .append( "I am a " + this.type + ", " )
-​
-      // `two` maps to `they`, the 2nd additional
-      // argument in the $.proxy function call
-      .append( "and they are " + two.type + ".<br>" )
-​
-      // The event type is "click"
-      .append( "Thanks for " + event.type + "ing." )
-​
-      // The clicked element is `event.target`,
-      // and its type is "button"
-      .append( "the " + event.target.type + "." );
-  }
-};
-​
-var you = { type: "cat" };
-var they = { type: "fish" };
-​
-// Set up handler to execute me.test() in the context
-// of `me`, with `you` and `they` as additional arguments
-var proxy = $.proxy( me.test, me, you, they );
-​
-$( "#test" )
-  .on( "click", proxy );
-</script>
-</body>
-</html>
-```
      */
     proxy<TReturn,
         A, B, C, D, E, F, G,
@@ -10966,149 +3239,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
-     * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  type: "zombie",
-  test: function( event ) {
-    // Without proxy, `this` would refer to the event target
-    // use event.target to reference that element.
-    var element = event.target;
-    $( element ).css( "background-color", "red" );
-​
-    // With proxy, `this` refers to the me object encapsulating
-    // this function.
-    $( "#log" ).append( "Hello " + this.type + "<br>" );
-    $( "#test" ).off( "click", this.test );
-  }
-};
-​
-var you = {
-  type: "person",
-  test: function( event ) {
-    $( "#log" ).append( this.type + " " );
-  }
-};
-​
-// Execute you.test() in the context of the `you` object
-// no matter where it is called
-// i.e. the `this` keyword will refer to `you`
-var youClick = $.proxy( you.test, you );
-​
-// attach click handlers to #test
-$( "#test" )
-  // this === "zombie"; handler unbound after first click
-  .on( "click", $.proxy( me.test, me ) )
-​
-  // this === "person"
-  .on( "click", youClick )
-​
-  // this === "zombie"
-  .on( "click", $.proxy( you.test, me ) )
-​
-  // this === "<button> element"
-  .on( "click", you.test );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Change the context of a function bound to the click handler,
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  // I'm a dog
-  type: "dog",
-​
-  // Note that event comes *after* one and two
-  test: function( one, two, event ) {
-    $( "#log" )
-​
-      // `one` maps to `you`, the 1st additional
-      // argument in the $.proxy function call
-      .append( "<h3>Hello " + one.type + ":</h3>" )
-​
-      // The `this` keyword refers to `me`
-      // (the 2nd, context, argument of $.proxy)
-      .append( "I am a " + this.type + ", " )
-​
-      // `two` maps to `they`, the 2nd additional
-      // argument in the $.proxy function call
-      .append( "and they are " + two.type + ".<br>" )
-​
-      // The event type is "click"
-      .append( "Thanks for " + event.type + "ing." )
-​
-      // The clicked element is `event.target`,
-      // and its type is "button"
-      .append( "the " + event.target.type + "." );
-  }
-};
-​
-var you = { type: "cat" };
-var they = { type: "fish" };
-​
-// Set up handler to execute me.test() in the context
-// of `me`, with `you` and `they` as additional arguments
-var proxy = $.proxy( me.test, me, you, they );
-​
-$( "#test" )
-  .on( "click", proxy );
-</script>
-</body>
-</html>
-```
      */
     proxy<TReturn,
         A, B, C, D, E, F,
@@ -11124,149 +3254,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
-     * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  type: "zombie",
-  test: function( event ) {
-    // Without proxy, `this` would refer to the event target
-    // use event.target to reference that element.
-    var element = event.target;
-    $( element ).css( "background-color", "red" );
-​
-    // With proxy, `this` refers to the me object encapsulating
-    // this function.
-    $( "#log" ).append( "Hello " + this.type + "<br>" );
-    $( "#test" ).off( "click", this.test );
-  }
-};
-​
-var you = {
-  type: "person",
-  test: function( event ) {
-    $( "#log" ).append( this.type + " " );
-  }
-};
-​
-// Execute you.test() in the context of the `you` object
-// no matter where it is called
-// i.e. the `this` keyword will refer to `you`
-var youClick = $.proxy( you.test, you );
-​
-// attach click handlers to #test
-$( "#test" )
-  // this === "zombie"; handler unbound after first click
-  .on( "click", $.proxy( me.test, me ) )
-​
-  // this === "person"
-  .on( "click", youClick )
-​
-  // this === "zombie"
-  .on( "click", $.proxy( you.test, me ) )
-​
-  // this === "<button> element"
-  .on( "click", you.test );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Change the context of a function bound to the click handler,
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  // I'm a dog
-  type: "dog",
-​
-  // Note that event comes *after* one and two
-  test: function( one, two, event ) {
-    $( "#log" )
-​
-      // `one` maps to `you`, the 1st additional
-      // argument in the $.proxy function call
-      .append( "<h3>Hello " + one.type + ":</h3>" )
-​
-      // The `this` keyword refers to `me`
-      // (the 2nd, context, argument of $.proxy)
-      .append( "I am a " + this.type + ", " )
-​
-      // `two` maps to `they`, the 2nd additional
-      // argument in the $.proxy function call
-      .append( "and they are " + two.type + ".<br>" )
-​
-      // The event type is "click"
-      .append( "Thanks for " + event.type + "ing." )
-​
-      // The clicked element is `event.target`,
-      // and its type is "button"
-      .append( "the " + event.target.type + "." );
-  }
-};
-​
-var you = { type: "cat" };
-var they = { type: "fish" };
-​
-// Set up handler to execute me.test() in the context
-// of `me`, with `you` and `they` as additional arguments
-var proxy = $.proxy( me.test, me, you, they );
-​
-$( "#test" )
-  .on( "click", proxy );
-</script>
-</body>
-</html>
-```
      */
     proxy<TReturn,
         A, B, C, D, E,
@@ -11282,149 +3269,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
-     * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  type: "zombie",
-  test: function( event ) {
-    // Without proxy, `this` would refer to the event target
-    // use event.target to reference that element.
-    var element = event.target;
-    $( element ).css( "background-color", "red" );
-​
-    // With proxy, `this` refers to the me object encapsulating
-    // this function.
-    $( "#log" ).append( "Hello " + this.type + "<br>" );
-    $( "#test" ).off( "click", this.test );
-  }
-};
-​
-var you = {
-  type: "person",
-  test: function( event ) {
-    $( "#log" ).append( this.type + " " );
-  }
-};
-​
-// Execute you.test() in the context of the `you` object
-// no matter where it is called
-// i.e. the `this` keyword will refer to `you`
-var youClick = $.proxy( you.test, you );
-​
-// attach click handlers to #test
-$( "#test" )
-  // this === "zombie"; handler unbound after first click
-  .on( "click", $.proxy( me.test, me ) )
-​
-  // this === "person"
-  .on( "click", youClick )
-​
-  // this === "zombie"
-  .on( "click", $.proxy( you.test, me ) )
-​
-  // this === "<button> element"
-  .on( "click", you.test );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Change the context of a function bound to the click handler,
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  // I'm a dog
-  type: "dog",
-​
-  // Note that event comes *after* one and two
-  test: function( one, two, event ) {
-    $( "#log" )
-​
-      // `one` maps to `you`, the 1st additional
-      // argument in the $.proxy function call
-      .append( "<h3>Hello " + one.type + ":</h3>" )
-​
-      // The `this` keyword refers to `me`
-      // (the 2nd, context, argument of $.proxy)
-      .append( "I am a " + this.type + ", " )
-​
-      // `two` maps to `they`, the 2nd additional
-      // argument in the $.proxy function call
-      .append( "and they are " + two.type + ".<br>" )
-​
-      // The event type is "click"
-      .append( "Thanks for " + event.type + "ing." )
-​
-      // The clicked element is `event.target`,
-      // and its type is "button"
-      .append( "the " + event.target.type + "." );
-  }
-};
-​
-var you = { type: "cat" };
-var they = { type: "fish" };
-​
-// Set up handler to execute me.test() in the context
-// of `me`, with `you` and `they` as additional arguments
-var proxy = $.proxy( me.test, me, you, they );
-​
-$( "#test" )
-  .on( "click", proxy );
-</script>
-</body>
-</html>
-```
      */
     proxy<TReturn,
         A, B, C, D,
@@ -11440,149 +3284,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
-     * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  type: "zombie",
-  test: function( event ) {
-    // Without proxy, `this` would refer to the event target
-    // use event.target to reference that element.
-    var element = event.target;
-    $( element ).css( "background-color", "red" );
-​
-    // With proxy, `this` refers to the me object encapsulating
-    // this function.
-    $( "#log" ).append( "Hello " + this.type + "<br>" );
-    $( "#test" ).off( "click", this.test );
-  }
-};
-​
-var you = {
-  type: "person",
-  test: function( event ) {
-    $( "#log" ).append( this.type + " " );
-  }
-};
-​
-// Execute you.test() in the context of the `you` object
-// no matter where it is called
-// i.e. the `this` keyword will refer to `you`
-var youClick = $.proxy( you.test, you );
-​
-// attach click handlers to #test
-$( "#test" )
-  // this === "zombie"; handler unbound after first click
-  .on( "click", $.proxy( me.test, me ) )
-​
-  // this === "person"
-  .on( "click", youClick )
-​
-  // this === "zombie"
-  .on( "click", $.proxy( you.test, me ) )
-​
-  // this === "<button> element"
-  .on( "click", you.test );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Change the context of a function bound to the click handler,
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  // I'm a dog
-  type: "dog",
-​
-  // Note that event comes *after* one and two
-  test: function( one, two, event ) {
-    $( "#log" )
-​
-      // `one` maps to `you`, the 1st additional
-      // argument in the $.proxy function call
-      .append( "<h3>Hello " + one.type + ":</h3>" )
-​
-      // The `this` keyword refers to `me`
-      // (the 2nd, context, argument of $.proxy)
-      .append( "I am a " + this.type + ", " )
-​
-      // `two` maps to `they`, the 2nd additional
-      // argument in the $.proxy function call
-      .append( "and they are " + two.type + ".<br>" )
-​
-      // The event type is "click"
-      .append( "Thanks for " + event.type + "ing." )
-​
-      // The clicked element is `event.target`,
-      // and its type is "button"
-      .append( "the " + event.target.type + "." );
-  }
-};
-​
-var you = { type: "cat" };
-var they = { type: "fish" };
-​
-// Set up handler to execute me.test() in the context
-// of `me`, with `you` and `they` as additional arguments
-var proxy = $.proxy( me.test, me, you, they );
-​
-$( "#test" )
-  .on( "click", proxy );
-</script>
-</body>
-</html>
-```
      */
     proxy<TReturn,
         A, B, C,
@@ -11598,149 +3299,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
-     * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  type: "zombie",
-  test: function( event ) {
-    // Without proxy, `this` would refer to the event target
-    // use event.target to reference that element.
-    var element = event.target;
-    $( element ).css( "background-color", "red" );
-​
-    // With proxy, `this` refers to the me object encapsulating
-    // this function.
-    $( "#log" ).append( "Hello " + this.type + "<br>" );
-    $( "#test" ).off( "click", this.test );
-  }
-};
-​
-var you = {
-  type: "person",
-  test: function( event ) {
-    $( "#log" ).append( this.type + " " );
-  }
-};
-​
-// Execute you.test() in the context of the `you` object
-// no matter where it is called
-// i.e. the `this` keyword will refer to `you`
-var youClick = $.proxy( you.test, you );
-​
-// attach click handlers to #test
-$( "#test" )
-  // this === "zombie"; handler unbound after first click
-  .on( "click", $.proxy( me.test, me ) )
-​
-  // this === "person"
-  .on( "click", youClick )
-​
-  // this === "zombie"
-  .on( "click", $.proxy( you.test, me ) )
-​
-  // this === "<button> element"
-  .on( "click", you.test );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Change the context of a function bound to the click handler,
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  // I'm a dog
-  type: "dog",
-​
-  // Note that event comes *after* one and two
-  test: function( one, two, event ) {
-    $( "#log" )
-​
-      // `one` maps to `you`, the 1st additional
-      // argument in the $.proxy function call
-      .append( "<h3>Hello " + one.type + ":</h3>" )
-​
-      // The `this` keyword refers to `me`
-      // (the 2nd, context, argument of $.proxy)
-      .append( "I am a " + this.type + ", " )
-​
-      // `two` maps to `they`, the 2nd additional
-      // argument in the $.proxy function call
-      .append( "and they are " + two.type + ".<br>" )
-​
-      // The event type is "click"
-      .append( "Thanks for " + event.type + "ing." )
-​
-      // The clicked element is `event.target`,
-      // and its type is "button"
-      .append( "the " + event.target.type + "." );
-  }
-};
-​
-var you = { type: "cat" };
-var they = { type: "fish" };
-​
-// Set up handler to execute me.test() in the context
-// of `me`, with `you` and `they` as additional arguments
-var proxy = $.proxy( me.test, me, you, they );
-​
-$( "#test" )
-  .on( "click", proxy );
-</script>
-</body>
-</html>
-```
      */
     proxy<TReturn,
         A, B,
@@ -11756,149 +3314,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
-     * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  type: "zombie",
-  test: function( event ) {
-    // Without proxy, `this` would refer to the event target
-    // use event.target to reference that element.
-    var element = event.target;
-    $( element ).css( "background-color", "red" );
-​
-    // With proxy, `this` refers to the me object encapsulating
-    // this function.
-    $( "#log" ).append( "Hello " + this.type + "<br>" );
-    $( "#test" ).off( "click", this.test );
-  }
-};
-​
-var you = {
-  type: "person",
-  test: function( event ) {
-    $( "#log" ).append( this.type + " " );
-  }
-};
-​
-// Execute you.test() in the context of the `you` object
-// no matter where it is called
-// i.e. the `this` keyword will refer to `you`
-var youClick = $.proxy( you.test, you );
-​
-// attach click handlers to #test
-$( "#test" )
-  // this === "zombie"; handler unbound after first click
-  .on( "click", $.proxy( me.test, me ) )
-​
-  // this === "person"
-  .on( "click", youClick )
-​
-  // this === "zombie"
-  .on( "click", $.proxy( you.test, me ) )
-​
-  // this === "<button> element"
-  .on( "click", you.test );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Change the context of a function bound to the click handler,
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  // I'm a dog
-  type: "dog",
-​
-  // Note that event comes *after* one and two
-  test: function( one, two, event ) {
-    $( "#log" )
-​
-      // `one` maps to `you`, the 1st additional
-      // argument in the $.proxy function call
-      .append( "<h3>Hello " + one.type + ":</h3>" )
-​
-      // The `this` keyword refers to `me`
-      // (the 2nd, context, argument of $.proxy)
-      .append( "I am a " + this.type + ", " )
-​
-      // `two` maps to `they`, the 2nd additional
-      // argument in the $.proxy function call
-      .append( "and they are " + two.type + ".<br>" )
-​
-      // The event type is "click"
-      .append( "Thanks for " + event.type + "ing." )
-​
-      // The clicked element is `event.target`,
-      // and its type is "button"
-      .append( "the " + event.target.type + "." );
-  }
-};
-​
-var you = { type: "cat" };
-var they = { type: "fish" };
-​
-// Set up handler to execute me.test() in the context
-// of `me`, with `you` and `they` as additional arguments
-var proxy = $.proxy( me.test, me, you, they );
-​
-$( "#test" )
-  .on( "click", proxy );
-</script>
-</body>
-</html>
-```
      */
     proxy<TReturn,
         A,
@@ -11914,149 +3329,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
-     * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  type: "zombie",
-  test: function( event ) {
-    // Without proxy, `this` would refer to the event target
-    // use event.target to reference that element.
-    var element = event.target;
-    $( element ).css( "background-color", "red" );
-​
-    // With proxy, `this` refers to the me object encapsulating
-    // this function.
-    $( "#log" ).append( "Hello " + this.type + "<br>" );
-    $( "#test" ).off( "click", this.test );
-  }
-};
-​
-var you = {
-  type: "person",
-  test: function( event ) {
-    $( "#log" ).append( this.type + " " );
-  }
-};
-​
-// Execute you.test() in the context of the `you` object
-// no matter where it is called
-// i.e. the `this` keyword will refer to `you`
-var youClick = $.proxy( you.test, you );
-​
-// attach click handlers to #test
-$( "#test" )
-  // this === "zombie"; handler unbound after first click
-  .on( "click", $.proxy( me.test, me ) )
-​
-  // this === "person"
-  .on( "click", youClick )
-​
-  // this === "zombie"
-  .on( "click", $.proxy( you.test, me ) )
-​
-  // this === "<button> element"
-  .on( "click", you.test );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Change the context of a function bound to the click handler,
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  // I'm a dog
-  type: "dog",
-​
-  // Note that event comes *after* one and two
-  test: function( one, two, event ) {
-    $( "#log" )
-​
-      // `one` maps to `you`, the 1st additional
-      // argument in the $.proxy function call
-      .append( "<h3>Hello " + one.type + ":</h3>" )
-​
-      // The `this` keyword refers to `me`
-      // (the 2nd, context, argument of $.proxy)
-      .append( "I am a " + this.type + ", " )
-​
-      // `two` maps to `they`, the 2nd additional
-      // argument in the $.proxy function call
-      .append( "and they are " + two.type + ".<br>" )
-​
-      // The event type is "click"
-      .append( "Thanks for " + event.type + "ing." )
-​
-      // The clicked element is `event.target`,
-      // and its type is "button"
-      .append( "the " + event.target.type + "." );
-  }
-};
-​
-var you = { type: "cat" };
-var they = { type: "fish" };
-​
-// Set up handler to execute me.test() in the context
-// of `me`, with `you` and `they` as additional arguments
-var proxy = $.proxy( me.test, me, you, they );
-​
-$( "#test" )
-  .on( "click", proxy );
-</script>
-</body>
-</html>
-```
      */
     proxy<TReturn,
         T, U, V>(fn: (t: T, u: U, v: V) => TReturn,
@@ -12075,149 +3347,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
-     * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  type: "zombie",
-  test: function( event ) {
-    // Without proxy, `this` would refer to the event target
-    // use event.target to reference that element.
-    var element = event.target;
-    $( element ).css( "background-color", "red" );
-​
-    // With proxy, `this` refers to the me object encapsulating
-    // this function.
-    $( "#log" ).append( "Hello " + this.type + "<br>" );
-    $( "#test" ).off( "click", this.test );
-  }
-};
-​
-var you = {
-  type: "person",
-  test: function( event ) {
-    $( "#log" ).append( this.type + " " );
-  }
-};
-​
-// Execute you.test() in the context of the `you` object
-// no matter where it is called
-// i.e. the `this` keyword will refer to `you`
-var youClick = $.proxy( you.test, you );
-​
-// attach click handlers to #test
-$( "#test" )
-  // this === "zombie"; handler unbound after first click
-  .on( "click", $.proxy( me.test, me ) )
-​
-  // this === "person"
-  .on( "click", youClick )
-​
-  // this === "zombie"
-  .on( "click", $.proxy( you.test, me ) )
-​
-  // this === "<button> element"
-  .on( "click", you.test );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Change the context of a function bound to the click handler,
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  // I'm a dog
-  type: "dog",
-​
-  // Note that event comes *after* one and two
-  test: function( one, two, event ) {
-    $( "#log" )
-​
-      // `one` maps to `you`, the 1st additional
-      // argument in the $.proxy function call
-      .append( "<h3>Hello " + one.type + ":</h3>" )
-​
-      // The `this` keyword refers to `me`
-      // (the 2nd, context, argument of $.proxy)
-      .append( "I am a " + this.type + ", " )
-​
-      // `two` maps to `they`, the 2nd additional
-      // argument in the $.proxy function call
-      .append( "and they are " + two.type + ".<br>" )
-​
-      // The event type is "click"
-      .append( "Thanks for " + event.type + "ing." )
-​
-      // The clicked element is `event.target`,
-      // and its type is "button"
-      .append( "the " + event.target.type + "." );
-  }
-};
-​
-var you = { type: "cat" };
-var they = { type: "fish" };
-​
-// Set up handler to execute me.test() in the context
-// of `me`, with `you` and `they` as additional arguments
-var proxy = $.proxy( me.test, me, you, they );
-​
-$( "#test" )
-  .on( "click", proxy );
-</script>
-</body>
-</html>
-```
      */
     proxy<TReturn,
         A, B, C, D, E, F, G,
@@ -12233,149 +3362,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
-     * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  type: "zombie",
-  test: function( event ) {
-    // Without proxy, `this` would refer to the event target
-    // use event.target to reference that element.
-    var element = event.target;
-    $( element ).css( "background-color", "red" );
-​
-    // With proxy, `this` refers to the me object encapsulating
-    // this function.
-    $( "#log" ).append( "Hello " + this.type + "<br>" );
-    $( "#test" ).off( "click", this.test );
-  }
-};
-​
-var you = {
-  type: "person",
-  test: function( event ) {
-    $( "#log" ).append( this.type + " " );
-  }
-};
-​
-// Execute you.test() in the context of the `you` object
-// no matter where it is called
-// i.e. the `this` keyword will refer to `you`
-var youClick = $.proxy( you.test, you );
-​
-// attach click handlers to #test
-$( "#test" )
-  // this === "zombie"; handler unbound after first click
-  .on( "click", $.proxy( me.test, me ) )
-​
-  // this === "person"
-  .on( "click", youClick )
-​
-  // this === "zombie"
-  .on( "click", $.proxy( you.test, me ) )
-​
-  // this === "<button> element"
-  .on( "click", you.test );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Change the context of a function bound to the click handler,
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  // I'm a dog
-  type: "dog",
-​
-  // Note that event comes *after* one and two
-  test: function( one, two, event ) {
-    $( "#log" )
-​
-      // `one` maps to `you`, the 1st additional
-      // argument in the $.proxy function call
-      .append( "<h3>Hello " + one.type + ":</h3>" )
-​
-      // The `this` keyword refers to `me`
-      // (the 2nd, context, argument of $.proxy)
-      .append( "I am a " + this.type + ", " )
-​
-      // `two` maps to `they`, the 2nd additional
-      // argument in the $.proxy function call
-      .append( "and they are " + two.type + ".<br>" )
-​
-      // The event type is "click"
-      .append( "Thanks for " + event.type + "ing." )
-​
-      // The clicked element is `event.target`,
-      // and its type is "button"
-      .append( "the " + event.target.type + "." );
-  }
-};
-​
-var you = { type: "cat" };
-var they = { type: "fish" };
-​
-// Set up handler to execute me.test() in the context
-// of `me`, with `you` and `they` as additional arguments
-var proxy = $.proxy( me.test, me, you, they );
-​
-$( "#test" )
-  .on( "click", proxy );
-</script>
-</body>
-</html>
-```
      */
     proxy<TReturn,
         A, B, C, D, E, F,
@@ -12391,149 +3377,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
-     * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  type: "zombie",
-  test: function( event ) {
-    // Without proxy, `this` would refer to the event target
-    // use event.target to reference that element.
-    var element = event.target;
-    $( element ).css( "background-color", "red" );
-​
-    // With proxy, `this` refers to the me object encapsulating
-    // this function.
-    $( "#log" ).append( "Hello " + this.type + "<br>" );
-    $( "#test" ).off( "click", this.test );
-  }
-};
-​
-var you = {
-  type: "person",
-  test: function( event ) {
-    $( "#log" ).append( this.type + " " );
-  }
-};
-​
-// Execute you.test() in the context of the `you` object
-// no matter where it is called
-// i.e. the `this` keyword will refer to `you`
-var youClick = $.proxy( you.test, you );
-​
-// attach click handlers to #test
-$( "#test" )
-  // this === "zombie"; handler unbound after first click
-  .on( "click", $.proxy( me.test, me ) )
-​
-  // this === "person"
-  .on( "click", youClick )
-​
-  // this === "zombie"
-  .on( "click", $.proxy( you.test, me ) )
-​
-  // this === "<button> element"
-  .on( "click", you.test );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Change the context of a function bound to the click handler,
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  // I'm a dog
-  type: "dog",
-​
-  // Note that event comes *after* one and two
-  test: function( one, two, event ) {
-    $( "#log" )
-​
-      // `one` maps to `you`, the 1st additional
-      // argument in the $.proxy function call
-      .append( "<h3>Hello " + one.type + ":</h3>" )
-​
-      // The `this` keyword refers to `me`
-      // (the 2nd, context, argument of $.proxy)
-      .append( "I am a " + this.type + ", " )
-​
-      // `two` maps to `they`, the 2nd additional
-      // argument in the $.proxy function call
-      .append( "and they are " + two.type + ".<br>" )
-​
-      // The event type is "click"
-      .append( "Thanks for " + event.type + "ing." )
-​
-      // The clicked element is `event.target`,
-      // and its type is "button"
-      .append( "the " + event.target.type + "." );
-  }
-};
-​
-var you = { type: "cat" };
-var they = { type: "fish" };
-​
-// Set up handler to execute me.test() in the context
-// of `me`, with `you` and `they` as additional arguments
-var proxy = $.proxy( me.test, me, you, they );
-​
-$( "#test" )
-  .on( "click", proxy );
-</script>
-</body>
-</html>
-```
      */
     proxy<TReturn,
         A, B, C, D, E,
@@ -12549,149 +3392,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
-     * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  type: "zombie",
-  test: function( event ) {
-    // Without proxy, `this` would refer to the event target
-    // use event.target to reference that element.
-    var element = event.target;
-    $( element ).css( "background-color", "red" );
-​
-    // With proxy, `this` refers to the me object encapsulating
-    // this function.
-    $( "#log" ).append( "Hello " + this.type + "<br>" );
-    $( "#test" ).off( "click", this.test );
-  }
-};
-​
-var you = {
-  type: "person",
-  test: function( event ) {
-    $( "#log" ).append( this.type + " " );
-  }
-};
-​
-// Execute you.test() in the context of the `you` object
-// no matter where it is called
-// i.e. the `this` keyword will refer to `you`
-var youClick = $.proxy( you.test, you );
-​
-// attach click handlers to #test
-$( "#test" )
-  // this === "zombie"; handler unbound after first click
-  .on( "click", $.proxy( me.test, me ) )
-​
-  // this === "person"
-  .on( "click", youClick )
-​
-  // this === "zombie"
-  .on( "click", $.proxy( you.test, me ) )
-​
-  // this === "<button> element"
-  .on( "click", you.test );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Change the context of a function bound to the click handler,
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  // I'm a dog
-  type: "dog",
-​
-  // Note that event comes *after* one and two
-  test: function( one, two, event ) {
-    $( "#log" )
-​
-      // `one` maps to `you`, the 1st additional
-      // argument in the $.proxy function call
-      .append( "<h3>Hello " + one.type + ":</h3>" )
-​
-      // The `this` keyword refers to `me`
-      // (the 2nd, context, argument of $.proxy)
-      .append( "I am a " + this.type + ", " )
-​
-      // `two` maps to `they`, the 2nd additional
-      // argument in the $.proxy function call
-      .append( "and they are " + two.type + ".<br>" )
-​
-      // The event type is "click"
-      .append( "Thanks for " + event.type + "ing." )
-​
-      // The clicked element is `event.target`,
-      // and its type is "button"
-      .append( "the " + event.target.type + "." );
-  }
-};
-​
-var you = { type: "cat" };
-var they = { type: "fish" };
-​
-// Set up handler to execute me.test() in the context
-// of `me`, with `you` and `they` as additional arguments
-var proxy = $.proxy( me.test, me, you, they );
-​
-$( "#test" )
-  .on( "click", proxy );
-</script>
-</body>
-</html>
-```
      */
     proxy<TReturn,
         A, B, C, D,
@@ -12707,149 +3407,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
-     * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  type: "zombie",
-  test: function( event ) {
-    // Without proxy, `this` would refer to the event target
-    // use event.target to reference that element.
-    var element = event.target;
-    $( element ).css( "background-color", "red" );
-​
-    // With proxy, `this` refers to the me object encapsulating
-    // this function.
-    $( "#log" ).append( "Hello " + this.type + "<br>" );
-    $( "#test" ).off( "click", this.test );
-  }
-};
-​
-var you = {
-  type: "person",
-  test: function( event ) {
-    $( "#log" ).append( this.type + " " );
-  }
-};
-​
-// Execute you.test() in the context of the `you` object
-// no matter where it is called
-// i.e. the `this` keyword will refer to `you`
-var youClick = $.proxy( you.test, you );
-​
-// attach click handlers to #test
-$( "#test" )
-  // this === "zombie"; handler unbound after first click
-  .on( "click", $.proxy( me.test, me ) )
-​
-  // this === "person"
-  .on( "click", youClick )
-​
-  // this === "zombie"
-  .on( "click", $.proxy( you.test, me ) )
-​
-  // this === "<button> element"
-  .on( "click", you.test );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Change the context of a function bound to the click handler,
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  // I'm a dog
-  type: "dog",
-​
-  // Note that event comes *after* one and two
-  test: function( one, two, event ) {
-    $( "#log" )
-​
-      // `one` maps to `you`, the 1st additional
-      // argument in the $.proxy function call
-      .append( "<h3>Hello " + one.type + ":</h3>" )
-​
-      // The `this` keyword refers to `me`
-      // (the 2nd, context, argument of $.proxy)
-      .append( "I am a " + this.type + ", " )
-​
-      // `two` maps to `they`, the 2nd additional
-      // argument in the $.proxy function call
-      .append( "and they are " + two.type + ".<br>" )
-​
-      // The event type is "click"
-      .append( "Thanks for " + event.type + "ing." )
-​
-      // The clicked element is `event.target`,
-      // and its type is "button"
-      .append( "the " + event.target.type + "." );
-  }
-};
-​
-var you = { type: "cat" };
-var they = { type: "fish" };
-​
-// Set up handler to execute me.test() in the context
-// of `me`, with `you` and `they` as additional arguments
-var proxy = $.proxy( me.test, me, you, they );
-​
-$( "#test" )
-  .on( "click", proxy );
-</script>
-</body>
-</html>
-```
      */
     proxy<TReturn,
         A, B, C,
@@ -12865,149 +3422,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
-     * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  type: "zombie",
-  test: function( event ) {
-    // Without proxy, `this` would refer to the event target
-    // use event.target to reference that element.
-    var element = event.target;
-    $( element ).css( "background-color", "red" );
-​
-    // With proxy, `this` refers to the me object encapsulating
-    // this function.
-    $( "#log" ).append( "Hello " + this.type + "<br>" );
-    $( "#test" ).off( "click", this.test );
-  }
-};
-​
-var you = {
-  type: "person",
-  test: function( event ) {
-    $( "#log" ).append( this.type + " " );
-  }
-};
-​
-// Execute you.test() in the context of the `you` object
-// no matter where it is called
-// i.e. the `this` keyword will refer to `you`
-var youClick = $.proxy( you.test, you );
-​
-// attach click handlers to #test
-$( "#test" )
-  // this === "zombie"; handler unbound after first click
-  .on( "click", $.proxy( me.test, me ) )
-​
-  // this === "person"
-  .on( "click", youClick )
-​
-  // this === "zombie"
-  .on( "click", $.proxy( you.test, me ) )
-​
-  // this === "<button> element"
-  .on( "click", you.test );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Change the context of a function bound to the click handler,
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  // I'm a dog
-  type: "dog",
-​
-  // Note that event comes *after* one and two
-  test: function( one, two, event ) {
-    $( "#log" )
-​
-      // `one` maps to `you`, the 1st additional
-      // argument in the $.proxy function call
-      .append( "<h3>Hello " + one.type + ":</h3>" )
-​
-      // The `this` keyword refers to `me`
-      // (the 2nd, context, argument of $.proxy)
-      .append( "I am a " + this.type + ", " )
-​
-      // `two` maps to `they`, the 2nd additional
-      // argument in the $.proxy function call
-      .append( "and they are " + two.type + ".<br>" )
-​
-      // The event type is "click"
-      .append( "Thanks for " + event.type + "ing." )
-​
-      // The clicked element is `event.target`,
-      // and its type is "button"
-      .append( "the " + event.target.type + "." );
-  }
-};
-​
-var you = { type: "cat" };
-var they = { type: "fish" };
-​
-// Set up handler to execute me.test() in the context
-// of `me`, with `you` and `they` as additional arguments
-var proxy = $.proxy( me.test, me, you, they );
-​
-$( "#test" )
-  .on( "click", proxy );
-</script>
-</body>
-</html>
-```
      */
     proxy<TReturn,
         A, B,
@@ -13023,149 +3437,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
-     * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  type: "zombie",
-  test: function( event ) {
-    // Without proxy, `this` would refer to the event target
-    // use event.target to reference that element.
-    var element = event.target;
-    $( element ).css( "background-color", "red" );
-​
-    // With proxy, `this` refers to the me object encapsulating
-    // this function.
-    $( "#log" ).append( "Hello " + this.type + "<br>" );
-    $( "#test" ).off( "click", this.test );
-  }
-};
-​
-var you = {
-  type: "person",
-  test: function( event ) {
-    $( "#log" ).append( this.type + " " );
-  }
-};
-​
-// Execute you.test() in the context of the `you` object
-// no matter where it is called
-// i.e. the `this` keyword will refer to `you`
-var youClick = $.proxy( you.test, you );
-​
-// attach click handlers to #test
-$( "#test" )
-  // this === "zombie"; handler unbound after first click
-  .on( "click", $.proxy( me.test, me ) )
-​
-  // this === "person"
-  .on( "click", youClick )
-​
-  // this === "zombie"
-  .on( "click", $.proxy( you.test, me ) )
-​
-  // this === "<button> element"
-  .on( "click", you.test );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Change the context of a function bound to the click handler,
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  // I'm a dog
-  type: "dog",
-​
-  // Note that event comes *after* one and two
-  test: function( one, two, event ) {
-    $( "#log" )
-​
-      // `one` maps to `you`, the 1st additional
-      // argument in the $.proxy function call
-      .append( "<h3>Hello " + one.type + ":</h3>" )
-​
-      // The `this` keyword refers to `me`
-      // (the 2nd, context, argument of $.proxy)
-      .append( "I am a " + this.type + ", " )
-​
-      // `two` maps to `they`, the 2nd additional
-      // argument in the $.proxy function call
-      .append( "and they are " + two.type + ".<br>" )
-​
-      // The event type is "click"
-      .append( "Thanks for " + event.type + "ing." )
-​
-      // The clicked element is `event.target`,
-      // and its type is "button"
-      .append( "the " + event.target.type + "." );
-  }
-};
-​
-var you = { type: "cat" };
-var they = { type: "fish" };
-​
-// Set up handler to execute me.test() in the context
-// of `me`, with `you` and `they` as additional arguments
-var proxy = $.proxy( me.test, me, you, they );
-​
-$( "#test" )
-  .on( "click", proxy );
-</script>
-</body>
-</html>
-```
      */
     proxy<TReturn,
         A,
@@ -13181,149 +3452,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
-     * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  type: "zombie",
-  test: function( event ) {
-    // Without proxy, `this` would refer to the event target
-    // use event.target to reference that element.
-    var element = event.target;
-    $( element ).css( "background-color", "red" );
-​
-    // With proxy, `this` refers to the me object encapsulating
-    // this function.
-    $( "#log" ).append( "Hello " + this.type + "<br>" );
-    $( "#test" ).off( "click", this.test );
-  }
-};
-​
-var you = {
-  type: "person",
-  test: function( event ) {
-    $( "#log" ).append( this.type + " " );
-  }
-};
-​
-// Execute you.test() in the context of the `you` object
-// no matter where it is called
-// i.e. the `this` keyword will refer to `you`
-var youClick = $.proxy( you.test, you );
-​
-// attach click handlers to #test
-$( "#test" )
-  // this === "zombie"; handler unbound after first click
-  .on( "click", $.proxy( me.test, me ) )
-​
-  // this === "person"
-  .on( "click", youClick )
-​
-  // this === "zombie"
-  .on( "click", $.proxy( you.test, me ) )
-​
-  // this === "<button> element"
-  .on( "click", you.test );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Change the context of a function bound to the click handler,
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  // I'm a dog
-  type: "dog",
-​
-  // Note that event comes *after* one and two
-  test: function( one, two, event ) {
-    $( "#log" )
-​
-      // `one` maps to `you`, the 1st additional
-      // argument in the $.proxy function call
-      .append( "<h3>Hello " + one.type + ":</h3>" )
-​
-      // The `this` keyword refers to `me`
-      // (the 2nd, context, argument of $.proxy)
-      .append( "I am a " + this.type + ", " )
-​
-      // `two` maps to `they`, the 2nd additional
-      // argument in the $.proxy function call
-      .append( "and they are " + two.type + ".<br>" )
-​
-      // The event type is "click"
-      .append( "Thanks for " + event.type + "ing." )
-​
-      // The clicked element is `event.target`,
-      // and its type is "button"
-      .append( "the " + event.target.type + "." );
-  }
-};
-​
-var you = { type: "cat" };
-var they = { type: "fish" };
-​
-// Set up handler to execute me.test() in the context
-// of `me`, with `you` and `they` as additional arguments
-var proxy = $.proxy( me.test, me, you, they );
-​
-$( "#test" )
-  .on( "click", proxy );
-</script>
-</body>
-</html>
-```
      */
     proxy<TReturn,
         T, U, V, W>(fn: (t: T, u: U, v: V, w: W) => TReturn,
@@ -13342,149 +3470,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
-     * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  type: "zombie",
-  test: function( event ) {
-    // Without proxy, `this` would refer to the event target
-    // use event.target to reference that element.
-    var element = event.target;
-    $( element ).css( "background-color", "red" );
-​
-    // With proxy, `this` refers to the me object encapsulating
-    // this function.
-    $( "#log" ).append( "Hello " + this.type + "<br>" );
-    $( "#test" ).off( "click", this.test );
-  }
-};
-​
-var you = {
-  type: "person",
-  test: function( event ) {
-    $( "#log" ).append( this.type + " " );
-  }
-};
-​
-// Execute you.test() in the context of the `you` object
-// no matter where it is called
-// i.e. the `this` keyword will refer to `you`
-var youClick = $.proxy( you.test, you );
-​
-// attach click handlers to #test
-$( "#test" )
-  // this === "zombie"; handler unbound after first click
-  .on( "click", $.proxy( me.test, me ) )
-​
-  // this === "person"
-  .on( "click", youClick )
-​
-  // this === "zombie"
-  .on( "click", $.proxy( you.test, me ) )
-​
-  // this === "<button> element"
-  .on( "click", you.test );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Change the context of a function bound to the click handler,
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  // I'm a dog
-  type: "dog",
-​
-  // Note that event comes *after* one and two
-  test: function( one, two, event ) {
-    $( "#log" )
-​
-      // `one` maps to `you`, the 1st additional
-      // argument in the $.proxy function call
-      .append( "<h3>Hello " + one.type + ":</h3>" )
-​
-      // The `this` keyword refers to `me`
-      // (the 2nd, context, argument of $.proxy)
-      .append( "I am a " + this.type + ", " )
-​
-      // `two` maps to `they`, the 2nd additional
-      // argument in the $.proxy function call
-      .append( "and they are " + two.type + ".<br>" )
-​
-      // The event type is "click"
-      .append( "Thanks for " + event.type + "ing." )
-​
-      // The clicked element is `event.target`,
-      // and its type is "button"
-      .append( "the " + event.target.type + "." );
-  }
-};
-​
-var you = { type: "cat" };
-var they = { type: "fish" };
-​
-// Set up handler to execute me.test() in the context
-// of `me`, with `you` and `they` as additional arguments
-var proxy = $.proxy( me.test, me, you, they );
-​
-$( "#test" )
-  .on( "click", proxy );
-</script>
-</body>
-</html>
-```
      */
     proxy<TReturn,
         A, B, C, D, E, F, G,
@@ -13500,149 +3485,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
-     * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  type: "zombie",
-  test: function( event ) {
-    // Without proxy, `this` would refer to the event target
-    // use event.target to reference that element.
-    var element = event.target;
-    $( element ).css( "background-color", "red" );
-​
-    // With proxy, `this` refers to the me object encapsulating
-    // this function.
-    $( "#log" ).append( "Hello " + this.type + "<br>" );
-    $( "#test" ).off( "click", this.test );
-  }
-};
-​
-var you = {
-  type: "person",
-  test: function( event ) {
-    $( "#log" ).append( this.type + " " );
-  }
-};
-​
-// Execute you.test() in the context of the `you` object
-// no matter where it is called
-// i.e. the `this` keyword will refer to `you`
-var youClick = $.proxy( you.test, you );
-​
-// attach click handlers to #test
-$( "#test" )
-  // this === "zombie"; handler unbound after first click
-  .on( "click", $.proxy( me.test, me ) )
-​
-  // this === "person"
-  .on( "click", youClick )
-​
-  // this === "zombie"
-  .on( "click", $.proxy( you.test, me ) )
-​
-  // this === "<button> element"
-  .on( "click", you.test );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Change the context of a function bound to the click handler,
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  // I'm a dog
-  type: "dog",
-​
-  // Note that event comes *after* one and two
-  test: function( one, two, event ) {
-    $( "#log" )
-​
-      // `one` maps to `you`, the 1st additional
-      // argument in the $.proxy function call
-      .append( "<h3>Hello " + one.type + ":</h3>" )
-​
-      // The `this` keyword refers to `me`
-      // (the 2nd, context, argument of $.proxy)
-      .append( "I am a " + this.type + ", " )
-​
-      // `two` maps to `they`, the 2nd additional
-      // argument in the $.proxy function call
-      .append( "and they are " + two.type + ".<br>" )
-​
-      // The event type is "click"
-      .append( "Thanks for " + event.type + "ing." )
-​
-      // The clicked element is `event.target`,
-      // and its type is "button"
-      .append( "the " + event.target.type + "." );
-  }
-};
-​
-var you = { type: "cat" };
-var they = { type: "fish" };
-​
-// Set up handler to execute me.test() in the context
-// of `me`, with `you` and `they` as additional arguments
-var proxy = $.proxy( me.test, me, you, they );
-​
-$( "#test" )
-  .on( "click", proxy );
-</script>
-</body>
-</html>
-```
      */
     proxy<TReturn,
         A, B, C, D, E, F,
@@ -13658,149 +3500,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
-     * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  type: "zombie",
-  test: function( event ) {
-    // Without proxy, `this` would refer to the event target
-    // use event.target to reference that element.
-    var element = event.target;
-    $( element ).css( "background-color", "red" );
-​
-    // With proxy, `this` refers to the me object encapsulating
-    // this function.
-    $( "#log" ).append( "Hello " + this.type + "<br>" );
-    $( "#test" ).off( "click", this.test );
-  }
-};
-​
-var you = {
-  type: "person",
-  test: function( event ) {
-    $( "#log" ).append( this.type + " " );
-  }
-};
-​
-// Execute you.test() in the context of the `you` object
-// no matter where it is called
-// i.e. the `this` keyword will refer to `you`
-var youClick = $.proxy( you.test, you );
-​
-// attach click handlers to #test
-$( "#test" )
-  // this === "zombie"; handler unbound after first click
-  .on( "click", $.proxy( me.test, me ) )
-​
-  // this === "person"
-  .on( "click", youClick )
-​
-  // this === "zombie"
-  .on( "click", $.proxy( you.test, me ) )
-​
-  // this === "<button> element"
-  .on( "click", you.test );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Change the context of a function bound to the click handler,
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  // I'm a dog
-  type: "dog",
-​
-  // Note that event comes *after* one and two
-  test: function( one, two, event ) {
-    $( "#log" )
-​
-      // `one` maps to `you`, the 1st additional
-      // argument in the $.proxy function call
-      .append( "<h3>Hello " + one.type + ":</h3>" )
-​
-      // The `this` keyword refers to `me`
-      // (the 2nd, context, argument of $.proxy)
-      .append( "I am a " + this.type + ", " )
-​
-      // `two` maps to `they`, the 2nd additional
-      // argument in the $.proxy function call
-      .append( "and they are " + two.type + ".<br>" )
-​
-      // The event type is "click"
-      .append( "Thanks for " + event.type + "ing." )
-​
-      // The clicked element is `event.target`,
-      // and its type is "button"
-      .append( "the " + event.target.type + "." );
-  }
-};
-​
-var you = { type: "cat" };
-var they = { type: "fish" };
-​
-// Set up handler to execute me.test() in the context
-// of `me`, with `you` and `they` as additional arguments
-var proxy = $.proxy( me.test, me, you, they );
-​
-$( "#test" )
-  .on( "click", proxy );
-</script>
-</body>
-</html>
-```
      */
     proxy<TReturn,
         A, B, C, D, E,
@@ -13816,149 +3515,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
-     * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  type: "zombie",
-  test: function( event ) {
-    // Without proxy, `this` would refer to the event target
-    // use event.target to reference that element.
-    var element = event.target;
-    $( element ).css( "background-color", "red" );
-​
-    // With proxy, `this` refers to the me object encapsulating
-    // this function.
-    $( "#log" ).append( "Hello " + this.type + "<br>" );
-    $( "#test" ).off( "click", this.test );
-  }
-};
-​
-var you = {
-  type: "person",
-  test: function( event ) {
-    $( "#log" ).append( this.type + " " );
-  }
-};
-​
-// Execute you.test() in the context of the `you` object
-// no matter where it is called
-// i.e. the `this` keyword will refer to `you`
-var youClick = $.proxy( you.test, you );
-​
-// attach click handlers to #test
-$( "#test" )
-  // this === "zombie"; handler unbound after first click
-  .on( "click", $.proxy( me.test, me ) )
-​
-  // this === "person"
-  .on( "click", youClick )
-​
-  // this === "zombie"
-  .on( "click", $.proxy( you.test, me ) )
-​
-  // this === "<button> element"
-  .on( "click", you.test );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Change the context of a function bound to the click handler,
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  // I'm a dog
-  type: "dog",
-​
-  // Note that event comes *after* one and two
-  test: function( one, two, event ) {
-    $( "#log" )
-​
-      // `one` maps to `you`, the 1st additional
-      // argument in the $.proxy function call
-      .append( "<h3>Hello " + one.type + ":</h3>" )
-​
-      // The `this` keyword refers to `me`
-      // (the 2nd, context, argument of $.proxy)
-      .append( "I am a " + this.type + ", " )
-​
-      // `two` maps to `they`, the 2nd additional
-      // argument in the $.proxy function call
-      .append( "and they are " + two.type + ".<br>" )
-​
-      // The event type is "click"
-      .append( "Thanks for " + event.type + "ing." )
-​
-      // The clicked element is `event.target`,
-      // and its type is "button"
-      .append( "the " + event.target.type + "." );
-  }
-};
-​
-var you = { type: "cat" };
-var they = { type: "fish" };
-​
-// Set up handler to execute me.test() in the context
-// of `me`, with `you` and `they` as additional arguments
-var proxy = $.proxy( me.test, me, you, they );
-​
-$( "#test" )
-  .on( "click", proxy );
-</script>
-</body>
-</html>
-```
      */
     proxy<TReturn,
         A, B, C, D,
@@ -13974,149 +3530,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
-     * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  type: "zombie",
-  test: function( event ) {
-    // Without proxy, `this` would refer to the event target
-    // use event.target to reference that element.
-    var element = event.target;
-    $( element ).css( "background-color", "red" );
-​
-    // With proxy, `this` refers to the me object encapsulating
-    // this function.
-    $( "#log" ).append( "Hello " + this.type + "<br>" );
-    $( "#test" ).off( "click", this.test );
-  }
-};
-​
-var you = {
-  type: "person",
-  test: function( event ) {
-    $( "#log" ).append( this.type + " " );
-  }
-};
-​
-// Execute you.test() in the context of the `you` object
-// no matter where it is called
-// i.e. the `this` keyword will refer to `you`
-var youClick = $.proxy( you.test, you );
-​
-// attach click handlers to #test
-$( "#test" )
-  // this === "zombie"; handler unbound after first click
-  .on( "click", $.proxy( me.test, me ) )
-​
-  // this === "person"
-  .on( "click", youClick )
-​
-  // this === "zombie"
-  .on( "click", $.proxy( you.test, me ) )
-​
-  // this === "<button> element"
-  .on( "click", you.test );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Change the context of a function bound to the click handler,
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  // I'm a dog
-  type: "dog",
-​
-  // Note that event comes *after* one and two
-  test: function( one, two, event ) {
-    $( "#log" )
-​
-      // `one` maps to `you`, the 1st additional
-      // argument in the $.proxy function call
-      .append( "<h3>Hello " + one.type + ":</h3>" )
-​
-      // The `this` keyword refers to `me`
-      // (the 2nd, context, argument of $.proxy)
-      .append( "I am a " + this.type + ", " )
-​
-      // `two` maps to `they`, the 2nd additional
-      // argument in the $.proxy function call
-      .append( "and they are " + two.type + ".<br>" )
-​
-      // The event type is "click"
-      .append( "Thanks for " + event.type + "ing." )
-​
-      // The clicked element is `event.target`,
-      // and its type is "button"
-      .append( "the " + event.target.type + "." );
-  }
-};
-​
-var you = { type: "cat" };
-var they = { type: "fish" };
-​
-// Set up handler to execute me.test() in the context
-// of `me`, with `you` and `they` as additional arguments
-var proxy = $.proxy( me.test, me, you, they );
-​
-$( "#test" )
-  .on( "click", proxy );
-</script>
-</body>
-</html>
-```
      */
     proxy<TReturn,
         A, B, C,
@@ -14132,149 +3545,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
-     * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  type: "zombie",
-  test: function( event ) {
-    // Without proxy, `this` would refer to the event target
-    // use event.target to reference that element.
-    var element = event.target;
-    $( element ).css( "background-color", "red" );
-​
-    // With proxy, `this` refers to the me object encapsulating
-    // this function.
-    $( "#log" ).append( "Hello " + this.type + "<br>" );
-    $( "#test" ).off( "click", this.test );
-  }
-};
-​
-var you = {
-  type: "person",
-  test: function( event ) {
-    $( "#log" ).append( this.type + " " );
-  }
-};
-​
-// Execute you.test() in the context of the `you` object
-// no matter where it is called
-// i.e. the `this` keyword will refer to `you`
-var youClick = $.proxy( you.test, you );
-​
-// attach click handlers to #test
-$( "#test" )
-  // this === "zombie"; handler unbound after first click
-  .on( "click", $.proxy( me.test, me ) )
-​
-  // this === "person"
-  .on( "click", youClick )
-​
-  // this === "zombie"
-  .on( "click", $.proxy( you.test, me ) )
-​
-  // this === "<button> element"
-  .on( "click", you.test );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Change the context of a function bound to the click handler,
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  // I'm a dog
-  type: "dog",
-​
-  // Note that event comes *after* one and two
-  test: function( one, two, event ) {
-    $( "#log" )
-​
-      // `one` maps to `you`, the 1st additional
-      // argument in the $.proxy function call
-      .append( "<h3>Hello " + one.type + ":</h3>" )
-​
-      // The `this` keyword refers to `me`
-      // (the 2nd, context, argument of $.proxy)
-      .append( "I am a " + this.type + ", " )
-​
-      // `two` maps to `they`, the 2nd additional
-      // argument in the $.proxy function call
-      .append( "and they are " + two.type + ".<br>" )
-​
-      // The event type is "click"
-      .append( "Thanks for " + event.type + "ing." )
-​
-      // The clicked element is `event.target`,
-      // and its type is "button"
-      .append( "the " + event.target.type + "." );
-  }
-};
-​
-var you = { type: "cat" };
-var they = { type: "fish" };
-​
-// Set up handler to execute me.test() in the context
-// of `me`, with `you` and `they` as additional arguments
-var proxy = $.proxy( me.test, me, you, they );
-​
-$( "#test" )
-  .on( "click", proxy );
-</script>
-</body>
-</html>
-```
      */
     proxy<TReturn,
         A, B,
@@ -14290,149 +3560,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
-     * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  type: "zombie",
-  test: function( event ) {
-    // Without proxy, `this` would refer to the event target
-    // use event.target to reference that element.
-    var element = event.target;
-    $( element ).css( "background-color", "red" );
-​
-    // With proxy, `this` refers to the me object encapsulating
-    // this function.
-    $( "#log" ).append( "Hello " + this.type + "<br>" );
-    $( "#test" ).off( "click", this.test );
-  }
-};
-​
-var you = {
-  type: "person",
-  test: function( event ) {
-    $( "#log" ).append( this.type + " " );
-  }
-};
-​
-// Execute you.test() in the context of the `you` object
-// no matter where it is called
-// i.e. the `this` keyword will refer to `you`
-var youClick = $.proxy( you.test, you );
-​
-// attach click handlers to #test
-$( "#test" )
-  // this === "zombie"; handler unbound after first click
-  .on( "click", $.proxy( me.test, me ) )
-​
-  // this === "person"
-  .on( "click", youClick )
-​
-  // this === "zombie"
-  .on( "click", $.proxy( you.test, me ) )
-​
-  // this === "<button> element"
-  .on( "click", you.test );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Change the context of a function bound to the click handler,
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  // I'm a dog
-  type: "dog",
-​
-  // Note that event comes *after* one and two
-  test: function( one, two, event ) {
-    $( "#log" )
-​
-      // `one` maps to `you`, the 1st additional
-      // argument in the $.proxy function call
-      .append( "<h3>Hello " + one.type + ":</h3>" )
-​
-      // The `this` keyword refers to `me`
-      // (the 2nd, context, argument of $.proxy)
-      .append( "I am a " + this.type + ", " )
-​
-      // `two` maps to `they`, the 2nd additional
-      // argument in the $.proxy function call
-      .append( "and they are " + two.type + ".<br>" )
-​
-      // The event type is "click"
-      .append( "Thanks for " + event.type + "ing." )
-​
-      // The clicked element is `event.target`,
-      // and its type is "button"
-      .append( "the " + event.target.type + "." );
-  }
-};
-​
-var you = { type: "cat" };
-var they = { type: "fish" };
-​
-// Set up handler to execute me.test() in the context
-// of `me`, with `you` and `they` as additional arguments
-var proxy = $.proxy( me.test, me, you, they );
-​
-$( "#test" )
-  .on( "click", proxy );
-</script>
-</body>
-</html>
-```
      */
     proxy<TReturn,
         A,
@@ -14448,149 +3575,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
-     * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  type: "zombie",
-  test: function( event ) {
-    // Without proxy, `this` would refer to the event target
-    // use event.target to reference that element.
-    var element = event.target;
-    $( element ).css( "background-color", "red" );
-​
-    // With proxy, `this` refers to the me object encapsulating
-    // this function.
-    $( "#log" ).append( "Hello " + this.type + "<br>" );
-    $( "#test" ).off( "click", this.test );
-  }
-};
-​
-var you = {
-  type: "person",
-  test: function( event ) {
-    $( "#log" ).append( this.type + " " );
-  }
-};
-​
-// Execute you.test() in the context of the `you` object
-// no matter where it is called
-// i.e. the `this` keyword will refer to `you`
-var youClick = $.proxy( you.test, you );
-​
-// attach click handlers to #test
-$( "#test" )
-  // this === "zombie"; handler unbound after first click
-  .on( "click", $.proxy( me.test, me ) )
-​
-  // this === "person"
-  .on( "click", youClick )
-​
-  // this === "zombie"
-  .on( "click", $.proxy( you.test, me ) )
-​
-  // this === "<button> element"
-  .on( "click", you.test );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Change the context of a function bound to the click handler,
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  // I'm a dog
-  type: "dog",
-​
-  // Note that event comes *after* one and two
-  test: function( one, two, event ) {
-    $( "#log" )
-​
-      // `one` maps to `you`, the 1st additional
-      // argument in the $.proxy function call
-      .append( "<h3>Hello " + one.type + ":</h3>" )
-​
-      // The `this` keyword refers to `me`
-      // (the 2nd, context, argument of $.proxy)
-      .append( "I am a " + this.type + ", " )
-​
-      // `two` maps to `they`, the 2nd additional
-      // argument in the $.proxy function call
-      .append( "and they are " + two.type + ".<br>" )
-​
-      // The event type is "click"
-      .append( "Thanks for " + event.type + "ing." )
-​
-      // The clicked element is `event.target`,
-      // and its type is "button"
-      .append( "the " + event.target.type + "." );
-  }
-};
-​
-var you = { type: "cat" };
-var they = { type: "fish" };
-​
-// Set up handler to execute me.test() in the context
-// of `me`, with `you` and `they` as additional arguments
-var proxy = $.proxy( me.test, me, you, they );
-​
-$( "#test" )
-  .on( "click", proxy );
-</script>
-</body>
-</html>
-```
      */
     proxy<TReturn,
         T, U, V, W, X>(fn: (t: T, u: U, v: V, w: W, x: X) => TReturn,
@@ -14609,149 +3593,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
-     * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  type: "zombie",
-  test: function( event ) {
-    // Without proxy, `this` would refer to the event target
-    // use event.target to reference that element.
-    var element = event.target;
-    $( element ).css( "background-color", "red" );
-​
-    // With proxy, `this` refers to the me object encapsulating
-    // this function.
-    $( "#log" ).append( "Hello " + this.type + "<br>" );
-    $( "#test" ).off( "click", this.test );
-  }
-};
-​
-var you = {
-  type: "person",
-  test: function( event ) {
-    $( "#log" ).append( this.type + " " );
-  }
-};
-​
-// Execute you.test() in the context of the `you` object
-// no matter where it is called
-// i.e. the `this` keyword will refer to `you`
-var youClick = $.proxy( you.test, you );
-​
-// attach click handlers to #test
-$( "#test" )
-  // this === "zombie"; handler unbound after first click
-  .on( "click", $.proxy( me.test, me ) )
-​
-  // this === "person"
-  .on( "click", youClick )
-​
-  // this === "zombie"
-  .on( "click", $.proxy( you.test, me ) )
-​
-  // this === "<button> element"
-  .on( "click", you.test );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Change the context of a function bound to the click handler,
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  // I'm a dog
-  type: "dog",
-​
-  // Note that event comes *after* one and two
-  test: function( one, two, event ) {
-    $( "#log" )
-​
-      // `one` maps to `you`, the 1st additional
-      // argument in the $.proxy function call
-      .append( "<h3>Hello " + one.type + ":</h3>" )
-​
-      // The `this` keyword refers to `me`
-      // (the 2nd, context, argument of $.proxy)
-      .append( "I am a " + this.type + ", " )
-​
-      // `two` maps to `they`, the 2nd additional
-      // argument in the $.proxy function call
-      .append( "and they are " + two.type + ".<br>" )
-​
-      // The event type is "click"
-      .append( "Thanks for " + event.type + "ing." )
-​
-      // The clicked element is `event.target`,
-      // and its type is "button"
-      .append( "the " + event.target.type + "." );
-  }
-};
-​
-var you = { type: "cat" };
-var they = { type: "fish" };
-​
-// Set up handler to execute me.test() in the context
-// of `me`, with `you` and `they` as additional arguments
-var proxy = $.proxy( me.test, me, you, they );
-​
-$( "#test" )
-  .on( "click", proxy );
-</script>
-</body>
-</html>
-```
      */
     proxy<TReturn,
         A, B, C, D, E, F, G,
@@ -14767,149 +3608,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
-     * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  type: "zombie",
-  test: function( event ) {
-    // Without proxy, `this` would refer to the event target
-    // use event.target to reference that element.
-    var element = event.target;
-    $( element ).css( "background-color", "red" );
-​
-    // With proxy, `this` refers to the me object encapsulating
-    // this function.
-    $( "#log" ).append( "Hello " + this.type + "<br>" );
-    $( "#test" ).off( "click", this.test );
-  }
-};
-​
-var you = {
-  type: "person",
-  test: function( event ) {
-    $( "#log" ).append( this.type + " " );
-  }
-};
-​
-// Execute you.test() in the context of the `you` object
-// no matter where it is called
-// i.e. the `this` keyword will refer to `you`
-var youClick = $.proxy( you.test, you );
-​
-// attach click handlers to #test
-$( "#test" )
-  // this === "zombie"; handler unbound after first click
-  .on( "click", $.proxy( me.test, me ) )
-​
-  // this === "person"
-  .on( "click", youClick )
-​
-  // this === "zombie"
-  .on( "click", $.proxy( you.test, me ) )
-​
-  // this === "<button> element"
-  .on( "click", you.test );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Change the context of a function bound to the click handler,
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  // I'm a dog
-  type: "dog",
-​
-  // Note that event comes *after* one and two
-  test: function( one, two, event ) {
-    $( "#log" )
-​
-      // `one` maps to `you`, the 1st additional
-      // argument in the $.proxy function call
-      .append( "<h3>Hello " + one.type + ":</h3>" )
-​
-      // The `this` keyword refers to `me`
-      // (the 2nd, context, argument of $.proxy)
-      .append( "I am a " + this.type + ", " )
-​
-      // `two` maps to `they`, the 2nd additional
-      // argument in the $.proxy function call
-      .append( "and they are " + two.type + ".<br>" )
-​
-      // The event type is "click"
-      .append( "Thanks for " + event.type + "ing." )
-​
-      // The clicked element is `event.target`,
-      // and its type is "button"
-      .append( "the " + event.target.type + "." );
-  }
-};
-​
-var you = { type: "cat" };
-var they = { type: "fish" };
-​
-// Set up handler to execute me.test() in the context
-// of `me`, with `you` and `they` as additional arguments
-var proxy = $.proxy( me.test, me, you, they );
-​
-$( "#test" )
-  .on( "click", proxy );
-</script>
-</body>
-</html>
-```
      */
     proxy<TReturn,
         A, B, C, D, E, F,
@@ -14925,149 +3623,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
-     * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  type: "zombie",
-  test: function( event ) {
-    // Without proxy, `this` would refer to the event target
-    // use event.target to reference that element.
-    var element = event.target;
-    $( element ).css( "background-color", "red" );
-​
-    // With proxy, `this` refers to the me object encapsulating
-    // this function.
-    $( "#log" ).append( "Hello " + this.type + "<br>" );
-    $( "#test" ).off( "click", this.test );
-  }
-};
-​
-var you = {
-  type: "person",
-  test: function( event ) {
-    $( "#log" ).append( this.type + " " );
-  }
-};
-​
-// Execute you.test() in the context of the `you` object
-// no matter where it is called
-// i.e. the `this` keyword will refer to `you`
-var youClick = $.proxy( you.test, you );
-​
-// attach click handlers to #test
-$( "#test" )
-  // this === "zombie"; handler unbound after first click
-  .on( "click", $.proxy( me.test, me ) )
-​
-  // this === "person"
-  .on( "click", youClick )
-​
-  // this === "zombie"
-  .on( "click", $.proxy( you.test, me ) )
-​
-  // this === "<button> element"
-  .on( "click", you.test );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Change the context of a function bound to the click handler,
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  // I'm a dog
-  type: "dog",
-​
-  // Note that event comes *after* one and two
-  test: function( one, two, event ) {
-    $( "#log" )
-​
-      // `one` maps to `you`, the 1st additional
-      // argument in the $.proxy function call
-      .append( "<h3>Hello " + one.type + ":</h3>" )
-​
-      // The `this` keyword refers to `me`
-      // (the 2nd, context, argument of $.proxy)
-      .append( "I am a " + this.type + ", " )
-​
-      // `two` maps to `they`, the 2nd additional
-      // argument in the $.proxy function call
-      .append( "and they are " + two.type + ".<br>" )
-​
-      // The event type is "click"
-      .append( "Thanks for " + event.type + "ing." )
-​
-      // The clicked element is `event.target`,
-      // and its type is "button"
-      .append( "the " + event.target.type + "." );
-  }
-};
-​
-var you = { type: "cat" };
-var they = { type: "fish" };
-​
-// Set up handler to execute me.test() in the context
-// of `me`, with `you` and `they` as additional arguments
-var proxy = $.proxy( me.test, me, you, they );
-​
-$( "#test" )
-  .on( "click", proxy );
-</script>
-</body>
-</html>
-```
      */
     proxy<TReturn,
         A, B, C, D, E,
@@ -15083,149 +3638,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
-     * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  type: "zombie",
-  test: function( event ) {
-    // Without proxy, `this` would refer to the event target
-    // use event.target to reference that element.
-    var element = event.target;
-    $( element ).css( "background-color", "red" );
-​
-    // With proxy, `this` refers to the me object encapsulating
-    // this function.
-    $( "#log" ).append( "Hello " + this.type + "<br>" );
-    $( "#test" ).off( "click", this.test );
-  }
-};
-​
-var you = {
-  type: "person",
-  test: function( event ) {
-    $( "#log" ).append( this.type + " " );
-  }
-};
-​
-// Execute you.test() in the context of the `you` object
-// no matter where it is called
-// i.e. the `this` keyword will refer to `you`
-var youClick = $.proxy( you.test, you );
-​
-// attach click handlers to #test
-$( "#test" )
-  // this === "zombie"; handler unbound after first click
-  .on( "click", $.proxy( me.test, me ) )
-​
-  // this === "person"
-  .on( "click", youClick )
-​
-  // this === "zombie"
-  .on( "click", $.proxy( you.test, me ) )
-​
-  // this === "<button> element"
-  .on( "click", you.test );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Change the context of a function bound to the click handler,
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  // I'm a dog
-  type: "dog",
-​
-  // Note that event comes *after* one and two
-  test: function( one, two, event ) {
-    $( "#log" )
-​
-      // `one` maps to `you`, the 1st additional
-      // argument in the $.proxy function call
-      .append( "<h3>Hello " + one.type + ":</h3>" )
-​
-      // The `this` keyword refers to `me`
-      // (the 2nd, context, argument of $.proxy)
-      .append( "I am a " + this.type + ", " )
-​
-      // `two` maps to `they`, the 2nd additional
-      // argument in the $.proxy function call
-      .append( "and they are " + two.type + ".<br>" )
-​
-      // The event type is "click"
-      .append( "Thanks for " + event.type + "ing." )
-​
-      // The clicked element is `event.target`,
-      // and its type is "button"
-      .append( "the " + event.target.type + "." );
-  }
-};
-​
-var you = { type: "cat" };
-var they = { type: "fish" };
-​
-// Set up handler to execute me.test() in the context
-// of `me`, with `you` and `they` as additional arguments
-var proxy = $.proxy( me.test, me, you, they );
-​
-$( "#test" )
-  .on( "click", proxy );
-</script>
-</body>
-</html>
-```
      */
     proxy<TReturn,
         A, B, C, D,
@@ -15241,149 +3653,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
-     * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  type: "zombie",
-  test: function( event ) {
-    // Without proxy, `this` would refer to the event target
-    // use event.target to reference that element.
-    var element = event.target;
-    $( element ).css( "background-color", "red" );
-​
-    // With proxy, `this` refers to the me object encapsulating
-    // this function.
-    $( "#log" ).append( "Hello " + this.type + "<br>" );
-    $( "#test" ).off( "click", this.test );
-  }
-};
-​
-var you = {
-  type: "person",
-  test: function( event ) {
-    $( "#log" ).append( this.type + " " );
-  }
-};
-​
-// Execute you.test() in the context of the `you` object
-// no matter where it is called
-// i.e. the `this` keyword will refer to `you`
-var youClick = $.proxy( you.test, you );
-​
-// attach click handlers to #test
-$( "#test" )
-  // this === "zombie"; handler unbound after first click
-  .on( "click", $.proxy( me.test, me ) )
-​
-  // this === "person"
-  .on( "click", youClick )
-​
-  // this === "zombie"
-  .on( "click", $.proxy( you.test, me ) )
-​
-  // this === "<button> element"
-  .on( "click", you.test );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Change the context of a function bound to the click handler,
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  // I'm a dog
-  type: "dog",
-​
-  // Note that event comes *after* one and two
-  test: function( one, two, event ) {
-    $( "#log" )
-​
-      // `one` maps to `you`, the 1st additional
-      // argument in the $.proxy function call
-      .append( "<h3>Hello " + one.type + ":</h3>" )
-​
-      // The `this` keyword refers to `me`
-      // (the 2nd, context, argument of $.proxy)
-      .append( "I am a " + this.type + ", " )
-​
-      // `two` maps to `they`, the 2nd additional
-      // argument in the $.proxy function call
-      .append( "and they are " + two.type + ".<br>" )
-​
-      // The event type is "click"
-      .append( "Thanks for " + event.type + "ing." )
-​
-      // The clicked element is `event.target`,
-      // and its type is "button"
-      .append( "the " + event.target.type + "." );
-  }
-};
-​
-var you = { type: "cat" };
-var they = { type: "fish" };
-​
-// Set up handler to execute me.test() in the context
-// of `me`, with `you` and `they` as additional arguments
-var proxy = $.proxy( me.test, me, you, they );
-​
-$( "#test" )
-  .on( "click", proxy );
-</script>
-</body>
-</html>
-```
      */
     proxy<TReturn,
         A, B, C,
@@ -15399,149 +3668,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
-     * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  type: "zombie",
-  test: function( event ) {
-    // Without proxy, `this` would refer to the event target
-    // use event.target to reference that element.
-    var element = event.target;
-    $( element ).css( "background-color", "red" );
-​
-    // With proxy, `this` refers to the me object encapsulating
-    // this function.
-    $( "#log" ).append( "Hello " + this.type + "<br>" );
-    $( "#test" ).off( "click", this.test );
-  }
-};
-​
-var you = {
-  type: "person",
-  test: function( event ) {
-    $( "#log" ).append( this.type + " " );
-  }
-};
-​
-// Execute you.test() in the context of the `you` object
-// no matter where it is called
-// i.e. the `this` keyword will refer to `you`
-var youClick = $.proxy( you.test, you );
-​
-// attach click handlers to #test
-$( "#test" )
-  // this === "zombie"; handler unbound after first click
-  .on( "click", $.proxy( me.test, me ) )
-​
-  // this === "person"
-  .on( "click", youClick )
-​
-  // this === "zombie"
-  .on( "click", $.proxy( you.test, me ) )
-​
-  // this === "<button> element"
-  .on( "click", you.test );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Change the context of a function bound to the click handler,
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  // I'm a dog
-  type: "dog",
-​
-  // Note that event comes *after* one and two
-  test: function( one, two, event ) {
-    $( "#log" )
-​
-      // `one` maps to `you`, the 1st additional
-      // argument in the $.proxy function call
-      .append( "<h3>Hello " + one.type + ":</h3>" )
-​
-      // The `this` keyword refers to `me`
-      // (the 2nd, context, argument of $.proxy)
-      .append( "I am a " + this.type + ", " )
-​
-      // `two` maps to `they`, the 2nd additional
-      // argument in the $.proxy function call
-      .append( "and they are " + two.type + ".<br>" )
-​
-      // The event type is "click"
-      .append( "Thanks for " + event.type + "ing." )
-​
-      // The clicked element is `event.target`,
-      // and its type is "button"
-      .append( "the " + event.target.type + "." );
-  }
-};
-​
-var you = { type: "cat" };
-var they = { type: "fish" };
-​
-// Set up handler to execute me.test() in the context
-// of `me`, with `you` and `they` as additional arguments
-var proxy = $.proxy( me.test, me, you, they );
-​
-$( "#test" )
-  .on( "click", proxy );
-</script>
-</body>
-</html>
-```
      */
     proxy<TReturn,
         A, B,
@@ -15557,149 +3683,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
-     * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  type: "zombie",
-  test: function( event ) {
-    // Without proxy, `this` would refer to the event target
-    // use event.target to reference that element.
-    var element = event.target;
-    $( element ).css( "background-color", "red" );
-​
-    // With proxy, `this` refers to the me object encapsulating
-    // this function.
-    $( "#log" ).append( "Hello " + this.type + "<br>" );
-    $( "#test" ).off( "click", this.test );
-  }
-};
-​
-var you = {
-  type: "person",
-  test: function( event ) {
-    $( "#log" ).append( this.type + " " );
-  }
-};
-​
-// Execute you.test() in the context of the `you` object
-// no matter where it is called
-// i.e. the `this` keyword will refer to `you`
-var youClick = $.proxy( you.test, you );
-​
-// attach click handlers to #test
-$( "#test" )
-  // this === "zombie"; handler unbound after first click
-  .on( "click", $.proxy( me.test, me ) )
-​
-  // this === "person"
-  .on( "click", youClick )
-​
-  // this === "zombie"
-  .on( "click", $.proxy( you.test, me ) )
-​
-  // this === "<button> element"
-  .on( "click", you.test );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Change the context of a function bound to the click handler,
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  // I'm a dog
-  type: "dog",
-​
-  // Note that event comes *after* one and two
-  test: function( one, two, event ) {
-    $( "#log" )
-​
-      // `one` maps to `you`, the 1st additional
-      // argument in the $.proxy function call
-      .append( "<h3>Hello " + one.type + ":</h3>" )
-​
-      // The `this` keyword refers to `me`
-      // (the 2nd, context, argument of $.proxy)
-      .append( "I am a " + this.type + ", " )
-​
-      // `two` maps to `they`, the 2nd additional
-      // argument in the $.proxy function call
-      .append( "and they are " + two.type + ".<br>" )
-​
-      // The event type is "click"
-      .append( "Thanks for " + event.type + "ing." )
-​
-      // The clicked element is `event.target`,
-      // and its type is "button"
-      .append( "the " + event.target.type + "." );
-  }
-};
-​
-var you = { type: "cat" };
-var they = { type: "fish" };
-​
-// Set up handler to execute me.test() in the context
-// of `me`, with `you` and `they` as additional arguments
-var proxy = $.proxy( me.test, me, you, they );
-​
-$( "#test" )
-  .on( "click", proxy );
-</script>
-</body>
-</html>
-```
      */
     proxy<TReturn,
         A,
@@ -15715,149 +3698,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
-     * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  type: "zombie",
-  test: function( event ) {
-    // Without proxy, `this` would refer to the event target
-    // use event.target to reference that element.
-    var element = event.target;
-    $( element ).css( "background-color", "red" );
-​
-    // With proxy, `this` refers to the me object encapsulating
-    // this function.
-    $( "#log" ).append( "Hello " + this.type + "<br>" );
-    $( "#test" ).off( "click", this.test );
-  }
-};
-​
-var you = {
-  type: "person",
-  test: function( event ) {
-    $( "#log" ).append( this.type + " " );
-  }
-};
-​
-// Execute you.test() in the context of the `you` object
-// no matter where it is called
-// i.e. the `this` keyword will refer to `you`
-var youClick = $.proxy( you.test, you );
-​
-// attach click handlers to #test
-$( "#test" )
-  // this === "zombie"; handler unbound after first click
-  .on( "click", $.proxy( me.test, me ) )
-​
-  // this === "person"
-  .on( "click", youClick )
-​
-  // this === "zombie"
-  .on( "click", $.proxy( you.test, me ) )
-​
-  // this === "<button> element"
-  .on( "click", you.test );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Change the context of a function bound to the click handler,
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  // I'm a dog
-  type: "dog",
-​
-  // Note that event comes *after* one and two
-  test: function( one, two, event ) {
-    $( "#log" )
-​
-      // `one` maps to `you`, the 1st additional
-      // argument in the $.proxy function call
-      .append( "<h3>Hello " + one.type + ":</h3>" )
-​
-      // The `this` keyword refers to `me`
-      // (the 2nd, context, argument of $.proxy)
-      .append( "I am a " + this.type + ", " )
-​
-      // `two` maps to `they`, the 2nd additional
-      // argument in the $.proxy function call
-      .append( "and they are " + two.type + ".<br>" )
-​
-      // The event type is "click"
-      .append( "Thanks for " + event.type + "ing." )
-​
-      // The clicked element is `event.target`,
-      // and its type is "button"
-      .append( "the " + event.target.type + "." );
-  }
-};
-​
-var you = { type: "cat" };
-var they = { type: "fish" };
-​
-// Set up handler to execute me.test() in the context
-// of `me`, with `you` and `they` as additional arguments
-var proxy = $.proxy( me.test, me, you, they );
-​
-$( "#test" )
-  .on( "click", proxy );
-</script>
-</body>
-</html>
-```
      */
     proxy<TReturn,
         T, U, V, W, X, Y>(fn: (t: T, u: U, v: V, w: W, x: X, y: Y) => TReturn,
@@ -15876,149 +3716,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
-     * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  type: "zombie",
-  test: function( event ) {
-    // Without proxy, `this` would refer to the event target
-    // use event.target to reference that element.
-    var element = event.target;
-    $( element ).css( "background-color", "red" );
-​
-    // With proxy, `this` refers to the me object encapsulating
-    // this function.
-    $( "#log" ).append( "Hello " + this.type + "<br>" );
-    $( "#test" ).off( "click", this.test );
-  }
-};
-​
-var you = {
-  type: "person",
-  test: function( event ) {
-    $( "#log" ).append( this.type + " " );
-  }
-};
-​
-// Execute you.test() in the context of the `you` object
-// no matter where it is called
-// i.e. the `this` keyword will refer to `you`
-var youClick = $.proxy( you.test, you );
-​
-// attach click handlers to #test
-$( "#test" )
-  // this === "zombie"; handler unbound after first click
-  .on( "click", $.proxy( me.test, me ) )
-​
-  // this === "person"
-  .on( "click", youClick )
-​
-  // this === "zombie"
-  .on( "click", $.proxy( you.test, me ) )
-​
-  // this === "<button> element"
-  .on( "click", you.test );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Change the context of a function bound to the click handler,
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  // I'm a dog
-  type: "dog",
-​
-  // Note that event comes *after* one and two
-  test: function( one, two, event ) {
-    $( "#log" )
-​
-      // `one` maps to `you`, the 1st additional
-      // argument in the $.proxy function call
-      .append( "<h3>Hello " + one.type + ":</h3>" )
-​
-      // The `this` keyword refers to `me`
-      // (the 2nd, context, argument of $.proxy)
-      .append( "I am a " + this.type + ", " )
-​
-      // `two` maps to `they`, the 2nd additional
-      // argument in the $.proxy function call
-      .append( "and they are " + two.type + ".<br>" )
-​
-      // The event type is "click"
-      .append( "Thanks for " + event.type + "ing." )
-​
-      // The clicked element is `event.target`,
-      // and its type is "button"
-      .append( "the " + event.target.type + "." );
-  }
-};
-​
-var you = { type: "cat" };
-var they = { type: "fish" };
-​
-// Set up handler to execute me.test() in the context
-// of `me`, with `you` and `they` as additional arguments
-var proxy = $.proxy( me.test, me, you, they );
-​
-$( "#test" )
-  .on( "click", proxy );
-</script>
-</body>
-</html>
-```
      */
     proxy<TReturn,
         A, B, C, D, E, F, G,
@@ -16034,149 +3731,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
-     * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  type: "zombie",
-  test: function( event ) {
-    // Without proxy, `this` would refer to the event target
-    // use event.target to reference that element.
-    var element = event.target;
-    $( element ).css( "background-color", "red" );
-​
-    // With proxy, `this` refers to the me object encapsulating
-    // this function.
-    $( "#log" ).append( "Hello " + this.type + "<br>" );
-    $( "#test" ).off( "click", this.test );
-  }
-};
-​
-var you = {
-  type: "person",
-  test: function( event ) {
-    $( "#log" ).append( this.type + " " );
-  }
-};
-​
-// Execute you.test() in the context of the `you` object
-// no matter where it is called
-// i.e. the `this` keyword will refer to `you`
-var youClick = $.proxy( you.test, you );
-​
-// attach click handlers to #test
-$( "#test" )
-  // this === "zombie"; handler unbound after first click
-  .on( "click", $.proxy( me.test, me ) )
-​
-  // this === "person"
-  .on( "click", youClick )
-​
-  // this === "zombie"
-  .on( "click", $.proxy( you.test, me ) )
-​
-  // this === "<button> element"
-  .on( "click", you.test );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Change the context of a function bound to the click handler,
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  // I'm a dog
-  type: "dog",
-​
-  // Note that event comes *after* one and two
-  test: function( one, two, event ) {
-    $( "#log" )
-​
-      // `one` maps to `you`, the 1st additional
-      // argument in the $.proxy function call
-      .append( "<h3>Hello " + one.type + ":</h3>" )
-​
-      // The `this` keyword refers to `me`
-      // (the 2nd, context, argument of $.proxy)
-      .append( "I am a " + this.type + ", " )
-​
-      // `two` maps to `they`, the 2nd additional
-      // argument in the $.proxy function call
-      .append( "and they are " + two.type + ".<br>" )
-​
-      // The event type is "click"
-      .append( "Thanks for " + event.type + "ing." )
-​
-      // The clicked element is `event.target`,
-      // and its type is "button"
-      .append( "the " + event.target.type + "." );
-  }
-};
-​
-var you = { type: "cat" };
-var they = { type: "fish" };
-​
-// Set up handler to execute me.test() in the context
-// of `me`, with `you` and `they` as additional arguments
-var proxy = $.proxy( me.test, me, you, they );
-​
-$( "#test" )
-  .on( "click", proxy );
-</script>
-</body>
-</html>
-```
      */
     proxy<TReturn,
         A, B, C, D, E, F,
@@ -16192,149 +3746,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
-     * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  type: "zombie",
-  test: function( event ) {
-    // Without proxy, `this` would refer to the event target
-    // use event.target to reference that element.
-    var element = event.target;
-    $( element ).css( "background-color", "red" );
-​
-    // With proxy, `this` refers to the me object encapsulating
-    // this function.
-    $( "#log" ).append( "Hello " + this.type + "<br>" );
-    $( "#test" ).off( "click", this.test );
-  }
-};
-​
-var you = {
-  type: "person",
-  test: function( event ) {
-    $( "#log" ).append( this.type + " " );
-  }
-};
-​
-// Execute you.test() in the context of the `you` object
-// no matter where it is called
-// i.e. the `this` keyword will refer to `you`
-var youClick = $.proxy( you.test, you );
-​
-// attach click handlers to #test
-$( "#test" )
-  // this === "zombie"; handler unbound after first click
-  .on( "click", $.proxy( me.test, me ) )
-​
-  // this === "person"
-  .on( "click", youClick )
-​
-  // this === "zombie"
-  .on( "click", $.proxy( you.test, me ) )
-​
-  // this === "<button> element"
-  .on( "click", you.test );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Change the context of a function bound to the click handler,
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  // I'm a dog
-  type: "dog",
-​
-  // Note that event comes *after* one and two
-  test: function( one, two, event ) {
-    $( "#log" )
-​
-      // `one` maps to `you`, the 1st additional
-      // argument in the $.proxy function call
-      .append( "<h3>Hello " + one.type + ":</h3>" )
-​
-      // The `this` keyword refers to `me`
-      // (the 2nd, context, argument of $.proxy)
-      .append( "I am a " + this.type + ", " )
-​
-      // `two` maps to `they`, the 2nd additional
-      // argument in the $.proxy function call
-      .append( "and they are " + two.type + ".<br>" )
-​
-      // The event type is "click"
-      .append( "Thanks for " + event.type + "ing." )
-​
-      // The clicked element is `event.target`,
-      // and its type is "button"
-      .append( "the " + event.target.type + "." );
-  }
-};
-​
-var you = { type: "cat" };
-var they = { type: "fish" };
-​
-// Set up handler to execute me.test() in the context
-// of `me`, with `you` and `they` as additional arguments
-var proxy = $.proxy( me.test, me, you, they );
-​
-$( "#test" )
-  .on( "click", proxy );
-</script>
-</body>
-</html>
-```
      */
     proxy<TReturn,
         A, B, C, D, E,
@@ -16350,149 +3761,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
-     * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  type: "zombie",
-  test: function( event ) {
-    // Without proxy, `this` would refer to the event target
-    // use event.target to reference that element.
-    var element = event.target;
-    $( element ).css( "background-color", "red" );
-​
-    // With proxy, `this` refers to the me object encapsulating
-    // this function.
-    $( "#log" ).append( "Hello " + this.type + "<br>" );
-    $( "#test" ).off( "click", this.test );
-  }
-};
-​
-var you = {
-  type: "person",
-  test: function( event ) {
-    $( "#log" ).append( this.type + " " );
-  }
-};
-​
-// Execute you.test() in the context of the `you` object
-// no matter where it is called
-// i.e. the `this` keyword will refer to `you`
-var youClick = $.proxy( you.test, you );
-​
-// attach click handlers to #test
-$( "#test" )
-  // this === "zombie"; handler unbound after first click
-  .on( "click", $.proxy( me.test, me ) )
-​
-  // this === "person"
-  .on( "click", youClick )
-​
-  // this === "zombie"
-  .on( "click", $.proxy( you.test, me ) )
-​
-  // this === "<button> element"
-  .on( "click", you.test );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Change the context of a function bound to the click handler,
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  // I'm a dog
-  type: "dog",
-​
-  // Note that event comes *after* one and two
-  test: function( one, two, event ) {
-    $( "#log" )
-​
-      // `one` maps to `you`, the 1st additional
-      // argument in the $.proxy function call
-      .append( "<h3>Hello " + one.type + ":</h3>" )
-​
-      // The `this` keyword refers to `me`
-      // (the 2nd, context, argument of $.proxy)
-      .append( "I am a " + this.type + ", " )
-​
-      // `two` maps to `they`, the 2nd additional
-      // argument in the $.proxy function call
-      .append( "and they are " + two.type + ".<br>" )
-​
-      // The event type is "click"
-      .append( "Thanks for " + event.type + "ing." )
-​
-      // The clicked element is `event.target`,
-      // and its type is "button"
-      .append( "the " + event.target.type + "." );
-  }
-};
-​
-var you = { type: "cat" };
-var they = { type: "fish" };
-​
-// Set up handler to execute me.test() in the context
-// of `me`, with `you` and `they` as additional arguments
-var proxy = $.proxy( me.test, me, you, they );
-​
-$( "#test" )
-  .on( "click", proxy );
-</script>
-</body>
-</html>
-```
      */
     proxy<TReturn,
         A, B, C, D,
@@ -16508,149 +3776,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
-     * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  type: "zombie",
-  test: function( event ) {
-    // Without proxy, `this` would refer to the event target
-    // use event.target to reference that element.
-    var element = event.target;
-    $( element ).css( "background-color", "red" );
-​
-    // With proxy, `this` refers to the me object encapsulating
-    // this function.
-    $( "#log" ).append( "Hello " + this.type + "<br>" );
-    $( "#test" ).off( "click", this.test );
-  }
-};
-​
-var you = {
-  type: "person",
-  test: function( event ) {
-    $( "#log" ).append( this.type + " " );
-  }
-};
-​
-// Execute you.test() in the context of the `you` object
-// no matter where it is called
-// i.e. the `this` keyword will refer to `you`
-var youClick = $.proxy( you.test, you );
-​
-// attach click handlers to #test
-$( "#test" )
-  // this === "zombie"; handler unbound after first click
-  .on( "click", $.proxy( me.test, me ) )
-​
-  // this === "person"
-  .on( "click", youClick )
-​
-  // this === "zombie"
-  .on( "click", $.proxy( you.test, me ) )
-​
-  // this === "<button> element"
-  .on( "click", you.test );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Change the context of a function bound to the click handler,
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  // I'm a dog
-  type: "dog",
-​
-  // Note that event comes *after* one and two
-  test: function( one, two, event ) {
-    $( "#log" )
-​
-      // `one` maps to `you`, the 1st additional
-      // argument in the $.proxy function call
-      .append( "<h3>Hello " + one.type + ":</h3>" )
-​
-      // The `this` keyword refers to `me`
-      // (the 2nd, context, argument of $.proxy)
-      .append( "I am a " + this.type + ", " )
-​
-      // `two` maps to `they`, the 2nd additional
-      // argument in the $.proxy function call
-      .append( "and they are " + two.type + ".<br>" )
-​
-      // The event type is "click"
-      .append( "Thanks for " + event.type + "ing." )
-​
-      // The clicked element is `event.target`,
-      // and its type is "button"
-      .append( "the " + event.target.type + "." );
-  }
-};
-​
-var you = { type: "cat" };
-var they = { type: "fish" };
-​
-// Set up handler to execute me.test() in the context
-// of `me`, with `you` and `they` as additional arguments
-var proxy = $.proxy( me.test, me, you, they );
-​
-$( "#test" )
-  .on( "click", proxy );
-</script>
-</body>
-</html>
-```
      */
     proxy<TReturn,
         A, B, C,
@@ -16666,149 +3791,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
-     * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  type: "zombie",
-  test: function( event ) {
-    // Without proxy, `this` would refer to the event target
-    // use event.target to reference that element.
-    var element = event.target;
-    $( element ).css( "background-color", "red" );
-​
-    // With proxy, `this` refers to the me object encapsulating
-    // this function.
-    $( "#log" ).append( "Hello " + this.type + "<br>" );
-    $( "#test" ).off( "click", this.test );
-  }
-};
-​
-var you = {
-  type: "person",
-  test: function( event ) {
-    $( "#log" ).append( this.type + " " );
-  }
-};
-​
-// Execute you.test() in the context of the `you` object
-// no matter where it is called
-// i.e. the `this` keyword will refer to `you`
-var youClick = $.proxy( you.test, you );
-​
-// attach click handlers to #test
-$( "#test" )
-  // this === "zombie"; handler unbound after first click
-  .on( "click", $.proxy( me.test, me ) )
-​
-  // this === "person"
-  .on( "click", youClick )
-​
-  // this === "zombie"
-  .on( "click", $.proxy( you.test, me ) )
-​
-  // this === "<button> element"
-  .on( "click", you.test );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Change the context of a function bound to the click handler,
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  // I'm a dog
-  type: "dog",
-​
-  // Note that event comes *after* one and two
-  test: function( one, two, event ) {
-    $( "#log" )
-​
-      // `one` maps to `you`, the 1st additional
-      // argument in the $.proxy function call
-      .append( "<h3>Hello " + one.type + ":</h3>" )
-​
-      // The `this` keyword refers to `me`
-      // (the 2nd, context, argument of $.proxy)
-      .append( "I am a " + this.type + ", " )
-​
-      // `two` maps to `they`, the 2nd additional
-      // argument in the $.proxy function call
-      .append( "and they are " + two.type + ".<br>" )
-​
-      // The event type is "click"
-      .append( "Thanks for " + event.type + "ing." )
-​
-      // The clicked element is `event.target`,
-      // and its type is "button"
-      .append( "the " + event.target.type + "." );
-  }
-};
-​
-var you = { type: "cat" };
-var they = { type: "fish" };
-​
-// Set up handler to execute me.test() in the context
-// of `me`, with `you` and `they` as additional arguments
-var proxy = $.proxy( me.test, me, you, they );
-​
-$( "#test" )
-  .on( "click", proxy );
-</script>
-</body>
-</html>
-```
      */
     proxy<TReturn,
         A, B,
@@ -16824,149 +3806,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
-     * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  type: "zombie",
-  test: function( event ) {
-    // Without proxy, `this` would refer to the event target
-    // use event.target to reference that element.
-    var element = event.target;
-    $( element ).css( "background-color", "red" );
-​
-    // With proxy, `this` refers to the me object encapsulating
-    // this function.
-    $( "#log" ).append( "Hello " + this.type + "<br>" );
-    $( "#test" ).off( "click", this.test );
-  }
-};
-​
-var you = {
-  type: "person",
-  test: function( event ) {
-    $( "#log" ).append( this.type + " " );
-  }
-};
-​
-// Execute you.test() in the context of the `you` object
-// no matter where it is called
-// i.e. the `this` keyword will refer to `you`
-var youClick = $.proxy( you.test, you );
-​
-// attach click handlers to #test
-$( "#test" )
-  // this === "zombie"; handler unbound after first click
-  .on( "click", $.proxy( me.test, me ) )
-​
-  // this === "person"
-  .on( "click", youClick )
-​
-  // this === "zombie"
-  .on( "click", $.proxy( you.test, me ) )
-​
-  // this === "<button> element"
-  .on( "click", you.test );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Change the context of a function bound to the click handler,
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  // I'm a dog
-  type: "dog",
-​
-  // Note that event comes *after* one and two
-  test: function( one, two, event ) {
-    $( "#log" )
-​
-      // `one` maps to `you`, the 1st additional
-      // argument in the $.proxy function call
-      .append( "<h3>Hello " + one.type + ":</h3>" )
-​
-      // The `this` keyword refers to `me`
-      // (the 2nd, context, argument of $.proxy)
-      .append( "I am a " + this.type + ", " )
-​
-      // `two` maps to `they`, the 2nd additional
-      // argument in the $.proxy function call
-      .append( "and they are " + two.type + ".<br>" )
-​
-      // The event type is "click"
-      .append( "Thanks for " + event.type + "ing." )
-​
-      // The clicked element is `event.target`,
-      // and its type is "button"
-      .append( "the " + event.target.type + "." );
-  }
-};
-​
-var you = { type: "cat" };
-var they = { type: "fish" };
-​
-// Set up handler to execute me.test() in the context
-// of `me`, with `you` and `they` as additional arguments
-var proxy = $.proxy( me.test, me, you, they );
-​
-$( "#test" )
-  .on( "click", proxy );
-</script>
-</body>
-</html>
-```
      */
     proxy<TReturn,
         A,
@@ -16982,149 +3821,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
-     * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  type: "zombie",
-  test: function( event ) {
-    // Without proxy, `this` would refer to the event target
-    // use event.target to reference that element.
-    var element = event.target;
-    $( element ).css( "background-color", "red" );
-​
-    // With proxy, `this` refers to the me object encapsulating
-    // this function.
-    $( "#log" ).append( "Hello " + this.type + "<br>" );
-    $( "#test" ).off( "click", this.test );
-  }
-};
-​
-var you = {
-  type: "person",
-  test: function( event ) {
-    $( "#log" ).append( this.type + " " );
-  }
-};
-​
-// Execute you.test() in the context of the `you` object
-// no matter where it is called
-// i.e. the `this` keyword will refer to `you`
-var youClick = $.proxy( you.test, you );
-​
-// attach click handlers to #test
-$( "#test" )
-  // this === "zombie"; handler unbound after first click
-  .on( "click", $.proxy( me.test, me ) )
-​
-  // this === "person"
-  .on( "click", youClick )
-​
-  // this === "zombie"
-  .on( "click", $.proxy( you.test, me ) )
-​
-  // this === "<button> element"
-  .on( "click", you.test );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Change the context of a function bound to the click handler,
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  // I'm a dog
-  type: "dog",
-​
-  // Note that event comes *after* one and two
-  test: function( one, two, event ) {
-    $( "#log" )
-​
-      // `one` maps to `you`, the 1st additional
-      // argument in the $.proxy function call
-      .append( "<h3>Hello " + one.type + ":</h3>" )
-​
-      // The `this` keyword refers to `me`
-      // (the 2nd, context, argument of $.proxy)
-      .append( "I am a " + this.type + ", " )
-​
-      // `two` maps to `they`, the 2nd additional
-      // argument in the $.proxy function call
-      .append( "and they are " + two.type + ".<br>" )
-​
-      // The event type is "click"
-      .append( "Thanks for " + event.type + "ing." )
-​
-      // The clicked element is `event.target`,
-      // and its type is "button"
-      .append( "the " + event.target.type + "." );
-  }
-};
-​
-var you = { type: "cat" };
-var they = { type: "fish" };
-​
-// Set up handler to execute me.test() in the context
-// of `me`, with `you` and `they` as additional arguments
-var proxy = $.proxy( me.test, me, you, they );
-​
-$( "#test" )
-  .on( "click", proxy );
-</script>
-</body>
-</html>
-```
      */
     proxy<TReturn,
         T, U, V, W, X, Y, Z>(fn: (t: T, u: U, v: V, w: W, x: X, y: Y, z: Z, ...args: any[]) => TReturn,
@@ -17146,149 +3842,6 @@ $( "#test" )
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
-     * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  type: "zombie",
-  test: function( event ) {
-    // Without proxy, `this` would refer to the event target
-    // use event.target to reference that element.
-    var element = event.target;
-    $( element ).css( "background-color", "red" );
-​
-    // With proxy, `this` refers to the me object encapsulating
-    // this function.
-    $( "#log" ).append( "Hello " + this.type + "<br>" );
-    $( "#test" ).off( "click", this.test );
-  }
-};
-​
-var you = {
-  type: "person",
-  test: function( event ) {
-    $( "#log" ).append( this.type + " " );
-  }
-};
-​
-// Execute you.test() in the context of the `you` object
-// no matter where it is called
-// i.e. the `this` keyword will refer to `you`
-var youClick = $.proxy( you.test, you );
-​
-// attach click handlers to #test
-$( "#test" )
-  // this === "zombie"; handler unbound after first click
-  .on( "click", $.proxy( me.test, me ) )
-​
-  // this === "person"
-  .on( "click", youClick )
-​
-  // this === "zombie"
-  .on( "click", $.proxy( you.test, me ) )
-​
-  // this === "<button> element"
-  .on( "click", you.test );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Change the context of a function bound to the click handler,
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  // I'm a dog
-  type: "dog",
-​
-  // Note that event comes *after* one and two
-  test: function( one, two, event ) {
-    $( "#log" )
-​
-      // `one` maps to `you`, the 1st additional
-      // argument in the $.proxy function call
-      .append( "<h3>Hello " + one.type + ":</h3>" )
-​
-      // The `this` keyword refers to `me`
-      // (the 2nd, context, argument of $.proxy)
-      .append( "I am a " + this.type + ", " )
-​
-      // `two` maps to `they`, the 2nd additional
-      // argument in the $.proxy function call
-      .append( "and they are " + two.type + ".<br>" )
-​
-      // The event type is "click"
-      .append( "Thanks for " + event.type + "ing." )
-​
-      // The clicked element is `event.target`,
-      // and its type is "button"
-      .append( "the " + event.target.type + "." );
-  }
-};
-​
-var you = { type: "cat" };
-var they = { type: "fish" };
-​
-// Set up handler to execute me.test() in the context
-// of `me`, with `you` and `they` as additional arguments
-var proxy = $.proxy( me.test, me, you, they );
-​
-$( "#test" )
-  .on( "click", proxy );
-</script>
-</body>
-</html>
-```
      */
     proxy<TReturn>(fn: (...args: any[]) => TReturn,
                    context: null | undefined,
@@ -17372,33 +3925,7 @@ $( "#test" )
   // this === "<button> element"
   .on( "click", you.test );
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
 </body>
 </html>
 ```
@@ -17456,6 +3983,7 @@ var proxy = $.proxy( me.test, me, you, they );
 $( "#test" )
   .on( "click", proxy );
 </script>
+​
 </body>
 </html>
 ```
@@ -17530,33 +4058,7 @@ $( "#test" )
   // this === "<button> element"
   .on( "click", you.test );
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
 </body>
 </html>
 ```
@@ -17614,6 +4116,7 @@ var proxy = $.proxy( me.test, me, you, they );
 $( "#test" )
   .on( "click", proxy );
 </script>
+​
 </body>
 </html>
 ```
@@ -17688,33 +4191,7 @@ $( "#test" )
   // this === "<button> element"
   .on( "click", you.test );
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
 </body>
 </html>
 ```
@@ -17772,6 +4249,7 @@ var proxy = $.proxy( me.test, me, you, they );
 $( "#test" )
   .on( "click", proxy );
 </script>
+​
 </body>
 </html>
 ```
@@ -17846,33 +4324,7 @@ $( "#test" )
   // this === "<button> element"
   .on( "click", you.test );
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
 </body>
 </html>
 ```
@@ -17930,6 +4382,7 @@ var proxy = $.proxy( me.test, me, you, they );
 $( "#test" )
   .on( "click", proxy );
 </script>
+​
 </body>
 </html>
 ```
@@ -18004,33 +4457,7 @@ $( "#test" )
   // this === "<button> element"
   .on( "click", you.test );
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
 </body>
 </html>
 ```
@@ -18088,6 +4515,7 @@ var proxy = $.proxy( me.test, me, you, they );
 $( "#test" )
   .on( "click", proxy );
 </script>
+​
 </body>
 </html>
 ```
@@ -18162,33 +4590,7 @@ $( "#test" )
   // this === "<button> element"
   .on( "click", you.test );
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
 </body>
 </html>
 ```
@@ -18246,6 +4648,7 @@ var proxy = $.proxy( me.test, me, you, they );
 $( "#test" )
   .on( "click", proxy );
 </script>
+​
 </body>
 </html>
 ```
@@ -18320,33 +4723,7 @@ $( "#test" )
   // this === "<button> element"
   .on( "click", you.test );
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
 </body>
 </html>
 ```
@@ -18404,6 +4781,7 @@ var proxy = $.proxy( me.test, me, you, they );
 $( "#test" )
   .on( "click", proxy );
 </script>
+​
 </body>
 </html>
 ```
@@ -18478,33 +4856,7 @@ $( "#test" )
   // this === "<button> element"
   .on( "click", you.test );
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
 </body>
 </html>
 ```
@@ -18562,6 +4914,7 @@ var proxy = $.proxy( me.test, me, you, they );
 $( "#test" )
   .on( "click", proxy );
 </script>
+​
 </body>
 </html>
 ```
@@ -18640,33 +4993,7 @@ $( "#test" )
   // this === "<button> element"
   .on( "click", you.test );
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
 </body>
 </html>
 ```
@@ -18724,6 +5051,7 @@ var proxy = $.proxy( me.test, me, you, they );
 $( "#test" )
   .on( "click", proxy );
 </script>
+​
 </body>
 </html>
 ```
@@ -18800,33 +5128,7 @@ $( "#test" )
   // this === "<button> element"
   .on( "click", you.test );
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
 </body>
 </html>
 ```
@@ -18884,6 +5186,7 @@ var proxy = $.proxy( me.test, me, you, they );
 $( "#test" )
   .on( "click", proxy );
 </script>
+​
 </body>
 </html>
 ```
@@ -18960,33 +5263,7 @@ $( "#test" )
   // this === "<button> element"
   .on( "click", you.test );
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
 </body>
 </html>
 ```
@@ -19044,6 +5321,7 @@ var proxy = $.proxy( me.test, me, you, they );
 $( "#test" )
   .on( "click", proxy );
 </script>
+​
 </body>
 </html>
 ```
@@ -19120,33 +5398,7 @@ $( "#test" )
   // this === "<button> element"
   .on( "click", you.test );
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
 </body>
 </html>
 ```
@@ -19204,6 +5456,7 @@ var proxy = $.proxy( me.test, me, you, they );
 $( "#test" )
   .on( "click", proxy );
 </script>
+​
 </body>
 </html>
 ```
@@ -19280,33 +5533,7 @@ $( "#test" )
   // this === "<button> element"
   .on( "click", you.test );
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
 </body>
 </html>
 ```
@@ -19364,6 +5591,7 @@ var proxy = $.proxy( me.test, me, you, they );
 $( "#test" )
   .on( "click", proxy );
 </script>
+​
 </body>
 </html>
 ```
@@ -19440,33 +5668,7 @@ $( "#test" )
   // this === "<button> element"
   .on( "click", you.test );
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
 </body>
 </html>
 ```
@@ -19524,6 +5726,7 @@ var proxy = $.proxy( me.test, me, you, they );
 $( "#test" )
   .on( "click", proxy );
 </script>
+​
 </body>
 </html>
 ```
@@ -19600,33 +5803,7 @@ $( "#test" )
   // this === "<button> element"
   .on( "click", you.test );
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
 </body>
 </html>
 ```
@@ -19684,6 +5861,7 @@ var proxy = $.proxy( me.test, me, you, they );
 $( "#test" )
   .on( "click", proxy );
 </script>
+​
 </body>
 </html>
 ```
@@ -19760,33 +5938,7 @@ $( "#test" )
   // this === "<button> element"
   .on( "click", you.test );
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
 </body>
 </html>
 ```
@@ -19844,6 +5996,7 @@ var proxy = $.proxy( me.test, me, you, they );
 $( "#test" )
   .on( "click", proxy );
 </script>
+​
 </body>
 </html>
 ```
@@ -19923,33 +6076,7 @@ $( "#test" )
   // this === "<button> element"
   .on( "click", you.test );
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
 </body>
 </html>
 ```
@@ -20007,6 +6134,7 @@ var proxy = $.proxy( me.test, me, you, they );
 $( "#test" )
   .on( "click", proxy );
 </script>
+​
 </body>
 </html>
 ```
@@ -20083,33 +6211,7 @@ $( "#test" )
   // this === "<button> element"
   .on( "click", you.test );
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
 </body>
 </html>
 ```
@@ -20167,6 +6269,7 @@ var proxy = $.proxy( me.test, me, you, they );
 $( "#test" )
   .on( "click", proxy );
 </script>
+​
 </body>
 </html>
 ```
@@ -20243,33 +6346,7 @@ $( "#test" )
   // this === "<button> element"
   .on( "click", you.test );
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
 </body>
 </html>
 ```
@@ -20327,6 +6404,7 @@ var proxy = $.proxy( me.test, me, you, they );
 $( "#test" )
   .on( "click", proxy );
 </script>
+​
 </body>
 </html>
 ```
@@ -20403,33 +6481,7 @@ $( "#test" )
   // this === "<button> element"
   .on( "click", you.test );
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
 </body>
 </html>
 ```
@@ -20487,6 +6539,7 @@ var proxy = $.proxy( me.test, me, you, they );
 $( "#test" )
   .on( "click", proxy );
 </script>
+​
 </body>
 </html>
 ```
@@ -20563,33 +6616,7 @@ $( "#test" )
   // this === "<button> element"
   .on( "click", you.test );
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
 </body>
 </html>
 ```
@@ -20647,6 +6674,7 @@ var proxy = $.proxy( me.test, me, you, they );
 $( "#test" )
   .on( "click", proxy );
 </script>
+​
 </body>
 </html>
 ```
@@ -20723,33 +6751,7 @@ $( "#test" )
   // this === "<button> element"
   .on( "click", you.test );
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
 </body>
 </html>
 ```
@@ -20807,6 +6809,7 @@ var proxy = $.proxy( me.test, me, you, they );
 $( "#test" )
   .on( "click", proxy );
 </script>
+​
 </body>
 </html>
 ```
@@ -20883,33 +6886,7 @@ $( "#test" )
   // this === "<button> element"
   .on( "click", you.test );
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
 </body>
 </html>
 ```
@@ -20967,6 +6944,7 @@ var proxy = $.proxy( me.test, me, you, they );
 $( "#test" )
   .on( "click", proxy );
 </script>
+​
 </body>
 </html>
 ```
@@ -21043,33 +7021,7 @@ $( "#test" )
   // this === "<button> element"
   .on( "click", you.test );
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
 </body>
 </html>
 ```
@@ -21127,6 +7079,7 @@ var proxy = $.proxy( me.test, me, you, they );
 $( "#test" )
   .on( "click", proxy );
 </script>
+​
 </body>
 </html>
 ```
@@ -21206,33 +7159,7 @@ $( "#test" )
   // this === "<button> element"
   .on( "click", you.test );
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
 </body>
 </html>
 ```
@@ -21290,6 +7217,7 @@ var proxy = $.proxy( me.test, me, you, they );
 $( "#test" )
   .on( "click", proxy );
 </script>
+​
 </body>
 </html>
 ```
@@ -21366,33 +7294,7 @@ $( "#test" )
   // this === "<button> element"
   .on( "click", you.test );
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
 </body>
 </html>
 ```
@@ -21450,6 +7352,7 @@ var proxy = $.proxy( me.test, me, you, they );
 $( "#test" )
   .on( "click", proxy );
 </script>
+​
 </body>
 </html>
 ```
@@ -21526,33 +7429,7 @@ $( "#test" )
   // this === "<button> element"
   .on( "click", you.test );
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
 </body>
 </html>
 ```
@@ -21610,6 +7487,7 @@ var proxy = $.proxy( me.test, me, you, they );
 $( "#test" )
   .on( "click", proxy );
 </script>
+​
 </body>
 </html>
 ```
@@ -21686,33 +7564,7 @@ $( "#test" )
   // this === "<button> element"
   .on( "click", you.test );
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
 </body>
 </html>
 ```
@@ -21770,6 +7622,7 @@ var proxy = $.proxy( me.test, me, you, they );
 $( "#test" )
   .on( "click", proxy );
 </script>
+​
 </body>
 </html>
 ```
@@ -21846,33 +7699,7 @@ $( "#test" )
   // this === "<button> element"
   .on( "click", you.test );
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
 </body>
 </html>
 ```
@@ -21930,6 +7757,7 @@ var proxy = $.proxy( me.test, me, you, they );
 $( "#test" )
   .on( "click", proxy );
 </script>
+​
 </body>
 </html>
 ```
@@ -22006,33 +7834,7 @@ $( "#test" )
   // this === "<button> element"
   .on( "click", you.test );
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
 </body>
 </html>
 ```
@@ -22090,6 +7892,7 @@ var proxy = $.proxy( me.test, me, you, they );
 $( "#test" )
   .on( "click", proxy );
 </script>
+​
 </body>
 </html>
 ```
@@ -22166,33 +7969,7 @@ $( "#test" )
   // this === "<button> element"
   .on( "click", you.test );
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
 </body>
 </html>
 ```
@@ -22250,6 +8027,7 @@ var proxy = $.proxy( me.test, me, you, they );
 $( "#test" )
   .on( "click", proxy );
 </script>
+​
 </body>
 </html>
 ```
@@ -22326,33 +8104,7 @@ $( "#test" )
   // this === "<button> element"
   .on( "click", you.test );
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
 </body>
 </html>
 ```
@@ -22410,6 +8162,7 @@ var proxy = $.proxy( me.test, me, you, they );
 $( "#test" )
   .on( "click", proxy );
 </script>
+​
 </body>
 </html>
 ```
@@ -22489,33 +8242,7 @@ $( "#test" )
   // this === "<button> element"
   .on( "click", you.test );
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
 </body>
 </html>
 ```
@@ -22573,6 +8300,7 @@ var proxy = $.proxy( me.test, me, you, they );
 $( "#test" )
   .on( "click", proxy );
 </script>
+​
 </body>
 </html>
 ```
@@ -22649,33 +8377,7 @@ $( "#test" )
   // this === "<button> element"
   .on( "click", you.test );
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
 </body>
 </html>
 ```
@@ -22733,6 +8435,7 @@ var proxy = $.proxy( me.test, me, you, they );
 $( "#test" )
   .on( "click", proxy );
 </script>
+​
 </body>
 </html>
 ```
@@ -22809,33 +8512,7 @@ $( "#test" )
   // this === "<button> element"
   .on( "click", you.test );
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
 </body>
 </html>
 ```
@@ -22893,6 +8570,7 @@ var proxy = $.proxy( me.test, me, you, they );
 $( "#test" )
   .on( "click", proxy );
 </script>
+​
 </body>
 </html>
 ```
@@ -22969,33 +8647,7 @@ $( "#test" )
   // this === "<button> element"
   .on( "click", you.test );
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
 </body>
 </html>
 ```
@@ -23053,6 +8705,7 @@ var proxy = $.proxy( me.test, me, you, they );
 $( "#test" )
   .on( "click", proxy );
 </script>
+​
 </body>
 </html>
 ```
@@ -23129,33 +8782,7 @@ $( "#test" )
   // this === "<button> element"
   .on( "click", you.test );
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
 </body>
 </html>
 ```
@@ -23213,6 +8840,7 @@ var proxy = $.proxy( me.test, me, you, they );
 $( "#test" )
   .on( "click", proxy );
 </script>
+​
 </body>
 </html>
 ```
@@ -23289,33 +8917,7 @@ $( "#test" )
   // this === "<button> element"
   .on( "click", you.test );
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
 </body>
 </html>
 ```
@@ -23373,6 +8975,7 @@ var proxy = $.proxy( me.test, me, you, they );
 $( "#test" )
   .on( "click", proxy );
 </script>
+​
 </body>
 </html>
 ```
@@ -23449,33 +9052,7 @@ $( "#test" )
   // this === "<button> element"
   .on( "click", you.test );
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
 </body>
 </html>
 ```
@@ -23533,6 +9110,7 @@ var proxy = $.proxy( me.test, me, you, they );
 $( "#test" )
   .on( "click", proxy );
 </script>
+​
 </body>
 </html>
 ```
@@ -23609,33 +9187,7 @@ $( "#test" )
   // this === "<button> element"
   .on( "click", you.test );
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
 </body>
 </html>
 ```
@@ -23693,6 +9245,7 @@ var proxy = $.proxy( me.test, me, you, they );
 $( "#test" )
   .on( "click", proxy );
 </script>
+​
 </body>
 </html>
 ```
@@ -23772,33 +9325,7 @@ $( "#test" )
   // this === "<button> element"
   .on( "click", you.test );
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
 </body>
 </html>
 ```
@@ -23856,6 +9383,7 @@ var proxy = $.proxy( me.test, me, you, they );
 $( "#test" )
   .on( "click", proxy );
 </script>
+​
 </body>
 </html>
 ```
@@ -23932,33 +9460,7 @@ $( "#test" )
   // this === "<button> element"
   .on( "click", you.test );
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
 </body>
 </html>
 ```
@@ -24016,6 +9518,7 @@ var proxy = $.proxy( me.test, me, you, they );
 $( "#test" )
   .on( "click", proxy );
 </script>
+​
 </body>
 </html>
 ```
@@ -24092,33 +9595,7 @@ $( "#test" )
   // this === "<button> element"
   .on( "click", you.test );
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
 </body>
 </html>
 ```
@@ -24176,6 +9653,7 @@ var proxy = $.proxy( me.test, me, you, they );
 $( "#test" )
   .on( "click", proxy );
 </script>
+​
 </body>
 </html>
 ```
@@ -24252,33 +9730,7 @@ $( "#test" )
   // this === "<button> element"
   .on( "click", you.test );
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
 </body>
 </html>
 ```
@@ -24336,6 +9788,7 @@ var proxy = $.proxy( me.test, me, you, they );
 $( "#test" )
   .on( "click", proxy );
 </script>
+​
 </body>
 </html>
 ```
@@ -24412,33 +9865,7 @@ $( "#test" )
   // this === "<button> element"
   .on( "click", you.test );
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
 </body>
 </html>
 ```
@@ -24496,6 +9923,7 @@ var proxy = $.proxy( me.test, me, you, they );
 $( "#test" )
   .on( "click", proxy );
 </script>
+​
 </body>
 </html>
 ```
@@ -24572,33 +10000,7 @@ $( "#test" )
   // this === "<button> element"
   .on( "click", you.test );
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
 </body>
 </html>
 ```
@@ -24656,6 +10058,7 @@ var proxy = $.proxy( me.test, me, you, they );
 $( "#test" )
   .on( "click", proxy );
 </script>
+​
 </body>
 </html>
 ```
@@ -24732,33 +10135,7 @@ $( "#test" )
   // this === "<button> element"
   .on( "click", you.test );
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
 </body>
 </html>
 ```
@@ -24816,6 +10193,7 @@ var proxy = $.proxy( me.test, me, you, they );
 $( "#test" )
   .on( "click", proxy );
 </script>
+​
 </body>
 </html>
 ```
@@ -24892,33 +10270,7 @@ $( "#test" )
   // this === "<button> element"
   .on( "click", you.test );
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
 </body>
 </html>
 ```
@@ -24976,6 +10328,7 @@ var proxy = $.proxy( me.test, me, you, they );
 $( "#test" )
   .on( "click", proxy );
 </script>
+​
 </body>
 </html>
 ```
@@ -25055,33 +10408,7 @@ $( "#test" )
   // this === "<button> element"
   .on( "click", you.test );
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
 </body>
 </html>
 ```
@@ -25139,6 +10466,7 @@ var proxy = $.proxy( me.test, me, you, they );
 $( "#test" )
   .on( "click", proxy );
 </script>
+​
 </body>
 </html>
 ```
@@ -25215,33 +10543,7 @@ $( "#test" )
   // this === "<button> element"
   .on( "click", you.test );
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
 </body>
 </html>
 ```
@@ -25299,6 +10601,7 @@ var proxy = $.proxy( me.test, me, you, they );
 $( "#test" )
   .on( "click", proxy );
 </script>
+​
 </body>
 </html>
 ```
@@ -25375,33 +10678,7 @@ $( "#test" )
   // this === "<button> element"
   .on( "click", you.test );
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
 </body>
 </html>
 ```
@@ -25459,6 +10736,7 @@ var proxy = $.proxy( me.test, me, you, they );
 $( "#test" )
   .on( "click", proxy );
 </script>
+​
 </body>
 </html>
 ```
@@ -25535,33 +10813,7 @@ $( "#test" )
   // this === "<button> element"
   .on( "click", you.test );
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
 </body>
 </html>
 ```
@@ -25619,6 +10871,7 @@ var proxy = $.proxy( me.test, me, you, they );
 $( "#test" )
   .on( "click", proxy );
 </script>
+​
 </body>
 </html>
 ```
@@ -25695,33 +10948,7 @@ $( "#test" )
   // this === "<button> element"
   .on( "click", you.test );
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
 </body>
 </html>
 ```
@@ -25779,6 +11006,7 @@ var proxy = $.proxy( me.test, me, you, they );
 $( "#test" )
   .on( "click", proxy );
 </script>
+​
 </body>
 </html>
 ```
@@ -25855,33 +11083,7 @@ $( "#test" )
   // this === "<button> element"
   .on( "click", you.test );
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
 </body>
 </html>
 ```
@@ -25939,6 +11141,7 @@ var proxy = $.proxy( me.test, me, you, they );
 $( "#test" )
   .on( "click", proxy );
 </script>
+​
 </body>
 </html>
 ```
@@ -26015,33 +11218,7 @@ $( "#test" )
   // this === "<button> element"
   .on( "click", you.test );
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
 </body>
 </html>
 ```
@@ -26099,6 +11276,7 @@ var proxy = $.proxy( me.test, me, you, they );
 $( "#test" )
   .on( "click", proxy );
 </script>
+​
 </body>
 </html>
 ```
@@ -26175,33 +11353,7 @@ $( "#test" )
   // this === "<button> element"
   .on( "click", you.test );
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
 </body>
 </html>
 ```
@@ -26259,6 +11411,7 @@ var proxy = $.proxy( me.test, me, you, they );
 $( "#test" )
   .on( "click", proxy );
 </script>
+​
 </body>
 </html>
 ```
@@ -26338,33 +11491,7 @@ $( "#test" )
   // this === "<button> element"
   .on( "click", you.test );
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
 </body>
 </html>
 ```
@@ -26422,6 +11549,7 @@ var proxy = $.proxy( me.test, me, you, they );
 $( "#test" )
   .on( "click", proxy );
 </script>
+​
 </body>
 </html>
 ```
@@ -26498,33 +11626,7 @@ $( "#test" )
   // this === "<button> element"
   .on( "click", you.test );
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
 </body>
 </html>
 ```
@@ -26582,6 +11684,7 @@ var proxy = $.proxy( me.test, me, you, they );
 $( "#test" )
   .on( "click", proxy );
 </script>
+​
 </body>
 </html>
 ```
@@ -26658,33 +11761,7 @@ $( "#test" )
   // this === "<button> element"
   .on( "click", you.test );
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
 </body>
 </html>
 ```
@@ -26742,6 +11819,7 @@ var proxy = $.proxy( me.test, me, you, they );
 $( "#test" )
   .on( "click", proxy );
 </script>
+​
 </body>
 </html>
 ```
@@ -26818,33 +11896,7 @@ $( "#test" )
   // this === "<button> element"
   .on( "click", you.test );
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
 </body>
 </html>
 ```
@@ -26902,6 +11954,7 @@ var proxy = $.proxy( me.test, me, you, they );
 $( "#test" )
   .on( "click", proxy );
 </script>
+​
 </body>
 </html>
 ```
@@ -26978,33 +12031,7 @@ $( "#test" )
   // this === "<button> element"
   .on( "click", you.test );
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
 </body>
 </html>
 ```
@@ -27062,6 +12089,7 @@ var proxy = $.proxy( me.test, me, you, they );
 $( "#test" )
   .on( "click", proxy );
 </script>
+​
 </body>
 </html>
 ```
@@ -27138,33 +12166,7 @@ $( "#test" )
   // this === "<button> element"
   .on( "click", you.test );
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
 </body>
 </html>
 ```
@@ -27222,6 +12224,7 @@ var proxy = $.proxy( me.test, me, you, they );
 $( "#test" )
   .on( "click", proxy );
 </script>
+​
 </body>
 </html>
 ```
@@ -27298,33 +12301,7 @@ $( "#test" )
   // this === "<button> element"
   .on( "click", you.test );
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
 </body>
 </html>
 ```
@@ -27382,6 +12359,7 @@ var proxy = $.proxy( me.test, me, you, they );
 $( "#test" )
   .on( "click", proxy );
 </script>
+​
 </body>
 </html>
 ```
@@ -27458,33 +12436,7 @@ $( "#test" )
   // this === "<button> element"
   .on( "click", you.test );
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
 </body>
 </html>
 ```
@@ -27542,6 +12494,7 @@ var proxy = $.proxy( me.test, me, you, they );
 $( "#test" )
   .on( "click", proxy );
 </script>
+​
 </body>
 </html>
 ```
@@ -27624,33 +12577,7 @@ $( "#test" )
   // this === "<button> element"
   .on( "click", you.test );
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-  <p><button id="test">Test</button></p>
-  <p id="log"></p>
-​
-<script>
-var obj = {
-  name: "John",
-  test: function() {
-    $( "#log" ).append( this.name );
-    $( "#test" ).off( "click", obj.test );
-  }
-};
-$( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
-</script>
 </body>
 </html>
 ```
@@ -27708,6 +12635,7 @@ var proxy = $.proxy( me.test, me, you, they );
 $( "#test" )
   .on( "click", proxy );
 </script>
+​
 </body>
 </html>
 ```
@@ -27734,65 +12662,6 @@ $( "#test" )
      * @since 1.4
      * @since 1.6
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
-     * @example ​ ````Change the context of functions bound to a click handler using the &quot;function, context&quot; signature. Unbind the first handler after first click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  type: "zombie",
-  test: function( event ) {
-    // Without proxy, `this` would refer to the event target
-    // use event.target to reference that element.
-    var element = event.target;
-    $( element ).css( "background-color", "red" );
-​
-    // With proxy, `this` refers to the me object encapsulating
-    // this function.
-    $( "#log" ).append( "Hello " + this.type + "<br>" );
-    $( "#test" ).off( "click", this.test );
-  }
-};
-​
-var you = {
-  type: "person",
-  test: function( event ) {
-    $( "#log" ).append( this.type + " " );
-  }
-};
-​
-// Execute you.test() in the context of the `you` object
-// no matter where it is called
-// i.e. the `this` keyword will refer to `you`
-var youClick = $.proxy( you.test, you );
-​
-// attach click handlers to #test
-$( "#test" )
-  // this === "zombie"; handler unbound after first click
-  .on( "click", $.proxy( me.test, me ) )
-​
-  // this === "person"
-  .on( "click", youClick )
-​
-  // this === "zombie"
-  .on( "click", $.proxy( you.test, me ) )
-​
-  // this === "<button> element"
-  .on( "click", you.test );
-</script>
-</body>
-</html>
-```
      * @example ​ ````Enforce the context of the function using the &quot;context, function name&quot; signature. Unbind the handler after first click.
 ```html
 <!doctype html>
@@ -27817,63 +12686,7 @@ var obj = {
 };
 $( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Change the context of a function bound to the click handler,
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.proxy demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-<p><button type="button" id="test">Test</button></p>
-<div id="log"></div>
-​
-<script>
-var me = {
-  // I'm a dog
-  type: "dog",
-​
-  // Note that event comes *after* one and two
-  test: function( one, two, event ) {
-    $( "#log" )
-​
-      // `one` maps to `you`, the 1st additional
-      // argument in the $.proxy function call
-      .append( "<h3>Hello " + one.type + ":</h3>" )
-​
-      // The `this` keyword refers to `me`
-      // (the 2nd, context, argument of $.proxy)
-      .append( "I am a " + this.type + ", " )
-​
-      // `two` maps to `they`, the 2nd additional
-      // argument in the $.proxy function call
-      .append( "and they are " + two.type + ".<br>" )
-​
-      // The event type is "click"
-      .append( "Thanks for " + event.type + "ing." )
-​
-      // The clicked element is `event.target`,
-      // and its type is "button"
-      .append( "the " + event.target.type + "." );
-  }
-};
-​
-var you = { type: "cat" };
-var they = { type: "fish" };
-​
-// Set up handler to execute me.test() in the context
-// of `me`, with `you` and `they` as additional arguments
-var proxy = $.proxy( me.test, me, you, they );
-​
-$( "#test" )
-  .on( "click", proxy );
-</script>
 </body>
 </html>
 ```
@@ -27952,6 +12765,7 @@ function runIt() {
 ​
 runIt();
 </script>
+​
 </body>
 </html>
 ```
@@ -28001,6 +12815,7 @@ $( document.body ).click(function() {
   divs.slideUp();
 });
 </script>
+​
 </body>
 </html>
 ```
@@ -28055,6 +12870,7 @@ $( "#stop" ).click(function() {
   $( "div" ).stop();
 });
 </script>
+​
 </body>
 </html>
 ```
@@ -28067,23 +12883,10 @@ $( "#stop" ).click(function() {
      * @see \`{@link https://api.jquery.com/jQuery.readyException/ }\`
      * @since 3.1
      * @example ​ ````Pass the received error to console.error.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.readyException demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 jQuery.readyException = function( error ) {
   console.error( error );
 };
-</script>
-</body>
-</html>
 ```
      */
     readyException(error: Error): any;
@@ -28129,6 +12932,7 @@ jQuery.removeData( div, "test1" );
 $( "span:eq(2)" ).text( "" + jQuery.data( div, "test1" ) );
 $( "span:eq(3)" ).text( "" + jQuery.data( div, "test2" ) );
 </script>
+​
 </body>
 </html>
 ```
@@ -28191,25 +12995,17 @@ var str = "         lots of spaces before and after         ";
 $( "#original" ).html( "Original String: '" + str + "'" );
 $( "#trimmed" ).html( "$.trim()'ed: '" + $.trim(str) + "'" );
 </script>
+​
 </body>
 </html>
 ```
      * @example ​ ````Remove the white spaces at the start and at the end of the string.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.trim demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $.trim("    hello, how are you?    ");
-</script>
-</body>
-</html>
+```
+     * @example ​ ````Remove the white spaces at the start and at the end of the string.
+```javascript
+$.trim("    hello, how are you?    ");
 ```
      */
     trim(str: string): string;
@@ -28236,6 +13032,7 @@ Is it a RegExp? <b></b>
 <script>
 $( "b" ).append( "" + jQuery.type( /test/ ) );
 </script>
+​
 </body>
 </html>
 ```
@@ -28288,6 +13085,7 @@ divs = jQuery.unique( divs );
 $( "div:eq(2)" ).text( "Post-unique there are " + divs.length + " elements." )
   .css( "color", "red" );
 </script>
+​
 </body>
 </html>
 ```
@@ -28336,6 +13134,7 @@ divs = jQuery.uniqueSort( divs );
 $( "div:eq(2)" ).text( "Post-unique there are " + divs.length + " elements." )
   .css( "color", "red" );
 </script>
+​
 </body>
 </html>
 ```
@@ -28348,17 +13147,7 @@ $( "div:eq(2)" ).text( "Post-unique there are " + divs.length + " elements." )
      * @see \`{@link https://api.jquery.com/jQuery.when/ }\`
      * @since 1.5
      * @example ​ ````Execute a function after two Ajax requests are successful. (See the jQuery.ajax() documentation for a complete description of success and error cases for an ajax request).
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.when demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $.when( $.ajax( "/page1.php" ), $.ajax( "/page2.php" ) ).done(function( a1, a2 ) {
   // a1 and a2 are arguments resolved for the page1 and page2 ajax requests, respectively.
   // Each argument is an array with the following structure: [ data, statusText, jqXHR ]
@@ -28367,34 +13156,20 @@ $.when( $.ajax( "/page1.php" ), $.ajax( "/page2.php" ) ).done(function( a1, a2 )
     alert( "We got what we came for!" );
   }
 });
-</script>
-</body>
-</html>
 ```
      * @example ​ ````Execute the function myFunc when both ajax requests are successful, or myFailure if either one has an error.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.when demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $.when( $.ajax( "/page1.php" ), $.ajax( "/page2.php" ) )
   .then( myFunc, myFailure );
-</script>
-</body>
-</html>
 ```
      */
     when<TR1, UR1, VR1,
         TJ1 = any, UJ1 = any, VJ1 = any>(
-            deferredT: JQuery.Promise<TR1, TJ1, any> | JQuery.Thenable<TR1> | TR1, // tslint:disable-line:use-default-type-parameter
-            deferredU: JQuery.Promise<UR1, UJ1, any> | JQuery.Thenable<UR1> | UR1, // tslint:disable-line:use-default-type-parameter
-            deferredV: JQuery.Promise<VR1, VJ1, any> | JQuery.Thenable<VR1> | VR1): JQuery.Promise3<TR1, TJ1, never,  // tslint:disable-line:use-default-type-parameter
+            deferredT: JQuery.Promise<TR1, TJ1> | JQuery.Thenable<TR1> | TR1,
+            deferredU: JQuery.Promise<UR1, UJ1> | JQuery.Thenable<UR1> | UR1,
+            deferredV: JQuery.Promise<VR1, VJ1> | JQuery.Thenable<VR1> | VR1,
+    ): JQuery.Promise3<
+        TR1, TJ1, never,
         UR1, UJ1, never,
         VR1, VJ1, never>;
     /**
@@ -28404,17 +13179,7 @@ $.when( $.ajax( "/page1.php" ), $.ajax( "/page2.php" ) )
      * @see \`{@link https://api.jquery.com/jQuery.when/ }\`
      * @since 1.5
      * @example ​ ````Execute a function after two Ajax requests are successful. (See the jQuery.ajax() documentation for a complete description of success and error cases for an ajax request).
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.when demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $.when( $.ajax( "/page1.php" ), $.ajax( "/page2.php" ) ).done(function( a1, a2 ) {
   // a1 and a2 are arguments resolved for the page1 and page2 ajax requests, respectively.
   // Each argument is an array with the following structure: [ data, statusText, jqXHR ]
@@ -28423,33 +13188,19 @@ $.when( $.ajax( "/page1.php" ), $.ajax( "/page2.php" ) ).done(function( a1, a2 )
     alert( "We got what we came for!" );
   }
 });
-</script>
-</body>
-</html>
 ```
      * @example ​ ````Execute the function myFunc when both ajax requests are successful, or myFailure if either one has an error.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.when demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $.when( $.ajax( "/page1.php" ), $.ajax( "/page2.php" ) )
   .then( myFunc, myFailure );
-</script>
-</body>
-</html>
 ```
      */
     when<TR1, UR1,
         TJ1 = any, UJ1 = any>(
-            deferredT: JQuery.Promise<TR1, TJ1, any> | JQuery.Thenable<TR1> | TR1, // tslint:disable-line:use-default-type-parameter
-            deferredU: JQuery.Promise<UR1, UJ1, any> | JQuery.Thenable<UR1> | UR1): JQuery.Promise2<TR1, TJ1, never, // tslint:disable-line:use-default-type-parameter
+            deferredT: JQuery.Promise<TR1, TJ1> | JQuery.Thenable<TR1> | TR1,
+            deferredU: JQuery.Promise<UR1, UJ1> | JQuery.Thenable<UR1> | UR1,
+    ): JQuery.Promise2<
+        TR1, TJ1, never,
         UR1, UJ1, never>;
     /**
      * Provides a way to execute callback functions based on zero or more Thenable objects, usually
@@ -28458,17 +13209,7 @@ $.when( $.ajax( "/page1.php" ), $.ajax( "/page2.php" ) )
      * @see \`{@link https://api.jquery.com/jQuery.when/ }\`
      * @since 1.5
      * @example ​ ````Execute a function after two Ajax requests are successful. (See the jQuery.ajax() documentation for a complete description of success and error cases for an ajax request).
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.when demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $.when( $.ajax( "/page1.php" ), $.ajax( "/page2.php" ) ).done(function( a1, a2 ) {
   // a1 and a2 are arguments resolved for the page1 and page2 ajax requests, respectively.
   // Each argument is an array with the following structure: [ data, statusText, jqXHR ]
@@ -28477,34 +13218,22 @@ $.when( $.ajax( "/page1.php" ), $.ajax( "/page2.php" ) ).done(function( a1, a2 )
     alert( "We got what we came for!" );
   }
 });
-</script>
-</body>
-</html>
 ```
      * @example ​ ````Execute the function myFunc when both ajax requests are successful, or myFailure if either one has an error.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.when demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $.when( $.ajax( "/page1.php" ), $.ajax( "/page2.php" ) )
   .then( myFunc, myFailure );
-</script>
-</body>
-</html>
 ```
      */
     when<TR1, TJ1,
         TR2, TJ2,
         TR3 = never, TJ3 = never>(
             deferredT: JQuery.Promise3<TR1, TJ1, any, TR2, TJ2, any, TR3, TJ3, any> |
-                       JQuery.Promise2<TR1, TJ1, any, TR2, TJ2, any>): JQuery.Promise3<TR1, TJ1, never, TR2, TJ2, never, TR3, TJ3, never>;
+                       JQuery.Promise2<TR1, TJ1, any, TR2, TJ2, any>
+    ): JQuery.Promise3<
+        TR1, TJ1, never,
+        TR2, TJ2, never,
+        TR3, TJ3, never>;
     /**
      * Provides a way to execute callback functions based on zero or more Thenable objects, usually
      * Deferred objects that represent asynchronous events.
@@ -28512,17 +13241,7 @@ $.when( $.ajax( "/page1.php" ), $.ajax( "/page2.php" ) )
      * @see \`{@link https://api.jquery.com/jQuery.when/ }\`
      * @since 1.5
      * @example ​ ````Execute a function after two Ajax requests are successful. (See the jQuery.ajax() documentation for a complete description of success and error cases for an ajax request).
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.when demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $.when( $.ajax( "/page1.php" ), $.ajax( "/page2.php" ) ).done(function( a1, a2 ) {
   // a1 and a2 are arguments resolved for the page1 and page2 ajax requests, respectively.
   // Each argument is an array with the following structure: [ data, statusText, jqXHR ]
@@ -28531,30 +13250,14 @@ $.when( $.ajax( "/page1.php" ), $.ajax( "/page2.php" ) ).done(function( a1, a2 )
     alert( "We got what we came for!" );
   }
 });
-</script>
-</body>
-</html>
 ```
      * @example ​ ````Execute the function myFunc when both ajax requests are successful, or myFailure if either one has an error.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.when demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $.when( $.ajax( "/page1.php" ), $.ajax( "/page2.php" ) )
   .then( myFunc, myFailure );
-</script>
-</body>
-</html>
 ```
      */
-    when<TR1, TJ1 = any>(deferred: JQuery.Promise<TR1, TJ1, any> | JQuery.Thenable<TR1> | TR1): JQuery.Promise<TR1, TJ1, never>; // tslint:disable-line:use-default-type-parameter
+    when<TR1, TJ1 = any>(deferred: JQuery.Promise<TR1, TJ1> | JQuery.Thenable<TR1> | TR1): JQuery.Promise<TR1, TJ1, never>;
     /**
      * Provides a way to execute callback functions based on zero or more Thenable objects, usually
      * Deferred objects that represent asynchronous events.
@@ -28563,17 +13266,7 @@ $.when( $.ajax( "/page1.php" ), $.ajax( "/page2.php" ) )
      * @see \`{@link https://api.jquery.com/jQuery.when/ }\`
      * @since 1.5
      * @example ​ ````Execute a function after two Ajax requests are successful. (See the jQuery.ajax() documentation for a complete description of success and error cases for an ajax request).
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.when demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $.when( $.ajax( "/page1.php" ), $.ajax( "/page2.php" ) ).done(function( a1, a2 ) {
   // a1 and a2 are arguments resolved for the page1 and page2 ajax requests, respectively.
   // Each argument is an array with the following structure: [ data, statusText, jqXHR ]
@@ -28582,30 +13275,14 @@ $.when( $.ajax( "/page1.php" ), $.ajax( "/page2.php" ) ).done(function( a1, a2 )
     alert( "We got what we came for!" );
   }
 });
-</script>
-</body>
-</html>
 ```
      * @example ​ ````Execute the function myFunc when both ajax requests are successful, or myFailure if either one has an error.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.when demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $.when( $.ajax( "/page1.php" ), $.ajax( "/page2.php" ) )
   .then( myFunc, myFailure );
-</script>
-</body>
-</html>
 ```
      */
-    when<TR1 = never, TJ1 = never>(...deferreds: Array<JQuery.Promise<TR1, TJ1, any> | JQuery.Thenable<TR1> | TR1>): JQuery.Promise<TR1, TJ1, never>; // tslint:disable-line:use-default-type-parameter
+    when<TR1 = never, TJ1 = never>(...deferreds: Array<JQuery.Promise<TR1, TJ1> | JQuery.Thenable<TR1> | TR1>): JQuery.Promise<TR1, TJ1, never>;
     /**
      * Provides a way to execute callback functions based on zero or more Thenable objects, usually
      * Deferred objects that represent asynchronous events.
@@ -28614,17 +13291,7 @@ $.when( $.ajax( "/page1.php" ), $.ajax( "/page2.php" ) )
      * @see \`{@link https://api.jquery.com/jQuery.when/ }\`
      * @since 1.5
      * @example ​ ````Execute a function after two Ajax requests are successful. (See the jQuery.ajax() documentation for a complete description of success and error cases for an ajax request).
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.when demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $.when( $.ajax( "/page1.php" ), $.ajax( "/page2.php" ) ).done(function( a1, a2 ) {
   // a1 and a2 are arguments resolved for the page1 and page2 ajax requests, respectively.
   // Each argument is an array with the following structure: [ data, statusText, jqXHR ]
@@ -28633,27 +13300,11 @@ $.when( $.ajax( "/page1.php" ), $.ajax( "/page2.php" ) ).done(function( a1, a2 )
     alert( "We got what we came for!" );
   }
 });
-</script>
-</body>
-</html>
 ```
      * @example ​ ````Execute the function myFunc when both ajax requests are successful, or myFailure if either one has an error.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jQuery.when demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $.when( $.ajax( "/page1.php" ), $.ajax( "/page2.php" ) )
   .then( myFunc, myFailure );
-</script>
-</body>
-</html>
 ```
      */
     when(...deferreds: any[]): JQuery.Promise<any, any, never>;
@@ -38192,6 +22843,7 @@ $( "button" ).click(function() {
 <head>
   <meta charset="utf-8">
   <title>removeAttr demo</title>
+  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
 </head>
 <body>
 ​
@@ -38454,6 +23106,7 @@ para
 <head>
   <meta charset="utf-8">
   <title>replaceAll demo</title>
+  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
 </head>
 <body>
 ​
@@ -38525,6 +23178,7 @@ $( "button" ).click(function() {
 <head>
   <meta charset="utf-8">
   <title>replaceWith demo</title>
+  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
 </head>
 <body>
 ​
@@ -39328,6 +23982,7 @@ $( "b" ).text( len );
 <head>
   <meta charset="utf-8">
   <title>siblings demo</title>
+  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
 </head>
 <body>
 ​
@@ -40148,6 +24803,7 @@ disp( $( "div" ).toArray().reverse() );
 <head>
   <meta charset="utf-8">
   <title>toggle demo</title>
+  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
 </head>
 <body>
 ​
@@ -40202,6 +24858,7 @@ $( "button" ).click(function() {
 <head>
   <meta charset="utf-8">
   <title>toggle demo</title>
+  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
 </head>
 <body>
 ​
@@ -40519,6 +25176,7 @@ $( "body" ).trigger({
 <head>
   <meta charset="utf-8">
   <title>triggerHandler demo</title>
+  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
 </head>
 <body>
 ​
@@ -40863,6 +25521,7 @@ $( "button" ).click(function() {
 <head>
   <meta charset="utf-8">
   <title>val demo</title>
+  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
 </head>
 <body>
 ​

--- a/types/jquery/index.d.ts
+++ b/types/jquery/index.d.ts
@@ -27570,23 +27570,10 @@ callbacks.fire( "world" );
          * @see \`{@link https://api.jquery.com/deferred.always/ }\`
          * @since 1.6
          * @example ​ ````Since the jQuery.get() method returns a jqXHR object, which is derived from a Deferred object, we can attach a callback for both success and error using the deferred.always() method.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>deferred.always demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $.get( "test.php" ).always(function() {
   alert( "$.get completed with success or error callback arguments" );
 });
-</script>
-</body>
-</html>
 ```
          */
         always(alwaysCallback: TypeOrArray<Deferred.CallbackBase<TR | TJ, UR | UJ, VR | VJ, SR | SJ>>,
@@ -27599,23 +27586,10 @@ $.get( "test.php" ).always(function() {
          * @see \`{@link https://api.jquery.com/deferred.done/ }\`
          * @since 1.5
          * @example ​ ````Since the jQuery.get method returns a jqXHR object, which is derived from a Deferred object, we can attach a success callback using the .done() method.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>deferred.done demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $.get( "test.php" ).done(function() {
   alert( "$.get succeeded" );
 });
-</script>
-</body>
-</html>
 ```
          * @example ​ ````Resolve a Deferred object when the user clicks a button, triggering a number of callback functions:
 ```html
@@ -27660,6 +27634,7 @@ $( "button" ).on( "click", function() {
   dfd.resolve( "and" );
 });
 </script>
+​
 </body>
 </html>
 ```
@@ -27674,17 +27649,7 @@ $( "button" ).on( "click", function() {
          * @see \`{@link https://api.jquery.com/deferred.fail/ }\`
          * @since 1.5
          * @example ​ ````Since the jQuery.get method returns a jqXHR object, which is derived from a Deferred, you can attach a success and failure callback using the deferred.done() and deferred.fail() methods.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>deferred.fail demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $.get( "test.php" )
   .done(function() {
     alert( "$.get succeeded" );
@@ -27692,9 +27657,6 @@ $.get( "test.php" )
   .fail(function() {
     alert( "$.get failed!" );
   });
-</script>
-</body>
-</html>
 ```
          */
         fail(failCallback: TypeOrArray<Deferred.CallbackBase<TJ, UJ, VJ, SJ>>,
@@ -27717,17 +27679,7 @@ $.get( "test.php" )
          * @see \`{@link https://api.jquery.com/deferred.promise/ }\`
          * @since 1.5
          * @example ​ ````Create a Deferred and set two timer-based functions to either resolve or reject the Deferred after a random interval. Whichever one fires first &quot;wins&quot; and will call one of the callbacks. The second timeout has no effect since the Deferred is already complete (in a resolved or rejected state) from the first timeout action. Also set a timer-based progress notification function, and call a progress handler that adds &quot;working...&quot; to the document body.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>deferred.promise demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 function asyncEvent() {
   var dfd = jQuery.Deferred();
 ​
@@ -27765,44 +27717,6 @@ $.when( asyncEvent() ).then(
     $( "body" ).append( status );
   }
 );
-</script>
-</body>
-</html>
-```
-         * @example ​ ````Use the target argument to promote an existing object to a Promise:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>deferred.promise demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-// Existing object
-var obj = {
-    hello: function( name ) {
-      alert( "Hello " + name );
-    }
-  },
-  // Create a Deferred
-  defer = $.Deferred();
-​
-// Set object as a promise
-defer.promise( obj );
-​
-// Resolve the deferred
-defer.resolve( "John" );
-​
-// Use the object as a Promise
-obj.done(function( name ) {
-  obj.hello( name ); // Will alert "Hello John"
-}).hello( "Karl" ); // Will alert "Hello Karl"
-</script>
-</body>
-</html>
 ```
          */
         promise<TTarget extends object>(target: TTarget): this & TTarget;
@@ -27811,71 +27725,8 @@ obj.done(function( name ) {
          *
          * @see \`{@link https://api.jquery.com/deferred.promise/ }\`
          * @since 1.5
-         * @example ​ ````Create a Deferred and set two timer-based functions to either resolve or reject the Deferred after a random interval. Whichever one fires first &quot;wins&quot; and will call one of the callbacks. The second timeout has no effect since the Deferred is already complete (in a resolved or rejected state) from the first timeout action. Also set a timer-based progress notification function, and call a progress handler that adds &quot;working...&quot; to the document body.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>deferred.promise demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-function asyncEvent() {
-  var dfd = jQuery.Deferred();
-​
-  // Resolve after a random interval
-  setTimeout(function() {
-    dfd.resolve( "hurray" );
-  }, Math.floor( 400 + Math.random() * 2000 ) );
-​
-  // Reject after a random interval
-  setTimeout(function() {
-    dfd.reject( "sorry" );
-  }, Math.floor( 400 + Math.random() * 2000 ) );
-​
-  // Show a "working..." message every half-second
-  setTimeout(function working() {
-    if ( dfd.state() === "pending" ) {
-      dfd.notify( "working... " );
-      setTimeout( working, 500 );
-    }
-  }, 1 );
-​
-  // Return the Promise so caller can't change the Deferred
-  return dfd.promise();
-}
-​
-// Attach a done, fail, and progress handler for the asyncEvent
-$.when( asyncEvent() ).then(
-  function( status ) {
-    alert( status + ", things are going well" );
-  },
-  function( status ) {
-    alert( status + ", you fail this time" );
-  },
-  function( status ) {
-    $( "body" ).append( status );
-  }
-);
-</script>
-</body>
-</html>
-```
          * @example ​ ````Use the target argument to promote an existing object to a Promise:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>deferred.promise demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 // Existing object
 var obj = {
     hello: function( name ) {
@@ -27895,9 +27746,6 @@ defer.resolve( "John" );
 obj.done(function( name ) {
   obj.hello( name ); // Will alert "Hello John"
 }).hello( "Karl" ); // Will alert "Hello Karl"
-</script>
-</body>
-</html>
 ```
          */
         promise(): this;
@@ -27927,17 +27775,7 @@ obj.done(function( name ) {
          *
          * **Solution**: In most cases it is sufficient to change all occurrences of `.pipe()` to `.then()`. Ensure that you aren't relying on context/state propagation (e.g., using `this`) or synchronous callback invocation, which were dropped from `.then()` for Promises/A+ interoperability as of jQuery 3.0.
          * @example ​ ````Filter resolve value:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>deferred.pipe demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 var defer = $.Deferred(),
   filtered = defer.pipe(function( value ) {
     return value * 2;
@@ -27947,22 +27785,9 @@ defer.resolve( 5 );
 filtered.done(function( value ) {
   alert( "Value is ( 2*5 = ) 10: " + value );
 });
-</script>
-</body>
-</html>
 ```
          * @example ​ ````Filter reject value:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>deferred.pipe demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 var defer = $.Deferred(),
   filtered = defer.pipe( null, function( value ) {
     return value * 3;
@@ -27972,22 +27797,9 @@ defer.reject( 6 );
 filtered.fail(function( value ) {
   alert( "Value is ( 3*6 = ) 18: " + value );
 });
-</script>
-</body>
-</html>
 ```
          * @example ​ ````Chain tasks:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>deferred.pipe demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 var request = $.ajax( url, { dataType: "json" } ),
   chained = request.pipe(function( data ) {
     return $.ajax( url2, { data: { user: data.userId } } );
@@ -27996,9 +27808,6 @@ var request = $.ajax( url, { dataType: "json" } ),
 chained.done(function( data ) {
   // data retrieved from url2 as provided by the first request
 });
-</script>
-</body>
-</html>
 ```
          */
         pipe<ARD = never, AJD = never, AND = never,
@@ -28042,43 +27851,8 @@ chained.done(function( data ) {
          * **Cause**: The `.pipe()` method on a `jQuery.Deferred` object was deprecated as of jQuery 1.8, when the `.then()` method was changed to perform the same function.
          *
          * **Solution**: In most cases it is sufficient to change all occurrences of `.pipe()` to `.then()`. Ensure that you aren't relying on context/state propagation (e.g., using `this`) or synchronous callback invocation, which were dropped from `.then()` for Promises/A+ interoperability as of jQuery 3.0.
-         * @example ​ ````Filter resolve value:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>deferred.pipe demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-var defer = $.Deferred(),
-  filtered = defer.pipe(function( value ) {
-    return value * 2;
-  });
-​
-defer.resolve( 5 );
-filtered.done(function( value ) {
-  alert( "Value is ( 2*5 = ) 10: " + value );
-});
-</script>
-</body>
-</html>
-```
          * @example ​ ````Filter reject value:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>deferred.pipe demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 var defer = $.Deferred(),
   filtered = defer.pipe( null, function( value ) {
     return value * 3;
@@ -28088,22 +27862,9 @@ defer.reject( 6 );
 filtered.fail(function( value ) {
   alert( "Value is ( 3*6 = ) 18: " + value );
 });
-</script>
-</body>
-</html>
 ```
          * @example ​ ````Chain tasks:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>deferred.pipe demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 var request = $.ajax( url, { dataType: "json" } ),
   chained = request.pipe(function( data ) {
     return $.ajax( url2, { data: { user: data.userId } } );
@@ -28112,9 +27873,6 @@ var request = $.ajax( url, { dataType: "json" } ),
 chained.done(function( data ) {
   // data retrieved from url2 as provided by the first request
 });
-</script>
-</body>
-</html>
 ```
          */
         pipe<ARF = never, AJF = never, ANF = never,
@@ -28152,17 +27910,7 @@ chained.done(function( data ) {
          *
          * **Solution**: In most cases it is sufficient to change all occurrences of `.pipe()` to `.then()`. Ensure that you aren't relying on context/state propagation (e.g., using `this`) or synchronous callback invocation, which were dropped from `.then()` for Promises/A+ interoperability as of jQuery 3.0.
          * @example ​ ````Filter resolve value:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>deferred.pipe demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 var defer = $.Deferred(),
   filtered = defer.pipe(function( value ) {
     return value * 2;
@@ -28172,47 +27920,9 @@ defer.resolve( 5 );
 filtered.done(function( value ) {
   alert( "Value is ( 2*5 = ) 10: " + value );
 });
-</script>
-</body>
-</html>
-```
-         * @example ​ ````Filter reject value:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>deferred.pipe demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-var defer = $.Deferred(),
-  filtered = defer.pipe( null, function( value ) {
-    return value * 3;
-  });
-​
-defer.reject( 6 );
-filtered.fail(function( value ) {
-  alert( "Value is ( 3*6 = ) 18: " + value );
-});
-</script>
-</body>
-</html>
 ```
          * @example ​ ````Chain tasks:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>deferred.pipe demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 var request = $.ajax( url, { dataType: "json" } ),
   chained = request.pipe(function( data ) {
     return $.ajax( url2, { data: { user: data.userId } } );
@@ -28221,9 +27931,6 @@ var request = $.ajax( url, { dataType: "json" } ),
 chained.done(function( data ) {
   // data retrieved from url2 as provided by the first request
 });
-</script>
-</body>
-</html>
 ```
          */
         pipe<ARD = never, AJD = never, AND = never,
@@ -28260,68 +27967,8 @@ chained.done(function( data ) {
          * **Cause**: The `.pipe()` method on a `jQuery.Deferred` object was deprecated as of jQuery 1.8, when the `.then()` method was changed to perform the same function.
          *
          * **Solution**: In most cases it is sufficient to change all occurrences of `.pipe()` to `.then()`. Ensure that you aren't relying on context/state propagation (e.g., using `this`) or synchronous callback invocation, which were dropped from `.then()` for Promises/A+ interoperability as of jQuery 3.0.
-         * @example ​ ````Filter resolve value:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>deferred.pipe demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-var defer = $.Deferred(),
-  filtered = defer.pipe(function( value ) {
-    return value * 2;
-  });
-​
-defer.resolve( 5 );
-filtered.done(function( value ) {
-  alert( "Value is ( 2*5 = ) 10: " + value );
-});
-</script>
-</body>
-</html>
-```
-         * @example ​ ````Filter reject value:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>deferred.pipe demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-var defer = $.Deferred(),
-  filtered = defer.pipe( null, function( value ) {
-    return value * 3;
-  });
-​
-defer.reject( 6 );
-filtered.fail(function( value ) {
-  alert( "Value is ( 3*6 = ) 18: " + value );
-});
-</script>
-</body>
-</html>
-```
          * @example ​ ````Chain tasks:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>deferred.pipe demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 var request = $.ajax( url, { dataType: "json" } ),
   chained = request.pipe(function( data ) {
     return $.ajax( url2, { data: { user: data.userId } } );
@@ -28330,9 +27977,6 @@ var request = $.ajax( url, { dataType: "json" } ),
 chained.done(function( data ) {
   // data retrieved from url2 as provided by the first request
 });
-</script>
-</body>
-</html>
 ```
          */
         pipe<ARP = never, AJP = never, ANP = never,
@@ -28363,17 +28007,7 @@ chained.done(function( data ) {
          *
          * **Solution**: In most cases it is sufficient to change all occurrences of `.pipe()` to `.then()`. Ensure that you aren't relying on context/state propagation (e.g., using `this`) or synchronous callback invocation, which were dropped from `.then()` for Promises/A+ interoperability as of jQuery 3.0.
          * @example ​ ````Filter resolve value:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>deferred.pipe demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 var defer = $.Deferred(),
   filtered = defer.pipe(function( value ) {
     return value * 2;
@@ -28383,22 +28017,9 @@ defer.resolve( 5 );
 filtered.done(function( value ) {
   alert( "Value is ( 2*5 = ) 10: " + value );
 });
-</script>
-</body>
-</html>
 ```
          * @example ​ ````Filter reject value:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>deferred.pipe demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 var defer = $.Deferred(),
   filtered = defer.pipe( null, function( value ) {
     return value * 3;
@@ -28408,22 +28029,9 @@ defer.reject( 6 );
 filtered.fail(function( value ) {
   alert( "Value is ( 3*6 = ) 18: " + value );
 });
-</script>
-</body>
-</html>
 ```
          * @example ​ ````Chain tasks:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>deferred.pipe demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 var request = $.ajax( url, { dataType: "json" } ),
   chained = request.pipe(function( data ) {
     return $.ajax( url2, { data: { user: data.userId } } );
@@ -28432,9 +28040,6 @@ var request = $.ajax( url, { dataType: "json" } ),
 chained.done(function( data ) {
   // data retrieved from url2 as provided by the first request
 });
-</script>
-</body>
-</html>
 ```
          */
         pipe<ARD = never, AJD = never, AND = never,
@@ -28471,43 +28076,8 @@ chained.done(function( data ) {
          * **Cause**: The `.pipe()` method on a `jQuery.Deferred` object was deprecated as of jQuery 1.8, when the `.then()` method was changed to perform the same function.
          *
          * **Solution**: In most cases it is sufficient to change all occurrences of `.pipe()` to `.then()`. Ensure that you aren't relying on context/state propagation (e.g., using `this`) or synchronous callback invocation, which were dropped from `.then()` for Promises/A+ interoperability as of jQuery 3.0.
-         * @example ​ ````Filter resolve value:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>deferred.pipe demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-var defer = $.Deferred(),
-  filtered = defer.pipe(function( value ) {
-    return value * 2;
-  });
-​
-defer.resolve( 5 );
-filtered.done(function( value ) {
-  alert( "Value is ( 2*5 = ) 10: " + value );
-});
-</script>
-</body>
-</html>
-```
          * @example ​ ````Filter reject value:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>deferred.pipe demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 var defer = $.Deferred(),
   filtered = defer.pipe( null, function( value ) {
     return value * 3;
@@ -28517,22 +28087,9 @@ defer.reject( 6 );
 filtered.fail(function( value ) {
   alert( "Value is ( 3*6 = ) 18: " + value );
 });
-</script>
-</body>
-</html>
 ```
          * @example ​ ````Chain tasks:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>deferred.pipe demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 var request = $.ajax( url, { dataType: "json" } ),
   chained = request.pipe(function( data ) {
     return $.ajax( url2, { data: { user: data.userId } } );
@@ -28541,9 +28098,6 @@ var request = $.ajax( url, { dataType: "json" } ),
 chained.done(function( data ) {
   // data retrieved from url2 as provided by the first request
 });
-</script>
-</body>
-</html>
 ```
          */
         pipe<ARF = never, AJF = never, ANF = never,
@@ -28574,17 +28128,7 @@ chained.done(function( data ) {
          *
          * **Solution**: In most cases it is sufficient to change all occurrences of `.pipe()` to `.then()`. Ensure that you aren't relying on context/state propagation (e.g., using `this`) or synchronous callback invocation, which were dropped from `.then()` for Promises/A+ interoperability as of jQuery 3.0.
          * @example ​ ````Filter resolve value:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>deferred.pipe demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 var defer = $.Deferred(),
   filtered = defer.pipe(function( value ) {
     return value * 2;
@@ -28594,47 +28138,9 @@ defer.resolve( 5 );
 filtered.done(function( value ) {
   alert( "Value is ( 2*5 = ) 10: " + value );
 });
-</script>
-</body>
-</html>
-```
-         * @example ​ ````Filter reject value:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>deferred.pipe demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-var defer = $.Deferred(),
-  filtered = defer.pipe( null, function( value ) {
-    return value * 3;
-  });
-​
-defer.reject( 6 );
-filtered.fail(function( value ) {
-  alert( "Value is ( 3*6 = ) 18: " + value );
-});
-</script>
-</body>
-</html>
 ```
          * @example ​ ````Chain tasks:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>deferred.pipe demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 var request = $.ajax( url, { dataType: "json" } ),
   chained = request.pipe(function( data ) {
     return $.ajax( url2, { data: { user: data.userId } } );
@@ -28643,9 +28149,6 @@ var request = $.ajax( url, { dataType: "json" } ),
 chained.done(function( data ) {
   // data retrieved from url2 as provided by the first request
 });
-</script>
-</body>
-</html>
 ```
          */
         pipe<ARD = never, AJD = never, AND = never,
@@ -28676,17 +28179,7 @@ chained.done(function( data ) {
          * @see \`{@link https://api.jquery.com/deferred.then/ }\`
          * @since 1.8
          * @example ​ ````Since the jQuery.get method returns a jqXHR object, which is derived from a Deferred object, we can attach handlers using the .then method.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>deferred.then demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $.get( "test.php" ).then(
   function() {
     alert( "$.get succeeded" );
@@ -28694,9 +28187,6 @@ $.get( "test.php" ).then(
     alert( "$.get failed!" );
   }
 );
-</script>
-</body>
-</html>
 ```
          * @example ​ ````Filter the resolve value:
 ```html
@@ -28727,21 +28217,12 @@ var filterResolve = function() {
 ​
 $( "button" ).on( "click", filterResolve );
 </script>
+​
 </body>
 </html>
 ```
          * @example ​ ````Filter reject value:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>deferred.then demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 var defer = $.Deferred(),
   filtered = defer.then( null, function( value ) {
     return value * 3;
@@ -28751,22 +28232,9 @@ defer.reject( 6 );
 filtered.fail(function( value ) {
   alert( "Value is ( 3*6 = ) 18: " + value );
 });
-</script>
-</body>
-</html>
 ```
          * @example ​ ````Chain tasks:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>deferred.then demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 var request = $.ajax( url, { dataType: "json" } ),
   chained = request.then(function( data ) {
     return $.ajax( url2, { data: { user: data.userId } } );
@@ -28775,9 +28243,6 @@ var request = $.ajax( url, { dataType: "json" } ),
 chained.done(function( data ) {
   // data retrieved from url2 as provided by the first request
 });
-</script>
-</body>
-</html>
 ```
          */
         then<ARD = never, AJD = never, AND = never,
@@ -28815,73 +28280,8 @@ chained.done(function( data ) {
          * @param progressFilter An optional function that is called when progress notifications are sent to the Deferred.
          * @see \`{@link https://api.jquery.com/deferred.then/ }\`
          * @since 1.8
-         * @example ​ ````Since the jQuery.get method returns a jqXHR object, which is derived from a Deferred object, we can attach handlers using the .then method.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>deferred.then demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$.get( "test.php" ).then(
-  function() {
-    alert( "$.get succeeded" );
-  }, function() {
-    alert( "$.get failed!" );
-  }
-);
-</script>
-</body>
-</html>
-```
-         * @example ​ ````Filter the resolve value:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>deferred.then demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<button>Filter Resolve</button>
-<p></p>
-​
-<script>
-var filterResolve = function() {
-  var defer = $.Deferred(),
-    filtered = defer.then(function( value ) {
-      return value * 2;
-    });
-​
-  defer.resolve( 5 );
-  filtered.done(function( value ) {
-    $( "p" ).html( "Value is ( 2*5 = ) 10: " + value );
-  });
-};
-​
-$( "button" ).on( "click", filterResolve );
-</script>
-</body>
-</html>
-```
          * @example ​ ````Filter reject value:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>deferred.then demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 var defer = $.Deferred(),
   filtered = defer.then( null, function( value ) {
     return value * 3;
@@ -28891,22 +28291,9 @@ defer.reject( 6 );
 filtered.fail(function( value ) {
   alert( "Value is ( 3*6 = ) 18: " + value );
 });
-</script>
-</body>
-</html>
 ```
          * @example ​ ````Chain tasks:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>deferred.then demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 var request = $.ajax( url, { dataType: "json" } ),
   chained = request.then(function( data ) {
     return $.ajax( url2, { data: { user: data.userId } } );
@@ -28915,9 +28302,6 @@ var request = $.ajax( url, { dataType: "json" } ),
 chained.done(function( data ) {
   // data retrieved from url2 as provided by the first request
 });
-</script>
-</body>
-</html>
 ```
          */
         then<ARF = never, AJF = never, ANF = never,
@@ -28948,29 +28332,6 @@ chained.done(function( data ) {
          * @param progressFilter An optional function that is called when progress notifications are sent to the Deferred.
          * @see \`{@link https://api.jquery.com/deferred.then/ }\`
          * @since 1.8
-         * @example ​ ````Since the jQuery.get method returns a jqXHR object, which is derived from a Deferred object, we can attach handlers using the .then method.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>deferred.then demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$.get( "test.php" ).then(
-  function() {
-    alert( "$.get succeeded" );
-  }, function() {
-    alert( "$.get failed!" );
-  }
-);
-</script>
-</body>
-</html>
-```
          * @example ​ ````Filter the resolve value:
 ```html
 <!doctype html>
@@ -29000,46 +28361,12 @@ var filterResolve = function() {
 ​
 $( "button" ).on( "click", filterResolve );
 </script>
-</body>
-</html>
-```
-         * @example ​ ````Filter reject value:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>deferred.then demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-var defer = $.Deferred(),
-  filtered = defer.then( null, function( value ) {
-    return value * 3;
-  });
 ​
-defer.reject( 6 );
-filtered.fail(function( value ) {
-  alert( "Value is ( 3*6 = ) 18: " + value );
-});
-</script>
 </body>
 </html>
 ```
          * @example ​ ````Chain tasks:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>deferred.then demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 var request = $.ajax( url, { dataType: "json" } ),
   chained = request.then(function( data ) {
     return $.ajax( url2, { data: { user: data.userId } } );
@@ -29048,9 +28375,6 @@ var request = $.ajax( url, { dataType: "json" } ),
 chained.done(function( data ) {
   // data retrieved from url2 as provided by the first request
 });
-</script>
-</body>
-</html>
 ```
          */
         then<ARD = never, AJD = never, AND = never,
@@ -29081,98 +28405,8 @@ chained.done(function( data ) {
          * @param progressFilter An optional function that is called when progress notifications are sent to the Deferred.
          * @see \`{@link https://api.jquery.com/deferred.then/ }\`
          * @since 1.8
-         * @example ​ ````Since the jQuery.get method returns a jqXHR object, which is derived from a Deferred object, we can attach handlers using the .then method.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>deferred.then demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$.get( "test.php" ).then(
-  function() {
-    alert( "$.get succeeded" );
-  }, function() {
-    alert( "$.get failed!" );
-  }
-);
-</script>
-</body>
-</html>
-```
-         * @example ​ ````Filter the resolve value:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>deferred.then demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<button>Filter Resolve</button>
-<p></p>
-​
-<script>
-var filterResolve = function() {
-  var defer = $.Deferred(),
-    filtered = defer.then(function( value ) {
-      return value * 2;
-    });
-​
-  defer.resolve( 5 );
-  filtered.done(function( value ) {
-    $( "p" ).html( "Value is ( 2*5 = ) 10: " + value );
-  });
-};
-​
-$( "button" ).on( "click", filterResolve );
-</script>
-</body>
-</html>
-```
-         * @example ​ ````Filter reject value:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>deferred.then demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-var defer = $.Deferred(),
-  filtered = defer.then( null, function( value ) {
-    return value * 3;
-  });
-​
-defer.reject( 6 );
-filtered.fail(function( value ) {
-  alert( "Value is ( 3*6 = ) 18: " + value );
-});
-</script>
-</body>
-</html>
-```
          * @example ​ ````Chain tasks:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>deferred.then demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 var request = $.ajax( url, { dataType: "json" } ),
   chained = request.then(function( data ) {
     return $.ajax( url2, { data: { user: data.userId } } );
@@ -29181,9 +28415,6 @@ var request = $.ajax( url, { dataType: "json" } ),
 chained.done(function( data ) {
   // data retrieved from url2 as provided by the first request
 });
-</script>
-</body>
-</html>
 ```
          */
         then<ARP = never, AJP = never, ANP = never,
@@ -29208,17 +28439,7 @@ chained.done(function( data ) {
          * @see \`{@link https://api.jquery.com/deferred.then/ }\`
          * @since 1.8
          * @example ​ ````Since the jQuery.get method returns a jqXHR object, which is derived from a Deferred object, we can attach handlers using the .then method.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>deferred.then demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $.get( "test.php" ).then(
   function() {
     alert( "$.get succeeded" );
@@ -29226,9 +28447,6 @@ $.get( "test.php" ).then(
     alert( "$.get failed!" );
   }
 );
-</script>
-</body>
-</html>
 ```
          * @example ​ ````Filter the resolve value:
 ```html
@@ -29259,21 +28477,12 @@ var filterResolve = function() {
 ​
 $( "button" ).on( "click", filterResolve );
 </script>
+​
 </body>
 </html>
 ```
          * @example ​ ````Filter reject value:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>deferred.then demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 var defer = $.Deferred(),
   filtered = defer.then( null, function( value ) {
     return value * 3;
@@ -29283,22 +28492,9 @@ defer.reject( 6 );
 filtered.fail(function( value ) {
   alert( "Value is ( 3*6 = ) 18: " + value );
 });
-</script>
-</body>
-</html>
 ```
          * @example ​ ````Chain tasks:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>deferred.then demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 var request = $.ajax( url, { dataType: "json" } ),
   chained = request.then(function( data ) {
     return $.ajax( url2, { data: { user: data.userId } } );
@@ -29307,9 +28503,6 @@ var request = $.ajax( url, { dataType: "json" } ),
 chained.done(function( data ) {
   // data retrieved from url2 as provided by the first request
 });
-</script>
-</body>
-</html>
 ```
          */
         then<ARD = never, AJD = never, AND = never,
@@ -29340,73 +28533,8 @@ chained.done(function( data ) {
          * @param progressFilter An optional function that is called when progress notifications are sent to the Deferred.
          * @see \`{@link https://api.jquery.com/deferred.then/ }\`
          * @since 1.8
-         * @example ​ ````Since the jQuery.get method returns a jqXHR object, which is derived from a Deferred object, we can attach handlers using the .then method.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>deferred.then demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$.get( "test.php" ).then(
-  function() {
-    alert( "$.get succeeded" );
-  }, function() {
-    alert( "$.get failed!" );
-  }
-);
-</script>
-</body>
-</html>
-```
-         * @example ​ ````Filter the resolve value:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>deferred.then demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<button>Filter Resolve</button>
-<p></p>
-​
-<script>
-var filterResolve = function() {
-  var defer = $.Deferred(),
-    filtered = defer.then(function( value ) {
-      return value * 2;
-    });
-​
-  defer.resolve( 5 );
-  filtered.done(function( value ) {
-    $( "p" ).html( "Value is ( 2*5 = ) 10: " + value );
-  });
-};
-​
-$( "button" ).on( "click", filterResolve );
-</script>
-</body>
-</html>
-```
          * @example ​ ````Filter reject value:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>deferred.then demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 var defer = $.Deferred(),
   filtered = defer.then( null, function( value ) {
     return value * 3;
@@ -29416,22 +28544,9 @@ defer.reject( 6 );
 filtered.fail(function( value ) {
   alert( "Value is ( 3*6 = ) 18: " + value );
 });
-</script>
-</body>
-</html>
 ```
          * @example ​ ````Chain tasks:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>deferred.then demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 var request = $.ajax( url, { dataType: "json" } ),
   chained = request.then(function( data ) {
     return $.ajax( url2, { data: { user: data.userId } } );
@@ -29440,9 +28555,6 @@ var request = $.ajax( url, { dataType: "json" } ),
 chained.done(function( data ) {
   // data retrieved from url2 as provided by the first request
 });
-</script>
-</body>
-</html>
 ```
          */
         then<ARF = never, AJF = never, ANF = never,
@@ -29466,29 +28578,6 @@ chained.done(function( data ) {
          * @param progressFilter An optional function that is called when progress notifications are sent to the Deferred.
          * @see \`{@link https://api.jquery.com/deferred.then/ }\`
          * @since 1.8
-         * @example ​ ````Since the jQuery.get method returns a jqXHR object, which is derived from a Deferred object, we can attach handlers using the .then method.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>deferred.then demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$.get( "test.php" ).then(
-  function() {
-    alert( "$.get succeeded" );
-  }, function() {
-    alert( "$.get failed!" );
-  }
-);
-</script>
-</body>
-</html>
-```
          * @example ​ ````Filter the resolve value:
 ```html
 <!doctype html>
@@ -29518,46 +28607,12 @@ var filterResolve = function() {
 ​
 $( "button" ).on( "click", filterResolve );
 </script>
-</body>
-</html>
-```
-         * @example ​ ````Filter reject value:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>deferred.then demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-var defer = $.Deferred(),
-  filtered = defer.then( null, function( value ) {
-    return value * 3;
-  });
 ​
-defer.reject( 6 );
-filtered.fail(function( value ) {
-  alert( "Value is ( 3*6 = ) 18: " + value );
-});
-</script>
 </body>
 </html>
 ```
          * @example ​ ````Chain tasks:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>deferred.then demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 var request = $.ajax( url, { dataType: "json" } ),
   chained = request.then(function( data ) {
     return $.ajax( url2, { data: { user: data.userId } } );
@@ -29566,9 +28621,6 @@ var request = $.ajax( url, { dataType: "json" } ),
 chained.done(function( data ) {
   // data retrieved from url2 as provided by the first request
 });
-</script>
-</body>
-</html>
 ```
          */
         then<ARD = never, AJD = never, AND = never,
@@ -29594,17 +28646,7 @@ chained.done(function( data ) {
          * @see \`{@link https://api.jquery.com/deferred.catch/ }\`
          * @since 3.0
          * @example ​ ````Since the jQuery.get method returns a jqXHR object, which is derived from a Deferred object, we can rejection handlers using the .catch method.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>deferred.catch demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $.get( "test.php" )
   .then( function() {
     alert( "$.get succeeded" );
@@ -29612,9 +28654,6 @@ $.get( "test.php" )
   .catch( function() {
     alert( "$.get failed!" );
   } );
-</script>
-</body>
-</html>
 ```
          */
         catch<ARF = never, AJF = never, ANF = never,
@@ -29742,23 +28781,10 @@ $.get( "test.php" )
          * @see \`{@link https://api.jquery.com/deferred.always/ }\`
          * @since 1.6
          * @example ​ ````Since the jQuery.get() method returns a jqXHR object, which is derived from a Deferred object, we can attach a callback for both success and error using the deferred.always() method.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>deferred.always demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $.get( "test.php" ).always(function() {
   alert( "$.get completed with success or error callback arguments" );
 });
-</script>
-</body>
-</html>
 ```
          */
         always(alwaysCallback: TypeOrArray<Deferred.Callback<TR | TJ>>,
@@ -29771,23 +28797,10 @@ $.get( "test.php" ).always(function() {
          * @see \`{@link https://api.jquery.com/deferred.done/ }\`
          * @since 1.5
          * @example ​ ````Since the jQuery.get method returns a jqXHR object, which is derived from a Deferred object, we can attach a success callback using the .done() method.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>deferred.done demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $.get( "test.php" ).done(function() {
   alert( "$.get succeeded" );
 });
-</script>
-</body>
-</html>
 ```
          * @example ​ ````Resolve a Deferred object when the user clicks a button, triggering a number of callback functions:
 ```html
@@ -29832,6 +28845,7 @@ $( "button" ).on( "click", function() {
   dfd.resolve( "and" );
 });
 </script>
+​
 </body>
 </html>
 ```
@@ -29846,17 +28860,7 @@ $( "button" ).on( "click", function() {
          * @see \`{@link https://api.jquery.com/deferred.fail/ }\`
          * @since 1.5
          * @example ​ ````Since the jQuery.get method returns a jqXHR object, which is derived from a Deferred, you can attach a success and failure callback using the deferred.done() and deferred.fail() methods.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>deferred.fail demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $.get( "test.php" )
   .done(function() {
     alert( "$.get succeeded" );
@@ -29864,9 +28868,6 @@ $.get( "test.php" )
   .fail(function() {
     alert( "$.get failed!" );
   });
-</script>
-</body>
-</html>
 ```
          */
         fail(failCallback: TypeOrArray<Deferred.Callback<TJ>>,
@@ -29888,71 +28889,8 @@ $.get( "test.php" )
          * @param target Object onto which the promise methods have to be attached
          * @see \`{@link https://api.jquery.com/deferred.promise/ }\`
          * @since 1.5
-         * @example ​ ````Create a Deferred and set two timer-based functions to either resolve or reject the Deferred after a random interval. Whichever one fires first &quot;wins&quot; and will call one of the callbacks. The second timeout has no effect since the Deferred is already complete (in a resolved or rejected state) from the first timeout action. Also set a timer-based progress notification function, and call a progress handler that adds &quot;working...&quot; to the document body.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>deferred.promise demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-function asyncEvent() {
-  var dfd = jQuery.Deferred();
-​
-  // Resolve after a random interval
-  setTimeout(function() {
-    dfd.resolve( "hurray" );
-  }, Math.floor( 400 + Math.random() * 2000 ) );
-​
-  // Reject after a random interval
-  setTimeout(function() {
-    dfd.reject( "sorry" );
-  }, Math.floor( 400 + Math.random() * 2000 ) );
-​
-  // Show a "working..." message every half-second
-  setTimeout(function working() {
-    if ( dfd.state() === "pending" ) {
-      dfd.notify( "working... " );
-      setTimeout( working, 500 );
-    }
-  }, 1 );
-​
-  // Return the Promise so caller can't change the Deferred
-  return dfd.promise();
-}
-​
-// Attach a done, fail, and progress handler for the asyncEvent
-$.when( asyncEvent() ).then(
-  function( status ) {
-    alert( status + ", things are going well" );
-  },
-  function( status ) {
-    alert( status + ", you fail this time" );
-  },
-  function( status ) {
-    $( "body" ).append( status );
-  }
-);
-</script>
-</body>
-</html>
-```
          * @example ​ ````Use the target argument to promote an existing object to a Promise:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>deferred.promise demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 // Existing object
 var obj = {
     hello: function( name ) {
@@ -29972,9 +28910,6 @@ defer.resolve( "John" );
 obj.done(function( name ) {
   obj.hello( name ); // Will alert "Hello John"
 }).hello( "Karl" ); // Will alert "Hello Karl"
-</script>
-</body>
-</html>
 ```
          */
         promise<TTarget extends object>(target: TTarget): Promise<TR, TJ, TN> & TTarget;
@@ -29984,17 +28919,7 @@ obj.done(function( name ) {
          * @see \`{@link https://api.jquery.com/deferred.promise/ }\`
          * @since 1.5
          * @example ​ ````Create a Deferred and set two timer-based functions to either resolve or reject the Deferred after a random interval. Whichever one fires first &quot;wins&quot; and will call one of the callbacks. The second timeout has no effect since the Deferred is already complete (in a resolved or rejected state) from the first timeout action. Also set a timer-based progress notification function, and call a progress handler that adds &quot;working...&quot; to the document body.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>deferred.promise demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 function asyncEvent() {
   var dfd = jQuery.Deferred();
 ​
@@ -30032,44 +28957,6 @@ $.when( asyncEvent() ).then(
     $( "body" ).append( status );
   }
 );
-</script>
-</body>
-</html>
-```
-         * @example ​ ````Use the target argument to promote an existing object to a Promise:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>deferred.promise demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-// Existing object
-var obj = {
-    hello: function( name ) {
-      alert( "Hello " + name );
-    }
-  },
-  // Create a Deferred
-  defer = $.Deferred();
-​
-// Set object as a promise
-defer.promise( obj );
-​
-// Resolve the deferred
-defer.resolve( "John" );
-​
-// Use the object as a Promise
-obj.done(function( name ) {
-  obj.hello( name ); // Will alert "Hello John"
-}).hello( "Karl" ); // Will alert "Hello Karl"
-</script>
-</body>
-</html>
 ```
          */
         promise(): Promise<TR, TJ, TN>;
@@ -30099,17 +28986,7 @@ obj.done(function( name ) {
          *
          * **Solution**: In most cases it is sufficient to change all occurrences of `.pipe()` to `.then()`. Ensure that you aren't relying on context/state propagation (e.g., using `this`) or synchronous callback invocation, which were dropped from `.then()` for Promises/A+ interoperability as of jQuery 3.0.
          * @example ​ ````Filter resolve value:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>deferred.pipe demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 var defer = $.Deferred(),
   filtered = defer.pipe(function( value ) {
     return value * 2;
@@ -30119,22 +28996,9 @@ defer.resolve( 5 );
 filtered.done(function( value ) {
   alert( "Value is ( 2*5 = ) 10: " + value );
 });
-</script>
-</body>
-</html>
 ```
          * @example ​ ````Filter reject value:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>deferred.pipe demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 var defer = $.Deferred(),
   filtered = defer.pipe( null, function( value ) {
     return value * 3;
@@ -30144,22 +29008,9 @@ defer.reject( 6 );
 filtered.fail(function( value ) {
   alert( "Value is ( 3*6 = ) 18: " + value );
 });
-</script>
-</body>
-</html>
 ```
          * @example ​ ````Chain tasks:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>deferred.pipe demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 var request = $.ajax( url, { dataType: "json" } ),
   chained = request.pipe(function( data ) {
     return $.ajax( url2, { data: { user: data.userId } } );
@@ -30168,9 +29019,6 @@ var request = $.ajax( url, { dataType: "json" } ),
 chained.done(function( data ) {
   // data retrieved from url2 as provided by the first request
 });
-</script>
-</body>
-</html>
 ```
          */
         pipe<ARD = never, AJD = never, AND = never,
@@ -30214,43 +29062,8 @@ chained.done(function( data ) {
          * **Cause**: The `.pipe()` method on a `jQuery.Deferred` object was deprecated as of jQuery 1.8, when the `.then()` method was changed to perform the same function.
          *
          * **Solution**: In most cases it is sufficient to change all occurrences of `.pipe()` to `.then()`. Ensure that you aren't relying on context/state propagation (e.g., using `this`) or synchronous callback invocation, which were dropped from `.then()` for Promises/A+ interoperability as of jQuery 3.0.
-         * @example ​ ````Filter resolve value:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>deferred.pipe demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-var defer = $.Deferred(),
-  filtered = defer.pipe(function( value ) {
-    return value * 2;
-  });
-​
-defer.resolve( 5 );
-filtered.done(function( value ) {
-  alert( "Value is ( 2*5 = ) 10: " + value );
-});
-</script>
-</body>
-</html>
-```
          * @example ​ ````Filter reject value:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>deferred.pipe demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 var defer = $.Deferred(),
   filtered = defer.pipe( null, function( value ) {
     return value * 3;
@@ -30260,22 +29073,9 @@ defer.reject( 6 );
 filtered.fail(function( value ) {
   alert( "Value is ( 3*6 = ) 18: " + value );
 });
-</script>
-</body>
-</html>
 ```
          * @example ​ ````Chain tasks:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>deferred.pipe demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 var request = $.ajax( url, { dataType: "json" } ),
   chained = request.pipe(function( data ) {
     return $.ajax( url2, { data: { user: data.userId } } );
@@ -30284,9 +29084,6 @@ var request = $.ajax( url, { dataType: "json" } ),
 chained.done(function( data ) {
   // data retrieved from url2 as provided by the first request
 });
-</script>
-</body>
-</html>
 ```
          */
         pipe<ARF = never, AJF = never, ANF = never,
@@ -30324,17 +29121,7 @@ chained.done(function( data ) {
          *
          * **Solution**: In most cases it is sufficient to change all occurrences of `.pipe()` to `.then()`. Ensure that you aren't relying on context/state propagation (e.g., using `this`) or synchronous callback invocation, which were dropped from `.then()` for Promises/A+ interoperability as of jQuery 3.0.
          * @example ​ ````Filter resolve value:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>deferred.pipe demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 var defer = $.Deferred(),
   filtered = defer.pipe(function( value ) {
     return value * 2;
@@ -30344,47 +29131,9 @@ defer.resolve( 5 );
 filtered.done(function( value ) {
   alert( "Value is ( 2*5 = ) 10: " + value );
 });
-</script>
-</body>
-</html>
-```
-         * @example ​ ````Filter reject value:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>deferred.pipe demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-var defer = $.Deferred(),
-  filtered = defer.pipe( null, function( value ) {
-    return value * 3;
-  });
-​
-defer.reject( 6 );
-filtered.fail(function( value ) {
-  alert( "Value is ( 3*6 = ) 18: " + value );
-});
-</script>
-</body>
-</html>
 ```
          * @example ​ ````Chain tasks:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>deferred.pipe demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 var request = $.ajax( url, { dataType: "json" } ),
   chained = request.pipe(function( data ) {
     return $.ajax( url2, { data: { user: data.userId } } );
@@ -30393,9 +29142,6 @@ var request = $.ajax( url, { dataType: "json" } ),
 chained.done(function( data ) {
   // data retrieved from url2 as provided by the first request
 });
-</script>
-</body>
-</html>
 ```
          */
         pipe<ARD = never, AJD = never, AND = never,
@@ -30432,68 +29178,8 @@ chained.done(function( data ) {
          * **Cause**: The `.pipe()` method on a `jQuery.Deferred` object was deprecated as of jQuery 1.8, when the `.then()` method was changed to perform the same function.
          *
          * **Solution**: In most cases it is sufficient to change all occurrences of `.pipe()` to `.then()`. Ensure that you aren't relying on context/state propagation (e.g., using `this`) or synchronous callback invocation, which were dropped from `.then()` for Promises/A+ interoperability as of jQuery 3.0.
-         * @example ​ ````Filter resolve value:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>deferred.pipe demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-var defer = $.Deferred(),
-  filtered = defer.pipe(function( value ) {
-    return value * 2;
-  });
-​
-defer.resolve( 5 );
-filtered.done(function( value ) {
-  alert( "Value is ( 2*5 = ) 10: " + value );
-});
-</script>
-</body>
-</html>
-```
-         * @example ​ ````Filter reject value:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>deferred.pipe demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-var defer = $.Deferred(),
-  filtered = defer.pipe( null, function( value ) {
-    return value * 3;
-  });
-​
-defer.reject( 6 );
-filtered.fail(function( value ) {
-  alert( "Value is ( 3*6 = ) 18: " + value );
-});
-</script>
-</body>
-</html>
-```
          * @example ​ ````Chain tasks:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>deferred.pipe demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 var request = $.ajax( url, { dataType: "json" } ),
   chained = request.pipe(function( data ) {
     return $.ajax( url2, { data: { user: data.userId } } );
@@ -30502,9 +29188,6 @@ var request = $.ajax( url, { dataType: "json" } ),
 chained.done(function( data ) {
   // data retrieved from url2 as provided by the first request
 });
-</script>
-</body>
-</html>
 ```
          */
         pipe<ARP = never, AJP = never, ANP = never,
@@ -30535,17 +29218,7 @@ chained.done(function( data ) {
          *
          * **Solution**: In most cases it is sufficient to change all occurrences of `.pipe()` to `.then()`. Ensure that you aren't relying on context/state propagation (e.g., using `this`) or synchronous callback invocation, which were dropped from `.then()` for Promises/A+ interoperability as of jQuery 3.0.
          * @example ​ ````Filter resolve value:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>deferred.pipe demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 var defer = $.Deferred(),
   filtered = defer.pipe(function( value ) {
     return value * 2;
@@ -30555,22 +29228,9 @@ defer.resolve( 5 );
 filtered.done(function( value ) {
   alert( "Value is ( 2*5 = ) 10: " + value );
 });
-</script>
-</body>
-</html>
 ```
          * @example ​ ````Filter reject value:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>deferred.pipe demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 var defer = $.Deferred(),
   filtered = defer.pipe( null, function( value ) {
     return value * 3;
@@ -30580,22 +29240,9 @@ defer.reject( 6 );
 filtered.fail(function( value ) {
   alert( "Value is ( 3*6 = ) 18: " + value );
 });
-</script>
-</body>
-</html>
 ```
          * @example ​ ````Chain tasks:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>deferred.pipe demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 var request = $.ajax( url, { dataType: "json" } ),
   chained = request.pipe(function( data ) {
     return $.ajax( url2, { data: { user: data.userId } } );
@@ -30604,9 +29251,6 @@ var request = $.ajax( url, { dataType: "json" } ),
 chained.done(function( data ) {
   // data retrieved from url2 as provided by the first request
 });
-</script>
-</body>
-</html>
 ```
          */
         pipe<ARD = never, AJD = never, AND = never,
@@ -30643,43 +29287,8 @@ chained.done(function( data ) {
          * **Cause**: The `.pipe()` method on a `jQuery.Deferred` object was deprecated as of jQuery 1.8, when the `.then()` method was changed to perform the same function.
          *
          * **Solution**: In most cases it is sufficient to change all occurrences of `.pipe()` to `.then()`. Ensure that you aren't relying on context/state propagation (e.g., using `this`) or synchronous callback invocation, which were dropped from `.then()` for Promises/A+ interoperability as of jQuery 3.0.
-         * @example ​ ````Filter resolve value:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>deferred.pipe demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-var defer = $.Deferred(),
-  filtered = defer.pipe(function( value ) {
-    return value * 2;
-  });
-​
-defer.resolve( 5 );
-filtered.done(function( value ) {
-  alert( "Value is ( 2*5 = ) 10: " + value );
-});
-</script>
-</body>
-</html>
-```
          * @example ​ ````Filter reject value:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>deferred.pipe demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 var defer = $.Deferred(),
   filtered = defer.pipe( null, function( value ) {
     return value * 3;
@@ -30689,22 +29298,9 @@ defer.reject( 6 );
 filtered.fail(function( value ) {
   alert( "Value is ( 3*6 = ) 18: " + value );
 });
-</script>
-</body>
-</html>
 ```
          * @example ​ ````Chain tasks:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>deferred.pipe demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 var request = $.ajax( url, { dataType: "json" } ),
   chained = request.pipe(function( data ) {
     return $.ajax( url2, { data: { user: data.userId } } );
@@ -30713,9 +29309,6 @@ var request = $.ajax( url, { dataType: "json" } ),
 chained.done(function( data ) {
   // data retrieved from url2 as provided by the first request
 });
-</script>
-</body>
-</html>
 ```
          */
         pipe<ARF = never, AJF = never, ANF = never,
@@ -30746,17 +29339,7 @@ chained.done(function( data ) {
          *
          * **Solution**: In most cases it is sufficient to change all occurrences of `.pipe()` to `.then()`. Ensure that you aren't relying on context/state propagation (e.g., using `this`) or synchronous callback invocation, which were dropped from `.then()` for Promises/A+ interoperability as of jQuery 3.0.
          * @example ​ ````Filter resolve value:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>deferred.pipe demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 var defer = $.Deferred(),
   filtered = defer.pipe(function( value ) {
     return value * 2;
@@ -30766,47 +29349,9 @@ defer.resolve( 5 );
 filtered.done(function( value ) {
   alert( "Value is ( 2*5 = ) 10: " + value );
 });
-</script>
-</body>
-</html>
-```
-         * @example ​ ````Filter reject value:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>deferred.pipe demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-var defer = $.Deferred(),
-  filtered = defer.pipe( null, function( value ) {
-    return value * 3;
-  });
-​
-defer.reject( 6 );
-filtered.fail(function( value ) {
-  alert( "Value is ( 3*6 = ) 18: " + value );
-});
-</script>
-</body>
-</html>
 ```
          * @example ​ ````Chain tasks:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>deferred.pipe demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 var request = $.ajax( url, { dataType: "json" } ),
   chained = request.pipe(function( data ) {
     return $.ajax( url2, { data: { user: data.userId } } );
@@ -30815,9 +29360,6 @@ var request = $.ajax( url, { dataType: "json" } ),
 chained.done(function( data ) {
   // data retrieved from url2 as provided by the first request
 });
-</script>
-</body>
-</html>
 ```
          */
         pipe<ARD = never, AJD = never, AND = never,
@@ -30848,17 +29390,7 @@ chained.done(function( data ) {
          * @see \`{@link https://api.jquery.com/deferred.then/ }\`
          * @since 1.8
          * @example ​ ````Since the jQuery.get method returns a jqXHR object, which is derived from a Deferred object, we can attach handlers using the .then method.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>deferred.then demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $.get( "test.php" ).then(
   function() {
     alert( "$.get succeeded" );
@@ -30866,9 +29398,6 @@ $.get( "test.php" ).then(
     alert( "$.get failed!" );
   }
 );
-</script>
-</body>
-</html>
 ```
          * @example ​ ````Filter the resolve value:
 ```html
@@ -30899,21 +29428,12 @@ var filterResolve = function() {
 ​
 $( "button" ).on( "click", filterResolve );
 </script>
+​
 </body>
 </html>
 ```
          * @example ​ ````Filter reject value:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>deferred.then demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 var defer = $.Deferred(),
   filtered = defer.then( null, function( value ) {
     return value * 3;
@@ -30923,22 +29443,9 @@ defer.reject( 6 );
 filtered.fail(function( value ) {
   alert( "Value is ( 3*6 = ) 18: " + value );
 });
-</script>
-</body>
-</html>
 ```
          * @example ​ ````Chain tasks:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>deferred.then demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 var request = $.ajax( url, { dataType: "json" } ),
   chained = request.then(function( data ) {
     return $.ajax( url2, { data: { user: data.userId } } );
@@ -30947,9 +29454,6 @@ var request = $.ajax( url, { dataType: "json" } ),
 chained.done(function( data ) {
   // data retrieved from url2 as provided by the first request
 });
-</script>
-</body>
-</html>
 ```
          */
         then<ARD = never, AJD = never, AND = never,
@@ -30987,73 +29491,8 @@ chained.done(function( data ) {
          * @param progressFilter An optional function that is called when progress notifications are sent to the Deferred.
          * @see \`{@link https://api.jquery.com/deferred.then/ }\`
          * @since 1.8
-         * @example ​ ````Since the jQuery.get method returns a jqXHR object, which is derived from a Deferred object, we can attach handlers using the .then method.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>deferred.then demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$.get( "test.php" ).then(
-  function() {
-    alert( "$.get succeeded" );
-  }, function() {
-    alert( "$.get failed!" );
-  }
-);
-</script>
-</body>
-</html>
-```
-         * @example ​ ````Filter the resolve value:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>deferred.then demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<button>Filter Resolve</button>
-<p></p>
-​
-<script>
-var filterResolve = function() {
-  var defer = $.Deferred(),
-    filtered = defer.then(function( value ) {
-      return value * 2;
-    });
-​
-  defer.resolve( 5 );
-  filtered.done(function( value ) {
-    $( "p" ).html( "Value is ( 2*5 = ) 10: " + value );
-  });
-};
-​
-$( "button" ).on( "click", filterResolve );
-</script>
-</body>
-</html>
-```
          * @example ​ ````Filter reject value:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>deferred.then demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 var defer = $.Deferred(),
   filtered = defer.then( null, function( value ) {
     return value * 3;
@@ -31063,22 +29502,9 @@ defer.reject( 6 );
 filtered.fail(function( value ) {
   alert( "Value is ( 3*6 = ) 18: " + value );
 });
-</script>
-</body>
-</html>
 ```
          * @example ​ ````Chain tasks:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>deferred.then demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 var request = $.ajax( url, { dataType: "json" } ),
   chained = request.then(function( data ) {
     return $.ajax( url2, { data: { user: data.userId } } );
@@ -31087,9 +29513,6 @@ var request = $.ajax( url, { dataType: "json" } ),
 chained.done(function( data ) {
   // data retrieved from url2 as provided by the first request
 });
-</script>
-</body>
-</html>
 ```
          */
         then<ARF = never, AJF = never, ANF = never,
@@ -31120,29 +29543,6 @@ chained.done(function( data ) {
          * @param progressFilter An optional function that is called when progress notifications are sent to the Deferred.
          * @see \`{@link https://api.jquery.com/deferred.then/ }\`
          * @since 1.8
-         * @example ​ ````Since the jQuery.get method returns a jqXHR object, which is derived from a Deferred object, we can attach handlers using the .then method.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>deferred.then demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$.get( "test.php" ).then(
-  function() {
-    alert( "$.get succeeded" );
-  }, function() {
-    alert( "$.get failed!" );
-  }
-);
-</script>
-</body>
-</html>
-```
          * @example ​ ````Filter the resolve value:
 ```html
 <!doctype html>
@@ -31172,46 +29572,12 @@ var filterResolve = function() {
 ​
 $( "button" ).on( "click", filterResolve );
 </script>
-</body>
-</html>
-```
-         * @example ​ ````Filter reject value:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>deferred.then demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-var defer = $.Deferred(),
-  filtered = defer.then( null, function( value ) {
-    return value * 3;
-  });
 ​
-defer.reject( 6 );
-filtered.fail(function( value ) {
-  alert( "Value is ( 3*6 = ) 18: " + value );
-});
-</script>
 </body>
 </html>
 ```
          * @example ​ ````Chain tasks:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>deferred.then demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 var request = $.ajax( url, { dataType: "json" } ),
   chained = request.then(function( data ) {
     return $.ajax( url2, { data: { user: data.userId } } );
@@ -31220,9 +29586,6 @@ var request = $.ajax( url, { dataType: "json" } ),
 chained.done(function( data ) {
   // data retrieved from url2 as provided by the first request
 });
-</script>
-</body>
-</html>
 ```
          */
         then<ARD = never, AJD = never, AND = never,
@@ -31253,98 +29616,8 @@ chained.done(function( data ) {
          * @param progressFilter An optional function that is called when progress notifications are sent to the Deferred.
          * @see \`{@link https://api.jquery.com/deferred.then/ }\`
          * @since 1.8
-         * @example ​ ````Since the jQuery.get method returns a jqXHR object, which is derived from a Deferred object, we can attach handlers using the .then method.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>deferred.then demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$.get( "test.php" ).then(
-  function() {
-    alert( "$.get succeeded" );
-  }, function() {
-    alert( "$.get failed!" );
-  }
-);
-</script>
-</body>
-</html>
-```
-         * @example ​ ````Filter the resolve value:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>deferred.then demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<button>Filter Resolve</button>
-<p></p>
-​
-<script>
-var filterResolve = function() {
-  var defer = $.Deferred(),
-    filtered = defer.then(function( value ) {
-      return value * 2;
-    });
-​
-  defer.resolve( 5 );
-  filtered.done(function( value ) {
-    $( "p" ).html( "Value is ( 2*5 = ) 10: " + value );
-  });
-};
-​
-$( "button" ).on( "click", filterResolve );
-</script>
-</body>
-</html>
-```
-         * @example ​ ````Filter reject value:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>deferred.then demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-var defer = $.Deferred(),
-  filtered = defer.then( null, function( value ) {
-    return value * 3;
-  });
-​
-defer.reject( 6 );
-filtered.fail(function( value ) {
-  alert( "Value is ( 3*6 = ) 18: " + value );
-});
-</script>
-</body>
-</html>
-```
          * @example ​ ````Chain tasks:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>deferred.then demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 var request = $.ajax( url, { dataType: "json" } ),
   chained = request.then(function( data ) {
     return $.ajax( url2, { data: { user: data.userId } } );
@@ -31353,9 +29626,6 @@ var request = $.ajax( url, { dataType: "json" } ),
 chained.done(function( data ) {
   // data retrieved from url2 as provided by the first request
 });
-</script>
-</body>
-</html>
 ```
          */
         then<ARP = never, AJP = never, ANP = never,
@@ -31380,17 +29650,7 @@ chained.done(function( data ) {
          * @see \`{@link https://api.jquery.com/deferred.then/ }\`
          * @since 1.8
          * @example ​ ````Since the jQuery.get method returns a jqXHR object, which is derived from a Deferred object, we can attach handlers using the .then method.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>deferred.then demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $.get( "test.php" ).then(
   function() {
     alert( "$.get succeeded" );
@@ -31398,9 +29658,6 @@ $.get( "test.php" ).then(
     alert( "$.get failed!" );
   }
 );
-</script>
-</body>
-</html>
 ```
          * @example ​ ````Filter the resolve value:
 ```html
@@ -31431,21 +29688,12 @@ var filterResolve = function() {
 ​
 $( "button" ).on( "click", filterResolve );
 </script>
+​
 </body>
 </html>
 ```
          * @example ​ ````Filter reject value:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>deferred.then demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 var defer = $.Deferred(),
   filtered = defer.then( null, function( value ) {
     return value * 3;
@@ -31455,22 +29703,9 @@ defer.reject( 6 );
 filtered.fail(function( value ) {
   alert( "Value is ( 3*6 = ) 18: " + value );
 });
-</script>
-</body>
-</html>
 ```
          * @example ​ ````Chain tasks:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>deferred.then demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 var request = $.ajax( url, { dataType: "json" } ),
   chained = request.then(function( data ) {
     return $.ajax( url2, { data: { user: data.userId } } );
@@ -31479,9 +29714,6 @@ var request = $.ajax( url, { dataType: "json" } ),
 chained.done(function( data ) {
   // data retrieved from url2 as provided by the first request
 });
-</script>
-</body>
-</html>
 ```
          */
         then<ARD = never, AJD = never, AND = never,
@@ -31512,73 +29744,8 @@ chained.done(function( data ) {
          * @param progressFilter An optional function that is called when progress notifications are sent to the Deferred.
          * @see \`{@link https://api.jquery.com/deferred.then/ }\`
          * @since 1.8
-         * @example ​ ````Since the jQuery.get method returns a jqXHR object, which is derived from a Deferred object, we can attach handlers using the .then method.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>deferred.then demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$.get( "test.php" ).then(
-  function() {
-    alert( "$.get succeeded" );
-  }, function() {
-    alert( "$.get failed!" );
-  }
-);
-</script>
-</body>
-</html>
-```
-         * @example ​ ````Filter the resolve value:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>deferred.then demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<button>Filter Resolve</button>
-<p></p>
-​
-<script>
-var filterResolve = function() {
-  var defer = $.Deferred(),
-    filtered = defer.then(function( value ) {
-      return value * 2;
-    });
-​
-  defer.resolve( 5 );
-  filtered.done(function( value ) {
-    $( "p" ).html( "Value is ( 2*5 = ) 10: " + value );
-  });
-};
-​
-$( "button" ).on( "click", filterResolve );
-</script>
-</body>
-</html>
-```
          * @example ​ ````Filter reject value:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>deferred.then demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 var defer = $.Deferred(),
   filtered = defer.then( null, function( value ) {
     return value * 3;
@@ -31588,22 +29755,9 @@ defer.reject( 6 );
 filtered.fail(function( value ) {
   alert( "Value is ( 3*6 = ) 18: " + value );
 });
-</script>
-</body>
-</html>
 ```
          * @example ​ ````Chain tasks:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>deferred.then demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 var request = $.ajax( url, { dataType: "json" } ),
   chained = request.then(function( data ) {
     return $.ajax( url2, { data: { user: data.userId } } );
@@ -31612,9 +29766,6 @@ var request = $.ajax( url, { dataType: "json" } ),
 chained.done(function( data ) {
   // data retrieved from url2 as provided by the first request
 });
-</script>
-</body>
-</html>
 ```
          */
         then<ARF = never, AJF = never, ANF = never,
@@ -31638,29 +29789,6 @@ chained.done(function( data ) {
          * @param progressFilter An optional function that is called when progress notifications are sent to the Deferred.
          * @see \`{@link https://api.jquery.com/deferred.then/ }\`
          * @since 1.8
-         * @example ​ ````Since the jQuery.get method returns a jqXHR object, which is derived from a Deferred object, we can attach handlers using the .then method.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>deferred.then demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$.get( "test.php" ).then(
-  function() {
-    alert( "$.get succeeded" );
-  }, function() {
-    alert( "$.get failed!" );
-  }
-);
-</script>
-</body>
-</html>
-```
          * @example ​ ````Filter the resolve value:
 ```html
 <!doctype html>
@@ -31690,46 +29818,12 @@ var filterResolve = function() {
 ​
 $( "button" ).on( "click", filterResolve );
 </script>
-</body>
-</html>
-```
-         * @example ​ ````Filter reject value:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>deferred.then demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-var defer = $.Deferred(),
-  filtered = defer.then( null, function( value ) {
-    return value * 3;
-  });
 ​
-defer.reject( 6 );
-filtered.fail(function( value ) {
-  alert( "Value is ( 3*6 = ) 18: " + value );
-});
-</script>
 </body>
 </html>
 ```
          * @example ​ ````Chain tasks:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>deferred.then demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 var request = $.ajax( url, { dataType: "json" } ),
   chained = request.then(function( data ) {
     return $.ajax( url2, { data: { user: data.userId } } );
@@ -31738,9 +29832,6 @@ var request = $.ajax( url, { dataType: "json" } ),
 chained.done(function( data ) {
   // data retrieved from url2 as provided by the first request
 });
-</script>
-</body>
-</html>
 ```
          */
         then<ARD = never, AJD = never, AND = never,
@@ -31766,17 +29857,7 @@ chained.done(function( data ) {
          * @see \`{@link https://api.jquery.com/deferred.catch/ }\`
          * @since 3.0
          * @example ​ ````Since the jQuery.get method returns a jqXHR object, which is derived from a Deferred object, we can rejection handlers using the .catch method.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>deferred.catch demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $.get( "test.php" )
   .then( function() {
     alert( "$.get succeeded" );
@@ -31784,9 +29865,6 @@ $.get( "test.php" )
   .catch( function() {
     alert( "$.get failed!" );
   } );
-</script>
-</body>
-</html>
 ```
          */
         catch<ARF = never, AJF = never, ANF = never,

--- a/types/jquery/index.d.ts
+++ b/types/jquery/index.d.ts
@@ -51,6 +51,7 @@ interface JQueryStatic {
      * @deprecated ​ Deprecated. Use \`{@link ajaxSetup }\`.
      */
     ajaxSettings: JQuery.AjaxSettings;
+    Callbacks: JQuery.CallbacksStatic;
     Deferred: JQuery.DeferredStatic;
     Event: JQuery.EventStatic;
     /**
@@ -1564,15 +1565,6 @@ jQuery(function( $ ) {
      */
     // tslint:disable-next-line:no-unnecessary-generics
     <TElement = HTMLElement>(): JQuery<TElement>;
-    /**
-     * A multi-purpose callbacks list object that provides a powerful way to manage callback lists.
-     *
-     * @param flags An optional list of space-separated flags that change how the callback list behaves.
-     * @see \`{@link https://api.jquery.com/jQuery.Callbacks/ }\`
-     * @since 1.7
-     */
-    // tslint:disable-next-line:ban-types no-unnecessary-generics
-    Callbacks<T extends Function>(flags?: string): JQuery.Callbacks<T>;
     /**
      * Perform an asynchronous HTTP (Ajax) request.
      *
@@ -56672,6 +56664,18 @@ declare namespace JQuery {
 
     // region Callbacks
     // #region Callbacks
+
+    interface CallbacksStatic {
+        /**
+         * A multi-purpose callbacks list object that provides a powerful way to manage callback lists.
+         *
+         * @param flags An optional list of space-separated flags that change how the callback list behaves.
+         * @see \`{@link https://api.jquery.com/jQuery.Callbacks/ }\`
+         * @since 1.7
+         */
+        // tslint:disable-next-line:ban-types no-unnecessary-generics
+        <T extends Function>(flags?: string): Callbacks<T>;
+    }
 
     // tslint:disable-next-line:ban-types
     interface Callbacks<T extends Function = Function> {

--- a/types/jquery/index.d.ts
+++ b/types/jquery/index.d.ts
@@ -1840,6 +1840,14 @@ $.getScript( url, function() {
     getScript(url: string,
               success?: JQuery.jqXHR.DoneCallback<string | undefined>): JQuery.jqXHR<string | undefined>;
     /**
+     * Load a JavaScript file from the server using a GET HTTP request, then execute it.
+     *
+     * @see \`{@link https://api.jquery.com/jQuery.getScript/ }\`
+     * @since 1.12
+     * @since 2.2
+     */
+    getScript(options: JQuery.UrlAjaxSettings): JQuery.jqXHR<string | undefined>;
+    /**
      * Execute some JavaScript code globally.
      *
      * @param code The JavaScript code to execute.

--- a/types/jquery/index.d.ts
+++ b/types/jquery/index.d.ts
@@ -27086,17 +27086,7 @@ declare namespace JQuery {
          * @see \`{@link https://api.jquery.com/callbacks.add/ }\`
          * @since 1.7
          * @example ​ ````Use callbacks.add() to add new callbacks to a callback list:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>callbacks.add demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 // A sample logging function to be added to a callbacks list
 var foo = function( value ) {
   console.log( "foo: " + value );
@@ -27125,9 +27115,6 @@ callbacks.fire( "world" );
 // Outputs:
 // "foo: world"
 // "bar: world"
-</script>
-</body>
-</html>
 ```
          */
         add(callback: TypeOrArray<T>, ...callbacks: Array<TypeOrArray<T>>): this;
@@ -27137,17 +27124,7 @@ callbacks.fire( "world" );
          * @see \`{@link https://api.jquery.com/callbacks.disable/ }\`
          * @since 1.7
          * @example ​ ````Use callbacks.disable() to disable further calls to a callback list:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>callbacks.disable demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 // A sample logging function to be added to a callbacks list
 var foo = function( value ) {
   console.log( value );
@@ -27168,9 +27145,6 @@ callbacks.disable();
 // Attempt to fire with "foobar" as an argument
 callbacks.fire( "foobar" );
 // foobar isn't output
-</script>
-</body>
-</html>
 ```
          */
         disable(): this;
@@ -27180,17 +27154,7 @@ callbacks.fire( "foobar" );
          * @see \`{@link https://api.jquery.com/callbacks.disabled/ }\`
          * @since 1.7
          * @example ​ ````Use callbacks.disabled() to determine if the callbacks list has been disabled:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>callbacks.disabled demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 // A sample logging function to be added to a callbacks list
 var foo = function( value ) {
   console.log( "foo:" + value );
@@ -27211,9 +27175,6 @@ callbacks.disable();
 // Test the disabled state of the list
 console.log ( callbacks.disabled() );
 // Outputs: true
-</script>
-</body>
-</html>
 ```
          */
         disabled(): boolean;
@@ -27223,17 +27184,7 @@ console.log ( callbacks.disabled() );
          * @see \`{@link https://api.jquery.com/callbacks.empty/ }\`
          * @since 1.7
          * @example ​ ````Use callbacks.empty() to empty a list of callbacks:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>callbacks.empty demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 // A sample logging function to be added to a callbacks list
 var foo = function( value1, value2 ) {
   console.log( "foo: " + value1 + "," + value2 );
@@ -27258,9 +27209,6 @@ console.log( callbacks.has( foo ) );
 // false
 console.log( callbacks.has( bar ) );
 // false
-</script>
-</body>
-</html>
 ```
          */
         empty(): this;
@@ -27271,17 +27219,7 @@ console.log( callbacks.has( bar ) );
          * @see \`{@link https://api.jquery.com/callbacks.fire/ }\`
          * @since 1.7
          * @example ​ ````Use callbacks.fire() to invoke the callbacks in a list with any arguments that have been passed:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>callbacks.fire demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 // A sample logging function to be added to a callbacks list
 var foo = function( value ) {
   console.log( "foo:" + value );
@@ -27309,9 +27247,6 @@ callbacks.fire( "hello again" );
 // Outputs:
 // "foo: hello again"
 // "bar: hello again"
-</script>
-</body>
-</html>
 ```
          */
         fire(...args: any[]): this;
@@ -27323,17 +27258,7 @@ callbacks.fire( "hello again" );
          * @see \`{@link https://api.jquery.com/callbacks.fireWith/ }\`
          * @since 1.7
          * @example ​ ````Use callbacks.fireWith() to fire a list of callbacks with a specific context and an array of arguments:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>callbacks.fireWith demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 // A sample logging function to be added to a callbacks list
 var log = function( value1, value2 ) {
   console.log( "Received: " + value1 + "," + value2 );
@@ -27349,9 +27274,6 @@ callbacks.add( log );
 ​
 callbacks.fireWith( window, [ "foo","bar" ] );
 // Outputs: "Received: foo, bar"
-</script>
-</body>
-</html>
 ```
          */
         fireWith(context: object, args?: ArrayLike<any>): this;
@@ -27361,17 +27283,7 @@ callbacks.fireWith( window, [ "foo","bar" ] );
          * @see \`{@link https://api.jquery.com/callbacks.fired/ }\`
          * @since 1.7
          * @example ​ ````Use callbacks.fired() to determine if the callbacks in a list have been called at least once:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>callbacks.fired demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 // A sample logging function to be added to a callbacks list
 var foo = function( value ) {
   console.log( "foo:" + value );
@@ -27388,9 +27300,6 @@ callbacks.fire( "world" ); // Outputs: "foo: world"
 ​
 // Test to establish if the callbacks have been called
 console.log( callbacks.fired() );
-</script>
-</body>
-</html>
 ```
          */
         fired(): boolean;
@@ -27402,17 +27311,7 @@ console.log( callbacks.fired() );
          * @see \`{@link https://api.jquery.com/callbacks.has/ }\`
          * @since 1.7
          * @example ​ ````Use callbacks.has() to check if a callback list contains a specific callback:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>callbacks.has demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 // A sample logging function to be added to a callbacks list
 var foo = function( value1, value2 ) {
   console.log( "Received: " + value1 + "," + value2 );
@@ -27433,9 +27332,6 @@ console.log( callbacks.has( foo ) );
 // true
 console.log( callbacks.has( bar ) );
 // false
-</script>
-</body>
-</html>
 ```
          */
         has(callback?: T): boolean;
@@ -27445,17 +27341,7 @@ console.log( callbacks.has( bar ) );
          * @see \`{@link https://api.jquery.com/callbacks.lock/ }\`
          * @since 1.7
          * @example ​ ````Use callbacks.lock() to lock a callback list to avoid further changes being made to the list state:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>callbacks.lock demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 // A sample logging function to be added to a callbacks list
 var foo = function( value ) {
   console.log( "foo:" + value );
@@ -27478,9 +27364,6 @@ callbacks.fire( "world" );
 ​
 // As the list was locked, no items were called,
 // so "world" isn't logged
-</script>
-</body>
-</html>
 ```
          * @example ​ ````Use callbacks.lock() to lock a callback list with &quot;memory,&quot; and then resume using the list:
 ```html
@@ -27541,6 +27424,7 @@ callbacks.fire( "youHadMeAtHello" );
 // Outputs "bar: hello" because the list is still locked,
 // and the argument value is still stored in memory
 </script>
+​
 </body>
 </html>
 ```
@@ -27552,17 +27436,7 @@ callbacks.fire( "youHadMeAtHello" );
          * @see \`{@link https://api.jquery.com/callbacks.locked/ }\`
          * @since 1.7
          * @example ​ ````Use callbacks.locked() to determine the lock-state of a callback list:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>callbacks.locked demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 // A sample logging function to be added to a callbacks list
 var foo = function( value ) {
   console.log( "foo: " + value );
@@ -27583,9 +27457,6 @@ callbacks.lock();
 // Test the lock-state of the list
 console.log ( callbacks.locked() );
 // true
-</script>
-</body>
-</html>
 ```
          */
         locked(): boolean;
@@ -27596,17 +27467,7 @@ console.log ( callbacks.locked() );
          * @see \`{@link https://api.jquery.com/callbacks.remove/ }\`
          * @since 1.7
          * @example ​ ````Use callbacks.remove() to remove callbacks from a callback list:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>callbacks.remove demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 // A sample logging function to be added to a callbacks list
 var foo = function( value ) {
   console.log( "foo: " + value );
@@ -27628,9 +27489,6 @@ callbacks.remove( foo );
 callbacks.fire( "world" );
 ​
 // Nothing output as "foo" is no longer in the list
-</script>
-</body>
-</html>
 ```
          */
         remove(...callbacks: T[]): this;

--- a/types/jquery/index.d.ts
+++ b/types/jquery/index.d.ts
@@ -28666,17 +28666,7 @@ interface JQuery<TElement = HTMLElement> extends Iterable<TElement> {
      * @see \`{@link https://api.jquery.com/jquery-2/#jquery1 }\`
      * @since 1.0
      * @example ​ ````Determine if an object is a jQuery object
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jquery demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 var a = { what: "A regular JS object" },
   b = $( "body" );
 ​
@@ -28687,26 +28677,10 @@ if ( a.jquery ) { // Falsy, since it's undefined
 if ( b.jquery ) { // Truthy, since it's a string
     alert( "b is a jQuery object!" );
 }
-</script>
-</body>
-</html>
 ```
      * @example ​ ````Get the current version of jQuery running on the page
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>jquery demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 alert( "You are running jQuery version: " + $.fn.jquery );
-</script>
-</body>
-</html>
 ```
      */
     jquery: string;
@@ -28753,6 +28727,7 @@ $( document.body )
   // Trigger the click to start
   .trigger( "click" );
 </script>
+​
 </body>
 </html>
 ```
@@ -28766,132 +28741,6 @@ $( document.body )
      *                argument of the $(selector, context) method.
      * @see \`{@link https://api.jquery.com/add/ }\`
      * @since 1.4
-     * @example ​ ````Finds all divs and makes a border.  Then adds all paragraphs to the jQuery object to set their backgrounds yellow.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>add demo</title>
-  <style>
-  div {
-    width: 60px;
-    height: 60px;
-    margin: 10px;
-    float: left;
-  }
-  p {
-    clear: left;
-    font-weight: bold;
-    font-size: 16px;
-    color: blue;
-    margin: 0 10px;
-    padding: 2px;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<div></div>
-<div></div>
-<div></div>
-<div></div>
-<div></div>
-<div></div>
-​
-<p>Added this... (notice no border)</p>
-​
-<script>
-$( "div" ).css( "border", "2px solid red" )
-  .add( "p" )
-  .css( "background", "yellow" );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Adds more elements, matched by the given expression, to the set of matched elements.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>add demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p>Hello</p>
-<span>Hello Again</span>
-​
-<script>
-$( "p" ).add( "span" ).css( "background", "yellow" );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Adds more elements, created on the fly, to the set of matched elements.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>add demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p>Hello</p>
-​
-<script>
-$( "p" ).clone().add( "<span>Again</span>" ).appendTo( document.body );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Adds one or more Elements to the set of matched elements.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>add demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p>Hello</p>
-<span id="a">Hello Again</span>
-​
-<script>
-$( "p" ).add( document.getElementById( "a" ) ).css( "background", "yellow" );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Demonstrates how to add (or push) elements to an existing collection
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>add demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p>Hello</p>
-<span id="a">Hello Again</span>
-​
-<script>
-var collection = $( "p" );
-// Capture the new collection
-collection = collection.add( document.getElementById( "a" ) );
-collection.css( "background", "yellow" );
-</script>
-</body>
-</html>
-```
      */
     add(selector: JQuery.Selector, context: Element): this;
     /**
@@ -28945,6 +28794,7 @@ $( "div" ).css( "border", "2px solid red" )
   .add( "p" )
   .css( "background", "yellow" );
 </script>
+​
 </body>
 </html>
 ```
@@ -28965,6 +28815,7 @@ $( "div" ).css( "border", "2px solid red" )
 <script>
 $( "p" ).add( "span" ).css( "background", "yellow" );
 </script>
+​
 </body>
 </html>
 ```
@@ -28984,6 +28835,7 @@ $( "p" ).add( "span" ).css( "background", "yellow" );
 <script>
 $( "p" ).clone().add( "<span>Again</span>" ).appendTo( document.body );
 </script>
+​
 </body>
 </html>
 ```
@@ -29004,6 +28856,7 @@ $( "p" ).clone().add( "<span>Again</span>" ).appendTo( document.body );
 <script>
 $( "p" ).add( document.getElementById( "a" ) ).css( "background", "yellow" );
 </script>
+​
 </body>
 </html>
 ```
@@ -29027,6 +28880,7 @@ var collection = $( "p" );
 collection = collection.add( document.getElementById( "a" ) );
 collection.css( "background", "yellow" );
 </script>
+​
 </body>
 </html>
 ```
@@ -29092,6 +28946,7 @@ $( "div.before-addback" ).find( "p" ).addClass( "background" );
 // Second Example
 $( "div.after-addback" ).find( "p" ).addBack().addClass( "background" );
 </script>
+​
 </body>
 </html>
 ```
@@ -29139,6 +28994,7 @@ $( "div.after-addback" ).find( "p" ).addBack().addClass( "background" );
 <script>
 $( "p" ).last().addClass( "selected" );
 </script>
+​
 </body>
 </html>
 ```
@@ -29172,6 +29028,7 @@ $( "p" ).last().addClass( "selected" );
 <script>
 $( "p:last" ).addClass( "selected highlight" );
 </script>
+​
 </body>
 </html>
 ```
@@ -29215,6 +29072,7 @@ $( "div" ).addClass(function( index, currentClass ) {
   return addedClass;
 });
 </script>
+​
 </body>
 </html>
 ```
@@ -29248,6 +29106,7 @@ $( "div" ).addClass(function( index, currentClass ) {
 <script>
 $( "p" ).after( "<b>Hello</b>" );
 </script>
+​
 </body>
 </html>
 ```
@@ -29272,6 +29131,7 @@ $( "p" ).after( "<b>Hello</b>" );
 <script>
 $( "p" ).after( document.createTextNode( "Hello" ) );
 </script>
+​
 </body>
 </html>
 ```
@@ -29297,6 +29157,7 @@ $( "p" ).after( document.createTextNode( "Hello" ) );
 <script>
 $( "p" ).after( $( "b" ) );
 </script>
+​
 </body>
 </html>
 ```
@@ -29312,79 +29173,6 @@ $( "p" ).after( $( "b" ) );
      * @see \`{@link https://api.jquery.com/after/ }\`
      * @since 1.4
      * @since 1.10
-     * @example ​ ````Inserts some HTML after all paragraphs.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>after demo</title>
-  <style>
-  p {
-    background: yellow;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p>I would like to say: </p>
-​
-<script>
-$( "p" ).after( "<b>Hello</b>" );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Inserts a DOM element after all paragraphs.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>after demo</title>
-  <style>
-  p {
-    background: yellow;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p>I would like to say: </p>
-​
-<script>
-$( "p" ).after( document.createTextNode( "Hello" ) );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Inserts a jQuery object (similar to an Array of DOM Elements) after all paragraphs.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>after demo</title>
-  <style>
-  p {
-    background: yellow;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<b>Hello</b>
-<p>I would like to say: </p>
-​
-<script>
-$( "p" ).after( $( "b" ) );
-</script>
-</body>
-</html>
-```
      */
     after(fn: (this: TElement, index: number, html: string) => JQuery.htmlString | JQuery.TypeOrArray<JQuery.Node | JQuery<JQuery.Node>>): this;
     /**
@@ -29394,23 +29182,10 @@ $( "p" ).after( $( "b" ) );
      * @see \`{@link https://api.jquery.com/ajaxComplete/ }\`
      * @since 1.0
      * @example ​ ````Show a message when an Ajax request completes.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>ajaxComplete demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $( document ).ajaxComplete(function( event, request, settings ) {
   $( "#msg" ).append( "<li>Request Complete.</li>" );
 });
-</script>
-</body>
-</html>
 ```
      */
     ajaxComplete(handler: (this: Document, event: JQuery.Event<Document>, jqXHR: JQuery.jqXHR, ajaxOptions: JQuery.AjaxSettings) => void | false): this;
@@ -29421,23 +29196,10 @@ $( document ).ajaxComplete(function( event, request, settings ) {
      * @see \`{@link https://api.jquery.com/ajaxError/ }\`
      * @since 1.0
      * @example ​ ````Show a message when an Ajax request fails.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>ajaxError demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $( document ).ajaxError(function( event, request, settings ) {
   $( "#msg" ).append( "<li>Error requesting page " + settings.url + "</li>" );
 });
-</script>
-</body>
-</html>
 ```
      */
     ajaxError(handler: (this: Document, event: JQuery.Event<Document>, jqXHR: JQuery.jqXHR, ajaxSettings: JQuery.AjaxSettings, thrownError: string) => void | false): this;
@@ -29448,23 +29210,10 @@ $( document ).ajaxError(function( event, request, settings ) {
      * @see \`{@link https://api.jquery.com/ajaxSend/ }\`
      * @since 1.0
      * @example ​ ````Show a message before an Ajax request is sent.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>ajaxSend demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $( document ).ajaxSend(function( event, request, settings ) {
   $( "#msg" ).append( "<li>Starting request at " + settings.url + "</li>" );
 });
-</script>
-</body>
-</html>
 ```
      */
     ajaxSend(handler: (this: Document, event: JQuery.Event<Document>, jqXHR: JQuery.jqXHR, ajaxOptions: JQuery.AjaxSettings) => void | false): this;
@@ -29475,23 +29224,10 @@ $( document ).ajaxSend(function( event, request, settings ) {
      * @see \`{@link https://api.jquery.com/ajaxStart/ }\`
      * @since 1.0
      * @example ​ ````Show a loading message whenever an Ajax request starts (and none is already active).
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>ajaxStart demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $( document ).ajaxStart(function() {
   $( "#loading" ).show();
 });
-</script>
-</body>
-</html>
 ```
      */
     ajaxStart(handler: (this: Document) => void | false): this;
@@ -29502,23 +29238,10 @@ $( document ).ajaxStart(function() {
      * @see \`{@link https://api.jquery.com/ajaxStop/ }\`
      * @since 1.0
      * @example ​ ````Hide a loading message after all the Ajax requests have stopped.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>ajaxStop demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $( document ).ajaxStop(function() {
   $( "#loading" ).hide();
 });
-</script>
-</body>
-</html>
 ```
      */
     ajaxStop(handler: (this: Document) => void | false): this;
@@ -29529,23 +29252,10 @@ $( document ).ajaxStop(function() {
      * @see \`{@link https://api.jquery.com/ajaxSuccess/ }\`
      * @since 1.0
      * @example ​ ````Show a message when an Ajax request completes successfully.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>ajaxSuccess demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $( document ).ajaxSuccess(function( event, request, settings ) {
   $( "#msg" ).append( "<li>Successful Request!</li>" );
 });
-</script>
-</body>
-</html>
 ```
      */
     ajaxSuccess(handler: (this: Document, event: JQuery.Event<Document>, jqXHR: JQuery.jqXHR, ajaxOptions: JQuery.AjaxSettings, data: JQuery.PlainObject) => void | false): this;
@@ -29558,331 +29268,14 @@ $( document ).ajaxSuccess(function( event, request, settings ) {
      * @param complete A function to call once the animation is complete, called once per matched element.
      * @see \`{@link https://api.jquery.com/animate/ }\`
      * @since 1.0
-     * @example ​ ````Click the button to animate the div with a number of different properties.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>animate demo</title>
-  <style>
-  div {
-    background-color: #bca;
-    width: 100px;
-    border: 1px solid green;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<button id="go">&raquo; Run</button>
-<div id="block">Hello!</div>
-​
-<script>
-// Using multiple unit types within one animation.
-​
-$( "#go" ).click(function() {
-  $( "#block" ).animate({
-    width: "70%",
-    opacity: 0.4,
-    marginLeft: "0.6in",
-    fontSize: "3em",
-    borderWidth: "10px"
-  }, 1500 );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Animates a div&#39;s left property with a relative value. Click several times on the buttons to see the relative animations queued up.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>animate demo</title>
-  <style>
-  div {
-    position: absolute;
-    background-color: #abc;
-    left: 50px;
-    width: 90px;
-    height: 90px;
-    margin: 5px;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<button id="left">&laquo;</button>
-<button id="right">&raquo;</button>
-<div class="block"></div>
-​
-<script>
-$( "#right" ).click(function() {
-  $( ".block" ).animate({ "left": "+=50px" }, "slow" );
-});
-​
-$( "#left" ).click(function(){
-  $( ".block" ).animate({ "left": "-=50px" }, "slow" );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````The first button shows how an unqueued animation works.  It expands the div out to 90% width while the font-size is increasing. Once the font-size change is complete, the border animation will begin.
-
-The second button starts a traditional chained animation, where each animation will start once the previous animation on the element has completed.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>animate demo</title>
-  <style>
-  div {
-    background-color: #bca;
-    width: 200px;
-    height: 1.1em;
-    text-align: center;
-    border: 2px solid green;
-    margin: 3px;
-    font-size: 14px;
-  }
-  button {
-    font-size: 14px;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<button id="go1">&raquo; Animate Block1</button>
-<button id="go2">&raquo; Animate Block2</button>
-<button id="go3">&raquo; Animate Both</button>
-<button id="go4">&raquo; Reset</button>
-<div id="block1">Block1</div>
-<div id="block2">Block2</div>
-​
-<script>
-$( "#go1" ).click(function() {
-  $( "#block1" )
-    .animate({
-      width: "90%"
-    }, {
-      queue: false,
-      duration: 3000
-    })
-    .animate({ fontSize: "24px" }, 1500 )
-    .animate({ borderRightWidth: "15px" }, 1500 );
-});
-​
-$( "#go2" ).click(function() {
-  $( "#block2" )
-    .animate({ width: "90%" }, 1000 )
-    .animate({ fontSize: "24px" }, 1000 )
-    .animate({ borderLeftWidth: "15px" }, 1000 );
-});
-​
-$( "#go3" ).click(function() {
-  $( "#go1" ).add( "#go2" ).click();
-});
-​
-$( "#go4" ).click(function() {
-  $( "div" ).css({
-    width: "",
-    fontSize: "",
-    borderWidth: ""
-  });
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Animates the first div&#39;s left property and synchronizes the remaining divs, using the step function to set their left properties at each stage of the animation.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>animate demo</title>
-  <style>
-  div {
-    position: relative;
-    background-color: #abc;
-    width: 40px;
-    height: 40px;
-    float: left;
-    margin: 5px;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button id="go">Run »</button></p>
-<div class="block"></div>
-<div class="block"></div>
-<div class="block"></div>
-<div class="block"></div>
-<div class="block"></div>
-<div class="block"></div>
-​
-<script>
-$( "#go" ).click(function() {
-  $( ".block:first" ).animate({
-    left: 100
-  }, {
-    duration: 1000,
-    step: function( now, fx ){
-      $( ".block:gt(0)" ).css( "left", now );
-    }
-  });
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Animate all paragraphs to toggle both height and opacity, completing the animation within 600 milliseconds.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>animate demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "p" ).animate({
-  height: "toggle",
-  opacity: "toggle"
-}, "slow" );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Animate all paragraphs to a left style of 50 and opacity of 1 (opaque, visible), completing the animation within 500 milliseconds.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>animate demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "p" ).animate({
-  left: 50,
-  opacity: 1
-}, 500 );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Animate the left and opacity style properties of all paragraphs; run the animation outside the queue, so that it will automatically start without waiting for its turn.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>animate demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "p" ).animate({
-  left: "50px",
-  opacity: 1
-}, {
-  duration: 500,
-  queue: false
-});
-</script>
-</body>
-</html>
-```
      * @example ​ ````An example of using an &#39;easing&#39; function to provide a different style of animation. This will only work if you have a plugin that provides this easing function.  Note, this code will do nothing unless the paragraph element is hidden.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>animate demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $( "p" ).animate({
   opacity: "show"
 }, "slow", "easein" );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Animates all paragraphs to toggle both height and opacity, completing the animation within 600 milliseconds.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>animate demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "p" ).animate({
-  height: "toggle",
-  opacity: "toggle"
-}, {
-  duration: "slow"
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Use an easing function to provide a different style of animation. This will only work if you have a plugin that provides this easing function.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>animate demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "p" ).animate({
-  opacity: "show"
-}, {
-  duration: "slow",
-  easing: "easein"
-});
-</script>
-</body>
-</html>
 ```
      * @example ​ ````Animate all paragraphs and execute a callback function when the animation is complete.  The first argument is an object of CSS properties, the second specifies that the animation should take 1000 milliseconds to complete, the third states the easing type, and the fourth argument is an anonymous callback function.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>animate demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $( "p" ).animate({
   height: 200,
   width: 400,
@@ -29890,9 +29283,6 @@ $( "p" ).animate({
 }, 1000, "linear", function() {
   alert( "all done" );
 });
-</script>
-</body>
-</html>
 ```
      */
     animate(properties: JQuery.PlainObject,
@@ -29942,6 +29332,7 @@ $( "#go" ).click(function() {
   }, 1500 );
 });
 </script>
+​
 </body>
 </html>
 ```
@@ -29979,270 +29370,23 @@ $( "#left" ).click(function(){
   $( ".block" ).animate({ "left": "-=50px" }, "slow" );
 });
 </script>
-</body>
-</html>
-```
-     * @example ​ ````The first button shows how an unqueued animation works.  It expands the div out to 90% width while the font-size is increasing. Once the font-size change is complete, the border animation will begin.
-
-The second button starts a traditional chained animation, where each animation will start once the previous animation on the element has completed.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>animate demo</title>
-  <style>
-  div {
-    background-color: #bca;
-    width: 200px;
-    height: 1.1em;
-    text-align: center;
-    border: 2px solid green;
-    margin: 3px;
-    font-size: 14px;
-  }
-  button {
-    font-size: 14px;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-<button id="go1">&raquo; Animate Block1</button>
-<button id="go2">&raquo; Animate Block2</button>
-<button id="go3">&raquo; Animate Both</button>
-<button id="go4">&raquo; Reset</button>
-<div id="block1">Block1</div>
-<div id="block2">Block2</div>
-​
-<script>
-$( "#go1" ).click(function() {
-  $( "#block1" )
-    .animate({
-      width: "90%"
-    }, {
-      queue: false,
-      duration: 3000
-    })
-    .animate({ fontSize: "24px" }, 1500 )
-    .animate({ borderRightWidth: "15px" }, 1500 );
-});
-​
-$( "#go2" ).click(function() {
-  $( "#block2" )
-    .animate({ width: "90%" }, 1000 )
-    .animate({ fontSize: "24px" }, 1000 )
-    .animate({ borderLeftWidth: "15px" }, 1000 );
-});
-​
-$( "#go3" ).click(function() {
-  $( "#go1" ).add( "#go2" ).click();
-});
-​
-$( "#go4" ).click(function() {
-  $( "div" ).css({
-    width: "",
-    fontSize: "",
-    borderWidth: ""
-  });
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Animates the first div&#39;s left property and synchronizes the remaining divs, using the step function to set their left properties at each stage of the animation.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>animate demo</title>
-  <style>
-  div {
-    position: relative;
-    background-color: #abc;
-    width: 40px;
-    height: 40px;
-    float: left;
-    margin: 5px;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button id="go">Run »</button></p>
-<div class="block"></div>
-<div class="block"></div>
-<div class="block"></div>
-<div class="block"></div>
-<div class="block"></div>
-<div class="block"></div>
-​
-<script>
-$( "#go" ).click(function() {
-  $( ".block:first" ).animate({
-    left: 100
-  }, {
-    duration: 1000,
-    step: function( now, fx ){
-      $( ".block:gt(0)" ).css( "left", now );
-    }
-  });
-});
-</script>
 </body>
 </html>
 ```
      * @example ​ ````Animate all paragraphs to toggle both height and opacity, completing the animation within 600 milliseconds.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>animate demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $( "p" ).animate({
   height: "toggle",
   opacity: "toggle"
 }, "slow" );
-</script>
-</body>
-</html>
 ```
      * @example ​ ````Animate all paragraphs to a left style of 50 and opacity of 1 (opaque, visible), completing the animation within 500 milliseconds.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>animate demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $( "p" ).animate({
   left: 50,
   opacity: 1
 }, 500 );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Animate the left and opacity style properties of all paragraphs; run the animation outside the queue, so that it will automatically start without waiting for its turn.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>animate demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "p" ).animate({
-  left: "50px",
-  opacity: 1
-}, {
-  duration: 500,
-  queue: false
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````An example of using an &#39;easing&#39; function to provide a different style of animation. This will only work if you have a plugin that provides this easing function.  Note, this code will do nothing unless the paragraph element is hidden.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>animate demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "p" ).animate({
-  opacity: "show"
-}, "slow", "easein" );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Animates all paragraphs to toggle both height and opacity, completing the animation within 600 milliseconds.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>animate demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "p" ).animate({
-  height: "toggle",
-  opacity: "toggle"
-}, {
-  duration: "slow"
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Use an easing function to provide a different style of animation. This will only work if you have a plugin that provides this easing function.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>animate demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "p" ).animate({
-  opacity: "show"
-}, {
-  duration: "slow",
-  easing: "easein"
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Animate all paragraphs and execute a callback function when the animation is complete.  The first argument is an object of CSS properties, the second specifies that the animation should take 1000 milliseconds to complete, the third states the easing type, and the fourth argument is an anonymous callback function.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>animate demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "p" ).animate({
-  height: 200,
-  width: 400,
-  opacity: 0.5
-}, 1000, "linear", function() {
-  alert( "all done" );
-});
-</script>
-</body>
-</html>
 ```
      */
     animate(properties: JQuery.PlainObject,
@@ -30255,80 +29399,6 @@ $( "p" ).animate({
      * @param options A map of additional options to pass to the method.
      * @see \`{@link https://api.jquery.com/animate/ }\`
      * @since 1.0
-     * @example ​ ````Click the button to animate the div with a number of different properties.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>animate demo</title>
-  <style>
-  div {
-    background-color: #bca;
-    width: 100px;
-    border: 1px solid green;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<button id="go">&raquo; Run</button>
-<div id="block">Hello!</div>
-​
-<script>
-// Using multiple unit types within one animation.
-​
-$( "#go" ).click(function() {
-  $( "#block" ).animate({
-    width: "70%",
-    opacity: 0.4,
-    marginLeft: "0.6in",
-    fontSize: "3em",
-    borderWidth: "10px"
-  }, 1500 );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Animates a div&#39;s left property with a relative value. Click several times on the buttons to see the relative animations queued up.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>animate demo</title>
-  <style>
-  div {
-    position: absolute;
-    background-color: #abc;
-    left: 50px;
-    width: 90px;
-    height: 90px;
-    margin: 5px;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<button id="left">&laquo;</button>
-<button id="right">&raquo;</button>
-<div class="block"></div>
-​
-<script>
-$( "#right" ).click(function() {
-  $( ".block" ).animate({ "left": "+=50px" }, "slow" );
-});
-​
-$( "#left" ).click(function(){
-  $( ".block" ).animate({ "left": "-=50px" }, "slow" );
-});
-</script>
-</body>
-</html>
-```
      * @example ​ ````The first button shows how an unqueued animation works.  It expands the div out to 90% width while the font-size is increasing. Once the font-size change is complete, the border animation will begin.
 
 The second button starts a traditional chained animation, where each animation will start once the previous animation on the element has completed.
@@ -30395,6 +29465,7 @@ $( "#go4" ).click(function() {
   });
 });
 </script>
+​
 </body>
 </html>
 ```
@@ -30439,61 +29510,12 @@ $( "#go" ).click(function() {
   });
 });
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Animate all paragraphs to toggle both height and opacity, completing the animation within 600 milliseconds.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>animate demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "p" ).animate({
-  height: "toggle",
-  opacity: "toggle"
-}, "slow" );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Animate all paragraphs to a left style of 50 and opacity of 1 (opaque, visible), completing the animation within 500 milliseconds.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>animate demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "p" ).animate({
-  left: 50,
-  opacity: 1
-}, 500 );
-</script>
+​
 </body>
 </html>
 ```
      * @example ​ ````Animate the left and opacity style properties of all paragraphs; run the animation outside the queue, so that it will automatically start without waiting for its turn.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>animate demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $( "p" ).animate({
   left: "50px",
   opacity: 1
@@ -30501,95 +29523,24 @@ $( "p" ).animate({
   duration: 500,
   queue: false
 });
-</script>
-</body>
-</html>
-```
-     * @example ​ ````An example of using an &#39;easing&#39; function to provide a different style of animation. This will only work if you have a plugin that provides this easing function.  Note, this code will do nothing unless the paragraph element is hidden.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>animate demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "p" ).animate({
-  opacity: "show"
-}, "slow", "easein" );
-</script>
-</body>
-</html>
 ```
      * @example ​ ````Animates all paragraphs to toggle both height and opacity, completing the animation within 600 milliseconds.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>animate demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $( "p" ).animate({
   height: "toggle",
   opacity: "toggle"
 }, {
   duration: "slow"
 });
-</script>
-</body>
-</html>
 ```
      * @example ​ ````Use an easing function to provide a different style of animation. This will only work if you have a plugin that provides this easing function.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>animate demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $( "p" ).animate({
   opacity: "show"
 }, {
   duration: "slow",
   easing: "easein"
 });
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Animate all paragraphs and execute a callback function when the animation is complete.  The first argument is an object of CSS properties, the second specifies that the animation should take 1000 milliseconds to complete, the third states the easing type, and the fourth argument is an anonymous callback function.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>animate demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "p" ).animate({
-  height: 200,
-  width: 400,
-  opacity: 0.5
-}, 1000, "linear", function() {
-  alert( "all done" );
-});
-</script>
-</body>
-</html>
 ```
      */
     animate(properties: JQuery.PlainObject,
@@ -30601,342 +29552,6 @@ $( "p" ).animate({
      * @param complete A function to call once the animation is complete, called once per matched element.
      * @see \`{@link https://api.jquery.com/animate/ }\`
      * @since 1.0
-     * @example ​ ````Click the button to animate the div with a number of different properties.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>animate demo</title>
-  <style>
-  div {
-    background-color: #bca;
-    width: 100px;
-    border: 1px solid green;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<button id="go">&raquo; Run</button>
-<div id="block">Hello!</div>
-​
-<script>
-// Using multiple unit types within one animation.
-​
-$( "#go" ).click(function() {
-  $( "#block" ).animate({
-    width: "70%",
-    opacity: 0.4,
-    marginLeft: "0.6in",
-    fontSize: "3em",
-    borderWidth: "10px"
-  }, 1500 );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Animates a div&#39;s left property with a relative value. Click several times on the buttons to see the relative animations queued up.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>animate demo</title>
-  <style>
-  div {
-    position: absolute;
-    background-color: #abc;
-    left: 50px;
-    width: 90px;
-    height: 90px;
-    margin: 5px;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<button id="left">&laquo;</button>
-<button id="right">&raquo;</button>
-<div class="block"></div>
-​
-<script>
-$( "#right" ).click(function() {
-  $( ".block" ).animate({ "left": "+=50px" }, "slow" );
-});
-​
-$( "#left" ).click(function(){
-  $( ".block" ).animate({ "left": "-=50px" }, "slow" );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````The first button shows how an unqueued animation works.  It expands the div out to 90% width while the font-size is increasing. Once the font-size change is complete, the border animation will begin.
-
-The second button starts a traditional chained animation, where each animation will start once the previous animation on the element has completed.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>animate demo</title>
-  <style>
-  div {
-    background-color: #bca;
-    width: 200px;
-    height: 1.1em;
-    text-align: center;
-    border: 2px solid green;
-    margin: 3px;
-    font-size: 14px;
-  }
-  button {
-    font-size: 14px;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<button id="go1">&raquo; Animate Block1</button>
-<button id="go2">&raquo; Animate Block2</button>
-<button id="go3">&raquo; Animate Both</button>
-<button id="go4">&raquo; Reset</button>
-<div id="block1">Block1</div>
-<div id="block2">Block2</div>
-​
-<script>
-$( "#go1" ).click(function() {
-  $( "#block1" )
-    .animate({
-      width: "90%"
-    }, {
-      queue: false,
-      duration: 3000
-    })
-    .animate({ fontSize: "24px" }, 1500 )
-    .animate({ borderRightWidth: "15px" }, 1500 );
-});
-​
-$( "#go2" ).click(function() {
-  $( "#block2" )
-    .animate({ width: "90%" }, 1000 )
-    .animate({ fontSize: "24px" }, 1000 )
-    .animate({ borderLeftWidth: "15px" }, 1000 );
-});
-​
-$( "#go3" ).click(function() {
-  $( "#go1" ).add( "#go2" ).click();
-});
-​
-$( "#go4" ).click(function() {
-  $( "div" ).css({
-    width: "",
-    fontSize: "",
-    borderWidth: ""
-  });
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Animates the first div&#39;s left property and synchronizes the remaining divs, using the step function to set their left properties at each stage of the animation.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>animate demo</title>
-  <style>
-  div {
-    position: relative;
-    background-color: #abc;
-    width: 40px;
-    height: 40px;
-    float: left;
-    margin: 5px;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><button id="go">Run »</button></p>
-<div class="block"></div>
-<div class="block"></div>
-<div class="block"></div>
-<div class="block"></div>
-<div class="block"></div>
-<div class="block"></div>
-​
-<script>
-$( "#go" ).click(function() {
-  $( ".block:first" ).animate({
-    left: 100
-  }, {
-    duration: 1000,
-    step: function( now, fx ){
-      $( ".block:gt(0)" ).css( "left", now );
-    }
-  });
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Animate all paragraphs to toggle both height and opacity, completing the animation within 600 milliseconds.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>animate demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "p" ).animate({
-  height: "toggle",
-  opacity: "toggle"
-}, "slow" );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Animate all paragraphs to a left style of 50 and opacity of 1 (opaque, visible), completing the animation within 500 milliseconds.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>animate demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "p" ).animate({
-  left: 50,
-  opacity: 1
-}, 500 );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Animate the left and opacity style properties of all paragraphs; run the animation outside the queue, so that it will automatically start without waiting for its turn.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>animate demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "p" ).animate({
-  left: "50px",
-  opacity: 1
-}, {
-  duration: 500,
-  queue: false
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````An example of using an &#39;easing&#39; function to provide a different style of animation. This will only work if you have a plugin that provides this easing function.  Note, this code will do nothing unless the paragraph element is hidden.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>animate demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "p" ).animate({
-  opacity: "show"
-}, "slow", "easein" );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Animates all paragraphs to toggle both height and opacity, completing the animation within 600 milliseconds.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>animate demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "p" ).animate({
-  height: "toggle",
-  opacity: "toggle"
-}, {
-  duration: "slow"
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Use an easing function to provide a different style of animation. This will only work if you have a plugin that provides this easing function.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>animate demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "p" ).animate({
-  opacity: "show"
-}, {
-  duration: "slow",
-  easing: "easein"
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Animate all paragraphs and execute a callback function when the animation is complete.  The first argument is an object of CSS properties, the second specifies that the animation should take 1000 milliseconds to complete, the third states the easing type, and the fourth argument is an anonymous callback function.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>animate demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "p" ).animate({
-  height: 200,
-  width: 400,
-  opacity: 0.5
-}, 1000, "linear", function() {
-  alert( "all done" );
-});
-</script>
-</body>
-</html>
-```
      */
     animate(properties: JQuery.PlainObject,
             complete?: (this: TElement) => void): this;
@@ -30968,6 +29583,7 @@ $( "p" ).animate({
 <script>
 $( "p" ).append( "<strong>Hello</strong>" );
 </script>
+​
 </body>
 </html>
 ```
@@ -30992,6 +29608,7 @@ $( "p" ).append( "<strong>Hello</strong>" );
 <script>
 $( "p" ).append( document.createTextNode( "Hello" ) );
 </script>
+​
 </body>
 </html>
 ```
@@ -31017,6 +29634,7 @@ $( "p" ).append( document.createTextNode( "Hello" ) );
 <script>
 $( "p" ).append( $( "strong" ) );
 </script>
+​
 </body>
 </html>
 ```
@@ -31031,79 +29649,6 @@ $( "p" ).append( $( "strong" ) );
      *           the current element in the set.
      * @see \`{@link https://api.jquery.com/append/ }\`
      * @since 1.4
-     * @example ​ ````Appends some HTML to all paragraphs.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>append demo</title>
-  <style>
-  p {
-    background: yellow;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p>I would like to say: </p>
-​
-<script>
-$( "p" ).append( "<strong>Hello</strong>" );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Appends an Element to all paragraphs.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>append demo</title>
-  <style>
-  p {
-    background: yellow;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p>I would like to say: </p>
-​
-<script>
-$( "p" ).append( document.createTextNode( "Hello" ) );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Appends a jQuery object (similar to an Array of DOM Elements) to all paragraphs.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>append demo</title>
-  <style>
-  p {
-    background: yellow;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<strong>Hello world!!!</strong>
-<p>I would like to say: </p>
-​
-<script>
-$( "p" ).append( $( "strong" ) );
-</script>
-</body>
-</html>
-```
      */
     append(fn: (this: TElement, index: number, html: string) => JQuery.htmlString | JQuery.TypeOrArray<JQuery.Node | JQuery<JQuery.Node>>): this;
     /**
@@ -31136,6 +29681,7 @@ $( "p" ).append( $( "strong" ) );
 <script>
 $( "span" ).appendTo( "#foo" );
 </script>
+​
 </body>
 </html>
 ```
@@ -31151,110 +29697,6 @@ $( "span" ).appendTo( "#foo" );
      * @see \`{@link https://api.jquery.com/attr/ }\`
      * @since 1.0
      * @since 1.1
-     * @example ​ ````Display the checked attribute and property of a checkbox as it changes.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>attr demo</title>
-  <style>
-  p {
-    margin: 20px 0 0;
-  }
-  b {
-    color: blue;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<input id="check1" type="checkbox" checked="checked">
-<label for="check1">Check me</label>
-<p></p>
-​
-<script>
-$( "input" )
-  .change(function() {
-    var $input = $( this );
-    $( "p" ).html( ".attr( 'checked' ): <b>" + $input.attr( "checked" ) + "</b><br>" +
-      ".prop( 'checked' ): <b>" + $input.prop( "checked" ) + "</b><br>" +
-      ".is( ':checked' ): <b>" + $input.is( ":checked" ) + "</b>" );
-  })
-  .change();
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Find the title attribute of the first &lt;em&gt; in the page.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>attr demo</title>
-  <style>
-  em {
-    color: blue;
-    font-weight: bold;
-  }
-  div {
-    color: red;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p>Once there was a <em title="huge, gigantic">large</em> dinosaur...</p>
-​
-The title of the emphasis is:<div></div>
-​
-<script>
-var title = $( "em" ).attr( "title" );
-$( "div" ).text( title );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Set some attributes for all &lt;img&gt;s in the page.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>attr demo</title>
-  <style>
-  img {
-    padding: 10px;
-  }
-  div {
-    color: red;
-    font-size: 24px;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<img>
-<img>
-<img>
-​
-<div><b>Attribute of Ajax</b></div>
-​
-<script>
-$( "img" ).attr({
-  src: "/resources/hat.gif",
-  title: "jQuery",
-  alt: "jQuery Logo"
-});
-$( "div" ).text( $( "img" ).attr( "alt" ) );
-</script>
-</body>
-</html>
-```
      * @example ​ ````Set the id for divs based on the position in the page.
 ```html
 <!doctype html>
@@ -31290,6 +29732,7 @@ $( "div" )
     $( "span", this ).html( "(id = '<b>" + this.id + "</b>')" );
 });
 </script>
+​
 </body>
 </html>
 ```
@@ -31311,6 +29754,7 @@ $( "img" ).attr( "src", function() {
   return "/resources/" + this.title;
 });
 </script>
+​
 </body>
 </html>
 ```
@@ -31323,73 +29767,6 @@ $( "img" ).attr( "src", function() {
      * @param attributes An object of attribute-value pairs to set.
      * @see \`{@link https://api.jquery.com/attr/ }\`
      * @since 1.0
-     * @example ​ ````Display the checked attribute and property of a checkbox as it changes.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>attr demo</title>
-  <style>
-  p {
-    margin: 20px 0 0;
-  }
-  b {
-    color: blue;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<input id="check1" type="checkbox" checked="checked">
-<label for="check1">Check me</label>
-<p></p>
-​
-<script>
-$( "input" )
-  .change(function() {
-    var $input = $( this );
-    $( "p" ).html( ".attr( 'checked' ): <b>" + $input.attr( "checked" ) + "</b><br>" +
-      ".prop( 'checked' ): <b>" + $input.prop( "checked" ) + "</b><br>" +
-      ".is( ':checked' ): <b>" + $input.is( ":checked" ) + "</b>" );
-  })
-  .change();
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Find the title attribute of the first &lt;em&gt; in the page.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>attr demo</title>
-  <style>
-  em {
-    color: blue;
-    font-weight: bold;
-  }
-  div {
-    color: red;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p>Once there was a <em title="huge, gigantic">large</em> dinosaur...</p>
-​
-The title of the emphasis is:<div></div>
-​
-<script>
-var title = $( "em" ).attr( "title" );
-$( "div" ).text( title );
-</script>
-</body>
-</html>
-```
      * @example ​ ````Set some attributes for all &lt;img&gt;s in the page.
 ```html
 <!doctype html>
@@ -31424,65 +29801,7 @@ $( "img" ).attr({
 });
 $( "div" ).text( $( "img" ).attr( "alt" ) );
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Set the id for divs based on the position in the page.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>attr demo</title>
-  <style>
-  div {
-    color: blue;
-  }
-  span {
-    color: red;
-  }
-  b {
-    font-weight: bolder;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-<div>Zero-th <span></span></div>
-<div>First <span></span></div>
-<div>Second <span></span></div>
-​
-<script>
-$( "div" )
-  .attr( "id", function( arr ) {
-    return "div-id" + arr;
-  })
-  .each(function() {
-    $( "span", this ).html( "(id = '<b>" + this.id + "</b>')" );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Set the src attribute from title attribute on the image.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>attr demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<img title="hat.gif">
-​
-<script>
-$( "img" ).attr( "src", function() {
-  return "/resources/" + this.title;
-});
-</script>
 </body>
 </html>
 ```
@@ -31527,6 +29846,7 @@ $( "input" )
   })
   .change();
 </script>
+​
 </body>
 </html>
 ```
@@ -31558,102 +29878,7 @@ The title of the emphasis is:<div></div>
 var title = $( "em" ).attr( "title" );
 $( "div" ).text( title );
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Set some attributes for all &lt;img&gt;s in the page.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>attr demo</title>
-  <style>
-  img {
-    padding: 10px;
-  }
-  div {
-    color: red;
-    font-size: 24px;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-<img>
-<img>
-<img>
-​
-<div><b>Attribute of Ajax</b></div>
-​
-<script>
-$( "img" ).attr({
-  src: "/resources/hat.gif",
-  title: "jQuery",
-  alt: "jQuery Logo"
-});
-$( "div" ).text( $( "img" ).attr( "alt" ) );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Set the id for divs based on the position in the page.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>attr demo</title>
-  <style>
-  div {
-    color: blue;
-  }
-  span {
-    color: red;
-  }
-  b {
-    font-weight: bolder;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<div>Zero-th <span></span></div>
-<div>First <span></span></div>
-<div>Second <span></span></div>
-​
-<script>
-$( "div" )
-  .attr( "id", function( arr ) {
-    return "div-id" + arr;
-  })
-  .each(function() {
-    $( "span", this ).html( "(id = '<b>" + this.id + "</b>')" );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Set the src attribute from title attribute on the image.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>attr demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<img title="hat.gif">
-​
-<script>
-$( "img" ).attr( "src", function() {
-  return "/resources/" + this.title;
-});
-</script>
 </body>
 </html>
 ```
@@ -31687,6 +29912,7 @@ $( "img" ).attr( "src", function() {
 <script>
 $( "p" ).before( "<b>Hello</b>" );
 </script>
+​
 </body>
 </html>
 ```
@@ -31711,6 +29937,7 @@ $( "p" ).before( "<b>Hello</b>" );
 <script>
 $( "p" ).before( document.createTextNode( "Hello" ) );
 </script>
+​
 </body>
 </html>
 ```
@@ -31735,6 +29962,7 @@ $( "p" ).before( document.createTextNode( "Hello" ) );
 <script>
 $( "p" ).before( $( "b" ) );
 </script>
+​
 </body>
 </html>
 ```
@@ -31750,78 +29978,6 @@ $( "p" ).before( $( "b" ) );
      * @see \`{@link https://api.jquery.com/before/ }\`
      * @since 1.4
      * @since 1.10
-     * @example ​ ````Inserts some HTML before all paragraphs.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>before demo</title>
-  <style>
-  p {
-    background: yellow;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p> is what I said...</p>
-​
-<script>
-$( "p" ).before( "<b>Hello</b>" );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Inserts a DOM element before all paragraphs.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>before demo</title>
-  <style>
-  p {
-    background: yellow;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p> is what I said...</p>
-​
-<script>
-$( "p" ).before( document.createTextNode( "Hello" ) );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Inserts a jQuery object (similar to an Array of DOM Elements) before all paragraphs.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>before demo</title>
-  <style>
-  p {
-    background: yellow;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p> is what I said...</p><b>Hello</b>
-​
-<script>
-$( "p" ).before( $( "b" ) );
-</script>
-</body>
-</html>
-```
      */
     before(fn: (this: TElement, index: number, html: string) => JQuery.htmlString | JQuery.TypeOrArray<JQuery.Node | JQuery<JQuery.Node>>): this;
     // [bind() overloads] https://github.com/jquery/api.jquery.com/issues/1048
@@ -31839,214 +29995,6 @@ $( "p" ).before( $( "b" ) );
      * **Cause**: These event binding methods have been deprecated in favor of the `.on()` and `.off()` methods which can handle both delegated and direct event binding. Although the older methods are still present in jQuery 3.0, they may be removed as early as the next major-version update.
      *
      * **Solution**: Change the method call to use `.on()` or `.off()`, the documentation for the old methods include specific instructions. In general, the `.bind()` and `.unbind()` methods can be renamed directly to `.on()` and `.off()` respectively since the argument orders are identical.
-     * @example ​ ````Handle click and double-click for the paragraph.  Note: the coordinates are window relative, so in this case relative to the demo iframe.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>bind demo</title>
-  <style>
-  p {
-    background: yellow;
-    font-weight: bold;
-    cursor: pointer;
-    padding: 5px;
-  }
-  p.over {
-     background: #ccc;
-  }
-  span {
-    color: red;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p>Click or double click here.</p>
-<span></span>
-​
-<script>
-$( "p" ).bind( "click", function( event ) {
-  var str = "( " + event.pageX + ", " + event.pageY + " )";
-  $( "span" ).text( "Click happened! " + str );
-});
-$( "p" ).bind( "dblclick", function() {
-  $( "span" ).text( "Double-click happened in " + this.nodeName );
-});
-$( "p" ).bind( "mouseenter mouseleave", function( event ) {
-  $( this ).toggleClass( "over" );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````To display each paragraph&#39;s text in an alert box whenever it is clicked:
-```html
-<!doctype html>
-<html lang="en">link trigger
-<head>
-  <meta charset="utf-8">
-  <title>bind demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "p" ).bind( "click", function() {
-  alert( $( this ).text() );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````You can pass some extra data before the event handler:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>bind demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-function handler( event ) {
-  alert( event.data.foo );
-}
-$( "p" ).bind( "click", {
-  foo: "bar"
-}, handler );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Cancel a default action and prevent it from bubbling up by returning false:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>bind demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "form" ).bind( "submit", function() {
-  return false;
-})
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Cancel only the default action by using the .preventDefault() method.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>bind demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "form" ).bind( "submit", function( event ) {
-  event.preventDefault();
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Stop an event from bubbling without preventing the default action by using the .stopPropagation() method.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>bind demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "form" ).bind( "submit", function( event ) {
-  event.stopPropagation();
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Bind custom events.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>bind demo</title>
-  <style>
-  p {
-    color: red;
-  }
-  span {
-    color: blue;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p>Has an attached custom event.</p>
-<button>Trigger custom event</button>
-<span style="display: none;"></span>
-​
-<script>
-$( "p" ).bind( "myCustomEvent", function( e, myName, myValue ) {
-  $( this ).text( myName + ", hi there!" );
-  $( "span" )
-    .stop()
-    .css( "opacity", 1 )
-    .text( "myName = " + myName )
-    .fadeIn( 30 )
-    .fadeOut( 1000 );
-  });
-$( "button" ).click(function() {
-  $( "p" ).trigger( "myCustomEvent", [ "John" ] );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Bind multiple events simultaneously.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>bind demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "div.test" ).bind({
-  click: function() {
-    $( this ).addClass( "active" );
-  },
-  mouseenter: function() {
-    $( this ).addClass( "inside" );
-  },
-  mouseleave: function() {
-    $( this ).removeClass( "inside" );
-  }
-});
-</script>
-</body>
-</html>
-```
      */
     bind<TData>(eventType: string,
                 eventData: TData,
@@ -32106,106 +30054,33 @@ $( "p" ).bind( "mouseenter mouseleave", function( event ) {
   $( this ).toggleClass( "over" );
 });
 </script>
+​
 </body>
 </html>
 ```
      * @example ​ ````To display each paragraph&#39;s text in an alert box whenever it is clicked:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>bind demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $( "p" ).bind( "click", function() {
   alert( $( this ).text() );
 });
-</script>
-</body>
-</html>
-```
-     * @example ​ ````You can pass some extra data before the event handler:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>bind demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-function handler( event ) {
-  alert( event.data.foo );
-}
-$( "p" ).bind( "click", {
-  foo: "bar"
-}, handler );
-</script>
-</body>
-</html>
 ```
      * @example ​ ````Cancel a default action and prevent it from bubbling up by returning false:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>bind demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $( "form" ).bind( "submit", function() {
   return false;
 })
-</script>
-</body>
-</html>
 ```
      * @example ​ ````Cancel only the default action by using the .preventDefault() method.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>bind demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $( "form" ).bind( "submit", function( event ) {
   event.preventDefault();
 });
-</script>
-</body>
-</html>
 ```
      * @example ​ ````Stop an event from bubbling without preventing the default action by using the .stopPropagation() method.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>bind demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $( "form" ).bind( "submit", function( event ) {
   event.stopPropagation();
 });
-</script>
-</body>
-</html>
 ```
      * @example ​ ````Bind custom events.
 ```html
@@ -32244,33 +30119,7 @@ $( "button" ).click(function() {
   $( "p" ).trigger( "myCustomEvent", [ "John" ] );
 });
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Bind multiple events simultaneously.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>bind demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "div.test" ).bind({
-  click: function() {
-    $( this ).addClass( "active" );
-  },
-  mouseenter: function() {
-    $( this ).addClass( "inside" );
-  },
-  mouseleave: function() {
-    $( this ).removeClass( "inside" );
-  }
-});
-</script>
+​
 </body>
 </html>
 ```
@@ -32288,199 +30137,8 @@ $( "div.test" ).bind({
      * **Cause**: These event binding methods have been deprecated in favor of the `.on()` and `.off()` methods which can handle both delegated and direct event binding. Although the older methods are still present in jQuery 3.0, they may be removed as early as the next major-version update.
      *
      * **Solution**: Change the method call to use `.on()` or `.off()`, the documentation for the old methods include specific instructions. In general, the `.bind()` and `.unbind()` methods can be renamed directly to `.on()` and `.off()` respectively since the argument orders are identical.
-     * @example ​ ````Handle click and double-click for the paragraph.  Note: the coordinates are window relative, so in this case relative to the demo iframe.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>bind demo</title>
-  <style>
-  p {
-    background: yellow;
-    font-weight: bold;
-    cursor: pointer;
-    padding: 5px;
-  }
-  p.over {
-     background: #ccc;
-  }
-  span {
-    color: red;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p>Click or double click here.</p>
-<span></span>
-​
-<script>
-$( "p" ).bind( "click", function( event ) {
-  var str = "( " + event.pageX + ", " + event.pageY + " )";
-  $( "span" ).text( "Click happened! " + str );
-});
-$( "p" ).bind( "dblclick", function() {
-  $( "span" ).text( "Double-click happened in " + this.nodeName );
-});
-$( "p" ).bind( "mouseenter mouseleave", function( event ) {
-  $( this ).toggleClass( "over" );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````To display each paragraph&#39;s text in an alert box whenever it is clicked:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>bind demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "p" ).bind( "click", function() {
-  alert( $( this ).text() );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````You can pass some extra data before the event handler:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>bind demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-function handler( event ) {
-  alert( event.data.foo );
-}
-$( "p" ).bind( "click", {
-  foo: "bar"
-}, handler );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Cancel a default action and prevent it from bubbling up by returning false:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>bind demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "form" ).bind( "submit", function() {
-  return false;
-})
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Cancel only the default action by using the .preventDefault() method.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>bind demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "form" ).bind( "submit", function( event ) {
-  event.preventDefault();
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Stop an event from bubbling without preventing the default action by using the .stopPropagation() method.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>bind demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "form" ).bind( "submit", function( event ) {
-  event.stopPropagation();
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Bind custom events.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>bind demo</title>
-  <style>
-  p {
-    color: red;
-  }
-  span {
-    color: blue;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p>Has an attached custom event.</p>
-<button>Trigger custom event</button>
-<span style="display: none;"></span>
-​
-<script>
-$( "p" ).bind( "myCustomEvent", function( e, myName, myValue ) {
-  $( this ).text( myName + ", hi there!" );
-  $( "span" )
-    .stop()
-    .css( "opacity", 1 )
-    .text( "myName = " + myName )
-    .fadeIn( 30 )
-    .fadeOut( 1000 );
-  });
-$( "button" ).click(function() {
-  $( "p" ).trigger( "myCustomEvent", [ "John" ] );
-});
-</script>
-</body>
-</html>
-```
      * @example ​ ````Bind multiple events simultaneously.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>bind demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $( "div.test" ).bind({
   click: function() {
     $( this ).addClass( "active" );
@@ -32492,9 +30150,6 @@ $( "div.test" ).bind({
     $( this ).removeClass( "inside" );
   }
 });
-</script>
-</body>
-</html>
 ```
      */
     bind(events: JQuery.PlainObject<JQuery.EventHandler<TElement> | JQuery.EventHandlerBase<any, JQuery.Event<TElement>> | false>): this;
@@ -32510,23 +30165,6 @@ $( "div.test" ).bind({
      * **Cause**: The `.on()` and `.trigger()` methods can set an event handler or generate an event for any event type, and should be used instead of the shortcut methods. This message also applies to the other event shorthands, including: blur, focus, focusin, focusout, resize, scroll, dblclick, mousedown, mouseup, mousemove, mouseover, mouseout, mouseenter, mouseleave, change, select, submit, keydown, keypress, keyup, and contextmenu.
      *
      * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
-     * @example ​ ````To trigger the blur event on all paragraphs:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>blur demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "p" ).blur();
-</script>
-</body>
-</html>
-```
      */
     blur<TData>(eventData: TData,
                 handler: JQuery.EventHandler<TElement, TData> | JQuery.EventHandlerBase<any, JQuery.Event<TElement, TData>>): this;
@@ -32542,21 +30180,8 @@ $( "p" ).blur();
      *
      * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
      * @example ​ ````To trigger the blur event on all paragraphs:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>blur demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $( "p" ).blur();
-</script>
-</body>
-</html>
 ```
      */
     blur(handler?: JQuery.EventHandler<TElement> | JQuery.EventHandlerBase<any, JQuery.Event<TElement>> | false): this;
@@ -32572,65 +30197,6 @@ $( "p" ).blur();
      * **Cause**: The `.on()` and `.trigger()` methods can set an event handler or generate an event for any event type, and should be used instead of the shortcut methods. This message also applies to the other event shorthands, including: blur, focus, focusin, focusout, resize, scroll, dblclick, mousedown, mouseup, mousemove, mouseover, mouseout, mouseenter, mouseleave, change, select, submit, keydown, keypress, keyup, and contextmenu.
      *
      * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
-     * @example ​ ````Attaches a change event to the select that gets the text for each selected option and writes them in the div.  It then triggers the event for the initial text draw.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>change demo</title>
-  <style>
-  div {
-    color: red;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<select name="sweets" multiple="multiple">
-  <option>Chocolate</option>
-  <option selected="selected">Candy</option>
-  <option>Taffy</option>
-  <option selected="selected">Caramel</option>
-  <option>Fudge</option>
-  <option>Cookie</option>
-</select>
-<div></div>
-​
-<script>
-$( "select" )
-  .change(function () {
-    var str = "";
-    $( "select option:selected" ).each(function() {
-      str += $( this ).text() + " ";
-    });
-    $( "div" ).text( str );
-  })
-  .change();
-</script>
-</body>
-</html>
-```
-     * @example ​ ````To add a validity test to all text input elements:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>change demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "input[type='text']" ).change(function() {
-  // Check input( $( this ).val() ) for validity here
-});
-</script>
-</body>
-</html>
-```
      */
     change<TData>(eventData: TData,
                   handler: JQuery.EventHandler<TElement, TData> | JQuery.EventHandlerBase<any, JQuery.Event<TElement, TData>>): this;
@@ -32682,27 +30248,15 @@ $( "select" )
   })
   .change();
 </script>
+​
 </body>
 </html>
 ```
      * @example ​ ````To add a validity test to all text input elements:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>change demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $( "input[type='text']" ).change(function() {
   // Check input( $( this ).val() ) for validity here
 });
-</script>
-</body>
-</html>
 ```
      */
     change(handler?: JQuery.EventHandler<TElement> | JQuery.EventHandlerBase<any, JQuery.Event<TElement>> | false): this;
@@ -32797,6 +30351,7 @@ $( "#container" ).click(function ( event ) {
   event.preventDefault();
 });
 </script>
+​
 </body>
 </html>
 ```
@@ -32833,6 +30388,7 @@ $( "#container" ).click(function ( event ) {
 <script>
 $( "div" ).children().css( "border-bottom", "3px double red" );
 </script>
+​
 </body>
 </html>
 ```
@@ -32866,6 +30422,7 @@ $( "div" ).children().css( "border-bottom", "3px double red" );
 <script>
 $( "div" ).children( ".selected" ).css( "color", "blue" );
 </script>
+​
 </body>
 </html>
 ```
@@ -32938,6 +30495,7 @@ $( "#stop" ).click(function() {
   myDiv.stop();
 });
 </script>
+​
 </body>
 </html>
 ```
@@ -32955,56 +30513,6 @@ $( "#stop" ).click(function() {
      * **Cause**: The `.on()` and `.trigger()` methods can set an event handler or generate an event for any event type, and should be used instead of the shortcut methods. This message also applies to the other event shorthands, including: blur, focus, focusin, focusout, resize, scroll, dblclick, mousedown, mouseup, mousemove, mouseover, mouseout, mouseenter, mouseleave, change, select, submit, keydown, keypress, keyup, and contextmenu.
      *
      * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
-     * @example ​ ````Hide paragraphs on a page when they are clicked:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>click demo</title>
-  <style>
-  p {
-    color: red;
-    margin: 5px;
-    cursor: pointer;
-  }
-  p:hover {
-    background: yellow;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p>First Paragraph</p>
-<p>Second Paragraph</p>
-<p>Yet one more Paragraph</p>
-​
-<script>
-$( "p" ).click(function() {
-  $( this ).slideUp();
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Trigger the click event on all of the paragraphs on the page:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>click demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "p" ).click();
-</script>
-</body>
-</html>
-```
      */
     click<TData>(eventData: TData,
                  handler: JQuery.EventHandler<TElement, TData> | JQuery.EventHandlerBase<any, JQuery.Event<TElement, TData>>): this;
@@ -33049,25 +30557,13 @@ $( "p" ).click(function() {
   $( this ).slideUp();
 });
 </script>
+​
 </body>
 </html>
 ```
      * @example ​ ````Trigger the click event on all of the paragraphs on the page:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>click demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $( "p" ).click();
-</script>
-</body>
-</html>
 ```
      */
     click(handler?: JQuery.EventHandler<TElement> | JQuery.EventHandlerBase<any, JQuery.Event<TElement>> | false): this;
@@ -33098,6 +30594,7 @@ $( "p" ).click();
 <script>
 $( "b" ).clone().prependTo( "p" );
 </script>
+​
 </body>
 </html>
 ```
@@ -33111,75 +30608,6 @@ $( "b" ).clone().prependTo( "p" );
      * @param context A DOM element within which a matching element may be found.
      * @see \`{@link https://api.jquery.com/closest/ }\`
      * @since 1.4
-     * @example ​ ````Show how event delegation can be done with closest. The closest list element toggles a yellow background when it or its descendent is clicked.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>closest demo</title>
-  <style>
-  li {
-    margin: 3px;
-    padding: 3px;
-    background: #EEEEEE;
-  }
-  li.highlight {
-    background: yellow;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<ul>
-  <li><b>Click me!</b></li>
-  <li>You can also <b>Click me!</b></li>
-</ul>
-​
-<script>
-$( document ).on( "click", function( event ) {
-  $( event.target ).closest( "li" ).toggleClass( "highlight" );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Pass a jQuery object to closest. The closest list element toggles a yellow background when it or its descendent is clicked.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>closest demo</title>
-  <style>
-  li {
-    margin: 3px;
-    padding: 3px;
-    background: #EEEEEE;
-  }
-  li.highlight {
-    background: yellow;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<ul>
-  <li><b>Click me!</b></li>
-  <li>You can also <b>Click me!</b></li>
-</ul>
-​
-<script>
-var listElements = $( "li" ).css( "color", "blue" );
-$( document ).on( "click", function( event ) {
-  $( event.target ).closest( listElements ).toggleClass( "highlight" );
-});
-</script>
-</body>
-</html>
-```
      */
     closest(selector: JQuery.Selector, context: Element): this;
     /**
@@ -33223,6 +30651,7 @@ $( document ).on( "click", function( event ) {
   $( event.target ).closest( "li" ).toggleClass( "highlight" );
 });
 </script>
+​
 </body>
 </html>
 ```
@@ -33258,6 +30687,7 @@ $( document ).on( "click", function( event ) {
   $( event.target ).closest( listElements ).toggleClass( "highlight" );
 });
 </script>
+​
 </body>
 </html>
 ```
@@ -33289,6 +30719,7 @@ $( "p" )
   })
   .wrap( "<b></b>" );
 </script>
+​
 </body>
 </html>
 ```
@@ -33308,6 +30739,7 @@ $( "p" )
 <script>
 $( "#frameDemo" ).contents().find( "a" ).css( "background-color", "#BADA55" );
 </script>
+​
 </body>
 </html>
 ```
@@ -33325,60 +30757,6 @@ $( "#frameDemo" ).contents().find( "a" ).css( "background-color", "#BADA55" );
      * **Cause**: The `.on()` and `.trigger()` methods can set an event handler or generate an event for any event type, and should be used instead of the shortcut methods. This message also applies to the other event shorthands, including: blur, focus, focusin, focusout, resize, scroll, dblclick, mousedown, mouseup, mousemove, mouseover, mouseout, mouseenter, mouseleave, change, select, submit, keydown, keypress, keyup, and contextmenu.
      *
      * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
-     * @example ​ ````To show a &quot;Hello World!&quot; alert box when the contextmenu event is triggered on a paragraph on the page:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>contextmenu demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "p" ).contextmenu(function() {
-  alert( "Hello World!" );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Right click to toggle background color.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>contextmenu demo</title>
-  <style>
-  div {
-    background: blue;
-    color: white;
-    height: 100px;
-    width: 150px;
- }
-  div.contextmenu {
-    background: yellow;
-    color: black;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<div></div>
-<span>Right click the block</span>
-​
-<script>
-var div = $( "div:first" );
-div.contextmenu(function() {
-  div.toggleClass( "contextmenu" );
-});
-</script>
-</body>
-</html>
-```
      */
     contextmenu<TData>(eventData: TData,
                        handler: JQuery.EventHandler<TElement, TData> | JQuery.EventHandlerBase<any, JQuery.Event<TElement, TData>>): this;
@@ -33394,23 +30772,10 @@ div.contextmenu(function() {
      *
      * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
      * @example ​ ````To show a &quot;Hello World!&quot; alert box when the contextmenu event is triggered on a paragraph on the page:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>contextmenu demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $( "p" ).contextmenu(function() {
   alert( "Hello World!" );
 });
-</script>
-</body>
-</html>
 ```
      * @example ​ ````Right click to toggle background color.
 ```html
@@ -33444,6 +30809,7 @@ div.contextmenu(function() {
   div.toggleClass( "contextmenu" );
 });
 </script>
+​
 </body>
 </html>
 ```
@@ -33459,102 +30825,6 @@ div.contextmenu(function() {
      * @see \`{@link https://api.jquery.com/css/ }\`
      * @since 1.0
      * @since 1.4
-     * @example ​ ````Get the background color of a clicked div.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>css demo</title>
-  <style>
-  div {
-    width: 60px;
-    height: 60px;
-    margin: 5px;
-    float: left;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<span id="result">&nbsp;</span>
-<div style="background-color:blue;"></div>
-<div style="background-color:rgb(15,99,30);"></div>
-<div style="background-color:#123456;"></div>
-<div style="background-color:#f11;"></div>
-​
-<script>
-$( "div" ).click(function() {
-  var color = $( this ).css( "background-color" );
-  $( "#result" ).html( "That div is <span style='color:" +
-    color + ";'>" + color + "</span>." );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Get the width, height, text color, and background color of a clicked div.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>css demo</title>
-  <style>
-  div {
-    height: 50px;
-    margin: 5px;
-    padding: 5px;
-    float: left;
-  }
-  #box1 {
-    width: 50px;
-    color: yellow;
-    background-color: blue;
-  }
-  #box2 {
-    width: 80px;
-    color: rgb(255, 255, 255);
-    background-color: rgb(15, 99, 30);
-  }
-  #box3 {
-    width: 40px;
-    color: #fcc;
-    background-color: #123456;
-  }
-  #box4 {
-    width: 70px;
-    background-color: #f11;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p id="result">&nbsp;</p>
-<div id="box1">1</div>
-<div id="box2">2</div>
-<div id="box3">3</div>
-<div id="box4">4</div>
-​
-<script>
-$( "div" ).click(function() {
-  var html = [ "The clicked div has the following styles:" ];
-​
-  var styleProps = $( this ).css([
-    "width", "height", "color", "background-color"
-  ]);
-  $.each( styleProps, function( prop, value ) {
-    html.push( prop + ": " + value );
-  });
-​
-  $( "#result" ).html( html.join( "<br>" ) );
-});
-</script>
-</body>
-</html>
-```
      * @example ​ ````Change the color of any paragraph to red on mouseover event.
 ```html
 <!doctype html>
@@ -33582,6 +30852,7 @@ $( "p" ).on( "mouseover", function() {
   $( this ).css( "color", "red" );
 });
 </script>
+​
 </body>
 </html>
 ```
@@ -33611,6 +30882,7 @@ $( "#box" ).one( "click", function() {
   $( this ).css( "width", "+=200" );
 });
 </script>
+​
 </body>
 </html>
 ```
@@ -33648,80 +30920,7 @@ $( "span" ).on( "click", function() {
   $( this ).css( "background-color", "yellow" );
 });
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Change the font weight and background color on mouseenter and mouseleave.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>css demo</title>
-  <style>
-  p {
-    color: green;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-<p>Move the mouse over a paragraph.</p>
-<p>Like this one or the one above.</p>
-​
-<script>
-$( "p" )
-  .on( "mouseenter", function() {
-    $( this ).css({
-      "background-color": "yellow",
-      "font-weight": "bolder"
-    });
-  })
-  .on( "mouseleave", function() {
-    var styles = {
-      backgroundColor : "#ddd",
-      fontWeight: ""
-    };
-    $( this ).css( styles );
-  });
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Increase the size of a div when you click it.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>css demo</title>
-  <style>
-  div {
-    width: 20px;
-    height: 15px;
-    background-color: #f33;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<div>click</div>
-<div>click</div>
-​
-<script>
-$( "div" ).on( "click", function() {
-  $( this ).css({
-    width: function( index, value ) {
-      return parseFloat( value ) * 1.2;
-    },
-    height: function( index, value ) {
-      return parseFloat( value ) * 1.2;
-    }
-  });
-});
-</script>
 </body>
 </html>
 ```
@@ -33734,198 +30933,6 @@ $( "div" ).on( "click", function() {
      * @param properties An object of property-value pairs to set.
      * @see \`{@link https://api.jquery.com/css/ }\`
      * @since 1.0
-     * @example ​ ````Get the background color of a clicked div.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>css demo</title>
-  <style>
-  div {
-    width: 60px;
-    height: 60px;
-    margin: 5px;
-    float: left;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<span id="result">&nbsp;</span>
-<div style="background-color:blue;"></div>
-<div style="background-color:rgb(15,99,30);"></div>
-<div style="background-color:#123456;"></div>
-<div style="background-color:#f11;"></div>
-​
-<script>
-$( "div" ).click(function() {
-  var color = $( this ).css( "background-color" );
-  $( "#result" ).html( "That div is <span style='color:" +
-    color + ";'>" + color + "</span>." );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Get the width, height, text color, and background color of a clicked div.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>css demo</title>
-  <style>
-  div {
-    height: 50px;
-    margin: 5px;
-    padding: 5px;
-    float: left;
-  }
-  #box1 {
-    width: 50px;
-    color: yellow;
-    background-color: blue;
-  }
-  #box2 {
-    width: 80px;
-    color: rgb(255, 255, 255);
-    background-color: rgb(15, 99, 30);
-  }
-  #box3 {
-    width: 40px;
-    color: #fcc;
-    background-color: #123456;
-  }
-  #box4 {
-    width: 70px;
-    background-color: #f11;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p id="result">&nbsp;</p>
-<div id="box1">1</div>
-<div id="box2">2</div>
-<div id="box3">3</div>
-<div id="box4">4</div>
-​
-<script>
-$( "div" ).click(function() {
-  var html = [ "The clicked div has the following styles:" ];
-​
-  var styleProps = $( this ).css([
-    "width", "height", "color", "background-color"
-  ]);
-  $.each( styleProps, function( prop, value ) {
-    html.push( prop + ": " + value );
-  });
-​
-  $( "#result" ).html( html.join( "<br>" ) );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Change the color of any paragraph to red on mouseover event.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>css demo</title>
-  <style>
-  p {
-    color: blue;
-    width: 200px;
-    font-size: 14px;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-  <p>Just roll the mouse over me.</p>
-​
-  <p>Or me to see a color change.</p>
-​
-<script>
-$( "p" ).on( "mouseover", function() {
-  $( this ).css( "color", "red" );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Increase the width of #box by 200 pixels the first time it is clicked.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>css demo</title>
-  <style>
-  #box {
-    background: black;
-    color: snow;
-    width: 100px;
-    padding: 10px;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<div id="box">Click me to grow</div>
-​
-<script>
-$( "#box" ).one( "click", function() {
-  $( this ).css( "width", "+=200" );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Highlight a clicked word in the paragraph.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>css demo</title>
-  <style>
-  p {
-    color: blue;
-    font-weight: bold;
-    cursor: pointer;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p>
-  Once upon a time there was a man
-  who lived in a pizza parlor. This
-  man just loved pizza and ate it all
-  the time.  He went on to be the
-  happiest man in the world.  The end.
-</p>
-​
-<script>
-var words = $( "p" ).first().text().split( /\s+/ );
-var text = words.join( "</span> <span>" );
-$( "p" ).first().html( "<span>" + text + "</span>" );
-$( "span" ).on( "click", function() {
-  $( this ).css( "background-color", "yellow" );
-});
-</script>
-</body>
-</html>
-```
      * @example ​ ````Change the font weight and background color on mouseenter and mouseleave.
 ```html
 <!doctype html>
@@ -33961,6 +30968,7 @@ $( "p" )
     $( this ).css( styles );
   });
 </script>
+​
 </body>
 </html>
 ```
@@ -33997,6 +31005,7 @@ $( "div" ).on( "click", function() {
   });
 });
 </script>
+​
 </body>
 </html>
 ```
@@ -34041,237 +31050,7 @@ $( "div" ).click(function() {
     color + ";'>" + color + "</span>." );
 });
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Get the width, height, text color, and background color of a clicked div.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>css demo</title>
-  <style>
-  div {
-    height: 50px;
-    margin: 5px;
-    padding: 5px;
-    float: left;
-  }
-  #box1 {
-    width: 50px;
-    color: yellow;
-    background-color: blue;
-  }
-  #box2 {
-    width: 80px;
-    color: rgb(255, 255, 255);
-    background-color: rgb(15, 99, 30);
-  }
-  #box3 {
-    width: 40px;
-    color: #fcc;
-    background-color: #123456;
-  }
-  #box4 {
-    width: 70px;
-    background-color: #f11;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-<p id="result">&nbsp;</p>
-<div id="box1">1</div>
-<div id="box2">2</div>
-<div id="box3">3</div>
-<div id="box4">4</div>
-​
-<script>
-$( "div" ).click(function() {
-  var html = [ "The clicked div has the following styles:" ];
-​
-  var styleProps = $( this ).css([
-    "width", "height", "color", "background-color"
-  ]);
-  $.each( styleProps, function( prop, value ) {
-    html.push( prop + ": " + value );
-  });
-​
-  $( "#result" ).html( html.join( "<br>" ) );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Change the color of any paragraph to red on mouseover event.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>css demo</title>
-  <style>
-  p {
-    color: blue;
-    width: 200px;
-    font-size: 14px;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-  <p>Just roll the mouse over me.</p>
-​
-  <p>Or me to see a color change.</p>
-​
-<script>
-$( "p" ).on( "mouseover", function() {
-  $( this ).css( "color", "red" );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Increase the width of #box by 200 pixels the first time it is clicked.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>css demo</title>
-  <style>
-  #box {
-    background: black;
-    color: snow;
-    width: 100px;
-    padding: 10px;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<div id="box">Click me to grow</div>
-​
-<script>
-$( "#box" ).one( "click", function() {
-  $( this ).css( "width", "+=200" );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Highlight a clicked word in the paragraph.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>css demo</title>
-  <style>
-  p {
-    color: blue;
-    font-weight: bold;
-    cursor: pointer;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p>
-  Once upon a time there was a man
-  who lived in a pizza parlor. This
-  man just loved pizza and ate it all
-  the time.  He went on to be the
-  happiest man in the world.  The end.
-</p>
-​
-<script>
-var words = $( "p" ).first().text().split( /\s+/ );
-var text = words.join( "</span> <span>" );
-$( "p" ).first().html( "<span>" + text + "</span>" );
-$( "span" ).on( "click", function() {
-  $( this ).css( "background-color", "yellow" );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Change the font weight and background color on mouseenter and mouseleave.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>css demo</title>
-  <style>
-  p {
-    color: green;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p>Move the mouse over a paragraph.</p>
-<p>Like this one or the one above.</p>
-​
-<script>
-$( "p" )
-  .on( "mouseenter", function() {
-    $( this ).css({
-      "background-color": "yellow",
-      "font-weight": "bolder"
-    });
-  })
-  .on( "mouseleave", function() {
-    var styles = {
-      backgroundColor : "#ddd",
-      fontWeight: ""
-    };
-    $( this ).css( styles );
-  });
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Increase the size of a div when you click it.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>css demo</title>
-  <style>
-  div {
-    width: 20px;
-    height: 15px;
-    background-color: #f33;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<div>click</div>
-<div>click</div>
-​
-<script>
-$( "div" ).on( "click", function() {
-  $( this ).css({
-    width: function( index, value ) {
-      return parseFloat( value ) * 1.2;
-    },
-    height: function( index, value ) {
-      return parseFloat( value ) * 1.2;
-    }
-  });
-});
-</script>
 </body>
 </html>
 ```
@@ -34283,41 +31062,6 @@ $( "div" ).on( "click", function() {
      * @param propertyNames An array of one or more CSS properties.
      * @see \`{@link https://api.jquery.com/css/ }\`
      * @since 1.9
-     * @example ​ ````Get the background color of a clicked div.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>css demo</title>
-  <style>
-  div {
-    width: 60px;
-    height: 60px;
-    margin: 5px;
-    float: left;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<span id="result">&nbsp;</span>
-<div style="background-color:blue;"></div>
-<div style="background-color:rgb(15,99,30);"></div>
-<div style="background-color:#123456;"></div>
-<div style="background-color:#f11;"></div>
-​
-<script>
-$( "div" ).click(function() {
-  var color = $( this ).css( "background-color" );
-  $( "#result" ).html( "That div is <span style='color:" +
-    color + ";'>" + color + "</span>." );
-});
-</script>
-</body>
-</html>
-```
      * @example ​ ````Get the width, height, text color, and background color of a clicked div.
 ```html
 <!doctype html>
@@ -34376,176 +31120,7 @@ $( "div" ).click(function() {
   $( "#result" ).html( html.join( "<br>" ) );
 });
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Change the color of any paragraph to red on mouseover event.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>css demo</title>
-  <style>
-  p {
-    color: blue;
-    width: 200px;
-    font-size: 14px;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-  <p>Just roll the mouse over me.</p>
-​
-  <p>Or me to see a color change.</p>
-​
-<script>
-$( "p" ).on( "mouseover", function() {
-  $( this ).css( "color", "red" );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Increase the width of #box by 200 pixels the first time it is clicked.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>css demo</title>
-  <style>
-  #box {
-    background: black;
-    color: snow;
-    width: 100px;
-    padding: 10px;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<div id="box">Click me to grow</div>
-​
-<script>
-$( "#box" ).one( "click", function() {
-  $( this ).css( "width", "+=200" );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Highlight a clicked word in the paragraph.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>css demo</title>
-  <style>
-  p {
-    color: blue;
-    font-weight: bold;
-    cursor: pointer;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p>
-  Once upon a time there was a man
-  who lived in a pizza parlor. This
-  man just loved pizza and ate it all
-  the time.  He went on to be the
-  happiest man in the world.  The end.
-</p>
-​
-<script>
-var words = $( "p" ).first().text().split( /\s+/ );
-var text = words.join( "</span> <span>" );
-$( "p" ).first().html( "<span>" + text + "</span>" );
-$( "span" ).on( "click", function() {
-  $( this ).css( "background-color", "yellow" );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Change the font weight and background color on mouseenter and mouseleave.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>css demo</title>
-  <style>
-  p {
-    color: green;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p>Move the mouse over a paragraph.</p>
-<p>Like this one or the one above.</p>
-​
-<script>
-$( "p" )
-  .on( "mouseenter", function() {
-    $( this ).css({
-      "background-color": "yellow",
-      "font-weight": "bolder"
-    });
-  })
-  .on( "mouseleave", function() {
-    var styles = {
-      backgroundColor : "#ddd",
-      fontWeight: ""
-    };
-    $( this ).css( styles );
-  });
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Increase the size of a div when you click it.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>css demo</title>
-  <style>
-  div {
-    width: 20px;
-    height: 15px;
-    background-color: #f33;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<div>click</div>
-<div>click</div>
-​
-<script>
-$( "div" ).on( "click", function() {
-  $( this ).css({
-    width: function( index, value ) {
-      return parseFloat( value ) * 1.2;
-    },
-    height: function( index, value ) {
-      return parseFloat( value ) * 1.2;
-    }
-  });
-});
-</script>
 </body>
 </html>
 ```
@@ -34589,69 +31164,7 @@ $( "div" ).data( "test", { first: 16, last: "pizza!" } );
 $( "span:first" ).text( $( "div" ).data( "test" ).first );
 $( "span:last" ).text( $( "div" ).data( "test" ).last );
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Get the data named &quot;blah&quot; stored at for an element.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>data demo</title>
-  <style>
-  div {
-    margin: 5px;
-    background: yellow;
-  }
-  button {
-    margin: 5px;
-    font-size: 14px;
-  }
-  p {
-    margin: 5px;
-    color: blue;
-  }
-  span {
-    color: red;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-<div>A div</div>
-<button>Get "blah" from the div</button>
-<button>Set "blah" to "hello"</button>
-<button>Set "blah" to 86</button>
-<button>Remove "blah" from the div</button>
-<p>The "blah" value of this div is <span>?</span></p>
-​
-<script>
-$( "button" ).click(function() {
-  var value;
-​
-  switch ( $( "button" ).index( this ) ) {
-    case 0 :
-      value = $( "div" ).data( "blah" );
-      break;
-    case 1 :
-      $( "div" ).data( "blah", "hello" );
-      value = "Stored!";
-      break;
-    case 2 :
-      $( "div" ).data( "blah", 86 );
-      value = "Stored!";
-      break;
-    case 3 :
-      $( "div" ).removeData( "blah" );
-      value = "Removed!";
-      break;
-  }
-​
-  $( "span" ).text( "" + value );
-});
-</script>
 </body>
 </html>
 ```
@@ -34663,103 +31176,6 @@ $( "button" ).click(function() {
      * @param obj An object of key-value pairs of data to update.
      * @see \`{@link https://api.jquery.com/data/ }\`
      * @since 1.4.3
-     * @example ​ ````Store then retrieve a value from the div element.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>data demo</title>
-  <style>
-  div {
-    color: blue;
-  }
-  span {
-    color: red;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<div>
-  The values stored were
-  <span></span>
-  and
-  <span></span>
-</div>
-​
-<script>
-$( "div" ).data( "test", { first: 16, last: "pizza!" } );
-$( "span:first" ).text( $( "div" ).data( "test" ).first );
-$( "span:last" ).text( $( "div" ).data( "test" ).last );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Get the data named &quot;blah&quot; stored at for an element.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>data demo</title>
-  <style>
-  div {
-    margin: 5px;
-    background: yellow;
-  }
-  button {
-    margin: 5px;
-    font-size: 14px;
-  }
-  p {
-    margin: 5px;
-    color: blue;
-  }
-  span {
-    color: red;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<div>A div</div>
-<button>Get "blah" from the div</button>
-<button>Set "blah" to "hello"</button>
-<button>Set "blah" to 86</button>
-<button>Remove "blah" from the div</button>
-<p>The "blah" value of this div is <span>?</span></p>
-​
-<script>
-$( "button" ).click(function() {
-  var value;
-​
-  switch ( $( "button" ).index( this ) ) {
-    case 0 :
-      value = $( "div" ).data( "blah" );
-      break;
-    case 1 :
-      $( "div" ).data( "blah", "hello" );
-      value = "Stored!";
-      break;
-    case 2 :
-      $( "div" ).data( "blah", 86 );
-      value = "Stored!";
-      break;
-    case 3 :
-      $( "div" ).removeData( "blah" );
-      value = "Removed!";
-      break;
-  }
-​
-  $( "span" ).text( "" + value );
-});
-</script>
-</body>
-</html>
-```
      */
     data(obj: JQuery.PlainObject): this;
     /**
@@ -34771,103 +31187,6 @@ $( "button" ).click(function() {
      *              will return the jQuery object that it was called on, allowing for chaining.
      * @see \`{@link https://api.jquery.com/data/ }\`
      * @since 1.2.3
-     * @example ​ ````Store then retrieve a value from the div element.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>data demo</title>
-  <style>
-  div {
-    color: blue;
-  }
-  span {
-    color: red;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<div>
-  The values stored were
-  <span></span>
-  and
-  <span></span>
-</div>
-​
-<script>
-$( "div" ).data( "test", { first: 16, last: "pizza!" } );
-$( "span:first" ).text( $( "div" ).data( "test" ).first );
-$( "span:last" ).text( $( "div" ).data( "test" ).last );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Get the data named &quot;blah&quot; stored at for an element.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>data demo</title>
-  <style>
-  div {
-    margin: 5px;
-    background: yellow;
-  }
-  button {
-    margin: 5px;
-    font-size: 14px;
-  }
-  p {
-    margin: 5px;
-    color: blue;
-  }
-  span {
-    color: red;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<div>A div</div>
-<button>Get "blah" from the div</button>
-<button>Set "blah" to "hello"</button>
-<button>Set "blah" to 86</button>
-<button>Remove "blah" from the div</button>
-<p>The "blah" value of this div is <span>?</span></p>
-​
-<script>
-$( "button" ).click(function() {
-  var value;
-​
-  switch ( $( "button" ).index( this ) ) {
-    case 0 :
-      value = $( "div" ).data( "blah" );
-      break;
-    case 1 :
-      $( "div" ).data( "blah", "hello" );
-      value = "Stored!";
-      break;
-    case 2 :
-      $( "div" ).data( "blah", 86 );
-      value = "Stored!";
-      break;
-    case 3 :
-      $( "div" ).removeData( "blah" );
-      value = "Removed!";
-      break;
-  }
-​
-  $( "span" ).text( "" + value );
-});
-</script>
-</body>
-</html>
-```
      */
     // `unified-signatures` is disabled so that behavior when passing `undefined` to `value` can be documented. Unifying the signatures
     // results in potential confusion for users from an unexpected parameter.
@@ -34880,40 +31199,6 @@ $( "button" ).click(function() {
      * @param key Name of the data stored.
      * @see \`{@link https://api.jquery.com/data/ }\`
      * @since 1.2.3
-     * @example ​ ````Store then retrieve a value from the div element.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>data demo</title>
-  <style>
-  div {
-    color: blue;
-  }
-  span {
-    color: red;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<div>
-  The values stored were
-  <span></span>
-  and
-  <span></span>
-</div>
-​
-<script>
-$( "div" ).data( "test", { first: 16, last: "pizza!" } );
-$( "span:first" ).text( $( "div" ).data( "test" ).first );
-$( "span:last" ).text( $( "div" ).data( "test" ).last );
-</script>
-</body>
-</html>
-```
      * @example ​ ````Get the data named &quot;blah&quot; stored at for an element.
 ```html
 <!doctype html>
@@ -34974,6 +31259,7 @@ $( "button" ).click(function() {
   $( "span" ).text( "" + value );
 });
 </script>
+​
 </body>
 </html>
 ```
@@ -34985,103 +31271,6 @@ $( "button" ).click(function() {
      *
      * @see \`{@link https://api.jquery.com/data/ }\`
      * @since 1.4
-     * @example ​ ````Store then retrieve a value from the div element.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>data demo</title>
-  <style>
-  div {
-    color: blue;
-  }
-  span {
-    color: red;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<div>
-  The values stored were
-  <span></span>
-  and
-  <span></span>
-</div>
-​
-<script>
-$( "div" ).data( "test", { first: 16, last: "pizza!" } );
-$( "span:first" ).text( $( "div" ).data( "test" ).first );
-$( "span:last" ).text( $( "div" ).data( "test" ).last );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Get the data named &quot;blah&quot; stored at for an element.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>data demo</title>
-  <style>
-  div {
-    margin: 5px;
-    background: yellow;
-  }
-  button {
-    margin: 5px;
-    font-size: 14px;
-  }
-  p {
-    margin: 5px;
-    color: blue;
-  }
-  span {
-    color: red;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<div>A div</div>
-<button>Get "blah" from the div</button>
-<button>Set "blah" to "hello"</button>
-<button>Set "blah" to 86</button>
-<button>Remove "blah" from the div</button>
-<p>The "blah" value of this div is <span>?</span></p>
-​
-<script>
-$( "button" ).click(function() {
-  var value;
-​
-  switch ( $( "button" ).index( this ) ) {
-    case 0 :
-      value = $( "div" ).data( "blah" );
-      break;
-    case 1 :
-      $( "div" ).data( "blah", "hello" );
-      value = "Stored!";
-      break;
-    case 2 :
-      $( "div" ).data( "blah", 86 );
-      value = "Stored!";
-      break;
-    case 3 :
-      $( "div" ).removeData( "blah" );
-      value = "Removed!";
-      break;
-  }
-​
-  $( "span" ).text( "" + value );
-});
-</script>
-</body>
-</html>
-```
      */
     data(): JQuery.PlainObject;
     /**
@@ -35096,60 +31285,6 @@ $( "button" ).click(function() {
      * **Cause**: The `.on()` and `.trigger()` methods can set an event handler or generate an event for any event type, and should be used instead of the shortcut methods. This message also applies to the other event shorthands, including: blur, focus, focusin, focusout, resize, scroll, dblclick, mousedown, mouseup, mousemove, mouseover, mouseout, mouseenter, mouseleave, change, select, submit, keydown, keypress, keyup, and contextmenu.
      *
      * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
-     * @example ​ ````To bind a &quot;Hello World!&quot; alert box to the dblclick event on every paragraph on the page:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>dblclick demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "p" ).dblclick(function() {
-  alert( "Hello World!" );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Double click to toggle background color.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>dblclick demo</title>
-  <style>
-  div {
-    background: blue;
-    color: white;
-    height: 100px;
-    width: 150px;
- }
-  div.dbl {
-    background: yellow;
-    color: black;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<div></div>
-<span>Double click the block</span>
-​
-<script>
-var divdbl = $( "div:first" );
-divdbl.dblclick(function() {
-  divdbl.toggleClass( "dbl" );
-});
-</script>
-</body>
-</html>
-```
      */
     dblclick<TData>(eventData: TData,
                     handler: JQuery.EventHandler<TElement, TData> | JQuery.EventHandlerBase<any, JQuery.Event<TElement, TData>>): this;
@@ -35165,23 +31300,10 @@ divdbl.dblclick(function() {
      *
      * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
      * @example ​ ````To bind a &quot;Hello World!&quot; alert box to the dblclick event on every paragraph on the page:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>dblclick demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $( "p" ).dblclick(function() {
   alert( "Hello World!" );
 });
-</script>
-</body>
-</html>
 ```
      * @example ​ ````Double click to toggle background color.
 ```html
@@ -35215,6 +31337,7 @@ divdbl.dblclick(function() {
   divdbl.toggleClass( "dbl" );
 });
 </script>
+​
 </body>
 </html>
 ```
@@ -35264,6 +31387,7 @@ $( "button" ).click(function() {
   $( "div.second" ).slideUp( 300 ).fadeIn( 400 );
 });
 </script>
+​
 </body>
 </html>
 ```
@@ -35285,140 +31409,6 @@ $( "button" ).click(function() {
      * **Cause**: These event binding methods have been deprecated in favor of the `.on()` and `.off()` methods which can handle both delegated and direct event binding. Although the older methods are still present in jQuery 3.0, they may be removed as early as the next major-version update.
      *
      * **Solution**: Change the method call to use `.on()` or `.off()`, the documentation for the old methods include specific instructions. In general, the `.bind()` and `.unbind()` methods can be renamed directly to `.on()` and `.off()` respectively since the argument orders are identical.
-     * @example ​ ````Click a paragraph to add another. Note that .delegate() attaches a click event handler to all paragraphs - even new ones.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>delegate demo</title>
-  <style>
-  p {
-    background: yellow;
-    font-weight: bold;
-    cursor: pointer;
-    padding: 5px;
-  }
-  p.over {
-    background: #ccc;
-  }
-  span {
-    color: red;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p>Click me!</p>
-​
-<span></span>
-​
-<script>
-$( "body" ).delegate( "p", "click", function() {
-  $( this ).after( "<p>Another paragraph!</p>" );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````To display each paragraph&#39;s text in an alert box whenever it is clicked:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>delegate demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "body" ).delegate( "p", "click", function() {
-  alert( $( this ).text() );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````To cancel a default action and prevent it from bubbling up, return false:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>delegate demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "body" ).delegate( "a", "click", function() {
-  return false;
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````To cancel only the default action by using the preventDefault method.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>delegate demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "body" ).delegate( "a", "click", function( event ) {
-  event.preventDefault();
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Can bind custom events too.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>delegate demo</title>
-  <style>
-  p {
-    color: red;
-  }
-  span {
-    color: blue;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p>Has an attached custom event.</p>
-<button>Trigger custom event</button>
-<span style="display:none;"></span>
-​
-<script>
-$( "body" ).delegate( "p", "myCustomEvent", function( e, myName, myValue ) {
-  $( this ).text( "Hi there!" );
-  $( "span" )
-    .stop()
-    .css( "opacity", 1 )
-    .text( "myName = " + myName )
-    .fadeIn( 30 )
-    .fadeOut( 1000 );
-});
-$( "button" ).click(function() {
-  $( "p" ).trigger( "myCustomEvent" );
-});
-</script>
-</body>
-</html>
-```
      */
     delegate<TData>(selector: JQuery.Selector,
                     eventType: string,
@@ -35473,65 +31463,27 @@ $( "body" ).delegate( "p", "click", function() {
   $( this ).after( "<p>Another paragraph!</p>" );
 });
 </script>
+​
 </body>
 </html>
 ```
      * @example ​ ````To display each paragraph&#39;s text in an alert box whenever it is clicked:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>delegate demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $( "body" ).delegate( "p", "click", function() {
   alert( $( this ).text() );
 });
-</script>
-</body>
-</html>
 ```
      * @example ​ ````To cancel a default action and prevent it from bubbling up, return false:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>delegate demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $( "body" ).delegate( "a", "click", function() {
   return false;
 });
-</script>
-</body>
-</html>
 ```
      * @example ​ ````To cancel only the default action by using the preventDefault method.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>delegate demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $( "body" ).delegate( "a", "click", function( event ) {
   event.preventDefault();
 });
-</script>
-</body>
-</html>
 ```
      * @example ​ ````Can bind custom events too.
 ```html
@@ -35570,6 +31522,7 @@ $( "button" ).click(function() {
   $( "p" ).trigger( "myCustomEvent" );
 });
 </script>
+​
 </body>
 </html>
 ```
@@ -35590,140 +31543,6 @@ $( "button" ).click(function() {
      * **Cause**: These event binding methods have been deprecated in favor of the `.on()` and `.off()` methods which can handle both delegated and direct event binding. Although the older methods are still present in jQuery 3.0, they may be removed as early as the next major-version update.
      *
      * **Solution**: Change the method call to use `.on()` or `.off()`, the documentation for the old methods include specific instructions. In general, the `.bind()` and `.unbind()` methods can be renamed directly to `.on()` and `.off()` respectively since the argument orders are identical.
-     * @example ​ ````Click a paragraph to add another. Note that .delegate() attaches a click event handler to all paragraphs - even new ones.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>delegate demo</title>
-  <style>
-  p {
-    background: yellow;
-    font-weight: bold;
-    cursor: pointer;
-    padding: 5px;
-  }
-  p.over {
-    background: #ccc;
-  }
-  span {
-    color: red;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p>Click me!</p>
-​
-<span></span>
-​
-<script>
-$( "body" ).delegate( "p", "click", function() {
-  $( this ).after( "<p>Another paragraph!</p>" );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````To display each paragraph&#39;s text in an alert box whenever it is clicked:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>delegate demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "body" ).delegate( "p", "click", function() {
-  alert( $( this ).text() );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````To cancel a default action and prevent it from bubbling up, return false:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>delegate demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "body" ).delegate( "a", "click", function() {
-  return false;
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````To cancel only the default action by using the preventDefault method.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>delegate demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "body" ).delegate( "a", "click", function( event ) {
-  event.preventDefault();
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Can bind custom events too.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>delegate demo</title>
-  <style>
-  p {
-    color: red;
-  }
-  span {
-    color: blue;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p>Has an attached custom event.</p>
-<button>Trigger custom event</button>
-<span style="display:none;"></span>
-​
-<script>
-$( "body" ).delegate( "p", "myCustomEvent", function( e, myName, myValue ) {
-  $( this ).text( "Hi there!" );
-  $( "span" )
-    .stop()
-    .css( "opacity", 1 )
-    .text( "myName = " + myName )
-    .fadeIn( 30 )
-    .fadeOut( 1000 );
-});
-$( "button" ).click(function() {
-  $( "p" ).trigger( "myCustomEvent" );
-});
-</script>
-</body>
-</html>
-```
      */
     delegate(selector: JQuery.Selector,
              events: JQuery.PlainObject<JQuery.EventHandler<TElement> | JQuery.EventHandlerBase<any, JQuery.Event<TElement>> | false>): this;
@@ -35772,6 +31591,7 @@ $( "button" ).click(function() {
     .animate({ left:"10px", top:"30px" }, 700 );
 });
 </script>
+​
 </body>
 </html>
 ```
@@ -35822,6 +31642,7 @@ $( "button" ).click(function() {
   }
 });
 </script>
+​
 </body>
 </html>
 ```
@@ -35868,6 +31689,7 @@ $( document.body ).click(function() {
   });
 });
 </script>
+​
 </body>
 </html>
 ```
@@ -35910,6 +31732,7 @@ $( "span" ).click(function() {
   });
 });
 </script>
+​
 </body>
 </html>
 ```
@@ -35960,6 +31783,7 @@ $( "button" ).click(function() {
   });
 });
 </script>
+​
 </body>
 </html>
 ```
@@ -35997,6 +31821,7 @@ $( "button" ).click(function() {
   $( "p" ).empty();
 });
 </script>
+​
 </body>
 </html>
 ```
@@ -36075,6 +31900,7 @@ $( "p" )
   .showTags( 2 )
   .css( "font-style", "italic" );
 </script>
+​
 </body>
 </html>
 ```
@@ -36103,6 +31929,7 @@ $( "p" )
   .end()
   .css( "border", "2px red solid" );
 </script>
+​
 </body>
 </html>
 ```
@@ -36149,6 +31976,7 @@ $( "p" )
 <script>
 $( "body" ).find( "div" ).eq( 2 ).addClass( "blue" );
 </script>
+​
 </body>
 </html>
 ```
@@ -36197,6 +32025,7 @@ jQuery.fn.extend({
 // Use the newly created .check() method
 $( "input[type='checkbox']" ).check();
 </script>
+​
 </body>
 </html>
 ```
@@ -36210,105 +32039,6 @@ $( "input[type='checkbox']" ).check();
      * @param complete A function to call once the animation is complete, called once per matched element.
      * @see \`{@link https://api.jquery.com/fadeIn/ }\`
      * @since 1.4.3
-     * @example ​ ````Animates hidden divs to fade in one by one, completing each animation within 600 milliseconds.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>fadeIn demo</title>
-  <style>
-  span {
-    color: red;
-    cursor: pointer;
-  }
-  div {
-    margin: 3px;
-    width: 80px;
-    display: none;
-    height: 80px;
-    float: left;
-  }
-  #one {
-    background: #f00;
-  }
-  #two {
-    background: #0f0;
-  }
-  #three {
-    background: #00f;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<span>Click here...</span>
-<div id="one"></div>
-<div id="two"></div>
-<div id="three"></div>
-​
-<script>
-$( document.body ).click(function() {
-  $( "div:hidden:first" ).fadeIn( "slow" );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Fades a red block in over the text. Once the animation is done, it quickly fades in more text on top.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>fadeIn demo</title>
-  <style>
-  p {
-    position: relative;
-    width: 400px;
-    height: 90px;
-  }
-  div {
-    position: absolute;
-    width: 400px;
-    height: 65px;
-    font-size: 36px;
-    text-align: center;
-    color: yellow;
-    background: red;
-    padding-top: 25px;
-    top: 0;
-    left: 0;
-    display: none;
-  }
-  span {
-    display: none;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p>
-  Let it be known that the party of the first part
-  and the party of the second part are henceforth
-  and hereto directed to assess the allegations
-  for factual correctness... (<a href="#">click!</a>)
-  <div><span>CENSORED!</span></div>
-</p>
-​
-<script>
-$( "a" ).click(function() {
-  $( "div" ).fadeIn( 3000, function() {
-    $( "span" ).fadeIn( 100 );
-  });
-  return false;
-});
-</script>
-</body>
-</html>
-```
      */
     fadeIn(duration: JQuery.Duration, easing: string, complete?: (this: TElement) => void): this;
     /**
@@ -36320,52 +32050,6 @@ $( "a" ).click(function() {
      * @see \`{@link https://api.jquery.com/fadeIn/ }\`
      * @since 1.0
      * @since 1.4.3
-     * @example ​ ````Animates hidden divs to fade in one by one, completing each animation within 600 milliseconds.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>fadeIn demo</title>
-  <style>
-  span {
-    color: red;
-    cursor: pointer;
-  }
-  div {
-    margin: 3px;
-    width: 80px;
-    display: none;
-    height: 80px;
-    float: left;
-  }
-  #one {
-    background: #f00;
-  }
-  #two {
-    background: #0f0;
-  }
-  #three {
-    background: #00f;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<span>Click here...</span>
-<div id="one"></div>
-<div id="two"></div>
-<div id="three"></div>
-​
-<script>
-$( document.body ).click(function() {
-  $( "div:hidden:first" ).fadeIn( "slow" );
-});
-</script>
-</body>
-</html>
-```
      * @example ​ ````Fades a red block in over the text. Once the animation is done, it quickly fades in more text on top.
 ```html
 <!doctype html>
@@ -36416,6 +32100,7 @@ $( "a" ).click(function() {
   return false;
 });
 </script>
+​
 </body>
 </html>
 ```
@@ -36474,59 +32159,7 @@ $( document.body ).click(function() {
   $( "div:hidden:first" ).fadeIn( "slow" );
 });
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Fades a red block in over the text. Once the animation is done, it quickly fades in more text on top.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>fadeIn demo</title>
-  <style>
-  p {
-    position: relative;
-    width: 400px;
-    height: 90px;
-  }
-  div {
-    position: absolute;
-    width: 400px;
-    height: 65px;
-    font-size: 36px;
-    text-align: center;
-    color: yellow;
-    background: red;
-    padding-top: 25px;
-    top: 0;
-    left: 0;
-    display: none;
-  }
-  span {
-    display: none;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-<p>
-  Let it be known that the party of the first part
-  and the party of the second part are henceforth
-  and hereto directed to assess the allegations
-  for factual correctness... (<a href="#">click!</a>)
-  <div><span>CENSORED!</span></div>
-</p>
-​
-<script>
-$( "a" ).click(function() {
-  $( "div" ).fadeIn( 3000, function() {
-    $( "span" ).fadeIn( 100 );
-  });
-  return false;
-});
-</script>
 </body>
 </html>
 ```
@@ -36540,83 +32173,6 @@ $( "a" ).click(function() {
      * @param complete A function to call once the animation is complete, called once per matched element.
      * @see \`{@link https://api.jquery.com/fadeOut/ }\`
      * @since 1.4.3
-     * @example ​ ````Animates all paragraphs to fade out, completing the animation within 600 milliseconds.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>fadeOut demo</title>
-  <style>
-  p {
-    font-size: 150%;
-    cursor: pointer;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p>
-  If you click on this paragraph
-  you'll see it just fade away.
-</p>
-​
-<script>
-$( "p" ).click(function() {
-  $( "p" ).fadeOut( "slow" );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Fades out spans in one section that you click on.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>fadeOut demo</title>
-  <style>
-  span {
-    cursor: pointer;
-  }
-  span.hilite {
-    background: yellow;
-  }
-  div {
-    display: inline;
-    color: red;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<h3>Find the modifiers - <div></div></h3>
-<p>
-  If you <span>really</span> want to go outside
-  <span>in the cold</span> then make sure to wear
-  your <span>warm</span> jacket given to you by
-  your <span>favorite</span> teacher.
-</p>
-​
-<script>
-$( "span" ).click(function() {
-  $( this ).fadeOut( 1000, function() {
-    $( "div" ).text( "'" + $( this ).text() + "' has faded!" );
-    $( this ).remove();
-  });
-});
-$( "span" ).hover(function() {
-  $( this ).addClass( "hilite" );
-}, function() {
-  $( this ).removeClass( "hilite" );
-});
-</script>
-</body>
-</html>
-```
      * @example ​ ````Fades out two divs, one with a &quot;linear&quot; easing and one with the default, &quot;swing,&quot; easing.
 ```html
 <!doctype html>
@@ -36665,6 +32221,7 @@ $( "#btn2" ).click(function() {
   $( "#log" ).empty();
 });
 </script>
+​
 </body>
 </html>
 ```
@@ -36679,36 +32236,6 @@ $( "#btn2" ).click(function() {
      * @see \`{@link https://api.jquery.com/fadeOut/ }\`
      * @since 1.0
      * @since 1.4.3
-     * @example ​ ````Animates all paragraphs to fade out, completing the animation within 600 milliseconds.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>fadeOut demo</title>
-  <style>
-  p {
-    font-size: 150%;
-    cursor: pointer;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p>
-  If you click on this paragraph
-  you'll see it just fade away.
-</p>
-​
-<script>
-$( "p" ).click(function() {
-  $( "p" ).fadeOut( "slow" );
-});
-</script>
-</body>
-</html>
-```
      * @example ​ ````Fades out spans in one section that you click on.
 ```html
 <!doctype html>
@@ -36753,57 +32280,7 @@ $( "span" ).hover(function() {
   $( this ).removeClass( "hilite" );
 });
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Fades out two divs, one with a &quot;linear&quot; easing and one with the default, &quot;swing,&quot; easing.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>fadeOut demo</title>
-  <style>
-  .box,
-  button {
-    float: left;
-    margin: 5px 10px 5px 0;
-  }
-  .box {
-    height: 80px;
-    width: 80px;
-    background: #090;
-  }
-  #log {
-    clear: left;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-<button id="btn1">fade out</button>
-<button id="btn2">show</button>
-​
-<div id="log"></div>
-​
-<div id="box1" class="box">linear</div>
-<div id="box2" class="box">swing</div>
-​
-<script>
-$( "#btn1" ).click(function() {
-  function complete() {
-    $( "<div>" ).text( this.id ).appendTo( "#log" );
-  }
-  $( "#box1" ).fadeOut( 1600, "linear", complete );
-  $( "#box2" ).fadeOut( 1600, complete );
-});
-​
-$( "#btn2" ).click(function() {
-  $( "div" ).show();
-  $( "#log" ).empty();
-});
-</script>
 </body>
 </html>
 ```
@@ -36846,104 +32323,7 @@ $( "p" ).click(function() {
   $( "p" ).fadeOut( "slow" );
 });
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Fades out spans in one section that you click on.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>fadeOut demo</title>
-  <style>
-  span {
-    cursor: pointer;
-  }
-  span.hilite {
-    background: yellow;
-  }
-  div {
-    display: inline;
-    color: red;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-<h3>Find the modifiers - <div></div></h3>
-<p>
-  If you <span>really</span> want to go outside
-  <span>in the cold</span> then make sure to wear
-  your <span>warm</span> jacket given to you by
-  your <span>favorite</span> teacher.
-</p>
-​
-<script>
-$( "span" ).click(function() {
-  $( this ).fadeOut( 1000, function() {
-    $( "div" ).text( "'" + $( this ).text() + "' has faded!" );
-    $( this ).remove();
-  });
-});
-$( "span" ).hover(function() {
-  $( this ).addClass( "hilite" );
-}, function() {
-  $( this ).removeClass( "hilite" );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Fades out two divs, one with a &quot;linear&quot; easing and one with the default, &quot;swing,&quot; easing.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>fadeOut demo</title>
-  <style>
-  .box,
-  button {
-    float: left;
-    margin: 5px 10px 5px 0;
-  }
-  .box {
-    height: 80px;
-    width: 80px;
-    background: #090;
-  }
-  #log {
-    clear: left;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<button id="btn1">fade out</button>
-<button id="btn2">show</button>
-​
-<div id="log"></div>
-​
-<div id="box1" class="box">linear</div>
-<div id="box2" class="box">swing</div>
-​
-<script>
-$( "#btn1" ).click(function() {
-  function complete() {
-    $( "<div>" ).text( this.id ).appendTo( "#log" );
-  }
-  $( "#box1" ).fadeOut( 1600, "linear", complete );
-  $( "#box2" ).fadeOut( 1600, complete );
-});
-​
-$( "#btn2" ).click(function() {
-  $( "div" ).show();
-  $( "#log" ).empty();
-});
-</script>
 </body>
 </html>
 ```
@@ -36958,151 +32338,6 @@ $( "#btn2" ).click(function() {
      * @param complete A function to call once the animation is complete, called once per matched element.
      * @see \`{@link https://api.jquery.com/fadeTo/ }\`
      * @since 1.4.3
-     * @example ​ ````Animates first paragraph to fade to an opacity of 0.33 (33%, about one third visible), completing the animation within 600 milliseconds.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>fadeTo demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p>
-Click this paragraph to see it fade.
-</p>
-​
-<p>
-Compare to this one that won't fade.
-</p>
-​
-<script>
-$( "p:first" ).click(function() {
-  $( this ).fadeTo( "slow", 0.33 );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Fade div to a random opacity on each click, completing the animation within 200 milliseconds.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>fadeTo demo</title>
-  <style>
-  p {
-    width: 80px;
-    margin: 0;
-    padding: 5px;
-  }
-  div {
-    width: 40px;
-    height: 40px;
-    position: absolute;
-  }
-  #one {
-    top: 0;
-    left: 0;
-    background: #f00;
-  }
-  #two {
-    top: 20px;
-    left: 20px;
-    background: #0f0;
-  }
-  #three {
-    top: 40px;
-    left:40px;
-    background:#00f;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p>And this is the library that John built...</p>
-​
-<div id="one"></div>
-<div id="two"></div>
-<div id="three"></div>
-​
-<script>
-$( "div" ).click(function() {
-  $( this ).fadeTo( "fast", Math.random() );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Find the right answer! The fade will take 250 milliseconds and change various styles when it completes.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>fadeTo demo</title>
-  <style>
-  div, p {
-    width: 80px;
-    height: 40px;
-    top: 0;
-    margin: 0;
-    position: absolute;
-    padding-top: 8px;
-  }
-  p {
-    background: #fcc;
-    text-align: center;
-  }
-  div {
-    background: blue;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p>Wrong</p>
-<div></div>
-<p>Wrong</p>
-<div></div>
-<p>Right!</p>
-<div></div>
-​
-<script>
-var getPos = function( n ) {
-  return (Math.floor( n ) * 90) + "px";
-};
-$( "p" ).each(function( n ) {
-  var r = Math.floor( Math.random() * 3 );
-  var tmp = $( this ).text();
-  $( this ).text( $( "p:eq(" + r + ")" ).text() );
-  $( "p:eq(" + r + ")" ).text( tmp );
-  $( this ).css( "left", getPos( n ) );
-});
-$( "div" )
-  .each(function( n ) {
-    $( this ).css( "left", getPos( n ) );
-  })
-  .css( "cursor", "pointer" )
-  .click( function() {
-    $( this ).fadeTo( 250, 0.25, function() {
-      $( this )
-        .css( "cursor", "" )
-        .prev()
-          .css({
-            "font-weight": "bolder",
-            "font-style": "italic"
-          });
-    });
-  });
-</script>
-</body>
-</html>
-```
      */
     fadeTo(duration: JQuery.Duration, opacity: number, easing: string, complete?: (this: TElement) => void): this;
     /**
@@ -37137,6 +32372,7 @@ $( "p:first" ).click(function() {
   $( this ).fadeTo( "slow", 0.33 );
 });
 </script>
+​
 </body>
 </html>
 ```
@@ -37189,6 +32425,7 @@ $( "div" ).click(function() {
   $( this ).fadeTo( "fast", Math.random() );
 });
 </script>
+​
 </body>
 </html>
 ```
@@ -37255,6 +32492,7 @@ $( "div" )
     });
   });
 </script>
+​
 </body>
 </html>
 ```
@@ -37295,6 +32533,7 @@ $( "button:last" ).click(function() {
   });
 });
 </script>
+​
 </body>
 </html>
 ```
@@ -37336,6 +32575,7 @@ $( "button:last" ).click(function() {
   });
 });
 </script>
+​
 </body>
 </html>
 ```
@@ -37351,36 +32591,6 @@ $( "button:last" ).click(function() {
      * @see \`{@link https://api.jquery.com/fadeToggle/ }\`
      * @since 1.0
      * @since 1.4.3
-     * @example ​ ````Fades first paragraph in or out, completing the animation within 600 milliseconds and using a linear easing. Fades last paragraph in or out for 200 milliseconds, inserting a &quot;finished&quot; message upon completion.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>fadeToggle demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<button>fadeToggle p1</button>
-<button>fadeToggle p2</button>
-<p>This paragraph has a slow, linear fade.</p>
-<p>This paragraph has a fast animation.</p>
-<div id="log"></div>
-​
-<script>
-$( "button:first" ).click(function() {
-  $( "p:first" ).fadeToggle( "slow", "linear" );
-});
-$( "button:last" ).click(function() {
-  $( "p:last" ).fadeToggle( "fast", function() {
-    $( "#log" ).append( "<div>finished</div>" );
-  });
-});
-</script>
-</body>
-</html>
-```
      */
     fadeToggle(duration_easing_complete_options?: JQuery.Duration | string | ((this: TElement) => void) | JQuery.EffectsOptions<TElement>): this;
     /**
@@ -37426,6 +32636,7 @@ $( "div" )
   .filter( ".middle" )
     .css( "border-color", "red" );
 </script>
+​
 </body>
 </html>
 ```
@@ -37464,42 +32675,17 @@ $( "div" )
   })
     .css( "border", "3px double red" );
 </script>
+​
 </body>
 </html>
 ```
      * @example ​ ````Select all divs and filter the selection with a DOM element, keeping only the one with an id of &quot;unique&quot;.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>filter demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $( "div" ).filter( document.getElementById( "unique" ) );
-</script>
-</body>
-</html>
 ```
      * @example ​ ````Select all divs and filter the selection with a jQuery object, keeping only the one with an id of &quot;unique&quot;.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>filter demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $( "div" ).filter( $( "#unique" ) );
-</script>
-</body>
-</html>
 ```
      */
     filter(selector: JQuery.Selector | JQuery.TypeOrArray<Element> | JQuery | ((this: TElement, index: number, element: TElement) => boolean)): this;
@@ -37529,6 +32715,7 @@ $( "div" ).filter( $( "#unique" ) );
 <script>
 $( "p" ).find( "span" ).css( "color", "red" );
 </script>
+​
 </body>
 </html>
 ```
@@ -37556,6 +32743,7 @@ $( "p" ).find( "span" ).css( "color", "red" );
 var spans = $( "span" );
 $( "p" ).find( spans ).css( "color", "red" );
 </script>
+​
 </body>
 </html>
 ```
@@ -37607,6 +32795,7 @@ $( "p" )
       "font-weight": "bolder"
     });
 </script>
+​
 </body>
 </html>
 ```
@@ -37725,6 +32914,7 @@ $( "#go" ).on( "click", function() {
     }, 3000 );
 });
 </script>
+​
 </body>
 </html>
 ```
@@ -37760,6 +32950,7 @@ $( "#go" ).on( "click", function() {
 <script>
 $( "p span" ).first().addClass( "highlight" );
 </script>
+​
 </body>
 </html>
 ```
@@ -37777,71 +32968,6 @@ $( "p span" ).first().addClass( "highlight" );
      * **Cause**: The `.on()` and `.trigger()` methods can set an event handler or generate an event for any event type, and should be used instead of the shortcut methods. This message also applies to the other event shorthands, including: blur, focus, focusin, focusout, resize, scroll, dblclick, mousedown, mouseup, mousemove, mouseover, mouseout, mouseenter, mouseleave, change, select, submit, keydown, keypress, keyup, and contextmenu.
      *
      * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
-     * @example ​ ````Fire focus.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>focus demo</title>
-  <style>
-  span {
-    display: none;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><input type="text"> <span>focus fire</span></p>
-<p><input type="password"> <span>focus fire</span></p>
-​
-<script>
-$( "input" ).focus(function() {
-  $( this ).next( "span" ).css( "display", "inline" ).fadeOut( 1000 );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````To stop people from writing in text input boxes, try:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>focus demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "input[type=text]" ).focus(function() {
-  $( this ).blur();
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````To focus on a login input box with id &#39;login&#39; on page startup, try:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>focus demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( document ).ready(function() {
-  $( "#login" ).focus();
-});
-</script>
-</body>
-</html>
-```
      */
     focus<TData>(eventData: TData,
                  handler: JQuery.EventHandler<TElement, TData> | JQuery.EventHandlerBase<any, JQuery.Event<TElement, TData>>): this;
@@ -37880,46 +33006,21 @@ $( "input" ).focus(function() {
   $( this ).next( "span" ).css( "display", "inline" ).fadeOut( 1000 );
 });
 </script>
+​
 </body>
 </html>
 ```
      * @example ​ ````To stop people from writing in text input boxes, try:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>focus demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $( "input[type=text]" ).focus(function() {
   $( this ).blur();
 });
-</script>
-</body>
-</html>
 ```
      * @example ​ ````To focus on a login input box with id &#39;login&#39; on page startup, try:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>focus demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $( document ).ready(function() {
   $( "#login" ).focus();
 });
-</script>
-</body>
-</html>
 ```
      */
     focus(handler?: JQuery.EventHandler<TElement> | JQuery.EventHandlerBase<any, JQuery.Event<TElement>> | false): this;
@@ -37935,33 +33036,6 @@ $( document ).ready(function() {
      * **Cause**: The `.on()` and `.trigger()` methods can set an event handler or generate an event for any event type, and should be used instead of the shortcut methods. This message also applies to the other event shorthands, including: blur, focus, focusin, focusout, resize, scroll, dblclick, mousedown, mouseup, mousemove, mouseover, mouseout, mouseenter, mouseleave, change, select, submit, keydown, keypress, keyup, and contextmenu.
      *
      * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
-     * @example ​ ````Watch for a focus to occur within the paragraphs on the page.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>focusin demo</title>
-  <style>
-  span {
-    display: none;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><input type="text"> <span>focusin fire</span></p>
-<p><input type="password"> <span>focusin fire</span></p>
-​
-<script>
-$( "p" ).focusin(function() {
-  $( this ).find( "span" ).css( "display", "inline" ).fadeOut( 1000 );
-});
-</script>
-</body>
-</html>
-```
      */
     focusin<TData>(eventData: TData,
                    handler: JQuery.EventHandler<TElement, TData> | JQuery.EventHandlerBase<any, JQuery.Event<TElement, TData>>): this;
@@ -38000,6 +33074,7 @@ $( "p" ).focusin(function() {
   $( this ).find( "span" ).css( "display", "inline" ).fadeOut( 1000 );
 });
 </script>
+​
 </body>
 </html>
 ```
@@ -38017,54 +33092,6 @@ $( "p" ).focusin(function() {
      * **Cause**: The `.on()` and `.trigger()` methods can set an event handler or generate an event for any event type, and should be used instead of the shortcut methods. This message also applies to the other event shorthands, including: blur, focus, focusin, focusout, resize, scroll, dblclick, mousedown, mouseup, mousemove, mouseover, mouseout, mouseenter, mouseleave, change, select, submit, keydown, keypress, keyup, and contextmenu.
      *
      * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
-     * @example ​ ````Watch for a loss of focus to occur inside paragraphs and note the difference between the focusout count and the blur count. (The blur count does not change because those events do not bubble.)
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>focusout demo</title>
-  <style>
-  .inputs {
-    float: left;
-    margin-right: 1em;
-  }
-  .inputs p {
-    margin-top: 0;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<div class="inputs">
-  <p>
-    <input type="text"><br>
-    <input type="text">
-  </p>
-  <p>
-    <input type="password">
-  </p>
-</div>
-<div id="focus-count">focusout fire</div>
-<div id="blur-count">blur fire</div>
-​
-<script>
-var focus = 0,
-  blur = 0;
-$( "p" )
-  .focusout(function() {
-    focus++;
-    $( "#focus-count" ).text( "focusout fired: " + focus + "x" );
-  })
-  .blur(function() {
-    blur++;
-    $( "#blur-count" ).text( "blur fired: " + blur + "x" );
-  });
-</script>
-</body>
-</html>
-```
      */
     focusout<TData>(eventData: TData,
                     handler: JQuery.EventHandler<TElement, TData> | JQuery.EventHandlerBase<any, JQuery.Event<TElement, TData>>): this;
@@ -38124,6 +33151,7 @@ $( "p" )
     $( "#blur-count" ).text( "blur fired: " + blur + "x" );
   });
 </script>
+​
 </body>
 </html>
 ```
@@ -38165,41 +33193,7 @@ $( "*", document.body ).click(function( event ) {
   $( "span:first" ).text( "Clicked on - " + domElement.nodeName );
 });
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Select all divs in the document and return the DOM Elements as an Array; then use the built-in reverse() method to reverse that array.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>get demo</title>
-  <style>
-  span {
-    color: red;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-Reversed - <span></span>
-​
-<div>One</div>
-<div>Two</div>
-<div>Three</div>
-​
-<script>
-function display( divs ) {
-  var a = [];
-  for ( var i = 0; i < divs.length; i++ ) {
-    a.push( divs[ i ].innerHTML );
-  }
-  $( "span" ).text( a.join(" ") );
-}
-display( $( "div" ).get().reverse() );
-</script>
 </body>
 </html>
 ```
@@ -38210,39 +33204,6 @@ display( $( "div" ).get().reverse() );
      *
      * @see \`{@link https://api.jquery.com/get/ }\`
      * @since 1.0
-     * @example ​ ````Display the tag name of the click element.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>get demo</title>
-  <style>
-  span {
-    color: red;
-  }
-  div {
-    background: yellow;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<span>&nbsp;</span>
-<p>In this paragraph is an <span>important</span> section</p>
-<div><input type="text"></div>
-​
-<script>
-$( "*", document.body ).click(function( event ) {
-  event.stopPropagation();
-  var domElement = $( this ).get( 0 );
-  $( "span:first" ).text( "Clicked on - " + domElement.nodeName );
-});
-</script>
-</body>
-</html>
-```
      * @example ​ ````Select all divs in the document and return the DOM Elements as an Array; then use the built-in reverse() method to reverse that array.
 ```html
 <!doctype html>
@@ -38275,6 +33236,7 @@ function display( divs ) {
 }
 display( $( "div" ).get().reverse() );
 </script>
+​
 </body>
 </html>
 ```
@@ -38311,6 +33273,7 @@ $( "ul" ).append( "<li>" +
   "</li>" );
 $( "ul" ).has( "li" ).addClass( "full" );
 </script>
+​
 </body>
 </html>
 ```
@@ -38353,6 +33316,7 @@ $( "#result1" ).append( $( "p:first" ).hasClass( "selected" ).toString() );
 $( "#result2" ).append( $( "p:last" ).hasClass( "selected" ).toString() );
 $( "#result3" ).append( $( "p" ).hasClass( "selected" ).toString() ) ;
 </script>
+​
 </body>
 </html>
 ```
@@ -38368,60 +33332,6 @@ $( "#result3" ).append( $( "p" ).hasClass( "selected" ).toString() ) ;
      * @see \`{@link https://api.jquery.com/height/ }\`
      * @since 1.0
      * @since 1.4.1
-     * @example ​ ````Show various heights.  Note the values are from the iframe so might be smaller than you expected.  The yellow highlight shows the iframe body.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>height demo</title>
-  <style>
-  body {
-    background: yellow;
-  }
-  button {
-    font-size: 12px;
-    margin: 2px;
-  }
-  p {
-    width: 150px;
-    border: 1px red solid;
-  }
-  div {
-    color: red;
-    font-weight: bold;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<button id="getp">Get Paragraph Height</button>
-<button id="getd">Get Document Height</button>
-<button id="getw">Get Window Height</button>
-​
-<div>&nbsp;</div>
-<p>
-  Sample paragraph to test height
-</p>
-​
-<script>
-function showHeight( element, height ) {
-  $( "div" ).text( "The height for the " + element + " is " + height + "px." );
-}
-$( "#getp" ).click(function() {
-  showHeight( "paragraph", $( "p" ).height() );
-});
-$( "#getd" ).click(function() {
-  showHeight( "document", $( document ).height() );
-});
-$( "#getw" ).click(function() {
-  showHeight( "window", $( window ).height() );
-});
-</script>
-</body>
-</html>
-```
      * @example ​ ````To set the height of each div on click to 30px plus a color change.
 ```html
 <!doctype html>
@@ -38457,6 +33367,7 @@ $( "div" ).one( "click", function() {
   });
 });
 </script>
+​
 </body>
 </html>
 ```
@@ -38518,44 +33429,7 @@ $( "#getw" ).click(function() {
   showHeight( "window", $( window ).height() );
 });
 </script>
-</body>
-</html>
-```
-     * @example ​ ````To set the height of each div on click to 30px plus a color change.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>height demo</title>
-  <style>
-  div {
-    width: 50px;
-    height: 70px;
-    float: left;
-    margin: 5px;
-    background: rgb(255,140,0);
-    cursor: pointer;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-<div></div>
-<div></div>
-<div></div>
-<div></div>
-<div></div>
-​
-<script>
-$( "div" ).one( "click", function() {
-  $( this ).height( 30 ).css({
-    cursor: "auto",
-    backgroundColor: "green"
-  });
-});
-</script>
 </body>
 </html>
 ```
@@ -38569,135 +33443,6 @@ $( "div" ).one( "click", function() {
      * @param complete A function to call once the animation is complete, called once per matched element.
      * @see \`{@link https://api.jquery.com/hide/ }\`
      * @since 1.4.3
-     * @example ​ ````Hides all paragraphs then the link on click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>hide demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p>Hello</p>
-<a href="#">Click to hide me too</a>
-<p>Here is another paragraph</p>
-​
-<script>
-$( "p" ).hide();
-$( "a" ).click(function( event ) {
-  event.preventDefault();
-  $( this ).hide();
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Animates all shown paragraphs to hide slowly, completing the animation within 600 milliseconds.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>hide demo</title>
-  <style>
-  p {
-    background: #dad;
-    font-weight: bold;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<button>Hide 'em</button>
-<p>Hiya</p>
-<p>Such interesting text, eh?</p>
-​
-<script>
-$( "button" ).click(function() {
-  $( "p" ).hide( "slow" );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Animates all spans (words in this case) to hide fastly, completing each animation within 200 milliseconds. Once each animation is done, it starts the next one.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>hide demo</title>
-  <style>
-  span {
-    background: #def3ca;
-    padding: 3px;
-    float: left;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<button id="hider">Hide</button>
-<button id="shower">Show</button>
-<div>
-  <span>Once</span> <span>upon</span> <span>a</span>
-  <span>time</span> <span>there</span> <span>were</span>
-  <span>three</span> <span>programmers...</span>
-</div>
-​
-<script>
-$( "#hider" ).click(function() {
-  $( "span:last-child" ).hide( "fast", function() {
-    // Use arguments.callee so we don't need a named function
-    $( this ).prev().hide( "fast", arguments.callee );
-  });
-});
-$( "#shower" ).click(function() {
-  $( "span" ).show( 2000 );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Hides the divs when clicked over 2 seconds, then removes the div element when its hidden.  Try clicking on more than one box at a time.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>hide demo</title>
-  <style>
-  div {
-    background: #ece023;
-    width: 30px;
-    height: 40px;
-    margin: 2px;
-    float: left;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<div></div>
-​
-<script>
-for ( var i = 0; i < 5; i++ ) {
-  $( "<div>" ).appendTo( document.body );
-}
-$( "div" ).click(function() {
-  $( this ).hide( 2000, function() {
-    $( this ).remove();
-  });
-});
-</script>
-</body>
-</html>
-```
      */
     hide(duration: JQuery.Duration, easing: string, complete: (this: TElement) => void): this;
     /**
@@ -38709,60 +33454,6 @@ $( "div" ).click(function() {
      * @see \`{@link https://api.jquery.com/hide/ }\`
      * @since 1.0
      * @since 1.4.3
-     * @example ​ ````Hides all paragraphs then the link on click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>hide demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p>Hello</p>
-<a href="#">Click to hide me too</a>
-<p>Here is another paragraph</p>
-​
-<script>
-$( "p" ).hide();
-$( "a" ).click(function( event ) {
-  event.preventDefault();
-  $( this ).hide();
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Animates all shown paragraphs to hide slowly, completing the animation within 600 milliseconds.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>hide demo</title>
-  <style>
-  p {
-    background: #dad;
-    font-weight: bold;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<button>Hide 'em</button>
-<p>Hiya</p>
-<p>Such interesting text, eh?</p>
-​
-<script>
-$( "button" ).click(function() {
-  $( "p" ).hide( "slow" );
-});
-</script>
-</body>
-</html>
-```
      * @example ​ ````Animates all spans (words in this case) to hide fastly, completing each animation within 200 milliseconds. Once each animation is done, it starts the next one.
 ```html
 <!doctype html>
@@ -38800,6 +33491,7 @@ $( "#shower" ).click(function() {
   $( "span" ).show( 2000 );
 });
 </script>
+​
 </body>
 </html>
 ```
@@ -38835,6 +33527,7 @@ $( "div" ).click(function() {
   });
 });
 </script>
+​
 </body>
 </html>
 ```
@@ -38870,6 +33563,7 @@ $( "a" ).click(function( event ) {
   $( this ).hide();
 });
 </script>
+​
 </body>
 </html>
 ```
@@ -38899,81 +33593,7 @@ $( "button" ).click(function() {
   $( "p" ).hide( "slow" );
 });
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Animates all spans (words in this case) to hide fastly, completing each animation within 200 milliseconds. Once each animation is done, it starts the next one.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>hide demo</title>
-  <style>
-  span {
-    background: #def3ca;
-    padding: 3px;
-    float: left;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-<button id="hider">Hide</button>
-<button id="shower">Show</button>
-<div>
-  <span>Once</span> <span>upon</span> <span>a</span>
-  <span>time</span> <span>there</span> <span>were</span>
-  <span>three</span> <span>programmers...</span>
-</div>
-​
-<script>
-$( "#hider" ).click(function() {
-  $( "span:last-child" ).hide( "fast", function() {
-    // Use arguments.callee so we don't need a named function
-    $( this ).prev().hide( "fast", arguments.callee );
-  });
-});
-$( "#shower" ).click(function() {
-  $( "span" ).show( 2000 );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Hides the divs when clicked over 2 seconds, then removes the div element when its hidden.  Try clicking on more than one box at a time.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>hide demo</title>
-  <style>
-  div {
-    background: #ece023;
-    width: 30px;
-    height: 40px;
-    margin: 2px;
-    float: left;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<div></div>
-​
-<script>
-for ( var i = 0; i < 5; i++ ) {
-  $( "<div>" ).appendTo( document.body );
-}
-$( "div" ).click(function() {
-  $( this ).hide( 2000, function() {
-    $( this ).remove();
-  });
-});
-</script>
 </body>
 </html>
 ```
@@ -39037,21 +33657,12 @@ $( "li.fade" ).hover(function() {
   $( this ).fadeIn( 500 );
 });
 </script>
+​
 </body>
 </html>
 ```
      * @example ​ ````To add a special style to table cells that are being hovered over, try:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>hover demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $( "td" ).hover(
   function() {
     $( this ).addClass( "hover" );
@@ -39059,26 +33670,10 @@ $( "td" ).hover(
     $( this ).removeClass( "hover" );
   }
 );
-</script>
-</body>
-</html>
 ```
      * @example ​ ````To unbind the above example use:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>hover demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $( "td" ).off( "mouseenter mouseleave" );
-</script>
-</body>
-</html>
 ```
      * @example ​ ````Slide the next sibling LI up or down on hover, and toggle a class.
 ```html
@@ -39130,6 +33725,7 @@ $( "li" )
           .slideToggle();
     });
 </script>
+​
 </body>
 </html>
 ```
@@ -39148,50 +33744,6 @@ $( "li" )
      * @see \`{@link https://api.jquery.com/html/ }\`
      * @since 1.0
      * @since 1.4
-     * @example ​ ````Click a paragraph to convert it from html to text.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>html demo</title>
-  <style>
-  p {
-    margin: 8px;
-    font-size: 20px;
-    color: blue;
-    cursor: pointer;
-  }
-  b {
-    text-decoration: underline;
-  }
-  button {
-    cursor: pointer;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p>
-  <b>Click</b> to change the <span id="tag">html</span>
-</p>
-<p>
-  to a <span id="text">text</span> node.
-</p>
-<p>
-  This <button name="nada">button</button> does nothing.
-</p>
-​
-<script>
-$( "p" ).click(function() {
-  var htmlString = $( this ).html();
-  $( this ).text( htmlString );
-});
-</script>
-</body>
-</html>
-```
      * @example ​ ````Add some html to each div.
 ```html
 <!doctype html>
@@ -39216,6 +33768,7 @@ $( "p" ).click(function() {
 <script>
 $( "div" ).html( "<span class='red'>Hello <b>Again</b></span>" );
 </script>
+​
 </body>
 </html>
 ```
@@ -39246,6 +33799,7 @@ $( "div b" )
   .append( document.createTextNode( "!!!" ) )
   .css( "color", "red" );
 </script>
+​
 </body>
 </html>
 ```
@@ -39297,63 +33851,7 @@ $( "p" ).click(function() {
   $( this ).text( htmlString );
 });
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Add some html to each div.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>html demo</title>
-  <style>
-  .red {
-    color: red;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-<span>Hello</span>
-<div></div>
-<div></div>
-<div></div>
-​
-<script>
-$( "div" ).html( "<span class='red'>Hello <b>Again</b></span>" );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Add some html to each div then immediately do further manipulations to the inserted html.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>html demo</title>
-  <style>
-  div {
-    color: blue;
-    font-size: 18px;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<div></div>
-<div></div>
-<div></div>
-​
-<script>
-$( "div" ).html( "<b>Wow!</b> Such excitement..." );
-$( "div b" )
-  .append( document.createTextNode( "!!!" ) )
-  .css( "color", "red" );
-</script>
 </body>
 </html>
 ```
@@ -39399,6 +33897,7 @@ $( "div" ).click(function() {
   $( "span" ).text( "That was div index #" + index );
 });
 </script>
+​
 </body>
 </html>
 ```
@@ -39430,6 +33929,7 @@ $( "div" ).click(function() {
 var listItem = $( "#bar" );
 $( "div" ).html( "Index: " + $( "li" ).index( listItem ) );
 </script>
+​
 </body>
 </html>
 ```
@@ -39461,6 +33961,7 @@ $( "div" ).html( "Index: " + $( "li" ).index( listItem ) );
 var listItems = $( "li:gt(0)" );
 $( "div" ).html( "Index: " + $( "li" ).index( listItems ) );
 </script>
+​
 </body>
 </html>
 ```
@@ -39491,6 +33992,7 @@ $( "div" ).html( "Index: " + $( "li" ).index( listItems ) );
 <script>
 $( "div" ).html( "Index: " +  $( "#bar" ).index( "li" ) );
 </script>
+​
 </body>
 </html>
 ```
@@ -39522,6 +34024,7 @@ $( "div" ).html( "Index: " +  $( "#bar" ).index( "li" ) );
 var barIndex = $( "#bar" ).index();
 $( "div" ).html( "Index: " +  barIndex );
 </script>
+​
 </body>
 </html>
 ```
@@ -39553,6 +34056,7 @@ $( "div" ).html( "Index: " +  barIndex );
 var foobar = $( "li" ).index( $( "#foobar" ) );
 $( "div" ).html( "Index: " + foobar );
 </script>
+​
 </body>
 </html>
 ```
@@ -39568,34 +34072,6 @@ $( "div" ).html( "Index: " + foobar );
      *              refers to the current element in the set.
      * @see \`{@link https://api.jquery.com/innerHeight/ }\`
      * @since 1.8.0
-     * @example ​ ````Get the innerHeight of a paragraph.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>innerHeight demo</title>
-  <style>
-  p {
-    margin: 10px;
-    padding: 5px;
-    border: 2px solid #666;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p>Hello</p>
-<p></p>
-​
-<script>
-var p = $( "p:first" );
-$( "p:last" ).text( "innerHeight:" + p.innerHeight() );
-</script>
-</body>
-</html>
-```
      * @example ​ ````Change the inner height of each div the first time it is clicked (and change its color).
 ```html
 <!doctype html>
@@ -39635,6 +34111,7 @@ $( "div" ).one( "click", function() {
   modHeight -= 8;
 });
 </script>
+​
 </body>
 </html>
 ```
@@ -39671,48 +34148,7 @@ $( "div" ).one( "click", function() {
 var p = $( "p:first" );
 $( "p:last" ).text( "innerHeight:" + p.innerHeight() );
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Change the inner height of each div the first time it is clicked (and change its color).
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>innerHeight demo</title>
-  <style>
-div {
-  width: 60px;
-  padding: 10px;
-  height: 70px;
-  float: left;
-  margin: 5px;
-  background: red;
-  cursor: pointer;
-}
-.mod {
-  background: blue;
-  cursor: default;
-}
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-<div>d</div>
-<div>d</div>
-<div>d</div>
-<div>d</div>
-<div>d</div>
-​
-<script>
-var modHeight = 70;
-$( "div" ).one( "click", function() {
-  $( this ).innerHeight( modHeight ).addClass( "mod" );
-  modHeight -= 8;
-});
-</script>
 </body>
 </html>
 ```
@@ -39728,34 +34164,6 @@ $( "div" ).one( "click", function() {
      *              refers to the current element in the set.
      * @see \`{@link https://api.jquery.com/innerWidth/ }\`
      * @since 1.8.0
-     * @example ​ ````Get the innerWidth of a paragraph.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>innerWidth demo</title>
-  <style>
-  p {
-    margin: 10px;
-    padding: 5px;
-    border: 2px solid #666;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p>Hello</p>
-<p></p>
-​
-<script>
-var p = $( "p:first" );
-$( "p:last" ).text( "innerWidth:" + p.innerWidth() );
-</script>
-</body>
-</html>
-```
      * @example ​ ````Change the inner width of each div the first time it is clicked (and change its color).
 ```html
 <!doctype html>
@@ -39795,6 +34203,7 @@ $( this ).innerWidth( modWidth ).addClass( "mod" );
 modWidth -= 8;
 });
 </script>
+​
 </body>
 </html>
 ```
@@ -39831,48 +34240,7 @@ modWidth -= 8;
 var p = $( "p:first" );
 $( "p:last" ).text( "innerWidth:" + p.innerWidth() );
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Change the inner width of each div the first time it is clicked (and change its color).
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>innerWidth demo</title>
-  <style>
-div {
-width: 60px;
-padding: 10px;
-height: 50px;
-float: left;
-margin: 5px;
-background: red;
-cursor: pointer;
-}
-.mod {
-background: blue;
-cursor: default;
-}
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-<div>d</div>
-<div>d</div>
-<div>d</div>
-<div>d</div>
-<div>d</div>
-​
-<script>
-var modWidth = 60;
-$( "div" ).one( "click", function() {
-$( this ).innerWidth( modWidth ).addClass( "mod" );
-modWidth -= 8;
-});
-</script>
 </body>
 </html>
 ```
@@ -39907,6 +34275,7 @@ modWidth -= 8;
 <script>
 $( "p" ).insertAfter( "#foo" );
 </script>
+​
 </body>
 </html>
 ```
@@ -39941,6 +34310,7 @@ $( "p" ).insertAfter( "#foo" );
 <script>
 $( "p" ).insertBefore( "#foo" );
 </script>
+​
 </body>
 </html>
 ```
@@ -40027,6 +34397,7 @@ $( "div" ).one( "click", function() {
   });
 });
 </script>
+​
 </body>
 </html>
 ```
@@ -40055,6 +34426,7 @@ $( "div" ).one( "click", function() {
 var isFormParent = $( "input[type='checkbox']" ).parent().is( "form" );
 $( "div" ).text( "isFormParent = " + isFormParent );
 </script>
+​
 </body>
 </html>
 ```
@@ -40083,6 +34455,7 @@ $( "div" ).text( "isFormParent = " + isFormParent );
 var isFormParent = $( "input[type='checkbox']" ).parent().is( "form" );
 $( "div" ).text( "isFormParent = " + isFormParent );
 </script>
+​
 </body>
 </html>
 ```
@@ -40120,6 +34493,7 @@ $( "li" ).click(function() {
   }
 });
 </script>
+​
 </body>
 </html>
 ```
@@ -40156,6 +34530,7 @@ $( "li" ).click(function() {
   }
 });
 </script>
+​
 </body>
 </html>
 ```
@@ -40173,65 +34548,6 @@ $( "li" ).click(function() {
      * **Cause**: The `.on()` and `.trigger()` methods can set an event handler or generate an event for any event type, and should be used instead of the shortcut methods. This message also applies to the other event shorthands, including: blur, focus, focusin, focusout, resize, scroll, dblclick, mousedown, mouseup, mousemove, mouseover, mouseout, mouseenter, mouseleave, change, select, submit, keydown, keypress, keyup, and contextmenu.
      *
      * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
-     * @example ​ ````Show the event object for the keydown handler when a key is pressed in the input.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>keydown demo</title>
-  <style>
-  fieldset {
-    margin-bottom: 1em;
-  }
-  input {
-    display: block;
-    margin-bottom: .25em;
-  }
-  #print-output {
-    width: 100%;
-  }
-  .print-output-line {
-    white-space: pre;
-    padding: 5px;
-    font-family: monaco, monospace;
-    font-size: .7em;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<form>
-  <fieldset>
-    <label for="target">Type Something:</label>
-    <input id="target" type="text">
-  </fieldset>
-</form>
-<button id="other">
-  Trigger the handler
-</button>
-<script type="text/javascript" src="/resources/events.js"></script>
-​
-<script>
-var xTriggered = 0;
-$( "#target" ).keydown(function( event ) {
-  if ( event.which == 13 ) {
-   event.preventDefault();
-  }
-  xTriggered++;
-  var msg = "Handler for .keydown() called " + xTriggered + " time(s).";
-  $.print( msg, "html" );
-  $.print( event );
-});
-​
-$( "#other" ).click(function() {
-  $( "#target" ).keydown();
-});
-</script>
-</body>
-</html>
-```
      */
     keydown<TData>(eventData: TData,
                    handler: JQuery.EventHandler<TElement, TData> | JQuery.EventHandlerBase<any, JQuery.Event<TElement, TData>>): this;
@@ -40302,6 +34618,7 @@ $( "#other" ).click(function() {
   $( "#target" ).keydown();
 });
 </script>
+​
 </body>
 </html>
 ```
@@ -40319,65 +34636,6 @@ $( "#other" ).click(function() {
      * **Cause**: The `.on()` and `.trigger()` methods can set an event handler or generate an event for any event type, and should be used instead of the shortcut methods. This message also applies to the other event shorthands, including: blur, focus, focusin, focusout, resize, scroll, dblclick, mousedown, mouseup, mousemove, mouseover, mouseout, mouseenter, mouseleave, change, select, submit, keydown, keypress, keyup, and contextmenu.
      *
      * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
-     * @example ​ ````Show the event object when a key is pressed in the input. Note: This demo relies on a simple $.print() plugin (https://api.jquery.com/resources/events.js) for the event object&#39;s output.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>keypress demo</title>
-  <style>
-  fieldset {
-    margin-bottom: 1em;
-  }
-  input {
-    display: block;
-    margin-bottom: .25em;
-  }
-  #print-output {
-    width: 100%;
-  }
-  .print-output-line {
-    white-space: pre;
-    padding: 5px;
-    font-family: monaco, monospace;
-    font-size: .7em;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<form>
-  <fieldset>
-    <label for="target">Type Something:</label>
-    <input id="target" type="text">
-  </fieldset>
-</form>
-<button id="other">
-  Trigger the handler
-</button>
-<script src="/resources/events.js"></script>
-​
-<script>
-var xTriggered = 0;
-$( "#target" ).keypress(function( event ) {
-  if ( event.which == 13 ) {
-     event.preventDefault();
-  }
-  xTriggered++;
-  var msg = "Handler for .keypress() called " + xTriggered + " time(s).";
-  $.print( msg, "html" );
-  $.print( event );
-});
-​
-$( "#other" ).click(function() {
-  $( "#target" ).keypress();
-});
-</script>
-</body>
-</html>
-```
      */
     keypress<TData>(eventData: TData,
                     handler: JQuery.EventHandler<TElement, TData> | JQuery.EventHandlerBase<any, JQuery.Event<TElement, TData>>): this;
@@ -40448,6 +34706,7 @@ $( "#other" ).click(function() {
   $( "#target" ).keypress();
 });
 </script>
+​
 </body>
 </html>
 ```
@@ -40465,66 +34724,6 @@ $( "#other" ).click(function() {
      * **Cause**: The `.on()` and `.trigger()` methods can set an event handler or generate an event for any event type, and should be used instead of the shortcut methods. This message also applies to the other event shorthands, including: blur, focus, focusin, focusout, resize, scroll, dblclick, mousedown, mouseup, mousemove, mouseover, mouseout, mouseenter, mouseleave, change, select, submit, keydown, keypress, keyup, and contextmenu.
      *
      * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
-     * @example ​ ````Show the event object for the keyup handler (using a simple $.print plugin) when a key is released in the input.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>keyup demo</title>
-  <style>
-  fieldset {
-    margin-bottom: 1em;
-  }
-  input {
-    display: block;
-    margin-bottom: .25em;
-  }
-  #print-output {
-    width: 100%;
-  }
-  .print-output-line {
-    white-space: pre;
-    padding: 5px;
-    font-family: monaco, monospace;
-    font-size: .7em;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<form>
-  <fieldset>
-    <label for="target">Type Something:</label>
-    <input id="target" type="text">
-  </fieldset>
-</form>
-<button id="other">
-  Trigger the handler
-</button>
-<script type="text/javascript" src="/resources/events.js"></script>
-​
-<script>
-var xTriggered = 0;
-$( "#target" ).keyup(function( event ) {
-  xTriggered++;
-  var msg = "Handler for .keyup() called " + xTriggered + " time(s).";
-  $.print( msg, "html" );
-  $.print( event );
-}).keydown(function( event ) {
-  if ( event.which == 13 ) {
-    event.preventDefault();
-  }
-});
-​
-$( "#other").click(function() {
-  $( "#target" ).keyup();
-});
-</script>
-</body>
-</html>
-```
      */
     keyup<TData>(eventData: TData,
                  handler: JQuery.EventHandler<TElement, TData> | JQuery.EventHandlerBase<any, JQuery.Event<TElement, TData>>): this;
@@ -40596,6 +34795,7 @@ $( "#other").click(function() {
   $( "#target" ).keyup();
 });
 </script>
+​
 </body>
 </html>
 ```
@@ -40627,6 +34827,7 @@ $( "#other").click(function() {
 <script>
 $( "p span" ).last().addClass( "highlight" );
 </script>
+​
 </body>
 </html>
 ```
@@ -40640,117 +34841,11 @@ $( "p span" ).last().addClass( "highlight" );
      * @param complete A callback function that is executed when the request completes.
      * @see \`{@link https://api.jquery.com/load/ }\`
      * @since 1.0
-     * @example ​ ````Load another page&#39;s list items into an ordered list.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>load demo</title>
-  <style>
-  body {
-    font-size: 12px;
-    font-family: Arial;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<b>Projects:</b>
-<ol id="new-projects"></ol>
-​
-<script>
-$( "#new-projects" ).load( "/resources/load.html #projects li" );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Display a notice if the Ajax request encounters an error.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>load demo</title>
-  <style>
-  body {
-    font-size: 12px;
-    font-family: Arial;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<b>Successful Response (should be blank):</b>
-<div id="success"></div>
-<b>Error Response:</b>
-<div id="error"></div>
-​
-<script>
-$( "#success" ).load( "/not-here.php", function( response, status, xhr ) {
-  if ( status == "error" ) {
-    var msg = "Sorry but there was an error: ";
-    $( "#error" ).html( msg + xhr.status + " " + xhr.statusText );
-  }
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Load the feeds.html file into the div with the ID of feeds.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>load demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "#feeds" ).load( "feeds.html" );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````pass arrays of data to the server.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>load demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "#objectID" ).load( "test.php", { "choices[]": [ "Jon", "Susan" ] } );
-</script>
-</body>
-</html>
-```
      * @example ​ ````Same as above, but will POST the additional parameters to the server and a callback that is executed when the server is finished responding.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>load demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $( "#feeds" ).load( "feeds.php", { limit: 25 }, function() {
   alert( "The last 25 entries in the feed have been loaded" );
 });
-</script>
-</body>
-</html>
 ```
      */
     load(url: string,
@@ -40787,6 +34882,7 @@ $( "#feeds" ).load( "feeds.php", { limit: 25 }, function() {
 <script>
 $( "#new-projects" ).load( "/resources/load.html #projects li" );
 </script>
+​
 </body>
 </html>
 ```
@@ -40820,61 +34916,17 @@ $( "#success" ).load( "/not-here.php", function( response, status, xhr ) {
   }
 });
 </script>
+​
 </body>
 </html>
 ```
      * @example ​ ````Load the feeds.html file into the div with the ID of feeds.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>load demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $( "#feeds" ).load( "feeds.html" );
-</script>
-</body>
-</html>
 ```
      * @example ​ ````pass arrays of data to the server.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>load demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $( "#objectID" ).load( "test.php", { "choices[]": [ "Jon", "Susan" ] } );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Same as above, but will POST the additional parameters to the server and a callback that is executed when the server is finished responding.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>load demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "#feeds" ).load( "feeds.php", { limit: 25 }, function() {
-  alert( "The last 25 entries in the feed have been loaded" );
-});
-</script>
-</body>
-</html>
 ```
      */
     load(url: string,
@@ -40917,6 +34969,7 @@ $( "p" )
   .get()
   .join( ", " ) );
 </script>
+​
 </body>
 </html>
 ```
@@ -40979,6 +35032,7 @@ var mappedItems = $( "li" ).map(function( index ) {
 });
 $( "#results" ).append( mappedItems );
 </script>
+​
 </body>
 </html>
 ```
@@ -41019,6 +35073,7 @@ $( "input" ).click(function() {
   $( "div" ).equalizeHeights();
 });
 </script>
+​
 </body>
 </html>
 ```
@@ -41036,31 +35091,6 @@ $( "input" ).click(function() {
      * **Cause**: The `.on()` and `.trigger()` methods can set an event handler or generate an event for any event type, and should be used instead of the shortcut methods. This message also applies to the other event shorthands, including: blur, focus, focusin, focusout, resize, scroll, dblclick, mousedown, mouseup, mousemove, mouseover, mouseout, mouseenter, mouseleave, change, select, submit, keydown, keypress, keyup, and contextmenu.
      *
      * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
-     * @example ​ ````Show texts when mouseup and mousedown event triggering.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>mousedown demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p>Press mouse and release here.</p>
-​
-<script>
-$( "p" )
-  .mouseup(function() {
-    $( this ).append( "<span style='color:#f00;'>Mouse up.</span>" );
-  })
-  .mousedown(function() {
-    $( this ).append( "<span style='color:#00f;'>Mouse down.</span>" );
-  });
-</script>
-</body>
-</html>
-```
      */
     mousedown<TData>(eventData: TData,
                      handler: JQuery.EventHandler<TElement, TData> | JQuery.EventHandlerBase<any, JQuery.Event<TElement, TData>>): this;
@@ -41097,6 +35127,7 @@ $( "p" )
     $( this ).append( "<span style='color:#00f;'>Mouse down.</span>" );
   });
 </script>
+​
 </body>
 </html>
 ```
@@ -41114,74 +35145,6 @@ $( "p" )
      * **Cause**: The `.on()` and `.trigger()` methods can set an event handler or generate an event for any event type, and should be used instead of the shortcut methods. This message also applies to the other event shorthands, including: blur, focus, focusin, focusout, resize, scroll, dblclick, mousedown, mouseup, mousemove, mouseover, mouseout, mouseenter, mouseleave, change, select, submit, keydown, keypress, keyup, and contextmenu.
      *
      * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
-     * @example ​ ````Show texts when mouseenter and mouseout event triggering.
-    mouseover fires when the pointer moves into the child element as well, while mouseenter fires only when the pointer moves into the bound element.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>mouseenter demo</title>
-  <style>
-  div.out {
-    width: 40%;
-    height: 120px;
-    margin: 0 15px;
-    background-color: #d6edfc;
-    float: left;
-  }
-  div.in {
-    width: 60%;
-    height: 60%;
-    background-color: #fc0;
-    margin: 10px auto;
-  }
-  p {
-    line-height: 1em;
-    margin: 0;
-    padding: 0;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<div class="out overout">
-  <p>move your mouse</p>
-  <div class="in overout"><p>move your mouse</p><p>0</p></div>
-  <p>0</p>
-</div>
-​
-<div class="out enterleave">
-  <p>move your mouse</p>
-  <div class="in enterleave"><p>move your mouse</p><p>0</p></div>
-  <p>0</p>
-</div>
-​
-<script>
-var i = 0;
-$( "div.overout" )
-  .mouseover(function() {
-    $( "p:first", this ).text( "mouse over" );
-    $( "p:last", this ).text( ++i );
-  })
-  .mouseout(function() {
-    $( "p:first", this ).text( "mouse out" );
-  });
-​
-var n = 0;
-$( "div.enterleave" )
-  .mouseenter(function() {
-    $( "p:first", this ).text( "mouse enter" );
-    $( "p:last", this ).text( ++n );
-  })
-  .mouseleave(function() {
-    $( "p:first", this ).text( "mouse leave" );
-  });
-</script>
-</body>
-</html>
-```
      */
     mouseenter<TData>(eventData: TData,
                       handler: JQuery.EventHandler<TElement, TData> | JQuery.EventHandlerBase<any, JQuery.Event<TElement, TData>>): this;
@@ -41261,6 +35224,7 @@ $( "div.enterleave" )
     $( "p:first", this ).text( "mouse leave" );
   });
 </script>
+​
 </body>
 </html>
 ```
@@ -41278,72 +35242,6 @@ $( "div.enterleave" )
      * **Cause**: The `.on()` and `.trigger()` methods can set an event handler or generate an event for any event type, and should be used instead of the shortcut methods. This message also applies to the other event shorthands, including: blur, focus, focusin, focusout, resize, scroll, dblclick, mousedown, mouseup, mousemove, mouseover, mouseout, mouseenter, mouseleave, change, select, submit, keydown, keypress, keyup, and contextmenu.
      *
      * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
-     * @example ​ ````Show number of times mouseout and mouseleave events are triggered. mouseout fires when the pointer moves out of child element as well, while mouseleave fires only when the pointer moves out of the bound element.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>mouseleave demo</title>
-  <style>
-  div.out {
-    width: 40%;
-    height: 120px;
-    margin: 0 15px;
-    background-color: #d6edfc;
-    float: left;
-  }
-  div.in {
-    width: 60%;
-    height: 60%;
-    background-color: #fc0;
-    margin: 10px auto;
-  }
-  p {
-    line-height: 1em;
-    margin: 0;
-    padding: 0;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<div class="out overout">
-  <p>move your mouse</p>
-  <div class="in overout"><p>move your mouse</p><p>0</p></div>
-  <p>0</p>
-</div>
-<div class="out enterleave">
-  <p>move your mouse</p>
-  <div class="in enterleave"><p>move your mouse</p><p>0</p></div>
-  <p>0</p>
-</div>
-​
-<script>
-var i = 0;
-$( "div.overout" )
-  .mouseover(function() {
-    $( "p:first", this ).text( "mouse over" );
-  })
-  .mouseout(function() {
-    $( "p:first", this ).text( "mouse out" );
-    $( "p:last", this ).text( ++i );
-  });
-​
-var n = 0;
-$( "div.enterleave" )
-  .mouseenter(function() {
-    $( "p:first", this ).text( "mouse enter" );
-  })
-  .mouseleave(function() {
-    $( "p:first", this ).text( "mouse leave" );
-    $( "p:last", this ).text( ++n );
-  });
-</script>
-</body>
-</html>
-```
      */
     mouseleave<TData>(eventData: TData,
                       handler: JQuery.EventHandler<TElement, TData> | JQuery.EventHandlerBase<any, JQuery.Event<TElement, TData>>): this;
@@ -41421,6 +35319,7 @@ $( "div.enterleave" )
     $( "p:last", this ).text( ++n );
   });
 </script>
+​
 </body>
 </html>
 ```
@@ -41438,57 +35337,6 @@ $( "div.enterleave" )
      * **Cause**: The `.on()` and `.trigger()` methods can set an event handler or generate an event for any event type, and should be used instead of the shortcut methods. This message also applies to the other event shorthands, including: blur, focus, focusin, focusout, resize, scroll, dblclick, mousedown, mouseup, mousemove, mouseover, mouseout, mouseenter, mouseleave, change, select, submit, keydown, keypress, keyup, and contextmenu.
      *
      * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
-     * @example ​ ````Show the mouse coordinates when the mouse is moved over the yellow div.  Coordinates are relative to the window, which in this case is the iframe.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>mousemove demo</title>
-  <style>
-  div {
-    width: 220px;
-    height: 170px;
-    margin: 10px 50px 10px 10px;
-    background: yellow;
-    border: 2px groove;
-    float: right;
-  }
-  p {
-    margin: 0;
-    margin-left: 10px;
-    color: red;
-    width: 220px;
-    height: 120px;
-    padding-top: 70px;
-    float: left;
-    font-size: 14px;
-  }
-  span {
-    display: block;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p>
-  <span>Move the mouse over the div.</span>
-  <span>&nbsp;</span>
-</p>
-<div></div>
-​
-<script>
-$( "div" ).mousemove(function( event ) {
-  var pageCoords = "( " + event.pageX + ", " + event.pageY + " )";
-  var clientCoords = "( " + event.clientX + ", " + event.clientY + " )";
-  $( "span:first" ).text( "( event.pageX, event.pageY ) : " + pageCoords );
-  $( "span:last" ).text( "( event.clientX, event.clientY ) : " + clientCoords );
-});
-</script>
-</body>
-</html>
-```
      */
     mousemove<TData>(eventData: TData,
                      handler: JQuery.EventHandler<TElement, TData> | JQuery.EventHandlerBase<any, JQuery.Event<TElement, TData>>): this;
@@ -41551,6 +35399,7 @@ $( "div" ).mousemove(function( event ) {
   $( "span:last" ).text( "( event.clientX, event.clientY ) : " + clientCoords );
 });
 </script>
+​
 </body>
 </html>
 ```
@@ -41568,74 +35417,6 @@ $( "div" ).mousemove(function( event ) {
      * **Cause**: The `.on()` and `.trigger()` methods can set an event handler or generate an event for any event type, and should be used instead of the shortcut methods. This message also applies to the other event shorthands, including: blur, focus, focusin, focusout, resize, scroll, dblclick, mousedown, mouseup, mousemove, mouseover, mouseout, mouseenter, mouseleave, change, select, submit, keydown, keypress, keyup, and contextmenu.
      *
      * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
-     * @example ​ ````Show the number of times mouseout and mouseleave events are triggered.
-  mouseout fires when the pointer moves out of the child element as well, while mouseleave fires only when the pointer moves out of the bound element.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>mouseout demo</title>
-  <style>
-  div.out {
-    width: 40%;
-    height: 120px;
-    margin: 0 15px;
-    background-color: #d6edfc;
-    float: left;
-  }
-  div.in {
-    width: 60%;
-    height: 60%;
-    background-color: #fc0;
-    margin: 10px auto;
-  }
-  p {
-    line-height: 1em;
-    margin: 0;
-    padding: 0;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<div class="out overout">
-  <p>move your mouse</p>
-  <div class="in overout"><p>move your mouse</p><p>0</p></div>
-  <p>0</p>
-</div>
-​
-<div class="out enterleave">
-  <p>move your mouse</p>
-  <div class="in enterleave"><p>move your mouse</p><p>0</p></div>
-  <p>0</p>
-</div>
-​
-<script>
-var i = 0;
-$( "div.overout" )
-  .mouseout(function() {
-    $( "p:first", this ).text( "mouse out" );
-    $( "p:last", this ).text( ++i );
-  })
-  .mouseover(function() {
-    $( "p:first", this ).text( "mouse over" );
-  });
-​
-var n = 0;
-$( "div.enterleave" )
-  .on( "mouseenter", function() {
-    $( "p:first", this ).text( "mouse enter" );
-  })
-  .on( "mouseleave", function() {
-    $( "p:first", this ).text( "mouse leave" );
-    $( "p:last", this ).text( ++n );
-  });
-</script>
-</body>
-</html>
-```
      */
     mouseout<TData>(eventData: TData,
                     handler: JQuery.EventHandler<TElement, TData> | JQuery.EventHandlerBase<any, JQuery.Event<TElement, TData>>): this;
@@ -41715,6 +35496,7 @@ $( "div.enterleave" )
     $( "p:last", this ).text( ++n );
   });
 </script>
+​
 </body>
 </html>
 ```
@@ -41732,74 +35514,6 @@ $( "div.enterleave" )
      * **Cause**: The `.on()` and `.trigger()` methods can set an event handler or generate an event for any event type, and should be used instead of the shortcut methods. This message also applies to the other event shorthands, including: blur, focus, focusin, focusout, resize, scroll, dblclick, mousedown, mouseup, mousemove, mouseover, mouseout, mouseenter, mouseleave, change, select, submit, keydown, keypress, keyup, and contextmenu.
      *
      * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
-     * @example ​ ````Show the number of times mouseover and mouseenter events are triggered.
-mouseover fires when the pointer moves into the child element as well, while mouseenter fires only when the pointer moves into the bound element.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>mouseover demo</title>
-  <style>
-  div.out {
-    width: 40%;
-    height: 120px;
-    margin: 0 15px;
-    background-color: #d6edfc;
-    float: left;
-  }
-  div.in {
-    width: 60%;
-    height: 60%;
-    background-color: #fc0;
-    margin: 10px auto;
-  }
-  p {
-    line-height: 1em;
-    margin: 0;
-    padding: 0;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<div class="out overout">
-  <span>move your mouse</span>
-  <div class="in">
-  </div>
-</div>
-​
-<div class="out enterleave">
-  <span>move your mouse</span>
-  <div class="in">
-  </div>
-</div>
-​
-<script>
-var i = 0;
-$( "div.overout" )
-  .mouseover(function() {
-    i += 1;
-    $( this ).find( "span" ).text( "mouse over x " + i );
-  })
-  .mouseout(function() {
-    $( this ).find( "span" ).text( "mouse out " );
-  });
-​
-var n = 0;
-$( "div.enterleave" )
-  .mouseenter(function() {
-    n += 1;
-    $( this ).find( "span" ).text( "mouse enter x " + n );
-  })
-  .mouseleave(function() {
-    $( this ).find( "span" ).text( "mouse leave" );
-  });
-</script>
-</body>
-</html>
-```
      */
     mouseover<TData>(eventData: TData,
                      handler: JQuery.EventHandler<TElement, TData> | JQuery.EventHandlerBase<any, JQuery.Event<TElement, TData>>): this;
@@ -41879,6 +35593,7 @@ $( "div.enterleave" )
     $( this ).find( "span" ).text( "mouse leave" );
   });
 </script>
+​
 </body>
 </html>
 ```
@@ -41896,31 +35611,6 @@ $( "div.enterleave" )
      * **Cause**: The `.on()` and `.trigger()` methods can set an event handler or generate an event for any event type, and should be used instead of the shortcut methods. This message also applies to the other event shorthands, including: blur, focus, focusin, focusout, resize, scroll, dblclick, mousedown, mouseup, mousemove, mouseover, mouseout, mouseenter, mouseleave, change, select, submit, keydown, keypress, keyup, and contextmenu.
      *
      * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
-     * @example ​ ````Show texts when mouseup and mousedown event triggering.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>mouseup demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p>Press mouse and release here.</p>
-​
-<script>
-$( "p" )
-  .mouseup(function() {
-    $( this ).append( "<span style='color:#f00;'>Mouse up.</span>" );
-  })
-  .mousedown(function() {
-    $( this ).append( "<span style='color:#00f;'>Mouse down.</span>" );
-  });
-</script>
-</body>
-</html>
-```
      */
     mouseup<TData>(eventData: TData,
                    handler: JQuery.EventHandler<TElement, TData> | JQuery.EventHandlerBase<any, JQuery.Event<TElement, TData>>): this;
@@ -41957,6 +35647,7 @@ $( "p" )
     $( this ).append( "<span style='color:#00f;'>Mouse down.</span>" );
   });
 </script>
+​
 </body>
 </html>
 ```
@@ -41996,6 +35687,7 @@ $( "p" )
 <script>
 $( "button[disabled]" ).next().text( "this button is disabled" );
 </script>
+​
 </body>
 </html>
 ```
@@ -42017,6 +35709,7 @@ $( "button[disabled]" ).next().text( "this button is disabled" );
 <script>
 $( "p" ).next( ".selected" ).css( "background", "yellow" );
 </script>
+​
 </body>
 </html>
 ```
@@ -42059,6 +35752,7 @@ $( "p" ).next( ".selected" ).css( "background", "yellow" );
 <script>
 $( "div:first" ).nextAll().addClass( "after" );
 </script>
+​
 </body>
 </html>
 ```
@@ -42097,6 +35791,7 @@ $( "div:first" ).nextAll().addClass( "after" );
 <script>
 $( ":nth-child(1)" ).nextAll( "p" ).addClass( "after" );
 </script>
+​
 </body>
 </html>
 ```
@@ -42147,6 +35842,7 @@ $( "#term-1" )
   .nextUntil( term3, "dd" )
     .css( "color", "green" );
 </script>
+​
 </body>
 </html>
 ```
@@ -42205,59 +35901,21 @@ $( "#term-1" )
 $( "div" ).not( ".green, #blueone" )
   .css( "border-color", "red" );
 </script>
+​
 </body>
 </html>
 ```
      * @example ​ ````Removes the element with the ID &quot;selected&quot; from the set of all paragraphs.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>not demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $( "p" ).not( $( "#selected" )[ 0 ] );
-</script>
-</body>
-</html>
 ```
      * @example ​ ````Removes the element with the ID &quot;selected&quot; from the set of all paragraphs.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>not demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $( "p" ).not( "#selected" );
-</script>
-</body>
-</html>
 ```
      * @example ​ ````Removes all elements that match &quot;div p.selected&quot; from the total set of all paragraphs.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>not demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $( "p" ).not( $( "div p.selected" ) );
-</script>
-</body>
-</html>
 ```
      */
     not(selector: JQuery.Selector | JQuery.TypeOrArray<Element> | JQuery | ((this: TElement, index: number, element: TElement) => boolean)): this;
@@ -42312,55 +35970,12 @@ $( "#unbind" ).click(function() {
       .text( "Does nothing..." );
 });
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Remove all event handlers from all paragraphs:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>off demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "p" ).off();
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Remove all delegated click handlers from all paragraphs:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>off demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "p" ).off( "click", "**" );
-</script>
+​
 </body>
 </html>
 ```
      * @example ​ ````Remove just one previously bound handler by passing it as the third argument:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>off demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 var foo = function() {
   // Code to handle some kind of event
 };
@@ -42370,36 +35985,6 @@ $( "body" ).on( "click", "p", foo );
 ​
 // ... Foo will no longer be called.
 $( "body" ).off( "click", "p", foo );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Unbind all delegated event handlers by their namespace:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>off demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-var validate = function() {
-  // Code to validate form entries
-};
-​
-// Delegate events under the ".validator" namespace
-$( "form" ).on( "click.validator", "button", validate );
-​
-$( "form" ).on( "keypress.validator", "input[type='text']", validate );
-​
-// Remove event handlers in the ".validator" namespace
-$( "form" ).off( ".validator" );
-</script>
-</body>
-</html>
 ```
      */
     off(events: string, selector: JQuery.Selector, handler: JQuery.EventHandlerBase<any, JQuery.Event<TElement, any>> | false): this;
@@ -42412,122 +35997,12 @@ $( "form" ).off( ".validator" );
      *                         A function to execute each time the event is triggered.
      * @see \`{@link https://api.jquery.com/off/ }\`
      * @since 1.7
-     * @example ​ ````Add and remove event handlers on the colored button.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>off demo</title>
-  <style>
-  button {
-    margin: 5px;
-  }
-  button#theone {
-    color: red;
-    background: yellow;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<button id="theone">Does nothing...</button>
-<button id="bind">Add Click</button>
-<button id="unbind">Remove Click</button>
-<div style="display:none;">Click!</div>
-​
-<script>
-function flash() {
-  $( "div" ).show().fadeOut( "slow" );
-}
-$( "#bind" ).click(function() {
-  $( "body" )
-    .on( "click", "#theone", flash )
-    .find( "#theone" )
-      .text( "Can Click!" );
-});
-$( "#unbind" ).click(function() {
-  $( "body" )
-    .off( "click", "#theone", flash )
-    .find( "#theone" )
-      .text( "Does nothing..." );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Remove all event handlers from all paragraphs:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>off demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "p" ).off();
-</script>
-</body>
-</html>
-```
      * @example ​ ````Remove all delegated click handlers from all paragraphs:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>off demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $( "p" ).off( "click", "**" );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Remove just one previously bound handler by passing it as the third argument:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>off demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-var foo = function() {
-  // Code to handle some kind of event
-};
-​
-// ... Now foo will be called when paragraphs are clicked ...
-$( "body" ).on( "click", "p", foo );
-​
-// ... Foo will no longer be called.
-$( "body" ).off( "click", "p", foo );
-</script>
-</body>
-</html>
 ```
      * @example ​ ````Unbind all delegated event handlers by their namespace:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>off demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 var validate = function() {
   // Code to validate form entries
 };
@@ -42539,9 +36014,6 @@ $( "form" ).on( "keypress.validator", "input[type='text']", validate );
 ​
 // Remove event handlers in the ".validator" namespace
 $( "form" ).off( ".validator" );
-</script>
-</body>
-</html>
 ```
      */
     off(events: string, selector_handler?: JQuery.Selector | JQuery.EventHandlerBase<any, JQuery.Event<TElement, any>> | false): this;
@@ -42553,137 +36025,6 @@ $( "form" ).off( ".validator" );
      * @param selector A selector which should match the one originally passed to .on() when attaching event handlers.
      * @see \`{@link https://api.jquery.com/off/ }\`
      * @since 1.7
-     * @example ​ ````Add and remove event handlers on the colored button.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>off demo</title>
-  <style>
-  button {
-    margin: 5px;
-  }
-  button#theone {
-    color: red;
-    background: yellow;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<button id="theone">Does nothing...</button>
-<button id="bind">Add Click</button>
-<button id="unbind">Remove Click</button>
-<div style="display:none;">Click!</div>
-​
-<script>
-function flash() {
-  $( "div" ).show().fadeOut( "slow" );
-}
-$( "#bind" ).click(function() {
-  $( "body" )
-    .on( "click", "#theone", flash )
-    .find( "#theone" )
-      .text( "Can Click!" );
-});
-$( "#unbind" ).click(function() {
-  $( "body" )
-    .off( "click", "#theone", flash )
-    .find( "#theone" )
-      .text( "Does nothing..." );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Remove all event handlers from all paragraphs:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>off demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "p" ).off();
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Remove all delegated click handlers from all paragraphs:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>off demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "p" ).off( "click", "**" );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Remove just one previously bound handler by passing it as the third argument:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>off demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-var foo = function() {
-  // Code to handle some kind of event
-};
-​
-// ... Now foo will be called when paragraphs are clicked ...
-$( "body" ).on( "click", "p", foo );
-​
-// ... Foo will no longer be called.
-$( "body" ).off( "click", "p", foo );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Unbind all delegated event handlers by their namespace:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>off demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-var validate = function() {
-  // Code to validate form entries
-};
-​
-// Delegate events under the ".validator" namespace
-$( "form" ).on( "click.validator", "button", validate );
-​
-$( "form" ).on( "keypress.validator", "input[type='text']", validate );
-​
-// Remove event handlers in the ".validator" namespace
-$( "form" ).off( ".validator" );
-</script>
-</body>
-</html>
-```
      */
     off(events: JQuery.PlainObject<JQuery.EventHandlerBase<any, JQuery.Event<TElement, any>> | false>, selector?: JQuery.Selector): this;
     /**
@@ -42692,136 +36033,9 @@ $( "form" ).off( ".validator" );
      * @param event A jQuery.Event object.
      * @see \`{@link https://api.jquery.com/off/ }\`
      * @since 1.7
-     * @example ​ ````Add and remove event handlers on the colored button.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>off demo</title>
-  <style>
-  button {
-    margin: 5px;
-  }
-  button#theone {
-    color: red;
-    background: yellow;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<button id="theone">Does nothing...</button>
-<button id="bind">Add Click</button>
-<button id="unbind">Remove Click</button>
-<div style="display:none;">Click!</div>
-​
-<script>
-function flash() {
-  $( "div" ).show().fadeOut( "slow" );
-}
-$( "#bind" ).click(function() {
-  $( "body" )
-    .on( "click", "#theone", flash )
-    .find( "#theone" )
-      .text( "Can Click!" );
-});
-$( "#unbind" ).click(function() {
-  $( "body" )
-    .off( "click", "#theone", flash )
-    .find( "#theone" )
-      .text( "Does nothing..." );
-});
-</script>
-</body>
-</html>
-```
      * @example ​ ````Remove all event handlers from all paragraphs:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>off demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $( "p" ).off();
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Remove all delegated click handlers from all paragraphs:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>off demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "p" ).off( "click", "**" );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Remove just one previously bound handler by passing it as the third argument:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>off demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-var foo = function() {
-  // Code to handle some kind of event
-};
-​
-// ... Now foo will be called when paragraphs are clicked ...
-$( "body" ).on( "click", "p", foo );
-​
-// ... Foo will no longer be called.
-$( "body" ).off( "click", "p", foo );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Unbind all delegated event handlers by their namespace:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>off demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-var validate = function() {
-  // Code to validate form entries
-};
-​
-// Delegate events under the ".validator" namespace
-$( "form" ).on( "click.validator", "button", validate );
-​
-$( "form" ).on( "keypress.validator", "input[type='text']", validate );
-​
-// Remove event handlers in the ".validator" namespace
-$( "form" ).off( ".validator" );
-</script>
-</body>
-</html>
 ```
      */
     off(event?: JQuery.Event<TElement>): this;
@@ -42835,82 +36049,6 @@ $( "form" ).off( ".validator" );
      *                    object with the new top and left properties.
      * @see \`{@link https://api.jquery.com/offset/ }\`
      * @since 1.4
-     * @example ​ ````Access the offset of the second paragraph:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>offset demo</title>
-  <style>
-  p {
-    margin-left: 10px;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p>Hello</p><p>2nd Paragraph</p>
-​
-<script>
-var p = $( "p:last" );
-var offset = p.offset();
-p.html( "left: " + offset.left + ", top: " + offset.top );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Click to see the offset.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>offset demo</title>
-  <style>
-  p {
-    margin-left: 10px;
-    color: blue;
-    width: 200px;
-    cursor: pointer;
-  }
-  span {
-    color: red;
-    cursor: pointer;
-  }
-  div.abs {
-    width: 50px;
-    height: 50px;
-    position: absolute;
-    left: 220px;
-    top: 35px;
-    background-color: green;
-    cursor: pointer;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<div id="result">Click an element.</div>
-<p>
-  This is the best way to <span>find</span> an offset.
-</p>
-<div class="abs">
-</div>
-​
-<script>
-$( "*", document.body ).click(function( event ) {
-  var offset = $( this ).offset();
-  event.stopPropagation();
-  $( "#result" ).text( this.tagName +
-    " coords ( " + offset.left + ", " + offset.top + " )" );
-});
-</script>
-</body>
-</html>
-```
      * @example ​ ````Set the offset of the second paragraph:
 ```html
 <!doctype html>
@@ -42932,6 +36070,7 @@ $( "*", document.body ).click(function( event ) {
 <script>
 $( "p:last" ).offset({ top: 10, left: 30 });
 </script>
+​
 </body>
 </html>
 ```
@@ -42965,6 +36104,7 @@ var p = $( "p:last" );
 var offset = p.offset();
 p.html( "left: " + offset.left + ", top: " + offset.top );
 </script>
+​
 </body>
 </html>
 ```
@@ -43015,30 +36155,7 @@ $( "*", document.body ).click(function( event ) {
     " coords ( " + offset.left + ", " + offset.top + " )" );
 });
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Set the offset of the second paragraph:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>offset demo</title>
-  <style>
-  p {
-    margin-left: 10px;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-<p>Hello</p><p>2nd Paragraph</p>
-​
-<script>
-$( "p:last" ).offset({ top: 10, left: 30 });
-</script>
 </body>
 </html>
 ```
@@ -43079,6 +36196,7 @@ $( "p:last" ).offset({ top: 10, left: 30 });
 </ul>
 ​
 <script>$( "li.item-a" ).offsetParent().css( "background-color", "red" );</script>
+​
 </body>
 </html>
 ```
@@ -43094,314 +36212,6 @@ $( "p:last" ).offset({ top: 10, left: 30 });
      * @param handler A function to execute when the event is triggered.
      * @see \`{@link https://api.jquery.com/on/ }\`
      * @since 1.7
-     * @example ​ ````Display a paragraph&#39;s text in an alert when it is clicked:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "p" ).on( "click", function() {
-  alert( $( this ).text() );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Pass data to the event handler, which is specified here by name:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-function myHandler( event ) {
-  alert( event.data.foo );
-}
-$( "p" ).on( "click", { foo: "bar" }, myHandler );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Cancel a form submit action and prevent the event from bubbling up by returning false:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "form" ).on( "submit", false );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Cancel only the default action by using .preventDefault().
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "form" ).on( "submit", function( event ) {
-  event.preventDefault();
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Stop submit events from bubbling without preventing form submit, using .stopPropagation().
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "form" ).on( "submit", function( event ) {
-  event.stopPropagation();
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Pass data to the event handler using the second argument to .trigger()
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "div" ).on( "click", function( event, person ) {
-  alert( "Hello, " + person.name );
-});
-$( "div" ).trigger( "click", { name: "Jim" } );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Use the the second argument of .trigger() to pass an array of data to the event handler
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "div" ).on( "click", function( event, salutation, name ) {
-  alert( salutation + ", " + name );
-});
-$( "div" ).trigger( "click", [ "Goodbye", "Jim" ] );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Attach and trigger custom (non-browser) events.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <style>
-  p {
-    color: red;
-  }
-  span {
-    color: blue;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p>Has an attached custom event.</p>
-<button>Trigger custom event</button>
-<span style="display:none;"></span>
-​
-<script>
-$( "p" ).on( "myCustomEvent", function( event, myName ) {
-  $( this ).text( myName + ", hi there!" );
-  $( "span" )
-    .stop()
-    .css( "opacity", 1 )
-    .text( "myName = " + myName )
-    .fadeIn( 30 )
-    .fadeOut( 1000 );
-});
-$( "button" ).click(function () {
-  $( "p" ).trigger( "myCustomEvent", [ "John" ] );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Attach multiple event handlers simultaneously using a plain object.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <style>
-  .test {
-    color: #000;
-    padding: .5em;
-    border: 1px solid #444;
-  }
-  .active {
-    color: #900;
-  }
-  .inside {
-    background-color: aqua;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<div class="test">test div</div>
-​
-<script>
-$( "div.test" ).on({
-  click: function() {
-    $( this ).toggleClass( "active" );
-  }, mouseenter: function() {
-    $( this ).addClass( "inside" );
-  }, mouseleave: function() {
-    $( this ).removeClass( "inside" );
-  }
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Click any paragraph to add another after it. Note that .on() allows a click event on any paragraph--even new ones--since the event is handled by the ever-present body element after it bubbles to there.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <style>
-  p {
-    background: yellow;
-    font-weight: bold;
-    cursor: pointer;
-    padding: 5px;
-  }
-  p.over {
-    background: #ccc;
-  }
-  span {
-    color: red;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p>Click me!</p>
-<span></span>
-​
-<script>
-var count = 0;
-$( "body" ).on( "click", "p", function() {
-  $( this ).after( "<p>Another paragraph! " + (++count) + "</p>" );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Display each paragraph&#39;s text in an alert box whenever it is clicked:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "body" ).on( "click", "p", function() {
-  alert( $( this ).text() );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Cancel a link&#39;s default action using the .preventDefault() method:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "body" ).on( "click", "a", function( event ) {
-  event.preventDefault();
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Attach multiple events—one on mouseenter and one on mouseleave to the same element:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "#cart" ).on( "mouseenter mouseleave", function( event ) {
-  $( this ).toggleClass( "active" );
-});
-</script>
-</body>
-</html>
-```
      */
     on<TData>(events: string,
               selector: JQuery.Selector | null,
@@ -43417,314 +36227,6 @@ $( "#cart" ).on( "mouseenter mouseleave", function( event ) {
      * @param handler A function to execute when the event is triggered.
      * @see \`{@link https://api.jquery.com/on/ }\`
      * @since 1.7
-     * @example ​ ````Display a paragraph&#39;s text in an alert when it is clicked:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "p" ).on( "click", function() {
-  alert( $( this ).text() );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Pass data to the event handler, which is specified here by name:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-function myHandler( event ) {
-  alert( event.data.foo );
-}
-$( "p" ).on( "click", { foo: "bar" }, myHandler );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Cancel a form submit action and prevent the event from bubbling up by returning false:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "form" ).on( "submit", false );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Cancel only the default action by using .preventDefault().
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "form" ).on( "submit", function( event ) {
-  event.preventDefault();
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Stop submit events from bubbling without preventing form submit, using .stopPropagation().
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "form" ).on( "submit", function( event ) {
-  event.stopPropagation();
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Pass data to the event handler using the second argument to .trigger()
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "div" ).on( "click", function( event, person ) {
-  alert( "Hello, " + person.name );
-});
-$( "div" ).trigger( "click", { name: "Jim" } );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Use the the second argument of .trigger() to pass an array of data to the event handler
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "div" ).on( "click", function( event, salutation, name ) {
-  alert( salutation + ", " + name );
-});
-$( "div" ).trigger( "click", [ "Goodbye", "Jim" ] );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Attach and trigger custom (non-browser) events.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <style>
-  p {
-    color: red;
-  }
-  span {
-    color: blue;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p>Has an attached custom event.</p>
-<button>Trigger custom event</button>
-<span style="display:none;"></span>
-​
-<script>
-$( "p" ).on( "myCustomEvent", function( event, myName ) {
-  $( this ).text( myName + ", hi there!" );
-  $( "span" )
-    .stop()
-    .css( "opacity", 1 )
-    .text( "myName = " + myName )
-    .fadeIn( 30 )
-    .fadeOut( 1000 );
-});
-$( "button" ).click(function () {
-  $( "p" ).trigger( "myCustomEvent", [ "John" ] );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Attach multiple event handlers simultaneously using a plain object.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <style>
-  .test {
-    color: #000;
-    padding: .5em;
-    border: 1px solid #444;
-  }
-  .active {
-    color: #900;
-  }
-  .inside {
-    background-color: aqua;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<div class="test">test div</div>
-​
-<script>
-$( "div.test" ).on({
-  click: function() {
-    $( this ).toggleClass( "active" );
-  }, mouseenter: function() {
-    $( this ).addClass( "inside" );
-  }, mouseleave: function() {
-    $( this ).removeClass( "inside" );
-  }
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Click any paragraph to add another after it. Note that .on() allows a click event on any paragraph--even new ones--since the event is handled by the ever-present body element after it bubbles to there.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <style>
-  p {
-    background: yellow;
-    font-weight: bold;
-    cursor: pointer;
-    padding: 5px;
-  }
-  p.over {
-    background: #ccc;
-  }
-  span {
-    color: red;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p>Click me!</p>
-<span></span>
-​
-<script>
-var count = 0;
-$( "body" ).on( "click", "p", function() {
-  $( this ).after( "<p>Another paragraph! " + (++count) + "</p>" );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Display each paragraph&#39;s text in an alert box whenever it is clicked:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "body" ).on( "click", "p", function() {
-  alert( $( this ).text() );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Cancel a link&#39;s default action using the .preventDefault() method:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "body" ).on( "click", "a", function( event ) {
-  event.preventDefault();
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Attach multiple events—one on mouseenter and one on mouseleave to the same element:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "#cart" ).on( "mouseenter mouseleave", function( event ) {
-  $( this ).toggleClass( "active" );
-});
-</script>
-</body>
-</html>
-```
      */
     on(events: string,
        selector: JQuery.Selector | null,
@@ -43740,220 +36242,6 @@ $( "#cart" ).on( "mouseenter mouseleave", function( event ) {
      *                for a function that simply does return false.
      * @see \`{@link https://api.jquery.com/on/ }\`
      * @since 1.7
-     * @example ​ ````Display a paragraph&#39;s text in an alert when it is clicked:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "p" ).on( "click", function() {
-  alert( $( this ).text() );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Pass data to the event handler, which is specified here by name:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-function myHandler( event ) {
-  alert( event.data.foo );
-}
-$( "p" ).on( "click", { foo: "bar" }, myHandler );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Cancel a form submit action and prevent the event from bubbling up by returning false:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "form" ).on( "submit", false );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Cancel only the default action by using .preventDefault().
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "form" ).on( "submit", function( event ) {
-  event.preventDefault();
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Stop submit events from bubbling without preventing form submit, using .stopPropagation().
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "form" ).on( "submit", function( event ) {
-  event.stopPropagation();
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Pass data to the event handler using the second argument to .trigger()
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "div" ).on( "click", function( event, person ) {
-  alert( "Hello, " + person.name );
-});
-$( "div" ).trigger( "click", { name: "Jim" } );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Use the the second argument of .trigger() to pass an array of data to the event handler
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "div" ).on( "click", function( event, salutation, name ) {
-  alert( salutation + ", " + name );
-});
-$( "div" ).trigger( "click", [ "Goodbye", "Jim" ] );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Attach and trigger custom (non-browser) events.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <style>
-  p {
-    color: red;
-  }
-  span {
-    color: blue;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p>Has an attached custom event.</p>
-<button>Trigger custom event</button>
-<span style="display:none;"></span>
-​
-<script>
-$( "p" ).on( "myCustomEvent", function( event, myName ) {
-  $( this ).text( myName + ", hi there!" );
-  $( "span" )
-    .stop()
-    .css( "opacity", 1 )
-    .text( "myName = " + myName )
-    .fadeIn( 30 )
-    .fadeOut( 1000 );
-});
-$( "button" ).click(function () {
-  $( "p" ).trigger( "myCustomEvent", [ "John" ] );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Attach multiple event handlers simultaneously using a plain object.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <style>
-  .test {
-    color: #000;
-    padding: .5em;
-    border: 1px solid #444;
-  }
-  .active {
-    color: #900;
-  }
-  .inside {
-    background-color: aqua;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<div class="test">test div</div>
-​
-<script>
-$( "div.test" ).on({
-  click: function() {
-    $( this ).toggleClass( "active" );
-  }, mouseenter: function() {
-    $( this ).addClass( "inside" );
-  }, mouseleave: function() {
-    $( this ).removeClass( "inside" );
-  }
-});
-</script>
-</body>
-</html>
-```
      * @example ​ ````Click any paragraph to add another after it. Note that .on() allows a click event on any paragraph--even new ones--since the event is handled by the ever-present body element after it bubbles to there.
 ```html
 <!doctype html>
@@ -43988,65 +36276,21 @@ $( "body" ).on( "click", "p", function() {
   $( this ).after( "<p>Another paragraph! " + (++count) + "</p>" );
 });
 </script>
+​
 </body>
 </html>
 ```
      * @example ​ ````Display each paragraph&#39;s text in an alert box whenever it is clicked:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $( "body" ).on( "click", "p", function() {
   alert( $( this ).text() );
 });
-</script>
-</body>
-</html>
 ```
      * @example ​ ````Cancel a link&#39;s default action using the .preventDefault() method:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $( "body" ).on( "click", "a", function( event ) {
   event.preventDefault();
 });
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Attach multiple events—one on mouseenter and one on mouseleave to the same element:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "#cart" ).on( "mouseenter mouseleave", function( event ) {
-  $( this ).toggleClass( "active" );
-});
-</script>
-</body>
-</html>
 ```
      */
     on(events: string,
@@ -44061,220 +36305,6 @@ $( "#cart" ).on( "mouseenter mouseleave", function( event ) {
      * @param handler A function to execute when the event is triggered.
      * @see \`{@link https://api.jquery.com/on/ }\`
      * @since 1.7
-     * @example ​ ````Display a paragraph&#39;s text in an alert when it is clicked:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "p" ).on( "click", function() {
-  alert( $( this ).text() );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Pass data to the event handler, which is specified here by name:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-function myHandler( event ) {
-  alert( event.data.foo );
-}
-$( "p" ).on( "click", { foo: "bar" }, myHandler );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Cancel a form submit action and prevent the event from bubbling up by returning false:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "form" ).on( "submit", false );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Cancel only the default action by using .preventDefault().
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "form" ).on( "submit", function( event ) {
-  event.preventDefault();
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Stop submit events from bubbling without preventing form submit, using .stopPropagation().
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "form" ).on( "submit", function( event ) {
-  event.stopPropagation();
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Pass data to the event handler using the second argument to .trigger()
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "div" ).on( "click", function( event, person ) {
-  alert( "Hello, " + person.name );
-});
-$( "div" ).trigger( "click", { name: "Jim" } );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Use the the second argument of .trigger() to pass an array of data to the event handler
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "div" ).on( "click", function( event, salutation, name ) {
-  alert( salutation + ", " + name );
-});
-$( "div" ).trigger( "click", [ "Goodbye", "Jim" ] );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Attach and trigger custom (non-browser) events.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <style>
-  p {
-    color: red;
-  }
-  span {
-    color: blue;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p>Has an attached custom event.</p>
-<button>Trigger custom event</button>
-<span style="display:none;"></span>
-​
-<script>
-$( "p" ).on( "myCustomEvent", function( event, myName ) {
-  $( this ).text( myName + ", hi there!" );
-  $( "span" )
-    .stop()
-    .css( "opacity", 1 )
-    .text( "myName = " + myName )
-    .fadeIn( 30 )
-    .fadeOut( 1000 );
-});
-$( "button" ).click(function () {
-  $( "p" ).trigger( "myCustomEvent", [ "John" ] );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Attach multiple event handlers simultaneously using a plain object.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <style>
-  .test {
-    color: #000;
-    padding: .5em;
-    border: 1px solid #444;
-  }
-  .active {
-    color: #900;
-  }
-  .inside {
-    background-color: aqua;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<div class="test">test div</div>
-​
-<script>
-$( "div.test" ).on({
-  click: function() {
-    $( this ).toggleClass( "active" );
-  }, mouseenter: function() {
-    $( this ).addClass( "inside" );
-  }, mouseleave: function() {
-    $( this ).removeClass( "inside" );
-  }
-});
-</script>
-</body>
-</html>
-```
      * @example ​ ````Click any paragraph to add another after it. Note that .on() allows a click event on any paragraph--even new ones--since the event is handled by the ever-present body element after it bubbles to there.
 ```html
 <!doctype html>
@@ -44309,65 +36339,21 @@ $( "body" ).on( "click", "p", function() {
   $( this ).after( "<p>Another paragraph! " + (++count) + "</p>" );
 });
 </script>
+​
 </body>
 </html>
 ```
      * @example ​ ````Display each paragraph&#39;s text in an alert box whenever it is clicked:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $( "body" ).on( "click", "p", function() {
   alert( $( this ).text() );
 });
-</script>
-</body>
-</html>
 ```
      * @example ​ ````Cancel a link&#39;s default action using the .preventDefault() method:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $( "body" ).on( "click", "a", function( event ) {
   event.preventDefault();
 });
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Attach multiple events—one on mouseenter and one on mouseleave to the same element:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "#cart" ).on( "mouseenter mouseleave", function( event ) {
-  $( this ).toggleClass( "active" );
-});
-</script>
-</body>
-</html>
 ```
      */
     on(events: string,
@@ -44381,313 +36367,12 @@ $( "#cart" ).on( "mouseenter mouseleave", function( event ) {
      * @param handler A function to execute when the event is triggered.
      * @see \`{@link https://api.jquery.com/on/ }\`
      * @since 1.7
-     * @example ​ ````Display a paragraph&#39;s text in an alert when it is clicked:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "p" ).on( "click", function() {
-  alert( $( this ).text() );
-});
-</script>
-</body>
-</html>
-```
      * @example ​ ````Pass data to the event handler, which is specified here by name:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 function myHandler( event ) {
   alert( event.data.foo );
 }
 $( "p" ).on( "click", { foo: "bar" }, myHandler );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Cancel a form submit action and prevent the event from bubbling up by returning false:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "form" ).on( "submit", false );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Cancel only the default action by using .preventDefault().
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "form" ).on( "submit", function( event ) {
-  event.preventDefault();
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Stop submit events from bubbling without preventing form submit, using .stopPropagation().
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "form" ).on( "submit", function( event ) {
-  event.stopPropagation();
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Pass data to the event handler using the second argument to .trigger()
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "div" ).on( "click", function( event, person ) {
-  alert( "Hello, " + person.name );
-});
-$( "div" ).trigger( "click", { name: "Jim" } );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Use the the second argument of .trigger() to pass an array of data to the event handler
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "div" ).on( "click", function( event, salutation, name ) {
-  alert( salutation + ", " + name );
-});
-$( "div" ).trigger( "click", [ "Goodbye", "Jim" ] );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Attach and trigger custom (non-browser) events.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <style>
-  p {
-    color: red;
-  }
-  span {
-    color: blue;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p>Has an attached custom event.</p>
-<button>Trigger custom event</button>
-<span style="display:none;"></span>
-​
-<script>
-$( "p" ).on( "myCustomEvent", function( event, myName ) {
-  $( this ).text( myName + ", hi there!" );
-  $( "span" )
-    .stop()
-    .css( "opacity", 1 )
-    .text( "myName = " + myName )
-    .fadeIn( 30 )
-    .fadeOut( 1000 );
-});
-$( "button" ).click(function () {
-  $( "p" ).trigger( "myCustomEvent", [ "John" ] );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Attach multiple event handlers simultaneously using a plain object.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <style>
-  .test {
-    color: #000;
-    padding: .5em;
-    border: 1px solid #444;
-  }
-  .active {
-    color: #900;
-  }
-  .inside {
-    background-color: aqua;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<div class="test">test div</div>
-​
-<script>
-$( "div.test" ).on({
-  click: function() {
-    $( this ).toggleClass( "active" );
-  }, mouseenter: function() {
-    $( this ).addClass( "inside" );
-  }, mouseleave: function() {
-    $( this ).removeClass( "inside" );
-  }
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Click any paragraph to add another after it. Note that .on() allows a click event on any paragraph--even new ones--since the event is handled by the ever-present body element after it bubbles to there.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <style>
-  p {
-    background: yellow;
-    font-weight: bold;
-    cursor: pointer;
-    padding: 5px;
-  }
-  p.over {
-    background: #ccc;
-  }
-  span {
-    color: red;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p>Click me!</p>
-<span></span>
-​
-<script>
-var count = 0;
-$( "body" ).on( "click", "p", function() {
-  $( this ).after( "<p>Another paragraph! " + (++count) + "</p>" );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Display each paragraph&#39;s text in an alert box whenever it is clicked:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "body" ).on( "click", "p", function() {
-  alert( $( this ).text() );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Cancel a link&#39;s default action using the .preventDefault() method:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "body" ).on( "click", "a", function( event ) {
-  event.preventDefault();
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Attach multiple events—one on mouseenter and one on mouseleave to the same element:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "#cart" ).on( "mouseenter mouseleave", function( event ) {
-  $( this ).toggleClass( "active" );
-});
-</script>
-</body>
-</html>
 ```
      */
     on<TData>(events: string,
@@ -44701,313 +36386,12 @@ $( "#cart" ).on( "mouseenter mouseleave", function( event ) {
      * @param handler A function to execute when the event is triggered.
      * @see \`{@link https://api.jquery.com/on/ }\`
      * @since 1.7
-     * @example ​ ````Display a paragraph&#39;s text in an alert when it is clicked:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "p" ).on( "click", function() {
-  alert( $( this ).text() );
-});
-</script>
-</body>
-</html>
-```
      * @example ​ ````Pass data to the event handler, which is specified here by name:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 function myHandler( event ) {
   alert( event.data.foo );
 }
 $( "p" ).on( "click", { foo: "bar" }, myHandler );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Cancel a form submit action and prevent the event from bubbling up by returning false:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "form" ).on( "submit", false );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Cancel only the default action by using .preventDefault().
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "form" ).on( "submit", function( event ) {
-  event.preventDefault();
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Stop submit events from bubbling without preventing form submit, using .stopPropagation().
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "form" ).on( "submit", function( event ) {
-  event.stopPropagation();
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Pass data to the event handler using the second argument to .trigger()
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "div" ).on( "click", function( event, person ) {
-  alert( "Hello, " + person.name );
-});
-$( "div" ).trigger( "click", { name: "Jim" } );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Use the the second argument of .trigger() to pass an array of data to the event handler
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "div" ).on( "click", function( event, salutation, name ) {
-  alert( salutation + ", " + name );
-});
-$( "div" ).trigger( "click", [ "Goodbye", "Jim" ] );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Attach and trigger custom (non-browser) events.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <style>
-  p {
-    color: red;
-  }
-  span {
-    color: blue;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p>Has an attached custom event.</p>
-<button>Trigger custom event</button>
-<span style="display:none;"></span>
-​
-<script>
-$( "p" ).on( "myCustomEvent", function( event, myName ) {
-  $( this ).text( myName + ", hi there!" );
-  $( "span" )
-    .stop()
-    .css( "opacity", 1 )
-    .text( "myName = " + myName )
-    .fadeIn( 30 )
-    .fadeOut( 1000 );
-});
-$( "button" ).click(function () {
-  $( "p" ).trigger( "myCustomEvent", [ "John" ] );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Attach multiple event handlers simultaneously using a plain object.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <style>
-  .test {
-    color: #000;
-    padding: .5em;
-    border: 1px solid #444;
-  }
-  .active {
-    color: #900;
-  }
-  .inside {
-    background-color: aqua;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<div class="test">test div</div>
-​
-<script>
-$( "div.test" ).on({
-  click: function() {
-    $( this ).toggleClass( "active" );
-  }, mouseenter: function() {
-    $( this ).addClass( "inside" );
-  }, mouseleave: function() {
-    $( this ).removeClass( "inside" );
-  }
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Click any paragraph to add another after it. Note that .on() allows a click event on any paragraph--even new ones--since the event is handled by the ever-present body element after it bubbles to there.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <style>
-  p {
-    background: yellow;
-    font-weight: bold;
-    cursor: pointer;
-    padding: 5px;
-  }
-  p.over {
-    background: #ccc;
-  }
-  span {
-    color: red;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p>Click me!</p>
-<span></span>
-​
-<script>
-var count = 0;
-$( "body" ).on( "click", "p", function() {
-  $( this ).after( "<p>Another paragraph! " + (++count) + "</p>" );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Display each paragraph&#39;s text in an alert box whenever it is clicked:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "body" ).on( "click", "p", function() {
-  alert( $( this ).text() );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Cancel a link&#39;s default action using the .preventDefault() method:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "body" ).on( "click", "a", function( event ) {
-  event.preventDefault();
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Attach multiple events—one on mouseenter and one on mouseleave to the same element:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "#cart" ).on( "mouseenter mouseleave", function( event ) {
-  $( this ).toggleClass( "active" );
-});
-</script>
-</body>
-</html>
 ```
      */
     on(events: string,
@@ -45022,138 +36406,40 @@ $( "#cart" ).on( "mouseenter mouseleave", function( event ) {
      * @see \`{@link https://api.jquery.com/on/ }\`
      * @since 1.7
      * @example ​ ````Display a paragraph&#39;s text in an alert when it is clicked:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $( "p" ).on( "click", function() {
   alert( $( this ).text() );
 });
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Pass data to the event handler, which is specified here by name:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-function myHandler( event ) {
-  alert( event.data.foo );
-}
-$( "p" ).on( "click", { foo: "bar" }, myHandler );
-</script>
-</body>
-</html>
 ```
      * @example ​ ````Cancel a form submit action and prevent the event from bubbling up by returning false:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $( "form" ).on( "submit", false );
-</script>
-</body>
-</html>
 ```
      * @example ​ ````Cancel only the default action by using .preventDefault().
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $( "form" ).on( "submit", function( event ) {
   event.preventDefault();
 });
-</script>
-</body>
-</html>
 ```
      * @example ​ ````Stop submit events from bubbling without preventing form submit, using .stopPropagation().
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $( "form" ).on( "submit", function( event ) {
   event.stopPropagation();
 });
-</script>
-</body>
-</html>
 ```
      * @example ​ ````Pass data to the event handler using the second argument to .trigger()
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $( "div" ).on( "click", function( event, person ) {
   alert( "Hello, " + person.name );
 });
 $( "div" ).trigger( "click", { name: "Jim" } );
-</script>
-</body>
-</html>
 ```
      * @example ​ ````Use the the second argument of .trigger() to pass an array of data to the event handler
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $( "div" ).on( "click", function( event, salutation, name ) {
   alert( salutation + ", " + name );
 });
 $( "div" ).trigger( "click", [ "Goodbye", "Jim" ] );
-</script>
-</body>
-</html>
 ```
      * @example ​ ````Attach and trigger custom (non-browser) events.
 ```html
@@ -45192,142 +36478,15 @@ $( "button" ).click(function () {
   $( "p" ).trigger( "myCustomEvent", [ "John" ] );
 });
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Attach multiple event handlers simultaneously using a plain object.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <style>
-  .test {
-    color: #000;
-    padding: .5em;
-    border: 1px solid #444;
-  }
-  .active {
-    color: #900;
-  }
-  .inside {
-    background-color: aqua;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-<div class="test">test div</div>
-​
-<script>
-$( "div.test" ).on({
-  click: function() {
-    $( this ).toggleClass( "active" );
-  }, mouseenter: function() {
-    $( this ).addClass( "inside" );
-  }, mouseleave: function() {
-    $( this ).removeClass( "inside" );
-  }
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Click any paragraph to add another after it. Note that .on() allows a click event on any paragraph--even new ones--since the event is handled by the ever-present body element after it bubbles to there.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <style>
-  p {
-    background: yellow;
-    font-weight: bold;
-    cursor: pointer;
-    padding: 5px;
-  }
-  p.over {
-    background: #ccc;
-  }
-  span {
-    color: red;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p>Click me!</p>
-<span></span>
-​
-<script>
-var count = 0;
-$( "body" ).on( "click", "p", function() {
-  $( this ).after( "<p>Another paragraph! " + (++count) + "</p>" );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Display each paragraph&#39;s text in an alert box whenever it is clicked:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "body" ).on( "click", "p", function() {
-  alert( $( this ).text() );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Cancel a link&#39;s default action using the .preventDefault() method:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "body" ).on( "click", "a", function( event ) {
-  event.preventDefault();
-});
-</script>
 </body>
 </html>
 ```
      * @example ​ ````Attach multiple events—one on mouseenter and one on mouseleave to the same element:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $( "#cart" ).on( "mouseenter mouseleave", function( event ) {
   $( this ).toggleClass( "active" );
 });
-</script>
-</body>
-</html>
 ```
      */
     on(events: string,
@@ -45340,138 +36499,40 @@ $( "#cart" ).on( "mouseenter mouseleave", function( event ) {
      * @see \`{@link https://api.jquery.com/on/ }\`
      * @since 1.7
      * @example ​ ````Display a paragraph&#39;s text in an alert when it is clicked:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $( "p" ).on( "click", function() {
   alert( $( this ).text() );
 });
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Pass data to the event handler, which is specified here by name:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-function myHandler( event ) {
-  alert( event.data.foo );
-}
-$( "p" ).on( "click", { foo: "bar" }, myHandler );
-</script>
-</body>
-</html>
 ```
      * @example ​ ````Cancel a form submit action and prevent the event from bubbling up by returning false:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $( "form" ).on( "submit", false );
-</script>
-</body>
-</html>
 ```
      * @example ​ ````Cancel only the default action by using .preventDefault().
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $( "form" ).on( "submit", function( event ) {
   event.preventDefault();
 });
-</script>
-</body>
-</html>
 ```
      * @example ​ ````Stop submit events from bubbling without preventing form submit, using .stopPropagation().
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $( "form" ).on( "submit", function( event ) {
   event.stopPropagation();
 });
-</script>
-</body>
-</html>
 ```
      * @example ​ ````Pass data to the event handler using the second argument to .trigger()
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $( "div" ).on( "click", function( event, person ) {
   alert( "Hello, " + person.name );
 });
 $( "div" ).trigger( "click", { name: "Jim" } );
-</script>
-</body>
-</html>
 ```
      * @example ​ ````Use the the second argument of .trigger() to pass an array of data to the event handler
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $( "div" ).on( "click", function( event, salutation, name ) {
   alert( salutation + ", " + name );
 });
 $( "div" ).trigger( "click", [ "Goodbye", "Jim" ] );
-</script>
-</body>
-</html>
 ```
      * @example ​ ````Attach and trigger custom (non-browser) events.
 ```html
@@ -45510,142 +36571,15 @@ $( "button" ).click(function () {
   $( "p" ).trigger( "myCustomEvent", [ "John" ] );
 });
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Attach multiple event handlers simultaneously using a plain object.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <style>
-  .test {
-    color: #000;
-    padding: .5em;
-    border: 1px solid #444;
-  }
-  .active {
-    color: #900;
-  }
-  .inside {
-    background-color: aqua;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-<div class="test">test div</div>
-​
-<script>
-$( "div.test" ).on({
-  click: function() {
-    $( this ).toggleClass( "active" );
-  }, mouseenter: function() {
-    $( this ).addClass( "inside" );
-  }, mouseleave: function() {
-    $( this ).removeClass( "inside" );
-  }
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Click any paragraph to add another after it. Note that .on() allows a click event on any paragraph--even new ones--since the event is handled by the ever-present body element after it bubbles to there.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <style>
-  p {
-    background: yellow;
-    font-weight: bold;
-    cursor: pointer;
-    padding: 5px;
-  }
-  p.over {
-    background: #ccc;
-  }
-  span {
-    color: red;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p>Click me!</p>
-<span></span>
-​
-<script>
-var count = 0;
-$( "body" ).on( "click", "p", function() {
-  $( this ).after( "<p>Another paragraph! " + (++count) + "</p>" );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Display each paragraph&#39;s text in an alert box whenever it is clicked:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "body" ).on( "click", "p", function() {
-  alert( $( this ).text() );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Cancel a link&#39;s default action using the .preventDefault() method:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "body" ).on( "click", "a", function( event ) {
-  event.preventDefault();
-});
-</script>
 </body>
 </html>
 ```
      * @example ​ ````Attach multiple events—one on mouseenter and one on mouseleave to the same element:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $( "#cart" ).on( "mouseenter mouseleave", function( event ) {
   $( this ).toggleClass( "active" );
 });
-</script>
-</body>
-</html>
 ```
      */
     on(events: string,
@@ -45660,314 +36594,6 @@ $( "#cart" ).on( "mouseenter mouseleave", function( event ) {
      * @param data Data to be passed to the handler in event.data when an event occurs.
      * @see \`{@link https://api.jquery.com/on/ }\`
      * @since 1.7
-     * @example ​ ````Display a paragraph&#39;s text in an alert when it is clicked:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "p" ).on( "click", function() {
-  alert( $( this ).text() );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Pass data to the event handler, which is specified here by name:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-function myHandler( event ) {
-  alert( event.data.foo );
-}
-$( "p" ).on( "click", { foo: "bar" }, myHandler );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Cancel a form submit action and prevent the event from bubbling up by returning false:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "form" ).on( "submit", false );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Cancel only the default action by using .preventDefault().
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "form" ).on( "submit", function( event ) {
-  event.preventDefault();
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Stop submit events from bubbling without preventing form submit, using .stopPropagation().
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "form" ).on( "submit", function( event ) {
-  event.stopPropagation();
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Pass data to the event handler using the second argument to .trigger()
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "div" ).on( "click", function( event, person ) {
-  alert( "Hello, " + person.name );
-});
-$( "div" ).trigger( "click", { name: "Jim" } );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Use the the second argument of .trigger() to pass an array of data to the event handler
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "div" ).on( "click", function( event, salutation, name ) {
-  alert( salutation + ", " + name );
-});
-$( "div" ).trigger( "click", [ "Goodbye", "Jim" ] );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Attach and trigger custom (non-browser) events.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <style>
-  p {
-    color: red;
-  }
-  span {
-    color: blue;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p>Has an attached custom event.</p>
-<button>Trigger custom event</button>
-<span style="display:none;"></span>
-​
-<script>
-$( "p" ).on( "myCustomEvent", function( event, myName ) {
-  $( this ).text( myName + ", hi there!" );
-  $( "span" )
-    .stop()
-    .css( "opacity", 1 )
-    .text( "myName = " + myName )
-    .fadeIn( 30 )
-    .fadeOut( 1000 );
-});
-$( "button" ).click(function () {
-  $( "p" ).trigger( "myCustomEvent", [ "John" ] );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Attach multiple event handlers simultaneously using a plain object.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <style>
-  .test {
-    color: #000;
-    padding: .5em;
-    border: 1px solid #444;
-  }
-  .active {
-    color: #900;
-  }
-  .inside {
-    background-color: aqua;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<div class="test">test div</div>
-​
-<script>
-$( "div.test" ).on({
-  click: function() {
-    $( this ).toggleClass( "active" );
-  }, mouseenter: function() {
-    $( this ).addClass( "inside" );
-  }, mouseleave: function() {
-    $( this ).removeClass( "inside" );
-  }
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Click any paragraph to add another after it. Note that .on() allows a click event on any paragraph--even new ones--since the event is handled by the ever-present body element after it bubbles to there.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <style>
-  p {
-    background: yellow;
-    font-weight: bold;
-    cursor: pointer;
-    padding: 5px;
-  }
-  p.over {
-    background: #ccc;
-  }
-  span {
-    color: red;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p>Click me!</p>
-<span></span>
-​
-<script>
-var count = 0;
-$( "body" ).on( "click", "p", function() {
-  $( this ).after( "<p>Another paragraph! " + (++count) + "</p>" );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Display each paragraph&#39;s text in an alert box whenever it is clicked:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "body" ).on( "click", "p", function() {
-  alert( $( this ).text() );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Cancel a link&#39;s default action using the .preventDefault() method:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "body" ).on( "click", "a", function( event ) {
-  event.preventDefault();
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Attach multiple events—one on mouseenter and one on mouseleave to the same element:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "#cart" ).on( "mouseenter mouseleave", function( event ) {
-  $( this ).toggleClass( "active" );
-});
-</script>
-</body>
-</html>
-```
      */
     on<TData>(events: JQuery.PlainObject<JQuery.EventHandler<TElement, TData> | JQuery.EventHandlerBase<any, JQuery.Event<TElement, TData>> | false>,
               selector: JQuery.Selector | null,
@@ -45981,314 +36607,6 @@ $( "#cart" ).on( "mouseenter mouseleave", function( event ) {
      *                 the selector is null or omitted, the handler is always called when it reaches the selected element.
      * @see \`{@link https://api.jquery.com/on/ }\`
      * @since 1.7
-     * @example ​ ````Display a paragraph&#39;s text in an alert when it is clicked:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "p" ).on( "click", function() {
-  alert( $( this ).text() );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Pass data to the event handler, which is specified here by name:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-function myHandler( event ) {
-  alert( event.data.foo );
-}
-$( "p" ).on( "click", { foo: "bar" }, myHandler );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Cancel a form submit action and prevent the event from bubbling up by returning false:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "form" ).on( "submit", false );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Cancel only the default action by using .preventDefault().
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "form" ).on( "submit", function( event ) {
-  event.preventDefault();
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Stop submit events from bubbling without preventing form submit, using .stopPropagation().
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "form" ).on( "submit", function( event ) {
-  event.stopPropagation();
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Pass data to the event handler using the second argument to .trigger()
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "div" ).on( "click", function( event, person ) {
-  alert( "Hello, " + person.name );
-});
-$( "div" ).trigger( "click", { name: "Jim" } );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Use the the second argument of .trigger() to pass an array of data to the event handler
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "div" ).on( "click", function( event, salutation, name ) {
-  alert( salutation + ", " + name );
-});
-$( "div" ).trigger( "click", [ "Goodbye", "Jim" ] );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Attach and trigger custom (non-browser) events.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <style>
-  p {
-    color: red;
-  }
-  span {
-    color: blue;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p>Has an attached custom event.</p>
-<button>Trigger custom event</button>
-<span style="display:none;"></span>
-​
-<script>
-$( "p" ).on( "myCustomEvent", function( event, myName ) {
-  $( this ).text( myName + ", hi there!" );
-  $( "span" )
-    .stop()
-    .css( "opacity", 1 )
-    .text( "myName = " + myName )
-    .fadeIn( 30 )
-    .fadeOut( 1000 );
-});
-$( "button" ).click(function () {
-  $( "p" ).trigger( "myCustomEvent", [ "John" ] );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Attach multiple event handlers simultaneously using a plain object.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <style>
-  .test {
-    color: #000;
-    padding: .5em;
-    border: 1px solid #444;
-  }
-  .active {
-    color: #900;
-  }
-  .inside {
-    background-color: aqua;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<div class="test">test div</div>
-​
-<script>
-$( "div.test" ).on({
-  click: function() {
-    $( this ).toggleClass( "active" );
-  }, mouseenter: function() {
-    $( this ).addClass( "inside" );
-  }, mouseleave: function() {
-    $( this ).removeClass( "inside" );
-  }
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Click any paragraph to add another after it. Note that .on() allows a click event on any paragraph--even new ones--since the event is handled by the ever-present body element after it bubbles to there.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <style>
-  p {
-    background: yellow;
-    font-weight: bold;
-    cursor: pointer;
-    padding: 5px;
-  }
-  p.over {
-    background: #ccc;
-  }
-  span {
-    color: red;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p>Click me!</p>
-<span></span>
-​
-<script>
-var count = 0;
-$( "body" ).on( "click", "p", function() {
-  $( this ).after( "<p>Another paragraph! " + (++count) + "</p>" );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Display each paragraph&#39;s text in an alert box whenever it is clicked:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "body" ).on( "click", "p", function() {
-  alert( $( this ).text() );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Cancel a link&#39;s default action using the .preventDefault() method:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "body" ).on( "click", "a", function( event ) {
-  event.preventDefault();
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Attach multiple events—one on mouseenter and one on mouseleave to the same element:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "#cart" ).on( "mouseenter mouseleave", function( event ) {
-  $( this ).toggleClass( "active" );
-});
-</script>
-</body>
-</html>
-```
      */
     on(events: JQuery.PlainObject<JQuery.EventHandler<TElement> | JQuery.EventHandlerBase<any, JQuery.Event<TElement>> | false>,
        selector: JQuery.Selector): this; // tslint:disable-line:unified-signatures
@@ -46300,314 +36618,6 @@ $( "#cart" ).on( "mouseenter mouseleave", function( event ) {
      * @param data Data to be passed to the handler in event.data when an event occurs.
      * @see \`{@link https://api.jquery.com/on/ }\`
      * @since 1.7
-     * @example ​ ````Display a paragraph&#39;s text in an alert when it is clicked:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "p" ).on( "click", function() {
-  alert( $( this ).text() );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Pass data to the event handler, which is specified here by name:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-function myHandler( event ) {
-  alert( event.data.foo );
-}
-$( "p" ).on( "click", { foo: "bar" }, myHandler );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Cancel a form submit action and prevent the event from bubbling up by returning false:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "form" ).on( "submit", false );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Cancel only the default action by using .preventDefault().
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "form" ).on( "submit", function( event ) {
-  event.preventDefault();
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Stop submit events from bubbling without preventing form submit, using .stopPropagation().
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "form" ).on( "submit", function( event ) {
-  event.stopPropagation();
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Pass data to the event handler using the second argument to .trigger()
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "div" ).on( "click", function( event, person ) {
-  alert( "Hello, " + person.name );
-});
-$( "div" ).trigger( "click", { name: "Jim" } );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Use the the second argument of .trigger() to pass an array of data to the event handler
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "div" ).on( "click", function( event, salutation, name ) {
-  alert( salutation + ", " + name );
-});
-$( "div" ).trigger( "click", [ "Goodbye", "Jim" ] );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Attach and trigger custom (non-browser) events.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <style>
-  p {
-    color: red;
-  }
-  span {
-    color: blue;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p>Has an attached custom event.</p>
-<button>Trigger custom event</button>
-<span style="display:none;"></span>
-​
-<script>
-$( "p" ).on( "myCustomEvent", function( event, myName ) {
-  $( this ).text( myName + ", hi there!" );
-  $( "span" )
-    .stop()
-    .css( "opacity", 1 )
-    .text( "myName = " + myName )
-    .fadeIn( 30 )
-    .fadeOut( 1000 );
-});
-$( "button" ).click(function () {
-  $( "p" ).trigger( "myCustomEvent", [ "John" ] );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Attach multiple event handlers simultaneously using a plain object.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <style>
-  .test {
-    color: #000;
-    padding: .5em;
-    border: 1px solid #444;
-  }
-  .active {
-    color: #900;
-  }
-  .inside {
-    background-color: aqua;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<div class="test">test div</div>
-​
-<script>
-$( "div.test" ).on({
-  click: function() {
-    $( this ).toggleClass( "active" );
-  }, mouseenter: function() {
-    $( this ).addClass( "inside" );
-  }, mouseleave: function() {
-    $( this ).removeClass( "inside" );
-  }
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Click any paragraph to add another after it. Note that .on() allows a click event on any paragraph--even new ones--since the event is handled by the ever-present body element after it bubbles to there.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <style>
-  p {
-    background: yellow;
-    font-weight: bold;
-    cursor: pointer;
-    padding: 5px;
-  }
-  p.over {
-    background: #ccc;
-  }
-  span {
-    color: red;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p>Click me!</p>
-<span></span>
-​
-<script>
-var count = 0;
-$( "body" ).on( "click", "p", function() {
-  $( this ).after( "<p>Another paragraph! " + (++count) + "</p>" );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Display each paragraph&#39;s text in an alert box whenever it is clicked:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "body" ).on( "click", "p", function() {
-  alert( $( this ).text() );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Cancel a link&#39;s default action using the .preventDefault() method:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "body" ).on( "click", "a", function( event ) {
-  event.preventDefault();
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Attach multiple events—one on mouseenter and one on mouseleave to the same element:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "#cart" ).on( "mouseenter mouseleave", function( event ) {
-  $( this ).toggleClass( "active" );
-});
-</script>
-</body>
-</html>
-```
      */
     on<TData>(events: JQuery.PlainObject<JQuery.EventHandler<TElement, TData> | JQuery.EventHandlerBase<any, JQuery.Event<TElement, TData>> | false>,
               data: TData): this;
@@ -46618,180 +36628,6 @@ $( "#cart" ).on( "mouseenter mouseleave", function( event ) {
      *               namespaces, and the values represent a handler function to be called for the event(s).
      * @see \`{@link https://api.jquery.com/on/ }\`
      * @since 1.7
-     * @example ​ ````Display a paragraph&#39;s text in an alert when it is clicked:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "p" ).on( "click", function() {
-  alert( $( this ).text() );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Pass data to the event handler, which is specified here by name:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-function myHandler( event ) {
-  alert( event.data.foo );
-}
-$( "p" ).on( "click", { foo: "bar" }, myHandler );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Cancel a form submit action and prevent the event from bubbling up by returning false:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "form" ).on( "submit", false );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Cancel only the default action by using .preventDefault().
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "form" ).on( "submit", function( event ) {
-  event.preventDefault();
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Stop submit events from bubbling without preventing form submit, using .stopPropagation().
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "form" ).on( "submit", function( event ) {
-  event.stopPropagation();
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Pass data to the event handler using the second argument to .trigger()
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "div" ).on( "click", function( event, person ) {
-  alert( "Hello, " + person.name );
-});
-$( "div" ).trigger( "click", { name: "Jim" } );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Use the the second argument of .trigger() to pass an array of data to the event handler
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "div" ).on( "click", function( event, salutation, name ) {
-  alert( salutation + ", " + name );
-});
-$( "div" ).trigger( "click", [ "Goodbye", "Jim" ] );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Attach and trigger custom (non-browser) events.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <style>
-  p {
-    color: red;
-  }
-  span {
-    color: blue;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p>Has an attached custom event.</p>
-<button>Trigger custom event</button>
-<span style="display:none;"></span>
-​
-<script>
-$( "p" ).on( "myCustomEvent", function( event, myName ) {
-  $( this ).text( myName + ", hi there!" );
-  $( "span" )
-    .stop()
-    .css( "opacity", 1 )
-    .text( "myName = " + myName )
-    .fadeIn( 30 )
-    .fadeOut( 1000 );
-});
-$( "button" ).click(function () {
-  $( "p" ).trigger( "myCustomEvent", [ "John" ] );
-});
-</script>
-</body>
-</html>
-```
      * @example ​ ````Attach multiple event handlers simultaneously using a plain object.
 ```html
 <!doctype html>
@@ -46829,100 +36665,7 @@ $( "div.test" ).on({
   }
 });
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Click any paragraph to add another after it. Note that .on() allows a click event on any paragraph--even new ones--since the event is handled by the ever-present body element after it bubbles to there.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <style>
-  p {
-    background: yellow;
-    font-weight: bold;
-    cursor: pointer;
-    padding: 5px;
-  }
-  p.over {
-    background: #ccc;
-  }
-  span {
-    color: red;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-<p>Click me!</p>
-<span></span>
-​
-<script>
-var count = 0;
-$( "body" ).on( "click", "p", function() {
-  $( this ).after( "<p>Another paragraph! " + (++count) + "</p>" );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Display each paragraph&#39;s text in an alert box whenever it is clicked:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "body" ).on( "click", "p", function() {
-  alert( $( this ).text() );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Cancel a link&#39;s default action using the .preventDefault() method:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "body" ).on( "click", "a", function( event ) {
-  event.preventDefault();
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Attach multiple events—one on mouseenter and one on mouseleave to the same element:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>on demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "#cart" ).on( "mouseenter mouseleave", function( event ) {
-  $( this ).toggleClass( "active" );
-});
-</script>
 </body>
 </html>
 ```
@@ -46938,97 +36681,6 @@ $( "#cart" ).on( "mouseenter mouseleave", function( event ) {
      * @param handler A function to execute when the event is triggered.
      * @see \`{@link https://api.jquery.com/one/ }\`
      * @since 1.7
-     * @example ​ ````Tie a one-time click to each div.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>one demo</title>
-  <style>
-  div {
-    width: 60px;
-    height: 60px;
-    margin: 5px;
-    float: left;
-    background: green;
-    border: 10px outset;
-    cursor:pointer;
-  }
-  p {
-    color: red;
-    margin: 0;
-    clear: left;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<div></div>
-<div></div>
-<div></div>
-<div></div>
-<div></div>
-<p>Click a green square...</p>
-​
-<script>
-var n = 0;
-$( "div" ).one( "click", function() {
-  var index = $( "div" ).index( this );
-  $( this ).css({
-    borderStyle: "inset",
-    cursor: "auto"
-  });
-  $( "p" ).text( "Div at index #" + index + " clicked." +
-    " That's " + (++n) + " total clicks." );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````To display the text of all paragraphs in an alert box the first time each of them is clicked:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>one demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "p" ).one( "click", function() {
-  alert( $( this ).text() );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Event handlers will trigger once per element per event type
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>one demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<div class="count">0</div>
-<div class="target">Hover/click me</div>
-​
-<script>
-var n = 0;
-$(".target").one("click mouseenter", function() {
-  $(".count").html(++n);
-});
-</script>
-</body>
-</html>
-```
      */
     one<TData>(events: string,
                selector: JQuery.Selector | null,
@@ -47044,97 +36696,6 @@ $(".target").one("click mouseenter", function() {
      *                for a function that simply does return false.
      * @see \`{@link https://api.jquery.com/one/ }\`
      * @since 1.7
-     * @example ​ ````Tie a one-time click to each div.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>one demo</title>
-  <style>
-  div {
-    width: 60px;
-    height: 60px;
-    margin: 5px;
-    float: left;
-    background: green;
-    border: 10px outset;
-    cursor:pointer;
-  }
-  p {
-    color: red;
-    margin: 0;
-    clear: left;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<div></div>
-<div></div>
-<div></div>
-<div></div>
-<div></div>
-<p>Click a green square...</p>
-​
-<script>
-var n = 0;
-$( "div" ).one( "click", function() {
-  var index = $( "div" ).index( this );
-  $( this ).css({
-    borderStyle: "inset",
-    cursor: "auto"
-  });
-  $( "p" ).text( "Div at index #" + index + " clicked." +
-    " That's " + (++n) + " total clicks." );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````To display the text of all paragraphs in an alert box the first time each of them is clicked:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>one demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "p" ).one( "click", function() {
-  alert( $( this ).text() );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Event handlers will trigger once per element per event type
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>one demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<div class="count">0</div>
-<div class="target">Hover/click me</div>
-​
-<script>
-var n = 0;
-$(".target").one("click mouseenter", function() {
-  $(".count").html(++n);
-});
-</script>
-</body>
-</html>
-```
      */
     one(events: string,
         selector: JQuery.Selector,
@@ -47147,97 +36708,6 @@ $(".target").one("click mouseenter", function() {
      * @param handler A function to execute when the event is triggered.
      * @see \`{@link https://api.jquery.com/one/ }\`
      * @since 1.7
-     * @example ​ ````Tie a one-time click to each div.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>one demo</title>
-  <style>
-  div {
-    width: 60px;
-    height: 60px;
-    margin: 5px;
-    float: left;
-    background: green;
-    border: 10px outset;
-    cursor:pointer;
-  }
-  p {
-    color: red;
-    margin: 0;
-    clear: left;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<div></div>
-<div></div>
-<div></div>
-<div></div>
-<div></div>
-<p>Click a green square...</p>
-​
-<script>
-var n = 0;
-$( "div" ).one( "click", function() {
-  var index = $( "div" ).index( this );
-  $( this ).css({
-    borderStyle: "inset",
-    cursor: "auto"
-  });
-  $( "p" ).text( "Div at index #" + index + " clicked." +
-    " That's " + (++n) + " total clicks." );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````To display the text of all paragraphs in an alert box the first time each of them is clicked:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>one demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "p" ).one( "click", function() {
-  alert( $( this ).text() );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Event handlers will trigger once per element per event type
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>one demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<div class="count">0</div>
-<div class="target">Hover/click me</div>
-​
-<script>
-var n = 0;
-$(".target").one("click mouseenter", function() {
-  $(".count").html(++n);
-});
-</script>
-</body>
-</html>
-```
      */
     one<TData>(events: string,
                data: TData,
@@ -47296,27 +36766,15 @@ $( "div" ).one( "click", function() {
     " That's " + (++n) + " total clicks." );
 });
 </script>
+​
 </body>
 </html>
 ```
      * @example ​ ````To display the text of all paragraphs in an alert box the first time each of them is clicked:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>one demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $( "p" ).one( "click", function() {
   alert( $( this ).text() );
 });
-</script>
-</body>
-</html>
 ```
      * @example ​ ````Event handlers will trigger once per element per event type
 ```html
@@ -47338,6 +36796,7 @@ $(".target").one("click mouseenter", function() {
   $(".count").html(++n);
 });
 </script>
+​
 </body>
 </html>
 ```
@@ -47354,97 +36813,6 @@ $(".target").one("click mouseenter", function() {
      * @param data Data to be passed to the handler in event.data when an event occurs.
      * @see \`{@link https://api.jquery.com/one/ }\`
      * @since 1.7
-     * @example ​ ````Tie a one-time click to each div.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>one demo</title>
-  <style>
-  div {
-    width: 60px;
-    height: 60px;
-    margin: 5px;
-    float: left;
-    background: green;
-    border: 10px outset;
-    cursor:pointer;
-  }
-  p {
-    color: red;
-    margin: 0;
-    clear: left;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<div></div>
-<div></div>
-<div></div>
-<div></div>
-<div></div>
-<p>Click a green square...</p>
-​
-<script>
-var n = 0;
-$( "div" ).one( "click", function() {
-  var index = $( "div" ).index( this );
-  $( this ).css({
-    borderStyle: "inset",
-    cursor: "auto"
-  });
-  $( "p" ).text( "Div at index #" + index + " clicked." +
-    " That's " + (++n) + " total clicks." );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````To display the text of all paragraphs in an alert box the first time each of them is clicked:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>one demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "p" ).one( "click", function() {
-  alert( $( this ).text() );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Event handlers will trigger once per element per event type
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>one demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<div class="count">0</div>
-<div class="target">Hover/click me</div>
-​
-<script>
-var n = 0;
-$(".target").one("click mouseenter", function() {
-  $(".count").html(++n);
-});
-</script>
-</body>
-</html>
-```
      */
     one<TData>(events: JQuery.PlainObject<JQuery.EventHandler<TElement, TData> | JQuery.EventHandlerBase<any, JQuery.Event<TElement, TData>> | false>,
                selector: JQuery.Selector | null,
@@ -47458,97 +36826,6 @@ $(".target").one("click mouseenter", function() {
      *                 the selector is null or omitted, the handler is always called when it reaches the selected element.
      * @see \`{@link https://api.jquery.com/one/ }\`
      * @since 1.7
-     * @example ​ ````Tie a one-time click to each div.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>one demo</title>
-  <style>
-  div {
-    width: 60px;
-    height: 60px;
-    margin: 5px;
-    float: left;
-    background: green;
-    border: 10px outset;
-    cursor:pointer;
-  }
-  p {
-    color: red;
-    margin: 0;
-    clear: left;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<div></div>
-<div></div>
-<div></div>
-<div></div>
-<div></div>
-<p>Click a green square...</p>
-​
-<script>
-var n = 0;
-$( "div" ).one( "click", function() {
-  var index = $( "div" ).index( this );
-  $( this ).css({
-    borderStyle: "inset",
-    cursor: "auto"
-  });
-  $( "p" ).text( "Div at index #" + index + " clicked." +
-    " That's " + (++n) + " total clicks." );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````To display the text of all paragraphs in an alert box the first time each of them is clicked:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>one demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "p" ).one( "click", function() {
-  alert( $( this ).text() );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Event handlers will trigger once per element per event type
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>one demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<div class="count">0</div>
-<div class="target">Hover/click me</div>
-​
-<script>
-var n = 0;
-$(".target").one("click mouseenter", function() {
-  $(".count").html(++n);
-});
-</script>
-</body>
-</html>
-```
      */
     one(events: JQuery.PlainObject<JQuery.EventHandler<TElement> | JQuery.EventHandlerBase<any, JQuery.Event<TElement>> | false>,
         selector: JQuery.Selector): this; // tslint:disable-line:unified-signatures
@@ -47560,97 +36837,6 @@ $(".target").one("click mouseenter", function() {
      * @param data Data to be passed to the handler in event.data when an event occurs.
      * @see \`{@link https://api.jquery.com/one/ }\`
      * @since 1.7
-     * @example ​ ````Tie a one-time click to each div.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>one demo</title>
-  <style>
-  div {
-    width: 60px;
-    height: 60px;
-    margin: 5px;
-    float: left;
-    background: green;
-    border: 10px outset;
-    cursor:pointer;
-  }
-  p {
-    color: red;
-    margin: 0;
-    clear: left;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<div></div>
-<div></div>
-<div></div>
-<div></div>
-<div></div>
-<p>Click a green square...</p>
-​
-<script>
-var n = 0;
-$( "div" ).one( "click", function() {
-  var index = $( "div" ).index( this );
-  $( this ).css({
-    borderStyle: "inset",
-    cursor: "auto"
-  });
-  $( "p" ).text( "Div at index #" + index + " clicked." +
-    " That's " + (++n) + " total clicks." );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````To display the text of all paragraphs in an alert box the first time each of them is clicked:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>one demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "p" ).one( "click", function() {
-  alert( $( this ).text() );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Event handlers will trigger once per element per event type
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>one demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<div class="count">0</div>
-<div class="target">Hover/click me</div>
-​
-<script>
-var n = 0;
-$(".target").one("click mouseenter", function() {
-  $(".count").html(++n);
-});
-</script>
-</body>
-</html>
-```
      */
     one<TData>(events: JQuery.PlainObject<JQuery.EventHandler<TElement, TData> | JQuery.EventHandlerBase<any, JQuery.Event<TElement, TData>> | false>,
                data: TData): this;
@@ -47661,97 +36847,6 @@ $(".target").one("click mouseenter", function() {
      *               namespaces, and the values represent a handler function to be called for the event(s).
      * @see \`{@link https://api.jquery.com/one/ }\`
      * @since 1.7
-     * @example ​ ````Tie a one-time click to each div.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>one demo</title>
-  <style>
-  div {
-    width: 60px;
-    height: 60px;
-    margin: 5px;
-    float: left;
-    background: green;
-    border: 10px outset;
-    cursor:pointer;
-  }
-  p {
-    color: red;
-    margin: 0;
-    clear: left;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<div></div>
-<div></div>
-<div></div>
-<div></div>
-<div></div>
-<p>Click a green square...</p>
-​
-<script>
-var n = 0;
-$( "div" ).one( "click", function() {
-  var index = $( "div" ).index( this );
-  $( this ).css({
-    borderStyle: "inset",
-    cursor: "auto"
-  });
-  $( "p" ).text( "Div at index #" + index + " clicked." +
-    " That's " + (++n) + " total clicks." );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````To display the text of all paragraphs in an alert box the first time each of them is clicked:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>one demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "p" ).one( "click", function() {
-  alert( $( this ).text() );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Event handlers will trigger once per element per event type
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>one demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<div class="count">0</div>
-<div class="target">Hover/click me</div>
-​
-<script>
-var n = 0;
-$(".target").one("click mouseenter", function() {
-  $(".count").html(++n);
-});
-</script>
-</body>
-</html>
-```
      */
     one(events: JQuery.PlainObject<JQuery.EventHandler<TElement> | JQuery.EventHandlerBase<any, JQuery.Event<TElement>> | false>): this;
     /**
@@ -47761,35 +36856,6 @@ $(".target").one("click mouseenter", function() {
      *              appended (as a string).
      * @see \`{@link https://api.jquery.com/outerHeight/ }\`
      * @since 1.8.0
-     * @example ​ ````Get the outerHeight of a paragraph.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>outerHeight demo</title>
-  <style>
-  p {
-    margin: 10px;
-    padding: 5px;
-    border: 2px solid #666;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p>Hello</p><p></p>
-​
-<script>
-var p = $( "p:first" );
-$( "p:last" ).text(
-  "outerHeight:" + p.outerHeight() +
-  " , outerHeight( true ):" + p.outerHeight( true ) );
-</script>
-</body>
-</html>
-```
      * @example ​ ````Change the outer height of each div the first time it is clicked (and change its color).
 ```html
 <!doctype html>
@@ -47829,6 +36895,7 @@ $( "div" ).one( "click", function() {
   modHeight -= 8;
 });
 </script>
+​
 </body>
 </html>
 ```
@@ -47867,48 +36934,7 @@ $( "p:last" ).text(
   "outerHeight:" + p.outerHeight() +
   " , outerHeight( true ):" + p.outerHeight( true ) );
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Change the outer height of each div the first time it is clicked (and change its color).
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>outerHeight demo</title>
-  <style>
-  div {
-    width: 50px;
-    padding: 10px;
-    height: 60px;
-    float: left;
-    margin: 5px;
-    background: red;
-    cursor: pointer;
-  }
-  .mod {
-    background: blue;
-    cursor: default;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-<div>d</div>
-<div>d</div>
-<div>d</div>
-<div>d</div>
-<div>d</div>
-​
-<script>
-var modHeight = 60;
-$( "div" ).one( "click", function() {
-  $( this ).outerHeight( modHeight ).addClass( "mod" );
-  modHeight -= 8;
-});
-</script>
 </body>
 </html>
 ```
@@ -47923,35 +36949,6 @@ $( "div" ).one( "click", function() {
      *              and the old outer width as arguments. Within the function, this refers to the current element in the set.
      * @see \`{@link https://api.jquery.com/outerWidth/ }\`
      * @since 1.8.0
-     * @example ​ ````Get the outerWidth of a paragraph.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>outerWidth demo</title>
-  <style>
-  p {
-    margin: 10px;
-    padding: 5px;
-    border: 2px solid #666;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p>Hello</p><p></p>
-​
-<script>
-var p = $( "p:first" );
-$( "p:last" ).text(
-  "outerWidth:" + p.outerWidth() +
-  " , outerWidth( true ):" + p.outerWidth( true ) );
-</script>
-</body>
-</html>
-```
      * @example ​ ````Change the outer width of each div the first time it is clicked (and change its color).
 ```html
 <!doctype html>
@@ -47991,6 +36988,7 @@ $( "div" ).one( "click", function() {
   modWidth -= 8;
 });
 </script>
+​
 </body>
 </html>
 ```
@@ -48029,48 +37027,7 @@ $( "p:last" ).text(
   "outerWidth:" + p.outerWidth() +
   " , outerWidth( true ):" + p.outerWidth( true ) );
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Change the outer width of each div the first time it is clicked (and change its color).
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>outerWidth demo</title>
-  <style>
-  div {
-    width: 60px;
-    padding: 10px;
-    height: 50px;
-    float: left;
-    margin: 5px;
-    background: red;
-    cursor: pointer;
-  }
-  .mod {
-    background: blue;
-    cursor: default;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-<div>d</div>
-<div>d</div>
-<div>d</div>
-<div>d</div>
-<div>d</div>
-​
-<script>
-var modWidth = 60;
-$( "div" ).one( "click", function() {
-  $( this ).outerWidth( modWidth ).addClass( "mod" );
-  modWidth -= 8;
-});
-</script>
 </body>
 </html>
 ```
@@ -48125,6 +37082,7 @@ $( "*", document.body ).each(function() {
   $( this ).prepend( document.createTextNode( parentTag + " > " ) );
 });
 </script>
+​
 </body>
 </html>
 ```
@@ -48145,6 +37103,7 @@ $( "*", document.body ).each(function() {
 <script>
 $( "p" ).parent( ".selected" ).css( "background", "yellow" );
 </script>
+​
 </body>
 </html>
 ```
@@ -48196,6 +37155,7 @@ var parentEls = $( "b" ).parents()
   .join( ", " );
 $( "b" ).append( "<strong>" + parentEls + "</strong>" );
 </script>
+​
 </body>
 </html>
 ```
@@ -48256,6 +37216,7 @@ $( "span" ).click(function() {
   showParents();
 });
 </script>
+​
 </body>
 </html>
 ```
@@ -48309,6 +37270,7 @@ $( "li.item-2" )
   .parentsUntil( $( "ul.level-1" ), ".yes" )
     .css( "border", "3px solid green" );
 </script>
+​
 </body>
 </html>
 ```
@@ -48348,6 +37310,7 @@ var p = $( "p:first" );
 var position = p.position();
 $( "p:last" ).text( "left: " + position.left + ", top: " + position.top );
 </script>
+​
 </body>
 </html>
 ```
@@ -48382,6 +37345,7 @@ $( "p:last" ).text( "left: " + position.left + ", top: " + position.top );
 <script>
 $( "p" ).prepend( "<b>Hello </b>" );
 </script>
+​
 </body>
 </html>
 ```
@@ -48407,6 +37371,7 @@ $( "p" ).prepend( "<b>Hello </b>" );
 <script>
 $( "p" ).prepend( document.createTextNode( "Hello " ) );
 </script>
+​
 </body>
 </html>
 ```
@@ -48431,6 +37396,7 @@ $( "p" ).prepend( document.createTextNode( "Hello " ) );
 <script>
 $( "p" ).prepend( $( "b" ) );
 </script>
+​
 </body>
 </html>
 ```
@@ -48445,80 +37411,6 @@ $( "p" ).prepend( $( "b" ) );
      *           refers to the current element in the set.
      * @see \`{@link https://api.jquery.com/prepend/ }\`
      * @since 1.4
-     * @example ​ ````Prepends some HTML to all paragraphs.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>prepend demo</title>
-  <style>
-  p {
-    background: yellow;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p>there, friend!</p>
-<p>amigo!</p>
-​
-<script>
-$( "p" ).prepend( "<b>Hello </b>" );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Prepends a DOM Element to all paragraphs.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>prepend demo</title>
-  <style>
-  p {
-    background: yellow;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p>is what I'd say</p>
-<p>is what I said</p>
-​
-<script>
-$( "p" ).prepend( document.createTextNode( "Hello " ) );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Prepends a jQuery object (similar to an Array of DOM Elements) to all paragraphs.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>prepend demo</title>
-  <style>
-  p {
-    background: yellow;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p> is what was said.</p><b>Hello</b>
-​
-<script>
-$( "p" ).prepend( $( "b" ) );
-</script>
-</body>
-</html>
-```
      */
     prepend(fn: (this: TElement, index: number, html: string) => JQuery.htmlString | JQuery.TypeOrArray<JQuery.Node | JQuery<JQuery.Node>>): this;
     /**
@@ -48550,6 +37442,7 @@ $( "p" ).prepend( $( "b" ) );
 <script>
 $( "span" ).prependTo( "#foo" );
 </script>
+​
 </body>
 </html>
 ```
@@ -48609,6 +37502,7 @@ $( "button" ).click(function() {
   $curr.css( "background", "#f99" );
 });
 </script>
+​
 </body>
 </html>
 ```
@@ -48630,6 +37524,7 @@ $( "button" ).click(function() {
 <script>
 $( "p" ).prev( ".selected" ).css( "background", "yellow" );
 </script>
+​
 </body>
 </html>
 ```
@@ -48673,6 +37568,7 @@ $( "p" ).prev( ".selected" ).css( "background", "yellow" );
 <script>
 $( "div:last" ).prevAll().addClass( "before" );
 </script>
+​
 </body>
 </html>
 ```
@@ -48724,6 +37620,7 @@ var term1 = document.getElementById( "term-1" );
 $( "#term-3" ).prevUntil( term1, "dd" )
   .css( "color", "green" );
 </script>
+​
 </body>
 </html>
 ```
@@ -48737,116 +37634,6 @@ $( "#term-3" ).prevUntil( term1, "dd" )
      * @param target Object onto which the promise methods have to be attached
      * @see \`{@link https://api.jquery.com/promise/ }\`
      * @since 1.6
-     * @example ​ ````Using .promise() on a collection with no active animation returns a resolved Promise:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>promise demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-var div = $( "<div>" );
-​
-div.promise().done(function( arg1 ) {
-  // Will fire right away and alert "true"
-  alert( this === div && arg1 === div );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Resolve the returned Promise when all animations have ended (including those initiated in the animation callback or added later on):
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>promise demo</title>
-  <style>
-  div {
-    height: 50px;
-    width: 50px;
-    float: left;
-    margin-right: 10px;
-    display: none;
-    background-color: #090;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<button>Go</button>
-<p>Ready...</p>
-<div></div>
-<div></div>
-<div></div>
-<div></div>
-​
-<script>
-$( "button" ).on( "click", function() {
-  $( "p" ).append( "Started..." );
-​
-  $( "div" ).each(function( i ) {
-    $( this ).fadeIn().fadeOut( 1000 * ( i + 1 ) );
-  });
-​
-  $( "div" ).promise().done(function() {
-    $( "p" ).append( " Finished! " );
-  });
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Resolve the returned Promise using a $.when() statement (the .promise() method makes it possible to do this with jQuery collections):
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>promise demo</title>
-  <style>
-  div {
-    height: 50px;
-    width: 50px;
-    float: left;
-    margin-right: 10px;
-    display: none;
-    background-color: #090;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<button>Go</button>
-<p>Ready...</p>
-<div></div>
-<div></div>
-<div></div>
-<div></div>
-​
-<script>
-var effect = function() {
-  return $( "div" ).fadeIn( 800 ).delay( 1200 ).fadeOut();
-};
-​
-$( "button" ).on( "click", function() {
-  $( "p" ).append( " Started... " );
-​
-  $.when( effect() ).done(function() {
-    $( "p" ).append( " Finished! " );
-  });
-});
-</script>
-</body>
-</html>
-```
      */
     promise<T extends object>(type: string, target: T): T & JQuery.Promise<this>;
     /**
@@ -48856,116 +37643,6 @@ $( "button" ).on( "click", function() {
      * @param target Object onto which the promise methods have to be attached
      * @see \`{@link https://api.jquery.com/promise/ }\`
      * @since 1.6
-     * @example ​ ````Using .promise() on a collection with no active animation returns a resolved Promise:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>promise demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-var div = $( "<div>" );
-​
-div.promise().done(function( arg1 ) {
-  // Will fire right away and alert "true"
-  alert( this === div && arg1 === div );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Resolve the returned Promise when all animations have ended (including those initiated in the animation callback or added later on):
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>promise demo</title>
-  <style>
-  div {
-    height: 50px;
-    width: 50px;
-    float: left;
-    margin-right: 10px;
-    display: none;
-    background-color: #090;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<button>Go</button>
-<p>Ready...</p>
-<div></div>
-<div></div>
-<div></div>
-<div></div>
-​
-<script>
-$( "button" ).on( "click", function() {
-  $( "p" ).append( "Started..." );
-​
-  $( "div" ).each(function( i ) {
-    $( this ).fadeIn().fadeOut( 1000 * ( i + 1 ) );
-  });
-​
-  $( "div" ).promise().done(function() {
-    $( "p" ).append( " Finished! " );
-  });
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Resolve the returned Promise using a $.when() statement (the .promise() method makes it possible to do this with jQuery collections):
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>promise demo</title>
-  <style>
-  div {
-    height: 50px;
-    width: 50px;
-    float: left;
-    margin-right: 10px;
-    display: none;
-    background-color: #090;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<button>Go</button>
-<p>Ready...</p>
-<div></div>
-<div></div>
-<div></div>
-<div></div>
-​
-<script>
-var effect = function() {
-  return $( "div" ).fadeIn( 800 ).delay( 1200 ).fadeOut();
-};
-​
-$( "button" ).on( "click", function() {
-  $( "p" ).append( " Started... " );
-​
-  $.when( effect() ).done(function() {
-    $( "p" ).append( " Finished! " );
-  });
-});
-</script>
-</body>
-</html>
-```
      */
     promise<T extends object>(target: T): T & JQuery.Promise<this>;
     /**
@@ -48976,26 +37653,13 @@ $( "button" ).on( "click", function() {
      * @see \`{@link https://api.jquery.com/promise/ }\`
      * @since 1.6
      * @example ​ ````Using .promise() on a collection with no active animation returns a resolved Promise:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>promise demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 var div = $( "<div>" );
 ​
 div.promise().done(function( arg1 ) {
   // Will fire right away and alert "true"
   alert( this === div && arg1 === div );
 });
-</script>
-</body>
-</html>
 ```
      * @example ​ ````Resolve the returned Promise when all animations have ended (including those initiated in the animation callback or added later on):
 ```html
@@ -49038,6 +37702,7 @@ $( "button" ).on( "click", function() {
   });
 });
 </script>
+​
 </body>
 </html>
 ```
@@ -49082,6 +37747,7 @@ $( "button" ).on( "click", function() {
   });
 });
 </script>
+​
 </body>
 </html>
 ```
@@ -49095,74 +37761,6 @@ $( "button" ).on( "click", function() {
      *              old property value as arguments. Within the function, the keyword this refers to the current element.
      * @see \`{@link https://api.jquery.com/prop/ }\`
      * @since 1.6
-     * @example ​ ````Display the checked property and attribute of a checkbox as it changes.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>prop demo</title>
-  <style>
-  p {
-    margin: 20px 0 0;
-  }
-  b {
-    color: blue;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<input id="check1" type="checkbox" checked="checked">
-<label for="check1">Check me</label>
-<p></p>
-​
-<script>
-$( "input" ).change(function() {
-  var $input = $( this );
-  $( "p" ).html(
-    ".attr( \"checked\" ): <b>" + $input.attr( "checked" ) + "</b><br>" +
-    ".prop( \"checked\" ): <b>" + $input.prop( "checked" ) + "</b><br>" +
-    ".is( \":checked\" ): <b>" + $input.is( ":checked" ) + "</b>" );
-}).change();
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Disable all checkboxes on the page.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>prop demo</title>
-  <style>
-  img {
-    padding: 10px;
-  }
-  div {
-    color: red;
-    font-size: 24px;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-  <input type="checkbox" checked="checked">
-  <input type="checkbox">
-  <input type="checkbox">
-  <input type="checkbox" checked="checked">
-​
-<script>
-$( "input[type='checkbox']" ).prop({
-  disabled: true
-});
-</script>
-</body>
-</html>
-```
      */
     prop(propertyName: string, value: (this: TElement, index: number, oldPropertyValue: any) => any): this;
     /**
@@ -49172,74 +37770,6 @@ $( "input[type='checkbox']" ).prop({
      * @param value A value to set for the property.
      * @see \`{@link https://api.jquery.com/prop/ }\`
      * @since 1.6
-     * @example ​ ````Display the checked property and attribute of a checkbox as it changes.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>prop demo</title>
-  <style>
-  p {
-    margin: 20px 0 0;
-  }
-  b {
-    color: blue;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<input id="check1" type="checkbox" checked="checked">
-<label for="check1">Check me</label>
-<p></p>
-​
-<script>
-$( "input" ).change(function() {
-  var $input = $( this );
-  $( "p" ).html(
-    ".attr( \"checked\" ): <b>" + $input.attr( "checked" ) + "</b><br>" +
-    ".prop( \"checked\" ): <b>" + $input.prop( "checked" ) + "</b><br>" +
-    ".is( \":checked\" ): <b>" + $input.is( ":checked" ) + "</b>" );
-}).change();
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Disable all checkboxes on the page.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>prop demo</title>
-  <style>
-  img {
-    padding: 10px;
-  }
-  div {
-    color: red;
-    font-size: 24px;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-  <input type="checkbox" checked="checked">
-  <input type="checkbox">
-  <input type="checkbox">
-  <input type="checkbox" checked="checked">
-​
-<script>
-$( "input[type='checkbox']" ).prop({
-  disabled: true
-});
-</script>
-</body>
-</html>
-```
      */
     prop(propertyName: string, value: any): this; // tslint:disable-line:unified-signatures
     /**
@@ -49248,41 +37778,6 @@ $( "input[type='checkbox']" ).prop({
      * @param properties An object of property-value pairs to set.
      * @see \`{@link https://api.jquery.com/prop/ }\`
      * @since 1.6
-     * @example ​ ````Display the checked property and attribute of a checkbox as it changes.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>prop demo</title>
-  <style>
-  p {
-    margin: 20px 0 0;
-  }
-  b {
-    color: blue;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<input id="check1" type="checkbox" checked="checked">
-<label for="check1">Check me</label>
-<p></p>
-​
-<script>
-$( "input" ).change(function() {
-  var $input = $( this );
-  $( "p" ).html(
-    ".attr( \"checked\" ): <b>" + $input.attr( "checked" ) + "</b><br>" +
-    ".prop( \"checked\" ): <b>" + $input.prop( "checked" ) + "</b><br>" +
-    ".is( \":checked\" ): <b>" + $input.is( ":checked" ) + "</b>" );
-}).change();
-</script>
-</body>
-</html>
-```
      * @example ​ ````Disable all checkboxes on the page.
 ```html
 <!doctype html>
@@ -49313,6 +37808,7 @@ $( "input[type='checkbox']" ).prop({
   disabled: true
 });
 </script>
+​
 </body>
 </html>
 ```
@@ -49356,39 +37852,7 @@ $( "input" ).change(function() {
     ".is( \":checked\" ): <b>" + $input.is( ":checked" ) + "</b>" );
 }).change();
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Disable all checkboxes on the page.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>prop demo</title>
-  <style>
-  img {
-    padding: 10px;
-  }
-  div {
-    color: red;
-    font-size: 24px;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-  <input type="checkbox" checked="checked">
-  <input type="checkbox">
-  <input type="checkbox">
-  <input type="checkbox" checked="checked">
-​
-<script>
-$( "input[type='checkbox']" ).prop({
-  disabled: true
-});
-</script>
 </body>
 </html>
 ```
@@ -49402,26 +37866,6 @@ $( "input[type='checkbox']" ).prop({
      * @param args The arguments that were passed in to the jQuery method (for serialization).
      * @see \`{@link https://api.jquery.com/pushStack/ }\`
      * @since 1.3
-     * @example ​ ````Add some elements onto the jQuery stack, then pop back off again.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>pushStack demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-jQuery([])
-  .pushStack( document.getElementsByTagName( "div" ) )
-  .remove()
-  .end();
-</script>
-</body>
-</html>
-```
      */
     pushStack(elements: ArrayLike<Element>, name: string, args: any[]): this;
     /**
@@ -49431,24 +37875,11 @@ jQuery([])
      * @see \`{@link https://api.jquery.com/pushStack/ }\`
      * @since 1.0
      * @example ​ ````Add some elements onto the jQuery stack, then pop back off again.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>pushStack demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 jQuery([])
   .pushStack( document.getElementsByTagName( "div" ) )
   .remove()
   .end();
-</script>
-</body>
-</html>
 ```
      */
     pushStack(elements: ArrayLike<Element>): this;
@@ -49460,112 +37891,6 @@ jQuery([])
      *                 An array of functions to replace the current queue contents.
      * @see \`{@link https://api.jquery.com/queue/ }\`
      * @since 1.2
-     * @example ​ ````Show the length of the queue.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>queue demo</title>
-  <style>
-  div {
-    margin: 3px;
-    width: 40px;
-    height: 40px;
-    position: absolute;
-    left: 0px;
-    top: 60px;
-    background: green;
-    display: none;
-  }
-  div.newcolor {
-    background: blue;
-  }
-  p {
-    color: red;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p>The queue length is: <span></span></p>
-<div></div>
-​
-<script>
-var div = $( "div" );
-​
-function runIt() {
-  div
-    .show( "slow" )
-    .animate({ left: "+=200" }, 2000 )
-    .slideToggle( 1000 )
-    .slideToggle( "fast" )
-    .animate({ left: "-=200" }, 1500 )
-    .hide( "slow" )
-    .show( 1200 )
-    .slideUp( "normal", runIt );
-}
-​
-function showIt() {
-  var n = div.queue( "fx" );
-  $( "span" ).text( n.length );
-  setTimeout( showIt, 100 );
-}
-​
-runIt();
-showIt();
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Queue a custom function.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>queue demo</title>
-  <style>
-  div {
-    margin: 3px;
-    width: 40px;
-    height: 40px;
-    position: absolute;
-    left: 0px;
-    top: 30px;
-    background: green;
-    display: none;
-  }
-  div.newcolor {
-    background: blue;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-Click here...
-<div></div>
-​
-<script>
-$( document.body ).click(function() {
-  $( "div" )
-    .show( "slow" )
-    .animate({ left: "+=200" }, 2000 )
-    .queue(function() {
-      $( this ).addClass( "newcolor" ).dequeue();
-    })
-    .animate({ left: "-=200" }, 500 )
-    .queue(function() {
-      $( this ).removeClass( "newcolor" ).dequeue();
-    })
-    .slideUp();
-});
-</script>
-</body>
-</html>
-```
      * @example ​ ````Set a queue array to delete the queue.
 ```html
 <!doctype html>
@@ -49616,6 +37941,7 @@ $( "#stop" ).click(function() {
     .stop();
 });
 </script>
+​
 </body>
 </html>
 ```
@@ -49628,65 +37954,6 @@ $( "#stop" ).click(function() {
      *                 An array of functions to replace the current queue contents.
      * @see \`{@link https://api.jquery.com/queue/ }\`
      * @since 1.2
-     * @example ​ ````Show the length of the queue.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>queue demo</title>
-  <style>
-  div {
-    margin: 3px;
-    width: 40px;
-    height: 40px;
-    position: absolute;
-    left: 0px;
-    top: 60px;
-    background: green;
-    display: none;
-  }
-  div.newcolor {
-    background: blue;
-  }
-  p {
-    color: red;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p>The queue length is: <span></span></p>
-<div></div>
-​
-<script>
-var div = $( "div" );
-​
-function runIt() {
-  div
-    .show( "slow" )
-    .animate({ left: "+=200" }, 2000 )
-    .slideToggle( 1000 )
-    .slideToggle( "fast" )
-    .animate({ left: "-=200" }, 1500 )
-    .hide( "slow" )
-    .show( 1200 )
-    .slideUp( "normal", runIt );
-}
-​
-function showIt() {
-  var n = div.queue( "fx" );
-  $( "span" ).text( n.length );
-  setTimeout( showIt, 100 );
-}
-​
-runIt();
-showIt();
-</script>
-</body>
-</html>
-```
      * @example ​ ````Queue a custom function.
 ```html
 <!doctype html>
@@ -49731,59 +37998,7 @@ $( document.body ).click(function() {
     .slideUp();
 });
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Set a queue array to delete the queue.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>queue demo</title>
-  <style>
-  div {
-    margin: 3px;
-    width: 40px;
-    height: 40px;
-    position: absolute;
-    left: 0px;
-    top: 30px;
-    background: green;
-    display: none;
-  }
-  div.newcolor {
-    background: blue;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-<button id="start">Start</button>
-<button id="stop">Stop</button>
-<div></div>
-​
-<script>
-$( "#start" ).click(function() {
-  $( "div" )
-    .show( "slow" )
-    .animate({ left: "+=200" }, 5000 )
-    .queue(function() {
-      $( this ).addClass( "newcolor" ).dequeue();
-    })
-    .animate({ left: '-=200' }, 1500 )
-    .queue(function() {
-      $( this ).removeClass( "newcolor" ).dequeue();
-    })
-    .slideUp();
-});
-$( "#stop" ).click(function() {
-  $( "div" )
-    .queue( "fx", [] )
-    .stop();
-});
-</script>
 </body>
 </html>
 ```
@@ -49851,106 +38066,7 @@ function showIt() {
 runIt();
 showIt();
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Queue a custom function.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>queue demo</title>
-  <style>
-  div {
-    margin: 3px;
-    width: 40px;
-    height: 40px;
-    position: absolute;
-    left: 0px;
-    top: 30px;
-    background: green;
-    display: none;
-  }
-  div.newcolor {
-    background: blue;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-Click here...
-<div></div>
-​
-<script>
-$( document.body ).click(function() {
-  $( "div" )
-    .show( "slow" )
-    .animate({ left: "+=200" }, 2000 )
-    .queue(function() {
-      $( this ).addClass( "newcolor" ).dequeue();
-    })
-    .animate({ left: "-=200" }, 500 )
-    .queue(function() {
-      $( this ).removeClass( "newcolor" ).dequeue();
-    })
-    .slideUp();
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Set a queue array to delete the queue.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>queue demo</title>
-  <style>
-  div {
-    margin: 3px;
-    width: 40px;
-    height: 40px;
-    position: absolute;
-    left: 0px;
-    top: 30px;
-    background: green;
-    display: none;
-  }
-  div.newcolor {
-    background: blue;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<button id="start">Start</button>
-<button id="stop">Stop</button>
-<div></div>
-​
-<script>
-$( "#start" ).click(function() {
-  $( "div" )
-    .show( "slow" )
-    .animate({ left: "+=200" }, 5000 )
-    .queue(function() {
-      $( this ).addClass( "newcolor" ).dequeue();
-    })
-    .animate({ left: '-=200' }, 1500 )
-    .queue(function() {
-      $( this ).removeClass( "newcolor" ).dequeue();
-    })
-    .slideUp();
-});
-$( "#stop" ).click(function() {
-  $( "div" )
-    .queue( "fx", [] )
-    .stop();
-});
-</script>
 </body>
 </html>
 ```
@@ -49975,19 +38091,19 @@ $( "#stop" ).click(function() {
     color: red;
   }
   </style>
-<script>
-
+  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
+  <script>
+​
   $(function() {
     $( "p" ).text( "The DOM is now loaded and can be manipulated." );
   });
-
-</script>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
+​
+  </script>
 </head>
 <body>
 ​
 <p>Not loaded yet.</p>
-
+​
 </body>
 </html>
 ```
@@ -50026,6 +38142,7 @@ $( "button" ).click(function() {
   $( "p" ).remove();
 });
 </script>
+​
 </body>
 </html>
 ```
@@ -50056,6 +38173,7 @@ $( "button" ).click(function() {
   $( "p" ).remove( ":contains('Hello')" );
 });
 </script>
+​
 </body>
 </html>
 ```
@@ -50074,7 +38192,6 @@ $( "button" ).click(function() {
 <head>
   <meta charset="utf-8">
   <title>removeAttr demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
 </head>
 <body>
 ​
@@ -50098,6 +38215,7 @@ $( "button" ).click(function() {
   });
 })();
 </script>
+​
 </body>
 </html>
 ```
@@ -50149,6 +38267,7 @@ $( "button" ).click(function() {
 <script>
 $( "p:even" ).removeClass( "blue" );
 </script>
+​
 </body>
 </html>
 ```
@@ -50187,6 +38306,7 @@ $( "p:even" ).removeClass( "blue" );
 <script>
 $( "p:odd" ).removeClass( "blue under" );
 </script>
+​
 </body>
 </html>
 ```
@@ -50225,6 +38345,7 @@ $( "p:odd" ).removeClass( "blue under" );
 <script>
 $( "p:eq(1)" ).removeClass();
 </script>
+​
 </body>
 </html>
 ```
@@ -50272,6 +38393,7 @@ $( "div" ).removeData( "test1" );
 $( "span:eq(2)" ).text( "" + $( "div" ).data( "test1" ) );
 $( "span:eq(3)" ).text( "" + $( "div" ).data( "test2" ) );
 </script>
+​
 </body>
 </html>
 ```
@@ -50313,6 +38435,7 @@ para
   .removeProp( "luggageCode" )
   .append( "Now the secret luggage code is: ", String( para.prop( "luggageCode" ) ), ". " );
 </script>
+​
 </body>
 </html>
 ```
@@ -50331,7 +38454,6 @@ para
 <head>
   <meta charset="utf-8">
   <title>replaceAll demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
 </head>
 <body>
 ​
@@ -50342,6 +38464,7 @@ para
 <script>
 $( "<b>Paragraph. </b>" ).replaceAll( "p" );
 </script>
+​
 </body>
 </html>
 ```
@@ -50391,6 +38514,7 @@ $( "button" ).click(function() {
   $( this ).replaceWith( "<div>" + $( this ).text() + "</div>" );
 });
 </script>
+​
 </body>
 </html>
 ```
@@ -50401,7 +38525,6 @@ $( "button" ).click(function() {
 <head>
   <meta charset="utf-8">
   <title>replaceWith demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
 </head>
 <body>
 ​
@@ -50412,6 +38535,7 @@ $( "button" ).click(function() {
 <script>
 $( "p" ).replaceWith( "<b>Paragraph. </b>" );
 </script>
+​
 </body>
 </html>
 ```
@@ -50449,6 +38573,7 @@ $( "p" ).click(function() {
   $( this ).replaceWith( $( "div" ) );
 });
 </script>
+​
 </body>
 </html>
 ```
@@ -50489,6 +38614,7 @@ $( "button" ).on( "click", function() {
   $( "p" ).append( $container.attr( "class" ) );
 });
 </script>
+​
 </body>
 </html>
 ```
@@ -50506,25 +38632,6 @@ $( "button" ).on( "click", function() {
      * **Cause**: The `.on()` and `.trigger()` methods can set an event handler or generate an event for any event type, and should be used instead of the shortcut methods. This message also applies to the other event shorthands, including: blur, focus, focusin, focusout, resize, scroll, dblclick, mousedown, mouseup, mousemove, mouseover, mouseout, mouseenter, mouseleave, change, select, submit, keydown, keypress, keyup, and contextmenu.
      *
      * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
-     * @example ​ ````To see the window width while (or after) it is resized, try:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>resize demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( window ).resize(function() {
-  $( "body" ).prepend( "<div>" + $( window ).width() + "</div>" );
-});
-</script>
-</body>
-</html>
-```
      */
     resize<TData>(eventData: TData,
                   handler: JQuery.EventHandler<TElement, TData> | JQuery.EventHandlerBase<any, JQuery.Event<TElement, TData>>): this;
@@ -50540,23 +38647,10 @@ $( window ).resize(function() {
      *
      * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
      * @example ​ ````To see the window width while (or after) it is resized, try:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>resize demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $( window ).resize(function() {
   $( "body" ).prepend( "<div>" + $( window ).width() + "</div>" );
 });
-</script>
-</body>
-</html>
 ```
      */
     resize(handler?: JQuery.EventHandler<TElement> | JQuery.EventHandlerBase<any, JQuery.Event<TElement>> | false): this;
@@ -50572,43 +38666,6 @@ $( window ).resize(function() {
      * **Cause**: The `.on()` and `.trigger()` methods can set an event handler or generate an event for any event type, and should be used instead of the shortcut methods. This message also applies to the other event shorthands, including: blur, focus, focusin, focusout, resize, scroll, dblclick, mousedown, mouseup, mousemove, mouseover, mouseout, mouseenter, mouseleave, change, select, submit, keydown, keypress, keyup, and contextmenu.
      *
      * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
-     * @example ​ ````To do something when your page is scrolled:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>scroll demo</title>
-  <style>
-  div {
-    color: blue;
-  }
-  p {
-    color: green;
-  }
-  span {
-    color: red;
-    display: none;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<div>Try scrolling the iframe.</div>
-<p>Paragraph - <span>Scroll happened!</span></p>
-​
-<script>
-$( "p" ).clone().appendTo( document.body );
-$( "p" ).clone().appendTo( document.body );
-$( "p" ).clone().appendTo( document.body );
-$( window ).scroll(function() {
-  $( "span" ).css( "display", "inline" ).fadeOut( "slow" );
-});
-</script>
-</body>
-</html>
-```
      */
     scroll<TData>(eventData: TData,
                   handler: JQuery.EventHandler<TElement, TData> | JQuery.EventHandlerBase<any, JQuery.Event<TElement, TData>>): this;
@@ -50657,6 +38714,7 @@ $( window ).scroll(function() {
   $( "span" ).css( "display", "inline" ).fadeOut( "slow" );
 });
 </script>
+​
 </body>
 </html>
 ```
@@ -50668,33 +38726,6 @@ $( window ).scroll(function() {
      * @param value An integer indicating the new position to set the scroll bar to.
      * @see \`{@link https://api.jquery.com/scrollLeft/ }\`
      * @since 1.2.6
-     * @example ​ ````Get the scrollLeft of a paragraph.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>scrollLeft demo</title>
-  <style>
-  p {
-    margin: 10px;
-    padding: 5px;
-    border: 2px solid #666;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p>Hello</p><p></p>
-​
-<script>
-var p = $( "p:first" );
-$( "p:last" ).text( "scrollLeft:" + p.scrollLeft() );
-</script>
-</body>
-</html>
-```
      * @example ​ ````Set the scrollLeft of a div.
 ```html
 <!doctype html>
@@ -50730,6 +38761,7 @@ $( "p:last" ).text( "scrollLeft:" + p.scrollLeft() );
 <script>
 $( "div.demo" ).scrollLeft( 300 );
 </script>
+​
 </body>
 </html>
 ```
@@ -50764,44 +38796,7 @@ $( "div.demo" ).scrollLeft( 300 );
 var p = $( "p:first" );
 $( "p:last" ).text( "scrollLeft:" + p.scrollLeft() );
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Set the scrollLeft of a div.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>scrollLeft demo</title>
-  <style>
-  div.demo {
-    background: #ccc none repeat scroll 0 0;
-    border: 3px solid #666;
-    margin: 5px;
-    padding: 5px;
-    position: relative;
-    width: 200px;
-    height: 100px;
-    overflow: auto;
-  }
-  p {
-    margin: 10px;
-    padding: 5px;
-    border: 2px solid #666;
-    width: 1000px;
-    height: 1000px;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-<div class="demo"><h1>lalala</h1><p>Hello</p></div>
-​
-<script>
-$( "div.demo" ).scrollLeft( 300 );
-</script>
 </body>
 </html>
 ```
@@ -50813,33 +38808,6 @@ $( "div.demo" ).scrollLeft( 300 );
      * @param value A number indicating the new position to set the scroll bar to.
      * @see \`{@link https://api.jquery.com/scrollTop/ }\`
      * @since 1.2.6
-     * @example ​ ````Get the scrollTop of a paragraph.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>scrollTop demo</title>
-  <style>
-  p {
-    margin: 10px;
-    padding: 5px;
-    border: 2px solid #666;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p>Hello</p><p></p>
-​
-<script>
-var p = $( "p:first" );
-$( "p:last" ).text( "scrollTop:" + p.scrollTop() );
-</script>
-</body>
-</html>
-```
      * @example ​ ````Set the scrollTop of a div.
 ```html
 <!doctype html>
@@ -50875,6 +38843,7 @@ $( "p:last" ).text( "scrollTop:" + p.scrollTop() );
 <script>
 $( "div.demo" ).scrollTop( 300 );
 </script>
+​
 </body>
 </html>
 ```
@@ -50910,44 +38879,7 @@ $( "div.demo" ).scrollTop( 300 );
 var p = $( "p:first" );
 $( "p:last" ).text( "scrollTop:" + p.scrollTop() );
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Set the scrollTop of a div.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>scrollTop demo</title>
-  <style>
-  div.demo {
-    background: #ccc none repeat scroll 0 0;
-    border: 3px solid #666;
-    margin: 5px;
-    padding: 5px;
-    position: relative;
-    width: 200px;
-    height: 100px;
-    overflow: auto;
-  }
-  p {
-    margin: 10px;
-    padding: 5px;
-    border: 2px solid #666;
-    width: 1000px;
-    height: 1000px;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-<div class="demo"><h1>lalala</h1><p>Hello</p></div>
-​
-<script>
-$( "div.demo" ).scrollTop( 300 );
-</script>
 </body>
 </html>
 ```
@@ -50965,55 +38897,6 @@ $( "div.demo" ).scrollTop( 300 );
      * **Cause**: The `.on()` and `.trigger()` methods can set an event handler or generate an event for any event type, and should be used instead of the shortcut methods. This message also applies to the other event shorthands, including: blur, focus, focusin, focusout, resize, scroll, dblclick, mousedown, mouseup, mousemove, mouseover, mouseout, mouseenter, mouseleave, change, select, submit, keydown, keypress, keyup, and contextmenu.
      *
      * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
-     * @example ​ ````To do something when text in input boxes is selected:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>select demo</title>
-  <style>
-  p {
-    color: blue;
-  }
-  div {
-    color: red;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-  <p>Click and drag the mouse to select text in the inputs.</p>
-  <input type="text" value="Some text">
-  <input type="text" value="to test on">
-  <div></div>
-  ​
-<script>
-$( ":input" ).select(function() {
-  $( "div" ).text( "Something was selected" ).show().fadeOut( 1000 );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````To trigger the select event on all input elements, try:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>select demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "input" ).select();
-</script>
-</body>
-</html>
-```
      */
     select<TData>(eventData: TData,
                   handler: JQuery.EventHandler<TElement, TData> | JQuery.EventHandlerBase<any, JQuery.Event<TElement, TData>>): this;
@@ -51057,25 +38940,13 @@ $( ":input" ).select(function() {
   $( "div" ).text( "Something was selected" ).show().fadeOut( 1000 );
 });
 </script>
+​
 </body>
 </html>
 ```
      * @example ​ ````To trigger the select event on all input elements, try:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>select demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $( "input" ).select();
-</script>
-</body>
-</html>
 ```
      */
     select(handler?: JQuery.EventHandler<TElement> | JQuery.EventHandlerBase<any, JQuery.Event<TElement>> | false): this;
@@ -51148,6 +39019,7 @@ $( "input" ).select();
   $( "select" ).on( "change", showValues );
   showValues();
 </script>
+​
 </body>
 </html>
 ```
@@ -51219,6 +39091,7 @@ $( "input" ).select();
   $( "select" ).change( showValues );
   showValues();
 </script>
+​
 </body>
 </html>
 ```
@@ -51232,129 +39105,6 @@ $( "input" ).select();
      * @param complete A function to call once the animation is complete, called once per matched element.
      * @see \`{@link https://api.jquery.com/show/ }\`
      * @since 1.4.3
-     * @example ​ ````Animates all hidden paragraphs to show slowly, completing the animation within 600 milliseconds.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>show demo</title>
-  <style>
-  p {
-    background: yellow;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<button>Show it</button>
-<p style="display: none">Hello  2</p>
-​
-<script>
-$( "button" ).click(function() {
-  $( "p" ).show( "slow" );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Show the first div, followed by each next adjacent sibling div in order, with a 200ms animation. Each animation starts when the previous sibling div&#39;s animation ends.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>show demo</title>
-  <style>
-  div {
-    background: #def3ca;
-    margin: 3px;
-    width: 80px;
-    display: none;
-    float: left;
-    text-align: center;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<button id="showr">Show</button>
-<button id="hidr">Hide</button>
-<div>Hello 3,</div>
-<div>how</div>
-<div>are</div>
-<div>you?</div>
-​
-<script>
-$( "#showr" ).click(function() {
-  $( "div" ).first().show( "fast", function showNext() {
-    $( this ).next( "div" ).show( "fast", showNext );
-  });
-});
-​
-$( "#hidr" ).click(function() {
-  $( "div" ).hide( 1000 );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Show all span and input elements with an animation. Change the text once the animation is done.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>show demo</title>
-  <style>
-  span {
-    display: none;
-  }
-  div {
-    display: none;
-  }
-  p {
-    font-weight: bold;
-    background-color: #fcd;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<button>Do it!</button>
-<span>Are you sure? (type 'yes' if you are) </span>
-<div>
-  <form>
-    <input type="text"  value="as;ldkfjalsdf">
-  </form>
-</div>
-<p style="display:none;">I'm hidden...</p>
-​
-<script>
-function doIt() {
-  $( "span,div" ).show( "slow" );
-}
-// Can pass in function name
-$( "button" ).click( doIt );
-​
-$( "form" ).submit(function( event ) {
-  if ( $( "input" ).val() === "yes" ) {
-    $( "p" ).show( 4000, function() {
-      $( this ).text( "Ok, DONE! (now showing)" );
-    });
-  }
-  $( "span,div" ).hide( "fast" );
-​
-  // Prevent form submission
-  event.preventDefault();
-});
-</script>
-</body>
-</html>
-```
      */
     show(duration: JQuery.Duration, easing: string, complete: (this: TElement) => void): this;
     /**
@@ -51366,33 +39116,6 @@ $( "form" ).submit(function( event ) {
      * @see \`{@link https://api.jquery.com/show/ }\`
      * @since 1.0
      * @since 1.4.3
-     * @example ​ ````Animates all hidden paragraphs to show slowly, completing the animation within 600 milliseconds.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>show demo</title>
-  <style>
-  p {
-    background: yellow;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<button>Show it</button>
-<p style="display: none">Hello  2</p>
-​
-<script>
-$( "button" ).click(function() {
-  $( "p" ).show( "slow" );
-});
-</script>
-</body>
-</html>
-```
      * @example ​ ````Show the first div, followed by each next adjacent sibling div in order, with a 200ms animation. Each animation starts when the previous sibling div&#39;s animation ends.
 ```html
 <!doctype html>
@@ -51432,6 +39155,7 @@ $( "#hidr" ).click(function() {
   $( "div" ).hide( 1000 );
 });
 </script>
+​
 </body>
 </html>
 ```
@@ -51486,6 +39210,7 @@ $( "form" ).submit(function( event ) {
   event.preventDefault();
 });
 </script>
+​
 </body>
 </html>
 ```
@@ -51523,102 +39248,7 @@ $( "button" ).click(function() {
   $( "p" ).show( "slow" );
 });
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Show the first div, followed by each next adjacent sibling div in order, with a 200ms animation. Each animation starts when the previous sibling div&#39;s animation ends.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>show demo</title>
-  <style>
-  div {
-    background: #def3ca;
-    margin: 3px;
-    width: 80px;
-    display: none;
-    float: left;
-    text-align: center;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-<button id="showr">Show</button>
-<button id="hidr">Hide</button>
-<div>Hello 3,</div>
-<div>how</div>
-<div>are</div>
-<div>you?</div>
-​
-<script>
-$( "#showr" ).click(function() {
-  $( "div" ).first().show( "fast", function showNext() {
-    $( this ).next( "div" ).show( "fast", showNext );
-  });
-});
-​
-$( "#hidr" ).click(function() {
-  $( "div" ).hide( 1000 );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Show all span and input elements with an animation. Change the text once the animation is done.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>show demo</title>
-  <style>
-  span {
-    display: none;
-  }
-  div {
-    display: none;
-  }
-  p {
-    font-weight: bold;
-    background-color: #fcd;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<button>Do it!</button>
-<span>Are you sure? (type 'yes' if you are) </span>
-<div>
-  <form>
-    <input type="text"  value="as;ldkfjalsdf">
-  </form>
-</div>
-<p style="display:none;">I'm hidden...</p>
-​
-<script>
-function doIt() {
-  $( "span,div" ).show( "slow" );
-}
-// Can pass in function name
-$( "button" ).click( doIt );
-​
-$( "form" ).submit(function( event ) {
-  if ( $( "input" ).val() === "yes" ) {
-    $( "p" ).show( 4000, function() {
-      $( this ).text( "Ok, DONE! (now showing)" );
-    });
-  }
-  $( "span,div" ).hide( "fast" );
-​
-  // Prevent form submission
-  event.preventDefault();
-});
-</script>
 </body>
 </html>
 ```
@@ -51687,6 +39317,7 @@ var len = $( ".hilite" ).siblings()
   .length;
 $( "b" ).text( len );
 </script>
+​
 </body>
 </html>
 ```
@@ -51697,7 +39328,6 @@ $( "b" ).text( len );
 <head>
   <meta charset="utf-8">
   <title>siblings demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
 </head>
 <body>
 ​
@@ -51708,6 +39338,7 @@ $( "b" ).text( len );
 <script>
 $( "p" ).siblings( ".selected" ).css( "background", "yellow" );
 </script>
+​
 </body>
 </html>
 ```
@@ -51783,93 +39414,29 @@ function colorEm() {
 ​
 $( "button" ).click( colorEm );
 </script>
+​
 </body>
 </html>
 ```
      * @example ​ ````Selects all paragraphs, then slices the selection to include only the first element.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>slice demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $( "p" ).slice( 0, 1 ).wrapInner( "<b></b>" );
-</script>
-</body>
-</html>
 ```
      * @example ​ ````Selects all paragraphs, then slices the selection to include only the first and second element.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>slice demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $( "p" ).slice( 0, 2 ).wrapInner( "<b></b>" );
-</script>
-</body>
-</html>
 ```
      * @example ​ ````Selects all paragraphs, then slices the selection to include only the second element.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>slice demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $( "p" ).slice( 1, 2 ).wrapInner( "<b></b>" );
-</script>
-</body>
-</html>
 ```
      * @example ​ ````Selects all paragraphs, then slices the selection to include only the second and third element.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>slice demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $( "p" ).slice( 1 ).wrapInner( "<b></b>" );
-</script>
-</body>
-</html>
 ```
      * @example ​ ````Selects all paragraphs, then slices the selection to include only the third element.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>slice demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $( "p" ).slice( -1 ).wrapInner( "<b></b>" );
-</script>
-</body>
-</html>
 ```
      */
     slice(start: number, end?: number): this;
@@ -51881,98 +39448,6 @@ $( "p" ).slice( -1 ).wrapInner( "<b></b>" );
      * @param complete A function to call once the animation is complete, called once per matched element.
      * @see \`{@link https://api.jquery.com/slideDown/ }\`
      * @since 1.4.3
-     * @example ​ ````Animates all divs to slide down and show themselves over 600 milliseconds.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>slideDown demo</title>
-  <style>
-  div {
-    background: #de9a44;
-    margin: 3px;
-    width: 80px;
-    height: 40px;
-    display: none;
-    float: left;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-Click me!
-<div></div>
-<div></div>
-<div></div>
-​
-<script>
-$( document.body ).click(function () {
-  if ( $( "div:first" ).is( ":hidden" ) ) {
-    $( "div" ).slideDown( "slow" );
-  } else {
-    $( "div" ).hide();
-  }
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Animates all inputs to slide down, completing the animation within 1000 milliseconds. Once the animation is done, the input look is changed especially if it is the middle input which gets the focus.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>slideDown demo</title>
-  <style>
-  div {
-    background: #cfd;
-    margin: 3px;
-    width: 50px;
-    text-align: center;
-    float: left;
-    cursor: pointer;
-    border: 2px outset black;
-    font-weight: bolder;
-  }
-  input {
-    display: none;
-    width: 120px;
-    float: left;
-    margin: 10px;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<div>Push!</div>
-<input type="text">
-<input type="text" class="middle">
-<input type="text">
-  ​
-<script>
-$( "div" ).click(function() {
-  $( this ).css({
-    borderStyle: "inset",
-    cursor: "wait"
-  });
-  $( "input" ).slideDown( 1000, function() {
-    $( this )
-      .css( "border", "2px red inset" )
-      .filter( ".middle" )
-        .css( "background", "yellow" )
-        .focus();
-    $( "div" ).css( "visibility", "hidden" );
-  });
-});
-​
-</script>
-</body>
-</html>
-```
      */
     slideDown(duration: JQuery.Duration, easing: string, complete?: (this: TElement) => void): this;
     /**
@@ -51984,44 +39459,6 @@ $( "div" ).click(function() {
      * @see \`{@link https://api.jquery.com/slideDown/ }\`
      * @since 1.0
      * @since 1.4.3
-     * @example ​ ````Animates all divs to slide down and show themselves over 600 milliseconds.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>slideDown demo</title>
-  <style>
-  div {
-    background: #de9a44;
-    margin: 3px;
-    width: 80px;
-    height: 40px;
-    display: none;
-    float: left;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-Click me!
-<div></div>
-<div></div>
-<div></div>
-​
-<script>
-$( document.body ).click(function () {
-  if ( $( "div:first" ).is( ":hidden" ) ) {
-    $( "div" ).slideDown( "slow" );
-  } else {
-    $( "div" ).hide();
-  }
-});
-</script>
-</body>
-</html>
-```
      * @example ​ ````Animates all inputs to slide down, completing the animation within 1000 milliseconds. Once the animation is done, the input look is changed especially if it is the middle input which gets the focus.
 ```html
 <!doctype html>
@@ -52073,6 +39510,7 @@ $( "div" ).click(function() {
 });
 ​
 </script>
+​
 </body>
 </html>
 ```
@@ -52123,60 +39561,7 @@ $( document.body ).click(function () {
   }
 });
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Animates all inputs to slide down, completing the animation within 1000 milliseconds. Once the animation is done, the input look is changed especially if it is the middle input which gets the focus.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>slideDown demo</title>
-  <style>
-  div {
-    background: #cfd;
-    margin: 3px;
-    width: 50px;
-    text-align: center;
-    float: left;
-    cursor: pointer;
-    border: 2px outset black;
-    font-weight: bolder;
-  }
-  input {
-    display: none;
-    width: 120px;
-    float: left;
-    margin: 10px;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-<div>Push!</div>
-<input type="text">
-<input type="text" class="middle">
-<input type="text">
-  ​
-<script>
-$( "div" ).click(function() {
-  $( this ).css({
-    borderStyle: "inset",
-    cursor: "wait"
-  });
-  $( "input" ).slideDown( 1000, function() {
-    $( this )
-      .css( "border", "2px red inset" )
-      .filter( ".middle" )
-        .css( "background", "yellow" )
-        .focus();
-    $( "div" ).css( "visibility", "hidden" );
-  });
-});
-​
-</script>
 </body>
 </html>
 ```
@@ -52190,94 +39575,6 @@ $( "div" ).click(function() {
      * @param complete A function to call once the animation is complete, called once per matched element.
      * @see \`{@link https://api.jquery.com/slideToggle/ }\`
      * @since 1.4.3
-     * @example ​ ````Animates all paragraphs to slide up or down, completing the animation within 600 milliseconds.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>slideToggle demo</title>
-  <style>
-  p {
-    width: 400px;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<button>Toggle</button>
-<p>
-  This is the paragraph to end all paragraphs.  You
-  should feel <em>lucky</em> to have seen such a paragraph in
-  your life.  Congratulations!
-</p>
-​
-<script>
-$( "button" ).click(function() {
-  $( "p" ).slideToggle( "slow" );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Animates divs between dividers with a toggle that makes some appear and some disappear.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>slideToggle demo</title>
-  <style>
-  div {
-    background: #b977d1;
-    margin: 3px;
-    width: 60px;
-    height: 60px;
-    float: left;
-  }
-  div.still {
-    background: #345;
-    width: 5px;
-  }
-  div.hider {
-    display: none;
-  }
-  span {
-    color: red;
-  }
-  p {
-    clear: left;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<div></div>
-<div class="still"></div>
-<div style="display:none;">
-</div><div class="still"></div>
-<div></div>
-<div class="still"></div>
-<div class="hider"></div>
-<div class="still"></div>
-<div class="hider"></div>
-<div class="still"></div>
-<div></div>
-<p><button id="aa">Toggle</button> There have been <span>0</span> toggled divs.</p>
-​
-<script>
-$( "#aa" ).click(function() {
-  $( "div:not(.still)" ).slideToggle( "slow", function() {
-    var n = parseInt( $( "span" ).text(), 10 );
-    $( "span" ).text( n + 1 );
-  });
-});
-</script>
-</body>
-</html>
-```
      */
     slideToggle(duration: JQuery.Duration, easing: string, complete?: (this: TElement) => void): this;
     /**
@@ -52289,37 +39586,6 @@ $( "#aa" ).click(function() {
      * @see \`{@link https://api.jquery.com/slideToggle/ }\`
      * @since 1.0
      * @since 1.4.3
-     * @example ​ ````Animates all paragraphs to slide up or down, completing the animation within 600 milliseconds.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>slideToggle demo</title>
-  <style>
-  p {
-    width: 400px;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<button>Toggle</button>
-<p>
-  This is the paragraph to end all paragraphs.  You
-  should feel <em>lucky</em> to have seen such a paragraph in
-  your life.  Congratulations!
-</p>
-​
-<script>
-$( "button" ).click(function() {
-  $( "p" ).slideToggle( "slow" );
-});
-</script>
-</body>
-</html>
-```
      * @example ​ ````Animates divs between dividers with a toggle that makes some appear and some disappear.
 ```html
 <!doctype html>
@@ -52374,6 +39640,7 @@ $( "#aa" ).click(function() {
   });
 });
 </script>
+​
 </body>
 </html>
 ```
@@ -52417,63 +39684,7 @@ $( "button" ).click(function() {
   $( "p" ).slideToggle( "slow" );
 });
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Animates divs between dividers with a toggle that makes some appear and some disappear.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>slideToggle demo</title>
-  <style>
-  div {
-    background: #b977d1;
-    margin: 3px;
-    width: 60px;
-    height: 60px;
-    float: left;
-  }
-  div.still {
-    background: #345;
-    width: 5px;
-  }
-  div.hider {
-    display: none;
-  }
-  span {
-    color: red;
-  }
-  p {
-    clear: left;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-<div></div>
-<div class="still"></div>
-<div style="display:none;">
-</div><div class="still"></div>
-<div></div>
-<div class="still"></div>
-<div class="hider"></div>
-<div class="still"></div>
-<div class="hider"></div>
-<div class="still"></div>
-<div></div>
-<p><button id="aa">Toggle</button> There have been <span>0</span> toggled divs.</p>
-​
-<script>
-$( "#aa" ).click(function() {
-  $( "div:not(.still)" ).slideToggle( "slow", function() {
-    var n = parseInt( $( "span" ).text(), 10 );
-    $( "span" ).text( n + 1 );
-  });
-});
-</script>
 </body>
 </html>
 ```
@@ -52487,88 +39698,6 @@ $( "#aa" ).click(function() {
      * @param complete A function to call once the animation is complete, called once per matched element.
      * @see \`{@link https://api.jquery.com/slideUp/ }\`
      * @since 1.4.3
-     * @example ​ ````Animates all divs to slide up, completing the animation within 400 milliseconds.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>slideUp demo</title>
-  <style>
-  div {
-    background: #3d9a44;
-    margin: 3px;
-    width: 80px;
-    height: 40px;
-    float: left;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-Click me!
-<div></div>
-<div></div>
-<div></div>
-<div></div>
-<div></div>
-​
-<script>
-$( document.body ).click(function() {
-  if ( $( "div:first" ).is( ":hidden" ) ) {
-    $( "div" ).show( "slow" );
-  } else {
-    $( "div" ).slideUp();
-  }
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Animates the parent paragraph to slide up, completing the animation within 200 milliseconds. Once the animation is done, it displays an alert.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>slideUp demo</title>
-  <style>
- div {
-   margin: 2px;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<div>
-  <button>Hide One</button>
-  <input type="text" value="One">
-</div>
-​
-<div>
-  <button>Hide Two</button>
-  <input type="text" value="Two">
-</div>
-​
-<div>
-  <button>Hide Three</button>
-  <input type="text" value="Three">
-</div>
-​
-<div id="msg"></div>
-​
-<script>
-$( "button" ).click(function() {
-  $( this ).parent().slideUp( "slow", function() {
-    $( "#msg" ).text( $( "button", this ).text() + " has completed." );
-  });
-});
-</script>
-</body>
-</html>
-```
      */
     slideUp(duration: JQuery.Duration, easing: string, complete?: (this: TElement) => void): this;
     /**
@@ -52580,45 +39709,6 @@ $( "button" ).click(function() {
      * @see \`{@link https://api.jquery.com/slideUp/ }\`
      * @since 1.0
      * @since 1.4.3
-     * @example ​ ````Animates all divs to slide up, completing the animation within 400 milliseconds.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>slideUp demo</title>
-  <style>
-  div {
-    background: #3d9a44;
-    margin: 3px;
-    width: 80px;
-    height: 40px;
-    float: left;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-Click me!
-<div></div>
-<div></div>
-<div></div>
-<div></div>
-<div></div>
-​
-<script>
-$( document.body ).click(function() {
-  if ( $( "div:first" ).is( ":hidden" ) ) {
-    $( "div" ).show( "slow" );
-  } else {
-    $( "div" ).slideUp();
-  }
-});
-</script>
-</body>
-</html>
-```
      * @example ​ ````Animates the parent paragraph to slide up, completing the animation within 200 milliseconds. Once the animation is done, it displays an alert.
 ```html
 <!doctype html>
@@ -52659,6 +39749,7 @@ $( "button" ).click(function() {
   });
 });
 </script>
+​
 </body>
 </html>
 ```
@@ -52710,49 +39801,7 @@ $( document.body ).click(function() {
   }
 });
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Animates the parent paragraph to slide up, completing the animation within 200 milliseconds. Once the animation is done, it displays an alert.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>slideUp demo</title>
-  <style>
- div {
-   margin: 2px;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-<div>
-  <button>Hide One</button>
-  <input type="text" value="One">
-</div>
-​
-<div>
-  <button>Hide Two</button>
-  <input type="text" value="Two">
-</div>
-​
-<div>
-  <button>Hide Three</button>
-  <input type="text" value="Three">
-</div>
-​
-<div id="msg"></div>
-​
-<script>
-$( "button" ).click(function() {
-  $( this ).parent().slideUp( "slow", function() {
-    $( "#msg" ).text( $( "button", this ).text() + " has completed." );
-  });
-});
-</script>
 </body>
 </html>
 ```
@@ -52766,86 +39815,6 @@ $( "button" ).click(function() {
      * @param jumpToEnd A Boolean indicating whether to complete the current animation immediately. Defaults to false.
      * @see \`{@link https://api.jquery.com/stop/ }\`
      * @since 1.7
-     * @example ​ ````Click the Go button once to start the animation, then click the STOP button to stop it where it&#39;s currently positioned.  Another option is to click several buttons to queue them up and see that stop just kills the currently playing one.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>stop demo</title>
-  <style>
-  div {
-    position: absolute;
-    background-color: #abc;
-    left: 0px;
-    top: 30px;
-    width: 60px;
-    height: 60px;
-    margin: 5px;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<button id="go">Go</button>
-<button id="stop">STOP!</button>
-<button id="back">Back</button>
-<div class="block"></div>
-​
-<script>
-// Start animation
-$( "#go" ).click(function() {
-  $( ".block" ).animate({ left: "+=100px" }, 2000 );
-});
-​
-// Stop animation when button is clicked
-$( "#stop" ).click(function() {
-  $( ".block" ).stop();
-});
-​
-// Start animation in the opposite direction
-$( "#back" ).click(function() {
-  $( ".block" ).animate({ left: "-=100px" }, 2000 );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Click the slideToggle button to start the animation, then click again before the animation is completed. The animation will toggle the other direction from the saved starting point.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>stop demo</title>
-  <style>
-  .block {
-    background-color: #abc;
-    border: 2px solid black;
-    width: 200px;
-    height: 80px;
-    margin: 10px;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<button id="toggle">slideToggle</button>
-<div class="block"></div>
-​
-<script>
-var $block = $( ".block" );
-​
-// Toggle a sliding animation animation
-$( "#toggle" ).on( "click", function() {
-  $block.stop().slideToggle( 1000 );
-});
-</script>
-</body>
-</html>
-```
      */
     stop(queue: string, clearQueue?: boolean, jumpToEnd?: boolean): this;
     /**
@@ -52898,6 +39867,7 @@ $( "#back" ).click(function() {
   $( ".block" ).animate({ left: "-=100px" }, 2000 );
 });
 </script>
+​
 </body>
 </html>
 ```
@@ -52932,6 +39902,7 @@ $( "#toggle" ).on( "click", function() {
   $block.stop().slideToggle( 1000 );
 });
 </script>
+​
 </body>
 </html>
 ```
@@ -52949,88 +39920,6 @@ $( "#toggle" ).on( "click", function() {
      * **Cause**: The `.on()` and `.trigger()` methods can set an event handler or generate an event for any event type, and should be used instead of the shortcut methods. This message also applies to the other event shorthands, including: blur, focus, focusin, focusout, resize, scroll, dblclick, mousedown, mouseup, mousemove, mouseover, mouseout, mouseenter, mouseleave, change, select, submit, keydown, keypress, keyup, and contextmenu.
      *
      * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
-     * @example ​ ````If you&#39;d like to prevent forms from being submitted unless a flag variable is set, try:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>submit demo</title>
-  <style>
-  p {
-    margin: 0;
-    color: blue;
-  }
-  div,p {
-    margin-left: 10px;
-  }
-  span {
-    color: red;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p>Type 'correct' to validate.</p>
-<form action="javascript:alert( 'success!' );">
-  <div>
-    <input type="text">
-    <input type="submit">
-  </div>
-</form>
-<span></span>
-​
-<script>
-$( "form" ).submit(function( event ) {
-  if ( $( "input:first" ).val() === "correct" ) {
-    $( "span" ).text( "Validated..." ).show();
-    return;
-  }
-​
-  $( "span" ).text( "Not valid!" ).show().fadeOut( 1000 );
-  event.preventDefault();
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````If you&#39;d like to prevent forms from being submitted unless a flag variable is set, try:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>submit demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "form" ).submit(function() {
-  return this.some_flag_variable;
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````To trigger the submit event on the first form on the page, try:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>submit demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "form:first" ).submit();
-</script>
-</body>
-</html>
-```
      */
     submit<TData>(eventData: TData,
                   handler: JQuery.EventHandler<TElement, TData> | JQuery.EventHandlerBase<any, JQuery.Event<TElement, TData>>): this;
@@ -53088,44 +39977,19 @@ $( "form" ).submit(function( event ) {
   event.preventDefault();
 });
 </script>
+​
 </body>
 </html>
 ```
      * @example ​ ````If you&#39;d like to prevent forms from being submitted unless a flag variable is set, try:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>submit demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $( "form" ).submit(function() {
   return this.some_flag_variable;
 });
-</script>
-</body>
-</html>
 ```
      * @example ​ ````To trigger the submit event on the first form on the page, try:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>submit demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $( "form:first" ).submit();
-</script>
-</body>
-</html>
 ```
      */
     submit(handler?: JQuery.EventHandler<TElement> | JQuery.EventHandlerBase<any, JQuery.Event<TElement>> | false): this;
@@ -53139,36 +40003,6 @@ $( "form:first" ).submit();
      * @see \`{@link https://api.jquery.com/text/ }\`
      * @since 1.0
      * @since 1.4
-     * @example ​ ````Find the text in the first paragraph (stripping out the html), then set the html of the last paragraph to show it is just text (the red bold is gone).
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>text demo</title>
-  <style>
-  p {
-    color: blue;
-    margin: 8px;
-  }
-  b {
-    color: red;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p><b>Test</b> Paragraph.</p>
-<p></p>
-​
-<script>
-var str = $( "p:first" ).text();
-$( "p:last" ).html( str );
-</script>
-</body>
-</html>
-```
      * @example ​ ````Add text to the paragraph (notice the bold tag is escaped).
 ```html
 <!doctype html>
@@ -53191,6 +40025,7 @@ $( "p:last" ).html( str );
 <script>
 $( "p" ).text( "<b>Some</b> new text." );
 </script>
+​
 </body>
 </html>
 ```
@@ -53228,31 +40063,7 @@ $( "p" ).text( "<b>Some</b> new text." );
 var str = $( "p:first" ).text();
 $( "p:last" ).html( str );
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Add text to the paragraph (notice the bold tag is escaped).
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>text demo</title>
-  <style>
-  p {
-    color: blue;
-    margin: 8px;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-<p>Test Paragraph.</p>
-​
-<script>
-$( "p" ).text( "<b>Some</b> new text." );
-</script>
 </body>
 </html>
 ```
@@ -53295,6 +40106,7 @@ function disp( divs ) {
 ​
 disp( $( "div" ).toArray().reverse() );
 </script>
+​
 </body>
 </html>
 ```
@@ -53308,83 +40120,6 @@ disp( $( "div" ).toArray().reverse() );
      * @param complete A function to call once the animation is complete, called once per matched element.
      * @see \`{@link https://api.jquery.com/toggle/ }\`
      * @since 1.4.3
-     * @example ​ ````Toggles all paragraphs.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>toggle demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<button>Toggle</button>
-<p>Hello</p>
-<p style="display: none">Good Bye</p>
-​
-<script>
-$( "button" ).click(function() {
-  $( "p" ).toggle();
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Animates all paragraphs to be shown if they are hidden and hidden if they are visible, completing the animation within 600 milliseconds.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>toggle demo</title>
-  <style>
-  p {
-    background: #dad;
-    font-weight: bold;
-    font-size: 16px;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<button>Toggle 'em</button>
-<p>Hiya</p>
-<p>Such interesting text, eh?</p>
-​
-<script>
-$( "button" ).click(function() {
-  $( "p" ).toggle( "slow" );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Shows all paragraphs, then hides them all, back and forth.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>toggle demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<button>Toggle</button>
-<p>Hello</p>
-<p style="display: none">Good Bye</p>
-​
-<script>
-var flip = 0;
-$( "button" ).click(function() {
-  $( "p" ).toggle( flip++ % 2 === 0 );
-});
-</script>
-</body>
-</html>
-```
      */
     toggle(duration: JQuery.Duration, easing: string, complete?: (this: TElement) => void): this;
     /**
@@ -53394,83 +40129,6 @@ $( "button" ).click(function() {
      * @param complete A function to call once the animation is complete, called once per matched element.
      * @see \`{@link https://api.jquery.com/toggle/ }\`
      * @since 1.0
-     * @example ​ ````Toggles all paragraphs.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>toggle demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<button>Toggle</button>
-<p>Hello</p>
-<p style="display: none">Good Bye</p>
-​
-<script>
-$( "button" ).click(function() {
-  $( "p" ).toggle();
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Animates all paragraphs to be shown if they are hidden and hidden if they are visible, completing the animation within 600 milliseconds.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>toggle demo</title>
-  <style>
-  p {
-    background: #dad;
-    font-weight: bold;
-    font-size: 16px;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<button>Toggle 'em</button>
-<p>Hiya</p>
-<p>Such interesting text, eh?</p>
-​
-<script>
-$( "button" ).click(function() {
-  $( "p" ).toggle( "slow" );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Shows all paragraphs, then hides them all, back and forth.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>toggle demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<button>Toggle</button>
-<p>Hello</p>
-<p style="display: none">Good Bye</p>
-​
-<script>
-var flip = 0;
-$( "button" ).click(function() {
-  $( "p" ).toggle( flip++ % 2 === 0 );
-});
-</script>
-</body>
-</html>
-```
      */
     toggle(duration: JQuery.Duration, complete: (this: TElement) => void): this;
     /**
@@ -53490,7 +40148,6 @@ $( "button" ).click(function() {
 <head>
   <meta charset="utf-8">
   <title>toggle demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
 </head>
 <body>
 ​
@@ -53503,6 +40160,7 @@ $( "button" ).click(function() {
   $( "p" ).toggle();
 });
 </script>
+​
 </body>
 </html>
 ```
@@ -53533,6 +40191,7 @@ $( "button" ).click(function() {
   $( "p" ).toggle( "slow" );
 });
 </script>
+​
 </body>
 </html>
 ```
@@ -53543,7 +40202,6 @@ $( "button" ).click(function() {
 <head>
   <meta charset="utf-8">
   <title>toggle demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
 </head>
 <body>
 ​
@@ -53557,6 +40215,7 @@ $( "button" ).click(function() {
   $( "p" ).toggle( flip++ % 2 === 0 );
 });
 </script>
+​
 </body>
 </html>
 ```
@@ -53611,6 +40270,7 @@ $( "p" ).click(function() {
   $( this ).toggleClass( "highlight" );
 });
 </script>
+​
 </body>
 </html>
 ```
@@ -53656,6 +40316,7 @@ $( "p" ).each(function() {
   });
 });
 </script>
+​
 </body>
 </html>
 ```
@@ -53727,6 +40388,7 @@ $( "a" ).on( "click", function( event ) {
   appendClass();
 });
 </script>
+​
 </body>
 </html>
 ```
@@ -53745,160 +40407,6 @@ $( "a" ).on( "click", function( event ) {
      * **Cause**: Calling `.toggleClass()` with no arguments, or with a single Boolean `true` or `false` argument, has been deprecated. Its behavior was poorly documented, but essentially the method saved away the current class value in a data item when the class was removed and restored the saved value when it was toggled back. If you do not believe you are specificially trying to use this form of the method, it is possible you are accidentally doing so via an inadvertent undefined value, as `.toggleClass( undefined )` toggles all classes.
      *
      * **Solution**: If this functionality is still needed, save the current full `.attr( "class" )` value in a data item and restore it when required.
-     * @example ​ ````Toggle the class &#39;highlight&#39; when a paragraph is clicked.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>toggleClass demo</title>
-  <style>
-  p {
-    margin: 4px;
-    font-size: 16px;
-    font-weight: bolder;
-    cursor: pointer;
-  }
-  .blue {
-    color: blue;
-  }
-  .highlight {
-    background: yellow;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p class="blue">Click to toggle</p>
-<p class="blue highlight">highlight</p>
-<p class="blue">on these</p>
-<p class="blue">paragraphs</p>
-​
-<script>
-$( "p" ).click(function() {
-  $( this ).toggleClass( "highlight" );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Add the &quot;highlight&quot; class to the clicked paragraph on every third click of that paragraph, remove it every first and second click.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>toggleClass demo</title>
-  <style>
-  p {
-    margin: 4px;
-    font-size: 16px;
-    font-weight: bolder;
-    cursor: pointer;
-  }
-  .blue {
-    color: blue;
-  }
-  .highlight {
-    background: red;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p class="blue">Click to toggle (<span>clicks: 0</span>)</p>
-<p class="blue highlight">highlight (<span>clicks: 0</span>)</p>
-<p class="blue">on these (<span>clicks: 0</span>)</p>
-<p class="blue">paragraphs (<span>clicks: 0</span>)</p>
-​
-<script>
-var count = 0;
-$( "p" ).each(function() {
-  var $thisParagraph = $( this );
-  var count = 0;
-  $thisParagraph.click(function() {
-    count++;
-    $thisParagraph.find( "span" ).text( "clicks: " + count );
-    $thisParagraph.toggleClass( "highlight", count % 3 === 0 );
-  });
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Toggle the class name(s) indicated on the buttons for each div.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>toggleClass demo</title>
-  <style>
-  .wrap > div {
-    float: left;
-    width: 100px;
-    margin: 1em 1em 0 0;
-    padding-left: 3px;
-    border: 1px solid #abc;
-  }
-  div.a {
-    background-color: aqua;
-  }
-  div.b {
-    background-color: burlywood;
-  }
-  div.c {
-    background-color: cornsilk;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<div class="buttons">
-  <button>toggle</button>
-  <button class="a">toggle a</button>
-  <button class="a b">toggle a b</button>
-  <button class="a b c">toggle a b c</button>
-  <a href="#">reset</a>
-</div>
-<div class="wrap">
-  <div></div>
-  <div class="b"></div>
-  <div class="a b"></div>
-  <div class="a c"></div>
-</div>
-​
-<script>
-var cls = [ "", "a", "a b", "a b c" ];
-var divs = $( "div.wrap" ).children();
-var appendClass = function() {
-  divs.append(function() {
-    return "<div>" + ( this.className || "none" ) + "</div>";
-  });
-};
-​
-appendClass();
-​
-$( "button" ).on( "click", function() {
-  var tc = this.className || undefined;
-  divs.toggleClass( tc );
-  appendClass();
-});
-​
-$( "a" ).on( "click", function( event ) {
-  event.preventDefault();
-  divs.empty().each(function( i ) {
-    this.className = cls[ i ];
-  });
-  appendClass();
-});
-</script>
-</body>
-</html>
-```
      */
     toggleClass(state?: boolean): this;
     /**
@@ -53953,109 +40461,45 @@ function update( j ) {
   j.text( n + 1 );
 }
 </script>
+​
 </body>
 </html>
 ```
      * @example ​ ````To submit the first form without using the submit() function, try:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>trigger demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $( "form:first" ).trigger( "submit" );
-</script>
-</body>
-</html>
 ```
      * @example ​ ````To submit the first form without using the submit() function, try:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>trigger demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 var event = jQuery.Event( "submit" );
 $( "form:first" ).trigger( event );
 if ( event.isDefaultPrevented() ) {
   // Perform an action...
 }
-</script>
-</body>
-</html>
 ```
      * @example ​ ````To pass arbitrary data to an event:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>trigger demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $( "p" )
   .click(function( event, a, b ) {
     // When a normal click fires, a and b are undefined
     // for a trigger like below a refers to "foo" and b refers to "bar"
   })
   .trigger( "click", [ "foo", "bar" ] );
-</script>
-</body>
-</html>
 ```
      * @example ​ ````To pass arbitrary data through an event object:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>trigger demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 var event = jQuery.Event( "logged" );
 event.user = "foo";
 event.pass = "bar";
 $( "body" ).trigger( event );
-</script>
-</body>
-</html>
 ```
      * @example ​ ````Alternative way to pass data through an event object:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>trigger demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $( "body" ).trigger({
   type:"logged",
   user:"foo",
   pass:"bar"
 });
-</script>
-</body>
-</html>
 ```
      */
     trigger(eventType: string | JQuery.Event<TElement>, extraParameters?: any[] | JQuery.PlainObject | string | number | boolean): this;
@@ -54075,7 +40519,6 @@ $( "body" ).trigger({
 <head>
   <meta charset="utf-8">
   <title>triggerHandler demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
 </head>
 <body>
 ​
@@ -54095,6 +40538,7 @@ $( "input" ).focus(function() {
   $( "<span>Focused!</span>" ).appendTo( "body" ).fadeOut( 1000 );
 });
 </script>
+​
 </body>
 </html>
 ```
@@ -54153,55 +40597,12 @@ $( "#unbind" ).click(function() {
     .text( "Does nothing..." );
 });
 </script>
-</body>
-</html>
-```
-     * @example ​ ````To unbind all events from all paragraphs, write:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>unbind demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "p" ).unbind();
-</script>
-</body>
-</html>
-```
-     * @example ​ ````To unbind all click events from all paragraphs, write:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>unbind demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "p" ).unbind( "click" );
-</script>
+​
 </body>
 </html>
 ```
      * @example ​ ````To unbind just one previously bound handler, pass the function in as the second argument:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>unbind demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 var foo = function() {
   // Code to handle some kind of event
 };
@@ -54209,9 +40610,6 @@ var foo = function() {
 $( "p" ).bind( "click", foo ); // ... Now foo will be called when paragraphs are clicked ...
 ​
 $( "p" ).unbind( "click", foo ); // ... foo will no longer be called.
-</script>
-</body>
-</html>
 ```
      */
     unbind(event: string, handler: JQuery.EventHandlerBase<any, JQuery.Event<TElement, any>> | false): this;
@@ -54227,105 +40625,13 @@ $( "p" ).unbind( "click", foo ); // ... foo will no longer be called.
      * **Cause**: These event binding methods have been deprecated in favor of the `.on()` and `.off()` methods which can handle both delegated and direct event binding. Although the older methods are still present in jQuery 3.0, they may be removed as early as the next major-version update.
      *
      * **Solution**: Change the method call to use `.on()` or `.off()`, the documentation for the old methods include specific instructions. In general, the `.bind()` and `.unbind()` methods can be renamed directly to `.on()` and `.off()` respectively since the argument orders are identical.
-     * @example ​ ````Can bind and unbind events to the colored button.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>unbind demo</title>
-  <style>
-  button {
-    margin: 5px;
-  }
-  button#theone {
-    color: red;
-    background: yellow;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<button id="theone">Does nothing...</button>
-<button id="bind">Bind Click</button>
-<button id="unbind">Unbind Click</button>
-<div style="display:none;">Click!</div>
-​
-<script>
-function aClick() {
-  $( "div" ).show().fadeOut( "slow" );
-}
-$( "#bind" ).click(function() {
-  $( "#theone" )
-    .bind( "click", aClick )
-    .text( "Can Click!" );
-});
-$( "#unbind" ).click(function() {
-  $( "#theone" )
-    .unbind( "click", aClick )
-    .text( "Does nothing..." );
-});
-</script>
-</body>
-</html>
-```
      * @example ​ ````To unbind all events from all paragraphs, write:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>unbind demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $( "p" ).unbind();
-</script>
-</body>
-</html>
 ```
      * @example ​ ````To unbind all click events from all paragraphs, write:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>unbind demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $( "p" ).unbind( "click" );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````To unbind just one previously bound handler, pass the function in as the second argument:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>unbind demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-var foo = function() {
-  // Code to handle some kind of event
-};
-​
-$( "p" ).bind( "click", foo ); // ... Now foo will be called when paragraphs are clicked ...
-​
-$( "p" ).unbind( "click", foo ); // ... foo will no longer be called.
-</script>
-</body>
-</html>
 ```
      */
     unbind(event?: string | JQuery.Event<TElement>): this;
@@ -54383,55 +40689,12 @@ $( "#unbind" ).click(function() {
     .find( "#theone" ).text( "Does nothing..." );
 });
 </script>
-</body>
-</html>
-```
-     * @example ​ ````To unbind all delegated events from all paragraphs, write:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>undelegate demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "p" ).undelegate();
-</script>
-</body>
-</html>
-```
-     * @example ​ ````To unbind all delegated click events from all paragraphs, write:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>undelegate demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "p" ).undelegate( "click" );
-</script>
+​
 </body>
 </html>
 ```
      * @example ​ ````To undelegate just one previously bound handler, pass the function in as the third argument:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>undelegate demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 var foo = function () {
   // Code to handle some kind of event
 };
@@ -54441,36 +40704,6 @@ $( "body" ).delegate( "p", "click", foo );
 ​
 // ... foo will no longer be called.
 $( "body" ).undelegate( "p", "click", foo );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````To unbind all delegated events by their namespace:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>undelegate demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-var foo = function() {
-  // Code to handle some kind of event
-};
-​
-// Delegate events under the ".whatever" namespace
-$( "form" ).delegate( ":button", "click.whatever", foo );
-​
-$( "form" ).delegate( "input[type='text'] ", "keypress.whatever", foo );
-​
-// Unbind all events delegated under the ".whatever" namespace
-$( "form" ).undelegate( ".whatever" );
-</script>
-</body>
-</html>
 ```
      */
     undelegate(selector: JQuery.Selector, eventType: string, handler: JQuery.EventHandlerBase<any, JQuery.Event<TElement, any>> | false): this;
@@ -54489,135 +40722,6 @@ $( "form" ).undelegate( ".whatever" );
      * **Cause**: These event binding methods have been deprecated in favor of the `.on()` and `.off()` methods which can handle both delegated and direct event binding. Although the older methods are still present in jQuery 3.0, they may be removed as early as the next major-version update.
      *
      * **Solution**: Change the method call to use `.on()` or `.off()`, the documentation for the old methods include specific instructions. In general, the `.bind()` and `.unbind()` methods can be renamed directly to `.on()` and `.off()` respectively since the argument orders are identical.
-     * @example ​ ````Can bind and unbind events to the colored button.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>undelegate demo</title>
-  <style>
-  button {
-    margin: 5px;
-  }
-  button#theone {
-    color: red;
-    background: yellow;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<button id="theone">Does nothing...</button>
-<button id="bind">Bind Click</button>
-<button id="unbind">Unbind Click</button>
-<div style="display:none;">Click!</div>
-​
-<script>
-function aClick() {
-  $( "div" ).show().fadeOut( "slow" );
-}
-$( "#bind" ).click(function() {
-  $( "body" )
-    .delegate( "#theone", "click", aClick )
-    .find( "#theone" ).text( "Can Click!" );
-});
-$( "#unbind" ).click(function() {
-  $( "body" )
-    .undelegate( "#theone", "click", aClick )
-    .find( "#theone" ).text( "Does nothing..." );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````To unbind all delegated events from all paragraphs, write:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>undelegate demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "p" ).undelegate();
-</script>
-</body>
-</html>
-```
-     * @example ​ ````To unbind all delegated click events from all paragraphs, write:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>undelegate demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-$( "p" ).undelegate( "click" );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````To undelegate just one previously bound handler, pass the function in as the third argument:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>undelegate demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-var foo = function () {
-  // Code to handle some kind of event
-};
-​
-// ... Now foo will be called when paragraphs are clicked ...
-$( "body" ).delegate( "p", "click", foo );
-​
-// ... foo will no longer be called.
-$( "body" ).undelegate( "p", "click", foo );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````To unbind all delegated events by their namespace:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>undelegate demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-var foo = function() {
-  // Code to handle some kind of event
-};
-​
-// Delegate events under the ".whatever" namespace
-$( "form" ).delegate( ":button", "click.whatever", foo );
-​
-$( "form" ).delegate( "input[type='text'] ", "keypress.whatever", foo );
-​
-// Unbind all events delegated under the ".whatever" namespace
-$( "form" ).undelegate( ".whatever" );
-</script>
-</body>
-</html>
-```
      */
     undelegate(selector: JQuery.Selector, eventTypes: string | JQuery.PlainObject<JQuery.EventHandlerBase<any, JQuery.Event<TElement, any>> | false>): this;
     /**
@@ -54633,120 +40737,16 @@ $( "form" ).undelegate( ".whatever" );
      * **Cause**: These event binding methods have been deprecated in favor of the `.on()` and `.off()` methods which can handle both delegated and direct event binding. Although the older methods are still present in jQuery 3.0, they may be removed as early as the next major-version update.
      *
      * **Solution**: Change the method call to use `.on()` or `.off()`, the documentation for the old methods include specific instructions. In general, the `.bind()` and `.unbind()` methods can be renamed directly to `.on()` and `.off()` respectively since the argument orders are identical.
-     * @example ​ ````Can bind and unbind events to the colored button.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>undelegate demo</title>
-  <style>
-  button {
-    margin: 5px;
-  }
-  button#theone {
-    color: red;
-    background: yellow;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<button id="theone">Does nothing...</button>
-<button id="bind">Bind Click</button>
-<button id="unbind">Unbind Click</button>
-<div style="display:none;">Click!</div>
-​
-<script>
-function aClick() {
-  $( "div" ).show().fadeOut( "slow" );
-}
-$( "#bind" ).click(function() {
-  $( "body" )
-    .delegate( "#theone", "click", aClick )
-    .find( "#theone" ).text( "Can Click!" );
-});
-$( "#unbind" ).click(function() {
-  $( "body" )
-    .undelegate( "#theone", "click", aClick )
-    .find( "#theone" ).text( "Does nothing..." );
-});
-</script>
-</body>
-</html>
-```
      * @example ​ ````To unbind all delegated events from all paragraphs, write:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>undelegate demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $( "p" ).undelegate();
-</script>
-</body>
-</html>
 ```
      * @example ​ ````To unbind all delegated click events from all paragraphs, write:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>undelegate demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 $( "p" ).undelegate( "click" );
-</script>
-</body>
-</html>
-```
-     * @example ​ ````To undelegate just one previously bound handler, pass the function in as the third argument:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>undelegate demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
-var foo = function () {
-  // Code to handle some kind of event
-};
-​
-// ... Now foo will be called when paragraphs are clicked ...
-$( "body" ).delegate( "p", "click", foo );
-​
-// ... foo will no longer be called.
-$( "body" ).undelegate( "p", "click", foo );
-</script>
-</body>
-</html>
 ```
      * @example ​ ````To unbind all delegated events by their namespace:
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>undelegate demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​​
-<script>
+```javascript
 var foo = function() {
   // Code to handle some kind of event
 };
@@ -54758,9 +40758,6 @@ $( "form" ).delegate( "input[type='text'] ", "keypress.whatever", foo );
 ​
 // Unbind all events delegated under the ".whatever" namespace
 $( "form" ).undelegate( ".whatever" );
-</script>
-</body>
-</html>
 ```
      */
     undelegate(namespace?: string): this;
@@ -54805,6 +40802,7 @@ $( "button" ).click(function() {
   }
 });
 </script>
+​
 </body>
 </html>
 ```
@@ -54820,86 +40818,6 @@ $( "button" ).click(function() {
      * @see \`{@link https://api.jquery.com/val/ }\`
      * @since 1.0
      * @since 1.4
-     * @example ​ ````Get the single value from a single select and an array of values from a multiple select and display their values.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>val demo</title>
-  <style>
-  p {
-    color: red;
-    margin: 4px;
-  }
-  b {
-    color: blue;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p></p>
-​
-<select id="single">
-  <option>Single</option>
-  <option>Single2</option>
-</select>
-​
-<select id="multiple" multiple="multiple">
-  <option selected="selected">Multiple</option>
-  <option>Multiple2</option>
-  <option selected="selected">Multiple3</option>
-</select>
-​
-<script>
-function displayVals() {
-  var singleValues = $( "#single" ).val();
-  var multipleValues = $( "#multiple" ).val() || [];
-  // When using jQuery 3:
-  // var multipleValues = $( "#multiple" ).val();
-  $( "p" ).html( "<b>Single:</b> " + singleValues +
-    " <b>Multiple:</b> " + multipleValues.join( ", " ) );
-}
-​
-$( "select" ).change( displayVals );
-displayVals();
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Find the value of an input box.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>val demo</title>
-  <style>
-  p {
-    color: blue;
-    margin: 8px;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<input type="text" value="some text">
-<p></p>
-​
-<script>
-$( "input" )
-  .keyup(function() {
-    var value = $( this ).val();
-    $( "p" ).text( value );
-  })
-  .keyup();
-</script>
-</body>
-</html>
-```
      * @example ​ ````Set the value of an input box.
 ```html
 <!doctype html>
@@ -54934,6 +40852,7 @@ $( "button" ).click(function() {
   $( "input" ).val( text );
 });
 </script>
+​
 </body>
 </html>
 ```
@@ -54944,7 +40863,6 @@ $( "button" ).click(function() {
 <head>
   <meta charset="utf-8">
   <title>val demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
 </head>
 <body>
 ​
@@ -54958,6 +40876,7 @@ $( "input" ).on( "blur", function() {
   });
 });
 </script>
+​
 </body>
 </html>
 ```
@@ -54999,6 +40918,7 @@ $( "#single" ).val( "Single2" );
 $( "#multiple" ).val([ "Multiple2", "Multiple3" ]);
 $( "input").val([ "check1", "check2", "radio1" ]);
 </script>
+​
 </body>
 </html>
 ```
@@ -55055,6 +40975,7 @@ function displayVals() {
 $( "select" ).change( displayVals );
 displayVals();
 </script>
+​
 </body>
 </html>
 ```
@@ -55086,108 +41007,7 @@ $( "input" )
   })
   .keyup();
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Set the value of an input box.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>val demo</title>
-  <style>
-  button {
-    margin: 4px;
-    cursor: pointer;
-  }
-  input {
-    margin: 4px;
-    color: blue;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-<div>
-  <button>Feed</button>
-  <button>the</button>
-  <button>Input</button>
-</div>
-<input type="text" value="click a button">
-​
-<script>
-$( "button" ).click(function() {
-  var text = $( this ).text();
-  $( "input" ).val( text );
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Use the function argument to modify the value of an input box.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>val demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<p>Type something and then click or tab out of the input.</p>
-<input type="text" value="type something">
-​
-<script>
-$( "input" ).on( "blur", function() {
-  $( this ).val(function( i, val ) {
-    return val.toUpperCase();
-  });
-});
-</script>
-</body>
-</html>
-```
-     * @example ​ ````Set a single select, a multiple select, checkboxes and a radio button .
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>val demo</title>
-  <style>
-  body {
-    color: blue;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<select id="single">
-  <option>Single</option>
-  <option>Single2</option>
-</select>
-​
-<select id="multiple" multiple="multiple">
-  <option selected="selected">Multiple</option>
-  <option>Multiple2</option>
-  <option selected="selected">Multiple3</option>
-</select>
-​
-<br>
-<input type="checkbox" name="checkboxname" value="check1"> check1
-<input type="checkbox" name="checkboxname" value="check2"> check2
-<input type="radio" name="r" value="radio1"> radio1
-<input type="radio" name="r" value="radio2"> radio2
-​
-<script>
-$( "#single" ).val( "Single2" );
-$( "#multiple" ).val([ "Multiple2", "Multiple3" ]);
-$( "input").val([ "check1", "check2", "radio1" ]);
-</script>
 </body>
 </html>
 ```
@@ -55203,59 +41023,6 @@ $( "input").val([ "check1", "check2", "radio1" ]);
      * @see \`{@link https://api.jquery.com/width/ }\`
      * @since 1.0
      * @since 1.4.1
-     * @example ​ ````Show various widths.  Note the values are from the iframe so might be smaller than you expected.  The yellow highlight shows the iframe body.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>width demo</title>
-  <style>
-  body {
-    background: yellow;
-  }
-  button {
-    font-size: 12px;
-    margin: 2px;
-  }
-  p {
-    width: 150px;
-    border: 1px red solid;
-  }
-  div {
-    color: red;
-    font-weight: bold;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<button id="getp">Get Paragraph Width</button>
-<button id="getd">Get Document Width</button>
-<button id="getw">Get Window Width</button>
-<div>&nbsp;</div>
-<p>
-  Sample paragraph to test width
-</p>
-​
-<script>
-function showWidth( ele, w ) {
-  $( "div" ).text( "The width for the " + ele + " is " + w + "px." );
-}
-$( "#getp" ).click(function() {
-  showWidth( "paragraph", $( "p" ).width() );
-});
-$( "#getd" ).click(function() {
-  showWidth( "document", $( document ).width() );
-});
-$("#getw").click(function() {
-  showWidth( "window", $( window ).width() );
-});
-</script>
-</body>
-</html>
-```
      * @example ​ ````Change the width of each div the first time it is clicked (and change its color).
 ```html
 <!doctype html>
@@ -55294,6 +41061,7 @@ $( "div" ).one( "click", function() {
   modWidth -= 8;
 });
 </script>
+​
 </body>
 </html>
 ```
@@ -55354,47 +41122,7 @@ $("#getw").click(function() {
   showWidth( "window", $( window ).width() );
 });
 </script>
-</body>
-</html>
-```
-     * @example ​ ````Change the width of each div the first time it is clicked (and change its color).
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>width demo</title>
-  <style>
-  div {
-    width: 70px;
-    height: 50px;
-    float: left;
-    margin: 5px;
-    background: red;
-    cursor: pointer;
-  }
-  .mod {
-    background: blue;
-    cursor: default;
-  }
-  </style>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
 ​
-<div>d</div>
-<div>d</div>
-<div>d</div>
-<div>d</div>
-<div>d</div>
-​
-<script>
-var modWidth = 50;
-$( "div" ).one( "click", function() {
-  $( this ).width( modWidth ).addClass( "mod" );
-  modWidth -= 8;
-});
-</script>
 </body>
 </html>
 ```
@@ -55439,6 +41167,7 @@ $( "div" ).one( "click", function() {
 <script>
 $( "p" ).wrap( "<div></div>" );
 </script>
+​
 </body>
 </html>
 ```
@@ -55475,6 +41204,7 @@ $( "p" ).wrap( "<div></div>" );
 <script>
 $( "span" ).wrap( "<div><div><p><em><b></b></em></p></div></div>" );
 </script>
+​
 </body>
 </html>
 ```
@@ -55505,6 +41235,7 @@ $( "span" ).wrap( "<div><div><p><em><b></b></em></p></div></div>" );
 <script>
 $( "p" ).wrap( document.createElement( "div" ) );
 </script>
+​
 </body>
 </html>
 ```
@@ -55542,6 +41273,7 @@ $( "p" ).wrap( document.createElement( "div" ) );
 <script>
 $( "p" ).wrap( $( ".doublediv" ) );
 </script>
+​
 </body>
 </html>
 ```
@@ -55585,6 +41317,7 @@ $( "p" ).wrap( $( ".doublediv" ) );
 <script>
 $( "p" ).wrapAll( "<div></div>" );
 </script>
+​
 </body>
 </html>
 ```
@@ -55621,6 +41354,7 @@ $( "p" ).wrapAll( "<div></div>" );
 <script>
 $( "span").wrapAll( "<div><div><p><em><b></b></em></p></div></div>" );
 </script>
+​
 </body>
 </html>
 ```
@@ -55651,6 +41385,7 @@ $( "span").wrapAll( "<div><div><p><em><b></b></em></p></div></div>" );
 <script>
 $( "p" ).wrapAll( document.createElement( "div" ) );
 </script>
+​
 </body>
 </html>
 ```
@@ -55688,6 +41423,7 @@ $( "p" ).wrapAll( document.createElement( "div" ) );
 <script>
 $( "p" ).wrapAll( $( ".doublediv" ) );
 </script>
+​
 </body>
 </html>
 ```
@@ -55727,6 +41463,7 @@ $( "p" ).wrapAll( $( ".doublediv" ) );
 <script>
 $( "p" ).wrapInner( "<b></b>" );
 </script>
+​
 </body>
 </html>
 ```
@@ -55758,6 +41495,7 @@ Plain old text, or is it?
 <script>
 $( "body" ).wrapInner( "<div><div><p><em><b></b></em></p></div></div>" );
 </script>
+​
 </body>
 </html>
 ```
@@ -55784,6 +41522,7 @@ $( "body" ).wrapInner( "<div><div><p><em><b></b></em></p></div></div>" );
 <script>
 $( "p" ).wrapInner( document.createElement( "b" ) );
 </script>
+​
 </body>
 </html>
 ```
@@ -55813,6 +41552,7 @@ $( "p" ).wrapInner( document.createElement( "b" ) );
 <script>
 $( "p" ).wrapInner( $( "<span class='red'></span>" ) );
 </script>
+​
 </body>
 </html>
 ```

--- a/types/jquery/index.d.ts
+++ b/types/jquery/index.d.ts
@@ -475,7 +475,7 @@ $( "button" ).click( function() {
 </html>
 ```
      */
-    data<T extends string | number | boolean | symbol | object | null>(element: Element, key: string, value: T): T;
+    data<T extends string | number | boolean | symbol | object | null>(element: Element | Document | Window | JQuery.PlainObject, key: string, value: T): T;
     /**
      * Returns value at named data store for the element, as set by `jQuery.data(element, name, value)`, or
      * the full data store for the element.
@@ -490,7 +490,7 @@ $( "button" ).click( function() {
     // `unified-signatures` is disabled so that behavior when passing `undefined` to `value` can be documented. Unifying the signatures
     // results in potential confusion for users from an unexpected parameter.
     // tslint:disable-next-line:unified-signatures
-    data(element: Element, key: string, value: undefined): any;
+    data(element: Element | Document | Window | JQuery.PlainObject, key: string, value: undefined): any;
     /**
      * Returns value at named data store for the element, as set by `jQuery.data(element, name, value)`, or
      * the full data store for the element.
@@ -540,7 +540,7 @@ $( "span:last" ).text( jQuery.data( div, "test" ).last );
 </html>
 ```
      */
-    data(element: Element, key?: string): any;
+    data(element: Element | Document | Window | JQuery.PlainObject, key?: string): any;
     /**
      * Execute the next function on the queue for the matched element.
      *
@@ -1976,7 +1976,7 @@ $p.append( jQuery.hasData( p ) + " " ); // false
 </html>
 ```
      */
-    hasData(element: Element): boolean;
+    hasData(element: Element | Document | Window | JQuery.PlainObject): boolean;
     /**
      * Holds or releases the execution of jQuery's ready event.
      *
@@ -12944,7 +12944,7 @@ $( "span:eq(3)" ).text( "" + jQuery.data( div, "test2" ) );
 </html>
 ```
      */
-    removeData(element: Element, name?: string): void;
+    removeData(element: Element | Document | Window | JQuery.PlainObject, name?: string): void;
     /**
      * Creates an object containing a set of properties ready to be used in the definition of custom animations.
      *

--- a/types/jquery/index.d.ts
+++ b/types/jquery/index.d.ts
@@ -51,15 +51,6 @@ interface JQueryStatic {
      * @deprecated ​ Deprecated. Use \`{@link ajaxSetup }\`.
      */
     ajaxSettings: JQuery.AjaxSettings;
-    /**
-     * A factory function that returns a chainable utility object with methods to register multiple
-     * callbacks into callback queues, invoke callback queues, and relay the success or failure state of
-     * any synchronous or asynchronous function.
-     *
-     * @param beforeStart A function that is called just before the constructor returns.
-     * @see \`{@link https://api.jquery.com/jQuery.Deferred/ }\`
-     * @since 1.5
-     */
     Deferred: JQuery.DeferredStatic;
     Event: JQuery.EventStatic;
     /**
@@ -59417,6 +59408,15 @@ $.get( "test.php" )
     interface DeferredStatic {
         // https://jquery.com/upgrade-guide/3.0/#callback-exit
         exceptionHook: any;
+        /**
+         * A factory function that returns a chainable utility object with methods to register multiple
+         * callbacks into callback queues, invoke callback queues, and relay the success or failure state of
+         * any synchronous or asynchronous function.
+         *
+         * @param beforeStart A function that is called just before the constructor returns.
+         * @see \`{@link https://api.jquery.com/jQuery.Deferred/ }\`
+         * @since 1.5
+         */
         <TR = any, TJ = any, TN = any>(beforeStart?: (this: Deferred<TR, TJ, TN>, deferred: Deferred<TR, TJ, TN>) => void): Deferred<TR, TJ, TN>;
     }
 

--- a/types/jquery/index.d.ts
+++ b/types/jquery/index.d.ts
@@ -52,8 +52,6 @@ interface JQueryStatic {
      */
     ajaxSettings: JQuery.AjaxSettings;
     Callbacks: JQuery.CallbacksStatic;
-    Deferred: JQuery.DeferredStatic;
-    Event: JQuery.EventStatic;
     /**
      * Hook directly into jQuery to override how particular CSS properties are retrieved or set, normalize
      * CSS property naming, or create custom properties.
@@ -71,7 +69,9 @@ interface JQueryStatic {
      * @since 1.4.3
      */
     cssNumber: JQuery.PlainObject<boolean>;
+    Deferred: JQuery.DeferredStatic;
     easing: JQuery.Easings;
+    Event: JQuery.EventStatic;
     expr: JQuery.Selectors;
     // Set to HTMLElement to minimize breaks but should probably be Element.
     readonly fn: JQuery;
@@ -27251,6 +27251,32 @@ callbacks.fire( "hello again" );
          */
         fire(...args: any[]): this;
         /**
+         * Determine if the callbacks have already been called at least once.
+         *
+         * @see \`{@link https://api.jquery.com/callbacks.fired/ }\`
+         * @since 1.7
+         * @example ​ ````Use callbacks.fired() to determine if the callbacks in a list have been called at least once:
+```javascript
+// A sample logging function to be added to a callbacks list
+var foo = function( value ) {
+  console.log( "foo:" + value );
+};
+​
+var callbacks = $.Callbacks();
+​
+// Add the function "foo" to the list
+callbacks.add( foo );
+​
+// Fire the items on the list
+callbacks.fire( "hello" ); // Outputs: "foo: hello"
+callbacks.fire( "world" ); // Outputs: "foo: world"
+​
+// Test to establish if the callbacks have been called
+console.log( callbacks.fired() );
+```
+         */
+        fired(): boolean;
+        /**
          * Call all callbacks in a list with the given context and arguments.
          *
          * @param context A reference to the context in which the callbacks in the list should be fired.
@@ -27277,32 +27303,6 @@ callbacks.fireWith( window, [ "foo","bar" ] );
 ```
          */
         fireWith(context: object, args?: ArrayLike<any>): this;
-        /**
-         * Determine if the callbacks have already been called at least once.
-         *
-         * @see \`{@link https://api.jquery.com/callbacks.fired/ }\`
-         * @since 1.7
-         * @example ​ ````Use callbacks.fired() to determine if the callbacks in a list have been called at least once:
-```javascript
-// A sample logging function to be added to a callbacks list
-var foo = function( value ) {
-  console.log( "foo:" + value );
-};
-​
-var callbacks = $.Callbacks();
-​
-// Add the function "foo" to the list
-callbacks.add( foo );
-​
-// Fire the items on the list
-callbacks.fire( "hello" ); // Outputs: "foo: hello"
-callbacks.fire( "world" ); // Outputs: "foo: world"
-​
-// Test to establish if the callbacks have been called
-console.log( callbacks.fired() );
-```
-         */
-        fired(): boolean;
         /**
          * Determine whether or not the list has any callbacks attached. If a callback is provided as an
          * argument, determine whether it is in a list.

--- a/types/jquery/index.d.ts
+++ b/types/jquery/index.d.ts
@@ -2953,8 +2953,7 @@ $.post( "test.php" );
      * @param fn The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
-     * @since 1.4`
-     * @since 1.6
+     * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
      */
     proxy<TReturn,

--- a/types/jquery/jquery-tests.ts
+++ b/types/jquery/jquery-tests.ts
@@ -147,20 +147,8 @@ function JQueryStatic() {
     }
 
     function fx() {
-        function interval() {
-            // $ExpectType number
-            $.fx.interval;
-        }
-
-        function off() {
-            // $ExpectType boolean
-            $.fx.off;
-        }
-
-        function step() {
-            // $ExpectType PlainObject<AnimationHook<Node>>
-            $.fx.step;
-        }
+        // $ExpectType Effects
+        $.fx;
     }
 
     function ready() {
@@ -6830,6 +6818,23 @@ function JQuery_Callbacks() {
     function remove() {
         // $ExpectType Callbacks<Function>
         $.Callbacks().remove(() => { }, () => { });
+    }
+}
+
+function JQuery_Effects() {
+    function interval() {
+        // $ExpectType number
+        $.fx.interval;
+    }
+
+    function off() {
+        // $ExpectType boolean
+        $.fx.off;
+    }
+
+    function step() {
+        // $ExpectType PlainObject<AnimationHook<Node>>
+        $.fx.step;
     }
 }
 

--- a/types/jquery/jquery-tests.ts
+++ b/types/jquery/jquery-tests.ts
@@ -3,6 +3,71 @@ function JQueryStatic() {
         const jq: JQueryStatic = $;
     }
 
+    function ajaxSettings() {
+        // $ExpectType AjaxSettings<any>
+        $.ajaxSettings;
+    }
+
+    function Callbacks() {
+        // $ExpectType CallbacksStatic
+        $.Callbacks;
+    }
+
+    function cssHooks() {
+        // $ExpectType PlainObject<CSSHook<HTMLElement>>
+        $.cssHooks;
+    }
+
+    function cssNumber() {
+        // $ExpectType PlainObject<boolean>
+        $.cssNumber;
+    }
+
+    function Deferred() {
+        // $ExpectType DeferredStatic
+        $.Deferred;
+    }
+
+    function easing() {
+        // $ExpectType Easings
+        $.easing;
+    }
+
+    function Event() {
+        // $ExpectType EventStatic
+        $.Event;
+    }
+
+    function expr() {
+        // $ExpectType Selectors
+        $.expr;
+    }
+
+    function fn() {
+        // $ExpectType JQuery<HTMLElement>
+        $.fn;
+    }
+
+    function fx() {
+        // $ExpectType Effects
+        $.fx;
+    }
+
+    function ready() {
+        // $ExpectType Thenable<JQueryStatic>
+        $.ready;
+    }
+
+    function support() {
+        // $ExpectType PlainObject<any>
+        $.support;
+    }
+
+    function valHooks() {
+        // $ExpectType PlainObject<ValHook<HTMLElement>>
+        $.valHooks;
+    }
+
     function call_signature() {
         // $ExpectType JQuery<HTMLElement>
         $('<p></p>', new Document());
@@ -109,71 +174,6 @@ function JQueryStatic() {
             // $ExpectType JQuery<Window>
             myWindowForced;
         }
-    }
-
-    function ajaxSettings() {
-        // $ExpectType AjaxSettings<any>
-        $.ajaxSettings;
-    }
-
-    function Event() {
-        // $ExpectType EventStatic
-        $.Event;
-    }
-
-    function cssHooks() {
-        // $ExpectType PlainObject<CSSHook<HTMLElement>>
-        $.cssHooks;
-    }
-
-    function cssNumber() {
-        // $ExpectType PlainObject<boolean>
-        $.cssNumber;
-    }
-
-    function easing() {
-        // $ExpectType Easings
-        $.easing;
-    }
-
-    function expr() {
-        // $ExpectType Selectors
-        $.expr;
-    }
-
-    function fn() {
-        // $ExpectType JQuery<HTMLElement>
-        $.fn;
-    }
-
-    function fx() {
-        // $ExpectType Effects
-        $.fx;
-    }
-
-    function ready() {
-        // $ExpectType Thenable<JQueryStatic>
-        $.ready;
-    }
-
-    function support() {
-        // $ExpectType PlainObject<any>
-        $.support;
-    }
-
-    function valHooks() {
-        // $ExpectType PlainObject<ValHook<HTMLElement>>
-        $.valHooks;
-    }
-
-    function Callbacks() {
-        // $ExpectType CallbacksStatic
-        $.Callbacks;
-    }
-
-    function Deferred() {
-        // $ExpectType DeferredStatic
-        $.Deferred;
     }
 
     function ajax() {
@@ -6691,215 +6691,6 @@ function JQuery_AjaxSettings() {
     });
 }
 
-function JQuery_CallbacksStatic() {
-    // $ExpectType Callbacks<Function>
-    $.Callbacks('once');
-
-    // $ExpectType Callbacks<Function>
-    $.Callbacks();
-}
-
-function JQuery_Callbacks() {
-    function add() {
-        const callbacks = $.Callbacks();
-
-        // $ExpectType Callbacks<Function>
-        callbacks.add(() => { }, [() => { }], () => { });
-
-        // $ExpectType Callbacks<Function>
-        callbacks.add(() => { }, [() => { }]);
-
-        // $ExpectType Callbacks<Function>
-        callbacks.add(() => { }, () => { });
-
-        // $ExpectType Callbacks<Function>
-        callbacks.add(() => { });
-
-        // $ExpectType Callbacks<Function>
-        callbacks.add([() => { }]);
-    }
-
-    function disable() {
-        // $ExpectType Callbacks<Function>
-        $.Callbacks().disable();
-    }
-
-    function disabled() {
-        // $ExpectType boolean
-        $.Callbacks().disabled();
-    }
-
-    function empty() {
-        // $ExpectType Callbacks<Function>
-        $.Callbacks().empty();
-    }
-
-    function fire() {
-        // $ExpectType Callbacks<Function>
-        $.Callbacks().fire(1);
-
-        // $ExpectType Callbacks<Function>
-        $.Callbacks().fire();
-    }
-
-    function fireWith() {
-        // $ExpectType Callbacks<Function>
-        $.Callbacks().fireWith(window, [1]);
-
-        // $ExpectType Callbacks<Function>
-        $.Callbacks().fireWith(window);
-    }
-
-    function fired() {
-        // $ExpectType boolean
-        $.Callbacks().fired();
-    }
-
-    function has() {
-        // $ExpectType boolean
-        $.Callbacks().has(() => { });
-
-        // $ExpectType boolean
-        $.Callbacks().has();
-    }
-
-    function lock() {
-        // $ExpectType Callbacks<Function>
-        $.Callbacks().lock();
-    }
-
-    function locked() {
-        // $ExpectType boolean
-        $.Callbacks().locked();
-    }
-
-    function remove() {
-        // $ExpectType Callbacks<Function>
-        $.Callbacks().remove(() => { }, () => { });
-    }
-}
-
-function JQuery_Effects() {
-    function interval() {
-        // $ExpectType number
-        $.fx.interval;
-    }
-
-    function off() {
-        // $ExpectType boolean
-        $.fx.off;
-    }
-
-    function step() {
-        // $ExpectType PlainObject<AnimationHook<Node>>
-        $.fx.step;
-    }
-}
-
-function JQuery_EffectsOptions() {
-    $('p').show({
-        always(animation, jumpToEnd) {
-            // $ExpectType HTMLElement
-            this;
-            // $ExpectType Promise<any, any, any>
-            animation;
-            // $ExpectType boolean
-            jumpToEnd;
-        },
-        complete() {
-            // $ExpectType HTMLElement
-            this;
-        },
-        done(animation, jumpToEnd) {
-            // $ExpectType HTMLElement
-            this;
-            // $ExpectType Promise<any, any, any>
-            animation;
-            // $ExpectType boolean
-            jumpToEnd;
-        },
-        duration: 5000,
-        easing: 'linear',
-        fail(animation, jumpToEnd) {
-            // $ExpectType HTMLElement
-            this;
-            // $ExpectType Promise<any, any, any>
-            animation;
-            // $ExpectType boolean
-            jumpToEnd;
-        },
-        progress(animation, progress, remainingMs) {
-            // $ExpectType HTMLElement
-            this;
-            // $ExpectType Promise<any, any, any>
-            animation;
-            // $ExpectType number
-            progress;
-            // $ExpectType number
-            remainingMs;
-        },
-        queue: true,
-        specialEasing: {
-            width: 'linear',
-            height: 'easeOutBounce'
-        },
-        start(animation) {
-            // $ExpectType HTMLElement
-            this;
-            // $ExpectType Promise<any, any, any>
-            animation;
-        },
-        step(now, tween) {
-            // $ExpectType HTMLElement
-            this;
-            // $ExpectType number
-            now;
-            // $ExpectType Tween<HTMLElement>
-            tween;
-        }
-    });
-}
-
-function JQuery_Easings() {
-    jQuery.easing.easeInCubic = (p: number, t: number, b: number, c: number, d: number) => {
-        return c * (t /= d) * t * t + b;
-    };
-
-    jQuery.easing.easeInCubic = (p: number) => {
-        return Math.pow(p, 3);
-    };
-}
-
-function JQuery_Event() {
-    function call_signature() {
-        // $ExpectType Event<HTMLElement, null> & Coordinates
-        $.Event('keydown', $('p').offset());
-
-        // $ExpectType Event<HTMLElement, null> & { type: string; }
-        $.Event({
-            type: 'keydown'
-        });
-    }
-
-    function constructor() {
-        // $ExpectType Event<HTMLElement, null> & Coordinates
-        new $.Event('keydown', $('p').offset());
-
-        // $ExpectType Event<HTMLElement, null> & { type: string; }
-        new $.Event({
-            type: 'keydown'
-        });
-    }
-
-    // https://stackoverflow.com/questions/49892574/trigger-a-jquery-3-event-with-ctrlkey-set
-    function stackoverflow_49892574() {
-        const event = $.Event<object, Window>("keydown");
-        event.which = 77;
-        event.ctrlKey = true;
-        $(window).trigger(event);
-    }
-}
-
 function JQuery_jqXHR() {
     const p: JQuery.jqXHR = {} as any;
 
@@ -7165,6 +6956,94 @@ function JQuery_jqXHR() {
 
     function compatibleWithJQueryPromise(): JQuery.Promise<any> {
         return p;
+    }
+}
+
+function JQuery_CallbacksStatic() {
+    // $ExpectType Callbacks<Function>
+    $.Callbacks('once');
+
+    // $ExpectType Callbacks<Function>
+    $.Callbacks();
+}
+
+function JQuery_Callbacks() {
+    function add() {
+        const callbacks = $.Callbacks();
+
+        // $ExpectType Callbacks<Function>
+        callbacks.add(() => { }, [() => { }], () => { });
+
+        // $ExpectType Callbacks<Function>
+        callbacks.add(() => { }, [() => { }]);
+
+        // $ExpectType Callbacks<Function>
+        callbacks.add(() => { }, () => { });
+
+        // $ExpectType Callbacks<Function>
+        callbacks.add(() => { });
+
+        // $ExpectType Callbacks<Function>
+        callbacks.add([() => { }]);
+    }
+
+    function disable() {
+        // $ExpectType Callbacks<Function>
+        $.Callbacks().disable();
+    }
+
+    function disabled() {
+        // $ExpectType boolean
+        $.Callbacks().disabled();
+    }
+
+    function empty() {
+        // $ExpectType Callbacks<Function>
+        $.Callbacks().empty();
+    }
+
+    function fire() {
+        // $ExpectType Callbacks<Function>
+        $.Callbacks().fire(1);
+
+        // $ExpectType Callbacks<Function>
+        $.Callbacks().fire();
+    }
+
+    function fired() {
+        // $ExpectType boolean
+        $.Callbacks().fired();
+    }
+
+    function fireWith() {
+        // $ExpectType Callbacks<Function>
+        $.Callbacks().fireWith(window, [1]);
+
+        // $ExpectType Callbacks<Function>
+        $.Callbacks().fireWith(window);
+    }
+
+    function has() {
+        // $ExpectType boolean
+        $.Callbacks().has(() => { });
+
+        // $ExpectType boolean
+        $.Callbacks().has();
+    }
+
+    function lock() {
+        // $ExpectType Callbacks<Function>
+        $.Callbacks().lock();
+    }
+
+    function locked() {
+        // $ExpectType boolean
+        $.Callbacks().locked();
+    }
+
+    function remove() {
+        // $ExpectType Callbacks<Function>
+        $.Callbacks().remove(() => { }, () => { });
     }
 }
 
@@ -7919,5 +7798,126 @@ function JQuery_Deferred() {
         d1.promise(target); // $ExpectType Promise<I1, I2, I3> & I1
 
         d1.promise(); // $ExpectType Promise<I1, I2, I3>
+    }
+}
+
+function JQuery_Effects() {
+    function interval() {
+        // $ExpectType number
+        $.fx.interval;
+    }
+
+    function off() {
+        // $ExpectType boolean
+        $.fx.off;
+    }
+
+    function step() {
+        // $ExpectType PlainObject<AnimationHook<Node>>
+        $.fx.step;
+    }
+}
+
+function JQuery_EffectsOptions() {
+    $('p').show({
+        always(animation, jumpToEnd) {
+            // $ExpectType HTMLElement
+            this;
+            // $ExpectType Promise<any, any, any>
+            animation;
+            // $ExpectType boolean
+            jumpToEnd;
+        },
+        complete() {
+            // $ExpectType HTMLElement
+            this;
+        },
+        done(animation, jumpToEnd) {
+            // $ExpectType HTMLElement
+            this;
+            // $ExpectType Promise<any, any, any>
+            animation;
+            // $ExpectType boolean
+            jumpToEnd;
+        },
+        duration: 5000,
+        easing: 'linear',
+        fail(animation, jumpToEnd) {
+            // $ExpectType HTMLElement
+            this;
+            // $ExpectType Promise<any, any, any>
+            animation;
+            // $ExpectType boolean
+            jumpToEnd;
+        },
+        progress(animation, progress, remainingMs) {
+            // $ExpectType HTMLElement
+            this;
+            // $ExpectType Promise<any, any, any>
+            animation;
+            // $ExpectType number
+            progress;
+            // $ExpectType number
+            remainingMs;
+        },
+        queue: true,
+        specialEasing: {
+            width: 'linear',
+            height: 'easeOutBounce'
+        },
+        start(animation) {
+            // $ExpectType HTMLElement
+            this;
+            // $ExpectType Promise<any, any, any>
+            animation;
+        },
+        step(now, tween) {
+            // $ExpectType HTMLElement
+            this;
+            // $ExpectType number
+            now;
+            // $ExpectType Tween<HTMLElement>
+            tween;
+        }
+    });
+}
+
+function JQuery_Easings() {
+    jQuery.easing.easeInCubic = (p: number, t: number, b: number, c: number, d: number) => {
+        return c * (t /= d) * t * t + b;
+    };
+
+    jQuery.easing.easeInCubic = (p: number) => {
+        return Math.pow(p, 3);
+    };
+}
+
+function JQuery_Event() {
+    function call_signature() {
+        // $ExpectType Event<HTMLElement, null> & Coordinates
+        $.Event('keydown', $('p').offset());
+
+        // $ExpectType Event<HTMLElement, null> & { type: string; }
+        $.Event({
+            type: 'keydown'
+        });
+    }
+
+    function constructor() {
+        // $ExpectType Event<HTMLElement, null> & Coordinates
+        new $.Event('keydown', $('p').offset());
+
+        // $ExpectType Event<HTMLElement, null> & { type: string; }
+        new $.Event({
+            type: 'keydown'
+        });
+    }
+
+    // https://stackoverflow.com/questions/49892574/trigger-a-jquery-3-event-with-ctrlkey-set
+    function stackoverflow_49892574() {
+        const event = $.Event<object, Window>("keydown");
+        event.which = 77;
+        event.ctrlKey = true;
+        $(window).trigger(event);
     }
 }

--- a/types/jquery/jquery-tests.ts
+++ b/types/jquery/jquery-tests.ts
@@ -273,6 +273,13 @@ function JQueryStatic() {
         $.camelCase('foo-bar');
     }
 
+    function cleanData() {
+        const elems: ArrayLike<Element | Document | Window | JQuery.PlainObject> = {} as any;
+
+        // $ExpectType void
+        $.cleanData(elems);
+    }
+
     function contains() {
         // $ExpectType boolean
         $.contains(new HTMLElement(), new HTMLElement());

--- a/types/jquery/jquery-tests.ts
+++ b/types/jquery/jquery-tests.ts
@@ -175,55 +175,8 @@ function JQueryStatic() {
     }
 
     function Deferred() {
-        function call_signature() {
-            // $ExpectType Deferred<boolean, string, number>
-            $.Deferred<boolean, string, number>(function(deferred) {
-                // $ExpectType Deferred<boolean, string, number>
-                this;
-                // $ExpectType Deferred<boolean, string, number>
-                deferred;
-            });
-
-            // $ExpectType Deferred<boolean, string, number>
-            $.Deferred<boolean, string, number>();
-
-            // $ExpectType Deferred<boolean, string, any>
-            $.Deferred<boolean, string>(function(deferred) {
-                // $ExpectType Deferred<boolean, string, any>
-                this;
-                // $ExpectType Deferred<boolean, string, any>
-                deferred;
-            });
-
-            // $ExpectType Deferred<boolean, string, any>
-            $.Deferred<boolean, string>();
-
-            // $ExpectType Deferred<boolean, any, any>
-            $.Deferred<boolean>(function(deferred) {
-                // $ExpectType Deferred<boolean, any, any>
-                this;
-                // $ExpectType Deferred<boolean, any, any>
-                deferred;
-            });
-
-            // $ExpectType Deferred<boolean, any, any>
-            $.Deferred<boolean>();
-
-            // $ExpectType Deferred<any, any, any>
-            $.Deferred(function(deferred) {
-                // $ExpectType Deferred<any, any, any>
-                this;
-                // $ExpectType Deferred<any, any, any>
-                deferred;
-            });
-
-            // $ExpectType Deferred<any, any, any>
-            $.Deferred();
-        }
-
-        function exceptionHook() {
-            $.Deferred.exceptionHook = undefined;
-        }
+        // $ExpectType DeferredStatic
+        $.Deferred;
     }
 
     function ajax() {
@@ -7893,6 +7846,58 @@ function JQuery_Promise(p: JQuery.Promise<string, Error, number>) {
 
     function compatibleWithPromise(): Promise<any> {
         return p;
+    }
+}
+
+function JQuery_DeferredStatic() {
+    function exceptionHook() {
+        $.Deferred.exceptionHook = undefined;
+    }
+
+    function call_signature() {
+        // $ExpectType Deferred<boolean, string, number>
+        $.Deferred<boolean, string, number>(function (deferred) {
+            // $ExpectType Deferred<boolean, string, number>
+            this;
+            // $ExpectType Deferred<boolean, string, number>
+            deferred;
+        });
+
+        // $ExpectType Deferred<boolean, string, number>
+        $.Deferred<boolean, string, number>();
+
+        // $ExpectType Deferred<boolean, string, any>
+        $.Deferred<boolean, string>(function (deferred) {
+            // $ExpectType Deferred<boolean, string, any>
+            this;
+            // $ExpectType Deferred<boolean, string, any>
+            deferred;
+        });
+
+        // $ExpectType Deferred<boolean, string, any>
+        $.Deferred<boolean, string>();
+
+        // $ExpectType Deferred<boolean, any, any>
+        $.Deferred<boolean>(function (deferred) {
+            // $ExpectType Deferred<boolean, any, any>
+            this;
+            // $ExpectType Deferred<boolean, any, any>
+            deferred;
+        });
+
+        // $ExpectType Deferred<boolean, any, any>
+        $.Deferred<boolean>();
+
+        // $ExpectType Deferred<any, any, any>
+        $.Deferred(function (deferred) {
+            // $ExpectType Deferred<any, any, any>
+            this;
+            // $ExpectType Deferred<any, any, any>
+            deferred;
+        });
+
+        // $ExpectType Deferred<any, any, any>
+        $.Deferred();
     }
 }
 

--- a/types/jquery/jquery-tests.ts
+++ b/types/jquery/jquery-tests.ts
@@ -576,6 +576,11 @@ function JQueryStatic() {
             // $ExpectType jqXHR<string | undefined>
             jqXHR;
         });
+
+        // $ExpectType jqXHR<string | undefined>
+        $.getScript({
+            url: 'url',
+        });
     }
 
     function globalEval() {

--- a/types/jquery/jquery-tests.ts
+++ b/types/jquery/jquery-tests.ts
@@ -284,21 +284,23 @@ function JQueryStatic() {
     }
 
     function data() {
+        const element: Element | Document | Window | JQuery.PlainObject = {} as any;
+
         const value: string | undefined = {} as any;
         // $ExpectError
-        $.data(new HTMLElement(), 'myKey', value);
+        $.data(element, 'myKey', value);
 
         // $ExpectType "myValue"
-        $.data(new HTMLElement(), 'myKey', 'myValue');
+        $.data(element, 'myKey', 'myValue');
 
         // $ExpectType any
-        $.data(new HTMLElement(), 'myKey', undefined);
+        $.data(element, 'myKey', undefined);
 
         // $ExpectType any
-        $.data(new HTMLElement(), 'myKey');
+        $.data(element, 'myKey');
 
         // $ExpectType any
-        $.data(new HTMLElement());
+        $.data(element);
     }
 
     function dequeue() {
@@ -611,8 +613,10 @@ function JQueryStatic() {
     }
 
     function hasData() {
+        const element: Element | Document | Window | JQuery.PlainObject = {} as any;
+
         // $ExpectType boolean
-        $.hasData(new HTMLElement());
+        $.hasData(element);
     }
 
     function holdReady() {
@@ -1731,11 +1735,13 @@ function JQueryStatic() {
     }
 
     function removeData() {
-        // $ExpectType void
-        $.removeData(new HTMLElement(), 'test1');
+        const element: Element | Document | Window | JQuery.PlainObject = {} as any;
 
         // $ExpectType void
-        $.removeData(new HTMLElement());
+        $.removeData(element, 'test1');
+
+        // $ExpectType void
+        $.removeData(element);
     }
 
     function speed() {

--- a/types/jquery/jquery-tests.ts
+++ b/types/jquery/jquery-tests.ts
@@ -167,11 +167,8 @@ function JQueryStatic() {
     }
 
     function Callbacks() {
-        // $ExpectType Callbacks<Function>
-        $.Callbacks('once');
-
-        // $ExpectType Callbacks<Function>
-        $.Callbacks();
+        // $ExpectType CallbacksStatic
+        $.Callbacks;
     }
 
     function Deferred() {
@@ -6694,6 +6691,14 @@ function JQuery_AjaxSettings() {
     });
 }
 
+function JQuery_CallbacksStatic() {
+    // $ExpectType Callbacks<Function>
+    $.Callbacks('once');
+
+    // $ExpectType Callbacks<Function>
+    $.Callbacks();
+}
+
 function JQuery_Callbacks() {
     function add() {
         const callbacks = $.Callbacks();
@@ -7856,7 +7861,7 @@ function JQuery_DeferredStatic() {
 
     function call_signature() {
         // $ExpectType Deferred<boolean, string, number>
-        $.Deferred<boolean, string, number>(function (deferred) {
+        $.Deferred<boolean, string, number>(function(deferred) {
             // $ExpectType Deferred<boolean, string, number>
             this;
             // $ExpectType Deferred<boolean, string, number>
@@ -7867,7 +7872,7 @@ function JQuery_DeferredStatic() {
         $.Deferred<boolean, string, number>();
 
         // $ExpectType Deferred<boolean, string, any>
-        $.Deferred<boolean, string>(function (deferred) {
+        $.Deferred<boolean, string>(function(deferred) {
             // $ExpectType Deferred<boolean, string, any>
             this;
             // $ExpectType Deferred<boolean, string, any>
@@ -7878,7 +7883,7 @@ function JQuery_DeferredStatic() {
         $.Deferred<boolean, string>();
 
         // $ExpectType Deferred<boolean, any, any>
-        $.Deferred<boolean>(function (deferred) {
+        $.Deferred<boolean>(function(deferred) {
             // $ExpectType Deferred<boolean, any, any>
             this;
             // $ExpectType Deferred<boolean, any, any>
@@ -7889,7 +7894,7 @@ function JQuery_DeferredStatic() {
         $.Deferred<boolean>();
 
         // $ExpectType Deferred<any, any, any>
-        $.Deferred(function (deferred) {
+        $.Deferred(function(deferred) {
             // $ExpectType Deferred<any, any, any>
             this;
             // $ExpectType Deferred<any, any, any>


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- ~~Provide a URL to documentation or source code which provides context for the suggested changes:~~
- ~~Increase the version number in the header if appropriate.~~
- ~~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.~~

---

#### Summary of changes

##### Reduce examples to only those relevant to the overload and use shorter template for code-only examples. (57202ba / 5d46054 / 861831c / e349a3b / f02ab1e)

Previously, all examples for all overloads of a method were shown for every overload of that method. Now, only relevant examples for each overload are shown. Also, code-only examples now use a much shorter template. This should improve the experience for consumers through less noise. These changes also takes `index.d.ts` back under 1 MB which re-enables GitHub features for it (e.g. syntax highlighting and linking to specific lines).

##### Minor changes (a8b6588 / 371a701 / ea00476)

These changes are for consistency and should have no impact on existing code.

* Add interface for `jQuery.fx`.
* Add interface for `jQuery.Callbacks`.
* Apply consistent ordering.

##### Documentation fixes (8686d9f / 8310859)

The documentation for `jQuery.Deferred` was incorrectly attached to its property instead of its call signature. This PR fixes it so that the correct documentation is displayed when using the call signature.

Also fixes documentation for an overload of `jQuery.proxy` that had incorrect `@since` tags and an errant `` ` ``.

##### Add `jQuery.getScript(options)`. (78fb12a)

See https://github.com/jquery/api.jquery.com/issues/1052.

##### Accept `Document`, `Window`, and `JQuery.PlainObject` for the `element` parameter of Data APIs. (cf0be56)

See https://github.com/jquery/jquery/blob/354f6036f251a3ce9b24cd7b228b4c7a79001520/test/unit/data.js#L142-L164 and jquery/api.jquery.com#1035.

##### Add `jQuery.cleanData`. (39bfedc)

See jquery/api.jquery.com#996.