### PR TITLE
[aws-lambda] Add Amazon Cognito Migrate User triggers

### DIFF
--- a/types/aws-lambda/aws-lambda-tests.ts
+++ b/types/aws-lambda/aws-lambda-tests.ts
@@ -383,6 +383,8 @@ cognitoUserPoolEvent.triggerSource === "TokenGeneration_Authentication";
 cognitoUserPoolEvent.triggerSource === "TokenGeneration_NewPasswordChallenge";
 cognitoUserPoolEvent.triggerSource === "TokenGeneration_AuthenticateDevice";
 cognitoUserPoolEvent.triggerSource === "TokenGeneration_RefreshTokens";
+cognitoUserPoolEvent.triggerSource === "UserMigration_Authentication";
+cognitoUserPoolEvent.triggerSource === "UserMigration_ForgotPassword";
 str = cognitoUserPoolEvent.region;
 str = cognitoUserPoolEvent.userPoolId;
 strOrUndefined = cognitoUserPoolEvent.userName;
@@ -404,6 +406,7 @@ strOrUndefined = cognitoUserPoolEvent.request.session![0].challengeMetadata;
 strOrUndefined = cognitoUserPoolEvent.request.challengeName;
 str = cognitoUserPoolEvent.request.privateChallengeParameters!["answer"];
 str = cognitoUserPoolEvent.request.challengeAnswer!;
+strOrUndefined = cognitoUserPoolEvent.request.password;
 boolOrUndefined = cognitoUserPoolEvent.response.answerCorrect;
 strOrUndefined = cognitoUserPoolEvent.response.smsMessage;
 strOrUndefined = cognitoUserPoolEvent.response.emailMessage;
@@ -415,6 +418,14 @@ str = cognitoUserPoolEvent.response.publicChallengeParameters!["captchaUrl"];
 str = cognitoUserPoolEvent.response.privateChallengeParameters!["answer"];
 strOrUndefined = cognitoUserPoolEvent.response.challengeMetadata;
 boolOrUndefined = cognitoUserPoolEvent.response.answerCorrect;
+str = cognitoUserPoolEvent.response.userAttributes!["username"];
+cognitoUserPoolEvent.response.finalUserStatus === "CONFIRMED";
+cognitoUserPoolEvent.response.finalUserStatus === "RESET_REQUIRED";
+cognitoUserPoolEvent.response.messageAction === "SUPPRESS";
+cognitoUserPoolEvent.response.desiredDeliveryMediums === ["EMAIL"];
+cognitoUserPoolEvent.response.desiredDeliveryMediums === ["SMS"];
+cognitoUserPoolEvent.response.desiredDeliveryMediums === ["SMS", "EMAIL"];
+boolOrUndefined = cognitoUserPoolEvent.response.forceAliasCreation;
 
 // CloudFormation Custom Resource
 switch (cloudformationCustomResourceEvent.RequestType) {

--- a/types/aws-lambda/index.d.ts
+++ b/types/aws-lambda/index.d.ts
@@ -22,6 +22,7 @@
 //                 Louis Larry <https://github.com/louislarry>
 //                 Daniel Papukchiev <https://github.com/dpapukchiev>
 //                 Oliver Hookins <https://github.com/ohookins>
+//                 James Gregory <https://github.com/jagregory>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -234,7 +235,9 @@ export interface CognitoUserPoolTriggerEvent {
     | "TokenGeneration_Authentication"
     | "TokenGeneration_NewPasswordChallenge"
     | "TokenGeneration_AuthenticateDevice"
-    | "TokenGeneration_RefreshTokens";
+    | "TokenGeneration_RefreshTokens"
+    | "UserMigration_Authentication"
+    | "UserMigration_ForgotPassword";
     region: string;
     userPoolId: string;
     userName?: string;
@@ -256,6 +259,7 @@ export interface CognitoUserPoolTriggerEvent {
         challengeName?: string;
         privateChallengeParameters?: { [key: string]: string };
         challengeAnswer?: string;
+        password?: string;
     };
     response: {
         autoConfirmUser?: boolean;
@@ -269,6 +273,11 @@ export interface CognitoUserPoolTriggerEvent {
         privateChallengeParameters?: { [key: string]: string };
         challengeMetadata?: string;
         answerCorrect?: boolean;
+        userAttributes?: { [key: string]: string };
+        finalUserStatus?: "CONFIRMED" | "RESET_REQUIRED";
+        messageAction?: "SUPPRESS";
+        desiredDeliveryMediums?: Array<"EMAIL" | "SMS">;
+        forceAliasCreation?: boolean;
     };
 }
 export type CognitoUserPoolEvent = CognitoUserPoolTriggerEvent;


### PR DESCRIPTION
This adds `triggerSource` values to cover Cognito User Pool user migrations, and the additional request and response object fields.

See:

1. https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-lambda-migrate-user.html
2. https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pools-import-using-lambda.html

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-lambda-migrate-user.html
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.