### PR TITLE
lambda-tester: expect methods return Promise<any> 

### DIFF
--- a/types/lambda-tester/index.d.ts
+++ b/types/lambda-tester/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for lambda-tester 3.5
 // Project: https://github.com/vandium-io/lambda-tester#readme
 // Definitions by: Ivan Kerin <https://github.com/ivank>
+//                 Hajo Aho-Mantila <https://github.com/HajoAhoMantila>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -19,12 +20,12 @@ declare namespace lambdaTester {
         ): this;
         timeout(seconds: number): this;
         xray(): this;
-        expectSucceed(verifier: Verifier): this;
-        expectFail(verifier: Verifier): this;
-        expectError(verifier: Verifier): this;
-        expectResult(verifier: Verifier): this;
-        expectReject(verifier: Verifier): this;
-        expectResolve(verifier: Verifier): this;
+        expectSucceed(verifier: Verifier): Promise<any>;
+        expectFail(verifier: Verifier): Promise<any>;
+        expectError(verifier: Verifier): Promise<any>;
+        expectResult(verifier: Verifier): Promise<any>;
+        expectReject(verifier: Verifier): Promise<any>;
+        expectResolve(verifier: Verifier): Promise<any>;
     }
 }
 

--- a/types/lambda-tester/lambda-tester-tests.ts
+++ b/types/lambda-tester/lambda-tester-tests.ts
@@ -12,27 +12,35 @@ interface TError {
     message: string;
 }
 
-lambdaTester(handler)
-    .event({ test: "123" })
+function lambdaTesterInstance() {
+    return lambdaTester(handler).event({ test: "123" });
+}
+
+lambdaTesterInstance()
     .context(context)
     .clientContext(clientContext)
     .xray()
     .identity("123", "123")
     .expectSucceed((result: TResult) => {
         const t: string = result.data;
-    })
-    .expectFail((error: TError) => {
-        const t: string = error.message;
-    })
-    .expectResolve((result: TResult) => {
-        const t: string = result.data;
-    })
-    .expectReject((error: TError) => {
-        const t: string = error.message;
-    })
-    .expectResult((result: TResult) => {
-        const t: string = result.data;
-    })
-    .expectError((error: TError) => {
-        const t: string = error.message;
     });
+
+lambdaTesterInstance().expectFail((error: TError) => {
+    const t: string = error.message;
+});
+
+lambdaTesterInstance().expectResolve((result: TResult) => {
+    const t: string = result.data;
+});
+
+lambdaTesterInstance().expectReject((error: TError) => {
+    const t: string = error.message;
+});
+
+lambdaTesterInstance().expectResult((result: TResult) => {
+    const t: string = result.data;
+});
+
+lambdaTesterInstance().expectError((error: TError) => {
+    const t: string = error.message;
+});


### PR DESCRIPTION
lambda-tester: fixed return type of expect/assertion methods which return Promises (compare https://github.com/vandium-io/lambda-tester/tree/master/docs). @ivank FYI.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

