### PR TITLE
[next] Add support for `next/constants`

### DIFF
--- a/types/next/constants.d.ts
+++ b/types/next/constants.d.ts
@@ -1,0 +1,23 @@
+export const PHASE_EXPORT: string;
+export const PHASE_PRODUCTION_BUILD: string;
+export const PHASE_PRODUCTION_SERVER: string;
+export const PHASE_DEVELOPMENT_SERVER: string;
+export const PAGES_MANIFEST: string;
+export const BUILD_MANIFEST: string;
+export const REACT_LOADABLE_MANIFEST: string;
+export const SERVER_DIRECTORY: string;
+export const CONFIG_FILE: string;
+export const BUILD_ID_FILE: string;
+export const BLOCKED_PAGES: string[];
+
+export const CLIENT_STATIC_FILES_PATH: string;
+export const CLIENT_STATIC_FILES_RUNTIME: string;
+export const CLIENT_STATIC_FILES_RUNTIME_PATH: string;
+/** static/runtime/main.js */
+export const CLIENT_STATIC_FILES_RUNTIME_MAIN: string;
+/** static/runtime/webpack.js */
+export const CLIENT_STATIC_FILES_RUNTIME_WEBPACK: string;
+/** matches static/<buildid>/pages/<page>.js */
+export const IS_BUNDLED_PAGE_REGEX: RegExp;
+/** matches static/<buildid>/pages/:page*.js */
+export const ROUTE_NAME_REGEX: RegExp;

--- a/types/next/test/next-constants-tests.ts
+++ b/types/next/test/next-constants-tests.ts
@@ -19,6 +19,7 @@ const config = (nextConfig: any = {}) => {
 
         webpack(config: any, options: any) {
             // do something here which only gets applied during development server phase
+
             if (typeof nextConfig.webpack === "function") {
                 return nextConfig.webpack(config, options);
             }

--- a/types/next/test/next-constants-tests.ts
+++ b/types/next/test/next-constants-tests.ts
@@ -1,0 +1,29 @@
+import {
+    PHASE_DEVELOPMENT_SERVER,
+    IS_BUNDLED_PAGE_REGEX
+} from "next/constants";
+
+const isIndexPage = IS_BUNDLED_PAGE_REGEX.test(
+    "static/CjW0mFnyG80HdP4eSUiy7/pages/index.js"
+);
+
+// Example taken from: https://github.com/cyrilwanner/next-compose-plugins/blob/a25b313899638912cc9defc0be072f4fe4a1e855/README.md
+const config = (nextConfig: any = {}) => {
+    return {
+        ...nextConfig,
+
+        // define in which phases this plugin should get applied.
+        // you can also use multiple phases or negate them.
+        // however, users can still overwrite them in their configuration if they really want to.
+        phases: [PHASE_DEVELOPMENT_SERVER],
+
+        webpack(config: any, options: any) {
+            // do something here which only gets applied during development server phase
+            if (typeof nextConfig.webpack === "function") {
+                return nextConfig.webpack(config, options);
+            }
+
+            return config;
+        }
+    };
+};

--- a/types/next/tsconfig.json
+++ b/types/next/tsconfig.json
@@ -20,6 +20,7 @@
     },
     "files": [
         "index.d.ts",
+        "constants.d.ts",
         "app.d.ts",
         "document.d.ts",
         "dynamic.d.ts",
@@ -29,6 +30,7 @@
         "router.d.ts",
         "config.d.ts",
         "test/next-tests.ts",
+        "test/next-constants-tests.ts",
         "test/next-app-tests.tsx",
         "test/next-error-tests.tsx",
         "test/next-head-tests.tsx",


### PR DESCRIPTION
Adds the exposed Next.js constants for build purposes.

Reference: https://github.com/zeit/next.js/blob/canary/packages/next-server/lib/constants.js

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/zeit/next.js/blob/canary/packages/next-server/lib/constants.js
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
