### PR TITLE
googlemaps: Fields option for AutoCompleteOptions was missing

### DIFF
--- a/types/googlemaps/index.d.ts
+++ b/types/googlemaps/index.d.ts
@@ -2613,6 +2613,7 @@ declare namespace google.maps {
       strictBounds?: boolean;
       types?: string[];
       type?: string;
+      fields?: string[];
     }
 
     export interface AutocompletePrediction {


### PR DESCRIPTION
Here is the documentation for the options where fields is an Array<string>: [AutocompleteOptions](https://developers.google.com/maps/documentation/javascript/reference/places-widget#AutocompleteOptions)
