### PR TITLE
Changed PlotMouseEvent to work for all chart types (not just scatter plots)

### DIFF
--- a/types/plotly.js/index.d.ts
+++ b/types/plotly.js/index.d.ts
@@ -39,8 +39,19 @@ export interface PlotScatterDataPoint {
 	yaxis: LayoutAxis;
 }
 
+export interface PlotDatum {
+	curveNumber: number;
+	data: PlotData;
+	pointIndex: number;
+	pointNumber: number;
+	x: Datum;
+	xaxis: LayoutAxis;
+	y: Datum;
+	yaxis: LayoutAxis;
+}
+
 export interface PlotMouseEvent {
-	points: PlotScatterDataPoint[];
+	points: PlotDatum[];
 	event: MouseEvent;
 }
 
@@ -55,10 +66,10 @@ export interface SelectionRange {
 	y: number[];
 }
 
-export type PlotSelectedData = Partial<PlotScatterDataPoint>;
+export type PlotSelectedData = Partial<PlotDatum>;
 
 export interface PlotSelectionEvent {
-	points: PlotScatterDataPoint[];
+	points: PlotDatum[];
 	range?: SelectionRange;
 	lassoPoints?: SelectionRange;
 }

--- a/types/plotly.js/test/core-tests.ts
+++ b/types/plotly.js/test/core-tests.ts
@@ -1,5 +1,5 @@
 import * as Plotly from 'plotly.js/lib/core';
-import { ScatterData, Layout, PlotlyHTMLElement, newPlot } from 'plotly.js/lib/core';
+import { Datum, ScatterData, Layout, PlotlyHTMLElement, newPlot } from 'plotly.js/lib/core';
 
 const graphDiv = '#test';
 
@@ -336,8 +336,8 @@ function rand() {
 	});
 
 	myPlot.on('plotly_selected', (data) => {
-		const x = [] as number[];
-		const y = [] as number[];
+		const x = [] as Datum[];
+		const y = [] as Datum[];
 		const N = 1000;
 		const color1 = '#7b3294';
 		const color1Light = '#c2a5cf';

--- a/types/plotly.js/test/index-tests.ts
+++ b/types/plotly.js/test/index-tests.ts
@@ -1,5 +1,5 @@
 import * as Plotly from 'plotly.js';
-import { Layout, PlotData, PlotlyHTMLElement, newPlot } from 'plotly.js';
+import { Datum, Layout, PlotData, PlotlyHTMLElement, newPlot } from 'plotly.js';
 
 const graphDiv = '#test';
 
@@ -446,8 +446,8 @@ function rand() {
 	});
 
 	myPlot.on('plotly_selected', (data) => {
-		const x = [] as number[];
-		const y = [] as number[];
+		const x = [] as Datum[];
+		const y = [] as Datum[];
 		const N = 1000;
 		const color1 = '#7b3294';
 		const color1Light = '#c2a5cf';


### PR DESCRIPTION
This is to fix the issue that click events can be for any type of chart, and therefore `x` and `y` can be any type of data instead of just a number. This isn't a breaking change, `PlotScatterDataPoint` still exists, but I created and use the new interface `PlotDatum` instead of just changing the attributes in `PlotScatterDataPoint` since the `points` returned from events are from any chart type.  

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://plot.ly/javascript/reference/#bar>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

