### PR TITLE
Update CometD 4.0.0 Types to Use Correct Shape for SubscriptionHandles

### DIFF
--- a/types/cometd/cometd-tests.ts
+++ b/types/cometd/cometd-tests.ts
@@ -1,4 +1,4 @@
-import { CometD, Listener, Message } from "cometd";
+import { CometD, Listener, Message, SubscriptionHandle } from "cometd";
 
 const cometd = new CometD();
 
@@ -78,7 +78,7 @@ cometd.unsubscribe(subscription3, additionalInfoUnsubscribe, unsubscribeReply =>
 // Subscribers versus Listeners
 // ============================
 
-let _reportListener: Listener | undefined;
+let _reportListener: SubscriptionHandle | undefined;
 
 cometd.addListener("/meta/handshake", message => {
     // Only subscribe if the handshake is successful
@@ -106,7 +106,7 @@ cometd.addListener("/meta/handshake", message => {
 // Dynamic Resubscription
 // ======================
 
-let _subscription: Listener | undefined;
+let _subscription: SubscriptionHandle | undefined;
 
 class Controller {
     dynamicSubscribe = () => {

--- a/types/cometd/index.d.ts
+++ b/types/cometd/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for CometD 4.0
 // Project: http://cometd.org
-// Definitions by: Derek Cicerone <https://github.com/derekcicerone>, Daniel Perez Alvarez <https://github.com/unindented>
+// Definitions by: Derek Cicerone <https://github.com/derekcicerone>, Daniel Perez Alvarez <https://github.com/unindented>, Alex Henry <https://github.com/alxHenry>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -75,6 +75,15 @@ export interface Message {
 }
 
 export type Listener = (message: Message) => void;
+export type Callback = (data: any) => void;
+
+export interface SubscriptionHandle {
+    id: number;
+    channel: string;
+    listener: boolean;
+    callback: Callback;
+    scope?: Function;
+}
 
 export interface Extension {
     incoming?: Listener;
@@ -234,7 +243,7 @@ export class CometD {
      * @param subscribeCallback a function to be invoked when the subscription is acknowledged
      * @return the subscription handle to be passed to `unsubscribe`
      */
-    subscribe(channel: string, callback: Listener, subscribeCallback?: Listener): Listener;
+    subscribe(channel: string, callback: Callback, subscribeCallback?: Listener): SubscriptionHandle;
 
     /**
      * Subscribes to the given channel, performing the given callback in the given scope when a
@@ -255,7 +264,7 @@ export class CometD {
      * @param subscribeCallback a function to be invoked when the subscription is acknowledged
      * @return the subscription handle to be passed to `unsubscribe`
      */
-    subscribe(channel: string, callback: Listener, subscribeProps: object, subscribeCallback?: Listener): Listener;
+    subscribe(channel: string, callback: Callback, subscribeProps: object, subscribeCallback?: Listener): SubscriptionHandle;
 
     /**
      * Unsubscribes the subscription obtained with a call to `subscribe`.
@@ -263,7 +272,7 @@ export class CometD {
      * @param subscription the subscription to unsubscribe.
      * @param unsubscribeCallback a function to be invoked when the unsubscription is acknowledged
      */
-    unsubscribe(subscription: Listener, unsubscribeCallback?: Listener): void;
+    unsubscribe(subscription: SubscriptionHandle, unsubscribeCallback?: Listener): void;
 
     /**
      * Unsubscribes the subscription obtained with a call to `subscribe`.
@@ -272,12 +281,12 @@ export class CometD {
      * @param unsubscribeProps an object to be merged with the unsubscribe message
      * @param unsubscribeCallback a function to be invoked when the unsubscription is acknowledged
      */
-    unsubscribe(subscription: Listener, unsubscribeProps: object, unsubscribeCallback?: Listener): void;
+    unsubscribe(subscription: SubscriptionHandle, unsubscribeProps: object, unsubscribeCallback?: Listener): void;
 
     /**
      * Resubscribes as necessary in case of a re-handshake.
      */
-    resubscribe(subscription: Listener, subscribeProps?: object): Listener;
+    resubscribe(subscription: SubscriptionHandle, subscribeProps?: object): SubscriptionHandle;
 
     /**
      * Removes all subscriptions added via `subscribe`, but does not remove the listeners added via

--- a/types/cometd/index.d.ts
+++ b/types/cometd/index.d.ts
@@ -211,14 +211,14 @@ export class CometD {
      * @param callback the callback to call when a message is sent to the channel
      * @returns the subscription handle to be passed to `removeListener`
      */
-    addListener(channel: string, callback: Listener): Listener;
+    addListener(channel: string, callback: Listener): SubscriptionHandle;
 
     /**
      * Removes the subscription obtained with a call to `addListener`.
      *
      * @param subscription the subscription to unsubscribe.
      */
-    removeListener(subscription: Listener): void;
+    removeListener(subscription: SubscriptionHandle): void;
 
     /**
      * Removes all listeners registered with `addListener` or `subscribe`.
@@ -472,5 +472,5 @@ export class CometD {
      * @param isListener whether it was a listener
      * @param message the message received from the Bayeux server
      */
-    onListenerException: (exception: any, subscriptionHandle: Listener, isListener: boolean, message: string) => void;
+    onListenerException: (exception: any, subscriptionHandle: SubscriptionHandle, isListener: boolean, message: string) => void;
 }

--- a/types/cometd/index.d.ts
+++ b/types/cometd/index.d.ts
@@ -82,7 +82,7 @@ export interface SubscriptionHandle {
     channel: string;
     listener: boolean;
     callback: Callback;
-    scope?: Function;
+    scope?: any;
 }
 
 export interface Extension {


### PR DESCRIPTION
The Subscriptions and Listeners in CometD use a SubscriptionHandler shape that I've added to the types and used as necessary. The relevant lines in the CometD source code are:

https://github.com/cometd/cometd/blob/4.0.x/cometd-javascript/common/src/main/webapp/js/cometd/cometd.js#L2701
https://github.com/cometd/cometd/blob/4.0.x/cometd-javascript/common/src/main/webapp/js/cometd/cometd.js#L2428

I've also added a generic Callback type and replaced the Listener type with it in some cases where the passed callback is a user defined method that accepts any data shape and does who knows what.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
