### PR TITLE
joi: Add type definition for validation of ISO 8601 duration string

### DIFF
--- a/types/joi/index.d.ts
+++ b/types/joi/index.d.ts
@@ -669,6 +669,11 @@ export interface StringSchema extends AnySchema {
     isoDate(): this;
 
     /**
+     * Requires the string value to be a valid ISO 8601 duration format.
+     */
+    isoDuration(): this;
+
+    /**
      * Requires the string value to be all lowercase. If the validation convert option is on (enabled by default), the string will be forced to lowercase.
      */
     lowercase(): this;

--- a/types/joi/joi-tests.ts
+++ b/types/joi/joi-tests.ts
@@ -815,6 +815,7 @@ strSchema = strSchema.hex();
 strSchema = strSchema.hex(hexOpts);
 strSchema = strSchema.hostname();
 strSchema = strSchema.isoDate();
+strSchema = strSchema.isoDuration();
 strSchema = strSchema.lowercase();
 strSchema = strSchema.uppercase();
 strSchema = strSchema.trim();


### PR DESCRIPTION
This is a type update for PR https://github.com/hapijs/joi/pull/1613 in the `joi` project.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present). - This fails! `Unexpected compiler option strictFunctionTypes`. I do not think this is to my changes

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/hapijs/joi/pull/1613
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

