### PR TITLE
@types/cash: Fix conflict with @types/jquery

### DIFF
--- a/types/cash/index.d.ts
+++ b/types/cash/index.d.ts
@@ -493,4 +493,3 @@ declare module "cash" {
     export = CashStatic;
 }
 declare var cash: CashStatic;
-declare var $: CashStatic;


### PR DESCRIPTION
@CiriousJoker @andy-ms 
This [change](https://github.com/DefinitelyTyped/DefinitelyTyped/commit/5e0ae37bedb585846866b6ae8d4db7c97ddc367d#diff-138ae409cf0ed11a88023bb376b56599) causes conflict with  @types/jquery/index.d.ts

Compile process fails with:
```
ERROR in [at-loader] ./node_modules/@types/cash/index.d.ts:496:13
    TS2451: Cannot redeclare block-scoped variable '$'.

ERROR in [at-loader] ./node_modules/@types/jquery/index.d.ts:43:15
    TS2451: Cannot redeclare block-scoped variable '$'.
```

The main reasion is 43 line in ```jquery/index.d.ts```:
```declare const $: JQueryStatic;```

Even if change 43 line with ```declare var $: JQueryStatic;``` it will be still conflicts and fails compile process with:
```
ERROR in [at-loader] ./node_modules/@types/jquery/index.d.ts:43:13
    TS2403: Subsequent variable declarations must have the same type.  Variable '$' must be of type 'CashStatic', but here has type 'JQueryStatic'.
``` 

So, current 496 line in ```@types/cash``` should be removed because it causes errors in compile process. You should find another way If you want to refer to the jquery type (i cannot propose any way).

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/jquery/index.d.ts#L43>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.