### PR TITLE
Puppeteer. Select method moved from Page to parent FrameBase class

### DIFF
--- a/types/puppeteer/index.d.ts
+++ b/types/puppeteer/index.d.ts
@@ -1168,7 +1168,7 @@ export interface FrameBase extends Evalable {
    * @param selector A selector to search for element to hover. If there are multiple elements satisfying the selector, the first will be hovered.
    */
   hover(selector: string): Promise<void>;
-  
+
   /**
    * Triggers a `change` and `input` event once all the provided options have been selected.
    * If there's no `<select>` element matching selector, the method throws an error.

--- a/types/puppeteer/index.d.ts
+++ b/types/puppeteer/index.d.ts
@@ -1168,6 +1168,15 @@ export interface FrameBase extends Evalable {
    * @param selector A selector to search for element to hover. If there are multiple elements satisfying the selector, the first will be hovered.
    */
   hover(selector: string): Promise<void>;
+  
+  /**
+   * Triggers a `change` and `input` event once all the provided options have been selected.
+   * If there's no `<select>` element matching selector, the method throws an error.
+   * @param selector A selector to query page for.
+   * @param values Values of options to select. If the `<select>` has the `multiple` attribute,
+   * all values are considered, otherwise only the first one is taken into account.
+   */
+  select(selector: string, ...values: string[]): Promise<string[]>;
 
   /**
    * Sets the page content.
@@ -1471,15 +1480,6 @@ export interface Page extends EventEmitter, FrameBase {
   screenshot(options?: Base64ScreenShotOptions): Promise<string>;
   screenshot(options?: BinaryScreenShotOptions): Promise<Buffer>;
   screenshot(options?: ScreenshotOptions): Promise<string | Buffer>;
-
-  /**
-   * Triggers a `change` and `input` event once all the provided options have been selected.
-   * If there's no `<select>` element matching selector, the method throws an error.
-   * @param selector A selector to query page for.
-   * @param values Values of options to select. If the `<select>` has the `multiple` attribute,
-   * all values are considered, otherwise only the first one is taken into account.
-   */
-  select(selector: string, ...values: string[]): Promise<string[]>;
 
   /**
    * Toggles bypassing page's Content-Security-Policy.


### PR DESCRIPTION
Select method moved from Page to parent FrameBase class. This allows perform selecting option in select html element in frame.