### PR TITLE
[react-native-share] Syncing with current flow types from repo

### DIFF
--- a/types/react-native-share/index.d.ts
+++ b/types/react-native-share/index.d.ts
@@ -1,32 +1,55 @@
-// Type definitions for react-native-share 1.0
+// Type definitions for react-native-share 1.1
 // Project: https://github.com/react-native-community/react-native-share#readme
 // Definitions by: Mark Nelissen <https://github.com/marknelissen>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.1
 
 declare namespace Share {
-    function open(options: OpenOptions): Promise<any>;
-    function shareSingle(options: ShareSingleOptions): Promise<any>;
+    function open(options: Options | MultipleOptions): Promise<OpenReturn>;
+    function shareSingle(
+        options: Options & { social: SupportedSocialApps }
+    ): Promise<ShareSingleReturn>;
 }
 
 export default Share;
 
-interface OpenOptions {
-    url: string;
-    type?: string;
+interface OpenReturn {
+    app?: string;
+    dismissedAction?: boolean;
+}
+
+interface ShareSingleReturn {
     message: string;
+}
+
+interface Options {
+    url: string;
+    urls?: string[];
+    type?: string;
+    message?: string;
     title?: string;
     subject?: string;
     excludedActivityTypes?: string;
-    showAppsToview?: boolean;
+    failOnCancel?: boolean;
+    showAppsToView?: boolean;
 }
-
-interface ShareSingleOptions {
-    url: string;
+interface MultipleOptions {
+    url?: string;
+    urls: string[];
     type?: string;
-    message: string;
+    message?: string;
     title?: string;
     subject?: string;
-    social: SupportedSocialApps;
+    excludedActivityTypes?: string;
+    failOnCancel?: boolean;
+    showAppsToView?: boolean;
 }
 
-type SupportedSocialApps = 'twitter' | 'facebook' | 'whatsapp' | 'googleplus' | 'email';
+type SupportedSocialApps =
+    | "facebook"
+    | "pagesmanager"
+    | "twitter"
+    | "whatsapp"
+    | "instagram"
+    | "googleplus"
+    | "email";

--- a/types/react-native-share/react-native-share-tests.ts
+++ b/types/react-native-share/react-native-share-tests.ts
@@ -1,12 +1,19 @@
 import Share from 'react-native-share';
 
-// $ExpectType Promise<any>
+// $ExpectType Promise<OpenReturn>
 Share.open({
     url: '',
     message: '',
 });
 
-// $ExpectType Promise<any>
+// $ExpectType Promise<OpenReturn>
+Share.open({
+    title: '',
+    message: '',
+    urls: [],
+});
+
+// $ExpectType Promise<OpenReturn>
 Share.open({
     url: '',
     type: '',
@@ -14,17 +21,17 @@ Share.open({
     title: '',
     subject: '',
     excludedActivityTypes: '',
-    showAppsToview: true,
+    showAppsToView: true,
 });
 
-// $ExpectType Promise<any>
+// $ExpectType Promise<ShareSingleReturn>
 Share.shareSingle({
     url: '',
     message: '',
     social: 'facebook',
 });
 
-// $ExpectType Promise<any>
+// $ExpectType Promise<ShareSingleReturn>
 Share.shareSingle({
     url: '',
     type: '',


### PR DESCRIPTION
The types `Options` and `MultiOptions` as well as `OpenReturn` and
`ShareSingleReturn` are taken directly from
https://github.com/react-native-community/react-native-share/blob/7535726eb42205260c09d9f0a2b39ba6d00ebc2c/index.js
and have only have been transformed to interfaces.

The signature of the `shareSingle` call is missing `social` in the
official repo as well, but from the native code it becomes apearent that
it is required: https://github.com/react-native-community/react-native-share/blob/7535726eb42205260c09d9f0a2b39ba6d00ebc2c/ios/RNShare.m#L85-L122

I also increased the version number to match the latest `react-native-share` version (`1.1.2`).

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: *See above*
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
