### PR TITLE
browser.(contextMenus|menus).onShown::info.mediaType is optional

### DIFF
--- a/types/firefox-webext-browser/index.d.ts
+++ b/types/firefox-webext-browser/index.d.ts
@@ -5890,7 +5890,7 @@ declare namespace browser.contextMenus {
         /** A list of all contexts that apply to the menu. */
         contexts: ContextType[];
         editable: boolean;
-        mediaType: string;
+        mediaType?: string;
         linkUrl?: string;
         linkText?: string;
         srcUrl?: string;
@@ -6131,7 +6131,7 @@ declare namespace browser.menus {
         /** A list of all contexts that apply to the menu. */
         contexts: ContextType[];
         editable: boolean;
-        mediaType: string;
+        mediaType?: string;
         linkUrl?: string;
         linkText?: string;
         srcUrl?: string;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
No test needed
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
Changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
Noticed thanks to DefinitelyTyped/DefinitelyTyped#29523
Fixed in generator at: https://github.com/jsmnbom/definitelytyped-firefox-webext-browser/commit/642693637921a5d7c432b015d59013c8aba6aa22
MDN backs up that it should be optional: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/menus/onShown#Parameters which links to https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/menus/OnClickData#Type
- [x] Increase the version number in the header if appropriate.
Not appropriate
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
Already exists