### PR TITLE
stylelint: differentiate between RuleOption and RuleValidationOption

### DIFF
--- a/types/stylelint/index.d.ts
+++ b/types/stylelint/index.d.ts
@@ -53,13 +53,15 @@ export namespace formatters {
 
 export function lint(options?: LinterOptions): Promise<LinterResult>;
 
-export type RuleOption = {
-    actual: any;
-    possible?: any;
+export type RuleOption = any;
+
+export type RuleValidationOption = {
+    actual: RuleOption;
+    possible?: RuleOption;
     optional?: false;
 } | {
-    actual?: any;
-    possible: any;
+    actual?: RuleOption;
+    possible: RuleOption;
     optional: true;
 };
 
@@ -76,7 +78,7 @@ export namespace utils {
 
     function ruleMessages(ruleName: string, messages: { [key: string]: any; }): typeof messages;
 
-    function validateOptions(result: LintResult, ruleName: string, ...options: RuleOption[]): boolean;
+    function validateOptions(result: LintResult, ruleName: string, ...options: RuleValidationOption[]): boolean;
 
     function checkAgainstRule(options: { ruleName: string; ruleSettings: any; root: any; }, callback: (warning: string) => void): void;
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/stylelint/stylelint/blob/master/lib/utils/validateOptions.js#L51-L53 (`opts` being `RuleValidationOption` and `opts.possible` being `RuleOption`)
- [x] Increase the version number in the header if appropriate.