### PR TITLE
[reactstrap] Fixed the error that was preventing from extending the Button component with custom props

### DIFF
--- a/types/reactstrap/lib/Button.d.ts
+++ b/types/reactstrap/lib/Button.d.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { CSSModule } from '../index';
 
-export type ButtonProps<T = {}> = React.HTMLProps<HTMLButtonElement> & {
+export type ButtonProps<T = {}> = React.AllHTMLAttributes<HTMLButtonElement> & {
   outline?: boolean;
   active?: boolean;
   block?: boolean;

--- a/types/reactstrap/lib/Button.d.ts
+++ b/types/reactstrap/lib/Button.d.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { CSSModule } from '../index';
 
-export type ButtonProps<T = {}> = React.AllHTMLAttributes<HTMLButtonElement> & {
+export type ButtonProps<T = {}> = React.ButtonHTMLAttributes<HTMLButtonElement> & {
   outline?: boolean;
   active?: boolean;
   block?: boolean;

--- a/types/reactstrap/reactstrap-tests.tsx
+++ b/types/reactstrap/reactstrap-tests.tsx
@@ -278,6 +278,11 @@ const Example13 = (
   </div>
 );
 
+interface CustomButtonProps extends ButtonProps {
+  customProp: string;
+}
+const CustomButton: React.SFC<CustomButtonProps> = props => <Button {...props} />;
+
 class Example14 extends React.Component<any, any> {
   state: any;
   constructor(props: any) {
@@ -3759,7 +3764,7 @@ import { default as Alert_ } from './lib/Alert'; /* tslint:disable-line: no-rela
 import { default as Badge_ } from './lib/Badge'; /* tslint:disable-line: no-relative-import-in-test */
 import { default as Breadcrumb_ } from './lib/Breadcrumb'; /* tslint:disable-line: no-relative-import-in-test */
 import { default as BreadcrumbItem_ } from './lib/BreadcrumbItem'; /* tslint:disable-line: no-relative-import-in-test */
-import { default as Button_ } from './lib/Button'; /* tslint:disable-line: no-relative-import-in-test */
+import { default as Button_, ButtonProps } from './lib/Button'; /* tslint:disable-line: no-relative-import-in-test */
 import { default as ButtonDropdown_ } from './lib/ButtonDropdown'; /* tslint:disable-line: no-relative-import-in-test */
 import { default as ButtonGroup_ } from './lib/ButtonGroup'; /* tslint:disable-line: no-relative-import-in-test */
 import { default as ButtonToolbar_ } from './lib/ButtonToolbar'; /* tslint:disable-line: no-relative-import-in-test */


### PR DESCRIPTION
Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [StackOverflow bug/solution](https://stackoverflow.com/questions/52728722/buttonprops-from-the-package-is-incompatible-with-button-component-from-the-pack)
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
