### PR TITLE
node: setImmediate returns Immediate

### DIFF
--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -211,12 +211,12 @@ declare namespace setTimeout {
 declare function clearTimeout(timeoutId: NodeJS.Timer): void;
 declare function setInterval(callback: (...args: any[]) => void, ms: number, ...args: any[]): NodeJS.Timer;
 declare function clearInterval(intervalId: NodeJS.Timer): void;
-declare function setImmediate(callback: (...args: any[]) => void, ...args: any[]): any;
+declare function setImmediate(callback: (...args: any[]) => void, ...args: any[]): NodeJS.Immediate;
 declare namespace setImmediate {
     function __promisify__(): Promise<void>;
     function __promisify__<T>(value: T): Promise<T>;
 }
-declare function clearImmediate(immediateId: any): void;
+declare function clearImmediate(immediateId: NodeJS.Immediate): void;
 
 // TODO: change to `type NodeRequireFunction = (id: string) => any;` in next mayor version.
 interface NodeRequireFunction {
@@ -955,7 +955,7 @@ declare namespace NodeJS {
         Uint8ClampedArray: Function;
         WeakMap: WeakMapConstructor;
         WeakSet: WeakSetConstructor;
-        clearImmediate: (immediateId: any) => void;
+        clearImmediate: (immediateId: Immediate) => void;
         clearInterval: (intervalId: Timer) => void;
         clearTimeout: (timeoutId: Timer) => void;
         console: typeof console;
@@ -972,13 +972,18 @@ declare namespace NodeJS {
         parseInt: typeof parseInt;
         process: Process;
         root: Global;
-        setImmediate: (callback: (...args: any[]) => void, ...args: any[]) => any;
+        setImmediate: (callback: (...args: any[]) => void, ...args: any[]) => Immediate;
         setInterval: (callback: (...args: any[]) => void, ms: number, ...args: any[]) => Timer;
         setTimeout: (callback: (...args: any[]) => void, ms: number, ...args: any[]) => Timer;
         undefined: typeof undefined;
         unescape: (str: string) => string;
         gc: () => void;
         v8debug?: any;
+    }
+
+    interface Immediate {
+        ref(): void;
+        unref(): void;
     }
 
     interface Timer {
@@ -7215,12 +7220,12 @@ declare module "timers" {
     function clearTimeout(timeoutId: NodeJS.Timer): void;
     function setInterval(callback: (...args: any[]) => void, ms: number, ...args: any[]): NodeJS.Timer;
     function clearInterval(intervalId: NodeJS.Timer): void;
-    function setImmediate(callback: (...args: any[]) => void, ...args: any[]): any;
+    function setImmediate(callback: (...args: any[]) => void, ...args: any[]): NodeJS.Immediate;
     namespace setImmediate {
         function __promisify__(): Promise<void>;
         function __promisify__<T>(value: T): Promise<T>;
     }
-    function clearImmediate(immediateId: any): void;
+    function clearImmediate(immediateId: NodeJS.Immediate): void;
 }
 
 declare module "console" {

--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -983,20 +983,20 @@ declare namespace NodeJS {
 
     interface Timer {
         ref(): void;
+        refresh(): void;
         unref(): void;
     }
 
-    class Immediate implements Timer {
+    class Immediate {
         ref(): void;
         unref(): void;
-        _onImmediate: Function;
+        _onImmediate: Function; // to distinguish it from the Timeout class
     }
 
     class Timeout implements Timer {
         ref(): void;
         refresh(): void;
         unref(): void;
-        _onTimeout: Function;
     }
 
     class Module {

--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -956,8 +956,8 @@ declare namespace NodeJS {
         WeakMap: WeakMapConstructor;
         WeakSet: WeakSetConstructor;
         clearImmediate: (immediateId: Immediate) => void;
-        clearInterval: (intervalId: Timer) => void;
-        clearTimeout: (timeoutId: Timer) => void;
+        clearInterval: (intervalId: Timeout) => void;
+        clearTimeout: (timeoutId: Timeout) => void;
         console: typeof console;
         decodeURI: typeof decodeURI;
         decodeURIComponent: typeof decodeURIComponent;
@@ -973,8 +973,8 @@ declare namespace NodeJS {
         process: Process;
         root: Global;
         setImmediate: (callback: (...args: any[]) => void, ...args: any[]) => Immediate;
-        setInterval: (callback: (...args: any[]) => void, ms: number, ...args: any[]) => Timer;
-        setTimeout: (callback: (...args: any[]) => void, ms: number, ...args: any[]) => Timer;
+        setInterval: (callback: (...args: any[]) => void, ms: number, ...args: any[]) => Timeout;
+        setTimeout: (callback: (...args: any[]) => void, ms: number, ...args: any[]) => Timeout;
         undefined: typeof undefined;
         unescape: (str: string) => string;
         gc: () => void;

--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -203,14 +203,14 @@ declare var console: Console;
 declare var __filename: string;
 declare var __dirname: string;
 
-declare function setTimeout(callback: (...args: any[]) => void, ms: number, ...args: any[]): NodeJS.Timer;
+declare function setTimeout(callback: (...args: any[]) => void, ms: number, ...args: any[]): NodeJS.Timeout;
 declare namespace setTimeout {
     function __promisify__(ms: number): Promise<void>;
     function __promisify__<T>(ms: number, value: T): Promise<T>;
 }
-declare function clearTimeout(timeoutId: NodeJS.Timer): void;
-declare function setInterval(callback: (...args: any[]) => void, ms: number, ...args: any[]): NodeJS.Timer;
-declare function clearInterval(intervalId: NodeJS.Timer): void;
+declare function clearTimeout(timeoutId: NodeJS.Timeout): void;
+declare function setInterval(callback: (...args: any[]) => void, ms: number, ...args: any[]): NodeJS.Timeout;
+declare function clearInterval(intervalId: NodeJS.Timeout): void;
 declare function setImmediate(callback: (...args: any[]) => void, ...args: any[]): NodeJS.Immediate;
 declare namespace setImmediate {
     function __promisify__(): Promise<void>;
@@ -981,14 +981,22 @@ declare namespace NodeJS {
         v8debug?: any;
     }
 
-    interface Immediate {
+    interface Timer {
         ref(): void;
         unref(): void;
     }
 
-    interface Timer {
+    class Immediate implements Timer {
         ref(): void;
         unref(): void;
+        _onImmediate: Function;
+    }
+
+    class Timeout implements Timer {
+        ref(): void;
+        refresh(): void;
+        unref(): void;
+        _onTimeout: Function;
     }
 
     class Module {
@@ -7212,14 +7220,14 @@ declare module "v8" {
 }
 
 declare module "timers" {
-    function setTimeout(callback: (...args: any[]) => void, ms: number, ...args: any[]): NodeJS.Timer;
+    function setTimeout(callback: (...args: any[]) => void, ms: number, ...args: any[]): NodeJS.Timeout;
     namespace setTimeout {
         function __promisify__(ms: number): Promise<void>;
         function __promisify__<T>(ms: number, value: T): Promise<T>;
     }
-    function clearTimeout(timeoutId: NodeJS.Timer): void;
-    function setInterval(callback: (...args: any[]) => void, ms: number, ...args: any[]): NodeJS.Timer;
-    function clearInterval(intervalId: NodeJS.Timer): void;
+    function clearTimeout(timeoutId: NodeJS.Timeout): void;
+    function setInterval(callback: (...args: any[]) => void, ms: number, ...args: any[]): NodeJS.Timeout;
+    function clearInterval(intervalId: NodeJS.Timeout): void;
     function setImmediate(callback: (...args: any[]) => void, ...args: any[]): NodeJS.Immediate;
     namespace setImmediate {
         function __promisify__(): Promise<void>;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/api/timers.html#timers_class_immediate

Documentation says `setImmediate` returns `Immediate` class which is different than `Timeout` class. With this change ie. is not possible to define timer with `setImmediate` and cancel it with `clearTimeout`.
 