### PR TITLE
fix: express-sitemap-xml takes objects

### DIFF
--- a/types/express-sitemap-xml/express-sitemap-xml-tests.ts
+++ b/types/express-sitemap-xml/express-sitemap-xml-tests.ts
@@ -1,16 +1,22 @@
 import * as express from 'express';
 
-import expressSitemapXml from 'express-sitemap-xml';
+import expressSitemapXml, { LeafObject } from 'express-sitemap-xml';
 
-const urls = ['/page1', '/page2'];
+const page2Leaf: LeafObject = {
+    changeFreq: 'weekly',
+    lastMod: new Date(),
+    url: '/page2'
+};
+
+const leaves = ['/page1', page2Leaf];
 const base = 'http://example.com';
-const getUrls = () => urls;
-const getUrlsPromise = () => Promise.resolve(urls);
+const getLeaves = () => leaves;
+const getLeavesPromise = () => Promise.resolve(leaves);
 
-expressSitemapXml.buildSitemaps(urls, base).then(sitemap => typeof sitemap === 'object');
+expressSitemapXml.buildSitemaps(leaves, base).then(sitemap => typeof sitemap === 'object');
 
-const sitemap1 = expressSitemapXml(getUrls, base);
-const sitemap2 = expressSitemapXml(getUrlsPromise, base);
+const sitemap1 = expressSitemapXml(getLeaves, base);
+const sitemap2 = expressSitemapXml(getLeavesPromise, base);
 
 express().use(sitemap1);
 express().use(sitemap2);

--- a/types/express-sitemap-xml/index.d.ts
+++ b/types/express-sitemap-xml/index.d.ts
@@ -6,14 +6,22 @@
 
 import * as express from 'express';
 
-export interface Sitemap {
-    [url: string]: string;
+export interface LeafObject {
+    changeFreq?: string;
+    lastMod?: string | Date;
+    url: string;
 }
 
-declare function expressSitemapXml(getUrls: (() => (string[] | Promise<string[]>)), base: string): express.RequestHandler;
+export type SitemapLeaf = string | LeafObject;
+
+export interface Sitemap {
+    [leaf: string]: string;
+}
+
+declare function expressSitemapXml(getUrls: (() => (SitemapLeaf[] | Promise<SitemapLeaf[]>)), base: string): express.RequestHandler;
 
 declare namespace expressSitemapXml {
-    function buildSitemaps(urls: string[], base: string): Promise<Sitemap>;
+    function buildSitemaps(urls: SitemapLeaf[], base: string): Promise<Sitemap>;
 }
 
 export default expressSitemapXml;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/feross/express-sitemap-xml/blob/master/index.js#L90
- [ x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
