### PR TITLE
N3: Added missing option for writer

### DIFF
--- a/types/n3/index.d.ts
+++ b/types/n3/index.d.ts
@@ -140,6 +140,7 @@ export interface N3StreamParser extends RDF.Stream, NodeJS.WritableStream, RDF.S
 export interface WriterOptions {
     format?: string;
     prefixes?: Prefixes;
+    end?: boolean;
 }
 
 export interface WriterConstructor {

--- a/types/n3/n3-tests.ts
+++ b/types/n3/n3-tests.ts
@@ -113,7 +113,7 @@ function test_doc_from_triples_to_string() {
 }
 
 function test_doc_from_triples_to_rdf_stream() {
-    const writer: N3.N3Writer = new N3.Writer(process.stdout, { prefixes: { c: N3.DataFactory.namedNode('http://example.org/cartoons#') } });
+    const writer: N3.N3Writer = new N3.Writer(process.stdout, { end: false, prefixes: { c: N3.DataFactory.namedNode('http://example.org/cartoons#') } });
     writer.addQuad(N3.DataFactory.quad(
       N3.DataFactory.namedNode('http://example.org/cartoons#Tom'),
       N3.DataFactory.namedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'),


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/rdfjs/N3.js/blob/master/README.md#from-quads-to-an-rdf-stream

The `end` field is missing as Writer options