### PR TITLE
@types/react-i18next: Create NamespacesConsumer component types

### DIFF
--- a/types/react-i18next/index.d.ts
+++ b/types/react-i18next/index.d.ts
@@ -23,6 +23,7 @@ import Interpolate from "./src/interpolate";
 import loadNamespaces from "./src/loadNamespaces";
 import Trans from "./src/trans";
 import translate from "./src/translate";
+import NamespacesConsumer from "./src/NamespacesConsumer";
 
 export {
     setDefaults,
@@ -37,7 +38,8 @@ export {
     loadNamespaces,
     Trans,
     translate,
-    TranslationFunction
+    TranslationFunction,
+    NamespacesConsumer
 };
 
 export { InjectedI18nProps, InjectedTranslateProps } from "./src/props";

--- a/types/react-i18next/src/NamespacesConsumer.d.ts
+++ b/types/react-i18next/src/NamespacesConsumer.d.ts
@@ -1,0 +1,22 @@
+import * as React from "react";
+import { i18n, TranslationFunction } from "i18next";
+import { ReactI18NextOptions } from './context';
+
+export interface TChildrenData {
+    i18n: i18n;
+    t: TranslationFunction;
+    lng: string;
+    ready: boolean;
+}
+
+type NSRenderFunction = (t: TranslationFunction, data: TChildrenData) => React.ReactNode;
+
+export interface NamespacesConsumerProps {
+    i18n?: i18n;
+    i18nOptions?: ReactI18NextOptions;
+    ns: Array<string>;
+    defaultNS?: string;
+    children: NSRenderFunction;
+}
+
+export default class NamespacesConsumer extends React.Component<NamespacesConsumerProps> { }

--- a/types/react-i18next/test/react-i18next-tests.tsx
+++ b/types/react-i18next/test/react-i18next-tests.tsx
@@ -11,7 +11,8 @@ import {
     loadNamespaces,
     Trans,
     I18n,
-    ReactI18NextOptions
+    ReactI18NextOptions,
+    NamespacesConsumer
 } from 'react-i18next';
 import { InjectedI18nProps } from 'react-i18next/src/props';
 
@@ -189,6 +190,14 @@ interface CustomTranslateFunctionProps {
 <I18n>
     {t => '123'}
 </I18n>;
+
+<NamespacesConsumer
+    ns={['translations']}
+>
+    {
+        t => <div>{t('test')}</div>
+    }
+</NamespacesConsumer>;
 
 const defaults: ReactI18NextOptions = {
     wait: true,


### PR DESCRIPTION
Add types for new `NamespacesConsumer` component from react-i18next.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/i18next/react-i18next/blob/master/src/NamespacesConsumer.js
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
