### PR TITLE
[jest] Add expand property on MatcherUtils

### DIFF
--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -317,6 +317,7 @@ declare namespace jest {
     }
 
     interface MatcherUtils {
+        readonly expand: boolean;
         readonly isNot: boolean;
         utils: {
             readonly EXPECTED_COLOR: (text: string) => string;

--- a/types/jest/jest-tests.ts
+++ b/types/jest/jest-tests.ts
@@ -444,6 +444,7 @@ expect.extend({
 expect.extend({
     foo(this: jest.MatcherUtils) {
         const isNot: boolean = this.isNot;
+        const expand: boolean = this.expand;
 
         const expectedColor = this.utils.EXPECTED_COLOR("blue");
         const receivedColor = this.utils.EXPECTED_COLOR("red");


### PR DESCRIPTION
Closes https://github.com/DefinitelyTyped/DefinitelyTyped/issues/29574 (via https://github.com/facebook/jest/issues/7091)

Apparently, `this.expand` should be a boolean when called within a matcher:

```js
expect.extend({
  toBe(received, actual) {
    console.log({ expand: this.expand });
    return { pass: true, message: () => '' };
  },
});
```

```
  console.log src/__tests__/index.js:3
    { expand: false }
```

- https://jestjs.io/docs/en/expect#custom-matchers-api
- https://github.com/facebook/jest/blob/ec382f527e75e0d6932e3e3954187d8a4d6c6240/packages/jest-jasmine2/src/jest_expect.js#L30
- https://github.com/facebook/jest/issues/7091
- https://github.com/facebook/jest/issues/7091#issuecomment-426685869