### PR TITLE
[react-table] type-safe accessor functions

### DIFF
--- a/types/react-table/index.d.ts
+++ b/types/react-table/index.d.ts
@@ -6,17 +6,17 @@
 import * as React from 'react';
 
 export type ReactTableFunction = (value?: any) => void;
-export type AccessorFunction<D> = (row: D) => any;
-export type Accessor<D> = string | string[] | AccessorFunction<D>;
+export type AccessorFunction<D = any> = (row: D) => any;
+export type Accessor<D = any> = string | string[] | AccessorFunction<D>;
 export type Aggregator = (values: any, rows: any) => any;
 export type TableCellRenderer = ((data: any, column: any) => React.ReactNode) | React.ReactNode;
-export type FilterRender = (params: { column: Column<any>, filter: any, onChange: ReactTableFunction, key?: string }) => React.ReactElement<any>;
+export type FilterRender = (params: { column: Column, filter: any, onChange: ReactTableFunction, key?: string }) => React.ReactElement<any>;
 export type PivotRenderer = ((cellInfo: any) => React.ReactNode) | (() => any) | string | React.ReactNode;
 
 export type ComponentPropsGetter0 = (finalState: any, rowInfo: undefined, column: undefined, instance?: any) => object | undefined;
 export type ComponentPropsGetterR = (finalState: any, rowInfo?: RowInfo, column?: undefined, instance?: any) => object | undefined;
-export type ComponentPropsGetterC = (finalState: any, rowInfo?: undefined, column?: Column<any>, instance?: any) => object | undefined;
-export type ComponentPropsGetterRC = (finalState: any, rowInfo?: RowInfo, column?: Column<any>, instance?: any) => object | undefined;
+export type ComponentPropsGetterC = (finalState: any, rowInfo?: undefined, column?: Column, instance?: any) => object | undefined;
+export type ComponentPropsGetterRC = (finalState: any, rowInfo?: RowInfo, column?: Column, instance?: any) => object | undefined;
 
 export type DefaultFilterFunction = (filter: Filter, row: any, column: any) => boolean;
 export type FilterFunction = (filter: Filter, rows: any[], column: any) => boolean;
@@ -46,7 +46,7 @@ export interface SortingRule {
     desc?: true;
 }
 
-export interface TableProps<D> extends
+export interface TableProps<D = any> extends
     Partial<TextProps>,
     Partial<ComponentDecoratorProps>,
     Partial<ControlledStateCallbackProps>,
@@ -548,7 +548,7 @@ export interface PivotDefaults {
     render: TableCellRenderer;
 }
 
-export interface Column<D> extends
+export interface Column<D = any> extends
     Partial<Column.Basics>,
     Partial<Column.CellProps>,
     Partial<Column.FilterProps>,
@@ -608,7 +608,7 @@ export interface Column<D> extends
     pivot?: boolean;
 }
 
