### PR TITLE
Add type definition for tcp-port-used

### DIFF
--- a/types/tcp-port-used/index.d.ts
+++ b/types/tcp-port-used/index.d.ts
@@ -1,0 +1,24 @@
+// Type definitions for tcp-port-used 1.0
+// Project: https://github.com/stdarg/tcp-port-used
+// Definitions by: Gaute Johansen <https://github.com/gautejohan>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export interface TcpPortUsedOptions {
+    port: number;
+    host: string;
+    status: boolean;
+    retryTimeMs: number;
+    timeOutMs: number;
+}
+
+export function check(port: number | TcpPortUsedOptions, host?: string): Promise<boolean>;
+
+export function waitForStatus(port: number | TcpPortUsedOptions, host?: string, inUse?: boolean, retryTimeMs?: number, timeOutMs?: number): Promise<void>;
+
+export function waitUntilFree(port: number | TcpPortUsedOptions, retryTimeMs?: number, timeOutMs?: number): Promise<void>;
+
+export function waitUntilFreeOnHost(port: number | TcpPortUsedOptions, host?: string, retryTimeMs?: number, timeOutMs?: number): Promise<void>;
+
+export function waitUntilUsed(port: number | TcpPortUsedOptions, retryTimeMs?: number, timeOutMs?: number): Promise<void>;
+
+export function waitUntilUsedOnHost(port: number | TcpPortUsedOptions, host?: string, retryTimeMs?: number, timeOutMs?: number): Promise<void>;

--- a/types/tcp-port-used/tcp-port-used-tests.ts
+++ b/types/tcp-port-used/tcp-port-used-tests.ts
@@ -1,0 +1,103 @@
+import * as tpu from 'tcp-port-used';
+
+// $ExpectedType boolean
+tpu.check(20000).then((isUsed: boolean) => {
+    // $ExpectedType boolean
+    isUsed;
+});
+
+// $ExpectedType boolean
+tpu.check(20000, 'localhost').then((isUsed: boolean) => {
+    // $ExpectedType boolean
+    isUsed;
+});
+
+// $ExpectedType boolean
+tpu.check({
+    port: 20000,
+    host: '127.0.0.1',
+    status: false,
+    retryTimeMs: 2000,
+    timeOutMs: 2000
+}).then((isUsed: boolean) => {
+    // $ExpectedType boolean
+    isUsed;
+});
+
+// $ExpectError
+tpu.check();
+
+// $Expected promise void
+tpu.waitForStatus(20000, '127.0.0.1', true, 1000, 2000).then(() => { });
+
+// $Expected promise void
+tpu.waitForStatus({
+    port: 20000,
+    host: '127.0.0.1',
+    status: true,
+    retryTimeMs: 2000,
+    timeOutMs: 2000
+}).then(() => { });
+
+// $ExpectError
+tpu.waitForStatus();
+
+// $Expected promise void
+tpu.waitUntilFree(20000, 1000, 2000);
+
+// $Expected promise void
+tpu.waitUntilFree({
+    port: 20000,
+    host: '127.0.0.1',
+    status: true,
+    retryTimeMs: 2000,
+    timeOutMs: 2000
+}).then(() => { });
+
+// $ExpectError
+tpu.waitUntilFree();
+
+// $Expected promise void
+tpu.waitUntilFreeOnHost(20000, '127.0.0.1', 1000, 2000).then(() => { });
+
+// $Expected promise void
+tpu.waitUntilFreeOnHost({
+    port: 20000,
+    host: '127.0.0.1',
+    status: true,
+    retryTimeMs: 2000,
+    timeOutMs: 2000
+}).then(() => { });
+
+// $ExpectError
+tpu.waitUntilFreeOnHost();
+
+// $Expected promise void
+tpu.waitUntilUsed(20000, 1000, 2000).then(() => { });
+
+// $Expected promise void
+tpu.waitUntilUsed({
+    port: 20000,
+    host: '127.0.0.1',
+    status: true,
+    retryTimeMs: 2000,
+    timeOutMs: 2000
+}).then(() => { });
+
+// $ExpectError
+tpu.waitUntilUsed();
+
+// $Expected promise void
+tpu.waitUntilUsedOnHost(20000, '127.0.0.1', 1000, 2000).then(() => { });
+
+// $Expected promise void
+tpu.waitUntilUsedOnHost({
+    port: 20000,
+    host: '127.0.0.1',
+    status: true,
+    retryTimeMs: 2000,
+    timeOutMs: 2000
+}).then(() => { });
+
+// $ExpectError
+tpu.waitUntilUsedOnHost();

--- a/types/tcp-port-used/tsconfig.json
+++ b/types/tcp-port-used/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "tcp-port-used-tests.ts"
+    ]
+}

--- a/types/tcp-port-used/tslint.json
+++ b/types/tcp-port-used/tslint.json
@@ -1,5 +1,3 @@
 {
-    "extends": "dtslint/dt.json",
-    "rules": {
-    }
+    "extends": "dtslint/dt.json"
 }

--- a/types/tcp-port-used/tslint.json
+++ b/types/tcp-port-used/tslint.json
@@ -1,0 +1,5 @@
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+    }
+}


### PR DESCRIPTION
Please fill in this template.

 Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

Had problems running `npm test` on osx: Unexpected path .DS_Store.
`npm run tcp-port-used` worked fine.