### PR TITLE
[meow] Infer flag properties from options

### DIFF
--- a/types/meow/index.d.ts
+++ b/types/meow/index.d.ts
@@ -5,7 +5,7 @@
 //                 Jason Dreyzehner <https://github.com/bitjson>
 //                 Daniel Perez Alvarez <https://github.com/danielpa9708>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.8
 
 import * as buildOptions from 'minimist-options';
 
@@ -35,7 +35,7 @@ declare namespace meow {
         booleanDefault?: boolean | null;
     }
 
-    type Result<O extends meow.Options, F = $PropertyType<O, 'flags'>> = {
+    interface Result<O extends meow.Options, F = $PropertyType<O, 'flags'>> {
         input: string[];
         flags: {
             [id in keyof F]: F[id] extends GenericOption<infer T>
@@ -48,7 +48,7 @@ declare namespace meow {
         showVersion(): void;
     };
 
-  type GenericOption<T extends buildOptions.Type = any> =
+  type GenericOption<T extends buildOptions.Type> =
     | {
       type: buildOptions.Type;
       alias?: string | string[];

--- a/types/meow/index.d.ts
+++ b/types/meow/index.d.ts
@@ -41,7 +41,7 @@ declare namespace meow {
             [id in keyof F]: F[id] extends GenericOption<infer T>
                 ? MapTypeToRealType<T>
                 : never
-        };
+        } & { [id: string]: any};
         pkg: any;
         help: string;
         showHelp(code?: number): void;

--- a/types/meow/index.d.ts
+++ b/types/meow/index.d.ts
@@ -3,18 +3,20 @@
 // Definitions by: KnisterPeter <https://github.com/KnisterPeter>
 //                 Lindsey Smith <https://github.com/praxxis>
 //                 Jason Dreyzehner <https://github.com/bitjson>
+//                 Daniel Perez Alvarez <https://github.com/danielpa9708>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
 import * as buildOptions from 'minimist-options';
 
-declare function meow(
+declare function meow<O extends meow.Options>(
     helpMessage: string | ReadonlyArray<string>,
-    options: meow.Options
-): meow.Result;
-declare function meow(
-    options: string | ReadonlyArray<string> | meow.Options
-): meow.Result;
+    options: O
+): meow.Result<O>;
+
+declare function meow<O extends meow.Options>(
+    options: string | ReadonlyArray<string> | O
+): meow.Result<O>;
 declare namespace meow {
     interface Options {
         description?: string | boolean;
@@ -33,14 +35,32 @@ declare namespace meow {
         booleanDefault?: boolean | null;
     }
 
-    interface Result {
+    type Result<O extends meow.Options, F = $PropertyType<O, 'flags'>> = {
         input: string[];
-        flags: { [name: string]: any };
+        flags: {
+            [id in keyof F]: F[id] extends GenericOption<infer T>
+                ? MapTypeToRealType<T>
+                : never
+        };
         pkg: any;
         help: string;
         showHelp(code?: number): void;
         showVersion(): void;
+    };
+
+  type GenericOption<T extends buildOptions.Type = any> =
+    | {
+      type: buildOptions.Type;
+      alias?: string | string[];
+      default?: any;
     }
+    | T;
+
+  type MapTypeToRealType<T extends buildOptions.Type> = T extends 'string'
+    ? string
+    : T extends 'boolean' ? boolean : never;
+
+  type $PropertyType<T extends object, K extends keyof T> = T[K]; // from utility-types
 }
 
 export = meow;

--- a/types/meow/index.d.ts
+++ b/types/meow/index.d.ts
@@ -35,7 +35,7 @@ declare namespace meow {
         booleanDefault?: boolean | null;
     }
 
-    interface Result<O extends meow.Options, F = $PropertyType<O, 'flags'>> {
+    interface Result<O extends Options, F = $PropertyType<O, 'flags'>> {
         input: string[];
         flags: {
             [id in keyof F]: F[id] extends GenericOption<infer T>
@@ -46,15 +46,15 @@ declare namespace meow {
         help: string;
         showHelp(code?: number): void;
         showVersion(): void;
-    };
-
-  type GenericOption<T extends buildOptions.Type> =
-    | {
-      type: buildOptions.Type;
-      alias?: string | string[];
-      default?: any;
     }
-    | T;
+
+    type GenericOption<T extends buildOptions.Type> =
+      | {
+        type: buildOptions.Type;
+        alias?: string | string[];
+        default?: any;
+      }
+      | T;
 
   type MapTypeToRealType<T extends buildOptions.Type> = T extends 'string'
     ? string

--- a/types/meow/index.d.ts
+++ b/types/meow/index.d.ts
@@ -41,7 +41,7 @@ declare namespace meow {
             [id in keyof F]: F[id] extends GenericOption<infer T>
                 ? MapTypeToRealType<T>
                 : never
-        } & { [id: string]: any};
+        } & { [id: string]: any };
         pkg: any;
         help: string;
         showHelp(code?: number): void;

--- a/types/meow/meow-tests.ts
+++ b/types/meow/meow-tests.ts
@@ -42,3 +42,16 @@ const cli3 = meow({
         }
     }
 });
+
+const cli4 = meow({
+    flags: {
+        unicorn: {
+            type: 'boolean',
+            alias: 'u'
+        },
+        fooBar: 'string'
+        // someWrongFlag: "asdf", // error
+    }
+});
+cli4.flags.unicorn;
+cli4.flags.fooBar;


### PR DESCRIPTION
The results.flag values are infered from the options and the flag types are validated eg
```ts
const cli4 = meow({
    flags: {
        unicorn: {
            type: 'boolean',
            alias: 'u'
        },
        fooBar: 'string',
        someWrongFlag: "asdf", // error
    }
});
cli4.flags.unicorn;
cli4.flags.fooBar;
cli4.flags.asd // error
```

This requires typescript v2.8 I think

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.