### PR TITLE
[webappsec-credential-management] Timeout field in PublicKeyCredentialRequestOptions is optional

### DIFF
--- a/types/webappsec-credential-management/index.d.ts
+++ b/types/webappsec-credential-management/index.d.ts
@@ -391,7 +391,7 @@ type UserVerificationRequirement = "required" | "preferred" | "discouraged";
  */
 interface PublicKeyCredentialRequestOptions {
     challenge: BufferSource;
-    timeout: number;
+    timeout?: number;
     rpId?: string;
     allowCredentials?: PublicKeyCredentialDescriptor[];
     userVerification?: UserVerificationRequirement;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://w3c.github.io/webauthn/#dictdef-publickeycredentialrequestoptions
>  Its challenge member MUST be present, while its other members are OPTIONAL.
> timeout, of type unsigned long This OPTIONAL member specifies a time, in milliseconds, [....]

- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
