### PR TITLE
d3-selection: Use $ExpectError

### DIFF
--- a/types/d3-selection/d3-selection-tests.ts
+++ b/types/d3-selection/d3-selection-tests.ts
@@ -74,7 +74,8 @@ let body: d3Selection.Selection<HTMLBodyElement, BodyDatum, HTMLElement, any> = 
 // with Group element of type BaseType and datum of type 'any' The parent element is of type 'null' with datum of type 'undefined'
 
 const baseTypeEl2: d3Selection.Selection<d3Selection.BaseType, any, null, undefined> = d3Selection.select(baseTypeEl.node());
-// let body2: d3Selection.Selection<HTMLElement, any, null, undefined> = d3Selection.select(baseTypeEl.node()); // fails as baseTypeEl.node() is of type cannot be assigned to HTMLElement
+// $ExpectError
+const body2: d3Selection.Selection<HTMLElement, any, null, undefined> = d3Selection.select(baseTypeEl.node()); // fails as baseTypeEl.node() is of type cannot be assigned to HTMLElement
 
 const body3: d3Selection.Selection<HTMLBodyElement, any, null, undefined> = d3Selection.select(body.node()!); // element types match, but datum is of type 'any' as it cannot be inferred from .node()
 
@@ -86,18 +87,21 @@ const body4: d3Selection.Selection<HTMLBodyElement, BodyDatum, null, undefined> 
 //  Explicitly cast body.node() to HTMLBodyElement to narrow selection definition.
 const body5: d3Selection.Selection<HTMLBodyElement, BodyDatum, null, undefined> = d3Selection.select<HTMLBodyElement, BodyDatum>(body.node()!);
 
-// d3Selection.select<HTMLBodyElement, BodyDatum>(baseTypeEl.node()!); // fails as baseTypeEl.node() is not of type HTMLBodyElement
+// $ExpectError
+d3Selection.select<HTMLBodyElement, BodyDatum>(baseTypeEl.node()!); // fails as baseTypeEl.node() is not of type HTMLBodyElement
 
 // test, when it is not certain, whether an element of the type to be selected exists
 let maybeSVG1: d3Selection.Selection<SVGSVGElement | null, any, HTMLElement, undefined>;
 maybeSVG1 = d3Selection.select<SVGSVGElement | null, any>('svg');
 
 let maybeSVG2: d3Selection.Selection<SVGSVGElement | null, any, null, undefined>;
-// maybeSVG2 = d3Selection.select<SVGSVGElement, any>(maybeSVG1.node()); // fails with strict function types
+// $ExpectError
+maybeSVG2 = d3Selection.select<SVGSVGElement, any>(maybeSVG1.node()); // fails with strict function types
 maybeSVG2 = d3Selection.select<SVGSVGElement | null, any>(maybeSVG1.node());
 
 // fails, as node type mismatches selection type
-// let body7: d3Selection.Selection<HTMLBodyElement | null, any, HTMLElement, undefined> = d3Selection.select<HTMLBodyElement | null, any>(maybeSVG1.node());
+// $ExpectError
+const body7: d3Selection.Selection<HTMLBodyElement | null, any, HTMLElement, undefined> = d3Selection.select<HTMLBodyElement | null, any>(maybeSVG1.node());
 
 // test "special case DOM objects"
 
@@ -127,7 +131,8 @@ const divElements: d3Selection.Selection<HTMLDivElement, DivDatum, HTMLElement, 
 
 const baseTypeElements2: d3Selection.Selection<d3Selection.BaseType, any, null, undefined> = d3Selection.selectAll(baseTypeElements.nodes());
 // fails, group elements types not of compatible for baseTypeElements
-// let divElements2: d3Selection.Selection<HTMLDivElement, any, null, undefined> = d3Selection.selectAll(baseTypeElements.nodes());
+// $ExpectError
+const divElements2: d3Selection.Selection<HTMLDivElement, any, null, undefined> = d3Selection.selectAll(baseTypeElements.nodes());
 
 // element types match, but datum is of type 'any' as it cannot be inferred from .nodes()
 const divElements3: d3Selection.Selection<HTMLDivElement, any, null, undefined> = d3Selection.selectAll(divElements.nodes());
@@ -137,7 +142,8 @@ const divElements3: d3Selection.Selection<HTMLDivElement, any, null, undefined> 
 
 const divElements4: d3Selection.Selection<HTMLDivElement, DivDatum, null, undefined> = d3Selection.selectAll<HTMLDivElement, DivDatum>(divElements.nodes());
 
