### PR TITLE
Add types exporting for react-sound package

### DIFF
--- a/types/react-sound/index.d.ts
+++ b/types/react-sound/index.d.ts
@@ -6,29 +6,32 @@
 
 import * as React from "react";
 
-declare namespace ReactSound {
-    type PlayStatus = 'PLAYING' | 'STOPPED' | 'PAUSED';
-
-    interface ReactSoundProps {
-        url: string;
-        playStatus: PlayStatus;
-        playFromPosition?: number;
-        position?: number;
-        volume?: number;
-        playbackRate?: number;
-        autoLoad?: boolean;
-        loop?: boolean;
-        onError?: () => void;
-        onLoading?: () => void;
-        onLoad?: () => void;
-        onPlaying?: () => void;
-        onPause?: () => void;
-        onResume?: () => void;
-        onStop?: () => void;
-        onFinishedPlaying?: () => void;
-        onBufferChange?: () => void;
-    }
+export enum PlayStatus {
+    Playing = 'PLAYING',
+    Stopped = 'STOPPED',
+    Paused = 'PAUSED'
 }
 
-declare const ReactSound: React.ComponentClass<ReactSound.ReactSoundProps>;
-export = ReactSound;
+export interface ReactSoundProps {
+    url: string;
+    playStatus: PlayStatus;
+    playFromPosition?: number;
+    position?: number;
+    volume?: number;
+    playbackRate?: number;
+    autoLoad?: boolean;
+    loop?: boolean;
+    onError?: () => void;
+    onLoading?: () => void;
+    onLoad?: () => void;
+    onPlaying?: () => void;
+    onPause?: () => void;
+    onResume?: () => void;
+    onStop?: () => void;
+    onFinishedPlaying?: () => void;
+    onBufferChange?: () => void;
+}
+
+declare const ReactSound: React.ComponentClass<ReactSoundProps>;
+
+export default ReactSound;

--- a/types/react-sound/react-sound-tests.tsx
+++ b/types/react-sound/react-sound-tests.tsx
@@ -1,10 +1,10 @@
-import ReactSound from "react-sound";
+import ReactSound, { PlayStatus } from "react-sound";
 import * as React from "react";
 
 const ReactSoundRequiredOptions: JSX.Element = (
     <ReactSound
         url="http://test.com"
-        playStatus="STOPPED"
+        playStatus={PlayStatus.Stopped}
     />
 );
 
@@ -13,7 +13,7 @@ const callbackFn = () => ({});
 const ReactSoundAllOptions: JSX.Element = (
     <ReactSound
         url="http://test.com/audio.mp3"
-        playStatus="STOPPED"
+        playStatus={PlayStatus.Paused}
         playFromPosition={0}
         position={0}
         volume={0}


### PR DESCRIPTION
This update adds export for `PlayStatus` enum that can be used to set the playback status of `ReactSound` component (https://github.com/leoasis/react-sound#example):

```ts
import ReactSound, { PlayStatus } from "react-sound";

<ReactSound
    url="http://test.com"
    playStatus={PlayStatus.Stopped}
/>
```

