### PR TITLE
[@types/restify] Fix Callback Typing on Restify Metrics Plugin

### DIFF
--- a/types/restify/index.d.ts
+++ b/types/restify/index.d.ts
@@ -1417,22 +1417,22 @@ export namespace plugins {
      */
     function throttle(options?: ThrottleOptions): RequestHandler;
 
-    interface MetricsCallback {
+    type MetricsCallback = (
         /**
          *  An error if the request had an error
          */
-        err: Error;
+        err: Error,
 
-        metrics: MetricsCallbackOptions;
+        metrics: MetricsCallbackOptions,
 
-        req: Request;
-        res: Response;
+        req: Request,
+        res: Response,
 
         /**
          * The route obj that serviced the request
          */
-        route: Route;
-    }
+        route: Route,
+    ) => void;
 
     type TMetricsCallback = 'close' | 'aborted' | undefined;
 

--- a/types/restify/index.d.ts
+++ b/types/restify/index.d.ts
@@ -1423,9 +1423,19 @@ export namespace plugins {
          */
         err: Error,
 
+        /**
+         *  Object that contains the various metrics that are returned
+         */
         metrics: MetricsCallbackOptions,
 
+        /**
+         * The request obj
+         */
         req: Request,
+
+        /**
+         * The response obj
+         */
         res: Response,
 
         /**

--- a/types/restify/index.d.ts
+++ b/types/restify/index.d.ts
@@ -1495,13 +1495,13 @@ export namespace plugins {
      * Listens to the server's after event and emits information about that request (5.x compatible only).
      *
      * ```
-     * server.on('after', plugins.metrics( (err, metrics) =>
+     * server.on('after', plugins.metrics({ server }, (err, metrics, req, res, route) =>
      * {
      *    // metrics is an object containing information about the request
      * }));
      * ```
      */
-    function metrics(opts: { server: Server }, callback: (options: MetricsCallback) => any): (...args: any[]) => void;
+    function metrics(opts: { server: Server }, callback: MetricsCallback): (...args: any[]) => void;
 
     /**
      * Parse the client's request for an OAUTH2 access tokensTable

--- a/types/restify/v5/index.d.ts
+++ b/types/restify/v5/index.d.ts
@@ -1251,13 +1251,13 @@ export namespace plugins {
      * Listens to the server's after event and emits information about that request (5.x compatible only).
      *
      * ```
-     * server.on('after', plugins.metrics( (err, metrics) =>
+     * server.on('after', plugins.metrics({ server }, (err, metrics, req, res, route) =>
      * {
      *    // metrics is an object containing information about the request
      * }));
      * ```
      */
-    function metrics(opts: { server: Server }, callback: (options: MetricsCallback) => any): (...args: any[]) => void;
+    function metrics(opts: { server: Server }, callback: MetricsCallback): (...args: any[]) => void;
 
     /**
      * Parse the client's request for an OAUTH2 access tokensTable


### PR DESCRIPTION
The typing was declared wrong for the metrics plugin callback, this resolves that problem.

Tasks:

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://restify.com/docs/plugins-api/#metrics
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

The function type declaration for the metrics callback was incorrect. The callback needed to be typed directly as `MetricsCallback`.

Example from Documentation:
```javascript
server.on('after', restify.plugins.metrics({ server: server },
    function (err, metrics, req, res, route) {
        // metrics is an object containing information about the request
}));
```
