### PR TITLE
StripeJS - Removed locale helper tag (caused StripeJS to throw a warning)

### DIFF
--- a/types/stripejs/element.d.ts
+++ b/types/stripejs/element.d.ts
@@ -47,21 +47,9 @@ export interface ElementCreatorOptions {
      * The translation that should be used for the element text
      * `auto` defaults to the browser language
      *
-     * NOTE: Only use the `string` option in combination with
-     * @see isLanguageTag
-     *
      * @default 'auto'
      */
     locale?: 'auto' | 'da' | 'de' | 'en' | 'es' | 'fi' | 'fr' | 'it' | 'ja' | 'no' | 'nl' | 'sv' | 'zh' | string;
-
-    /**
-     * Whether or not the locale is written in a language code
-     * This can be used in combination with localization libraries so that language names won't have to be formatted
-     * @example `en-US`
-     *
-     * @since 0.1.0
-     */
-    isIETFLocaleTag?: boolean;
 }
 
 export interface FontCSSElement {

--- a/types/stripejs/stripejs-tests.ts
+++ b/types/stripejs/stripejs-tests.ts
@@ -24,7 +24,7 @@ describe('StripeJS', () => {
     it('Should be possible to create and modify elements', () => {
         const creator = stripe.elements();
         stripe.elements({fonts: [], locale: 'nl'});
-        stripe.elements({fonts: [], locale: 'nl', isIETFLocaleTag: true});
+        stripe.elements({fonts: [], locale: 'nl'});
 
         const element = creator.create("cardCvc", {value: {postalCode: '94110'}});
         element.blur();


### PR DESCRIPTION
Typings updates that fix:
+ The tag is not from StripeJS but from a custom library. It causes StripeJS to give a warning on the key. So removing it to make sure no errors are thrown in the future.

    [ x ] Use a meaningful title for the pull request. Include the name of the package modified.
    [ x ] Test the change in your own code. (Compile and run.)
    [ x ] Add or edit tests to reflect the change. (Run with npm test.)
    [ x ] Run npm run lint package-name (or tsc if no tslint.json is present).

If changing an existing definition:

    [ x ] Provide a URL to documentation or source code which provides context for the suggested changes: [stripejs documentation](https://stripe.com/docs/stripe-js/reference#stripe-elements)
    [ x ] Increase the version number in the header if appropriate.
    [ x ] If you are making substantial changes, consider adding a tslint.json containing { "extends": "dtslint/dt.json" }.

