### PR TITLE
google.visualization: Allow null for reset on DataTable.setFormattedValue()

### DIFF
--- a/types/google.visualization/google.visualization-tests.ts
+++ b/types/google.visualization/google.visualization-tests.ts
@@ -363,6 +363,7 @@ function test_formatter_ArrowFormat() {
         ['Electronics', { v: -2.1, f: '-2.1%' }],
         ['Food', { v: 22, f: '22.0%' }]
     ]);
+    data.setFormattedValue(2, 1, null);
 
     var table = new google.visualization.Table(document.getElementById('arrowformat_div'));
 

--- a/types/google.visualization/index.d.ts
+++ b/types/google.visualization/index.d.ts
@@ -118,7 +118,7 @@ declare namespace google {
             setColumnLabel(columnIndex: number, label: string): void;
             setColumnProperty(columnIndex: number, name: string, value: any): void;
             setColumnProperties(columnIndex: number, properties: Properties): void;
-            setFormattedValue(rowIndex: number, columnIndex: number, formattedValue: string): void;
+            setFormattedValue(rowIndex: number, columnIndex: number, formattedValue: string | null): void;
             setProperty(rowIndex: number, columnIndex: number, name: string, value: any): void;
             setProperties(rowIndex: number, columnIndex: number, properties: Properties): void;
             setRowProperty(rowIndex: number, name: string, value: any): void;


### PR DESCRIPTION
The docs specifically allow `null` as a parameter to clear any formatted value in a specific cell.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developers.google.com/chart/interactive/docs/reference#DataTable_setFormattedValue
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
