### PR TITLE
stripe-checkout: add source callback

### DIFF
--- a/types/stripe-checkout/index.d.ts
+++ b/types/stripe-checkout/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Chris Wrench <https://github.com/cgwrench>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-/// <reference types="stripe-v2"/>
+/// <reference types="stripe-v3"/>
 
 interface StripeCheckoutStatic {
     configure(options: StripeCheckoutOptions): StripeCheckoutHandler;
@@ -16,7 +16,8 @@ interface StripeCheckoutHandler {
 
 interface StripeCheckoutOptions {
     key?: string;
-    token?(token: stripe.StripeCardTokenResponse): void;
+    token?(token: stripe.Token): void;
+    source?(source: stripe.Source): void;
     image?: string;
     name?: string;
     description?: string;

--- a/types/stripe-checkout/stripe-checkout-tests.ts
+++ b/types/stripe-checkout/stripe-checkout-tests.ts
@@ -1,9 +1,9 @@
 // Test the minimum amount of configuration required.
 let handler = StripeCheckout.configure({
-	key: "my-secret-key",
-	token: (token: stripe.StripeTokenResponse) => {
-		console.log(token.id);
-	}
+    key: "my-secret-key",
+    token: (token: stripe.Token) => {
+        console.log(token.id);
+    }
 });
 
 handler.open();
@@ -12,10 +12,13 @@ handler.close();
 
 // Test all configuration options.
 const options: StripeCheckoutOptions = {
-	key: "my-secret-key",
-	token: (token: stripe.StripeTokenResponse) => {
-		console.log(token.id);
-	},
+    key: "my-secret-key",
+    token: (token: stripe.Token) => {
+        console.log(token.id);
+    },
+    source: (src: stripe.Source) => {
+        console.log(src.id);
+    },
     image: "http://placehold.it/128x128",
     name: "Definitely Typed",
     description: "A DefinitelyTyped test for Stripe Checkout",


### PR DESCRIPTION
I'm not sure if a version bump is required; it does require bumping to the newer version of Stripe, but as far as I can tell Checkout only works with that anyways because it only supports loading the latest version directly from Stripe so I'm not sure how this was working anyways (likely I'm misunderstanding something; I couldn't even find a version for Checkout on Stripe's reference page).

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).


- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://stripe.com/docs/checkout#required
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.