### PR TITLE
Fix imports for p5.js type hints

### DIFF
--- a/types/p5/index.d.ts
+++ b/types/p5/index.d.ts
@@ -58,6 +58,8 @@
 /// <reference path="./src/core/p5.Renderer.d.ts" />
 /// <reference path="./literals.d.ts" />
 /// <reference path="./constants.d.ts" />
+/// <reference path="./lib/addons/p5.dom.d.ts" />
+/// <reference path="./lib/addons/p5.sound.d.ts" />
 export = p5;
 declare class p5 {
   /**


### PR DESCRIPTION
Index file lacks references to "addon" subdirectory. Adding this fixes typescript problem occuring when trying to use p5 installed with npm in webpack project. I did not investigate this any further, just a fix I found myself doing to get my project running.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
