### PR TITLE
Add missing gapi.signin2.render onfailure arg

### DIFF
--- a/types/gapi.auth2/gapi.auth2-tests.ts
+++ b/types/gapi.auth2/gapi.auth2-tests.ts
@@ -55,8 +55,8 @@ function test_render() {
   const success = (googleUser: gapi.auth2.GoogleUser): void => {
     console.log(googleUser);
   };
-  const failure = (): void => {
-    console.log('Failure callback');
+  const failure = (reason: { error: string }): void => {
+    console.log(`Failure callback: ${reason.error}`);
   };
 
   gapi.signin2.render('testId', {

--- a/types/gapi.auth2/index.d.ts
+++ b/types/gapi.auth2/index.d.ts
@@ -349,7 +349,7 @@ declare namespace gapi.signin2 {
     /**
      * The callback function to call when sign-in fails (default: none).
      */
-    onfailure?(): void;
+    onfailure?(reason: { error: string }): void;
 
     /**
      * The package name of the Android app to install over the air. See


### PR DESCRIPTION
According to https://developers.google.com/identity/sign-in/web/reference#gapisignin2renderid-options for the `onfailure` option:

> The callback function to call when sign-in fails. This function takes no arguments (default: none).

However, it actually does take arguments. For example, when the Google signin window pops open and the user just closes it (because maybe they changed their mind), it does give you an argument. This is super useful so you can opt to not log errors just because the user closed the window. See screenshot illustrating that it does actually give you this arg:

![image](https://user-images.githubusercontent.com/626664/47119803-0a189a00-d2b8-11e8-8bb8-652c07e7f7bd.png)

The only thing I'm not sure of is backwards compatibility. Are we meant to bump the major version so that we don't break existing code that relied on the definition without the argument?

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developers.google.com/identity/sign-in/web/reference#gapisignin2renderid-options
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
