### PR TITLE
Fix incorrect upng-js definitions

### DIFF
--- a/types/upng-js/index.d.ts
+++ b/types/upng-js/index.d.ts
@@ -26,7 +26,7 @@ export interface ImageTabText {
     [key: string]: string;
 }
 
-export interface ImageTab {
+export interface ImageTabs {
     acTL?: ImageTabACTL;
     pHYs?: number[];
     cHRM?: number[];
@@ -46,7 +46,7 @@ export interface Image {
     depth: number;
     ctype: number;
     frames: ImageFrame[];
-    tabs: ImageTab;
+    tabs: ImageTabs;
     data: ArrayBuffer;
 }
 

--- a/types/upng-js/index.d.ts
+++ b/types/upng-js/index.d.ts
@@ -1,20 +1,82 @@
 // Type definitions for upng-js 2.1
 // Project: https://github.com/photopea/UPNG.js
-// Definitions by: York Yao <https://github.com/plantain-00>
+// Definitions by: York Yao <https://github.com/plantain-00>, Sophie Kirschner <https://github.com/pineapplemachine>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-export function decode(buff: ArrayBuffer): PngData;
+export interface ImageFrameRect {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+}
 
-export function encode(bufs: ArrayBuffer, width: number, height: number, ps?: number, dels?: any[]): ArrayBuffer;
+export interface ImageFrame {
+    rect: ImageFrameRect;
+    delay: number;
+    dispose: number;
+    blend: number;
+}
 
-export function toRGBA8(out: PngData): ArrayBuffer;
+export interface ImageTabACTL {
+    num_frames: number;
+    num_plays: number;
+}
 
-export interface PngData {
+export interface ImageTabText {
+    [key: string]: string;
+}
+
+export interface ImageTab {
+    acTL?: ImageTabACTL;
+    pHYs?: number[];
+    cHRM?: number[];
+    tEXt?: ImageTabText;
+    iTXt?: ImageTabText;
+    PLTE?: number[];
+    hIST?: number[];
+    tRNS?: (number | number[]); // Depends on ctype
+    gAMA?: number;
+    sRGB?: number;
+    bKGD?: (number | number[]); // Depends on ctype
+}
+
+export interface Image {
     width: number;
     height: number;
     depth: number;
-    ctype: any;
-    frames: any;
-    tabs: any;
+    ctype: number;
+    frames: ImageFrame[];
+    tabs: ImageTab;
     data: ArrayBuffer;
 }
+
+export interface QuantizeResult {
+    abuf: ArrayBuffer;
+    inds: Uint8Array;
+    // Type is complicated and I am too lazy to work it out right now, sorry!
+    plte: any[];
+}
+
+export function encode(
+    imgs: ArrayBuffer[],
+    w: number,
+    h: number,
+    cnum: number,
+    dels?: number[]
+): ArrayBuffer;
+
+export function encodeLL(
+    imgs: ArrayBuffer[],
+    w: number,
+    h: number,
+    cc: number,
+    ac: number,
+    depth: number,
+    dels?: number[]
+): ArrayBuffer;
+
+export function decode(buffer: ArrayBuffer): Image;
+
+export function toRGBA8(out: Image): ArrayBuffer[];
+
+export function quantize(data: ArrayBuffer, psize: number): QuantizeResult;

--- a/types/upng-js/upng-js-tests.ts
+++ b/types/upng-js/upng-js-tests.ts
@@ -1,5 +1,12 @@
 import * as UPNG from 'upng-js';
 
-declare const buff: ArrayBuffer;
-const img = UPNG.decode(buff);
-const rgba = UPNG.toRGBA8(img);
+declare const buffer: ArrayBuffer;
+
+const image: UPNG.Image = UPNG.decode(buffer);
+const rgba: ArrayBuffer[] = UPNG.toRGBA8(image);
+const quantized: UPNG.QuantizeResult = UPNG.quantize(rgba[0], 256);
+
+const png1: ArrayBuffer = UPNG.encode([buffer], 32, 32, 0);
+const png2: ArrayBuffer = UPNG.encode([buffer, buffer], 32, 32, 0, [10, 10]);
+const png3: ArrayBuffer = UPNG.encodeLL([buffer], 32, 32, 3, 1, 8);
+const png4: ArrayBuffer = UPNG.encodeLL([buffer, buffer], 32, 32, 3, 1, 8, [10, 10]);


### PR DESCRIPTION
The previous definition for upng-js@2.1.0 (latest) was incomplete and incorrect. This definition is much more complete (though it lacks definitions for the quite complicated objects in the `plte` array given as an attribute of the `QuantizeAttribute` object) and it fixes errors present in the previous definition.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/photopea/UPNG.js
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
