### PR TITLE
Fix PluginStates in @types/hapi

### DIFF
--- a/types/hapi/index.d.ts
+++ b/types/hapi/index.d.ts
@@ -75,8 +75,8 @@ export interface PluginRegistered {
     options: object;
 }
 
-/* tslint:disable-next-line:no-empty-interface */
 export interface PluginsStates {
+    [pluginName: string]: any;
 }
 
 /* tslint:disable-next-line:no-empty-interface */


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://hapijs.com/api#-requestplugins
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

I was trying to upgrade hapi from 16.x.x to 17.6.0 and also use the latest version of `@types/hapi` (17.6.1 as of this writing(, and I ran into a problem involving custom `hapi` server plugins with that would yield the following error message:

`Property name 'ittehbittehkittehcommitteh' does not exist on type 'PluginsStates'`

I can see that it exists on the v16 version here: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/hapi/v16/index.d.ts#L2653 , so I'm a bit puzzled as to why it no longer exists in v17. I can see in the `hapi` documentation  (https://hapijs.com/api#-requestplugins) that `request/plugins` still has read/write access, so it is not that.

Consequently, I'm putting up this PR for review.