### PR TITLE
Fix react router static router context bug

### DIFF
--- a/types/react-router/index.d.ts
+++ b/types/react-router/index.d.ts
@@ -88,7 +88,7 @@ export interface RouterProps {
 }
 export class Router extends React.Component<RouterProps, any> { }
 
-export interface StaticRouterContext {
+export interface StaticRouterContext extends StaticContext {
   url?: string;
   action?: 'PUSH' | 'REPLACE';
   location?: object;

--- a/types/react-router/test/examples-from-react-router-website/StaticRouter.tsx
+++ b/types/react-router/test/examples-from-react-router-website/StaticRouter.tsx
@@ -1,10 +1,8 @@
 import * as React from 'react';
+import * as express from 'express';
+import { renderToString } from 'react-dom/server';
 import { StaticRouter, Route } from 'react-router-dom';
-import { StaticRouterContext } from 'react-router';
-
-interface StaticContext extends StaticRouterContext {
-    statusCode?: number;
-}
+import { StaticContext, StaticRouterContext } from 'react-router';
 
 interface RouteStatusProps {
     statusCode: number;
@@ -12,9 +10,9 @@ interface RouteStatusProps {
 
 const RouteStatus: React.SFC<RouteStatusProps> = (props) => (
     <Route
-        render={({ staticContext }) => {
+        render={({ staticContext }: {staticContext?: StaticContext}) => {
             if (staticContext) {
-                (staticContext as StaticContext).statusCode = props.statusCode;
+                staticContext.statusCode = props.statusCode;
             }
 
             return (
@@ -37,7 +35,7 @@ const PrintContext: React.SFC<PrintContextProps> = (props) => (
 );
 
 class StaticRouterExample extends React.Component {
-    staticContext: StaticContext = {};
+    staticContext: StaticRouterContext = {};
 
     render() {
         return (
@@ -52,5 +50,19 @@ class StaticRouterExample extends React.Component {
         );
     }
 }
+
+const app = express();
+
+app.get('*', (req, res) => {
+    const staticContext: StaticRouterContext = {};
+
+    const html = renderToString(
+        <StaticRouter location={req.url} context={staticContext}>
+            (includes the RouteStatus component below e.g. for 404 errors)
+        </StaticRouter>
+    );
+
+    res.status(staticContext.statusCode || 200).send(html);
+});
 
 export default StaticRouterExample;


### PR DESCRIPTION
PR #26541 introduced a bug that wasn't caught by the tests because the tests didn't actually use the types they were supposed to, and instead just made their own.

This is because the class `StaticRouterContext` also needs to include everything in `StaticContext`, since the only reason you would use the `context` object is if you wanted to do something in the `StaticRouterContext`, such as setting error codes for SSR applications.

I'm also unsure how to handle one issue: the `StaticContext` object type is currently limited to one key, `statusCode`, but according to the documentation there is no such restriction on this object. This is an object to store whatever data the user wants. That being said, the only use I've seen for it is with a status code for SSR, so I think it's fine to leave it.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://reacttraining.com/react-router/web/example/static-router
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
