### PR TITLE
[angular-ui-sortable] Fix types of property 'sortable' are incompatible

### DIFF
--- a/types/angular-ui-sortable/angular-ui-sortable-tests.ts
+++ b/types/angular-ui-sortable/angular-ui-sortable-tests.ts
@@ -16,6 +16,9 @@ interface SortLogInfo {
   Text: string;
 }
 
+// Ensure that the jQuery-ui defined `sortable()` method is not overwritten
+jQuery().sortable(); // $ExpectType JQuery<HTMLElement>
+
 myApp.controller('sortableController', function ($scope: MySortableControllerScope) {
   $scope.sortableOptions = {
     activate: function(e, ui) {
@@ -84,6 +87,7 @@ myApp.controller('sortableController', function ($scope: MySortableControllerSco
     update: function(e, ui) {
       var jQueryEventObject: JQueryEventObject = e;
       var uiSortableUIParams: ng.ui.UISortableUIParams<SortableModelInfo> = ui;
+      ui.item.sortable; // $ExpectType UISortableProperties<SortableModelInfo>
       var voidcanceled: void = ui.item.sortable.cancel();
       var isCanceled: Boolean = ui.item.sortable.isCanceled();
       var isCustomHelperUsed: Boolean =ui.item.sortable.isCustomHelperUsed();

--- a/types/angular-ui-sortable/index.d.ts
+++ b/types/angular-ui-sortable/index.d.ts
@@ -2,11 +2,15 @@
 // Project: https://github.com/angular-ui/ui-sortable
 // Definitions by: Thodoris Greasidis <https://github.com/thgreasi>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.4
 
 /// <reference types="angular" />
+/// <reference types="jqueryui" />
 
 import * as ng from 'angular';
+
+// Diff / Omit taken from https://github.com/Microsoft/TypeScript/issues/12215#issuecomment-311923766
+type Omit<T, K extends keyof T> = Pick<T, ({ [P in keyof T]: P } & { [P in K]: never } & { [x: string]: never, [x: number]: never })[keyof T]>;
 
 declare module 'angular' {
     export namespace ui {
@@ -79,11 +83,11 @@ declare module 'angular' {
             isCustomHelperUsed(): Boolean;
         }
 
-        interface UISortableUIItem<T> extends ng.IAugmentedJQuery {
+        interface UISortableUIItem<T> extends Omit<ng.IAugmentedJQuery, 'sortable'> {
             sortable: UISortableProperties<T>;
         }
 
-        interface UISortableUIParams<T> extends SortableUIParams {
+        interface UISortableUIParams<T> extends Omit<SortableUIParams, 'item'> {
             item: UISortableUIItem<T>;
         }
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Fixes #4641

I wen't ahead and added `jqueryui` as a type dependency since the package already requires `jqueryui`.
Typescript version was increased because I could not find a working `Omit` type that worked in Typescript 2.3.