### PR TITLE
ReactNative Remove circular type reference from NamedStyled

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -5214,12 +5214,12 @@ interface SubscribableMixin {
 
 // @see https://github.com/facebook/react-native/blob/0.34-stable\Libraries\StyleSheet\StyleSheetTypes.js
 export namespace StyleSheet {
-    type NamedStyles<T> = { [P in keyof T]: ViewStyle | TextStyle | ImageStyle };
+    type NamedStyles = { [key: string]: ViewStyle | TextStyle | ImageStyle };
 
     /**
      * Creates a StyleSheet style reference from the given object.
      */
-    export function create<T extends NamedStyles<T>>(styles: T): { [P in keyof T]: RegisteredStyle<T[P]> };
+    export function create<T extends NamedStyles>(styles: T): { [P in keyof T]: RegisteredStyle<T[P]> };
 
     /**
      * Flattens an array of style objects, into one aggregated style object.

--- a/types/react-native/test/index.tsx
+++ b/types/react-native/test/index.tsx
@@ -112,7 +112,7 @@ BackHandler.addEventListener("hardwareBackPress", () => {}).remove();
 
 BackAndroid.addEventListener("hardwareBackPress", () => {});
 
-interface LocalStyles {
+type LocalStyles = {
     container: ViewStyle;
     welcome: TextStyle;
     instructions: TextStyle;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/Microsoft/TypeScript/issues/27421, https://github.com/Microsoft/TypeScript/issues/27707, https://github.com/DefinitelyTyped/DefinitelyTyped/issues/29651, #29265>

- [ ] Increase the version number in the header if appropriate.

Should we increment the version number for this? If use was using `NameStyled` in their code then this will be a breaking change.