### PR TITLE
Added support for ECMAScript module import syntax to enzyme-adapter-react-16

### DIFF
--- a/types/enzyme-adapter-react-16/enzyme-adapter-react-16-tests.ts
+++ b/types/enzyme-adapter-react-16/enzyme-adapter-react-16-tests.ts
@@ -5,5 +5,5 @@ import AdapterCommonJs = require('enzyme-adapter-react-16');
 configure({ adapter: new AdapterCommonJs() });
 
 // ECMAScript module syntax
-import * as Adapter from 'enzyme-adapter-react-16';
-configure({ adapter: new Adapter() });
+import * as AdapterEcmaScript from 'enzyme-adapter-react-16';
+configure({ adapter: new AdapterEcmaScript() });

--- a/types/enzyme-adapter-react-16/enzyme-adapter-react-16-tests.ts
+++ b/types/enzyme-adapter-react-16/enzyme-adapter-react-16-tests.ts
@@ -1,4 +1,9 @@
 import { configure } from 'enzyme';
-import Adapter = require('enzyme-adapter-react-16');
 
+// CommonJS module syntax
+import AdapterCommonJs = require('enzyme-adapter-react-16');
+configure({ adapter: new AdapterCommonJs() });
+
+// ECMAScript module syntax
+import * as Adapter from 'enzyme-adapter-react-16';
 configure({ adapter: new Adapter() });

--- a/types/enzyme-adapter-react-16/index.d.ts
+++ b/types/enzyme-adapter-react-16/index.d.ts
@@ -1,12 +1,14 @@
-// Type definitions for enzyme-adapter-react-16 1.0
+// Type definitions for enzyme-adapter-react-16 1.1
 // Project: https://github.com/airbnb/enzyme
 // Definitions by: Tanguy Krotoff <https://github.com/tkrotoff>
+//                 Jimmy Headdon <https://github.com/jimmyheaddon>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
 import { EnzymeAdapter } from 'enzyme';
 
 declare class ReactSixteenAdapter extends EnzymeAdapter {
+    constructor();
 }
 
 declare const Adapter: typeof ReactSixteenAdapter;

--- a/types/enzyme-adapter-react-16/index.d.ts
+++ b/types/enzyme-adapter-react-16/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for enzyme-adapter-react-16 1.1
+// Type definitions for enzyme-adapter-react-16 1.6
 // Project: https://github.com/airbnb/enzyme
 // Definitions by: Tanguy Krotoff <https://github.com/tkrotoff>
 //                 Jimmy Headdon <https://github.com/jimmyheaddon>

--- a/types/enzyme-adapter-react-16/index.d.ts
+++ b/types/enzyme-adapter-react-16/index.d.ts
@@ -9,7 +9,5 @@ import { EnzymeAdapter } from 'enzyme';
 declare class ReactSixteenAdapter extends EnzymeAdapter {
 }
 
-declare namespace ReactSixteenAdapter {
-}
-
-export = ReactSixteenAdapter;
+declare const Adapter: typeof ReactSixteenAdapter;
+export = Adapter;

--- a/types/enzyme-adapter-react-16/index.d.ts
+++ b/types/enzyme-adapter-react-16/index.d.ts
@@ -10,5 +10,4 @@ import { EnzymeAdapter } from 'enzyme';
 declare class ReactSixteenAdapter extends EnzymeAdapter {
 }
 
-declare const Adapter: typeof ReactSixteenAdapter;
-export = Adapter;
+export = ReactSixteenAdapter;

--- a/types/enzyme-adapter-react-16/index.d.ts
+++ b/types/enzyme-adapter-react-16/index.d.ts
@@ -8,7 +8,6 @@
 import { EnzymeAdapter } from 'enzyme';
 
 declare class ReactSixteenAdapter extends EnzymeAdapter {
-    constructor();
 }
 
 declare const Adapter: typeof ReactSixteenAdapter;


### PR DESCRIPTION
Added support for ECMAScript module import syntax to enzyme-adapter-react-16, based on issue #29655.  A second test has been added to `enzyme-adapter-react-16-tests.ts`, to support the definition change.

**NOTE:** The use of `allowSyntheticDefaultImports: true` is required in `tsconfig.json` for ECMAScript syntax.  Whilst this is not ideal, it does allow compatibility that would otherwise not be possible.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://www.typescriptlang.org/docs/handbook/modules.html>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.