### PR TITLE
Add types for express-sitemap-xml

### DIFF
--- a/types/express-sitemap-xml/express-sitemap-xml-tests.ts
+++ b/types/express-sitemap-xml/express-sitemap-xml-tests.ts
@@ -1,0 +1,16 @@
+import * as express from 'express';
+
+import expressSitemapXml from 'express-sitemap-xml';
+
+const urls = ['/page1', '/page2'];
+const base = 'http://example.com';
+const getUrls = () => urls;
+const getUrlsPromise = () => Promise.resolve(urls);
+
+expressSitemapXml.buildSitemaps(urls, base).then(sitemap => typeof sitemap === 'object');
+
+const sitemap1 = expressSitemapXml(getUrls, base);
+const sitemap2 = expressSitemapXml(getUrlsPromise, base);
+
+express().use(sitemap1);
+express().use(sitemap2);

--- a/types/express-sitemap-xml/index.d.ts
+++ b/types/express-sitemap-xml/index.d.ts
@@ -1,0 +1,19 @@
+// Type definitions for express-sitemap-xml 1.0
+// Project: https://github.com/feross/express-sitemap-xml
+// Definitions by: Florian Keller <https://github.com/ffflorian>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.2
+
+import * as express from 'express';
+
+export interface Sitemap {
+    [url: string]: string;
+}
+
+declare function expressSitemapXml(getUrls: (() => (string[] | Promise<string[]>)), base: string): express.RequestHandler;
+
+declare namespace expressSitemapXml {
+    function buildSitemaps(urls: string[], base: string): Promise<Sitemap>;
+}
+
+export default expressSitemapXml;

--- a/types/express-sitemap-xml/tsconfig.json
+++ b/types/express-sitemap-xml/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "express-sitemap-xml-tests.ts"
+    ]
+}

--- a/types/express-sitemap-xml/tslint.json
+++ b/types/express-sitemap-xml/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
