### PR TITLE
Update react-select types

### DIFF
--- a/types/react-select/lib/Select.d.ts
+++ b/types/react-select/lib/Select.d.ts
@@ -16,7 +16,6 @@ import {
   formatGroupLabel,
   getOptionLabel,
   getOptionValue,
-  isOptionDisabled,
 } from './builtins';
 
 import {
@@ -105,13 +104,13 @@ export interface Props<OptionType> {
     rawInput: string
   ) => boolean) | null;
   /* Formats group labels in the menu as React components */
-  formatGroupLabel?: typeof formatGroupLabel;
+  formatGroupLabel?: formatGroupLabel<OptionType>;
   /* Formats option labels in the menu and control as React components */
   formatOptionLabel?: (option: OptionType, labelMeta: FormatOptionLabelMeta<OptionType>) => React.ReactNode;
   /* Resolves option data to a string to be displayed as the label by components */
-  getOptionLabel?: typeof getOptionLabel;
+  getOptionLabel?: getOptionLabel<OptionType>;
   /* Resolves option data to a string to compare options and specify value attributes */
-  getOptionValue?: typeof getOptionValue;
+  getOptionValue?: getOptionValue<OptionType>;
   /* Hide the selected option from the menu */
   hideSelectedOptions?: boolean;
   /* The id to set on the SelectContainer component. */
@@ -318,8 +317,8 @@ export default class Select<OptionType> extends React.Component<Props<OptionType
   getNextFocusedValue(nextSelectValue: OptionsType<OptionType>): OptionType;
 
   getNextFocusedOption(options: OptionsType<OptionType>): OptionType;
-  getOptionLabel: (data: OptionType) => string;
-  getOptionValue: (data: OptionType) => string;
+  getOptionLabel: getOptionLabel<OptionType>;
+  getOptionValue: getOptionValue<OptionType>;
   getStyles: (key: string, props: {}) => {};
   getElementId: (element: 'group' | 'input' | 'listbox' | 'option') => string;
   getActiveDescendentId: () => any;
@@ -344,7 +343,7 @@ export default class Select<OptionType> extends React.Component<Props<OptionType
   isOptionSelected(option: OptionType, selectValue: OptionsType<OptionType>): boolean;
   filterOption(option: {}, inputValue: string): boolean;
   formatOptionLabel(data: OptionType, context: FormatOptionLabelContext): React.ReactNode;
-  formatGroupLabel(data: GroupType<OptionType>): React.ReactNode;
+  formatGroupLabel: formatGroupLabel<OptionType>;
 
   // ==============================
   // Mouse Handlers

--- a/types/react-select/lib/Select.d.ts
+++ b/types/react-select/lib/Select.d.ts
@@ -50,7 +50,7 @@ export interface FormatOptionLabelMeta<OptionType> {
   selectValue: ValueType<OptionType>;
 }
 
-export interface Props<OptionType> {
+export interface Props<OptionType = { label: string; value: string }> {
   /* Aria label (for assistive tech) */
   'aria-label'?: string;
   /* HTML ID of an element that should be used as the label (for assistive tech) */

--- a/types/react-select/lib/builtins.d.ts
+++ b/types/react-select/lib/builtins.d.ts
@@ -1,10 +1,14 @@
 import { ReactNode } from 'react';
 import { GroupType } from './types';
 
-export function formatGroupLabel(group: GroupType<any>): ReactNode;
+export type formatGroupLabel<OptionType = any> = (group: GroupType<OptionType>) => ReactNode;
+export function formatGroupLabel<OptionType = any>(group: GroupType<OptionType>): ReactNode;
 
-export function getOptionLabel(option: any): string;
+export type getOptionLabel<OptionType = any> = (option: OptionType) => string;
+export function getOptionLabel<OptionType = any>(option: OptionType): string;
 
-export function getOptionValue(option: any): string;
+export type getOptionValue<OptionType = any> = (option: OptionType) => string;
+export function getOptionValue<OptionType = any>(option: OptionType): string;
 
-export function isOptionDisabled(option: any): boolean;
+export type isOptionDisabled<OptionType = any> = (option: OptionType) => boolean;
+export function isOptionDisabled<OptionType = any>(option: OptionType): boolean;

--- a/types/react-select/lib/builtins.d.ts
+++ b/types/react-select/lib/builtins.d.ts
@@ -2,7 +2,7 @@ import { ReactNode } from 'react';
 import { GroupType } from './types';
 
 export type formatGroupLabel<OptionType = any> = (group: GroupType<OptionType>) => ReactNode;
-export function formatGroupLabel(group: any): ReactNode;
+export function formatGroupLabel(group: GroupType<any>): ReactNode;
 
 export type getOptionLabel<OptionType = any> = (option: OptionType) => string;
 export function getOptionLabel(option: any): string;

--- a/types/react-select/lib/builtins.d.ts
+++ b/types/react-select/lib/builtins.d.ts
@@ -1,5 +1,5 @@
-import { ReactNode } from "react";
-import { GroupType } from "./types";
+import { ReactNode } from 'react';
+import { GroupType } from './types';
 
 export type formatGroupLabel<OptionType = any> = (group: GroupType<OptionType>) => ReactNode;
 export function formatGroupLabel(group: any): ReactNode;

--- a/types/react-select/lib/builtins.d.ts
+++ b/types/react-select/lib/builtins.d.ts
@@ -1,14 +1,14 @@
-import { ReactNode } from 'react';
-import { GroupType } from './types';
+import { ReactNode } from "react";
+import { GroupType } from "./types";
 
 export type formatGroupLabel<OptionType = any> = (group: GroupType<OptionType>) => ReactNode;
-export function formatGroupLabel<OptionType = any>(group: GroupType<OptionType>): ReactNode;
+export function formatGroupLabel(group: any): ReactNode;
 
 export type getOptionLabel<OptionType = any> = (option: OptionType) => string;
-export function getOptionLabel<OptionType = any>(option: OptionType): string;
+export function getOptionLabel(option: any): string;
 
 export type getOptionValue<OptionType = any> = (option: OptionType) => string;
-export function getOptionValue<OptionType = any>(option: OptionType): string;
+export function getOptionValue(option: any): string;
 
 export type isOptionDisabled<OptionType = any> = (option: OptionType) => boolean;
-export function isOptionDisabled<OptionType = any>(option: OptionType): boolean;
+export function isOptionDisabled(option: any): boolean;


### PR DESCRIPTION
Update the types for `getOptionLabel`, `getOptionValue`, `formatGroupLabel` to use the `OptionType` generic as appropriate

> *Note*: The "builtin" function for `isOptionDisabled` does not appear to match the signature of the function you could potentially provide, so I left that one as is. It still uses generics so its fine.


- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
