### PR TITLE
@types/swiper/ error TS2307: Cannot find module '../..'.

### DIFF
--- a/types/swiper/dist/js/swiper.esm.d.ts
+++ b/types/swiper/dist/js/swiper.esm.d.ts
@@ -1,9 +1,9 @@
-import Swiper, { DOM7Element } from '../..';
+import Swiper, { DOM7Element } from '../../index';
 
 // Reexport everything from `swiper` except the default export of the
 // `Swiper` class, which is instead provided as a named export by
 // `swiper.esm`.
-export * from '../..';
+export * from '../../index';
 export { Swiper };
 
 /*


### PR DESCRIPTION
I was getting an error when trying to compile the typescript with Swiper using `import Swiper from "swiper";`  The errors I received were: 

```unix
node_modules/@types/swiper/dist/js/swiper.esm.d.ts(1,37): error TS2307: Cannot find module '../..'.
node_modules/@types/swiper/dist/js/swiper.esm.d.ts(6,15): error TS2307: Cannot find module '../..'.
```

To fix this issue I changed the imports on lines 1 and 6 of the swiper.esm.d.ts to directly call index (`../../index`) rather than assuming that's the name of the file we would like to import.