-// d3Selection.selectAll<HTMLDivElement, DivDatum>(baseTypeElements.nodes()); // fails as baseTypeEl.node() is not of type HTMLBodyElement
+// $ExpectError
+d3Selection.selectAll<HTMLDivElement, DivDatum>(baseTypeElements.nodes()); // fails as baseTypeEl.node() is not of type HTMLBodyElement
 
 // selectAll(...) accepts NodeListOf<...> argument
 
@@ -161,8 +167,8 @@ const documentLinks: d3Selection.Selection<HTMLAnchorElement | HTMLAreaElement, 
 const svgEl: d3Selection.Selection<SVGSVGElement, SVGDatum, HTMLElement, any> = d3Selection.select<SVGSVGElement, SVGDatum>('svg');
 
 let firstG: d3Selection.Selection<SVGGElement, SVGDatum, HTMLElement, any> = svgEl.select<SVGGElement>('g');
-// let firstG_2: d3Selection.Selection<SVGGElement, SVGDatum, SVGSVGElement, any> = svgEl.select<SVGGElement>('g'); // fails, parent element of selection does not change with .select(...)
-// firstG = svgEl.select('g'); // fails, element type defaults to 'BaseType', but SVGGElement expected on left-hand side
+// $ExpectError
+const firstG_2: d3Selection.Selection<SVGGElement, SVGDatum, SVGSVGElement, any> = svgEl.select<SVGGElement>('g'); // fails, parent element of selection does not change with .select(...)
 // firstG = svgEl.select<SVGSVGElement>('svg'); // fails, element type of SVGSVGElement provided, but SVGGElement expected on left-hand side (silly test to begin with)
 
 // test, when it is not certain, whether an element of the type to be selected exists
