### PR TITLE
ElasticSearch - add "slices" option to UpdateDocumentByQueryParams and update Response too

### DIFF
--- a/types/elasticsearch/elasticsearch-tests.ts
+++ b/types/elasticsearch/elasticsearch-tests.ts
@@ -338,6 +338,21 @@ client.indices.updateAliases({
   // ...
 });
 
+client.reindex({
+    body: {
+        source: {
+          index: "twitter"
+        },
+        dest: {
+          index: "new_twitter"
+        }
+      }
+})
+.then(response => {
+    const { took, timed_out } = response;
+    // ...
+});
+
 // Errors
 function testErrors() {
     throw new elasticsearch.errors.AuthenticationException();

--- a/types/elasticsearch/index.d.ts
+++ b/types/elasticsearch/index.d.ts
@@ -800,7 +800,7 @@ export interface SliceUpdateResponse extends GenericUpdateResponse {
     slice_id: number;
 }
 
-interface GenericUpdateResponse {
+export interface GenericUpdateResponse {
     total: number;
     updated: number;
     deleted: number;

--- a/types/elasticsearch/index.d.ts
+++ b/types/elasticsearch/index.d.ts
@@ -281,26 +281,13 @@ export interface DeleteDocumentByQueryParams extends GenericParams {
     scrollSize?: number;
     waitForCompletion?: boolean;
     requestsPerSecond?: number;
+    slices?: number;
     index?: string;
     type?: string;
 }
 
-export interface DeleteDocumentByQueryResponse {
-    took: number;
-    timed_out: boolean;
-    deleted: number;
-    batches: number;
-    version_conflicts: number;
-    noops: number;
-    retries: {
-        bulk: number;
-        search: number;
-    };
-    throttled_millis: number;
-    requests_per_second: number;
-    throttled_until_millis: number;
-    total: number;
-    failures: any[];
+export interface DeleteDocumentByQueryResponse extends ReIndexOrByQueryResponse {
+    //DeleteDocumentByQueryResponse, UpdateDocumentByQueryResponse and ReindexResponse are identical
 }
 
 export interface DeleteScriptParams extends GenericParams {
@@ -531,6 +518,7 @@ export interface ReindexParams extends GenericParams {
     waitForActiveShards?: string;
     waitForCompletion?: boolean;
     requestsPerSecond?: number;
+    slices?: number;
     body: {
         conflicts?: string;
         source: {
@@ -559,18 +547,8 @@ export interface ReindexParams extends GenericParams {
     };
 }
 
-export interface ReindexResponse {
-    took: number;
-    updated: number;
-    created: number;
-    batches: number;
-    version_conflicts: number;
-    retries: {
-        bulk: number;
-        search: number;
-    };
-    throttled_millis: number;
-    failures: any[];
+export interface ReindexResponse extends ReIndexOrByQueryResponse {
+    //DeleteDocumentByQueryResponse, UpdateDocumentByQueryResponse and ReindexResponse are identical
 }
 
 export interface ReindexRethrottleParams extends GenericParams {
@@ -789,18 +767,22 @@ export interface UpdateDocumentByQueryParams extends GenericParams {
     type: NameList;
 }
 
-export interface UpdateDocumentByQueryResponse extends GenericUpdateResponse {
+export interface UpdateDocumentByQueryResponse extends ReIndexOrByQueryResponse {
+    //DeleteDocumentByQueryResponse, UpdateDocumentByQueryResponse and ReindexResponse are identical
+}
+
+export interface ReIndexOrByQueryResponse extends ReIndexOrByQueryResponseBase {
     took: number;
     timed_out: boolean;
     failures: any[];
-    slices?: SliceUpdateResponse[];
+    slices?: ReIndexOrByQueryResponseSlice[];
 }
 
-export interface SliceUpdateResponse extends GenericUpdateResponse {
+export interface ReIndexOrByQueryResponseSlice extends ReIndexOrByQueryResponseBase {
     slice_id: number;
 }
 
-export interface GenericUpdateResponse {
+export interface ReIndexOrByQueryResponseBase {
     total: number;
     updated: number;
     deleted: number;

--- a/types/elasticsearch/index.d.ts
+++ b/types/elasticsearch/index.d.ts
@@ -784,13 +784,24 @@ export interface UpdateDocumentByQueryParams extends GenericParams {
     scrollSize?: number;
     waitForCompletion?: boolean;
     requestsPerSecond?: number;
+    slices?: number;
     index: NameList;
     type: NameList;
 }
 
-export interface UpdateDocumentByQueryResponse {
+export interface UpdateDocumentByQueryResponse extends GenericUpdateResponse {
     took: number;
     timed_out: boolean;
+    failures: any[];
+    slices?: SliceUpdateResponse[];
+}
+
+export interface SliceUpdateResponse extends GenericUpdateResponse {
+    slice_id: number;
+}
+
+interface GenericUpdateResponse {
+    total: number;
     updated: number;
     deleted: number;
     batches: number;
@@ -803,8 +814,6 @@ export interface UpdateDocumentByQueryResponse {
     throttled_millis: number;
     requests_per_second: number;
     throttled_until_millis: number;
-    total: number;
-    failures: any[];
 }
 
 export interface Cat {

--- a/types/elasticsearch/index.d.ts
+++ b/types/elasticsearch/index.d.ts
@@ -286,8 +286,8 @@ export interface DeleteDocumentByQueryParams extends GenericParams {
     type?: string;
 }
 
-export interface DeleteDocumentByQueryResponse extends ReIndexOrByQueryResponse {
-    //DeleteDocumentByQueryResponse, UpdateDocumentByQueryResponse and ReindexResponse are identical
+export interface DeleteDocumentByQueryResponse extends ReindexResponse {
+    // DeleteDocumentByQueryResponse, UpdateDocumentByQueryResponse and ReindexResponse are identical
 }
 
 export interface DeleteScriptParams extends GenericParams {
@@ -547,10 +547,6 @@ export interface ReindexParams extends GenericParams {
     };
 }
 
-export interface ReindexResponse extends ReIndexOrByQueryResponse {
-    //DeleteDocumentByQueryResponse, UpdateDocumentByQueryResponse and ReindexResponse are identical
-}
-
 export interface ReindexRethrottleParams extends GenericParams {
     requestsPerSecond: number;
     taskId: string;
@@ -767,22 +763,22 @@ export interface UpdateDocumentByQueryParams extends GenericParams {
     type: NameList;
 }
 
-export interface UpdateDocumentByQueryResponse extends ReIndexOrByQueryResponse {
-    //DeleteDocumentByQueryResponse, UpdateDocumentByQueryResponse and ReindexResponse are identical
+export interface UpdateDocumentByQueryResponse extends ReindexResponse {
+    // DeleteDocumentByQueryResponse, UpdateDocumentByQueryResponse and ReindexResponse are identical
 }
 
-export interface ReIndexOrByQueryResponse extends ReIndexOrByQueryResponseBase {
+export interface ReindexResponse extends ReindexResponseBase {
     took: number;
     timed_out: boolean;
     failures: any[];
-    slices?: ReIndexOrByQueryResponseSlice[];
+    slices?: ReindexOrByQueryResponseSlice[];
 }
 
-export interface ReIndexOrByQueryResponseSlice extends ReIndexOrByQueryResponseBase {
+export interface ReindexOrByQueryResponseSlice extends ReindexResponseBase {
     slice_id: number;
 }
 
-export interface ReIndexOrByQueryResponseBase {
+export interface ReindexResponseBase {
     total: number;
     updated: number;
     deleted: number;


### PR DESCRIPTION
…for elasticsearch update_by_query
documentation: https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/current/api-reference.html#api-updatebyquery

'slices' was missing and speeds up execution of update_by_query.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

