### PR TITLE
react-redux-toastr: Add missing closeOnToastrClick-prop

### DIFF
--- a/types/react-redux-toastr/index.d.ts
+++ b/types/react-redux-toastr/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-redux-toastr 7.1
+// Type definitions for react-redux-toastr 7.4
 // Project: https://github.com/diegoddox/react-redux-toastr
 // Definitions by: Aleksandar Ivanov <https://github.com/Smiche>
 //                 Artyom Stukans <https://github.com/artyomsv>
@@ -102,6 +102,7 @@ interface ReduxToastrProps {
     transitionIn?: transitionInType;
     transitionOut?: transitionOutType;
     className?: string;
+    closeOnToastrClick?: boolean;
 }
 
 interface ToastrEmitter {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/diegoddox/react-redux-toastr/blob/master/src/ReduxToastr.js#L25
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