-export interface ColumnRenderProps<D> {
+export interface ColumnRenderProps<D = any> {
     /** Sorted data. */
     data: D[];
 
@@ -662,7 +662,7 @@ export interface RowInfo {
     original: any;
 }
 
-export interface FinalState<D> extends TableProps<D> {
+export interface FinalState<D = any> extends TableProps<D> {
     frozen: boolean;
     startRow: number;
     endRow: number;
@@ -681,10 +681,10 @@ export interface FinalState<D> extends TableProps<D> {
     headerGroups: any[];
 }
 
-export const ReactTableDefaults: TableProps<any>;
+export const ReactTableDefaults: TableProps;
 export default class ReactTable<D> extends React.Component<Partial<TableProps<D>>> { }
 
-export interface Instance<D> extends ReactTable<D> {
+export interface Instance<D = any> extends ReactTable<D> {
     context: any;
     props: Partial<TableProps<D>>;
     refs: any;

--- a/types/react-table/index.d.ts
+++ b/types/react-table/index.d.ts
@@ -1,22 +1,22 @@
 // Type definitions for react-table 6.7
 // Project: https://github.com/react-tools/react-table
-// Definitions by: Roy Xue <https://github.com/royxue>, Pavel Sakalo <https://github.com/psakalo>, Krzysztof Porębski <https://github.com/Havret>
+// Definitions by: Roy Xue <https://github.com/royxue>, Pavel Sakalo <https://github.com/psakalo>, Krzysztof Porębski <https://github.com/Havret>, Andy S <https://github.com/andys8>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 import * as React from 'react';
 
 export type ReactTableFunction = (value?: any) => void;
-export type AccessorFunction = (row: object) => any;
-export type Accessor = string | string[] | object | AccessorFunction;
+export type AccessorFunction<D> = (row: D) => any;
+export type Accessor<D> = string | string[] | AccessorFunction<D>;
 export type Aggregator = (values: any, rows: any) => any;
 export type TableCellRenderer = ((data: any, column: any) => React.ReactNode) | React.ReactNode;
-export type FilterRender = (params: { column: Column, filter: any, onChange: ReactTableFunction, key?: string }) => React.ReactElement<any>;
+export type FilterRender = (params: { column: Column<any>, filter: any, onChange: ReactTableFunction, key?: string }) => React.ReactElement<any>;
 export type PivotRenderer = ((cellInfo: any) => React.ReactNode) | (() => any) | string | React.ReactNode;
 
 export type ComponentPropsGetter0 = (finalState: any, rowInfo: undefined, column: undefined, instance?: any) => object | undefined;
 export type ComponentPropsGetterR = (finalState: any, rowInfo?: RowInfo, column?: undefined, instance?: any) => object | undefined;
-export type ComponentPropsGetterC = (finalState: any, rowInfo?: undefined, column?: Column, instance?: any) => object | undefined;
-export type ComponentPropsGetterRC = (finalState: any, rowInfo?: RowInfo, column?: Column, instance?: any) => object | undefined;
+export type ComponentPropsGetterC = (finalState: any, rowInfo?: undefined, column?: Column<any>, instance?: any) => object | undefined;
+export type ComponentPropsGetterRC = (finalState: any, rowInfo?: RowInfo, column?: Column<any>, instance?: any) => object | undefined;
 
 export type DefaultFilterFunction = (filter: Filter, row: any, column: any) => boolean;
 export type FilterFunction = (filter: Filter, rows: any[], column: any) => boolean;
@@ -46,7 +46,7 @@ export interface SortingRule {
     desc?: true;
 }
 
-export interface TableProps extends
+export interface TableProps<D> extends
     Partial<TextProps>,
     Partial<ComponentDecoratorProps>,
     Partial<ControlledStateCallbackProps>,
@@ -54,7 +54,7 @@ export interface TableProps extends
     Partial<ControlledStateOverrideProps>,
     Partial<ComponentProps> {
     /** Default: [] */
-    data: any[];
+    data: D[];
 
     /** Default: false */
     loading: boolean;
@@ -164,7 +164,7 @@ export interface TableProps extends
     column: Partial<GlobalColumn>;
 
     /** Array of all Available Columns */
-    columns?: Column[];
+    columns?: Array<Column<D>>;
 
     /** Expander defaults. */
     expanderDefaults: Partial<ExpanderDefaults>;
@@ -180,9 +180,9 @@ export interface TableProps extends
 
     /** Control callback for functional rendering */
     children: (
-        state: FinalState,
+        state: FinalState<D>,
         makeTable: () => React.ReactElement<any>,
-        instance: Instance
+        instance: Instance<D>
     ) => React.ReactNode;
 }
 
@@ -548,7 +548,7 @@ export interface PivotDefaults {
     render: TableCellRenderer;
 }
 
-export interface Column extends
+export interface Column<D> extends
     Partial<Column.Basics>,
     Partial<Column.CellProps>,
     Partial<Column.FilterProps>,
@@ -562,7 +562,7 @@ export interface Column extends
      * @example {"a": {"b": {"c": $}}}
      * @example (row) => row.propertyName
      */
-    accessor?: Accessor;
+    accessor?: Accessor<D>;
 
     /**
      * Conditional - A unique ID is required if the accessor is not a string or if you would like to override the column name used in server-side calls
@@ -598,7 +598,7 @@ export interface Column extends
     expander?: boolean;
 
     /** Header Groups only */
-    columns?: any[];
+    columns?: Array<Column<D>>;
 
     /**
      * Turns this column into a special column for specifying pivot position in your column definitions.
@@ -608,12 +608,12 @@ export interface Column extends
     pivot?: boolean;
 }
 
-export interface ColumnRenderProps {
+export interface ColumnRenderProps<D> {
     /** Sorted data. */
-    data: any[];
+    data: D[];
 
     /** The column. */
-    column: Column;
+    column: Column<D>;
 }
 
 export interface RowRenderProps extends Partial<RowInfo> {
@@ -662,7 +662,7 @@ export interface RowInfo {
     original: any;
 }
 
-export interface FinalState extends TableProps {
+export interface FinalState<D> extends TableProps<D> {
     frozen: boolean;
     startRow: number;
     endRow: number;
@@ -674,21 +674,21 @@ export interface FinalState extends TableProps {
     canNext: boolean;
     rowMinWidth: number;
 
-    allVisibleColumns: Column[];
-    allDecoratedColumns: Column[];
+    allVisibleColumns: Array<Column<D>>;
+    allDecoratedColumns: Array<Column<D>>;
     resolvedData: DerivedDataObject[];
     sortedData: DerivedDataObject[];
     headerGroups: any[];
 }
 
-export const ReactTableDefaults: TableProps;
-export default class ReactTable extends React.Component<Partial<TableProps>> { }
+export const ReactTableDefaults: TableProps<any>;
+export default class ReactTable<D> extends React.Component<Partial<TableProps<D>>> { }
 
-export interface Instance extends ReactTable {
+export interface Instance<D> extends ReactTable<D> {
     context: any;
-    props: Partial<TableProps>;
+    props: Partial<TableProps<D>>;
     refs: any;
-    state: FinalState;
+    state: FinalState<D>;
     filterColumn(...props: any[]): any;
     filterData(...props: any[]): any;
     fireFetchData(...props: any[]): any;

--- a/types/react-table/react-table-tests.tsx
+++ b/types/react-table/react-table-tests.tsx
@@ -5,7 +5,15 @@ import * as ReactDOM from 'react-dom';
 import ReactTable, { Column, FinalState, Instance } from "react-table";
 import "react-table/react-table.css";
 
-const columns: Column[] = [
+interface Data {
+  firstName: string;
+  lastName: string;
+  age: number;
+  visits: number;
+  progress: number;
+}
+
+const columns: Array<Column<Data>> = [
   {
     Header: "Name",
     columns: [
@@ -16,7 +24,7 @@ const columns: Column[] = [
   {
     Header: "Info",
     columns: [
-      { Header: "Age", accessor: "age" },
+      { Header: "Age", accessor: (data: Data) => data.age },
       { Header: "Status", accessor: "status" }
     ]
   },
@@ -29,7 +37,7 @@ const columns: Column[] = [
 ];
 
 const Component = (props: {}) => {
-  const data = [
+  const data: Data[] = [
     { firstName: "plastic", lastName: "leather", age: 1, visits: 87, progress: 53 },
     { firstName: "eggs", lastName: "quartz", age: 13, visits: 78, progress: 82 },
     { firstName: "wash", lastName: "wrench", age: 29, visits: 75, progress: 49 },
@@ -156,9 +164,9 @@ const Component = (props: {}) => {
         }}
       >
         {(
-          state: FinalState,
+          state: FinalState<Data>,
           makeTable: () => React.ReactChild,
-          instance: Instance
+          instance: Instance<Data>
         ) => {
           return (
             <div


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

---

### Purpose

`AccessorFunction` is of type `(row: object) => any`. This pull request has the purpose to type this depending on the given data `D[]`, so that `(row: D) => any` is the type.


### Further information 

The pull request removes `object` as a potential argument.

https://github.com/andys8/DefinitelyTyped/blob/52de94b301c4b5b4a8289690e13fe180f659ce7c/types/react-table/index.d.ts#L10

Since a `function` is also an `object` this would match wrong functions. It could be possible to use [conditional types](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-8.html) and exclude this case. I tried so, but I wasn't able to use it the intended way with typescript. The [documentation](https://react-table.js.org/#/story/readme) has not a lot of information, but as of now I think that there is no valid way to pass an `object` in typescript. Therefore I think it's better to remove this case.

![image](https://user-images.githubusercontent.com/13085980/46982926-aedf7f80-d0de-11e8-9b5b-c2f7d33094d9.png)
