### PR TITLE
[@types/randomcolor] change export to standard format

### DIFF
--- a/types/randomcolor/index.d.ts
+++ b/types/randomcolor/index.d.ts
@@ -1,12 +1,10 @@
-// Type definitions for randomColor 0.5.0
+// Type definitions for randomColor 0.5.3
 // Project: https://github.com/davidmerfield/randomColor
 // Definitions by: Mathias Feitzinger <https://github.com/feitzi>, Brady Liles <https://github.com/BradyLiles>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare function randomColor(options?: RandomColorOptions): string;
-
 interface RandomColorOptions {
-	hue?: number | "red" | "orange" | "yellow" | "green" | "blue" | "purple" | "pink" | "monochrome" | "random";
+	hue?: number | string | "red" | "orange" | "yellow" | "green" | "blue" | "purple" | "pink" | "monochrome" | "random";
 	luminosity?: "bright" | "light" | "dark" | "random";
 	count?: number;
 	seed?: number | string;
@@ -14,6 +12,4 @@ interface RandomColorOptions {
 	alpha?: number;
 }
 
-declare module "randomcolor" {
-	export = randomColor;
-}
+export function randomColor(options?: RandomColorOptions): string;


### PR DESCRIPTION
Adapted from https://github.com/davidmerfield/randomColor/blob/5079eeaed89350e28df11c0741dcc37da9bceba8/randomColor.d.ts

I would like to credit @davidmerfield for providing fixed definitions in the file itself but I think that would mean he would be called to review changes like this in the future, so I'll let him decide if he wants to be roped into that.

Also, the ` | string` change is to support hex colors in the hue argument, a change introduced in 0.5.2 of randomColor.

This is probably a breaking change but I couldn't get that darn module import working so I think it's for the better if this is made the standard.