### PR TITLE
[webpack] avoid recursive import with webpack-dev-server

### DIFF
--- a/types/webpack/index.d.ts
+++ b/types/webpack/index.d.ts
@@ -25,7 +25,6 @@ import { Tapable, HookMap,
          AsyncParallelBailHook, AsyncParallelHook, AsyncSeriesBailHook, AsyncSeriesHook, AsyncSeriesWaterfallHook } from 'tapable';
 import * as UglifyJS from 'uglify-js';
 import { RawSourceMap } from 'source-map';
-import * as WebpackDevServer from 'webpack-dev-server';
 
 export = webpack;
 
@@ -113,8 +112,6 @@ declare namespace webpack {
         parallelism?: number;
         /** Optimization options */
         optimization?: Options.Optimization;
-        /** A set of options picked up by `webpack-dev-server` to change the dev server's default behavior. */
-        devServer?: WebpackDevServer.Configuration;
     }
 
     interface Entry {

--- a/types/webpack/v3/index.d.ts
+++ b/types/webpack/v3/index.d.ts
@@ -20,7 +20,6 @@
 import Tapable = require('tapable');
 import * as UglifyJS from 'uglify-js';
 import { RawSourceMap } from 'source-map';
-import * as WebpackDevServer from 'webpack-dev-server';
 
 export = webpack;
 
@@ -106,8 +105,6 @@ declare namespace webpack {
         performance?: Options.Performance;
         /** Limit the number of parallel processed modules. Can be used to fine tune performance or to get more reliable profiling results */
         parallelism?: number;
-        /** A set of options picked up by `webpack-dev-server` to change the dev server's default behavior. */
-        devServer?: WebpackDevServer.Configuration;
     }
 
     interface Entry {


### PR DESCRIPTION
- fix recursive import between `webpack` and `webpack-dev-server`. caused by #29593.
- `webpack-dev-server` already augments the `webpack.Configuration` interface, so if a user needs that field, he should install @types/webpack-dev-server.

FYI @johnnyreilly @kuehlein 