### PR TITLE
[@types/stripe] deleteExternalAccount should return IDeleteConfirmation

### DIFF
--- a/types/stripe/index.d.ts
+++ b/types/stripe/index.d.ts
@@ -5481,8 +5481,8 @@ declare namespace Stripe {
              * currency is not the Stripe account's default currency. Otherwise, you must set another external account to be the default for the currency
              * before deleting it.
              */
-            deleteExternalAccount(accId: string, id: string, options: HeaderOptions, response?: IResponseFn<cards.ICard | bankAccounts.IBankAccount>): Promise<cards.ICard | bankAccounts.IBankAccount>;
-            deleteExternalAccount(accId: string, id: string, response?: IResponseFn<cards.ICard | bankAccounts.IBankAccount>): Promise<cards.ICard | bankAccounts.IBankAccount>;
+            deleteExternalAccount(accId: string, id: string, options: HeaderOptions, response?: IResponseFn<IDeleteConfirmation>): Promise<IDeleteConfirmation>;
+            deleteExternalAccount(accId: string, id: string, response?: IResponseFn<IDeleteConfirmation>): Promise<IDeleteConfirmation>;
 
             /**
              * You can see a list of the bank accounts belonging to a managed account. Note that the 10 most recent external accounts are always
@@ -7353,7 +7353,11 @@ declare namespace Stripe {
         (err: IStripeError, value: R): void;
     }
 
-    interface IDeleteConfirmation { id: string; deleted: boolean; }
+    interface IDeleteConfirmation {
+        id: string;
+        object: string;
+        deleted: boolean;
+    }
 
     /**
      * A filter on the list based on this object field. The value can


### PR DESCRIPTION
The return type for `stripe.accounts.deleteExternalAccount` is incorrect this fixes it to match the stripe docs (and actual data I received while using this library)

 https://stripe.com/docs/api?lang=node#account_delete_bank_account

This return type is the same as the exiting `stripe.accounts.del` which is already defined as `IDeleteConfirmation`

https://stripe.com/docs/api?lang=node#delete_account

Also, updated `IDeleteConfirmation` to add the missing `object` value.