### PR TITLE
[prop-types] Allow partial propTypes definition

### DIFF
--- a/types/prop-types/index.d.ts
+++ b/types/prop-types/index.d.ts
@@ -5,8 +5,24 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
+export interface ComponentLike {
+    setState(...args: any[]): any;
+    forceUpdate(...args: any[]): any;
+    render(): ReactNodeLike;
+    props: any;
+    state: any;
+    context: any;
+    refs: any;
+}
+
+export interface ComponentClassLike {
+    new (...args: any[]): ComponentLike;
+}
+
+export type SFCLike = (...args: any[]) => ReactElementLike | null;
+
 export interface ReactElementLike {
-    type: string | ((...args: any[]) => ReactElementLike);
+    type: string | ComponentClassLike | SFCLike;
     props: any;
     key: string | number | null;
     children?: ReactNodeLike;

--- a/types/prop-types/index.d.ts
+++ b/types/prop-types/index.d.ts
@@ -46,7 +46,10 @@ export type IsOptional<T> = undefined | null extends T ? true : undefined extend
 
 export type RequiredKeys<V> = { [K in keyof V]: V[K] extends Validator<infer T> ? IsOptional<T> extends true ? never : K : never }[keyof V];
 export type OptionalKeys<V> = Exclude<keyof V, RequiredKeys<V>>;
-export type InferPropsInner<V> = { [K in keyof V]: InferType<V[K]>; };
+export type InferTypeMap<V> = { [K in keyof V]: InferType<V[K]>; };
+export type InferPropsInner<V> =
+    & InferTypeMap<Pick<V, RequiredKeys<V>>>
+    & Partial<InferTypeMap<Pick<V, OptionalKeys<V>>>>;
 
 export interface Validator<T> {
     (props: object, propName: string, componentName: string, location: string, propFullName: string): Error | null;
@@ -57,12 +60,11 @@ export interface Requireable<T> extends Validator<T | undefined | null> {
     isRequired: Validator<NonNullable<T>>;
 }
 
-export type ValidationMap<T> = { [K in keyof T]-?: Validator<T[K]> };
+export type ValidationMap<T> = Partial<{ [K in keyof T]: Validator<T[K]> }>;
 
 export type InferType<V> = V extends Validator<infer T> ? T : any;
-export type InferProps<V> =
-    & InferPropsInner<Pick<V, RequiredKeys<V>>>
-    & Partial<InferPropsInner<Pick<V, OptionalKeys<V>>>>;
+
+export type InferProps<V> = InferPropsInner<Required<V>>;
 
 export const any: Requireable<any>;
 export const array: Requireable<any[]>;

--- a/types/prop-types/index.d.ts
+++ b/types/prop-types/index.d.ts
@@ -40,8 +40,6 @@ export type ReactNodeLike =
     | null
     | undefined;
 
-export const nominalTypeHack: unique symbol;
-
 export type IsOptional<T> = undefined | null extends T ? true : undefined extends T ? true : null extends T ? true : false;
 
 export type RequiredKeys<V> = { [K in keyof V]: V[K] extends Validator<infer T> ? IsOptional<T> extends true ? never : K : never }[keyof V];
@@ -51,10 +49,14 @@ export type InferPropsInner<V> =
     & InferTypeMap<Pick<V, RequiredKeys<V>>>
     & Partial<InferTypeMap<Pick<V, OptionalKeys<V>>>>;
 
-export interface Validator<T> {
-    (props: object, propName: string, componentName: string, location: string, propFullName: string): Error | null;
-    [nominalTypeHack]?: T;
-}
+export type Validator<T> = (
+    props: object,
+    propName: string,
+    componentName: string,
+    location: string,
+    propFullName: string,
+    _nominalTypeParam?: T,
+) => Error | null;
 
 export interface Requireable<T> extends Validator<T | undefined | null> {
     isRequired: Validator<NonNullable<T>>;

--- a/types/prop-types/prop-types-tests.ts
+++ b/types/prop-types/prop-types-tests.ts
@@ -129,31 +129,31 @@ type ExtractedPartialProps = PropTypes.InferProps<typeof partialPropTypes>;
 type ExtractedPropsWithoutAnnotation = PropTypes.InferProps<typeof propTypesWithoutAnnotation>;
 type ExtractedPropsFromOuterPropsWithoutAnnotation = PropTypes.InferProps<typeof outerPropTypesWithoutAnnotation>['props'];
 
-// $ExpectType: true
+// $ExpectType true
 type ExtractPropsMatch = ExtractedProps extends ExtractedPropsWithoutAnnotation ? true : false;
-// $ExpectType: true
+// $ExpectType true
 type ExtractPropsMatch2 = ExtractedPropsWithoutAnnotation extends ExtractedProps ? true : false;
-// $ExpectType: true
+// $ExpectType true
 type ExtractPropsMatch3 = ExtractedProps extends Props ? true : false;
-// $ExpectType: true
+// $ExpectType true
 type ExtractPropsMatch4 = Props extends ExtractedPropsWithoutAnnotation ? true : false;
-// $ExpectType: true
+// $ExpectType true
 type ExtractFromOuterPropsMatch = ExtractedPropsFromOuterProps extends ExtractedPropsFromOuterPropsWithoutAnnotation ? true : false;
-// $ExpectType: true
+// $ExpectType true
 type ExtractFromOuterPropsMatch2 = ExtractedPropsFromOuterPropsWithoutAnnotation extends ExtractedPropsFromOuterProps ? true : false;
-// $ExpectType: true
+// $ExpectType true
 type ExtractFromOuterPropsMatch3 = ExtractedPropsFromOuterProps extends Props ? true : false;
-// $ExpectType: true
+// $ExpectType true
 type ExtractFromOuterPropsMatch4 = Props extends ExtractedPropsFromOuterPropsWithoutAnnotation ? true : false;
 
-// $ExpectType: false
+// $ExpectType false
 type ExtractPropsMismatch = ExtractedPartialProps extends Props ? true : false;
 
-// $ExpectType: {}
+// $ExpectType {}
 type UnmatchedPropKeys = Pick<ExtractedPropsWithoutAnnotation, Extract<{
     [K in keyof ExtractedPropsWithoutAnnotation]: ExtractedPropsWithoutAnnotation[K] extends ExtractedProps[K] ? never : K
 }[keyof ExtractedPropsWithoutAnnotation], keyof ExtractedPropsWithoutAnnotation>>;
-// $ExpectType: {}
+// $ExpectType {}
 type UnmatchedPropKeys2 = Pick<ExtractedProps, Extract<{
     [K in keyof ExtractedProps]: ExtractedProps[K] extends ExtractedPropsWithoutAnnotation[K] ? never : K
 }[keyof ExtractedProps], keyof ExtractedProps>>;
@@ -189,7 +189,7 @@ const componentDefaultProps = {
 type DefaultizedProps = Defaultize<PropTypes.InferProps<typeof componentPropTypes>, typeof componentDefaultProps>;
 type UndefaultizedProps = Undefaultize<PropTypes.InferProps<typeof componentPropTypes>, typeof componentDefaultProps>;
 
-// $ExpectType: true
+// $ExpectType true
 type DefaultizedPropsTest = {
     fi?: (...args: any[]) => any;
     foo?: string | null;
@@ -197,7 +197,7 @@ type DefaultizedPropsTest = {
     baz?: boolean | null;
     bat?: ReactNode;
 } extends DefaultizedProps ? true : false;
-// $ExpectType: true
+// $ExpectType true
 type UndefaultizedPropsTest = {
     fi: (...args: any[]) => any;
     foo?: string | null;

--- a/types/prop-types/prop-types-tests.ts
+++ b/types/prop-types/prop-types-tests.ts
@@ -149,14 +149,16 @@ type ExtractFromOuterPropsMatch4 = Props extends ExtractedPropsFromOuterPropsWit
 // $ExpectType false
 type ExtractPropsMismatch = ExtractedPartialProps extends Props ? true : false;
 
-// $ExpectType {}
 type UnmatchedPropKeys = Pick<ExtractedPropsWithoutAnnotation, Extract<{
     [K in keyof ExtractedPropsWithoutAnnotation]: ExtractedPropsWithoutAnnotation[K] extends ExtractedProps[K] ? never : K
 }[keyof ExtractedPropsWithoutAnnotation], keyof ExtractedPropsWithoutAnnotation>>;
-// $ExpectType {}
+// $ExpectType never
+type KeyofUnmatchedPropKeys = keyof UnmatchedPropKeys;
 type UnmatchedPropKeys2 = Pick<ExtractedProps, Extract<{
     [K in keyof ExtractedProps]: ExtractedProps[K] extends ExtractedPropsWithoutAnnotation[K] ? never : K
 }[keyof ExtractedProps], keyof ExtractedProps>>;
+// $ExpectType never
+type KeyofUnmatchedPropKeys2 = keyof UnmatchedPropKeys2;
 
 PropTypes.checkPropTypes({ xs: PropTypes.array }, { xs: [] }, 'location', 'componentName');
 

--- a/types/prop-types/prop-types-tests.ts
+++ b/types/prop-types/prop-types-tests.ts
@@ -229,3 +229,25 @@ type PartialTestPropTypesMatchMap = PartialTestPropTypes extends PartialTestVali
 type PartialTestPropTypesInferProps = PropTypes.InferProps<PartialTestPropTypes>;
 // $ExpectType true
 type PartialTestPropTypesInferPropsMatch = PartialTestProps extends PartialTestPropTypesInferProps ? true : false;
+
+interface NominalTypeParamTestProps {
+    foo: string;
+    bar?: boolean;
+}
+
+// $ExpectType Partial<{ foo: Validator<string>; bar?: Validator<boolean | undefined> | undefined; }>
+type NominalTypeParamTestValidationMap = PropTypes.ValidationMap<NominalTypeParamTestProps>;
+
+type NominalTypeParamTestInferProps = PropTypes.InferProps<NominalTypeParamTestValidationMap>;
+
+const nominalTypeParamTestPropTypes = { bar: PropTypes.bool };
+type NominalTypeParamTestPropTypes = typeof nominalTypeParamTestPropTypes;
+// $ExpectType true
+type NominalTypeParamTestPropTypesMatches = NominalTypeParamTestPropTypes extends NominalTypeParamTestValidationMap ? true : false;
+type NominalTypeParamTestPropTypesInferProps = PropTypes.InferProps<NominalTypeParamTestPropTypes>;
+// $ExpectType boolean | undefined
+type NominalTypeParamTestInferPropsBar = NominalTypeParamTestInferProps['bar'];
+// $ExpectType boolean | null | undefined
+type NominalTypeParamTestPropTypesInferPropsBar = NominalTypeParamTestPropTypesInferProps['bar'];
+// $ExpectType true
+type NominalTypeParamTestPropTypesInferPropsMatch = NominalTypeParamTestProps extends NominalTypeParamTestPropTypesInferProps ? true : false;

--- a/types/prop-types/prop-types-tests.ts
+++ b/types/prop-types/prop-types-tests.ts
@@ -207,3 +207,25 @@ type UndefaultizedPropsTest = {
     baz: boolean;
     bat: Exclude<ReactNode, undefined>;
 } extends UndefaultizedProps ? true : false;
+
+interface PartialTestProps {
+    foo: string;
+    bar?: boolean | null;
+}
+
+// $ExpectType Partial<{ foo: Validator<string>; bar?: Validator<boolean | null | undefined> | undefined; }>
+type PartialTestValidationMap = PropTypes.ValidationMap<PartialTestProps>;
+
+type PartialTestInferProps = PropTypes.InferProps<PartialTestValidationMap>;
+// $ExpectType true
+type PartialTestInferPropsMatch = PartialTestProps extends PartialTestInferProps ? true : false;
+// $ExpectType true
+type PartialTestInferPropsMatch2 = PartialTestInferProps extends PartialTestProps ? true : false;
+
+const partialTestPropTypes = { bar: PropTypes.bool };
+type PartialTestPropTypes = typeof partialTestPropTypes;
+// $ExpectType true
+type PartialTestPropTypesMatchMap = PartialTestPropTypes extends PartialTestValidationMap ? true : false;
+type PartialTestPropTypesInferProps = PropTypes.InferProps<PartialTestPropTypes>;
+// $ExpectType true
+type PartialTestPropTypesInferPropsMatch = PartialTestProps extends PartialTestPropTypesInferProps ? true : false;

--- a/types/react/test/managedAttributes.tsx
+++ b/types/react/test/managedAttributes.tsx
@@ -1,160 +1,160 @@
 interface LeaveMeAloneDtslint { foo: string; }
-// Re-enable when we move @types/react to TS 3.0
+// // Re-enable when we move @types/react to TS 3.0
 
-import * as React from 'react';
-import * as PropTypes from 'prop-types';
+// import * as React from 'react';
+// import * as PropTypes from 'prop-types';
 
-interface Props {
-    bool?: boolean;
-    fnc: () => any;
-    node?: React.ReactNode;
-    num?: number;
-    reqNode: NonNullable<React.ReactNode>;
-    str: string;
-}
+// interface Props {
+//     bool?: boolean;
+//     fnc: () => any;
+//     node?: React.ReactNode;
+//     num?: number;
+//     reqNode: NonNullable<React.ReactNode>;
+//     str: string;
+// }
 
-const propTypes = {
-    bool: PropTypes.bool,
-    fnc: PropTypes.func.isRequired,
-    node: PropTypes.node,
-    num: PropTypes.number,
-    str: PropTypes.string.isRequired,
-    extraStr: PropTypes.string.isRequired,
-    extraNum: PropTypes.number
-};
+// const propTypes = {
+//     bool: PropTypes.bool,
+//     fnc: PropTypes.func.isRequired,
+//     node: PropTypes.node,
+//     num: PropTypes.number,
+//     str: PropTypes.string.isRequired,
+//     extraStr: PropTypes.string.isRequired,
+//     extraNum: PropTypes.number
+// };
 
-const defaultProps = {
-    fnc: (() => 'abc') as () => any,
-    extraBool: false,
-    reqNode: 'text_node' as React.ReactNode
-};
+// const defaultProps = {
+//     fnc: (() => 'abc') as () => any,
+//     extraBool: false,
+//     reqNode: 'text_node' as React.ReactNode
+// };
 
-class AnnotatedPropTypesAndDefaultProps extends React.Component<Props> {
-    static propTypes = propTypes;
-    static defaultProps = defaultProps;
-}
+// class AnnotatedPropTypesAndDefaultProps extends React.Component<Props> {
+//     static propTypes = propTypes;
+//     static defaultProps = defaultProps;
+// }
 
-const annotatedPropTypesAndDefaultPropsTests = [
-    // $ExpectError
-    <AnnotatedPropTypesAndDefaultProps />, // str and extraStr are required
-    <AnnotatedPropTypesAndDefaultProps extraStr='abc' str='abc' />,
-    // $ExpectError
-    <AnnotatedPropTypesAndDefaultProps num='abc' />, // num type mismatch
-    <AnnotatedPropTypesAndDefaultProps
-        bool={true}
-        extraBool={true}
-        extraNum={0}
-        extraStr='abc'
-        fnc={console.log}
-        node={<span />}
-        num={0}
-        reqNode={<span />}
-        str='abc'
-    />
-];
+// const annotatedPropTypesAndDefaultPropsTests = [
+//     // $ExpectError
+//     <AnnotatedPropTypesAndDefaultProps />, // str and extraStr are required
+//     <AnnotatedPropTypesAndDefaultProps extraStr='abc' str='abc' />,
+//     // $ExpectError
+//     <AnnotatedPropTypesAndDefaultProps num='abc' />, // num type mismatch
+//     <AnnotatedPropTypesAndDefaultProps
+//         bool={true}
+//         extraBool={true}
+//         extraNum={0}
+//         extraStr='abc'
+//         fnc={console.log}
+//         node={<span />}
+//         num={0}
+//         reqNode={<span />}
+//         str='abc'
+//     />
+// ];
 
-class UnannotatedPropTypesAndDefaultProps extends React.Component {
-    static propTypes = propTypes;
-    static defaultProps = defaultProps;
-}
+// class UnannotatedPropTypesAndDefaultProps extends React.Component {
+//     static propTypes = propTypes;
+//     static defaultProps = defaultProps;
+// }
 
-const unannotatedPropTypesAndDefaultPropsTests = [
-    // $ExpectError
-    <UnannotatedPropTypesAndDefaultProps />, // stra and extraStr are required
-    <UnannotatedPropTypesAndDefaultProps extraStr='abc' str='abc' />,
-    // $ExpectError
-    <UnannotatedPropTypesAndDefaultProps extraBool={0} />, // extraBool type mismatch
-    <UnannotatedPropTypesAndDefaultProps
-        bool={true}
-        extraBool={true}
-        extraNum={0}
-        extraStr='abc'
-        fnc={console.log}
-        node={<span />}
-        num={0}
-        reqNode={<span />}
-        str='abc'
-    />
-];
+// const unannotatedPropTypesAndDefaultPropsTests = [
+//     // $ExpectError
+//     <UnannotatedPropTypesAndDefaultProps />, // stra and extraStr are required
+//     <UnannotatedPropTypesAndDefaultProps extraStr='abc' str='abc' />,
+//     // $ExpectError
+//     <UnannotatedPropTypesAndDefaultProps extraBool={0} />, // extraBool type mismatch
+//     <UnannotatedPropTypesAndDefaultProps
+//         bool={true}
+//         extraBool={true}
+//         extraNum={0}
+//         extraStr='abc'
+//         fnc={console.log}
+//         node={<span />}
+//         num={0}
+//         reqNode={<span />}
+//         str='abc'
+//     />
+// ];
 
-class AnnotatedPropTypes extends React.Component<Props> {
-    static propTypes = propTypes;
-}
+// class AnnotatedPropTypes extends React.Component<Props> {
+//     static propTypes = propTypes;
+// }
 
-const annotatedPropTypesTests = [
-    // $ExpectError
-    <AnnotatedPropTypes />, // str, extraStr, reqNode and fnc are required
-    <AnnotatedPropTypes fnc={console.log} extraStr='abc' str='abc' reqNode={<span />} />,
-    // $ExpectError
-    <AnnotatedPropTypes fnc={console.log} extraStr='abc' str='abc' reqNode={<span />} extraBool={false} />, // extraBool doesn't exist
-    // $ExpectError
-    <AnnotatedPropTypes fnc={console.log} extraStr='abc' str='abc' reqNode={<span />} num='abc' />, // num type mismatch
-    <AnnotatedPropTypes
-        bool={false}
-        extraNum={0}
-        extraStr='abc'
-        fnc={console.log}
-        node={<React.Fragment />}
-        num={0}
-        reqNode={<React.Fragment />}
-        str='abc'
-    />
-];
+// const annotatedPropTypesTests = [
+//     // $ExpectError
+//     <AnnotatedPropTypes />, // str, extraStr, reqNode and fnc are required
+//     <AnnotatedPropTypes fnc={console.log} extraStr='abc' str='abc' reqNode={<span />} />,
+//     // $ExpectError
+//     <AnnotatedPropTypes fnc={console.log} extraStr='abc' str='abc' reqNode={<span />} extraBool={false} />, // extraBool doesn't exist
+//     // $ExpectError
+//     <AnnotatedPropTypes fnc={console.log} extraStr='abc' str='abc' reqNode={<span />} num='abc' />, // num type mismatch
+//     <AnnotatedPropTypes
+//         bool={false}
+//         extraNum={0}
+//         extraStr='abc'
+//         fnc={console.log}
+//         node={<React.Fragment />}
+//         num={0}
+//         reqNode={<React.Fragment />}
+//         str='abc'
+//     />
+// ];
 
-class UnannotatedPropTypes extends React.Component {
-    static propTypes = propTypes;
-}
+// class UnannotatedPropTypes extends React.Component {
+//     static propTypes = propTypes;
+// }
 
-const unannotatedPropTypesTests = [
-    // $ExpectError
-    <UnannotatedPropTypes />, // str, extraStr and fnc are required
-    <UnannotatedPropTypes fnc={console.log} extraStr='abc' str='abc' />,
-    // $ExpectError
-    <UnannotatedPropTypes fnc={console.log} extraStr='abc' str='abc' reqNode={<span />} />, // reqNode doesn't exist
-    // $ExpectError
-    <UnannotatedPropTypes fnc={console.log} extraStr='abc' str='abc' reqNode={<span />} num='abc' />, // num type mismatch
-    <UnannotatedPropTypes
-        bool={false}
-        extraNum={0}
-        extraStr='abc'
-        fnc={console.log}
-        node={<React.Fragment />}
-        num={0}
-        str='abc'
-    />
-];
+// const unannotatedPropTypesTests = [
+//     // $ExpectError
+//     <UnannotatedPropTypes />, // str, extraStr and fnc are required
+//     <UnannotatedPropTypes fnc={console.log} extraStr='abc' str='abc' />,
+//     // $ExpectError
+//     <UnannotatedPropTypes fnc={console.log} extraStr='abc' str='abc' reqNode={<span />} />, // reqNode doesn't exist
+//     // $ExpectError
+//     <UnannotatedPropTypes fnc={console.log} extraStr='abc' str='abc' reqNode={<span />} num='abc' />, // num type mismatch
+//     <UnannotatedPropTypes
+//         bool={false}
+//         extraNum={0}
+//         extraStr='abc'
+//         fnc={console.log}
+//         node={<React.Fragment />}
+//         num={0}
+//         str='abc'
+//     />
+// ];
 
-class AnnotatedDefaultProps extends React.Component<Props> {
-    static defaultProps = defaultProps;
-}
+// class AnnotatedDefaultProps extends React.Component<Props> {
+//     static defaultProps = defaultProps;
+// }
 
-const annotatedDefaultPropsTests = [
-    // $ExpectError
-    <AnnotatedDefaultProps />, // str is required
-    <AnnotatedDefaultProps str='abc' />,
-    <AnnotatedDefaultProps str='abc' reqNode={<span />} />,
-    // $ExpectError
-    <AnnotatedDefaultProps str={() => { }} />, // str type mismatch
-    <AnnotatedDefaultProps
-        bool={true}
-        extraBool={false}
-        fnc={console.log}
-        node={null}
-        num={0}
-        reqNode={undefined}
-        str='abc'
-    />
-];
+// const annotatedDefaultPropsTests = [
+//     // $ExpectError
+//     <AnnotatedDefaultProps />, // str is required
+//     <AnnotatedDefaultProps str='abc' />,
+//     <AnnotatedDefaultProps str='abc' reqNode={<span />} />,
+//     // $ExpectError
+//     <AnnotatedDefaultProps str={() => { }} />, // str type mismatch
+//     <AnnotatedDefaultProps
+//         bool={true}
+//         extraBool={false}
+//         fnc={console.log}
+//         node={null}
+//         num={0}
+//         reqNode={undefined}
+//         str='abc'
+//     />
+// ];
 
-class UnannotatedDefaultProps extends React.Component {
-    static defaultProps = defaultProps;
-}
+// class UnannotatedDefaultProps extends React.Component {
+//     static defaultProps = defaultProps;
+// }
 
-const unannotatedDefaultPropsTests = [
-    <UnannotatedDefaultProps />,
-    <UnannotatedDefaultProps
-        extraBool={true}
-        fnc={console.log}
-        reqNode={<span />}
-    />
-];
+// const unannotatedDefaultPropsTests = [
+//     <UnannotatedDefaultProps />,
+//     <UnannotatedDefaultProps
+//         extraBool={true}
+//         fnc={console.log}
+//         reqNode={<span />}
+//     />
+// ];

--- a/types/react/test/managedAttributes.tsx
+++ b/types/react/test/managedAttributes.tsx
@@ -1,160 +1,160 @@
 interface LeaveMeAloneDtslint { foo: string; }
-// // Re-enable when we move @types/react to TS 3.0
+// Re-enable when we move @types/react to TS 3.0
 
-// import * as React from 'react';
-// import * as PropTypes from 'prop-types';
+import * as React from 'react';
+import * as PropTypes from 'prop-types';
 
-// interface Props {
-//     bool?: boolean
-//     fnc: () => any
-//     node?: React.ReactNode
-//     num?: number
-//     reqNode: NonNullable<React.ReactNode>
-//     str: string
-// }
+interface Props {
+    bool?: boolean;
+    fnc: () => any;
+    node?: React.ReactNode;
+    num?: number;
+    reqNode: NonNullable<React.ReactNode>;
+    str: string;
+}
 
-// const propTypes = {
-//     bool: PropTypes.bool,
-//     fnc: PropTypes.func.isRequired,
-//     node: PropTypes.node,
-//     num: PropTypes.number,
-//     str: PropTypes.string.isRequired,
-//     extraStr: PropTypes.string.isRequired,
-//     extraNum: PropTypes.number
-// };
+const propTypes = {
+    bool: PropTypes.bool,
+    fnc: PropTypes.func.isRequired,
+    node: PropTypes.node,
+    num: PropTypes.number,
+    str: PropTypes.string.isRequired,
+    extraStr: PropTypes.string.isRequired,
+    extraNum: PropTypes.number
+};
 
-// const defaultProps = {
-//     fnc: function() { return 'abc' } as () => any,
-//     extraBool: false,
-//     reqNode: 'text_node' as React.ReactNode
-// };
+const defaultProps = {
+    fnc: (() => 'abc') as () => any,
+    extraBool: false,
+    reqNode: 'text_node' as React.ReactNode
+};
 
-// class AnnotatedPropTypesAndDefaultProps extends React.Component<Props> {
-//     static propTypes = propTypes;
-//     static defaultProps = defaultProps;
-// }
+class AnnotatedPropTypesAndDefaultProps extends React.Component<Props> {
+    static propTypes = propTypes;
+    static defaultProps = defaultProps;
+}
 
-// const annotatedPropTypesAndDefaultPropsTests = [
-//     // $ExpectError
-//     <AnnotatedPropTypesAndDefaultProps />, // str and extraStr are required
-//     <AnnotatedPropTypesAndDefaultProps extraStr='abc' str='abc' />,
-//     // $ExpectError
-//     <AnnotatedPropTypesAndDefaultProps num='abc' />, // num type mismatch
-//     <AnnotatedPropTypesAndDefaultProps
-//         bool={true}
-//         extraBool={true}
-//         extraNum={0}
-//         extraStr='abc'
-//         fnc={console.log}
-//         node={<span />}
-//         num={0}
-//         reqNode={<span />}
-//         str='abc'
-//     />
-// ];
+const annotatedPropTypesAndDefaultPropsTests = [
+    // $ExpectError
+    <AnnotatedPropTypesAndDefaultProps />, // str and extraStr are required
+    <AnnotatedPropTypesAndDefaultProps extraStr='abc' str='abc' />,
+    // $ExpectError
+    <AnnotatedPropTypesAndDefaultProps num='abc' />, // num type mismatch
+    <AnnotatedPropTypesAndDefaultProps
+        bool={true}
+        extraBool={true}
+        extraNum={0}
+        extraStr='abc'
+        fnc={console.log}
+        node={<span />}
+        num={0}
+        reqNode={<span />}
+        str='abc'
+    />
+];
 
-// class UnannotatedPropTypesAndDefaultProps extends React.Component {
-//     static propTypes = propTypes;
-//     static defaultProps = defaultProps;
-// }
+class UnannotatedPropTypesAndDefaultProps extends React.Component {
+    static propTypes = propTypes;
+    static defaultProps = defaultProps;
+}
 
-// const unannotatedPropTypesAndDefaultPropsTests = [
-//     // $ExpectError
-//     <UnannotatedPropTypesAndDefaultProps />, // stra and extraStr are required
-//     <UnannotatedPropTypesAndDefaultProps extraStr='abc' str='abc' />,
-//     // $ExpectError
-//     <UnannotatedPropTypesAndDefaultProps extraBool={0} />, // extraBool type mismatch
-//     <UnannotatedPropTypesAndDefaultProps
-//         bool={true}
-//         extraBool={true}
-//         extraNum={0}
-//         extraStr='abc'
-//         fnc={console.log}
-//         node={<span />}
-//         num={0}
-//         reqNode={<span />}
-//         str='abc'
-//     />
-// ];
+const unannotatedPropTypesAndDefaultPropsTests = [
+    // $ExpectError
+    <UnannotatedPropTypesAndDefaultProps />, // stra and extraStr are required
+    <UnannotatedPropTypesAndDefaultProps extraStr='abc' str='abc' />,
+    // $ExpectError
+    <UnannotatedPropTypesAndDefaultProps extraBool={0} />, // extraBool type mismatch
+    <UnannotatedPropTypesAndDefaultProps
+        bool={true}
+        extraBool={true}
+        extraNum={0}
+        extraStr='abc'
+        fnc={console.log}
+        node={<span />}
+        num={0}
+        reqNode={<span />}
+        str='abc'
+    />
+];
 
-// class AnnotatedPropTypes extends React.Component<Props> {
-//     static propTypes = propTypes;
-// }
+class AnnotatedPropTypes extends React.Component<Props> {
+    static propTypes = propTypes;
+}
 
-// const annotatedPropTypesTests = [
-//     // $ExpectError
-//     <AnnotatedPropTypes />, // str, extraStr, reqNode and fnc are required
-//     <AnnotatedPropTypes fnc={console.log} extraStr='abc' str='abc' reqNode={<span />} />,
-//     // $ExpectError
-//     <AnnotatedPropTypes fnc={console.log} extraStr='abc' str='abc' reqNode={<span />} extraBool={false} />, // extraBool doesn't exist
-//     // $ExpectError
-//     <AnnotatedPropTypes fnc={console.log} extraStr='abc' str='abc' reqNode={<span />} num='abc' />, // num type mismatch
-//     <AnnotatedPropTypes
-//         bool={false}
-//         extraNum={0}
-//         extraStr='abc'
-//         fnc={console.log}
-//         node={<React.Fragment />}
-//         num={0}
-//         reqNode={<React.Fragment />}
-//         str='abc'
-//     />
-// ];
+const annotatedPropTypesTests = [
+    // $ExpectError
+    <AnnotatedPropTypes />, // str, extraStr, reqNode and fnc are required
+    <AnnotatedPropTypes fnc={console.log} extraStr='abc' str='abc' reqNode={<span />} />,
+    // $ExpectError
+    <AnnotatedPropTypes fnc={console.log} extraStr='abc' str='abc' reqNode={<span />} extraBool={false} />, // extraBool doesn't exist
+    // $ExpectError
+    <AnnotatedPropTypes fnc={console.log} extraStr='abc' str='abc' reqNode={<span />} num='abc' />, // num type mismatch
+    <AnnotatedPropTypes
+        bool={false}
+        extraNum={0}
+        extraStr='abc'
+        fnc={console.log}
+        node={<React.Fragment />}
+        num={0}
+        reqNode={<React.Fragment />}
+        str='abc'
+    />
+];
 
-// class UnannotatedPropTypes extends React.Component {
-//     static propTypes = propTypes;
-// }
+class UnannotatedPropTypes extends React.Component {
+    static propTypes = propTypes;
+}
 
-// const unannotatedPropTypesTests = [
-//     // $ExpectError
-//     <UnannotatedPropTypes />, // str, extraStr and fnc are required
-//     <UnannotatedPropTypes fnc={console.log} extraStr='abc' str='abc' />,
-//     // $ExpectError
-//     <UnannotatedPropTypes fnc={console.log} extraStr='abc' str='abc' reqNode={<span />} />, // reqNode doesn't exist
-//     // $ExpectError
-//     <UnannotatedPropTypes fnc={console.log} extraStr='abc' str='abc' reqNode={<span />} num='abc' />, // num type mismatch
-//     <UnannotatedPropTypes
-//         bool={false}
-//         extraNum={0}
-//         extraStr='abc'
-//         fnc={console.log}
-//         node={<React.Fragment />}
-//         num={0}
-//         str='abc'
-//     />
-// ];
+const unannotatedPropTypesTests = [
+    // $ExpectError
+    <UnannotatedPropTypes />, // str, extraStr and fnc are required
+    <UnannotatedPropTypes fnc={console.log} extraStr='abc' str='abc' />,
+    // $ExpectError
+    <UnannotatedPropTypes fnc={console.log} extraStr='abc' str='abc' reqNode={<span />} />, // reqNode doesn't exist
+    // $ExpectError
+    <UnannotatedPropTypes fnc={console.log} extraStr='abc' str='abc' reqNode={<span />} num='abc' />, // num type mismatch
+    <UnannotatedPropTypes
+        bool={false}
+        extraNum={0}
+        extraStr='abc'
+        fnc={console.log}
+        node={<React.Fragment />}
+        num={0}
+        str='abc'
+    />
+];
 
-// class AnnotatedDefaultProps extends React.Component<Props> {
-//     static defaultProps = defaultProps;
-// }
+class AnnotatedDefaultProps extends React.Component<Props> {
+    static defaultProps = defaultProps;
+}
 
-// const annotatedDefaultPropsTests = [
-//     // $ExpectError
-//     <AnnotatedDefaultProps />, // str is required
-//     <AnnotatedDefaultProps str='abc' />,
-//     <AnnotatedDefaultProps str='abc' reqNode={<span />} />,
-//     // $ExpectError
-//     <AnnotatedDefaultProps str={() => { }} />, // str type mismatch
-//     <AnnotatedDefaultProps
-//         bool={true}
-//         extraBool={false}
-//         fnc={console.log}
-//         node={null}
-//         num={0}
-//         reqNode={undefined}
-//         str='abc'
-//     />
-// ];
+const annotatedDefaultPropsTests = [
+    // $ExpectError
+    <AnnotatedDefaultProps />, // str is required
+    <AnnotatedDefaultProps str='abc' />,
+    <AnnotatedDefaultProps str='abc' reqNode={<span />} />,
+    // $ExpectError
+    <AnnotatedDefaultProps str={() => { }} />, // str type mismatch
+    <AnnotatedDefaultProps
+        bool={true}
+        extraBool={false}
+        fnc={console.log}
+        node={null}
+        num={0}
+        reqNode={undefined}
+        str='abc'
+    />
+];
 
-// class UnannotatedDefaultProps extends React.Component {
-//     static defaultProps = defaultProps;
-// }
+class UnannotatedDefaultProps extends React.Component {
+    static defaultProps = defaultProps;
+}
 
-// const unannotatedDefaultPropsTests = [
-//     <UnannotatedDefaultProps />,
-//     <UnannotatedDefaultProps
-//         extraBool={true}
-//         fnc={console.log}
-//         reqNode={<span />}
-//     />
-// ];
+const unannotatedDefaultPropsTests = [
+    <UnannotatedDefaultProps />,
+    <UnannotatedDefaultProps
+        extraBool={true}
+        fnc={console.log}
+        reqNode={<span />}
+    />
+];


### PR DESCRIPTION
This is a revival of https://github.com/DefinitelyTyped/DefinitelyTyped/pull/29556 and https://github.com/DefinitelyTyped/DefinitelyTyped/pull/28179

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://reactjs.org/docs/typechecking-with-proptypes.html
- [ ] Increase the version number in the header if appropriate.

#28249 put it eloquently:

> React doesn't require prop types for every prop, nor does it require prop types at all. We should be following React's API, not what we think is best.

cc @milesj @rsolomon