### PR TITLE
d3 v4 and v5: activate strictNullChecks

### DIFF
--- a/types/d3/index.d.ts
+++ b/types/d3/index.d.ts
@@ -5,7 +5,6 @@
 //                 Boris Yankov <https://github.com/borisyankov>
 //                 denisname <https://github.com/denisname>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
 // Last module patch version validated against: 5.0.0 RC3

--- a/types/d3/index.d.ts
+++ b/types/d3/index.d.ts
@@ -1,6 +1,10 @@
 // Type definitions for D3JS d3 standard bundle 5.0
 // Project: https://github.com/d3/d3
-// Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
+// Definitions by: Tom Wanzek <https://github.com/tomwanzek>
+//                 Alex Ford <https://github.com/gustavderdrache>
+//                 Boris Yankov <https://github.com/borisyankov>
+//                 denisname <https://github.com/denisname>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -11,7 +15,11 @@
 
 export as namespace d3;
 
+/**
+ * Version number in format _Major.Minor.BugFix_, like 5.0.0.
+ */
 export const version: string;
+
 export * from 'd3-array';
 export * from 'd3-axis';
 export * from 'd3-brush';

--- a/types/d3/tsconfig.json
+++ b/types/d3/tsconfig.json
@@ -7,7 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
-        "strictNullChecks": false,
+        "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/d3/v4/index.d.ts
+++ b/types/d3/v4/index.d.ts
@@ -1,6 +1,9 @@
 // Type definitions for D3JS d3 standard bundle 4.13
 // Project: https://github.com/d3/d3
-// Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
+// Definitions by: Tom Wanzek <https://github.com/tomwanzek>
+//                 Alex Ford <https://github.com/gustavderdrache>
+//                 Boris Yankov <https://github.com/borisyankov>
+//                 denisname <https://github.com/denisname>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -8,7 +11,11 @@
 
 export as namespace d3;
 
+/**
+ * Version number in format _Major.Minor.BugFix_, like 4.13.0.
+ */
 export const version: string;
+
 export * from 'd3-array';
 export * from 'd3-axis';
 export * from 'd3-brush';

--- a/types/d3/v4/tsconfig.json
+++ b/types/d3/v4/tsconfig.json
@@ -7,7 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
-        "strictNullChecks": false,
+        "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../../",
         "typeRoots": [


### PR DESCRIPTION
All d3 v4 and v5 modules have strictNullChecks activated. 🎉
Add jsDoc for `version`.

Related: #23611.