@@ -180,14 +186,16 @@ firstG = svgEl.select(svgGroupSelector);
 
 firstG = svgEl.select(function() {
     const that: SVGSVGElement = this;
-    // const that2: HTMLElement  = this; // fails, type mismatch
+    // $ExpectError
+    const that2: HTMLElement  = this; // fails, type mismatch
     console.log('Get <svg> Element width using "this": ', this.width.baseVal.value); // 'this' type is SVGSVGElement
     return this.querySelector('g')!; // this of type SVGSVGElement by type inference
 });
 
 firstG = svgEl.select(function(d, i, g) {
     const that: SVGSVGElement = this;
-    // const that2: HTMLElement  = this; // fails, type mismatch
+    // $ExpectError
+    const that2: HTMLElement  = this; // fails, type mismatch
     const datum: SVGDatum = d;
     const index: number = i;
     const group: SVGSVGElement[] | d3Selection.ArrayLike<SVGSVGElement> = g;
@@ -199,9 +207,10 @@ firstG = svgEl.select(function(d, i, g) {
     return this.querySelector('g')!; // this of type SVGSVGElement by type inference
 });
 
-// firstG = svgEl.select(function() {
-//     return this.querySelector('a'); // fails, return type HTMLAnchorElement is not compatible with SVGGElement expected by firstG
-// });
+// $ExpectError
+firstG = svgEl.select(function() {
+    return this.querySelector('a'); // fails, return type HTMLAnchorElement is not compatible with SVGGElement expected by firstG
+});
 
 // selectAll(...) sub-selection --------------------------------------------------------------
 
@@ -219,7 +228,6 @@ emptySubSelection = svgEl.selectAll(undefined);
 let elementsUnknownData: d3Selection.Selection<SVGGElement, any, SVGSVGElement, SVGDatum> = svgEl.selectAll<SVGGElement, any>('g');
 // let elementsAndDataUnknown: d3Selection.Selection<d3Selection.BaseType, any, SVGSVGElement, SVGDatum> = svgEl.selectAll('g'); // fails with strictFunctionTypes
 let gElementsOldData: d3Selection.Selection<SVGGElement, CircleDatum, SVGSVGElement, SVGDatum> = svgEl.selectAll<SVGGElement, CircleDatum>('g');
-// gElementsOldData = svgEl.selectAll('g'); // fails default type parameters of selectAll for group element type and datum type do not match
 
 // Using selectAll(...) sub-selection with a selector function argument.
 
@@ -232,18 +240,21 @@ gElementsOldData = svgEl.selectAll<SVGGElement, CircleDatum>(svgGroupSelectorAll
 function wrongSvgGroupSelectorAll(this: HTMLElement, d: SVGDatum, i: number, groups: HTMLElement[]): NodeListOf<SVGGElement> {
     return this.querySelectorAll('g');
 }
-// gElementsOldData = svgEl.selectAll<SVGGElement, CircleDatum>(wrongSvgGroupSelectorAll); // fails, wrong this context
+// $ExpectError
+gElementsOldData = svgEl.selectAll<SVGGElement, CircleDatum>(wrongSvgGroupSelectorAll); // fails, wrong this context
 
 gElementsOldData = svgEl.selectAll<SVGGElement, CircleDatum>(function() {
     const that: SVGSVGElement = this;
-    // const that2: HTMLElement  = this; // fails, type mismatch
+    // $ExpectError
+    const that2: HTMLElement  = this; // fails, type mismatch
     console.log('Get <svg> Element width using "this": ', this.width.baseVal.value); // 'this' type is SVGSVGElement
     return this.querySelectorAll('g'); // this of type SVGSVGElement by type inference
 });
 
 gElementsOldData = svgEl.selectAll<SVGGElement, CircleDatum>(function(d, i, g) {
     const that: SVGSVGElement = this;
-    // const that2: HTMLElement  = this; // fails, type mismatch
+    // $ExpectError
+    const that2: HTMLElement  = this; // fails, type mismatch
     const datum: SVGDatum = d;
     const index: number = i;
     const group: SVGSVGElement[] | d3Selection.ArrayLike<SVGSVGElement> = g;
@@ -255,31 +266,32 @@ gElementsOldData = svgEl.selectAll<SVGGElement, CircleDatum>(function(d, i, g) {
     return this.querySelectorAll('g');
 });
 
-// gElementsOldData = svgEl.selectAll(function() { // fails, because Datum type is not compatible as selectAll defaults to 'any', but gElementsOldData expects CircleDatum
-//     return this.querySelectorAll('g');
-// });
-
-// gElementsOldData = svgEl.selectAll<SVGGElement, CircleDatum>(function() {  // fails, return type HTMLAnchorElement is not compatible with SVGGElement expected by selectAll-typing
-//     return this.querySelectorAll('a');
-// });
+// $ExpectError
+gElementsOldData = svgEl.selectAll<SVGGElement, CircleDatum>(function() {  // fails, return type HTMLAnchorElement is not compatible with SVGGElement expected by selectAll-typing
+    return this.querySelectorAll('a');
+});
 
 elementsUnknownData = svgEl.selectAll(svgGroupSelectorAll);
 
 elementsUnknownData = svgEl.selectAll(function() {
     const that: SVGSVGElement = this;
-    // const that2: HTMLElement  = this; // fails, type mismatch
+    // $ExpectError
+    const that2: HTMLElement  = this; // fails, type mismatch
     console.log('Get <svg> Element width using "this": ', this.width.baseVal.value); // 'this' type is SVGSVGElement
     return this.querySelectorAll('g'); // this of type SVGSVGElement by type inference
 });
 
-// gElementsUnknownData = svgEl.selectAll(function() { // fails, return type HTMLAnchorElement is not compatible with SVGGElement
-//     return this.querySelectorAll('a');
-// });
+// $ExpectError
+gElementsUnknownData = svgEl.selectAll(function() { // fails, return type HTMLAnchorElement is not compatible with SVGGElement
+    return this.querySelectorAll('a');
+});
 
 maybeG.selectAll(function(d, i, g) {
     const that: SVGGElement | null = this;
-    // const that2: SVGGElement = this; // fails with strictNullChecks
-    // const that3: HTMLElement | null  = this; // fails, type mismatch
+    // $ExpectError
+    const that2: SVGGElement = this; // fails with strictNullChecks
+    // $ExpectError
+    const that3: HTMLElement | null  = this; // fails, type mismatch
     const datum: SVGDatum = d;
     const index: number = i;
     const group: Array<SVGGElement | null> | d3Selection.ArrayLike<SVGGElement | null> = g;
@@ -290,11 +302,13 @@ maybeG.selectAll(function(d, i, g) {
 
 // selector(...) and selectorAll(...) ----------------------------------------------------
 
-// d3Selection.select<SVGGElement>(d3Selection.selector<SVGGElement>('g')); // fails, selector as argument to top-level select not supported
+// $ExpectError
+d3Selection.select<SVGGElement>(d3Selection.selector<SVGGElement>('g')); // fails, selector as argument to top-level select not supported
 
 // supported on sub-selection
 firstG = svgEl.select(d3Selection.selector<SVGGElement>('g')); // type parameter of select(...) inferred
-// firstG = svgEl.select<SVGGElement>(d3Selection.selector<HTMLDivElement>('div')); // fails, select and selector mismatch
+// $ExpectError
+firstG = svgEl.select<SVGGElement>(d3Selection.selector<HTMLDivElement>('div')); // fails, select and selector mismatch
 
 gElementsOldData = svgEl.selectAll<SVGGElement, CircleDatum>(d3Selection.selectorAll<SVGGElement>('g'));
 
@@ -308,7 +322,8 @@ filteredGElements = gElementsOldData.filter('.top-level');
 
 filteredGElements = gElementsOldData.filter(function(d, i, g) {
     const that: SVGGElement = this;
-    // const that2: HTMLElement  = this; // fails, type mismatch
+    // $ExpectError
+    const that2: HTMLElement  = this; // fails, type mismatch
     const datum: CircleDatum = d;
     const index: number = i;
     const group: SVGGElement[] | d3Selection.ArrayLike<SVGGElement> = g;
@@ -325,16 +340,18 @@ filteredGElements = gElementsOldData.filter(function(d, i, g) {
 let filteredGElements2: d3Selection.Selection<SVGGElement, any, HTMLElement, any>;
 
 filteredGElements2 = d3Selection.selectAll<SVGElement, any>('.any-svg-type').filter<SVGGElement>('g');
-// filteredGElements2 = d3Selection.selectAll('.any-type').filter('g'); // fails without using narrowing generic on filter method
+// $ExpectError
+filteredGElements2 = d3Selection.selectAll('.any-type').filter('g'); // fails without using narrowing generic on filter method
 
 filteredGElements2 = d3Selection.selectAll<SVGElement, any>('.any-svg-type').filter<SVGGElement>(function() {
     const that: SVGElement = this;
     return that.tagName === 'g' || that.tagName === 'G';
 });
-// filteredGElements2 = d3Selection.selectAll<SVGElement, any>('.any-svg-type').filter(function(){
-//     const that: SVGElement = this;
-//     return that.tagName === 'g'|| that.tagName === 'G';
-// }); // fails without using narrowing generic on filter method
+// $ExpectError
+filteredGElements2 = d3Selection.selectAll<SVGElement, any>('.any-svg-type').filter(function() {
+    const that: SVGElement = this;
+    return that.tagName === 'g' || that.tagName === 'G';
+}); // fails without using narrowing generic on filter method
 
 // matcher() -----------------------------------------------------------------------------
 
@@ -371,7 +388,8 @@ circles = d3Selection.selectAll<SVGCircleElement, CircleDatumAlternative>('circl
 circles = circles // re-assignment test chaining return-type
     .attr('cx', function(d, i, g) {
         const that: SVGGElement = this;
-        // const that2: HTMLElement  = this; // fails, type mismatch
+        // $ExpectError
+        const that2: HTMLElement  = this; // fails, type mismatch
         const datum: CircleDatum = d;
         const index: number = i;
         const group: SVGGElement[] | d3Selection.ArrayLike<SVGGElement> = g;
@@ -395,7 +413,8 @@ divs = divs
 divs = divs
     .classed('zero-px-padding', function(d, i, g) {
         const that: HTMLDivElement = this;
-        // const that2: SVGElement  = this; // fails, type mismatch
+        // $ExpectError
+        const that2: SVGElement  = this; // fails, type mismatch
         const datum: DivDatum = d;
         const index: number = i;
         const group: HTMLDivElement[] | d3Selection.ArrayLike<HTMLDivElement> = g;
@@ -411,13 +430,15 @@ divs = divs
 divs = divs
     .style('background-color', 'blue') // string
     .style('hidden', false) // boolean
-    // .style('color', 'green', 'test') // fails, invalid priority value
+    // $ExpectError
+    .style('color', 'green', 'test') // fails, invalid priority value
     .style('color', 'green', 'important');
 
 divs = divs
     .style('padding', function(d, i, g) {
         const that: HTMLDivElement = this;
-        // const that2: SVGElement  = this; // fails, type mismatch
+        // $ExpectError
+        const that2: SVGElement  = this; // fails, type mismatch
         const datum: DivDatum = d;
         const index: number = i;
         const group: HTMLDivElement[] | d3Selection.ArrayLike<HTMLDivElement> = g;
@@ -428,7 +449,8 @@ divs = divs
         return d.padding; // string return value
     })
     .style('hidden', () => true, null) // boolean return + test: priority = null
-    //    .style('color', function() { return 'green'; }, 'test') // fails, test: invalid priority value
+    // $ExpectError
+    .style('color', () => 'green', 'test') // fails, test: invalid priority value
     .style('color', () => 'green', 'important'); // boolean return + test: priority = 'important';
 
 // property(...) Tests
@@ -442,7 +464,8 @@ circles = circles
 circles = circles
     .property('__hitchhikersguide__', function(d, i, g) {
         const that: SVGCircleElement = this;
-        // const that2: HTMLElement  = this; // fails, type mismatch
+        // $ExpectError
+        const that2: HTMLElement  = this; // fails, type mismatch
         const datum: CircleDatumAlternative = d;
         const index: number = i;
         const group: SVGCircleElement[] | d3Selection.ArrayLike<SVGCircleElement> = g;
@@ -466,7 +489,8 @@ body = body
 body = body
     .text(function(d, i, g) {
         const that: HTMLBodyElement = this;
-        // const that2: SVGElement  = this; // fails, type mismatch
+        // $ExpectError
+        const that2: SVGElement  = this; // fails, type mismatch
         const datum: BodyDatum = d;
         const index: number = i;
         const group: HTMLBodyElement[] | d3Selection.ArrayLike<HTMLBodyElement> = g;
@@ -482,7 +506,8 @@ body = body
 body = body
     .html(function(d, i, g) {
         const that: HTMLBodyElement = this;
-        // const that2: SVGElement  = this; // fails, type mismatch
+        // $ExpectError
+        const that2: SVGElement  = this; // fails, type mismatch
         const datum: BodyDatum = d;
         const index: number = i;
         const group: HTMLBodyElement[] | d3Selection.ArrayLike<HTMLBodyElement> = g;
@@ -521,13 +546,15 @@ let newBodyDatum: { newFoo: string };
 
 newBodyDatum = body.datum({ newFoo: 'new foo' }).datum(); // inferred type
 
-// body.datum<BodyDatum>({ newFoo: 'new foo' }); // fails, data type incompatible
+// $ExpectError
+body.datum<BodyDatum>({ newFoo: 'new foo' }); // fails, data type incompatible
 
 // function-based
 
 newBodyDatum = body.datum(function(d, i, g) {
     const that: HTMLBodyElement = this;
-    // const that2: SVGElement  = this; // fails, type mismatch
+    // $ExpectError
+    const that2: SVGElement  = this; // fails, type mismatch
     const datum: BodyDatum = d;
     const index: number = i;
     const group: HTMLBodyElement[] | d3Selection.ArrayLike<HTMLBodyElement> = g;
@@ -536,10 +563,11 @@ newBodyDatum = body.datum(function(d, i, g) {
     return { newFoo: 'new foo' };
 }).datum(); // inferred type
 
-// newBodyDatum = body.datum<BodyDatum>(function(d) { // fails, data type incompatible with return value type
-//     console.log('HTML5 Custom Data Attributes of body: ', this.dataset); // this typings HTMLBodyElement
-//     return { newFoo: 'new foo' };
-// }).datum(); // inferred type
+// $ExpectError
+newBodyDatum = body.datum<BodyDatum>(function(d) { // fails, data type incompatible with return value type
+    console.log('HTML5 Custom Data Attributes of body: ', this.dataset); // this typings HTMLBodyElement
+    return { newFoo: 'new foo' };
+}).datum(); // inferred type
 
 // SCENARIO 1: Fully type-parameterized
 
@@ -560,7 +588,8 @@ d3Selection.select('#svg-1') // irrelevant typing to get contextual typing in la
     .datum(data2) // new data type inferred
     .classed('has-transform-property', function(d, i, g) {
         const that: SVGGElement = this;
-        // const that2: HTMLElement  = this; // fails, type mismatch
+        // $ExpectError
+        const that2: HTMLElement  = this; // fails, type mismatch
         const datum: CircleDatumAlternative[] = d;
         const index: number = i;
         const group: SVGGElement[] | d3Selection.ArrayLike<SVGGElement> = g;
@@ -569,14 +598,14 @@ d3Selection.select('#svg-1') // irrelevant typing to get contextual typing in la
     });
 
 // below fails, as 'this' in .classed(...) will default to BaseType, which may be null and does not have 'transform' property
-
-// d3Selection.select('#svg-1') // irrelevant typing to get contextual typing in last step of chain
-//     .select('g.circles-group') // missing typing of selected DOM element for use in .classed(...)
-//     .datum(data2) // new data type inferred
-//     .classed('has-transform-property', function(d) {
-//         console.log('Color of first data element array', d.length > 0? d[0].color:  'Data array empty'); // CircleDatumAlternative type
-//         return this.transform !== undefined;
-//     });
+d3Selection.select('#svg-1') // irrelevant typing to get contextual typing in last step of chain
+    .select('g.circles-group') // missing typing of selected DOM element for use in .classed(...)
+    .datum(data2) // new data type inferred
+    .classed('has-transform-property', function(d) {
+        console.log('Color of first data element array', d.length > 0 ? d[0].color : 'Data array empty'); // CircleDatumAlternative type
+        // $ExpectError
+        return this.transform !== undefined;
+    });
 
 // SCENARIO 3: Only inferred typing (To have datum-type in 'classed' method call, no need for DOM object access)
 
@@ -585,7 +614,8 @@ d3Selection.select('#svg-1') // irrelevant typing to get contextual typing in la
     .datum(data2) // new data type inferred
     .classed('has-green-first-data-element', function(d, i, g) {
         const that: d3Selection.BaseType = this;
-        // const that2: Element  = this; // fails, type mismatch
+        // $ExpectError
+        const that2: Element  = this; // fails, type mismatch
         const datum: CircleDatumAlternative[] = d;
         const index: number = i;
         const group: d3Selection.BaseType[] | d3Selection.ArrayLike<d3Selection.BaseType> = g;
@@ -663,7 +693,8 @@ circles2 = d3Selection.select<SVGSVGElement, any>('#svg2')
 circles2 = circles2 // returned update selection has the same type parameters as original selection, if data type is unchanged
     .data<CircleDatumAlternative>(endCircleData, d => d.nodeId);
 
-// circles2.data<DivDatum>(endCircleData, function(d) { return d.nodeId; }); // fails, forced data type parameter and data argument mismatch
+// $ExpectError
+circles2.data<DivDatum>(endCircleData, (d) => d.nodeId); // fails, forced data type parameter and data argument mismatch
 
 // ENTER-selection -----------------------------------------------------------------
 
@@ -690,7 +721,8 @@ const exitCircles = circles2.exit<CircleDatumAlternative>(); // Note: need to re
 exitCircles
     .style('opacity', function(d, i, g) {
         const that: SVGCircleElement = this;
-        // const that2: HTMLElement  = this; // fails, type mismatch
+        // $ExpectError
+        const that2: HTMLElement  = this; // fails, type mismatch
         const datum: CircleDatumAlternative = d;
         const index: number = i;
         const group: SVGCircleElement[] | d3Selection.ArrayLike<SVGCircleElement> = g;
@@ -702,12 +734,13 @@ exitCircles
 // Note: the alternative using only .exit() without typing, will fail, if access to datum properties is attempted.
 // If access to d is not required, the short-hand is acceptable e.g. circles2.exit().remove();
 
-// let exitCircles2 = circles2.exit(); // Note: Without explicit re-typing to the old data type, the data type default to '{}'
-// exitCircles2
-//     .style('opacity', function(d) {
-//         console.log('Circle Radius exit node: ', this.r.baseVal.value);
-//          return d.color === 'green' ? 1 : 0; // fails, as data type is defaulted to {}. If datum access is required, this should trigger the thought to type .exit<...>
-//     });
+const exitCircles2 = circles2.exit(); // Note: Without explicit re-typing to the old data type, the data type default to '{}'
+exitCircles2
+    .style('opacity', function(d) {
+        console.log('Circle Radius exit node: ', this.r.baseVal.value);
+        // $ExpectError
+        return d.color === 'green' ? 1 : 0; // fails, as data type is defaulted to {}. If datum access is required, this should trigger the thought to type .exit<...>
+    });
 
 // MERGE ENTER + UPDATE ------------------------------------------------------------------
 
@@ -733,8 +766,8 @@ tr = d3Selection.select('body')
     .append<HTMLTableElement>('table')
     .selectAll()
     .data(matrix)
-    // .data([{test: 1}, {test: 2}]) // fails, using this data statement instead, would fail assignment to tr due to the data type of tr Selection
-    // .data<number[]>([{test: 1}, {test: 2}]) // fails, using this data statement instead, would fail because of its type parameter not being met by input
+    // $ExpectError
+    .data<number[]>([{test: 1}, {test: 2}]) // fails, using this data statement instead, would fail because of its type parameter not being met by input
     .enter().append<HTMLTableRowElement>('tr');
 
 nMatrix = tr.data(); // i.e. matrix
@@ -745,7 +778,6 @@ td = tr.selectAll()
     .enter().append<HTMLTableDataCellElement>('td')
     .text(function(d, i, g) {
         const that: HTMLTableDataCellElement = this;
-        // const that2: Element  = this; // fails, type mismatch
         const datum: number = d;
         const index: number = i;
         const group: HTMLTableDataCellElement[] | d3Selection.ArrayLike<HTMLTableDataCellElement> = g;
@@ -787,11 +819,13 @@ newDiv2 = body.append<HTMLDivElement>('div');
 
 // using creator
 newDiv2 = body.append(d3Selection.creator<HTMLDivElement>('div'));
-// newDiv2 = body.append(d3Selection.creator('div')); // fails, as creator returns BaseType element, but HTMLDivElement is expected.
+// $ExpectError
+newDiv2 = body.append(d3Selection.creator('div')); // fails, as creator returns BaseType element, but HTMLDivElement is expected.
 
 newDiv2 = body.append(function(d, i, g) {
     const that: HTMLBodyElement = this;
-    // const that2: SVGElement  = this; // fails, type mismatch
+    // $ExpectError
+    const that2: SVGElement  = this; // fails, type mismatch
     const datum: BodyDatum = d;
     const index: number = i;
     const group: HTMLBodyElement[] | d3Selection.ArrayLike<HTMLBodyElement> = g;
@@ -799,13 +833,15 @@ newDiv2 = body.append(function(d, i, g) {
     return this.ownerDocument!.createElement('div'); // this-type HTMLBodyElement
 });
 
-// newDiv2 = body.append<HTMLDivElement>(function(d) {
-//     return this.ownerDocument.createElement('a'); // fails, HTMLDivElement expected by type parameter, HTMLAnchorElement returned
-// });
+// $ExpectError
+newDiv2 = body.append<HTMLDivElement>(function(d) {
+    return this.ownerDocument!.createElement('a'); // fails, HTMLDivElement expected by type parameter, HTMLAnchorElement returned
+});
 
-// newDiv2 = body.append(function(d) {
-//     return this.ownerDocument.createElement('a'); // fails, HTMLDivElement expected by inference, HTMLAnchorElement returned
-// });
+// $ExpectError
+newDiv2 = body.append(function(d) {
+    return this.ownerDocument!.createElement('a'); // fails, HTMLDivElement expected by inference, HTMLAnchorElement returned
+});
 
 // create a detached element
 
@@ -909,7 +945,8 @@ const size: number = gElementsOldData.size();
 // returns 'this' selection
 circles = circles.each(function(d, i, g) {  // check chaining return type by re-assigning
     const that: SVGCircleElement = this;
-    // const that2: HTMLElement  = this; // fails, type mismatch
+    // $ExpectError
+    const that2: HTMLElement  = this; // fails, type mismatch
     const datum: CircleDatum = d;
     const index: number = i;
     const group: SVGCircleElement[] | d3Selection.ArrayLike<SVGCircleElement> = g;
@@ -931,13 +968,15 @@ function enforceMinRadius(selection: d3Selection.Selection<SVGCircleElement, Cir
 // returns 'this' selection
 circles = circles.call(enforceMinRadius, 40); // check chaining return type by re-assigning
 
-// circles.call(function(selection: d3Selection.Selection<HTMLDivElement, CircleDatum, any, any>):void {
-//     // fails, group element types of selection not compatible: SVGCircleElement v HTMLDivElement
-// });
+// $ExpectError
+circles.call((selection: d3Selection.Selection<HTMLDivElement, CircleDatum, any, any>) => {
+    // fails, group element types of selection not compatible: SVGCircleElement v HTMLDivElement
+});
 
-// circles.call(function(selection: d3Selection.Selection<SVGCircleElement, DivDatum, any, any>):void {
-//     // fails, group datum types of selection not compatible: CircleDatumAlternative v DivDatum
-// });
+// $ExpectError
+circles.call((selection: d3Selection.Selection<SVGCircleElement, DivDatum, any, any>) => {
+    // fails, group datum types of selection not compatible: CircleDatumAlternative v DivDatum
+});
 
 // ---------------------------------------------------------------------------------------
 // Tests of Event Handling
@@ -949,7 +988,8 @@ let listener: undefined | ((this: HTMLBodyElement, datum: BodyDatum, index: numb
 
 body = body.on('click', function(d, i, g) {
     const that: HTMLBodyElement = this;
-    // const that2: SVGElement  = this; // fails, type mismatch
+    // $ExpectError
+    const that2: SVGElement  = this; // fails, type mismatch
     const datum: BodyDatum = d;
     const index: number = i;
     const group: HTMLBodyElement[] | d3Selection.ArrayLike<HTMLBodyElement> = g;
@@ -981,7 +1021,8 @@ body = body.dispatch('fooEvent', fooEventParam); // re-assign for chaining test;
 
 body = body.dispatch('fooEvent', function(d, i, g) { // re-assign for chaining test;
     const that: HTMLBodyElement = this;
-    // const that2: SVGElement  = this; // fails, type mismatch
+    // $ExpectError
+    const that2: SVGElement  = this; // fails, type mismatch
     const datum: BodyDatum = d;
     const index: number = i;
     const group: HTMLBodyElement[] | d3Selection.ArrayLike<HTMLBodyElement> = g;
@@ -1016,11 +1057,16 @@ function customListener(this: HTMLBodyElement | null, finalOpponent: string): st
 
 const resultText: string = d3Selection.customEvent(successEvent, customListener, body.node(), 'Wales');
 
-// let result = d3Selection.customEvent(successEvent, customListener, circles.nodes()[0], 'Wales'); // fails, incompatible 'this' context in call
-// let resultValue: number = d3Selection.customEvent(successEvent, customListener, body.node(), 'Wales'); // fails, incompatible return types
-// d3Selection.customEvent<SVGCircleElement, any>(successEvent, customListener, circles.nodes()[0], 'Wales'); // fails, incompatible 'this' context in type parameter and call
-// d3Selection.customEvent<HTMLBodyElement, any>(successEvent, customListener, circles.nodes()[0], 'Wales'); // fails, incompatible 'this' context in type parameter and call
-// d3Selection.customEvent<HTMLBodyElement, number>(successEvent, customListener, body.node(), 'Wales'); // fails, incompatible return types
+// $ExpectError
+const result = d3Selection.customEvent(successEvent, customListener, circles.nodes()[0], 'Wales'); // fails, incompatible 'this' context in call
+// $ExpectError
+const resultValue: number = d3Selection.customEvent(successEvent, customListener, body.node(), 'Wales'); // fails, incompatible return types
+// $ExpectError
+d3Selection.customEvent<SVGCircleElement, any>(successEvent, customListener, circles.nodes()[0], 'Wales'); // fails, incompatible 'this' context in type parameter and call
+// $ExpectError
+d3Selection.customEvent<HTMLBodyElement, any>(successEvent, customListener, circles.nodes()[0], 'Wales'); // fails, incompatible 'this' context in type parameter and call
+// $ExpectError
+d3Selection.customEvent<HTMLBodyElement, number>(successEvent, customListener, body.node(), 'Wales'); // fails, incompatible return types
 
 // mouse() ---------------------------------------------------------------------------------
 

--- a/types/d3-selection/index.d.ts
+++ b/types/d3-selection/index.d.ts
@@ -1,6 +1,9 @@
 // Type definitions for D3JS d3-selection module 1.3
 // Project: https://github.com/d3/d3-selection/
-// Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
+// Definitions by: Tom Wanzek <https://github.com/tomwanzek>
+//                 Alex Ford <https://github.com/gustavderdrache>
+//                 Boris Yankov <https://github.com/borisyankov>
+//                 denisname <https://github.com/denisname>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 // Last module patch version validated against: 1.3.0

--- a/types/react-native-svg-charts/tslint.json
+++ b/types/react-native-svg-charts/tslint.json
@@ -1,6 +1,6 @@
 { 
-		"extends": "dtslint/dt.json",
-		"rules": {
-				"strict-export-declare-modifiers": false
-		}
+	"extends": "dtslint/dt.json",
+	"rules": {
+		"strict-export-declare-modifiers": false
+	}
 }


### PR DESCRIPTION
Use $ExpectError in tests.
Some tests don't fail anymore, as TypeScript type inference has improved.