### PR TITLE
[rx-lite] Fix mergeAll having wrong return type 

### DIFF
--- a/types/rx-lite/index.d.ts
+++ b/types/rx-lite/index.d.ts
@@ -244,8 +244,8 @@ declare namespace Rx {
         merge(maxConcurrent: number): T;
         merge(other: Observable<T>): Observable<T>;
         merge(other: IPromise<T>): Observable<T>;
-        mergeAll(): Observable<T>;
-        mergeObservable(): Observable<T>;    // alias for mergeAll
+        mergeAll(): T;
+        mergeObservable(): T;    // alias for mergeAll
         skipUntil<T2>(other: Observable<T2>): Observable<T>;
         skipUntil<T2>(other: IPromise<T2>): Observable<T>;
         switch(): T;

--- a/types/rx-lite/rx-lite-tests.ts
+++ b/types/rx-lite/rx-lite-tests.ts
@@ -86,14 +86,19 @@ function test_concatAll() {
 		});
 }
 
+// https://github.com/Reactive-Extensions/RxJS/blob/master/doc/api/core/operators/mergeall.md
 function test_mergeAll() {
-	/* mergeAll example */
+    /* mergeAll example */
+
+    // $ExpectType Observable<number>
 	const source = Rx.Observable.range(0, 3)
 		.map(x => Rx.Observable.range(x, 3))
-		.mergeAll();
+        .mergeAll();
 
 	const subscription = source.subscribe(
 		x => {
+            // $ExpectType number
+            x;
 			console.log('Next: %s', x);
 		},
 		err => {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/Reactive-Extensions/RxJS/blob/master/doc/api/core/operators/mergeall.md
