### PR TITLE
[stellar-sdk]: Fix AccountRecord.data and add data_attr

### DIFF
--- a/types/stellar-sdk/index.d.ts
+++ b/types/stellar-sdk/index.d.ts
@@ -895,6 +895,7 @@ export namespace xdr {
         static fromXDR(xdr: Buffer): XDRStruct;
 
         toXDR(): Buffer;
+        toXDR(encoding: string): string;
     }
     class Operation<T extends Operation.Operation> extends XDRStruct { }
     class Asset extends XDRStruct { }

--- a/types/stellar-sdk/index.d.ts
+++ b/types/stellar-sdk/index.d.ts
@@ -10,7 +10,7 @@
 /// <reference types="node" />
 
 export class Account {
-    constructor(accountId: string, sequence: string | number)
+    constructor(accountId: string, sequence: string)
     accountId(): string;
     sequenceNumber(): string;
     incrementSequenceNumber(): void;
@@ -98,10 +98,10 @@ export interface AccountRecord extends Record {
         weight: number
     }
     >;
-    data: {
+    data: (options: {value: string}) => Promise<{value: string}>;
+    data_attr: {
         [key: string]: string
     };
-
     effects: CallCollectionFunction<EffectRecord>;
     offers: CallCollectionFunction<OfferRecord>;
     operations: CallCollectionFunction<OperationRecord>;
@@ -437,7 +437,8 @@ export class AccountResponse implements AccountRecord {
             weight: number
         }
         >;
-    data: {
+    data: (options: {value: string}) => Promise<{value: string}>;
+    data_attr: {
         [key: string]: string
     };
 

--- a/types/stellar-sdk/stellar-sdk-tests.ts
+++ b/types/stellar-sdk/stellar-sdk-tests.ts
@@ -2,7 +2,7 @@ import * as StellarSdk from 'stellar-sdk';
 
 const sourceKey = StellarSdk.Keypair.random(); // $ExpectType Keypair
 const destKey = StellarSdk.Keypair.random();
-const account = new StellarSdk.Account(sourceKey.publicKey(), 1);
+const account = new StellarSdk.Account(sourceKey.publicKey(), '1');
 const transaction = new StellarSdk.TransactionBuilder(account)
     .addOperation(StellarSdk.Operation.accountMerge({destination: destKey.publicKey()}))
     .addMemo(new StellarSdk.Memo(StellarSdk.MemoText, "memo"))


### PR DESCRIPTION
data is a function to call the /accounts/{id}/data/{key} endpoint, while data_attr is an object bag containing data for the account.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.stellar.org/developers/horizon/reference/endpoints/data-for-account.html
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.