### PR TITLE
fix(react-native): optional trackColor colors

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -8151,7 +8151,7 @@ export interface SwitchProps extends SwitchPropsIOS {
      *
      * Color when false and color when true
      */
-    trackColor?: { false: string, true: string };
+    trackColor?: { false?: string, true?: string };
 
     /**
      * If true the user won't be able to toggle the switch.

--- a/types/react-native/test/index.tsx
+++ b/types/react-native/test/index.tsx
@@ -821,7 +821,11 @@ const NativeBridgedComponent = requireNativeComponent("NativeBridgedComponent", 
 
 
 const SwitchColorTest = () => (
-    <Switch trackColor={{ true: 'pink', false: 'red'}} />
+    <React.Fragment>
+        <Switch trackColor={{ true: 'pink', false: 'red'}} />
+        <Switch trackColor={{ true: 'pink' }} />
+        <Switch trackColor={{ false: 'red' }} />
+    </React.Fragment>
 )
 
 const SwitchThumbColorTest = () => (


### PR DESCRIPTION
These changes fix a minor mistake in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/29477. The `trackColor` colors are optional so that the developer can only set one of them. For example, I only want to set a custom color for the track when the switch is toggled on, i.e., `{ true: 'green' }`.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: The trackColors are optional as can be seen from the Flow types https://github.com/facebook/react-native/blob/7536c9bdee27419ba21a46831de72edcad64dabc/Libraries/Components/Switch/Switch.js#L49-L50
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.