### PR TITLE
Mustache: tags should be a string array

### DIFF
--- a/types/mustache/index.d.ts
+++ b/types/mustache/index.d.ts
@@ -77,12 +77,12 @@ interface MustacheStatic {
      * @param partials
      * Either an object that contains the names and templates of partials that are used in a template
      *
-     * @param tags
-     * The tags to use.
-     *
      * -- or --
      *
      * A function that is used to load partial template on the fly that takes a single argument: the name of the partial.
+     *
+     * @param tags
+     * The tags to use.
      */
     render(template: string, view: any | MustacheContext, partials?: any, tags?: string[]): string;
 
@@ -219,12 +219,12 @@ declare class MustacheWriter {
      * @param partials
      * Either an object that contains the names and templates of partials that are used in a template
      *
-     * @param tags
-     * The tags to use.
-     *
      * -- or --
      *
      * A function that is used to load partial template on the fly that takes a single argument: the name of the partial.
+     *
+     * @param tags
+     * The tags to use.
      */
     render(template: string, view: any | MustacheContext, partials: any, tags?: string[]): string;
 

--- a/types/mustache/index.d.ts
+++ b/types/mustache/index.d.ts
@@ -205,7 +205,7 @@ declare class MustacheWriter {
      * @param tags
      * The tags to use.
      */
-    parse(template: string, tags?: any): any;
+    parse(template: string, tags?: string[]): any;
 
     /**
      * High-level method that is used to render the given `template` with the given `view`.

--- a/types/mustache/index.d.ts
+++ b/types/mustache/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Mustache 0.8.3
+// Type definitions for Mustache 0.8.4
 // Project: https://github.com/janl/mustache.js
 // Definitions by: Mark Ashley Bell <https://github.com/markashleybell>, Manuel Thalmann <https://github.com/manuth>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/mustache/index.d.ts
+++ b/types/mustache/index.d.ts
@@ -20,7 +20,7 @@ interface MustacheStatic {
     /**
      * The opening and closing tags to parse.
      */
-    tags: string;
+    tags: string[];
 
     /**
      * A simple string scanner that is used by the template parser to find tokens in template strings.
@@ -77,11 +77,14 @@ interface MustacheStatic {
      * @param partials
      * Either an object that contains the names and templates of partials that are used in a template
      *
+     * @param tags
+     * The tags to use.
+     *
      * -- or --
      *
      * A function that is used to load partial template on the fly that takes a single argument: the name of the partial.
      */
-    render(template: string, view: any | MustacheContext, partials?: any): string;
+    render(template: string, view: any | MustacheContext, partials?: any, tags?: string[]): string;
 
     /**
      * Renders the `template` with the given `view` and `partials` using the default writer.
@@ -198,6 +201,9 @@ declare class MustacheWriter {
      *
      * @param template
      * The template to parse.
+     *
+     * @param tags
+     * The tags to use.
      */
     parse(template: string, tags?: any): any;
 
@@ -213,11 +219,14 @@ declare class MustacheWriter {
      * @param partials
      * Either an object that contains the names and templates of partials that are used in a template
      *
+     * @param tags
+     * The tags to use.
+     *
      * -- or --
      *
      * A function that is used to load partial template on the fly that takes a single argument: the name of the partial.
      */
-    render(template: string, view: any | MustacheContext, partials: any): string;
+    render(template: string, view: any | MustacheContext, partials: any, tags?: string[]): string;
 
     /**
      * Low-level method that renders the given array of `tokens` using the given `context` and `partials`.

--- a/types/mustache/mustache-tests.ts
+++ b/types/mustache/mustache-tests.ts
@@ -27,3 +27,7 @@ var view4 = new class extends Mustache.Context
 };
 var template4 = "Hello, {{firstName}} {{lastName}}";
 var html4 = Mustache.render(template4, view4);
+
+var view5 = { title: "Joe", calc: function () { return 2 + 4; } };
+var template5 = "[[title]] spends [[calc]]";
+var output5 = Mustache.render(template5, view5, {}, ["[[", "]]"]);


### PR DESCRIPTION
According to official documentation, the `tags` should be treated as a string array.

The change modifies the type of the tags property and adds it to the render method as [documentation](https://github.com/janl/mustache.js#setting-in-javascript)

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/janl/mustache.js#setting-in-javascript
- [x] Increase the version number in the header if appropriate.
