### PR TITLE
[chai] Change arrays to be ReadonlyArray<T> for frozen parameter support

### DIFF
--- a/types/chai/chai-tests.ts
+++ b/types/chai/chai-tests.ts
@@ -808,6 +808,24 @@ function frozen() {
     expect(Object.freeze({})).to.be.frozen;
     ({}).should.be.not.frozen;
     Object.freeze({}).should.be.frozen;
+
+    expect([1, 2, 3]).to.have.all.members([1, 2, 3]);
+    expect([1, 2, 3]).to.have.all.members(Object.freeze([1, 2, 3]));
+
+    expect({1: "", 2: "", 3: ""}).to.have.all.keys([1, 2, 3]);
+    expect({1: "", 2: "", 3: ""}).to.have.all.keys(Object.freeze([1, 2, 3]));
+
+    assert.notDeepInclude([1, 2, 3], 1);
+    assert.notDeepInclude(Object.freeze([1, 2, 3]), 1);
+
+    assert.include([1, 2, 3], 1);
+    assert.include(Object.freeze([1, 2, 3]), 1);
+
+    assert.notInclude([1, 2, 3], 1);
+    assert.notInclude(Object.freeze([1, 2, 3]), 1);
+
+    expect([1, 2, 3]).to.have.oneOf([1, 2, 3]);
+    expect([1, 2, 3]).to.have.oneOf(Object.freeze([1, 2, 3]));
 }
 
 class PoorlyConstructedError {

--- a/types/chai/index.d.ts
+++ b/types/chai/index.d.ts
@@ -118,7 +118,7 @@ declare namespace Chai {
         extensible: Assertion;
         sealed: Assertion;
         frozen: Assertion;
-        oneOf(list: any[], message?: string): Assertion;
+        oneOf(list: ReadonlyArray<any>, message?: string): Assertion;
     }
 
     interface LanguageChains {
@@ -235,7 +235,7 @@ declare namespace Chai {
 
     interface Keys {
         (...keys: string[]): Assertion;
-        (keys: any[]|Object): Assertion;
+        (keys: ReadonlyArray<any>|Object): Assertion;
     }
 
     interface Throw {
@@ -252,7 +252,7 @@ declare namespace Chai {
     }
 
     interface Members {
-        (set: any[], message?: string): Assertion;
+        (set: ReadonlyArray<any>, message?: string): Assertion;
     }
 
     interface PropertyChange {
@@ -696,7 +696,7 @@ declare namespace Chai {
          * @param needle   Potential value contained in haystack.
          * @param message   Message to display on error.
          */
-        include<T>(haystack: T[], needle: T, message?: string): void;
+        include<T>(haystack: ReadonlyArray<T>, needle: T, message?: string): void;
 
         /**
          * Asserts that haystack does not include needle.
@@ -705,7 +705,7 @@ declare namespace Chai {
          * @param needle   Potential expected substring of haystack.
          * @param message   Message to display on error.
          */
-        notInclude(haystack: string | any[], needle: any, message?: string): void;
+        notInclude(haystack: string | ReadonlyArray<any>, needle: any, message?: string): void;
 
         /**
          * Asserts that haystack includes needle. Can be used to assert the inclusion of a value in an array or a subset of properties in an object. Deep equality is used.
@@ -732,7 +732,7 @@ declare namespace Chai {
          * @param needle   Potential expected substring of haystack.
          * @param message   Message to display on error.
          */
-        notDeepInclude(haystack: string | any[], needle: any, message?: string): void;
+        notDeepInclude(haystack: string | ReadonlyArray<any>, needle: any, message?: string): void;
 
         /**
          * Asserts that ‘haystack’ includes ‘needle’. Can be used to assert the inclusion of a subset of properties in an object.


### PR DESCRIPTION
Currently, the type definitions do not permit passing frozen/readonly arrays to some assertion functions. This PR changes `any[]` to `ReadonlyArray<T>` to enable this (this is also a [recommended practice](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes)).

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.chaijs.com/api/assert/#method_assert
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
