### PR TITLE
[koa-websocket] Fix to match with its implementation 

### DIFF
--- a/types/koa-websocket/index.d.ts
+++ b/types/koa-websocket/index.d.ts
@@ -13,12 +13,17 @@ import * as ws from 'ws';
 import * as http from 'http';
 import * as https from 'https';
 
+declare module "koa" {
+    interface Context {
+        websocket: ws;
+        path: string;
+    }
+}
+
 declare namespace KoaWebsocket {
     type Middleware = compose.Middleware<MiddlewareContext>;
 
     interface MiddlewareContext extends Koa.Context {
-        websocket: ws;
-        path: string;
     }
 
     class Server {

--- a/types/koa-websocket/index.d.ts
+++ b/types/koa-websocket/index.d.ts
@@ -24,10 +24,13 @@ declare namespace KoaWebsocket {
     type Middleware = compose.Middleware<MiddlewareContext>;
 
     interface MiddlewareContext extends Koa.Context {
+        // Limitation: Declaration merging cannot overwrap existing properties.
+        // That's why this property is here, not in the merged declaration above.
+        app: App;
     }
 
     class Server {
-        app: Koa;
+        app: App;
         middleware: Middleware[];
         server?: ws.Server;
 

--- a/types/koa-websocket/index.d.ts
+++ b/types/koa-websocket/index.d.ts
@@ -3,18 +3,18 @@
 // Definitions by: Maël Lavault <https://github.com/moimael>
 //                 Jaco Greeff <https://github.com/jacogr>
 //                 Martin Ždila <https://github.com/zdila>
+//                 Eunchong Yu <https://github.com/Kroisse>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
 import Koa = require('koa');
+import compose = require('koa-compose');
 import * as ws from 'ws';
 import * as http from 'http';
 import * as https from 'https';
 
 declare namespace KoaWebsocket {
-    type ConnectionHandler = (socket: ws) => void;
-
-    type Middleware = (this: MiddlewareContext, context: Koa.Context, next: () => Promise<any>) => any;
+    type Middleware = compose.Middleware<MiddlewareContext>;
 
     interface MiddlewareContext extends Koa.Context {
         websocket: ws;
@@ -23,12 +23,13 @@ declare namespace KoaWebsocket {
 
     class Server {
         app: Koa;
-        middleware: Koa.Middleware[];
+        middleware: Middleware[];
+        server?: ws.Server;
 
         constructor(app: Koa);
 
         listen(options: ws.ServerOptions): ws.Server;
-        onConnection(handler: ConnectionHandler): void;
+        onConnection(socket: ws, request: http.IncomingMessage): void;
         use(middleware: Middleware): this;
     }
 

--- a/types/koa-websocket/koa-websocket-tests.ts
+++ b/types/koa-websocket/koa-websocket-tests.ts
@@ -8,11 +8,11 @@ app.ws.use(async (ctx, next) => {
         console.log(message);
         const server = ctx.app.ws.server;
         if (server) {
-            for (const client of server.clients) {
+            server.clients.forEach(client => {
                 if (client !== ctx.websocket) {
                     client.send(message);
                 }
-            }
+            });
         }
     });
     ctx.websocket.send('Hello world');

--- a/types/koa-websocket/koa-websocket-tests.ts
+++ b/types/koa-websocket/koa-websocket-tests.ts
@@ -3,11 +3,11 @@ import websocket = require('koa-websocket');
 
 const app = websocket(new Koa());
 
-app.ws.use(async function(context, next) {
-    this.websocket.on('message', (message) => {
+app.ws.use(async (ctx, next) => {
+    ctx.websocket.on('message', (message) => {
         console.log(message);
     });
-    this.websocket.send('Hello world');
+    ctx.websocket.send('Hello world');
     await next();
 });
 

--- a/types/koa-websocket/koa-websocket-tests.ts
+++ b/types/koa-websocket/koa-websocket-tests.ts
@@ -6,6 +6,14 @@ const app = websocket(new Koa());
 app.ws.use(async (ctx, next) => {
     ctx.websocket.on('message', (message) => {
         console.log(message);
+        const server = ctx.app.ws.server;
+        if (server) {
+            for (const client of server.clients) {
+                if (client !== ctx.websocket) {
+                    client.send(message);
+                }
+            }
+        }
     });
     ctx.websocket.send('Hello world');
     await next();

--- a/types/koa-websocket/tsconfig.json
+++ b/types/koa-websocket/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "compilerOptions": {
         "module": "commonjs",
+        "target": "es6",
         "lib": [
             "es6"
         ],

--- a/types/koa-websocket/tsconfig.json
+++ b/types/koa-websocket/tsconfig.json
@@ -1,7 +1,6 @@
 {
     "compilerOptions": {
         "module": "commonjs",
-        "target": "es6",
         "lib": [
             "es6"
         ],


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/kudos/koa-websocket/blob/5.0.1/index.js
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

Former declaration was broken on koa-websocket 5.0. Latest version of Koa framework and its components doesn't rely on `this`. Middlewares shares the request context using their first parameter `Context`.