### PR TITLE
[mozilla-readability] remove deprecated code (Node global in tests and uri parameter)

### DIFF
--- a/types/mozilla-readability/index.d.ts
+++ b/types/mozilla-readability/index.d.ts
@@ -7,21 +7,13 @@
 export = Readability;
 
 declare class Readability {
-    constructor(uri: Readability.Uri, doc: Document, options?: Readability.Options);
+    constructor(doc: Document, options?: Readability.Options);
 
     parse(): Readability.ParseResult;
     isProbablyReaderable(helperIsVisible?: (node: any) => boolean): boolean;
 }
 
 declare namespace Readability {
-    interface Uri {
-        spec: string;
-        host: string;
-        prePath: string;
-        scheme: string;
-        pathBase: string;
-    }
-
     interface Options {
         debug?: boolean;
         maxElemsToParse?: number;
@@ -31,7 +23,6 @@ declare namespace Readability {
     }
 
     interface ParseResult {
-        uri: Uri;
         title: string;
         byline: string;
         dir: string;

--- a/types/mozilla-readability/mozilla-readability-tests.ts
+++ b/types/mozilla-readability/mozilla-readability-tests.ts
@@ -5,42 +5,25 @@ import { JSDOM } from 'jsdom';
 // because issue https://github.com/mozilla/readability/issues/346
 // requires global variable `Node` when using nodejs.
 
-const fakeUri: Readability.Uri = {
-    spec: "http://fakehost/test/page.html",
-    host: "fakehost",
-    prePath: "http://fakehost",
-    scheme: "http",
-    pathBase: "http://fakehost/test/"
-};
-
 function test_basic_usage() {
     const dom = new JSDOM(`<p>Hello</p><p><strong>Hi!</strong>`);
-    // Required until https://github.com/mozilla/readability/issues/346
-    // is fixed.
-    Node = dom.window.Node;
 
-    const reader = new Readability(fakeUri, dom.window.document);
+    const reader = new Readability(dom.window.document);
     const article = reader.parse();
 }
 
 function test_readability_with_options() {
     const dom = new JSDOM(`<p>Hello</p><p><strong>Hi!</strong>`);
-    // Required until https://github.com/mozilla/readability/issues/346
-    // is fixed.
-    Node = dom.window.Node;
 
     const options: Readability.Options = {
         debug: true,
         maxElemsToParse: 100,
     };
-    const article = new Readability(fakeUri, dom.window.document, options).parse();
+    const article = new Readability(dom.window.document, options).parse();
 }
 
 function test_is_probably_readerable() {
     const dom = new JSDOM(`<p>Hello</p><p><strong>Hi!</strong>`);
-    // Required until https://github.com/mozilla/readability/issues/346
-    // is fixed.
-    Node = dom.window.Node;
 
-    const isReadable = new Readability(fakeUri, dom.window.document).isProbablyReaderable();
+    const isReadable = new Readability(dom.window.document).isProbablyReaderable();
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/mozilla/readability/pull/438
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.