### PR TITLE
react-joyride: Fix callback type definition and add test

### DIFF
--- a/types/react-joyride/index.d.ts
+++ b/types/react-joyride/index.d.ts
@@ -137,6 +137,11 @@ export interface OverridableProps {
     showProgress?: boolean;
 
     /**
+     * Display a button to skip the tour.
+     */
+    showSkipButton?: boolean;
+
+    /**
      * Disable closing the tooltip on ESC. Defaults to false.
      */
     disableCloseOnEsc?: boolean;
@@ -150,6 +155,11 @@ export interface OverridableProps {
      * Don't close the tooltip when clicking the overlay. Defaults to false.
      */
     disableOverlayClose?: boolean;
+
+    /**
+     * Disable auto scrolling between steps.
+     */    
+    disableScrolling?: boolean;
 
     /**
      * The strings used in the tooltip. Defaults to `{ back: 'Back', close: 'Close', last: 'Last', next: 'Next', skip: 'Skip' }`
@@ -221,7 +231,7 @@ export interface Step extends OverridableProps {
     /**
      * The placement of the beacon. It will use the placement if nothing is passed and it can be: top, bottom, left, right.
      */
-    placementBeacon?: 'top' | 'bottom' | 'left' | 'right';
+    placementBeacon?: 'top' | 'bottom' | 'left' | 'right';    
 }
 export interface StepStyles {
     /**

--- a/types/react-joyride/index.d.ts
+++ b/types/react-joyride/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-joyride 2.0.0-15
+// Type definitions for react-joyride 2.0
 // Project: https://github.com/gilbarbara/react-joyride
 // Definitions by: DongYoon Kang <https://github.com/kdy1>
 //                 Kamran Ayub <https://github.com/kamranayub>

--- a/types/react-joyride/index.d.ts
+++ b/types/react-joyride/index.d.ts
@@ -1,6 +1,7 @@
-// Type definitions for react-joyride 2.0
+// Type definitions for react-joyride 2.0.0-15
 // Project: https://github.com/gilbarbara/react-joyride
 // Definitions by: DongYoon Kang <https://github.com/kdy1>
+//                 Kamran Ayub <https://github.com/kamranayub>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -106,7 +107,7 @@ export interface Props extends OverridableProps {
     /**
      * It will be called when Joyride's state changes. It returns a single parameter with the state.
      */
-    callback?(options: (data: State) => any): void;
+    callback?: (data: State) => any;
 
     /**
      * The tour is played sequentially with the Next button. Defaults to false.

--- a/types/react-joyride/index.d.ts
+++ b/types/react-joyride/index.d.ts
@@ -158,7 +158,7 @@ export interface OverridableProps {
 
     /**
      * Disable auto scrolling between steps.
-     */    
+     */
     disableScrolling?: boolean;
 
     /**
@@ -231,7 +231,7 @@ export interface Step extends OverridableProps {
     /**
      * The placement of the beacon. It will use the placement if nothing is passed and it can be: top, bottom, left, right.
      */
-    placementBeacon?: 'top' | 'bottom' | 'left' | 'right';    
+    placementBeacon?: 'top' | 'bottom' | 'left' | 'right';
 }
 export interface StepStyles {
     /**

--- a/types/react-joyride/react-joyride-tests.tsx
+++ b/types/react-joyride/react-joyride-tests.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import Joyride, { Step } from "react-joyride";
+import Joyride, { Step, State } from "react-joyride";
 
 class NewComponent extends React.Component<undefined, undefined> {
     j: Joyride;
@@ -42,7 +42,7 @@ class NewComponent extends React.Component<undefined, undefined> {
     }];
 
     render() {
-        return <Joyride ref="j" run={true} steps={this.steps} />;
+        return <Joyride ref="j" run={true} steps={this.steps} callback={this.onCallback} />;
     }
 
     doStuff() {
@@ -55,5 +55,9 @@ class NewComponent extends React.Component<undefined, undefined> {
         this.j.addTooltip(this.steps[0]);
 
         const { title, placement } = this.j.getProgress().step;
+    }
+
+    onCallback(data: State) {
+        return;
     }
 }


### PR DESCRIPTION
There was a bug with the way `callback` was typed. I've fixed it and added test coverage. Also added some missing props to `Step`.

---

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - https://github.com/gilbarbara/react-joyride (see demo code)
  - https://github.com/gilbarbara/react-joyride/blob/master/docs/step.md
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.