### PR TITLE
[jquery] Fix `TContext` declaration of `jQuery.proxy` on wrong value's type. 

### DIFF
--- a/types/jquery/JQueryStatic.d.ts
+++ b/types/jquery/JQueryStatic.d.ts
@@ -2757,6 +2757,13 @@ $.post( "test.php" );
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
+     * @param b An argument to be passed to the function referenced in the `function` argument.
+     * @param c An argument to be passed to the function referenced in the `function` argument.
+     * @param d An argument to be passed to the function referenced in the `function` argument.
+     * @param e An argument to be passed to the function referenced in the `function` argument.
+     * @param f An argument to be passed to the function referenced in the `function` argument.
+     * @param g An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
@@ -2769,6 +2776,12 @@ $.post( "test.php" );
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
+     * @param b An argument to be passed to the function referenced in the `function` argument.
+     * @param c An argument to be passed to the function referenced in the `function` argument.
+     * @param d An argument to be passed to the function referenced in the `function` argument.
+     * @param e An argument to be passed to the function referenced in the `function` argument.
+     * @param f An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
@@ -2781,6 +2794,11 @@ $.post( "test.php" );
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
+     * @param b An argument to be passed to the function referenced in the `function` argument.
+     * @param c An argument to be passed to the function referenced in the `function` argument.
+     * @param d An argument to be passed to the function referenced in the `function` argument.
+     * @param e An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
@@ -2793,6 +2811,10 @@ $.post( "test.php" );
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
+     * @param b An argument to be passed to the function referenced in the `function` argument.
+     * @param c An argument to be passed to the function referenced in the `function` argument.
+     * @param d An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
@@ -2805,6 +2827,9 @@ $.post( "test.php" );
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
+     * @param b An argument to be passed to the function referenced in the `function` argument.
+     * @param c An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
@@ -2817,6 +2842,8 @@ $.post( "test.php" );
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
+     * @param b An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
@@ -2829,6 +2856,7 @@ $.post( "test.php" );
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
@@ -2857,6 +2885,13 @@ $.post( "test.php" );
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
+     * @param b An argument to be passed to the function referenced in the `function` argument.
+     * @param c An argument to be passed to the function referenced in the `function` argument.
+     * @param d An argument to be passed to the function referenced in the `function` argument.
+     * @param e An argument to be passed to the function referenced in the `function` argument.
+     * @param f An argument to be passed to the function referenced in the `function` argument.
+     * @param g An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
@@ -2871,6 +2906,12 @@ $.post( "test.php" );
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
+     * @param b An argument to be passed to the function referenced in the `function` argument.
+     * @param c An argument to be passed to the function referenced in the `function` argument.
+     * @param d An argument to be passed to the function referenced in the `function` argument.
+     * @param e An argument to be passed to the function referenced in the `function` argument.
+     * @param f An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
@@ -2885,6 +2926,11 @@ $.post( "test.php" );
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
+     * @param b An argument to be passed to the function referenced in the `function` argument.
+     * @param c An argument to be passed to the function referenced in the `function` argument.
+     * @param d An argument to be passed to the function referenced in the `function` argument.
+     * @param e An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
@@ -2899,6 +2945,10 @@ $.post( "test.php" );
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
+     * @param b An argument to be passed to the function referenced in the `function` argument.
+     * @param c An argument to be passed to the function referenced in the `function` argument.
+     * @param d An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
@@ -2913,6 +2963,9 @@ $.post( "test.php" );
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
+     * @param b An argument to be passed to the function referenced in the `function` argument.
+     * @param c An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
@@ -2927,6 +2980,8 @@ $.post( "test.php" );
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
+     * @param b An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
@@ -2941,6 +2996,7 @@ $.post( "test.php" );
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
@@ -2972,6 +3028,13 @@ $.post( "test.php" );
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
+     * @param b An argument to be passed to the function referenced in the `function` argument.
+     * @param c An argument to be passed to the function referenced in the `function` argument.
+     * @param d An argument to be passed to the function referenced in the `function` argument.
+     * @param e An argument to be passed to the function referenced in the `function` argument.
+     * @param f An argument to be passed to the function referenced in the `function` argument.
+     * @param g An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
@@ -2986,6 +3049,12 @@ $.post( "test.php" );
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
+     * @param b An argument to be passed to the function referenced in the `function` argument.
+     * @param c An argument to be passed to the function referenced in the `function` argument.
+     * @param d An argument to be passed to the function referenced in the `function` argument.
+     * @param e An argument to be passed to the function referenced in the `function` argument.
+     * @param f An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
@@ -3000,6 +3069,11 @@ $.post( "test.php" );
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
+     * @param b An argument to be passed to the function referenced in the `function` argument.
+     * @param c An argument to be passed to the function referenced in the `function` argument.
+     * @param d An argument to be passed to the function referenced in the `function` argument.
+     * @param e An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
@@ -3014,6 +3088,10 @@ $.post( "test.php" );
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
+     * @param b An argument to be passed to the function referenced in the `function` argument.
+     * @param c An argument to be passed to the function referenced in the `function` argument.
+     * @param d An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
@@ -3028,6 +3106,9 @@ $.post( "test.php" );
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
+     * @param b An argument to be passed to the function referenced in the `function` argument.
+     * @param c An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
@@ -3042,6 +3123,8 @@ $.post( "test.php" );
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
+     * @param b An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
@@ -3056,6 +3139,7 @@ $.post( "test.php" );
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
@@ -3087,6 +3171,13 @@ $.post( "test.php" );
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
+     * @param b An argument to be passed to the function referenced in the `function` argument.
+     * @param c An argument to be passed to the function referenced in the `function` argument.
+     * @param d An argument to be passed to the function referenced in the `function` argument.
+     * @param e An argument to be passed to the function referenced in the `function` argument.
+     * @param f An argument to be passed to the function referenced in the `function` argument.
+     * @param g An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
@@ -3101,6 +3192,12 @@ $.post( "test.php" );
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
+     * @param b An argument to be passed to the function referenced in the `function` argument.
+     * @param c An argument to be passed to the function referenced in the `function` argument.
+     * @param d An argument to be passed to the function referenced in the `function` argument.
+     * @param e An argument to be passed to the function referenced in the `function` argument.
+     * @param f An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
@@ -3115,6 +3212,11 @@ $.post( "test.php" );
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
+     * @param b An argument to be passed to the function referenced in the `function` argument.
+     * @param c An argument to be passed to the function referenced in the `function` argument.
+     * @param d An argument to be passed to the function referenced in the `function` argument.
+     * @param e An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
@@ -3129,6 +3231,10 @@ $.post( "test.php" );
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
+     * @param b An argument to be passed to the function referenced in the `function` argument.
+     * @param c An argument to be passed to the function referenced in the `function` argument.
+     * @param d An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
@@ -3143,6 +3249,9 @@ $.post( "test.php" );
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
+     * @param b An argument to be passed to the function referenced in the `function` argument.
+     * @param c An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
@@ -3157,6 +3266,8 @@ $.post( "test.php" );
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
+     * @param b An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
@@ -3171,6 +3282,7 @@ $.post( "test.php" );
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
@@ -3202,6 +3314,13 @@ $.post( "test.php" );
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
+     * @param b An argument to be passed to the function referenced in the `function` argument.
+     * @param c An argument to be passed to the function referenced in the `function` argument.
+     * @param d An argument to be passed to the function referenced in the `function` argument.
+     * @param e An argument to be passed to the function referenced in the `function` argument.
+     * @param f An argument to be passed to the function referenced in the `function` argument.
+     * @param g An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
@@ -3216,6 +3335,12 @@ $.post( "test.php" );
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
+     * @param b An argument to be passed to the function referenced in the `function` argument.
+     * @param c An argument to be passed to the function referenced in the `function` argument.
+     * @param d An argument to be passed to the function referenced in the `function` argument.
+     * @param e An argument to be passed to the function referenced in the `function` argument.
+     * @param f An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
@@ -3230,6 +3355,11 @@ $.post( "test.php" );
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
+     * @param b An argument to be passed to the function referenced in the `function` argument.
+     * @param c An argument to be passed to the function referenced in the `function` argument.
+     * @param d An argument to be passed to the function referenced in the `function` argument.
+     * @param e An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
@@ -3244,6 +3374,10 @@ $.post( "test.php" );
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
+     * @param b An argument to be passed to the function referenced in the `function` argument.
+     * @param c An argument to be passed to the function referenced in the `function` argument.
+     * @param d An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
@@ -3258,6 +3392,9 @@ $.post( "test.php" );
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
+     * @param b An argument to be passed to the function referenced in the `function` argument.
+     * @param c An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
@@ -3272,6 +3409,8 @@ $.post( "test.php" );
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
+     * @param b An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
@@ -3286,6 +3425,7 @@ $.post( "test.php" );
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
@@ -3317,6 +3457,13 @@ $.post( "test.php" );
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
+     * @param b An argument to be passed to the function referenced in the `function` argument.
+     * @param c An argument to be passed to the function referenced in the `function` argument.
+     * @param d An argument to be passed to the function referenced in the `function` argument.
+     * @param e An argument to be passed to the function referenced in the `function` argument.
+     * @param f An argument to be passed to the function referenced in the `function` argument.
+     * @param g An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
@@ -3331,6 +3478,12 @@ $.post( "test.php" );
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
+     * @param b An argument to be passed to the function referenced in the `function` argument.
+     * @param c An argument to be passed to the function referenced in the `function` argument.
+     * @param d An argument to be passed to the function referenced in the `function` argument.
+     * @param e An argument to be passed to the function referenced in the `function` argument.
+     * @param f An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
@@ -3345,6 +3498,11 @@ $.post( "test.php" );
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
+     * @param b An argument to be passed to the function referenced in the `function` argument.
+     * @param c An argument to be passed to the function referenced in the `function` argument.
+     * @param d An argument to be passed to the function referenced in the `function` argument.
+     * @param e An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
@@ -3359,6 +3517,10 @@ $.post( "test.php" );
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
+     * @param b An argument to be passed to the function referenced in the `function` argument.
+     * @param c An argument to be passed to the function referenced in the `function` argument.
+     * @param d An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
@@ -3373,6 +3535,9 @@ $.post( "test.php" );
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
+     * @param b An argument to be passed to the function referenced in the `function` argument.
+     * @param c An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
@@ -3387,6 +3552,8 @@ $.post( "test.php" );
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
+     * @param b An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
@@ -3401,6 +3568,7 @@ $.post( "test.php" );
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
@@ -3432,6 +3600,13 @@ $.post( "test.php" );
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
+     * @param b An argument to be passed to the function referenced in the `function` argument.
+     * @param c An argument to be passed to the function referenced in the `function` argument.
+     * @param d An argument to be passed to the function referenced in the `function` argument.
+     * @param e An argument to be passed to the function referenced in the `function` argument.
+     * @param f An argument to be passed to the function referenced in the `function` argument.
+     * @param g An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
@@ -3446,6 +3621,12 @@ $.post( "test.php" );
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
+     * @param b An argument to be passed to the function referenced in the `function` argument.
+     * @param c An argument to be passed to the function referenced in the `function` argument.
+     * @param d An argument to be passed to the function referenced in the `function` argument.
+     * @param e An argument to be passed to the function referenced in the `function` argument.
+     * @param f An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
@@ -3460,6 +3641,11 @@ $.post( "test.php" );
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
+     * @param b An argument to be passed to the function referenced in the `function` argument.
+     * @param c An argument to be passed to the function referenced in the `function` argument.
+     * @param d An argument to be passed to the function referenced in the `function` argument.
+     * @param e An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
@@ -3474,6 +3660,10 @@ $.post( "test.php" );
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
+     * @param b An argument to be passed to the function referenced in the `function` argument.
+     * @param c An argument to be passed to the function referenced in the `function` argument.
+     * @param d An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
@@ -3488,6 +3678,9 @@ $.post( "test.php" );
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
+     * @param b An argument to be passed to the function referenced in the `function` argument.
+     * @param c An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
@@ -3502,6 +3695,8 @@ $.post( "test.php" );
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
+     * @param b An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
@@ -3516,6 +3711,7 @@ $.post( "test.php" );
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
@@ -3547,6 +3743,13 @@ $.post( "test.php" );
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
+     * @param b An argument to be passed to the function referenced in the `function` argument.
+     * @param c An argument to be passed to the function referenced in the `function` argument.
+     * @param d An argument to be passed to the function referenced in the `function` argument.
+     * @param e An argument to be passed to the function referenced in the `function` argument.
+     * @param f An argument to be passed to the function referenced in the `function` argument.
+     * @param g An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
@@ -3561,6 +3764,12 @@ $.post( "test.php" );
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
+     * @param b An argument to be passed to the function referenced in the `function` argument.
+     * @param c An argument to be passed to the function referenced in the `function` argument.
+     * @param d An argument to be passed to the function referenced in the `function` argument.
+     * @param e An argument to be passed to the function referenced in the `function` argument.
+     * @param f An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
@@ -3575,6 +3784,11 @@ $.post( "test.php" );
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
+     * @param b An argument to be passed to the function referenced in the `function` argument.
+     * @param c An argument to be passed to the function referenced in the `function` argument.
+     * @param d An argument to be passed to the function referenced in the `function` argument.
+     * @param e An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
@@ -3589,6 +3803,10 @@ $.post( "test.php" );
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
+     * @param b An argument to be passed to the function referenced in the `function` argument.
+     * @param c An argument to be passed to the function referenced in the `function` argument.
+     * @param d An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
@@ -3603,6 +3821,9 @@ $.post( "test.php" );
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
+     * @param b An argument to be passed to the function referenced in the `function` argument.
+     * @param c An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
@@ -3617,6 +3838,8 @@ $.post( "test.php" );
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
+     * @param b An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
@@ -3631,6 +3854,7 @@ $.post( "test.php" );
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
@@ -3690,6 +3914,13 @@ $.post( "test.php" );
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
+     * @param b An argument to be passed to the function referenced in the `function` argument.
+     * @param c An argument to be passed to the function referenced in the `function` argument.
+     * @param d An argument to be passed to the function referenced in the `function` argument.
+     * @param e An argument to be passed to the function referenced in the `function` argument.
+     * @param f An argument to be passed to the function referenced in the `function` argument.
+     * @param g An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -3822,6 +4053,12 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
+     * @param b An argument to be passed to the function referenced in the `function` argument.
+     * @param c An argument to be passed to the function referenced in the `function` argument.
+     * @param d An argument to be passed to the function referenced in the `function` argument.
+     * @param e An argument to be passed to the function referenced in the `function` argument.
+     * @param f An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -3954,6 +4191,11 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
+     * @param b An argument to be passed to the function referenced in the `function` argument.
+     * @param c An argument to be passed to the function referenced in the `function` argument.
+     * @param d An argument to be passed to the function referenced in the `function` argument.
+     * @param e An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -4086,6 +4328,10 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
+     * @param b An argument to be passed to the function referenced in the `function` argument.
+     * @param c An argument to be passed to the function referenced in the `function` argument.
+     * @param d An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -4218,6 +4464,9 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
+     * @param b An argument to be passed to the function referenced in the `function` argument.
+     * @param c An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -4350,6 +4599,8 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
+     * @param b An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -4482,6 +4733,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4`
      * @since 1.6
@@ -4750,6 +5002,13 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
+     * @param b An argument to be passed to the function referenced in the `function` argument.
+     * @param c An argument to be passed to the function referenced in the `function` argument.
+     * @param d An argument to be passed to the function referenced in the `function` argument.
+     * @param e An argument to be passed to the function referenced in the `function` argument.
+     * @param f An argument to be passed to the function referenced in the `function` argument.
+     * @param g An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -4884,6 +5143,12 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
+     * @param b An argument to be passed to the function referenced in the `function` argument.
+     * @param c An argument to be passed to the function referenced in the `function` argument.
+     * @param d An argument to be passed to the function referenced in the `function` argument.
+     * @param e An argument to be passed to the function referenced in the `function` argument.
+     * @param f An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -5018,6 +5283,11 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
+     * @param b An argument to be passed to the function referenced in the `function` argument.
+     * @param c An argument to be passed to the function referenced in the `function` argument.
+     * @param d An argument to be passed to the function referenced in the `function` argument.
+     * @param e An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -5152,6 +5422,10 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
+     * @param b An argument to be passed to the function referenced in the `function` argument.
+     * @param c An argument to be passed to the function referenced in the `function` argument.
+     * @param d An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -5286,6 +5560,9 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
+     * @param b An argument to be passed to the function referenced in the `function` argument.
+     * @param c An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -5420,6 +5697,8 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
+     * @param b An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -5554,6 +5833,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -5825,6 +6105,13 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
+     * @param b An argument to be passed to the function referenced in the `function` argument.
+     * @param c An argument to be passed to the function referenced in the `function` argument.
+     * @param d An argument to be passed to the function referenced in the `function` argument.
+     * @param e An argument to be passed to the function referenced in the `function` argument.
+     * @param f An argument to be passed to the function referenced in the `function` argument.
+     * @param g An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -5959,6 +6246,12 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
+     * @param b An argument to be passed to the function referenced in the `function` argument.
+     * @param c An argument to be passed to the function referenced in the `function` argument.
+     * @param d An argument to be passed to the function referenced in the `function` argument.
+     * @param e An argument to be passed to the function referenced in the `function` argument.
+     * @param f An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -6093,6 +6386,11 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
+     * @param b An argument to be passed to the function referenced in the `function` argument.
+     * @param c An argument to be passed to the function referenced in the `function` argument.
+     * @param d An argument to be passed to the function referenced in the `function` argument.
+     * @param e An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -6227,6 +6525,10 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
+     * @param b An argument to be passed to the function referenced in the `function` argument.
+     * @param c An argument to be passed to the function referenced in the `function` argument.
+     * @param d An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -6361,6 +6663,9 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
+     * @param b An argument to be passed to the function referenced in the `function` argument.
+     * @param c An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -6495,6 +6800,8 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
+     * @param b An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -6629,6 +6936,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -6900,6 +7208,13 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
+     * @param b An argument to be passed to the function referenced in the `function` argument.
+     * @param c An argument to be passed to the function referenced in the `function` argument.
+     * @param d An argument to be passed to the function referenced in the `function` argument.
+     * @param e An argument to be passed to the function referenced in the `function` argument.
+     * @param f An argument to be passed to the function referenced in the `function` argument.
+     * @param g An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -7034,6 +7349,12 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
+     * @param b An argument to be passed to the function referenced in the `function` argument.
+     * @param c An argument to be passed to the function referenced in the `function` argument.
+     * @param d An argument to be passed to the function referenced in the `function` argument.
+     * @param e An argument to be passed to the function referenced in the `function` argument.
+     * @param f An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -7168,6 +7489,11 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
+     * @param b An argument to be passed to the function referenced in the `function` argument.
+     * @param c An argument to be passed to the function referenced in the `function` argument.
+     * @param d An argument to be passed to the function referenced in the `function` argument.
+     * @param e An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -7302,6 +7628,10 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
+     * @param b An argument to be passed to the function referenced in the `function` argument.
+     * @param c An argument to be passed to the function referenced in the `function` argument.
+     * @param d An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -7436,6 +7766,9 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
+     * @param b An argument to be passed to the function referenced in the `function` argument.
+     * @param c An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -7570,6 +7903,8 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
+     * @param b An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -7704,6 +8039,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -7975,6 +8311,13 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
+     * @param b An argument to be passed to the function referenced in the `function` argument.
+     * @param c An argument to be passed to the function referenced in the `function` argument.
+     * @param d An argument to be passed to the function referenced in the `function` argument.
+     * @param e An argument to be passed to the function referenced in the `function` argument.
+     * @param f An argument to be passed to the function referenced in the `function` argument.
+     * @param g An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -8109,6 +8452,12 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
+     * @param b An argument to be passed to the function referenced in the `function` argument.
+     * @param c An argument to be passed to the function referenced in the `function` argument.
+     * @param d An argument to be passed to the function referenced in the `function` argument.
+     * @param e An argument to be passed to the function referenced in the `function` argument.
+     * @param f An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -8243,6 +8592,11 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
+     * @param b An argument to be passed to the function referenced in the `function` argument.
+     * @param c An argument to be passed to the function referenced in the `function` argument.
+     * @param d An argument to be passed to the function referenced in the `function` argument.
+     * @param e An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -8377,6 +8731,10 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
+     * @param b An argument to be passed to the function referenced in the `function` argument.
+     * @param c An argument to be passed to the function referenced in the `function` argument.
+     * @param d An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -8511,6 +8869,9 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
+     * @param b An argument to be passed to the function referenced in the `function` argument.
+     * @param c An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -8645,6 +9006,8 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
+     * @param b An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -8779,6 +9142,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -9050,6 +9414,13 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
+     * @param b An argument to be passed to the function referenced in the `function` argument.
+     * @param c An argument to be passed to the function referenced in the `function` argument.
+     * @param d An argument to be passed to the function referenced in the `function` argument.
+     * @param e An argument to be passed to the function referenced in the `function` argument.
+     * @param f An argument to be passed to the function referenced in the `function` argument.
+     * @param g An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -9184,6 +9555,12 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
+     * @param b An argument to be passed to the function referenced in the `function` argument.
+     * @param c An argument to be passed to the function referenced in the `function` argument.
+     * @param d An argument to be passed to the function referenced in the `function` argument.
+     * @param e An argument to be passed to the function referenced in the `function` argument.
+     * @param f An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -9318,6 +9695,11 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
+     * @param b An argument to be passed to the function referenced in the `function` argument.
+     * @param c An argument to be passed to the function referenced in the `function` argument.
+     * @param d An argument to be passed to the function referenced in the `function` argument.
+     * @param e An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -9452,6 +9834,10 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
+     * @param b An argument to be passed to the function referenced in the `function` argument.
+     * @param c An argument to be passed to the function referenced in the `function` argument.
+     * @param d An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -9586,6 +9972,9 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
+     * @param b An argument to be passed to the function referenced in the `function` argument.
+     * @param c An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -9720,6 +10109,8 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
+     * @param b An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -9854,6 +10245,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -10125,6 +10517,13 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
+     * @param b An argument to be passed to the function referenced in the `function` argument.
+     * @param c An argument to be passed to the function referenced in the `function` argument.
+     * @param d An argument to be passed to the function referenced in the `function` argument.
+     * @param e An argument to be passed to the function referenced in the `function` argument.
+     * @param f An argument to be passed to the function referenced in the `function` argument.
+     * @param g An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -10259,6 +10658,12 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
+     * @param b An argument to be passed to the function referenced in the `function` argument.
+     * @param c An argument to be passed to the function referenced in the `function` argument.
+     * @param d An argument to be passed to the function referenced in the `function` argument.
+     * @param e An argument to be passed to the function referenced in the `function` argument.
+     * @param f An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -10393,6 +10798,11 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
+     * @param b An argument to be passed to the function referenced in the `function` argument.
+     * @param c An argument to be passed to the function referenced in the `function` argument.
+     * @param d An argument to be passed to the function referenced in the `function` argument.
+     * @param e An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -10527,6 +10937,10 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
+     * @param b An argument to be passed to the function referenced in the `function` argument.
+     * @param c An argument to be passed to the function referenced in the `function` argument.
+     * @param d An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -10661,6 +11075,9 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
+     * @param b An argument to be passed to the function referenced in the `function` argument.
+     * @param c An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -10795,6 +11212,8 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
+     * @param b An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -10929,6 +11348,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -11200,6 +11620,13 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
+     * @param b An argument to be passed to the function referenced in the `function` argument.
+     * @param c An argument to be passed to the function referenced in the `function` argument.
+     * @param d An argument to be passed to the function referenced in the `function` argument.
+     * @param e An argument to be passed to the function referenced in the `function` argument.
+     * @param f An argument to be passed to the function referenced in the `function` argument.
+     * @param g An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -11334,6 +11761,12 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
+     * @param b An argument to be passed to the function referenced in the `function` argument.
+     * @param c An argument to be passed to the function referenced in the `function` argument.
+     * @param d An argument to be passed to the function referenced in the `function` argument.
+     * @param e An argument to be passed to the function referenced in the `function` argument.
+     * @param f An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -11468,6 +11901,11 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
+     * @param b An argument to be passed to the function referenced in the `function` argument.
+     * @param c An argument to be passed to the function referenced in the `function` argument.
+     * @param d An argument to be passed to the function referenced in the `function` argument.
+     * @param e An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -11602,6 +12040,10 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
+     * @param b An argument to be passed to the function referenced in the `function` argument.
+     * @param c An argument to be passed to the function referenced in the `function` argument.
+     * @param d An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -11736,6 +12178,9 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
+     * @param b An argument to be passed to the function referenced in the `function` argument.
+     * @param c An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -11870,6 +12315,8 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
+     * @param b An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6
@@ -12004,6 +12451,7 @@ $( "#test" )
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
+     * @param a An argument to be passed to the function referenced in the `function` argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
      * @since 1.6

--- a/types/jquery/JQueryStatic.d.ts
+++ b/types/jquery/JQueryStatic.d.ts
@@ -1772,8 +1772,9 @@ test();
     /**
      * Finds the elements of an array which satisfy a filter function. The original array is not affected.
      * @param array The array-like object to search through.
-     * @param fn The function to process each item against. The first argument to the function is the item, and the
-     *           second argument is the index. The function should return a Boolean value. this will be the global window object.
+     * @param funсtion The function to process each item against. The first argument to the function is the item, and the
+     *                 second argument is the index. The function should return a Boolean value. `this` will be the global
+     *                 window object.
      * @param invert If "invert" is false, or not provided, then the function returns an array consisting of all elements
      *               for which "callback" returns true. If "invert" is true, then the function returns an array
      *               consisting of all elements for which "callback" returns false.
@@ -1839,7 +1840,7 @@ $.grep( [ 0, 1, 2 ], function( n, i ) {
 ```
      */
     grep<T>(array: ArrayLike<T>,
-            fn: (elementOfArray: T, indexInArray: number) => boolean,
+            funсtion: (elementOfArray: T, indexInArray: number) => boolean,
             invert?: boolean): T[];
     /**
      * Determine whether an element has any jQuery data associated with it.
@@ -2743,8 +2744,8 @@ $.post( "test.php" );
     // region proxy
     // #region proxy
 
-    // region (fn, null | undefined)
-    // #region (fn, null | undefined)
+    // region (funсtion, null | undefined)
+    // #region (funсtion, null | undefined)
 
     // region 0 to 7 additional arguments
     // #region 0 to 7 additional arguments
@@ -2754,97 +2755,97 @@ $.post( "test.php" );
 
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
      */
     proxy<TReturn,
-        A, B, C, D, E, F, G>(fn: (a: A, b: B, c: C, d: D, e: E, f: F, g: G) => TReturn,
+        A, B, C, D, E, F, G>(funсtion: (a: A, b: B, c: C, d: D, e: E, f: F, g: G) => TReturn,
                              context: null | undefined,
                              a: A, b: B, c: C, d: D, e: E, f: F, g: G): () => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
      */
     proxy<TReturn,
-        A, B, C, D, E, F>(fn: (a: A, b: B, c: C, d: D, e: E, f: F) => TReturn,
+        A, B, C, D, E, F>(funсtion: (a: A, b: B, c: C, d: D, e: E, f: F) => TReturn,
                           context: null | undefined,
                           a: A, b: B, c: C, d: D, e: E, f: F): () => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
      */
     proxy<TReturn,
-        A, B, C, D, E>(fn: (a: A, b: B, c: C, d: D, e: E) => TReturn,
+        A, B, C, D, E>(funсtion: (a: A, b: B, c: C, d: D, e: E) => TReturn,
                        context: null | undefined,
                        a: A, b: B, c: C, d: D, e: E): () => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
      */
     proxy<TReturn,
-        A, B, C, D>(fn: (a: A, b: B, c: C, d: D) => TReturn,
+        A, B, C, D>(funсtion: (a: A, b: B, c: C, d: D) => TReturn,
                     context: null | undefined,
                     a: A, b: B, c: C, d: D): () => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
      */
     proxy<TReturn,
-        A, B, C>(fn: (a: A, b: B, c: C) => TReturn,
+        A, B, C>(funсtion: (a: A, b: B, c: C) => TReturn,
                  context: null | undefined,
                  a: A, b: B, c: C): () => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
      */
     proxy<TReturn,
-        A, B>(fn: (a: A, b: B) => TReturn,
+        A, B>(funсtion: (a: A, b: B) => TReturn,
               context: null | undefined,
               a: A, b: B): () => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
      */
     proxy<TReturn,
-        A>(fn: (a: A) => TReturn,
+        A>(funсtion: (a: A) => TReturn,
            context: null | undefined,
            a: A): () => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
      */
-    proxy<TReturn>(fn: () => TReturn,
+    proxy<TReturn>(funсtion: () => TReturn,
                    context: null | undefined): () => TReturn;
 
     // #endregion
@@ -2854,7 +2855,7 @@ $.post( "test.php" );
 
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
@@ -2862,13 +2863,13 @@ $.post( "test.php" );
      */
     proxy<TReturn,
         A, B, C, D, E, F, G,
-        T>(fn: (a: A, b: B, c: C, d: D, e: E, f: F, g: G,
-                t: T) => TReturn,
+        T>(funсtion: (a: A, b: B, c: C, d: D, e: E, f: F, g: G,
+                      t: T) => TReturn,
            context: null | undefined,
            a: A, b: B, c: C, d: D, e: E, f: F, g: G): (t: T) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
@@ -2876,13 +2877,13 @@ $.post( "test.php" );
      */
     proxy<TReturn,
         A, B, C, D, E, F,
-        T>(fn: (a: A, b: B, c: C, d: D, e: E, f: F,
-                t: T) => TReturn,
+        T>(funсtion: (a: A, b: B, c: C, d: D, e: E, f: F,
+                      t: T) => TReturn,
            context: null | undefined,
            a: A, b: B, c: C, d: D, e: E, f: F): (t: T) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
@@ -2890,13 +2891,13 @@ $.post( "test.php" );
      */
     proxy<TReturn,
         A, B, C, D, E,
-        T>(fn: (a: A, b: B, c: C, d: D, e: E,
-                t: T) => TReturn,
+        T>(funсtion: (a: A, b: B, c: C, d: D, e: E,
+                      t: T) => TReturn,
            context: null | undefined,
            a: A, b: B, c: C, d: D, e: E): (t: T) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
@@ -2904,13 +2905,13 @@ $.post( "test.php" );
      */
     proxy<TReturn,
         A, B, C, D,
-        T>(fn: (a: A, b: B, c: C, d: D,
-                t: T) => TReturn,
+        T>(funсtion: (a: A, b: B, c: C, d: D,
+                      t: T) => TReturn,
            context: null | undefined,
            a: A, b: B, c: C, d: D): (t: T) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
@@ -2918,13 +2919,13 @@ $.post( "test.php" );
      */
     proxy<TReturn,
         A, B, C,
-        T>(fn: (a: A, b: B, c: C,
-                t: T) => TReturn,
+        T>(funсtion: (a: A, b: B, c: C,
+                      t: T) => TReturn,
            context: null | undefined,
            a: A, b: B, c: C): (t: T) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
@@ -2932,13 +2933,13 @@ $.post( "test.php" );
      */
     proxy<TReturn,
         A, B,
-        T>(fn: (a: A, b: B,
-                t: T) => TReturn,
+        T>(funсtion: (a: A, b: B,
+                      t: T) => TReturn,
            context: null | undefined,
            a: A, b: B): (t: T) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
@@ -2946,20 +2947,20 @@ $.post( "test.php" );
      */
     proxy<TReturn,
         A,
-        T>(fn: (a: A,
-                t: T) => TReturn,
+        T>(funсtion: (a: A,
+                      t: T) => TReturn,
            context: null | undefined,
            a: A): (t: T) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
      */
     proxy<TReturn,
-        T>(fn: (t: T) => TReturn,
+        T>(funсtion: (t: T) => TReturn,
            context: null | undefined): (t: T) => TReturn;
 
     // #endregion
@@ -2969,7 +2970,7 @@ $.post( "test.php" );
 
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
@@ -2977,13 +2978,13 @@ $.post( "test.php" );
      */
     proxy<TReturn,
         A, B, C, D, E, F, G,
-        T, U>(fn: (a: A, b: B, c: C, d: D, e: E, f: F, g: G,
-                   t: T, u: U) => TReturn,
+        T, U>(funсtion: (a: A, b: B, c: C, d: D, e: E, f: F, g: G,
+                         t: T, u: U) => TReturn,
               context: null | undefined,
               a: A, b: B, c: C, d: D, e: E, f: F, g: G): (t: T, u: U) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
@@ -2991,13 +2992,13 @@ $.post( "test.php" );
      */
     proxy<TReturn,
         A, B, C, D, E, F,
-        T, U>(fn: (a: A, b: B, c: C, d: D, e: E, f: F,
-                   t: T, u: U) => TReturn,
+        T, U>(funсtion: (a: A, b: B, c: C, d: D, e: E, f: F,
+                         t: T, u: U) => TReturn,
               context: null | undefined,
               a: A, b: B, c: C, d: D, e: E, f: F): (t: T, u: U) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
@@ -3005,13 +3006,13 @@ $.post( "test.php" );
      */
     proxy<TReturn,
         A, B, C, D, E,
-        T, U>(fn: (a: A, b: B, c: C, d: D, e: E,
-                   t: T, u: U) => TReturn,
+        T, U>(funсtion: (a: A, b: B, c: C, d: D, e: E,
+                         t: T, u: U) => TReturn,
               context: null | undefined,
               a: A, b: B, c: C, d: D, e: E): (t: T, u: U) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
@@ -3019,13 +3020,13 @@ $.post( "test.php" );
      */
     proxy<TReturn,
         A, B, C, D,
-        T, U>(fn: (a: A, b: B, c: C, d: D,
-                   t: T, u: U) => TReturn,
+        T, U>(funсtion: (a: A, b: B, c: C, d: D,
+                         t: T, u: U) => TReturn,
               context: null | undefined,
               a: A, b: B, c: C, d: D): (t: T, u: U) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
@@ -3033,13 +3034,13 @@ $.post( "test.php" );
      */
     proxy<TReturn,
         A, B, C,
-        T, U>(fn: (a: A, b: B, c: C,
-                   t: T, u: U) => TReturn,
+        T, U>(funсtion: (a: A, b: B, c: C,
+                         t: T, u: U) => TReturn,
               context: null | undefined,
               a: A, b: B, c: C): (t: T, u: U) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
@@ -3047,13 +3048,13 @@ $.post( "test.php" );
      */
     proxy<TReturn,
         A, B,
-        T, U>(fn: (a: A, b: B,
-                   t: T, u: U) => TReturn,
+        T, U>(funсtion: (a: A, b: B,
+                         t: T, u: U) => TReturn,
               context: null | undefined,
               a: A, b: B): (t: T, u: U) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
@@ -3061,20 +3062,20 @@ $.post( "test.php" );
      */
     proxy<TReturn,
         A,
-        T, U>(fn: (a: A,
-                   t: T, u: U) => TReturn,
+        T, U>(funсtion: (a: A,
+                         t: T, u: U) => TReturn,
               context: null | undefined,
               a: A): (t: T, u: U) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
      */
     proxy<TReturn,
-        T, U>(fn: (t: T, u: U) => TReturn,
+        T, U>(funсtion: (t: T, u: U) => TReturn,
               context: null | undefined): (t: T, u: U) => TReturn;
 
     // #endregion
@@ -3084,7 +3085,7 @@ $.post( "test.php" );
 
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
@@ -3092,13 +3093,13 @@ $.post( "test.php" );
      */
     proxy<TReturn,
         A, B, C, D, E, F, G,
-        T, U, V>(fn: (a: A, b: B, c: C, d: D, e: E, f: F, g: G,
-                      t: T, u: U, v: V) => TReturn,
+        T, U, V>(funсtion: (a: A, b: B, c: C, d: D, e: E, f: F, g: G,
+                            t: T, u: U, v: V) => TReturn,
                  context: null | undefined,
                  a: A, b: B, c: C, d: D, e: E, f: F, g: G): (t: T, u: U, v: V) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
@@ -3106,13 +3107,13 @@ $.post( "test.php" );
      */
     proxy<TReturn,
         A, B, C, D, E, F,
-        T, U, V>(fn: (a: A, b: B, c: C, d: D, e: E, f: F,
-                      t: T, u: U, v: V) => TReturn,
+        T, U, V>(funсtion: (a: A, b: B, c: C, d: D, e: E, f: F,
+                            t: T, u: U, v: V) => TReturn,
                  context: null | undefined,
                  a: A, b: B, c: C, d: D, e: E, f: F): (t: T, u: U, v: V) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
@@ -3120,13 +3121,13 @@ $.post( "test.php" );
      */
     proxy<TReturn,
         A, B, C, D, E,
-        T, U, V>(fn: (a: A, b: B, c: C, d: D, e: E,
-                      t: T, u: U, v: V) => TReturn,
+        T, U, V>(funсtion: (a: A, b: B, c: C, d: D, e: E,
+                            t: T, u: U, v: V) => TReturn,
                  context: null | undefined,
                  a: A, b: B, c: C, d: D, e: E): (t: T, u: U, v: V) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
@@ -3134,13 +3135,13 @@ $.post( "test.php" );
      */
     proxy<TReturn,
         A, B, C, D,
-        T, U, V>(fn: (a: A, b: B, c: C, d: D,
-                      t: T, u: U, v: V) => TReturn,
+        T, U, V>(funсtion: (a: A, b: B, c: C, d: D,
+                            t: T, u: U, v: V) => TReturn,
                  context: null | undefined,
                  a: A, b: B, c: C, d: D): (t: T, u: U, v: V) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
@@ -3148,13 +3149,13 @@ $.post( "test.php" );
      */
     proxy<TReturn,
         A, B, C,
-        T, U, V>(fn: (a: A, b: B, c: C,
-                      t: T, u: U, v: V) => TReturn,
+        T, U, V>(funсtion: (a: A, b: B, c: C,
+                            t: T, u: U, v: V) => TReturn,
                  context: null | undefined,
                  a: A, b: B, c: C): (t: T, u: U, v: V) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
@@ -3162,13 +3163,13 @@ $.post( "test.php" );
      */
     proxy<TReturn,
         A, B,
-        T, U, V>(fn: (a: A, b: B,
-                      t: T, u: U, v: V) => TReturn,
+        T, U, V>(funсtion: (a: A, b: B,
+                            t: T, u: U, v: V) => TReturn,
                  context: null | undefined,
                  a: A, b: B): (t: T, u: U, v: V) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
@@ -3176,20 +3177,20 @@ $.post( "test.php" );
      */
     proxy<TReturn,
         A,
-        T, U, V>(fn: (a: A,
-                      t: T, u: U, v: V) => TReturn,
+        T, U, V>(funсtion: (a: A,
+                            t: T, u: U, v: V) => TReturn,
                  context: null | undefined,
                  a: A): (t: T, u: U, v: V) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
      */
     proxy<TReturn,
-        T, U, V>(fn: (t: T, u: U, v: V) => TReturn,
+        T, U, V>(funсtion: (t: T, u: U, v: V) => TReturn,
                  context: null | undefined): (t: T, u: U, v: V) => TReturn;
 
     // #endregion
@@ -3199,7 +3200,7 @@ $.post( "test.php" );
 
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
@@ -3207,13 +3208,13 @@ $.post( "test.php" );
      */
     proxy<TReturn,
         A, B, C, D, E, F, G,
-        T, U, V, W>(fn: (a: A, b: B, c: C, d: D, e: E, f: F, g: G,
-                         t: T, u: U, v: V, w: W) => TReturn,
+        T, U, V, W>(funсtion: (a: A, b: B, c: C, d: D, e: E, f: F, g: G,
+                               t: T, u: U, v: V, w: W) => TReturn,
                     context: null | undefined,
                     a: A, b: B, c: C, d: D, e: E, f: F, g: G): (t: T, u: U, v: V, w: W) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
@@ -3221,13 +3222,13 @@ $.post( "test.php" );
      */
     proxy<TReturn,
         A, B, C, D, E, F,
-        T, U, V, W>(fn: (a: A, b: B, c: C, d: D, e: E, f: F,
-                         t: T, u: U, v: V, w: W) => TReturn,
+        T, U, V, W>(funсtion: (a: A, b: B, c: C, d: D, e: E, f: F,
+                               t: T, u: U, v: V, w: W) => TReturn,
                     context: null | undefined,
                     a: A, b: B, c: C, d: D, e: E, f: F): (t: T, u: U, v: V, w: W) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
@@ -3235,13 +3236,13 @@ $.post( "test.php" );
      */
     proxy<TReturn,
         A, B, C, D, E,
-        T, U, V, W>(fn: (a: A, b: B, c: C, d: D, e: E,
-                         t: T, u: U, v: V, w: W) => TReturn,
+        T, U, V, W>(funсtion: (a: A, b: B, c: C, d: D, e: E,
+                               t: T, u: U, v: V, w: W) => TReturn,
                     context: null | undefined,
                     a: A, b: B, c: C, d: D, e: E): (t: T, u: U, v: V, w: W) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
@@ -3249,13 +3250,13 @@ $.post( "test.php" );
      */
     proxy<TReturn,
         A, B, C, D,
-        T, U, V, W>(fn: (a: A, b: B, c: C, d: D,
-                         t: T, u: U, v: V, w: W) => TReturn,
+        T, U, V, W>(funсtion: (a: A, b: B, c: C, d: D,
+                               t: T, u: U, v: V, w: W) => TReturn,
                     context: null | undefined,
                     a: A, b: B, c: C, d: D): (t: T, u: U, v: V, w: W) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
@@ -3263,13 +3264,13 @@ $.post( "test.php" );
      */
     proxy<TReturn,
         A, B, C,
-        T, U, V, W>(fn: (a: A, b: B, c: C,
-                         t: T, u: U, v: V, w: W) => TReturn,
+        T, U, V, W>(funсtion: (a: A, b: B, c: C,
+                               t: T, u: U, v: V, w: W) => TReturn,
                     context: null | undefined,
                     a: A, b: B, c: C): (t: T, u: U, v: V, w: W) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
@@ -3277,13 +3278,13 @@ $.post( "test.php" );
      */
     proxy<TReturn,
         A, B,
-        T, U, V, W>(fn: (a: A, b: B,
-                         t: T, u: U, v: V, w: W) => TReturn,
+        T, U, V, W>(funсtion: (a: A, b: B,
+                               t: T, u: U, v: V, w: W) => TReturn,
                     context: null | undefined,
                     a: A, b: B): (t: T, u: U, v: V, w: W) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
@@ -3291,20 +3292,20 @@ $.post( "test.php" );
      */
     proxy<TReturn,
         A,
-        T, U, V, W>(fn: (a: A,
-                         t: T, u: U, v: V, w: W) => TReturn,
+        T, U, V, W>(funсtion: (a: A,
+                               t: T, u: U, v: V, w: W) => TReturn,
                     context: null | undefined,
                     a: A): (t: T, u: U, v: V, w: W) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
      */
     proxy<TReturn,
-        T, U, V, W>(fn: (t: T, u: U, v: V, w: W) => TReturn,
+        T, U, V, W>(funсtion: (t: T, u: U, v: V, w: W) => TReturn,
                     context: null | undefined): (t: T, u: U, v: V, w: W) => TReturn;
 
     // #endregion
@@ -3314,7 +3315,7 @@ $.post( "test.php" );
 
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
@@ -3322,13 +3323,13 @@ $.post( "test.php" );
      */
     proxy<TReturn,
         A, B, C, D, E, F, G,
-        T, U, V, W, X>(fn: (a: A, b: B, c: C, d: D, e: E, f: F, g: G,
-                            t: T, u: U, v: V, w: W, x: X) => TReturn,
+        T, U, V, W, X>(funсtion: (a: A, b: B, c: C, d: D, e: E, f: F, g: G,
+                                  t: T, u: U, v: V, w: W, x: X) => TReturn,
                        context: null | undefined,
                        a: A, b: B, c: C, d: D, e: E, f: F, g: G): (t: T, u: U, v: V, w: W, x: X) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
@@ -3336,13 +3337,13 @@ $.post( "test.php" );
      */
     proxy<TReturn,
         A, B, C, D, E, F,
-        T, U, V, W, X>(fn: (a: A, b: B, c: C, d: D, e: E, f: F,
-                            t: T, u: U, v: V, w: W, x: X) => TReturn,
+        T, U, V, W, X>(funсtion: (a: A, b: B, c: C, d: D, e: E, f: F,
+                                  t: T, u: U, v: V, w: W, x: X) => TReturn,
                        context: null | undefined,
                        a: A, b: B, c: C, d: D, e: E, f: F): (t: T, u: U, v: V, w: W, x: X) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
@@ -3350,13 +3351,13 @@ $.post( "test.php" );
      */
     proxy<TReturn,
         A, B, C, D, E,
-        T, U, V, W, X>(fn: (a: A, b: B, c: C, d: D, e: E,
-                            t: T, u: U, v: V, w: W, x: X) => TReturn,
+        T, U, V, W, X>(funсtion: (a: A, b: B, c: C, d: D, e: E,
+                                  t: T, u: U, v: V, w: W, x: X) => TReturn,
                        context: null | undefined,
                        a: A, b: B, c: C, d: D, e: E): (t: T, u: U, v: V, w: W, x: X) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
@@ -3364,13 +3365,13 @@ $.post( "test.php" );
      */
     proxy<TReturn,
         A, B, C, D,
-        T, U, V, W, X>(fn: (a: A, b: B, c: C, d: D,
-                            t: T, u: U, v: V, w: W, x: X) => TReturn,
+        T, U, V, W, X>(funсtion: (a: A, b: B, c: C, d: D,
+                                  t: T, u: U, v: V, w: W, x: X) => TReturn,
                        context: null | undefined,
                        a: A, b: B, c: C, d: D): (t: T, u: U, v: V, w: W, x: X) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
@@ -3378,13 +3379,13 @@ $.post( "test.php" );
      */
     proxy<TReturn,
         A, B, C,
-        T, U, V, W, X>(fn: (a: A, b: B, c: C,
-                            t: T, u: U, v: V, w: W, x: X) => TReturn,
+        T, U, V, W, X>(funсtion: (a: A, b: B, c: C,
+                                  t: T, u: U, v: V, w: W, x: X) => TReturn,
                        context: null | undefined,
                        a: A, b: B, c: C): (t: T, u: U, v: V, w: W, x: X) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
@@ -3392,13 +3393,13 @@ $.post( "test.php" );
      */
     proxy<TReturn,
         A, B,
-        T, U, V, W, X>(fn: (a: A, b: B,
-                            t: T, u: U, v: V, w: W, x: X) => TReturn,
+        T, U, V, W, X>(funсtion: (a: A, b: B,
+                                  t: T, u: U, v: V, w: W, x: X) => TReturn,
                        context: null | undefined,
                        a: A, b: B): (t: T, u: U, v: V, w: W, x: X) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
@@ -3406,20 +3407,20 @@ $.post( "test.php" );
      */
     proxy<TReturn,
         A,
-        T, U, V, W, X>(fn: (a: A,
-                            t: T, u: U, v: V, w: W, x: X) => TReturn,
+        T, U, V, W, X>(funсtion: (a: A,
+                                  t: T, u: U, v: V, w: W, x: X) => TReturn,
                        context: null | undefined,
                        a: A): (t: T, u: U, v: V, w: W, x: X) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
      */
     proxy<TReturn,
-        T, U, V, W, X>(fn: (t: T, u: U, v: V, w: W, x: X) => TReturn,
+        T, U, V, W, X>(funсtion: (t: T, u: U, v: V, w: W, x: X) => TReturn,
                        context: null | undefined): (t: T, u: U, v: V, w: W, x: X) => TReturn;
 
     // #endregion
@@ -3429,7 +3430,7 @@ $.post( "test.php" );
 
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
@@ -3437,13 +3438,13 @@ $.post( "test.php" );
      */
     proxy<TReturn,
         A, B, C, D, E, F, G,
-        T, U, V, W, X, Y>(fn: (a: A, b: B, c: C, d: D, e: E, f: F, g: G,
-                               t: T, u: U, v: V, w: W, x: X, y: Y) => TReturn,
+        T, U, V, W, X, Y>(funсtion: (a: A, b: B, c: C, d: D, e: E, f: F, g: G,
+                                     t: T, u: U, v: V, w: W, x: X, y: Y) => TReturn,
                           context: null | undefined,
                           a: A, b: B, c: C, d: D, e: E, f: F, g: G): (t: T, u: U, v: V, w: W, x: X, y: Y) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
@@ -3451,13 +3452,13 @@ $.post( "test.php" );
      */
     proxy<TReturn,
         A, B, C, D, E, F,
-        T, U, V, W, X, Y>(fn: (a: A, b: B, c: C, d: D, e: E, f: F,
-                               t: T, u: U, v: V, w: W, x: X, y: Y) => TReturn,
+        T, U, V, W, X, Y>(funсtion: (a: A, b: B, c: C, d: D, e: E, f: F,
+                                     t: T, u: U, v: V, w: W, x: X, y: Y) => TReturn,
                           context: null | undefined,
                           a: A, b: B, c: C, d: D, e: E, f: F): (t: T, u: U, v: V, w: W, x: X, y: Y) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
@@ -3465,13 +3466,13 @@ $.post( "test.php" );
      */
     proxy<TReturn,
         A, B, C, D, E,
-        T, U, V, W, X, Y>(fn: (a: A, b: B, c: C, d: D, e: E,
-                               t: T, u: U, v: V, w: W, x: X, y: Y) => TReturn,
+        T, U, V, W, X, Y>(funсtion: (a: A, b: B, c: C, d: D, e: E,
+                                     t: T, u: U, v: V, w: W, x: X, y: Y) => TReturn,
                           context: null | undefined,
                           a: A, b: B, c: C, d: D, e: E): (t: T, u: U, v: V, w: W, x: X, y: Y) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
@@ -3479,13 +3480,13 @@ $.post( "test.php" );
      */
     proxy<TReturn,
         A, B, C, D,
-        T, U, V, W, X, Y>(fn: (a: A, b: B, c: C, d: D,
-                               t: T, u: U, v: V, w: W, x: X, y: Y) => TReturn,
+        T, U, V, W, X, Y>(funсtion: (a: A, b: B, c: C, d: D,
+                                     t: T, u: U, v: V, w: W, x: X, y: Y) => TReturn,
                           context: null | undefined,
                           a: A, b: B, c: C, d: D): (t: T, u: U, v: V, w: W, x: X, y: Y) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
@@ -3493,13 +3494,13 @@ $.post( "test.php" );
      */
     proxy<TReturn,
         A, B, C,
-        T, U, V, W, X, Y>(fn: (a: A, b: B, c: C,
-                               t: T, u: U, v: V, w: W, x: X, y: Y) => TReturn,
+        T, U, V, W, X, Y>(funсtion: (a: A, b: B, c: C,
+                                     t: T, u: U, v: V, w: W, x: X, y: Y) => TReturn,
                           context: null | undefined,
                           a: A, b: B, c: C): (t: T, u: U, v: V, w: W, x: X, y: Y) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
@@ -3507,13 +3508,13 @@ $.post( "test.php" );
      */
     proxy<TReturn,
         A, B,
-        T, U, V, W, X, Y>(fn: (a: A, b: B,
-                               t: T, u: U, v: V, w: W, x: X, y: Y) => TReturn,
+        T, U, V, W, X, Y>(funсtion: (a: A, b: B,
+                                     t: T, u: U, v: V, w: W, x: X, y: Y) => TReturn,
                           context: null | undefined,
                           a: A, b: B): (t: T, u: U, v: V, w: W, x: X, y: Y) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
@@ -3521,20 +3522,20 @@ $.post( "test.php" );
      */
     proxy<TReturn,
         A,
-        T, U, V, W, X, Y>(fn: (a: A,
-                               t: T, u: U, v: V, w: W, x: X, y: Y) => TReturn,
+        T, U, V, W, X, Y>(funсtion: (a: A,
+                                     t: T, u: U, v: V, w: W, x: X, y: Y) => TReturn,
                           context: null | undefined,
                           a: A): (t: T, u: U, v: V, w: W, x: X, y: Y) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
      */
     proxy<TReturn,
-        T, U, V, W, X, Y>(fn: (t: T, u: U, v: V, w: W, x: X, y: Y) => TReturn,
+        T, U, V, W, X, Y>(funсtion: (t: T, u: U, v: V, w: W, x: X, y: Y) => TReturn,
                           context: null | undefined): (t: T, u: U, v: V, w: W, x: X, y: Y) => TReturn;
 
     // #endregion
@@ -3544,7 +3545,7 @@ $.post( "test.php" );
 
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
@@ -3552,13 +3553,13 @@ $.post( "test.php" );
      */
     proxy<TReturn,
         A, B, C, D, E, F, G,
-        T, U, V, W, X, Y, Z>(fn: (a: A, b: B, c: C, d: D, e: E, f: F, g: G,
-                                  t: T, u: U, v: V, w: W, x: X, y: Y, z: Z, ...args: any[]) => TReturn,
+        T, U, V, W, X, Y, Z>(funсtion: (a: A, b: B, c: C, d: D, e: E, f: F, g: G,
+                                        t: T, u: U, v: V, w: W, x: X, y: Y, z: Z, ...args: any[]) => TReturn,
                              context: null | undefined,
                              a: A, b: B, c: C, d: D, e: E, f: F, g: G): (t: T, u: U, v: V, w: W, x: X, y: Y, z: Z, ...args: any[]) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
@@ -3566,13 +3567,13 @@ $.post( "test.php" );
      */
     proxy<TReturn,
         A, B, C, D, E, F,
-        T, U, V, W, X, Y, Z>(fn: (a: A, b: B, c: C, d: D, e: E, f: F,
-                                  t: T, u: U, v: V, w: W, x: X, y: Y, z: Z, ...args: any[]) => TReturn,
+        T, U, V, W, X, Y, Z>(funсtion: (a: A, b: B, c: C, d: D, e: E, f: F,
+                                        t: T, u: U, v: V, w: W, x: X, y: Y, z: Z, ...args: any[]) => TReturn,
                              context: null | undefined,
                              a: A, b: B, c: C, d: D, e: E, f: F): (t: T, u: U, v: V, w: W, x: X, y: Y, z: Z, ...args: any[]) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
@@ -3580,13 +3581,13 @@ $.post( "test.php" );
      */
     proxy<TReturn,
         A, B, C, D, E,
-        T, U, V, W, X, Y, Z>(fn: (a: A, b: B, c: C, d: D, e: E,
-                                  t: T, u: U, v: V, w: W, x: X, y: Y, z: Z, ...args: any[]) => TReturn,
+        T, U, V, W, X, Y, Z>(funсtion: (a: A, b: B, c: C, d: D, e: E,
+                                        t: T, u: U, v: V, w: W, x: X, y: Y, z: Z, ...args: any[]) => TReturn,
                              context: null | undefined,
                              a: A, b: B, c: C, d: D, e: E): (t: T, u: U, v: V, w: W, x: X, y: Y, z: Z, ...args: any[]) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
@@ -3594,13 +3595,13 @@ $.post( "test.php" );
      */
     proxy<TReturn,
         A, B, C, D,
-        T, U, V, W, X, Y, Z>(fn: (a: A, b: B, c: C, d: D,
-                                  t: T, u: U, v: V, w: W, x: X, y: Y, z: Z, ...args: any[]) => TReturn,
+        T, U, V, W, X, Y, Z>(funсtion: (a: A, b: B, c: C, d: D,
+                                        t: T, u: U, v: V, w: W, x: X, y: Y, z: Z, ...args: any[]) => TReturn,
                              context: null | undefined,
                              a: A, b: B, c: C, d: D): (t: T, u: U, v: V, w: W, x: X, y: Y, z: Z, ...args: any[]) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
@@ -3608,13 +3609,13 @@ $.post( "test.php" );
      */
     proxy<TReturn,
         A, B, C,
-        T, U, V, W, X, Y, Z>(fn: (a: A, b: B, c: C,
-                                  t: T, u: U, v: V, w: W, x: X, y: Y, z: Z, ...args: any[]) => TReturn,
+        T, U, V, W, X, Y, Z>(funсtion: (a: A, b: B, c: C,
+                                        t: T, u: U, v: V, w: W, x: X, y: Y, z: Z, ...args: any[]) => TReturn,
                              context: null | undefined,
                              a: A, b: B, c: C): (t: T, u: U, v: V, w: W, x: X, y: Y, z: Z, ...args: any[]) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
@@ -3622,13 +3623,13 @@ $.post( "test.php" );
      */
     proxy<TReturn,
         A, B,
-        T, U, V, W, X, Y, Z>(fn: (a: A, b: B,
-                                  t: T, u: U, v: V, w: W, x: X, y: Y, z: Z, ...args: any[]) => TReturn,
+        T, U, V, W, X, Y, Z>(funсtion: (a: A, b: B,
+                                        t: T, u: U, v: V, w: W, x: X, y: Y, z: Z, ...args: any[]) => TReturn,
                              context: null | undefined,
                              a: A, b: B): (t: T, u: U, v: V, w: W, x: X, y: Y, z: Z, ...args: any[]) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
@@ -3636,20 +3637,20 @@ $.post( "test.php" );
      */
     proxy<TReturn,
         A,
-        T, U, V, W, X, Y, Z>(fn: (a: A,
-                                  t: T, u: U, v: V, w: W, x: X, y: Y, z: Z, ...args: any[]) => TReturn,
+        T, U, V, W, X, Y, Z>(funсtion: (a: A,
+                                        t: T, u: U, v: V, w: W, x: X, y: Y, z: Z, ...args: any[]) => TReturn,
                              context: null | undefined,
                              a: A): (t: T, u: U, v: V, w: W, x: X, y: Y, z: Z, ...args: any[]) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
      */
     proxy<TReturn,
-        T, U, V, W, X, Y, Z>(fn: (t: T, u: U, v: V, w: W, x: X, y: Y, z: Z, ...args: any[]) => TReturn,
+        T, U, V, W, X, Y, Z>(funсtion: (t: T, u: U, v: V, w: W, x: X, y: Y, z: Z, ...args: any[]) => TReturn,
                              context: null | undefined): (t: T, u: U, v: V, w: W, x: X, y: Y, z: Z, ...args: any[]) => TReturn;
 
     // #endregion
@@ -3661,14 +3662,14 @@ $.post( "test.php" );
 
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @param additionalArguments Any number of arguments to be passed to the function referenced in the function argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.9
      * @deprecated ​ Deprecated since 3.3. Use \`{@link Function#bind }\`.
      */
-    proxy<TReturn>(fn: (...args: any[]) => TReturn,
+    proxy<TReturn>(funсtion: (...args: any[]) => TReturn,
                    context: null | undefined,
                    ...additionalArguments: any[]): (...args: any[]) => TReturn;
 
@@ -3676,8 +3677,8 @@ $.post( "test.php" );
 
     // #endregion
 
-    // region (fn, context)
-    // #region (fn, context)
+    // region (funсtion, context)
+    // #region (funсtion, context)
 
     // region 0 to 7 additional arguments
     // #region 0 to 7 additional arguments
@@ -3687,7 +3688,7 @@ $.post( "test.php" );
 
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
@@ -3814,12 +3815,12 @@ $( "#test" )
      */
     proxy<TContext extends object,
         TReturn,
-        A, B, C, D, E, F, G>(fn: (a: A, b: B, c: C, d: D, e: E, f: F, g: G) => TReturn,
+        A, B, C, D, E, F, G>(funсtion: (a: A, b: B, c: C, d: D, e: E, f: F, g: G) => TReturn,
                              context: TContext,
                              a: A, b: B, c: C, d: D, e: E, f: F, g: G): (this: TContext) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
@@ -3946,12 +3947,12 @@ $( "#test" )
      */
     proxy<TContext extends object,
         TReturn,
-        A, B, C, D, E, F>(fn: (a: A, b: B, c: C, d: D, e: E, f: F) => TReturn,
+        A, B, C, D, E, F>(funсtion: (a: A, b: B, c: C, d: D, e: E, f: F) => TReturn,
                           context: TContext,
                           a: A, b: B, c: C, d: D, e: E, f: F): (this: TContext) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
@@ -4078,12 +4079,12 @@ $( "#test" )
      */
     proxy<TContext extends object,
         TReturn,
-        A, B, C, D, E>(fn: (a: A, b: B, c: C, d: D, e: E) => TReturn,
+        A, B, C, D, E>(funсtion: (a: A, b: B, c: C, d: D, e: E) => TReturn,
                        context: TContext,
                        a: A, b: B, c: C, d: D, e: E): (this: TContext) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
@@ -4210,12 +4211,12 @@ $( "#test" )
      */
     proxy<TContext extends object,
         TReturn,
-        A, B, C, D>(fn: (a: A, b: B, c: C, d: D) => TReturn,
+        A, B, C, D>(funсtion: (a: A, b: B, c: C, d: D) => TReturn,
                     context: TContext,
                     a: A, b: B, c: C, d: D): (this: TContext) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
@@ -4342,12 +4343,12 @@ $( "#test" )
      */
     proxy<TContext extends object,
         TReturn,
-        A, B, C>(fn: (a: A, b: B, c: C) => TReturn,
+        A, B, C>(funсtion: (a: A, b: B, c: C) => TReturn,
                  context: TContext,
                  a: A, b: B, c: C): (this: TContext) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
@@ -4474,12 +4475,12 @@ $( "#test" )
      */
     proxy<TContext extends object,
         TReturn,
-        A, B>(fn: (a: A, b: B) => TReturn,
+        A, B>(funсtion: (a: A, b: B) => TReturn,
               context: TContext,
               a: A, b: B): (this: TContext) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4`
@@ -4606,12 +4607,12 @@ $( "#test" )
      */
     proxy<TContext extends object,
         TReturn,
-        A>(fn: (a: A) => TReturn,
+        A>(funсtion: (a: A) => TReturn,
            context: TContext,
            a: A): (this: TContext) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
@@ -4737,7 +4738,7 @@ $( "#test" )
 ```
      */
     proxy<TContext extends object,
-        TReturn>(fn: () => TReturn,
+        TReturn>(funсtion: () => TReturn,
                  context: TContext): (this: TContext) => TReturn;
 
     // #endregion
@@ -4747,7 +4748,7 @@ $( "#test" )
 
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
@@ -4875,13 +4876,13 @@ $( "#test" )
     proxy<TContext extends object,
         TReturn,
         A, B, C, D, E, F, G,
-        T>(fn: (a: A, b: B, c: C, d: D, e: E, f: F, g: G,
-                t: T) => TReturn,
+        T>(funсtion: (a: A, b: B, c: C, d: D, e: E, f: F, g: G,
+                      t: T) => TReturn,
            context: TContext,
            a: A, b: B, c: C, d: D, e: E, f: F, g: G): (this: TContext, t: T) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
@@ -5009,13 +5010,13 @@ $( "#test" )
     proxy<TContext extends object,
         TReturn,
         A, B, C, D, E, F,
-        T>(fn: (a: A, b: B, c: C, d: D, e: E, f: F,
-                t: T) => TReturn,
+        T>(funсtion: (a: A, b: B, c: C, d: D, e: E, f: F,
+                      t: T) => TReturn,
            context: TContext,
            a: A, b: B, c: C, d: D, e: E, f: F): (this: TContext, t: T) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
@@ -5143,13 +5144,13 @@ $( "#test" )
     proxy<TContext extends object,
         TReturn,
         A, B, C, D, E,
-        T>(fn: (a: A, b: B, c: C, d: D, e: E,
-                t: T) => TReturn,
+        T>(funсtion: (a: A, b: B, c: C, d: D, e: E,
+                      t: T) => TReturn,
            context: TContext,
            a: A, b: B, c: C, d: D, e: E): (this: TContext, t: T) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
@@ -5277,13 +5278,13 @@ $( "#test" )
     proxy<TContext extends object,
         TReturn,
         A, B, C, D,
-        T>(fn: (a: A, b: B, c: C, d: D,
-                t: T) => TReturn,
+        T>(funсtion: (a: A, b: B, c: C, d: D,
+                      t: T) => TReturn,
            context: TContext,
            a: A, b: B, c: C, d: D): (this: TContext, t: T) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
@@ -5411,13 +5412,13 @@ $( "#test" )
     proxy<TContext extends object,
         TReturn,
         A, B, C,
-        T>(fn: (a: A, b: B, c: C,
-                t: T) => TReturn,
+        T>(funсtion: (a: A, b: B, c: C,
+                      t: T) => TReturn,
            context: TContext,
            a: A, b: B, c: C): (this: TContext, t: T) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
@@ -5545,13 +5546,13 @@ $( "#test" )
     proxy<TContext extends object,
         TReturn,
         A, B,
-        T>(fn: (a: A, b: B,
-                t: T) => TReturn,
+        T>(funсtion: (a: A, b: B,
+                      t: T) => TReturn,
            context: TContext,
            a: A, b: B): (this: TContext, t: T) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
@@ -5679,13 +5680,13 @@ $( "#test" )
     proxy<TContext extends object,
         TReturn,
         A,
-        T>(fn: (a: A,
-                t: T) => TReturn,
+        T>(funсtion: (a: A,
+                      t: T) => TReturn,
            context: TContext,
            a: A): (this: TContext, t: T) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
@@ -5812,7 +5813,7 @@ $( "#test" )
      */
     proxy<TContext extends object,
         TReturn,
-        T>(fn: (t: T) => TReturn,
+        T>(funсtion: (t: T) => TReturn,
            context: TContext): (this: TContext, t: T) => TReturn;
 
     // #endregion
@@ -5822,7 +5823,7 @@ $( "#test" )
 
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
@@ -5950,13 +5951,13 @@ $( "#test" )
     proxy<TContext extends object,
         TReturn,
         A, B, C, D, E, F, G,
-        T, U>(fn: (a: A, b: B, c: C, d: D, e: E, f: F, g: G,
-                   t: T, u: U) => TReturn,
+        T, U>(funсtion: (a: A, b: B, c: C, d: D, e: E, f: F, g: G,
+                         t: T, u: U) => TReturn,
               context: TContext,
               a: A, b: B, c: C, d: D, e: E, f: F, g: G): (this: TContext, t: T, u: U) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
@@ -6084,13 +6085,13 @@ $( "#test" )
     proxy<TContext extends object,
         TReturn,
         A, B, C, D, E, F,
-        T, U>(fn: (a: A, b: B, c: C, d: D, e: E, f: F,
-                   t: T, u: U) => TReturn,
+        T, U>(funсtion: (a: A, b: B, c: C, d: D, e: E, f: F,
+                         t: T, u: U) => TReturn,
               context: TContext,
               a: A, b: B, c: C, d: D, e: E, f: F): (this: TContext, t: T, u: U) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
@@ -6218,13 +6219,13 @@ $( "#test" )
     proxy<TContext extends object,
         TReturn,
         A, B, C, D, E,
-        T, U>(fn: (a: A, b: B, c: C, d: D, e: E,
-                   t: T, u: U) => TReturn,
+        T, U>(funсtion: (a: A, b: B, c: C, d: D, e: E,
+                         t: T, u: U) => TReturn,
               context: TContext,
               a: A, b: B, c: C, d: D, e: E): (this: TContext, t: T, u: U) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
@@ -6352,13 +6353,13 @@ $( "#test" )
     proxy<TContext extends object,
         TReturn,
         A, B, C, D,
-        T, U>(fn: (a: A, b: B, c: C, d: D,
-                   t: T, u: U) => TReturn,
+        T, U>(funсtion: (a: A, b: B, c: C, d: D,
+                         t: T, u: U) => TReturn,
               context: TContext,
               a: A, b: B, c: C, d: D): (this: TContext, t: T, u: U) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
@@ -6486,13 +6487,13 @@ $( "#test" )
     proxy<TContext extends object,
         TReturn,
         A, B, C,
-        T, U>(fn: (a: A, b: B, c: C,
-                   t: T, u: U) => TReturn,
+        T, U>(funсtion: (a: A, b: B, c: C,
+                         t: T, u: U) => TReturn,
               context: TContext,
               a: A, b: B, c: C): (this: TContext, t: T, u: U) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
@@ -6620,13 +6621,13 @@ $( "#test" )
     proxy<TContext extends object,
         TReturn,
         A, B,
-        T, U>(fn: (a: A, b: B,
-                   t: T, u: U) => TReturn,
+        T, U>(funсtion: (a: A, b: B,
+                         t: T, u: U) => TReturn,
               context: TContext,
               a: A, b: B): (this: TContext, t: T, u: U) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
@@ -6754,13 +6755,13 @@ $( "#test" )
     proxy<TContext extends object,
         TReturn,
         A,
-        T, U>(fn: (a: A,
-                   t: T, u: U) => TReturn,
+        T, U>(funсtion: (a: A,
+                         t: T, u: U) => TReturn,
               context: TContext,
               a: A): (this: TContext, t: T, u: U) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
@@ -6887,7 +6888,7 @@ $( "#test" )
      */
     proxy<TContext extends object,
         TReturn,
-        T, U>(fn: (t: T, u: U) => TReturn,
+        T, U>(funсtion: (t: T, u: U) => TReturn,
               context: TContext): (this: TContext, t: T, u: U) => TReturn;
 
     // #endregion
@@ -6897,7 +6898,7 @@ $( "#test" )
 
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
@@ -7025,13 +7026,13 @@ $( "#test" )
     proxy<TContext extends object,
         TReturn,
         A, B, C, D, E, F, G,
-        T, U, V>(fn: (a: A, b: B, c: C, d: D, e: E, f: F, g: G,
-                      t: T, u: U, v: V) => TReturn,
+        T, U, V>(funсtion: (a: A, b: B, c: C, d: D, e: E, f: F, g: G,
+                            t: T, u: U, v: V) => TReturn,
                  context: TContext,
                  a: A, b: B, c: C, d: D, e: E, f: F, g: G): (this: TContext, t: T, u: U, v: V) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
@@ -7159,13 +7160,13 @@ $( "#test" )
     proxy<TContext extends object,
         TReturn,
         A, B, C, D, E, F,
-        T, U, V>(fn: (a: A, b: B, c: C, d: D, e: E, f: F,
-                      t: T, u: U, v: V) => TReturn,
+        T, U, V>(funсtion: (a: A, b: B, c: C, d: D, e: E, f: F,
+                            t: T, u: U, v: V) => TReturn,
                  context: TContext,
                  a: A, b: B, c: C, d: D, e: E, f: F): (this: TContext, t: T, u: U, v: V) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
@@ -7293,13 +7294,13 @@ $( "#test" )
     proxy<TContext extends object,
         TReturn,
         A, B, C, D, E,
-        T, U, V>(fn: (a: A, b: B, c: C, d: D, e: E,
-                      t: T, u: U, v: V) => TReturn,
+        T, U, V>(funсtion: (a: A, b: B, c: C, d: D, e: E,
+                            t: T, u: U, v: V) => TReturn,
                  context: TContext,
                  a: A, b: B, c: C, d: D, e: E): (this: TContext, t: T, u: U, v: V) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
@@ -7427,13 +7428,13 @@ $( "#test" )
     proxy<TContext extends object,
         TReturn,
         A, B, C, D,
-        T, U, V>(fn: (a: A, b: B, c: C, d: D,
-                      t: T, u: U, v: V) => TReturn,
+        T, U, V>(funсtion: (a: A, b: B, c: C, d: D,
+                            t: T, u: U, v: V) => TReturn,
                  context: TContext,
                  a: A, b: B, c: C, d: D): (this: TContext, t: T, u: U, v: V) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
@@ -7561,13 +7562,13 @@ $( "#test" )
     proxy<TContext extends object,
         TReturn,
         A, B, C,
-        T, U, V>(fn: (a: A, b: B, c: C,
-                      t: T, u: U, v: V) => TReturn,
+        T, U, V>(funсtion: (a: A, b: B, c: C,
+                            t: T, u: U, v: V) => TReturn,
                  context: TContext,
                  a: A, b: B, c: C): (this: TContext, t: T, u: U, v: V) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
@@ -7695,13 +7696,13 @@ $( "#test" )
     proxy<TContext extends object,
         TReturn,
         A, B,
-        T, U, V>(fn: (a: A, b: B,
-                      t: T, u: U, v: V) => TReturn,
+        T, U, V>(funсtion: (a: A, b: B,
+                            t: T, u: U, v: V) => TReturn,
                  context: TContext,
                  a: A, b: B): (this: TContext, t: T, u: U, v: V) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
@@ -7829,13 +7830,13 @@ $( "#test" )
     proxy<TContext extends object,
         TReturn,
         A,
-        T, U, V>(fn: (a: A,
-                      t: T, u: U, v: V) => TReturn,
+        T, U, V>(funсtion: (a: A,
+                            t: T, u: U, v: V) => TReturn,
                  context: TContext,
                  a: A): (this: TContext, t: T, u: U, v: V) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
@@ -7962,7 +7963,7 @@ $( "#test" )
      */
     proxy<TContext extends object,
         TReturn,
-        T, U, V>(fn: (t: T, u: U, v: V) => TReturn,
+        T, U, V>(funсtion: (t: T, u: U, v: V) => TReturn,
                  context: TContext): (this: TContext, t: T, u: U, v: V) => TReturn;
 
     // #endregion
@@ -7972,7 +7973,7 @@ $( "#test" )
 
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
@@ -8100,13 +8101,13 @@ $( "#test" )
     proxy<TContext extends object,
         TReturn,
         A, B, C, D, E, F, G,
-        T, U, V, W>(fn: (a: A, b: B, c: C, d: D, e: E, f: F, g: G,
-                         t: T, u: U, v: V, w: W) => TReturn,
+        T, U, V, W>(funсtion: (a: A, b: B, c: C, d: D, e: E, f: F, g: G,
+                               t: T, u: U, v: V, w: W) => TReturn,
                     context: TContext,
                     a: A, b: B, c: C, d: D, e: E, f: F, g: G): (this: TContext, t: T, u: U, v: V, w: W) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
@@ -8234,13 +8235,13 @@ $( "#test" )
     proxy<TContext extends object,
         TReturn,
         A, B, C, D, E, F,
-        T, U, V, W>(fn: (a: A, b: B, c: C, d: D, e: E, f: F,
-                         t: T, u: U, v: V, w: W) => TReturn,
+        T, U, V, W>(funсtion: (a: A, b: B, c: C, d: D, e: E, f: F,
+                               t: T, u: U, v: V, w: W) => TReturn,
                     context: TContext,
                     a: A, b: B, c: C, d: D, e: E, f: F): (this: TContext, t: T, u: U, v: V, w: W) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
@@ -8368,13 +8369,13 @@ $( "#test" )
     proxy<TContext extends object,
         TReturn,
         A, B, C, D, E,
-        T, U, V, W>(fn: (a: A, b: B, c: C, d: D, e: E,
-                         t: T, u: U, v: V, w: W) => TReturn,
+        T, U, V, W>(funсtion: (a: A, b: B, c: C, d: D, e: E,
+                               t: T, u: U, v: V, w: W) => TReturn,
                     context: TContext,
                     a: A, b: B, c: C, d: D, e: E): (this: TContext, t: T, u: U, v: V, w: W) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
@@ -8502,13 +8503,13 @@ $( "#test" )
     proxy<TContext extends object,
         TReturn,
         A, B, C, D,
-        T, U, V, W>(fn: (a: A, b: B, c: C, d: D,
-                         t: T, u: U, v: V, w: W) => TReturn,
+        T, U, V, W>(funсtion: (a: A, b: B, c: C, d: D,
+                               t: T, u: U, v: V, w: W) => TReturn,
                     context: TContext,
                     a: A, b: B, c: C, d: D): (this: TContext, t: T, u: U, v: V, w: W) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
@@ -8636,13 +8637,13 @@ $( "#test" )
     proxy<TContext extends object,
         TReturn,
         A, B, C,
-        T, U, V, W>(fn: (a: A, b: B, c: C,
-                         t: T, u: U, v: V, w: W) => TReturn,
+        T, U, V, W>(funсtion: (a: A, b: B, c: C,
+                               t: T, u: U, v: V, w: W) => TReturn,
                     context: TContext,
                     a: A, b: B, c: C): (this: TContext, t: T, u: U, v: V, w: W) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
@@ -8770,13 +8771,13 @@ $( "#test" )
     proxy<TContext extends object,
         TReturn,
         A, B,
-        T, U, V, W>(fn: (a: A, b: B,
-                         t: T, u: U, v: V, w: W) => TReturn,
+        T, U, V, W>(funсtion: (a: A, b: B,
+                               t: T, u: U, v: V, w: W) => TReturn,
                     context: TContext,
                     a: A, b: B): (this: TContext, t: T, u: U, v: V, w: W) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
@@ -8904,13 +8905,13 @@ $( "#test" )
     proxy<TContext extends object,
         TReturn,
         A,
-        T, U, V, W>(fn: (a: A,
-                         t: T, u: U, v: V, w: W) => TReturn,
+        T, U, V, W>(funсtion: (a: A,
+                               t: T, u: U, v: V, w: W) => TReturn,
                     context: TContext,
                     a: A): (this: TContext, t: T, u: U, v: V, w: W) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
@@ -9037,7 +9038,7 @@ $( "#test" )
      */
     proxy<TContext extends object,
         TReturn,
-        T, U, V, W>(fn: (t: T, u: U, v: V, w: W) => TReturn,
+        T, U, V, W>(funсtion: (t: T, u: U, v: V, w: W) => TReturn,
                     context: TContext): (this: TContext, t: T, u: U, v: V, w: W) => TReturn;
 
     // #endregion
@@ -9047,7 +9048,7 @@ $( "#test" )
 
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
@@ -9175,13 +9176,13 @@ $( "#test" )
     proxy<TContext extends object,
         TReturn,
         A, B, C, D, E, F, G,
-        T, U, V, W, X>(fn: (a: A, b: B, c: C, d: D, e: E, f: F, g: G,
-                            t: T, u: U, v: V, w: W, x: X) => TReturn,
+        T, U, V, W, X>(funсtion: (a: A, b: B, c: C, d: D, e: E, f: F, g: G,
+                                  t: T, u: U, v: V, w: W, x: X) => TReturn,
                        context: TContext,
                        a: A, b: B, c: C, d: D, e: E, f: F, g: G): (this: TContext, t: T, u: U, v: V, w: W, x: X) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
@@ -9309,13 +9310,13 @@ $( "#test" )
     proxy<TContext extends object,
         TReturn,
         A, B, C, D, E, F,
-        T, U, V, W, X>(fn: (a: A, b: B, c: C, d: D, e: E, f: F,
-                            t: T, u: U, v: V, w: W, x: X) => TReturn,
+        T, U, V, W, X>(funсtion: (a: A, b: B, c: C, d: D, e: E, f: F,
+                                  t: T, u: U, v: V, w: W, x: X) => TReturn,
                        context: TContext,
                        a: A, b: B, c: C, d: D, e: E, f: F): (this: TContext, t: T, u: U, v: V, w: W, x: X) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
@@ -9443,13 +9444,13 @@ $( "#test" )
     proxy<TContext extends object,
         TReturn,
         A, B, C, D, E,
-        T, U, V, W, X>(fn: (a: A, b: B, c: C, d: D, e: E,
-                            t: T, u: U, v: V, w: W, x: X) => TReturn,
+        T, U, V, W, X>(funсtion: (a: A, b: B, c: C, d: D, e: E,
+                                  t: T, u: U, v: V, w: W, x: X) => TReturn,
                        context: TContext,
                        a: A, b: B, c: C, d: D, e: E): (this: TContext, t: T, u: U, v: V, w: W, x: X) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
@@ -9577,13 +9578,13 @@ $( "#test" )
     proxy<TContext extends object,
         TReturn,
         A, B, C, D,
-        T, U, V, W, X>(fn: (a: A, b: B, c: C, d: D,
-                            t: T, u: U, v: V, w: W, x: X) => TReturn,
+        T, U, V, W, X>(funсtion: (a: A, b: B, c: C, d: D,
+                                  t: T, u: U, v: V, w: W, x: X) => TReturn,
                        context: TContext,
                        a: A, b: B, c: C, d: D): (this: TContext, t: T, u: U, v: V, w: W, x: X) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
@@ -9711,13 +9712,13 @@ $( "#test" )
     proxy<TContext extends object,
         TReturn,
         A, B, C,
-        T, U, V, W, X>(fn: (a: A, b: B, c: C,
-                            t: T, u: U, v: V, w: W, x: X) => TReturn,
+        T, U, V, W, X>(funсtion: (a: A, b: B, c: C,
+                                  t: T, u: U, v: V, w: W, x: X) => TReturn,
                        context: TContext,
                        a: A, b: B, c: C): (this: TContext, t: T, u: U, v: V, w: W, x: X) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
@@ -9845,13 +9846,13 @@ $( "#test" )
     proxy<TContext extends object,
         TReturn,
         A, B,
-        T, U, V, W, X>(fn: (a: A, b: B,
-                            t: T, u: U, v: V, w: W, x: X) => TReturn,
+        T, U, V, W, X>(funсtion: (a: A, b: B,
+                                  t: T, u: U, v: V, w: W, x: X) => TReturn,
                        context: TContext,
                        a: A, b: B): (this: TContext, t: T, u: U, v: V, w: W, x: X) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
@@ -9979,13 +9980,13 @@ $( "#test" )
     proxy<TContext extends object,
         TReturn,
         A,
-        T, U, V, W, X>(fn: (a: A,
-                            t: T, u: U, v: V, w: W, x: X) => TReturn,
+        T, U, V, W, X>(funсtion: (a: A,
+                                  t: T, u: U, v: V, w: W, x: X) => TReturn,
                        context: TContext,
                        a: A): (this: TContext, t: T, u: U, v: V, w: W, x: X) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
@@ -10112,7 +10113,7 @@ $( "#test" )
      */
     proxy<TContext extends object,
         TReturn,
-        T, U, V, W, X>(fn: (t: T, u: U, v: V, w: W, x: X) => TReturn,
+        T, U, V, W, X>(funсtion: (t: T, u: U, v: V, w: W, x: X) => TReturn,
                        context: TContext): (this: TContext, t: T, u: U, v: V, w: W, x: X) => TReturn;
 
     // #endregion
@@ -10122,7 +10123,7 @@ $( "#test" )
 
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
@@ -10250,13 +10251,13 @@ $( "#test" )
     proxy<TContext extends object,
         TReturn,
         A, B, C, D, E, F, G,
-        T, U, V, W, X, Y>(fn: (a: A, b: B, c: C, d: D, e: E, f: F, g: G,
-                               t: T, u: U, v: V, w: W, x: X, y: Y) => TReturn,
+        T, U, V, W, X, Y>(funсtion: (a: A, b: B, c: C, d: D, e: E, f: F, g: G,
+                                     t: T, u: U, v: V, w: W, x: X, y: Y) => TReturn,
                           context: TContext,
                           a: A, b: B, c: C, d: D, e: E, f: F, g: G): (this: TContext, t: T, u: U, v: V, w: W, x: X, y: Y) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
@@ -10384,13 +10385,13 @@ $( "#test" )
     proxy<TContext extends object,
         TReturn,
         A, B, C, D, E, F,
-        T, U, V, W, X, Y>(fn: (a: A, b: B, c: C, d: D, e: E, f: F,
-                               t: T, u: U, v: V, w: W, x: X, y: Y) => TReturn,
+        T, U, V, W, X, Y>(funсtion: (a: A, b: B, c: C, d: D, e: E, f: F,
+                                     t: T, u: U, v: V, w: W, x: X, y: Y) => TReturn,
                           context: TContext,
                           a: A, b: B, c: C, d: D, e: E, f: F): (this: TContext, t: T, u: U, v: V, w: W, x: X, y: Y) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
@@ -10518,13 +10519,13 @@ $( "#test" )
     proxy<TContext extends object,
         TReturn,
         A, B, C, D, E,
-        T, U, V, W, X, Y>(fn: (a: A, b: B, c: C, d: D, e: E,
-                               t: T, u: U, v: V, w: W, x: X, y: Y) => TReturn,
+        T, U, V, W, X, Y>(funсtion: (a: A, b: B, c: C, d: D, e: E,
+                                     t: T, u: U, v: V, w: W, x: X, y: Y) => TReturn,
                           context: TContext,
                           a: A, b: B, c: C, d: D, e: E): (this: TContext, t: T, u: U, v: V, w: W, x: X, y: Y) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
@@ -10652,13 +10653,13 @@ $( "#test" )
     proxy<TContext extends object,
         TReturn,
         A, B, C, D,
-        T, U, V, W, X, Y>(fn: (a: A, b: B, c: C, d: D,
-                               t: T, u: U, v: V, w: W, x: X, y: Y) => TReturn,
+        T, U, V, W, X, Y>(funсtion: (a: A, b: B, c: C, d: D,
+                                     t: T, u: U, v: V, w: W, x: X, y: Y) => TReturn,
                           context: TContext,
                           a: A, b: B, c: C, d: D): (this: TContext, t: T, u: U, v: V, w: W, x: X, y: Y) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
@@ -10786,13 +10787,13 @@ $( "#test" )
     proxy<TContext extends object,
         TReturn,
         A, B, C,
-        T, U, V, W, X, Y>(fn: (a: A, b: B, c: C,
-                               t: T, u: U, v: V, w: W, x: X, y: Y) => TReturn,
+        T, U, V, W, X, Y>(funсtion: (a: A, b: B, c: C,
+                                     t: T, u: U, v: V, w: W, x: X, y: Y) => TReturn,
                           context: TContext,
                           a: A, b: B, c: C): (this: TContext, t: T, u: U, v: V, w: W, x: X, y: Y) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
@@ -10920,13 +10921,13 @@ $( "#test" )
     proxy<TContext extends object,
         TReturn,
         A, B,
-        T, U, V, W, X, Y>(fn: (a: A, b: B,
-                               t: T, u: U, v: V, w: W, x: X, y: Y) => TReturn,
+        T, U, V, W, X, Y>(funсtion: (a: A, b: B,
+                                     t: T, u: U, v: V, w: W, x: X, y: Y) => TReturn,
                           context: TContext,
                           a: A, b: B): (this: TContext, t: T, u: U, v: V, w: W, x: X, y: Y) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
@@ -11054,13 +11055,13 @@ $( "#test" )
     proxy<TContext extends object,
         TReturn,
         A,
-        T, U, V, W, X, Y>(fn: (a: A,
-                               t: T, u: U, v: V, w: W, x: X, y: Y) => TReturn,
+        T, U, V, W, X, Y>(funсtion: (a: A,
+                                     t: T, u: U, v: V, w: W, x: X, y: Y) => TReturn,
                           context: TContext,
                           a: A): (this: TContext, t: T, u: U, v: V, w: W, x: X, y: Y) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
@@ -11187,7 +11188,7 @@ $( "#test" )
      */
     proxy<TContext extends object,
         TReturn,
-        T, U, V, W, X, Y>(fn: (t: T, u: U, v: V, w: W, x: X, y: Y) => TReturn,
+        T, U, V, W, X, Y>(funсtion: (t: T, u: U, v: V, w: W, x: X, y: Y) => TReturn,
                           context: TContext): (this: TContext, t: T, u: U, v: V, w: W, x: X, y: Y) => TReturn;
 
     // #endregion
@@ -11197,7 +11198,7 @@ $( "#test" )
 
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
@@ -11325,13 +11326,13 @@ $( "#test" )
     proxy<TContext extends object,
         TReturn,
         A, B, C, D, E, F, G,
-        T, U, V, W, X, Y, Z>(fn: (a: A, b: B, c: C, d: D, e: E, f: F, g: G,
-                                  t: T, u: U, v: V, w: W, x: X, y: Y, z: Z, ...args: any[]) => TReturn,
+        T, U, V, W, X, Y, Z>(funсtion: (a: A, b: B, c: C, d: D, e: E, f: F, g: G,
+                                        t: T, u: U, v: V, w: W, x: X, y: Y, z: Z, ...args: any[]) => TReturn,
                              context: TContext,
                              a: A, b: B, c: C, d: D, e: E, f: F, g: G): (this: TContext, t: T, u: U, v: V, w: W, x: X, y: Y, z: Z, ...args: any[]) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
@@ -11459,13 +11460,13 @@ $( "#test" )
     proxy<TContext extends object,
         TReturn,
         A, B, C, D, E, F,
-        T, U, V, W, X, Y, Z>(fn: (a: A, b: B, c: C, d: D, e: E, f: F,
-                                  t: T, u: U, v: V, w: W, x: X, y: Y, z: Z, ...args: any[]) => TReturn,
+        T, U, V, W, X, Y, Z>(funсtion: (a: A, b: B, c: C, d: D, e: E, f: F,
+                                        t: T, u: U, v: V, w: W, x: X, y: Y, z: Z, ...args: any[]) => TReturn,
                              context: TContext,
                              a: A, b: B, c: C, d: D, e: E, f: F): (this: TContext, t: T, u: U, v: V, w: W, x: X, y: Y, z: Z, ...args: any[]) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
@@ -11593,13 +11594,13 @@ $( "#test" )
     proxy<TContext extends object,
         TReturn,
         A, B, C, D, E,
-        T, U, V, W, X, Y, Z>(fn: (a: A, b: B, c: C, d: D, e: E,
-                                  t: T, u: U, v: V, w: W, x: X, y: Y, z: Z, ...args: any[]) => TReturn,
+        T, U, V, W, X, Y, Z>(funсtion: (a: A, b: B, c: C, d: D, e: E,
+                                        t: T, u: U, v: V, w: W, x: X, y: Y, z: Z, ...args: any[]) => TReturn,
                              context: TContext,
                              a: A, b: B, c: C, d: D, e: E): (this: TContext, t: T, u: U, v: V, w: W, x: X, y: Y, z: Z, ...args: any[]) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
@@ -11727,13 +11728,13 @@ $( "#test" )
     proxy<TContext extends object,
         TReturn,
         A, B, C, D,
-        T, U, V, W, X, Y, Z>(fn: (a: A, b: B, c: C, d: D,
-                                  t: T, u: U, v: V, w: W, x: X, y: Y, z: Z, ...args: any[]) => TReturn,
+        T, U, V, W, X, Y, Z>(funсtion: (a: A, b: B, c: C, d: D,
+                                        t: T, u: U, v: V, w: W, x: X, y: Y, z: Z, ...args: any[]) => TReturn,
                              context: TContext,
                              a: A, b: B, c: C, d: D): (this: TContext, t: T, u: U, v: V, w: W, x: X, y: Y, z: Z, ...args: any[]) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
@@ -11861,13 +11862,13 @@ $( "#test" )
     proxy<TContext extends object,
         TReturn,
         A, B, C,
-        T, U, V, W, X, Y, Z>(fn: (a: A, b: B, c: C,
-                                  t: T, u: U, v: V, w: W, x: X, y: Y, z: Z, ...args: any[]) => TReturn,
+        T, U, V, W, X, Y, Z>(funсtion: (a: A, b: B, c: C,
+                                        t: T, u: U, v: V, w: W, x: X, y: Y, z: Z, ...args: any[]) => TReturn,
                              context: TContext,
                              a: A, b: B, c: C): (this: TContext, t: T, u: U, v: V, w: W, x: X, y: Y, z: Z, ...args: any[]) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
@@ -11995,13 +11996,13 @@ $( "#test" )
     proxy<TContext extends object,
         TReturn,
         A, B,
-        T, U, V, W, X, Y, Z>(fn: (a: A, b: B,
-                                  t: T, u: U, v: V, w: W, x: X, y: Y, z: Z, ...args: any[]) => TReturn,
+        T, U, V, W, X, Y, Z>(funсtion: (a: A, b: B,
+                                        t: T, u: U, v: V, w: W, x: X, y: Y, z: Z, ...args: any[]) => TReturn,
                              context: TContext,
                              a: A, b: B): (this: TContext, t: T, u: U, v: V, w: W, x: X, y: Y, z: Z, ...args: any[]) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
@@ -12129,13 +12130,13 @@ $( "#test" )
     proxy<TContext extends object,
         TReturn,
         A,
-        T, U, V, W, X, Y, Z>(fn: (a: A,
-                                  t: T, u: U, v: V, w: W, x: X, y: Y, z: Z, ...args: any[]) => TReturn,
+        T, U, V, W, X, Y, Z>(funсtion: (a: A,
+                                        t: T, u: U, v: V, w: W, x: X, y: Y, z: Z, ...args: any[]) => TReturn,
                              context: TContext,
                              a: A): (this: TContext, t: T, u: U, v: V, w: W, x: X, y: Y, z: Z, ...args: any[]) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
      * @since 1.4
@@ -12262,7 +12263,7 @@ $( "#test" )
      */
     proxy<TContext extends object,
         TReturn,
-        T, U, V, W, X, Y, Z>(fn: (t: T, u: U, v: V, w: W, x: X, y: Y, z: Z, ...args: any[]) => TReturn,
+        T, U, V, W, X, Y, Z>(funсtion: (t: T, u: U, v: V, w: W, x: X, y: Y, z: Z, ...args: any[]) => TReturn,
                              context: TContext): (this: TContext, t: T, u: U, v: V, w: W, x: X, y: Y, z: Z, ...args: any[]) => TReturn;
 
     // #endregion
@@ -12274,7 +12275,7 @@ $( "#test" )
 
     /**
      * Takes a function and returns a new one that will always have a particular context.
-     * @param fn The function whose context will be changed.
+     * @param funсtion The function whose context will be changed.
      * @param context The object to which the context (`this`) of the function should be set.
      * @param additionalArguments Any number of arguments to be passed to the function referenced in the function argument.
      * @see \`{@link https://api.jquery.com/jQuery.proxy/ }\`
@@ -12401,7 +12402,7 @@ $( "#test" )
 ```
      */
     proxy<TContext extends object,
-        TReturn>(fn: (...args: any[]) => TReturn,
+        TReturn>(funсtion: (...args: any[]) => TReturn,
                  context: TContext,
                  ...additionalArguments: any[]): (this: TContext, ...args: any[]) => TReturn;
 

--- a/types/jquery/JQueryStatic.d.ts
+++ b/types/jquery/JQueryStatic.d.ts
@@ -4046,9 +4046,9 @@ $( "#test" )
      */
     proxy<TContext extends object,
         TReturn,
-        A, B, C, D, E, F, G>(funсtion: (a: A, b: B, c: C, d: D, e: E, f: F, g: G) => TReturn,
+        A, B, C, D, E, F, G>(funсtion: (this: TContext, a: A, b: B, c: C, d: D, e: E, f: F, g: G) => TReturn,
                              context: TContext,
-                             a: A, b: B, c: C, d: D, e: E, f: F, g: G): (this: TContext) => TReturn;
+                             a: A, b: B, c: C, d: D, e: E, f: F, g: G): () => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
@@ -4184,9 +4184,9 @@ $( "#test" )
      */
     proxy<TContext extends object,
         TReturn,
-        A, B, C, D, E, F>(funсtion: (a: A, b: B, c: C, d: D, e: E, f: F) => TReturn,
+        A, B, C, D, E, F>(funсtion: (this: TContext, a: A, b: B, c: C, d: D, e: E, f: F) => TReturn,
                           context: TContext,
-                          a: A, b: B, c: C, d: D, e: E, f: F): (this: TContext) => TReturn;
+                          a: A, b: B, c: C, d: D, e: E, f: F): () => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
@@ -4321,9 +4321,9 @@ $( "#test" )
      */
     proxy<TContext extends object,
         TReturn,
-        A, B, C, D, E>(funсtion: (a: A, b: B, c: C, d: D, e: E) => TReturn,
+        A, B, C, D, E>(funсtion: (this: TContext, a: A, b: B, c: C, d: D, e: E) => TReturn,
                        context: TContext,
-                       a: A, b: B, c: C, d: D, e: E): (this: TContext) => TReturn;
+                       a: A, b: B, c: C, d: D, e: E): () => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
@@ -4457,9 +4457,9 @@ $( "#test" )
      */
     proxy<TContext extends object,
         TReturn,
-        A, B, C, D>(funсtion: (a: A, b: B, c: C, d: D) => TReturn,
+        A, B, C, D>(funсtion: (this: TContext, a: A, b: B, c: C, d: D) => TReturn,
                     context: TContext,
-                    a: A, b: B, c: C, d: D): (this: TContext) => TReturn;
+                    a: A, b: B, c: C, d: D): () => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
@@ -4592,9 +4592,9 @@ $( "#test" )
      */
     proxy<TContext extends object,
         TReturn,
-        A, B, C>(funсtion: (a: A, b: B, c: C) => TReturn,
+        A, B, C>(funсtion: (this: TContext, a: A, b: B, c: C) => TReturn,
                  context: TContext,
-                 a: A, b: B, c: C): (this: TContext) => TReturn;
+                 a: A, b: B, c: C): () => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
@@ -4726,9 +4726,9 @@ $( "#test" )
      */
     proxy<TContext extends object,
         TReturn,
-        A, B>(funсtion: (a: A, b: B) => TReturn,
+        A, B>(funсtion: (this: TContext, a: A, b: B) => TReturn,
               context: TContext,
-              a: A, b: B): (this: TContext) => TReturn;
+              a: A, b: B): () => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
@@ -4859,9 +4859,9 @@ $( "#test" )
      */
     proxy<TContext extends object,
         TReturn,
-        A>(funсtion: (a: A) => TReturn,
+        A>(funсtion: (this: TContext, a: A) => TReturn,
            context: TContext,
-           a: A): (this: TContext) => TReturn;
+           a: A): () => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
@@ -4990,8 +4990,8 @@ $( "#test" )
 ```
      */
     proxy<TContext extends object,
-        TReturn>(funсtion: () => TReturn,
-                 context: TContext): (this: TContext) => TReturn;
+        TReturn>(funсtion: (this: TContext) => TReturn,
+                 context: TContext): () => TReturn;
 
     // #endregion
 
@@ -5135,10 +5135,10 @@ $( "#test" )
     proxy<TContext extends object,
         TReturn,
         A, B, C, D, E, F, G,
-        T>(funсtion: (a: A, b: B, c: C, d: D, e: E, f: F, g: G,
+        T>(funсtion: (this: TContext, a: A, b: B, c: C, d: D, e: E, f: F, g: G,
                       t: T) => TReturn,
            context: TContext,
-           a: A, b: B, c: C, d: D, e: E, f: F, g: G): (this: TContext, t: T) => TReturn;
+           a: A, b: B, c: C, d: D, e: E, f: F, g: G): (t: T) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
@@ -5275,10 +5275,10 @@ $( "#test" )
     proxy<TContext extends object,
         TReturn,
         A, B, C, D, E, F,
-        T>(funсtion: (a: A, b: B, c: C, d: D, e: E, f: F,
+        T>(funсtion: (this: TContext, a: A, b: B, c: C, d: D, e: E, f: F,
                       t: T) => TReturn,
            context: TContext,
-           a: A, b: B, c: C, d: D, e: E, f: F): (this: TContext, t: T) => TReturn;
+           a: A, b: B, c: C, d: D, e: E, f: F): (t: T) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
@@ -5414,10 +5414,10 @@ $( "#test" )
     proxy<TContext extends object,
         TReturn,
         A, B, C, D, E,
-        T>(funсtion: (a: A, b: B, c: C, d: D, e: E,
+        T>(funсtion: (this: TContext, a: A, b: B, c: C, d: D, e: E,
                       t: T) => TReturn,
            context: TContext,
-           a: A, b: B, c: C, d: D, e: E): (this: TContext, t: T) => TReturn;
+           a: A, b: B, c: C, d: D, e: E): (t: T) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
@@ -5552,10 +5552,10 @@ $( "#test" )
     proxy<TContext extends object,
         TReturn,
         A, B, C, D,
-        T>(funсtion: (a: A, b: B, c: C, d: D,
+        T>(funсtion: (this: TContext, a: A, b: B, c: C, d: D,
                       t: T) => TReturn,
            context: TContext,
-           a: A, b: B, c: C, d: D): (this: TContext, t: T) => TReturn;
+           a: A, b: B, c: C, d: D): (t: T) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
@@ -5689,10 +5689,10 @@ $( "#test" )
     proxy<TContext extends object,
         TReturn,
         A, B, C,
-        T>(funсtion: (a: A, b: B, c: C,
+        T>(funсtion: (this: TContext, a: A, b: B, c: C,
                       t: T) => TReturn,
            context: TContext,
-           a: A, b: B, c: C): (this: TContext, t: T) => TReturn;
+           a: A, b: B, c: C): (t: T) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
@@ -5825,10 +5825,10 @@ $( "#test" )
     proxy<TContext extends object,
         TReturn,
         A, B,
-        T>(funсtion: (a: A, b: B,
+        T>(funсtion: (this: TContext, a: A, b: B,
                       t: T) => TReturn,
            context: TContext,
-           a: A, b: B): (this: TContext, t: T) => TReturn;
+           a: A, b: B): (t: T) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
@@ -5960,10 +5960,10 @@ $( "#test" )
     proxy<TContext extends object,
         TReturn,
         A,
-        T>(funсtion: (a: A,
+        T>(funсtion: (this: TContext, a: A,
                       t: T) => TReturn,
            context: TContext,
-           a: A): (this: TContext, t: T) => TReturn;
+           a: A): (t: T) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
@@ -6093,8 +6093,8 @@ $( "#test" )
      */
     proxy<TContext extends object,
         TReturn,
-        T>(funсtion: (t: T) => TReturn,
-           context: TContext): (this: TContext, t: T) => TReturn;
+        T>(funсtion: (this: TContext, t: T) => TReturn,
+           context: TContext): (t: T) => TReturn;
 
     // #endregion
 
@@ -6238,10 +6238,10 @@ $( "#test" )
     proxy<TContext extends object,
         TReturn,
         A, B, C, D, E, F, G,
-        T, U>(funсtion: (a: A, b: B, c: C, d: D, e: E, f: F, g: G,
+        T, U>(funсtion: (this: TContext, a: A, b: B, c: C, d: D, e: E, f: F, g: G,
                          t: T, u: U) => TReturn,
               context: TContext,
-              a: A, b: B, c: C, d: D, e: E, f: F, g: G): (this: TContext, t: T, u: U) => TReturn;
+              a: A, b: B, c: C, d: D, e: E, f: F, g: G): (t: T, u: U) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
@@ -6378,10 +6378,10 @@ $( "#test" )
     proxy<TContext extends object,
         TReturn,
         A, B, C, D, E, F,
-        T, U>(funсtion: (a: A, b: B, c: C, d: D, e: E, f: F,
+        T, U>(funсtion: (this: TContext, a: A, b: B, c: C, d: D, e: E, f: F,
                          t: T, u: U) => TReturn,
               context: TContext,
-              a: A, b: B, c: C, d: D, e: E, f: F): (this: TContext, t: T, u: U) => TReturn;
+              a: A, b: B, c: C, d: D, e: E, f: F): (t: T, u: U) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
@@ -6517,10 +6517,10 @@ $( "#test" )
     proxy<TContext extends object,
         TReturn,
         A, B, C, D, E,
-        T, U>(funсtion: (a: A, b: B, c: C, d: D, e: E,
+        T, U>(funсtion: (this: TContext, a: A, b: B, c: C, d: D, e: E,
                          t: T, u: U) => TReturn,
               context: TContext,
-              a: A, b: B, c: C, d: D, e: E): (this: TContext, t: T, u: U) => TReturn;
+              a: A, b: B, c: C, d: D, e: E): (t: T, u: U) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
@@ -6655,10 +6655,10 @@ $( "#test" )
     proxy<TContext extends object,
         TReturn,
         A, B, C, D,
-        T, U>(funсtion: (a: A, b: B, c: C, d: D,
+        T, U>(funсtion: (this: TContext, a: A, b: B, c: C, d: D,
                          t: T, u: U) => TReturn,
               context: TContext,
-              a: A, b: B, c: C, d: D): (this: TContext, t: T, u: U) => TReturn;
+              a: A, b: B, c: C, d: D): (t: T, u: U) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
@@ -6792,10 +6792,10 @@ $( "#test" )
     proxy<TContext extends object,
         TReturn,
         A, B, C,
-        T, U>(funсtion: (a: A, b: B, c: C,
+        T, U>(funсtion: (this: TContext, a: A, b: B, c: C,
                          t: T, u: U) => TReturn,
               context: TContext,
-              a: A, b: B, c: C): (this: TContext, t: T, u: U) => TReturn;
+              a: A, b: B, c: C): (t: T, u: U) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
@@ -6928,10 +6928,10 @@ $( "#test" )
     proxy<TContext extends object,
         TReturn,
         A, B,
-        T, U>(funсtion: (a: A, b: B,
+        T, U>(funсtion: (this: TContext, a: A, b: B,
                          t: T, u: U) => TReturn,
               context: TContext,
-              a: A, b: B): (this: TContext, t: T, u: U) => TReturn;
+              a: A, b: B): (t: T, u: U) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
@@ -7063,10 +7063,10 @@ $( "#test" )
     proxy<TContext extends object,
         TReturn,
         A,
-        T, U>(funсtion: (a: A,
+        T, U>(funсtion: (this: TContext, a: A,
                          t: T, u: U) => TReturn,
               context: TContext,
-              a: A): (this: TContext, t: T, u: U) => TReturn;
+              a: A): (t: T, u: U) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
@@ -7196,8 +7196,8 @@ $( "#test" )
      */
     proxy<TContext extends object,
         TReturn,
-        T, U>(funсtion: (t: T, u: U) => TReturn,
-              context: TContext): (this: TContext, t: T, u: U) => TReturn;
+        T, U>(funсtion: (this: TContext, t: T, u: U) => TReturn,
+              context: TContext): (t: T, u: U) => TReturn;
 
     // #endregion
 
@@ -7341,10 +7341,10 @@ $( "#test" )
     proxy<TContext extends object,
         TReturn,
         A, B, C, D, E, F, G,
-        T, U, V>(funсtion: (a: A, b: B, c: C, d: D, e: E, f: F, g: G,
+        T, U, V>(funсtion: (this: TContext, a: A, b: B, c: C, d: D, e: E, f: F, g: G,
                             t: T, u: U, v: V) => TReturn,
                  context: TContext,
-                 a: A, b: B, c: C, d: D, e: E, f: F, g: G): (this: TContext, t: T, u: U, v: V) => TReturn;
+                 a: A, b: B, c: C, d: D, e: E, f: F, g: G): (t: T, u: U, v: V) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
@@ -7481,10 +7481,10 @@ $( "#test" )
     proxy<TContext extends object,
         TReturn,
         A, B, C, D, E, F,
-        T, U, V>(funсtion: (a: A, b: B, c: C, d: D, e: E, f: F,
+        T, U, V>(funсtion: (this: TContext, a: A, b: B, c: C, d: D, e: E, f: F,
                             t: T, u: U, v: V) => TReturn,
                  context: TContext,
-                 a: A, b: B, c: C, d: D, e: E, f: F): (this: TContext, t: T, u: U, v: V) => TReturn;
+                 a: A, b: B, c: C, d: D, e: E, f: F): (t: T, u: U, v: V) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
@@ -7620,10 +7620,10 @@ $( "#test" )
     proxy<TContext extends object,
         TReturn,
         A, B, C, D, E,
-        T, U, V>(funсtion: (a: A, b: B, c: C, d: D, e: E,
+        T, U, V>(funсtion: (this: TContext, a: A, b: B, c: C, d: D, e: E,
                             t: T, u: U, v: V) => TReturn,
                  context: TContext,
-                 a: A, b: B, c: C, d: D, e: E): (this: TContext, t: T, u: U, v: V) => TReturn;
+                 a: A, b: B, c: C, d: D, e: E): (t: T, u: U, v: V) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
@@ -7758,10 +7758,10 @@ $( "#test" )
     proxy<TContext extends object,
         TReturn,
         A, B, C, D,
-        T, U, V>(funсtion: (a: A, b: B, c: C, d: D,
+        T, U, V>(funсtion: (this: TContext, a: A, b: B, c: C, d: D,
                             t: T, u: U, v: V) => TReturn,
                  context: TContext,
-                 a: A, b: B, c: C, d: D): (this: TContext, t: T, u: U, v: V) => TReturn;
+                 a: A, b: B, c: C, d: D): (t: T, u: U, v: V) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
@@ -7895,10 +7895,10 @@ $( "#test" )
     proxy<TContext extends object,
         TReturn,
         A, B, C,
-        T, U, V>(funсtion: (a: A, b: B, c: C,
+        T, U, V>(funсtion: (this: TContext, a: A, b: B, c: C,
                             t: T, u: U, v: V) => TReturn,
                  context: TContext,
-                 a: A, b: B, c: C): (this: TContext, t: T, u: U, v: V) => TReturn;
+                 a: A, b: B, c: C): (t: T, u: U, v: V) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
@@ -8031,10 +8031,10 @@ $( "#test" )
     proxy<TContext extends object,
         TReturn,
         A, B,
-        T, U, V>(funсtion: (a: A, b: B,
+        T, U, V>(funсtion: (this: TContext, a: A, b: B,
                             t: T, u: U, v: V) => TReturn,
                  context: TContext,
-                 a: A, b: B): (this: TContext, t: T, u: U, v: V) => TReturn;
+                 a: A, b: B): (t: T, u: U, v: V) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
@@ -8166,10 +8166,10 @@ $( "#test" )
     proxy<TContext extends object,
         TReturn,
         A,
-        T, U, V>(funсtion: (a: A,
+        T, U, V>(funсtion: (this: TContext, a: A,
                             t: T, u: U, v: V) => TReturn,
                  context: TContext,
-                 a: A): (this: TContext, t: T, u: U, v: V) => TReturn;
+                 a: A): (t: T, u: U, v: V) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
@@ -8299,8 +8299,8 @@ $( "#test" )
      */
     proxy<TContext extends object,
         TReturn,
-        T, U, V>(funсtion: (t: T, u: U, v: V) => TReturn,
-                 context: TContext): (this: TContext, t: T, u: U, v: V) => TReturn;
+        T, U, V>(funсtion: (this: TContext, t: T, u: U, v: V) => TReturn,
+                 context: TContext): (t: T, u: U, v: V) => TReturn;
 
     // #endregion
 
@@ -8444,10 +8444,10 @@ $( "#test" )
     proxy<TContext extends object,
         TReturn,
         A, B, C, D, E, F, G,
-        T, U, V, W>(funсtion: (a: A, b: B, c: C, d: D, e: E, f: F, g: G,
+        T, U, V, W>(funсtion: (this: TContext, a: A, b: B, c: C, d: D, e: E, f: F, g: G,
                                t: T, u: U, v: V, w: W) => TReturn,
                     context: TContext,
-                    a: A, b: B, c: C, d: D, e: E, f: F, g: G): (this: TContext, t: T, u: U, v: V, w: W) => TReturn;
+                    a: A, b: B, c: C, d: D, e: E, f: F, g: G): (t: T, u: U, v: V, w: W) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
@@ -8584,10 +8584,10 @@ $( "#test" )
     proxy<TContext extends object,
         TReturn,
         A, B, C, D, E, F,
-        T, U, V, W>(funсtion: (a: A, b: B, c: C, d: D, e: E, f: F,
+        T, U, V, W>(funсtion: (this: TContext, a: A, b: B, c: C, d: D, e: E, f: F,
                                t: T, u: U, v: V, w: W) => TReturn,
                     context: TContext,
-                    a: A, b: B, c: C, d: D, e: E, f: F): (this: TContext, t: T, u: U, v: V, w: W) => TReturn;
+                    a: A, b: B, c: C, d: D, e: E, f: F): (t: T, u: U, v: V, w: W) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
@@ -8723,10 +8723,10 @@ $( "#test" )
     proxy<TContext extends object,
         TReturn,
         A, B, C, D, E,
-        T, U, V, W>(funсtion: (a: A, b: B, c: C, d: D, e: E,
+        T, U, V, W>(funсtion: (this: TContext, a: A, b: B, c: C, d: D, e: E,
                                t: T, u: U, v: V, w: W) => TReturn,
                     context: TContext,
-                    a: A, b: B, c: C, d: D, e: E): (this: TContext, t: T, u: U, v: V, w: W) => TReturn;
+                    a: A, b: B, c: C, d: D, e: E): (t: T, u: U, v: V, w: W) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
@@ -8861,10 +8861,10 @@ $( "#test" )
     proxy<TContext extends object,
         TReturn,
         A, B, C, D,
-        T, U, V, W>(funсtion: (a: A, b: B, c: C, d: D,
+        T, U, V, W>(funсtion: (this: TContext, a: A, b: B, c: C, d: D,
                                t: T, u: U, v: V, w: W) => TReturn,
                     context: TContext,
-                    a: A, b: B, c: C, d: D): (this: TContext, t: T, u: U, v: V, w: W) => TReturn;
+                    a: A, b: B, c: C, d: D): (t: T, u: U, v: V, w: W) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
@@ -8998,10 +8998,10 @@ $( "#test" )
     proxy<TContext extends object,
         TReturn,
         A, B, C,
-        T, U, V, W>(funсtion: (a: A, b: B, c: C,
+        T, U, V, W>(funсtion: (this: TContext, a: A, b: B, c: C,
                                t: T, u: U, v: V, w: W) => TReturn,
                     context: TContext,
-                    a: A, b: B, c: C): (this: TContext, t: T, u: U, v: V, w: W) => TReturn;
+                    a: A, b: B, c: C): (t: T, u: U, v: V, w: W) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
@@ -9134,10 +9134,10 @@ $( "#test" )
     proxy<TContext extends object,
         TReturn,
         A, B,
-        T, U, V, W>(funсtion: (a: A, b: B,
+        T, U, V, W>(funсtion: (this: TContext, a: A, b: B,
                                t: T, u: U, v: V, w: W) => TReturn,
                     context: TContext,
-                    a: A, b: B): (this: TContext, t: T, u: U, v: V, w: W) => TReturn;
+                    a: A, b: B): (t: T, u: U, v: V, w: W) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
@@ -9269,10 +9269,10 @@ $( "#test" )
     proxy<TContext extends object,
         TReturn,
         A,
-        T, U, V, W>(funсtion: (a: A,
+        T, U, V, W>(funсtion: (this: TContext, a: A,
                                t: T, u: U, v: V, w: W) => TReturn,
                     context: TContext,
-                    a: A): (this: TContext, t: T, u: U, v: V, w: W) => TReturn;
+                    a: A): (t: T, u: U, v: V, w: W) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
@@ -9402,8 +9402,8 @@ $( "#test" )
      */
     proxy<TContext extends object,
         TReturn,
-        T, U, V, W>(funсtion: (t: T, u: U, v: V, w: W) => TReturn,
-                    context: TContext): (this: TContext, t: T, u: U, v: V, w: W) => TReturn;
+        T, U, V, W>(funсtion: (this: TContext, t: T, u: U, v: V, w: W) => TReturn,
+                    context: TContext): (t: T, u: U, v: V, w: W) => TReturn;
 
     // #endregion
 
@@ -9547,10 +9547,10 @@ $( "#test" )
     proxy<TContext extends object,
         TReturn,
         A, B, C, D, E, F, G,
-        T, U, V, W, X>(funсtion: (a: A, b: B, c: C, d: D, e: E, f: F, g: G,
+        T, U, V, W, X>(funсtion: (this: TContext, a: A, b: B, c: C, d: D, e: E, f: F, g: G,
                                   t: T, u: U, v: V, w: W, x: X) => TReturn,
                        context: TContext,
-                       a: A, b: B, c: C, d: D, e: E, f: F, g: G): (this: TContext, t: T, u: U, v: V, w: W, x: X) => TReturn;
+                       a: A, b: B, c: C, d: D, e: E, f: F, g: G): (t: T, u: U, v: V, w: W, x: X) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
@@ -9687,10 +9687,10 @@ $( "#test" )
     proxy<TContext extends object,
         TReturn,
         A, B, C, D, E, F,
-        T, U, V, W, X>(funсtion: (a: A, b: B, c: C, d: D, e: E, f: F,
+        T, U, V, W, X>(funсtion: (this: TContext, a: A, b: B, c: C, d: D, e: E, f: F,
                                   t: T, u: U, v: V, w: W, x: X) => TReturn,
                        context: TContext,
-                       a: A, b: B, c: C, d: D, e: E, f: F): (this: TContext, t: T, u: U, v: V, w: W, x: X) => TReturn;
+                       a: A, b: B, c: C, d: D, e: E, f: F): (t: T, u: U, v: V, w: W, x: X) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
@@ -9826,10 +9826,10 @@ $( "#test" )
     proxy<TContext extends object,
         TReturn,
         A, B, C, D, E,
-        T, U, V, W, X>(funсtion: (a: A, b: B, c: C, d: D, e: E,
+        T, U, V, W, X>(funсtion: (this: TContext, a: A, b: B, c: C, d: D, e: E,
                                   t: T, u: U, v: V, w: W, x: X) => TReturn,
                        context: TContext,
-                       a: A, b: B, c: C, d: D, e: E): (this: TContext, t: T, u: U, v: V, w: W, x: X) => TReturn;
+                       a: A, b: B, c: C, d: D, e: E): (t: T, u: U, v: V, w: W, x: X) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
@@ -9964,10 +9964,10 @@ $( "#test" )
     proxy<TContext extends object,
         TReturn,
         A, B, C, D,
-        T, U, V, W, X>(funсtion: (a: A, b: B, c: C, d: D,
+        T, U, V, W, X>(funсtion: (this: TContext, a: A, b: B, c: C, d: D,
                                   t: T, u: U, v: V, w: W, x: X) => TReturn,
                        context: TContext,
-                       a: A, b: B, c: C, d: D): (this: TContext, t: T, u: U, v: V, w: W, x: X) => TReturn;
+                       a: A, b: B, c: C, d: D): (t: T, u: U, v: V, w: W, x: X) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
@@ -10101,10 +10101,10 @@ $( "#test" )
     proxy<TContext extends object,
         TReturn,
         A, B, C,
-        T, U, V, W, X>(funсtion: (a: A, b: B, c: C,
+        T, U, V, W, X>(funсtion: (this: TContext, a: A, b: B, c: C,
                                   t: T, u: U, v: V, w: W, x: X) => TReturn,
                        context: TContext,
-                       a: A, b: B, c: C): (this: TContext, t: T, u: U, v: V, w: W, x: X) => TReturn;
+                       a: A, b: B, c: C): (t: T, u: U, v: V, w: W, x: X) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
@@ -10237,10 +10237,10 @@ $( "#test" )
     proxy<TContext extends object,
         TReturn,
         A, B,
-        T, U, V, W, X>(funсtion: (a: A, b: B,
+        T, U, V, W, X>(funсtion: (this: TContext, a: A, b: B,
                                   t: T, u: U, v: V, w: W, x: X) => TReturn,
                        context: TContext,
-                       a: A, b: B): (this: TContext, t: T, u: U, v: V, w: W, x: X) => TReturn;
+                       a: A, b: B): (t: T, u: U, v: V, w: W, x: X) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
@@ -10372,10 +10372,10 @@ $( "#test" )
     proxy<TContext extends object,
         TReturn,
         A,
-        T, U, V, W, X>(funсtion: (a: A,
+        T, U, V, W, X>(funсtion: (this: TContext, a: A,
                                   t: T, u: U, v: V, w: W, x: X) => TReturn,
                        context: TContext,
-                       a: A): (this: TContext, t: T, u: U, v: V, w: W, x: X) => TReturn;
+                       a: A): (t: T, u: U, v: V, w: W, x: X) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
@@ -10505,8 +10505,8 @@ $( "#test" )
      */
     proxy<TContext extends object,
         TReturn,
-        T, U, V, W, X>(funсtion: (t: T, u: U, v: V, w: W, x: X) => TReturn,
-                       context: TContext): (this: TContext, t: T, u: U, v: V, w: W, x: X) => TReturn;
+        T, U, V, W, X>(funсtion: (this: TContext, t: T, u: U, v: V, w: W, x: X) => TReturn,
+                       context: TContext): (t: T, u: U, v: V, w: W, x: X) => TReturn;
 
     // #endregion
 
@@ -10650,10 +10650,10 @@ $( "#test" )
     proxy<TContext extends object,
         TReturn,
         A, B, C, D, E, F, G,
-        T, U, V, W, X, Y>(funсtion: (a: A, b: B, c: C, d: D, e: E, f: F, g: G,
+        T, U, V, W, X, Y>(funсtion: (this: TContext, a: A, b: B, c: C, d: D, e: E, f: F, g: G,
                                      t: T, u: U, v: V, w: W, x: X, y: Y) => TReturn,
                           context: TContext,
-                          a: A, b: B, c: C, d: D, e: E, f: F, g: G): (this: TContext, t: T, u: U, v: V, w: W, x: X, y: Y) => TReturn;
+                          a: A, b: B, c: C, d: D, e: E, f: F, g: G): (t: T, u: U, v: V, w: W, x: X, y: Y) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
@@ -10790,10 +10790,10 @@ $( "#test" )
     proxy<TContext extends object,
         TReturn,
         A, B, C, D, E, F,
-        T, U, V, W, X, Y>(funсtion: (a: A, b: B, c: C, d: D, e: E, f: F,
+        T, U, V, W, X, Y>(funсtion: (this: TContext, a: A, b: B, c: C, d: D, e: E, f: F,
                                      t: T, u: U, v: V, w: W, x: X, y: Y) => TReturn,
                           context: TContext,
-                          a: A, b: B, c: C, d: D, e: E, f: F): (this: TContext, t: T, u: U, v: V, w: W, x: X, y: Y) => TReturn;
+                          a: A, b: B, c: C, d: D, e: E, f: F): (t: T, u: U, v: V, w: W, x: X, y: Y) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
@@ -10929,10 +10929,10 @@ $( "#test" )
     proxy<TContext extends object,
         TReturn,
         A, B, C, D, E,
-        T, U, V, W, X, Y>(funсtion: (a: A, b: B, c: C, d: D, e: E,
+        T, U, V, W, X, Y>(funсtion: (this: TContext, a: A, b: B, c: C, d: D, e: E,
                                      t: T, u: U, v: V, w: W, x: X, y: Y) => TReturn,
                           context: TContext,
-                          a: A, b: B, c: C, d: D, e: E): (this: TContext, t: T, u: U, v: V, w: W, x: X, y: Y) => TReturn;
+                          a: A, b: B, c: C, d: D, e: E): (t: T, u: U, v: V, w: W, x: X, y: Y) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
@@ -11067,10 +11067,10 @@ $( "#test" )
     proxy<TContext extends object,
         TReturn,
         A, B, C, D,
-        T, U, V, W, X, Y>(funсtion: (a: A, b: B, c: C, d: D,
+        T, U, V, W, X, Y>(funсtion: (this: TContext, a: A, b: B, c: C, d: D,
                                      t: T, u: U, v: V, w: W, x: X, y: Y) => TReturn,
                           context: TContext,
-                          a: A, b: B, c: C, d: D): (this: TContext, t: T, u: U, v: V, w: W, x: X, y: Y) => TReturn;
+                          a: A, b: B, c: C, d: D): (t: T, u: U, v: V, w: W, x: X, y: Y) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
@@ -11204,10 +11204,10 @@ $( "#test" )
     proxy<TContext extends object,
         TReturn,
         A, B, C,
-        T, U, V, W, X, Y>(funсtion: (a: A, b: B, c: C,
+        T, U, V, W, X, Y>(funсtion: (this: TContext, a: A, b: B, c: C,
                                      t: T, u: U, v: V, w: W, x: X, y: Y) => TReturn,
                           context: TContext,
-                          a: A, b: B, c: C): (this: TContext, t: T, u: U, v: V, w: W, x: X, y: Y) => TReturn;
+                          a: A, b: B, c: C): (t: T, u: U, v: V, w: W, x: X, y: Y) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
@@ -11340,10 +11340,10 @@ $( "#test" )
     proxy<TContext extends object,
         TReturn,
         A, B,
-        T, U, V, W, X, Y>(funсtion: (a: A, b: B,
+        T, U, V, W, X, Y>(funсtion: (this: TContext, a: A, b: B,
                                      t: T, u: U, v: V, w: W, x: X, y: Y) => TReturn,
                           context: TContext,
-                          a: A, b: B): (this: TContext, t: T, u: U, v: V, w: W, x: X, y: Y) => TReturn;
+                          a: A, b: B): (t: T, u: U, v: V, w: W, x: X, y: Y) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
@@ -11475,10 +11475,10 @@ $( "#test" )
     proxy<TContext extends object,
         TReturn,
         A,
-        T, U, V, W, X, Y>(funсtion: (a: A,
+        T, U, V, W, X, Y>(funсtion: (this: TContext, a: A,
                                      t: T, u: U, v: V, w: W, x: X, y: Y) => TReturn,
                           context: TContext,
-                          a: A): (this: TContext, t: T, u: U, v: V, w: W, x: X, y: Y) => TReturn;
+                          a: A): (t: T, u: U, v: V, w: W, x: X, y: Y) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
@@ -11608,8 +11608,8 @@ $( "#test" )
      */
     proxy<TContext extends object,
         TReturn,
-        T, U, V, W, X, Y>(funсtion: (t: T, u: U, v: V, w: W, x: X, y: Y) => TReturn,
-                          context: TContext): (this: TContext, t: T, u: U, v: V, w: W, x: X, y: Y) => TReturn;
+        T, U, V, W, X, Y>(funсtion: (this: TContext, t: T, u: U, v: V, w: W, x: X, y: Y) => TReturn,
+                          context: TContext): (t: T, u: U, v: V, w: W, x: X, y: Y) => TReturn;
 
     // #endregion
 
@@ -11753,10 +11753,10 @@ $( "#test" )
     proxy<TContext extends object,
         TReturn,
         A, B, C, D, E, F, G,
-        T, U, V, W, X, Y, Z>(funсtion: (a: A, b: B, c: C, d: D, e: E, f: F, g: G,
+        T, U, V, W, X, Y, Z>(funсtion: (this: TContext, a: A, b: B, c: C, d: D, e: E, f: F, g: G,
                                         t: T, u: U, v: V, w: W, x: X, y: Y, z: Z, ...args: any[]) => TReturn,
                              context: TContext,
-                             a: A, b: B, c: C, d: D, e: E, f: F, g: G): (this: TContext, t: T, u: U, v: V, w: W, x: X, y: Y, z: Z, ...args: any[]) => TReturn;
+                             a: A, b: B, c: C, d: D, e: E, f: F, g: G): (t: T, u: U, v: V, w: W, x: X, y: Y, z: Z, ...args: any[]) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
@@ -11893,10 +11893,10 @@ $( "#test" )
     proxy<TContext extends object,
         TReturn,
         A, B, C, D, E, F,
-        T, U, V, W, X, Y, Z>(funсtion: (a: A, b: B, c: C, d: D, e: E, f: F,
+        T, U, V, W, X, Y, Z>(funсtion: (this: TContext, a: A, b: B, c: C, d: D, e: E, f: F,
                                         t: T, u: U, v: V, w: W, x: X, y: Y, z: Z, ...args: any[]) => TReturn,
                              context: TContext,
-                             a: A, b: B, c: C, d: D, e: E, f: F): (this: TContext, t: T, u: U, v: V, w: W, x: X, y: Y, z: Z, ...args: any[]) => TReturn;
+                             a: A, b: B, c: C, d: D, e: E, f: F): (t: T, u: U, v: V, w: W, x: X, y: Y, z: Z, ...args: any[]) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
@@ -12032,10 +12032,10 @@ $( "#test" )
     proxy<TContext extends object,
         TReturn,
         A, B, C, D, E,
-        T, U, V, W, X, Y, Z>(funсtion: (a: A, b: B, c: C, d: D, e: E,
+        T, U, V, W, X, Y, Z>(funсtion: (this: TContext, a: A, b: B, c: C, d: D, e: E,
                                         t: T, u: U, v: V, w: W, x: X, y: Y, z: Z, ...args: any[]) => TReturn,
                              context: TContext,
-                             a: A, b: B, c: C, d: D, e: E): (this: TContext, t: T, u: U, v: V, w: W, x: X, y: Y, z: Z, ...args: any[]) => TReturn;
+                             a: A, b: B, c: C, d: D, e: E): (t: T, u: U, v: V, w: W, x: X, y: Y, z: Z, ...args: any[]) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
@@ -12170,10 +12170,10 @@ $( "#test" )
     proxy<TContext extends object,
         TReturn,
         A, B, C, D,
-        T, U, V, W, X, Y, Z>(funсtion: (a: A, b: B, c: C, d: D,
+        T, U, V, W, X, Y, Z>(funсtion: (this: TContext, a: A, b: B, c: C, d: D,
                                         t: T, u: U, v: V, w: W, x: X, y: Y, z: Z, ...args: any[]) => TReturn,
                              context: TContext,
-                             a: A, b: B, c: C, d: D): (this: TContext, t: T, u: U, v: V, w: W, x: X, y: Y, z: Z, ...args: any[]) => TReturn;
+                             a: A, b: B, c: C, d: D): (t: T, u: U, v: V, w: W, x: X, y: Y, z: Z, ...args: any[]) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
@@ -12307,10 +12307,10 @@ $( "#test" )
     proxy<TContext extends object,
         TReturn,
         A, B, C,
-        T, U, V, W, X, Y, Z>(funсtion: (a: A, b: B, c: C,
+        T, U, V, W, X, Y, Z>(funсtion: (this: TContext, a: A, b: B, c: C,
                                         t: T, u: U, v: V, w: W, x: X, y: Y, z: Z, ...args: any[]) => TReturn,
                              context: TContext,
-                             a: A, b: B, c: C): (this: TContext, t: T, u: U, v: V, w: W, x: X, y: Y, z: Z, ...args: any[]) => TReturn;
+                             a: A, b: B, c: C): (t: T, u: U, v: V, w: W, x: X, y: Y, z: Z, ...args: any[]) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
@@ -12443,10 +12443,10 @@ $( "#test" )
     proxy<TContext extends object,
         TReturn,
         A, B,
-        T, U, V, W, X, Y, Z>(funсtion: (a: A, b: B,
+        T, U, V, W, X, Y, Z>(funсtion: (this: TContext, a: A, b: B,
                                         t: T, u: U, v: V, w: W, x: X, y: Y, z: Z, ...args: any[]) => TReturn,
                              context: TContext,
-                             a: A, b: B): (this: TContext, t: T, u: U, v: V, w: W, x: X, y: Y, z: Z, ...args: any[]) => TReturn;
+                             a: A, b: B): (t: T, u: U, v: V, w: W, x: X, y: Y, z: Z, ...args: any[]) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
@@ -12578,10 +12578,10 @@ $( "#test" )
     proxy<TContext extends object,
         TReturn,
         A,
-        T, U, V, W, X, Y, Z>(funсtion: (a: A,
+        T, U, V, W, X, Y, Z>(funсtion: (this: TContext, a: A,
                                         t: T, u: U, v: V, w: W, x: X, y: Y, z: Z, ...args: any[]) => TReturn,
                              context: TContext,
-                             a: A): (this: TContext, t: T, u: U, v: V, w: W, x: X, y: Y, z: Z, ...args: any[]) => TReturn;
+                             a: A): (t: T, u: U, v: V, w: W, x: X, y: Y, z: Z, ...args: any[]) => TReturn;
     /**
      * Takes a function and returns a new one that will always have a particular context.
      * @param funсtion The function whose context will be changed.
@@ -12711,8 +12711,8 @@ $( "#test" )
      */
     proxy<TContext extends object,
         TReturn,
-        T, U, V, W, X, Y, Z>(funсtion: (t: T, u: U, v: V, w: W, x: X, y: Y, z: Z, ...args: any[]) => TReturn,
-                             context: TContext): (this: TContext, t: T, u: U, v: V, w: W, x: X, y: Y, z: Z, ...args: any[]) => TReturn;
+        T, U, V, W, X, Y, Z>(funсtion: (this: TContext, t: T, u: U, v: V, w: W, x: X, y: Y, z: Z, ...args: any[]) => TReturn,
+                             context: TContext): (t: T, u: U, v: V, w: W, x: X, y: Y, z: Z, ...args: any[]) => TReturn;
 
     // #endregion
 
@@ -12850,9 +12850,9 @@ $( "#test" )
 ```
      */
     proxy<TContext extends object,
-        TReturn>(funсtion: (...args: any[]) => TReturn,
+        TReturn>(funсtion: (this: TContext, ...args: any[]) => TReturn,
                  context: TContext,
-                 ...additionalArguments: any[]): (this: TContext, ...args: any[]) => TReturn;
+                 ...additionalArguments: any[]): (...args: any[]) => TReturn;
 
     // #endregion
 
@@ -12901,7 +12901,7 @@ $( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
      */
     proxy<TContext extends object>(context: TContext,
                                    name: keyof TContext,
-                                   ...additionalArguments: any[]): (this: TContext, ...args: any[]) => any;
+                                   ...additionalArguments: any[]): (...args: any[]) => any;
 
     // #endregion
 

--- a/types/jquery/JQueryStatic.d.ts
+++ b/types/jquery/JQueryStatic.d.ts
@@ -4044,7 +4044,7 @@ $( "#test" )
 </html>
 ```
      */
-    proxy<TContext extends object,
+    proxy<TContext,
         TReturn,
         A, B, C, D, E, F, G>(funсtion: (this: TContext, a: A, b: B, c: C, d: D, e: E, f: F, g: G) => TReturn,
                              context: TContext,
@@ -4182,7 +4182,7 @@ $( "#test" )
 </html>
 ```
      */
-    proxy<TContext extends object,
+    proxy<TContext,
         TReturn,
         A, B, C, D, E, F>(funсtion: (this: TContext, a: A, b: B, c: C, d: D, e: E, f: F) => TReturn,
                           context: TContext,
@@ -4319,7 +4319,7 @@ $( "#test" )
 </html>
 ```
      */
-    proxy<TContext extends object,
+    proxy<TContext,
         TReturn,
         A, B, C, D, E>(funсtion: (this: TContext, a: A, b: B, c: C, d: D, e: E) => TReturn,
                        context: TContext,
@@ -4455,7 +4455,7 @@ $( "#test" )
 </html>
 ```
      */
-    proxy<TContext extends object,
+    proxy<TContext,
         TReturn,
         A, B, C, D>(funсtion: (this: TContext, a: A, b: B, c: C, d: D) => TReturn,
                     context: TContext,
@@ -4590,7 +4590,7 @@ $( "#test" )
 </html>
 ```
      */
-    proxy<TContext extends object,
+    proxy<TContext,
         TReturn,
         A, B, C>(funсtion: (this: TContext, a: A, b: B, c: C) => TReturn,
                  context: TContext,
@@ -4724,7 +4724,7 @@ $( "#test" )
 </html>
 ```
      */
-    proxy<TContext extends object,
+    proxy<TContext,
         TReturn,
         A, B>(funсtion: (this: TContext, a: A, b: B) => TReturn,
               context: TContext,
@@ -4857,7 +4857,7 @@ $( "#test" )
 </html>
 ```
      */
-    proxy<TContext extends object,
+    proxy<TContext,
         TReturn,
         A>(funсtion: (this: TContext, a: A) => TReturn,
            context: TContext,
@@ -4989,7 +4989,7 @@ $( "#test" )
 </html>
 ```
      */
-    proxy<TContext extends object,
+    proxy<TContext,
         TReturn>(funсtion: (this: TContext) => TReturn,
                  context: TContext): () => TReturn;
 
@@ -5132,7 +5132,7 @@ $( "#test" )
 </html>
 ```
      */
-    proxy<TContext extends object,
+    proxy<TContext,
         TReturn,
         A, B, C, D, E, F, G,
         T>(funсtion: (this: TContext, a: A, b: B, c: C, d: D, e: E, f: F, g: G,
@@ -5272,7 +5272,7 @@ $( "#test" )
 </html>
 ```
      */
-    proxy<TContext extends object,
+    proxy<TContext,
         TReturn,
         A, B, C, D, E, F,
         T>(funсtion: (this: TContext, a: A, b: B, c: C, d: D, e: E, f: F,
@@ -5411,7 +5411,7 @@ $( "#test" )
 </html>
 ```
      */
-    proxy<TContext extends object,
+    proxy<TContext,
         TReturn,
         A, B, C, D, E,
         T>(funсtion: (this: TContext, a: A, b: B, c: C, d: D, e: E,
@@ -5549,7 +5549,7 @@ $( "#test" )
 </html>
 ```
      */
-    proxy<TContext extends object,
+    proxy<TContext,
         TReturn,
         A, B, C, D,
         T>(funсtion: (this: TContext, a: A, b: B, c: C, d: D,
@@ -5686,7 +5686,7 @@ $( "#test" )
 </html>
 ```
      */
-    proxy<TContext extends object,
+    proxy<TContext,
         TReturn,
         A, B, C,
         T>(funсtion: (this: TContext, a: A, b: B, c: C,
@@ -5822,7 +5822,7 @@ $( "#test" )
 </html>
 ```
      */
-    proxy<TContext extends object,
+    proxy<TContext,
         TReturn,
         A, B,
         T>(funсtion: (this: TContext, a: A, b: B,
@@ -5957,7 +5957,7 @@ $( "#test" )
 </html>
 ```
      */
-    proxy<TContext extends object,
+    proxy<TContext,
         TReturn,
         A,
         T>(funсtion: (this: TContext, a: A,
@@ -6091,7 +6091,7 @@ $( "#test" )
 </html>
 ```
      */
-    proxy<TContext extends object,
+    proxy<TContext,
         TReturn,
         T>(funсtion: (this: TContext, t: T) => TReturn,
            context: TContext): (t: T) => TReturn;
@@ -6235,7 +6235,7 @@ $( "#test" )
 </html>
 ```
      */
-    proxy<TContext extends object,
+    proxy<TContext,
         TReturn,
         A, B, C, D, E, F, G,
         T, U>(funсtion: (this: TContext, a: A, b: B, c: C, d: D, e: E, f: F, g: G,
@@ -6375,7 +6375,7 @@ $( "#test" )
 </html>
 ```
      */
-    proxy<TContext extends object,
+    proxy<TContext,
         TReturn,
         A, B, C, D, E, F,
         T, U>(funсtion: (this: TContext, a: A, b: B, c: C, d: D, e: E, f: F,
@@ -6514,7 +6514,7 @@ $( "#test" )
 </html>
 ```
      */
-    proxy<TContext extends object,
+    proxy<TContext,
         TReturn,
         A, B, C, D, E,
         T, U>(funсtion: (this: TContext, a: A, b: B, c: C, d: D, e: E,
@@ -6652,7 +6652,7 @@ $( "#test" )
 </html>
 ```
      */
-    proxy<TContext extends object,
+    proxy<TContext,
         TReturn,
         A, B, C, D,
         T, U>(funсtion: (this: TContext, a: A, b: B, c: C, d: D,
@@ -6789,7 +6789,7 @@ $( "#test" )
 </html>
 ```
      */
-    proxy<TContext extends object,
+    proxy<TContext,
         TReturn,
         A, B, C,
         T, U>(funсtion: (this: TContext, a: A, b: B, c: C,
@@ -6925,7 +6925,7 @@ $( "#test" )
 </html>
 ```
      */
-    proxy<TContext extends object,
+    proxy<TContext,
         TReturn,
         A, B,
         T, U>(funсtion: (this: TContext, a: A, b: B,
@@ -7060,7 +7060,7 @@ $( "#test" )
 </html>
 ```
      */
-    proxy<TContext extends object,
+    proxy<TContext,
         TReturn,
         A,
         T, U>(funсtion: (this: TContext, a: A,
@@ -7194,7 +7194,7 @@ $( "#test" )
 </html>
 ```
      */
-    proxy<TContext extends object,
+    proxy<TContext,
         TReturn,
         T, U>(funсtion: (this: TContext, t: T, u: U) => TReturn,
               context: TContext): (t: T, u: U) => TReturn;
@@ -7338,7 +7338,7 @@ $( "#test" )
 </html>
 ```
      */
-    proxy<TContext extends object,
+    proxy<TContext,
         TReturn,
         A, B, C, D, E, F, G,
         T, U, V>(funсtion: (this: TContext, a: A, b: B, c: C, d: D, e: E, f: F, g: G,
@@ -7478,7 +7478,7 @@ $( "#test" )
 </html>
 ```
      */
-    proxy<TContext extends object,
+    proxy<TContext,
         TReturn,
         A, B, C, D, E, F,
         T, U, V>(funсtion: (this: TContext, a: A, b: B, c: C, d: D, e: E, f: F,
@@ -7617,7 +7617,7 @@ $( "#test" )
 </html>
 ```
      */
-    proxy<TContext extends object,
+    proxy<TContext,
         TReturn,
         A, B, C, D, E,
         T, U, V>(funсtion: (this: TContext, a: A, b: B, c: C, d: D, e: E,
@@ -7755,7 +7755,7 @@ $( "#test" )
 </html>
 ```
      */
-    proxy<TContext extends object,
+    proxy<TContext,
         TReturn,
         A, B, C, D,
         T, U, V>(funсtion: (this: TContext, a: A, b: B, c: C, d: D,
@@ -7892,7 +7892,7 @@ $( "#test" )
 </html>
 ```
      */
-    proxy<TContext extends object,
+    proxy<TContext,
         TReturn,
         A, B, C,
         T, U, V>(funсtion: (this: TContext, a: A, b: B, c: C,
@@ -8028,7 +8028,7 @@ $( "#test" )
 </html>
 ```
      */
-    proxy<TContext extends object,
+    proxy<TContext,
         TReturn,
         A, B,
         T, U, V>(funсtion: (this: TContext, a: A, b: B,
@@ -8163,7 +8163,7 @@ $( "#test" )
 </html>
 ```
      */
-    proxy<TContext extends object,
+    proxy<TContext,
         TReturn,
         A,
         T, U, V>(funсtion: (this: TContext, a: A,
@@ -8297,7 +8297,7 @@ $( "#test" )
 </html>
 ```
      */
-    proxy<TContext extends object,
+    proxy<TContext,
         TReturn,
         T, U, V>(funсtion: (this: TContext, t: T, u: U, v: V) => TReturn,
                  context: TContext): (t: T, u: U, v: V) => TReturn;
@@ -8441,7 +8441,7 @@ $( "#test" )
 </html>
 ```
      */
-    proxy<TContext extends object,
+    proxy<TContext,
         TReturn,
         A, B, C, D, E, F, G,
         T, U, V, W>(funсtion: (this: TContext, a: A, b: B, c: C, d: D, e: E, f: F, g: G,
@@ -8581,7 +8581,7 @@ $( "#test" )
 </html>
 ```
      */
-    proxy<TContext extends object,
+    proxy<TContext,
         TReturn,
         A, B, C, D, E, F,
         T, U, V, W>(funсtion: (this: TContext, a: A, b: B, c: C, d: D, e: E, f: F,
@@ -8720,7 +8720,7 @@ $( "#test" )
 </html>
 ```
      */
-    proxy<TContext extends object,
+    proxy<TContext,
         TReturn,
         A, B, C, D, E,
         T, U, V, W>(funсtion: (this: TContext, a: A, b: B, c: C, d: D, e: E,
@@ -8858,7 +8858,7 @@ $( "#test" )
 </html>
 ```
      */
-    proxy<TContext extends object,
+    proxy<TContext,
         TReturn,
         A, B, C, D,
         T, U, V, W>(funсtion: (this: TContext, a: A, b: B, c: C, d: D,
@@ -8995,7 +8995,7 @@ $( "#test" )
 </html>
 ```
      */
-    proxy<TContext extends object,
+    proxy<TContext,
         TReturn,
         A, B, C,
         T, U, V, W>(funсtion: (this: TContext, a: A, b: B, c: C,
@@ -9131,7 +9131,7 @@ $( "#test" )
 </html>
 ```
      */
-    proxy<TContext extends object,
+    proxy<TContext,
         TReturn,
         A, B,
         T, U, V, W>(funсtion: (this: TContext, a: A, b: B,
@@ -9266,7 +9266,7 @@ $( "#test" )
 </html>
 ```
      */
-    proxy<TContext extends object,
+    proxy<TContext,
         TReturn,
         A,
         T, U, V, W>(funсtion: (this: TContext, a: A,
@@ -9400,7 +9400,7 @@ $( "#test" )
 </html>
 ```
      */
-    proxy<TContext extends object,
+    proxy<TContext,
         TReturn,
         T, U, V, W>(funсtion: (this: TContext, t: T, u: U, v: V, w: W) => TReturn,
                     context: TContext): (t: T, u: U, v: V, w: W) => TReturn;
@@ -9544,7 +9544,7 @@ $( "#test" )
 </html>
 ```
      */
-    proxy<TContext extends object,
+    proxy<TContext,
         TReturn,
         A, B, C, D, E, F, G,
         T, U, V, W, X>(funсtion: (this: TContext, a: A, b: B, c: C, d: D, e: E, f: F, g: G,
@@ -9684,7 +9684,7 @@ $( "#test" )
 </html>
 ```
      */
-    proxy<TContext extends object,
+    proxy<TContext,
         TReturn,
         A, B, C, D, E, F,
         T, U, V, W, X>(funсtion: (this: TContext, a: A, b: B, c: C, d: D, e: E, f: F,
@@ -9823,7 +9823,7 @@ $( "#test" )
 </html>
 ```
      */
-    proxy<TContext extends object,
+    proxy<TContext,
         TReturn,
         A, B, C, D, E,
         T, U, V, W, X>(funсtion: (this: TContext, a: A, b: B, c: C, d: D, e: E,
@@ -9961,7 +9961,7 @@ $( "#test" )
 </html>
 ```
      */
-    proxy<TContext extends object,
+    proxy<TContext,
         TReturn,
         A, B, C, D,
         T, U, V, W, X>(funсtion: (this: TContext, a: A, b: B, c: C, d: D,
@@ -10098,7 +10098,7 @@ $( "#test" )
 </html>
 ```
      */
-    proxy<TContext extends object,
+    proxy<TContext,
         TReturn,
         A, B, C,
         T, U, V, W, X>(funсtion: (this: TContext, a: A, b: B, c: C,
@@ -10234,7 +10234,7 @@ $( "#test" )
 </html>
 ```
      */
-    proxy<TContext extends object,
+    proxy<TContext,
         TReturn,
         A, B,
         T, U, V, W, X>(funсtion: (this: TContext, a: A, b: B,
@@ -10369,7 +10369,7 @@ $( "#test" )
 </html>
 ```
      */
-    proxy<TContext extends object,
+    proxy<TContext,
         TReturn,
         A,
         T, U, V, W, X>(funсtion: (this: TContext, a: A,
@@ -10503,7 +10503,7 @@ $( "#test" )
 </html>
 ```
      */
-    proxy<TContext extends object,
+    proxy<TContext,
         TReturn,
         T, U, V, W, X>(funсtion: (this: TContext, t: T, u: U, v: V, w: W, x: X) => TReturn,
                        context: TContext): (t: T, u: U, v: V, w: W, x: X) => TReturn;
@@ -10647,7 +10647,7 @@ $( "#test" )
 </html>
 ```
      */
-    proxy<TContext extends object,
+    proxy<TContext,
         TReturn,
         A, B, C, D, E, F, G,
         T, U, V, W, X, Y>(funсtion: (this: TContext, a: A, b: B, c: C, d: D, e: E, f: F, g: G,
@@ -10787,7 +10787,7 @@ $( "#test" )
 </html>
 ```
      */
-    proxy<TContext extends object,
+    proxy<TContext,
         TReturn,
         A, B, C, D, E, F,
         T, U, V, W, X, Y>(funсtion: (this: TContext, a: A, b: B, c: C, d: D, e: E, f: F,
@@ -10926,7 +10926,7 @@ $( "#test" )
 </html>
 ```
      */
-    proxy<TContext extends object,
+    proxy<TContext,
         TReturn,
         A, B, C, D, E,
         T, U, V, W, X, Y>(funсtion: (this: TContext, a: A, b: B, c: C, d: D, e: E,
@@ -11064,7 +11064,7 @@ $( "#test" )
 </html>
 ```
      */
-    proxy<TContext extends object,
+    proxy<TContext,
         TReturn,
         A, B, C, D,
         T, U, V, W, X, Y>(funсtion: (this: TContext, a: A, b: B, c: C, d: D,
@@ -11201,7 +11201,7 @@ $( "#test" )
 </html>
 ```
      */
-    proxy<TContext extends object,
+    proxy<TContext,
         TReturn,
         A, B, C,
         T, U, V, W, X, Y>(funсtion: (this: TContext, a: A, b: B, c: C,
@@ -11337,7 +11337,7 @@ $( "#test" )
 </html>
 ```
      */
-    proxy<TContext extends object,
+    proxy<TContext,
         TReturn,
         A, B,
         T, U, V, W, X, Y>(funсtion: (this: TContext, a: A, b: B,
@@ -11472,7 +11472,7 @@ $( "#test" )
 </html>
 ```
      */
-    proxy<TContext extends object,
+    proxy<TContext,
         TReturn,
         A,
         T, U, V, W, X, Y>(funсtion: (this: TContext, a: A,
@@ -11606,7 +11606,7 @@ $( "#test" )
 </html>
 ```
      */
-    proxy<TContext extends object,
+    proxy<TContext,
         TReturn,
         T, U, V, W, X, Y>(funсtion: (this: TContext, t: T, u: U, v: V, w: W, x: X, y: Y) => TReturn,
                           context: TContext): (t: T, u: U, v: V, w: W, x: X, y: Y) => TReturn;
@@ -11750,7 +11750,7 @@ $( "#test" )
 </html>
 ```
      */
-    proxy<TContext extends object,
+    proxy<TContext,
         TReturn,
         A, B, C, D, E, F, G,
         T, U, V, W, X, Y, Z>(funсtion: (this: TContext, a: A, b: B, c: C, d: D, e: E, f: F, g: G,
@@ -11890,7 +11890,7 @@ $( "#test" )
 </html>
 ```
      */
-    proxy<TContext extends object,
+    proxy<TContext,
         TReturn,
         A, B, C, D, E, F,
         T, U, V, W, X, Y, Z>(funсtion: (this: TContext, a: A, b: B, c: C, d: D, e: E, f: F,
@@ -12029,7 +12029,7 @@ $( "#test" )
 </html>
 ```
      */
-    proxy<TContext extends object,
+    proxy<TContext,
         TReturn,
         A, B, C, D, E,
         T, U, V, W, X, Y, Z>(funсtion: (this: TContext, a: A, b: B, c: C, d: D, e: E,
@@ -12167,7 +12167,7 @@ $( "#test" )
 </html>
 ```
      */
-    proxy<TContext extends object,
+    proxy<TContext,
         TReturn,
         A, B, C, D,
         T, U, V, W, X, Y, Z>(funсtion: (this: TContext, a: A, b: B, c: C, d: D,
@@ -12304,7 +12304,7 @@ $( "#test" )
 </html>
 ```
      */
-    proxy<TContext extends object,
+    proxy<TContext,
         TReturn,
         A, B, C,
         T, U, V, W, X, Y, Z>(funсtion: (this: TContext, a: A, b: B, c: C,
@@ -12440,7 +12440,7 @@ $( "#test" )
 </html>
 ```
      */
-    proxy<TContext extends object,
+    proxy<TContext,
         TReturn,
         A, B,
         T, U, V, W, X, Y, Z>(funсtion: (this: TContext, a: A, b: B,
@@ -12575,7 +12575,7 @@ $( "#test" )
 </html>
 ```
      */
-    proxy<TContext extends object,
+    proxy<TContext,
         TReturn,
         A,
         T, U, V, W, X, Y, Z>(funсtion: (this: TContext, a: A,
@@ -12709,7 +12709,7 @@ $( "#test" )
 </html>
 ```
      */
-    proxy<TContext extends object,
+    proxy<TContext,
         TReturn,
         T, U, V, W, X, Y, Z>(funсtion: (this: TContext, t: T, u: U, v: V, w: W, x: X, y: Y, z: Z, ...args: any[]) => TReturn,
                              context: TContext): (t: T, u: U, v: V, w: W, x: X, y: Y, z: Z, ...args: any[]) => TReturn;
@@ -12849,7 +12849,7 @@ $( "#test" )
 </html>
 ```
      */
-    proxy<TContext extends object,
+    proxy<TContext,
         TReturn>(funсtion: (this: TContext, ...args: any[]) => TReturn,
                  context: TContext,
                  ...additionalArguments: any[]): (...args: any[]) => TReturn;
@@ -12899,9 +12899,9 @@ $( "#test" ).on( "click", jQuery.proxy( obj, "test" ) );
 </html>
 ```
      */
-    proxy<TContext extends object>(context: TContext,
-                                   name: keyof TContext,
-                                   ...additionalArguments: any[]): (...args: any[]) => any;
+    proxy<TContext>(context: TContext,
+                    name: keyof TContext,
+                    ...additionalArguments: any[]): (...args: any[]) => any;
 
     // #endregion
 

--- a/types/jquery/jquery-tests.ts
+++ b/types/jquery/jquery-tests.ts
@@ -1033,6 +1033,7 @@ function JQueryStatic() {
     }
 
     function proxy() {
+        interface JContext { kind: 'JContext'; }
         interface J1 { kind: 'J1'; }
         interface J2 { kind: 'J2'; }
         interface J3 { kind: 'J3'; }
@@ -1042,6 +1043,7 @@ function JQueryStatic() {
         interface J7 { kind: 'J7'; }
         interface J8 { kind: 'J8'; }
 
+        const context: JContext = {} as any;
         const a: J8 = {} as any;
         const b: J7 = {} as any;
         const c: J6 = {} as any;
@@ -1049,7 +1051,7 @@ function JQueryStatic() {
         const e: J4 = {} as any;
         const f: J3 = {} as any;
         const g: J2 = {} as any;
-        const h: J2 = {} as any;
+        const h: J1 = {} as any;
 
         type A = typeof a;
         type B = typeof b;
@@ -1058,7 +1060,6 @@ function JQueryStatic() {
         type E = typeof e;
         type F = typeof f;
         type G = typeof g;
-        type H = typeof h;
 
         // (funсtion, null)
         {
@@ -1506,230 +1507,449 @@ function JQueryStatic() {
 
         // (funсtion, context)
         {
-            // $ExpectType (this: {}) => void
-            $.proxy((a, b, c, d, e, f, g) => { }, {}, a, b, c, d, e, f, g);
-
-            // $ExpectType (this: {}) => void
-            $.proxy((a, b, c, d, e, f) => { }, {}, a, b, c, d, e, f);
-
-            // $ExpectType (this: {}) => void
-            $.proxy((a, b, c, d, e) => { }, {}, a, b, c, d, e);
-
-            // $ExpectType (this: {}) => void
-            $.proxy((a, b, c, d) => { }, {}, a, b, c, d);
-
-            // $ExpectType (this: {}) => void
-            $.proxy((a, b, c) => { }, {}, a, b, c);
-
-            // $ExpectType (this: {}) => void
-            $.proxy((a, b) => { }, {}, a, b);
-
-            // $ExpectType (this: {}) => void
-            $.proxy((a) => { }, {}, a);
-
-            // $ExpectType (this: {}) => void
-            $.proxy(() => { }, {});
-
-            // $ExpectType (this: {}, t: J1) => void
-            $.proxy((a: A, b: B, c: C, d: D, e: E, f: F, g: G, t: J1) => { }, {}, a, b, c, d, e, f, g);
-
-            // $ExpectType (this: {}, t: J1) => void
-            $.proxy((a: A, b: B, c: C, d: D, e: E, f: F, t: J1) => { }, {}, a, b, c, d, e, f);
-
-            // $ExpectType (this: {}, t: J1) => void
-            $.proxy((a: A, b: B, c: C, d: D, e: E, t: J1) => { }, {}, a, b, c, d, e);
-
-            // $ExpectType (this: {}, t: J1) => void
-            $.proxy((a: A, b: B, c: C, d: D, t: J1) => { }, {}, a, b, c, d);
-
-            // $ExpectType (this: {}, t: J1) => void
-            $.proxy((a: A, b: B, c: C, t: J1) => { }, {}, a, b, c);
-
-            // $ExpectType (this: {}, t: J1) => void
-            $.proxy((a: A, b: B, t: J1) => { }, {}, a, b);
-
-            // $ExpectType (this: {}, t: J1) => void
-            $.proxy((a: A, t: J1) => { }, {}, a);
-
-            // $ExpectType (this: {}, t: J1) => void
-            $.proxy((t: J1) => { }, {});
-
-            // $ExpectType (this: {}, t: J1, u: J2) => void
-            $.proxy((a: A, b: B, c: C, d: D, e: E, f: F, g: G, t: J1, u: J2) => { }, {}, a, b, c, d, e, f, g);
-
-            // $ExpectType (this: {}, t: J1, u: J2) => void
-            $.proxy((a: A, b: B, c: C, d: D, e: E, f: F, t: J1, u: J2) => { }, {}, a, b, c, d, e, f);
-
-            // $ExpectType (this: {}, t: J1, u: J2) => void
-            $.proxy((a: A, b: B, c: C, d: D, e: E, t: J1, u: J2) => { }, {}, a, b, c, d, e);
-
-            // $ExpectType (this: {}, t: J1, u: J2) => void
-            $.proxy((a: A, b: B, c: C, d: D, t: J1, u: J2) => { }, {}, a, b, c, d);
-
-            // $ExpectType (this: {}, t: J1, u: J2) => void
-            $.proxy((a: A, b: B, c: C, t: J1, u: J2) => { }, {}, a, b, c);
-
-            // $ExpectType (this: {}, t: J1, u: J2) => void
-            $.proxy((a: A, b: B, t: J1, u: J2) => { }, {}, a, b);
-
-            // $ExpectType (this: {}, t: J1, u: J2) => void
-            $.proxy((a: A, t: J1, u: J2) => { }, {}, a);
-
-            // $ExpectType (this: {}, t: J1, u: J2) => void
-            $.proxy((t: J1, u: J2) => { }, {});
-
-            // $ExpectType (this: {}, t: J1, u: J2, v: J3) => void
-            $.proxy((a: A, b: B, c: C, d: D, e: E, f: F, g: G, t: J1, u: J2, v: J3) => { }, {}, a, b, c, d, e, f, g);
-
-            // $ExpectType (this: {}, t: J1, u: J2, v: J3) => void
-            $.proxy((a: A, b: B, c: C, d: D, e: E, f: F, t: J1, u: J2, v: J3) => { }, {}, a, b, c, d, e, f);
-
-            // $ExpectType (this: {}, t: J1, u: J2, v: J3) => void
-            $.proxy((a: A, b: B, c: C, d: D, e: E, t: J1, u: J2, v: J3) => { }, {}, a, b, c, d, e);
-
-            // $ExpectType (this: {}, t: J1, u: J2, v: J3) => void
-            $.proxy((a: A, b: B, c: C, d: D, t: J1, u: J2, v: J3) => { }, {}, a, b, c, d);
-
-            // $ExpectType (this: {}, t: J1, u: J2, v: J3) => void
-            $.proxy((a: A, b: B, c: C, t: J1, u: J2, v: J3) => { }, {}, a, b, c);
-
-            // $ExpectType (this: {}, t: J1, u: J2, v: J3) => void
-            $.proxy((a: A, b: B, t: J1, u: J2, v: J3) => { }, {}, a, b);
-
-            // $ExpectType (this: {}, t: J1, u: J2, v: J3) => void
-            $.proxy((a: A, t: J1, u: J2, v: J3) => { }, {}, a);
-
-            // $ExpectType (this: {}, t: J1, u: J2, v: J3) => void
-            $.proxy((t: J1, u: J2, v: J3) => { }, {});
-
-            // $ExpectType (this: {}, t: J1, u: J2, v: J3, w: J4) => void
-            $.proxy((a: A, b: B, c: C, d: D, e: E, f: F, g: G, t: J1, u: J2, v: J3, w: J4) => { }, {}, a, b, c, d, e, f, g);
-
-            // $ExpectType (this: {}, t: J1, u: J2, v: J3, w: J4) => void
-            $.proxy((a: A, b: B, c: C, d: D, e: E, f: F, t: J1, u: J2, v: J3, w: J4) => { }, {}, a, b, c, d, e, f);
-
-            // $ExpectType (this: {}, t: J1, u: J2, v: J3, w: J4) => void
-            $.proxy((a: A, b: B, c: C, d: D, e: E, t: J1, u: J2, v: J3, w: J4) => { }, {}, a, b, c, d, e);
-
-            // $ExpectType (this: {}, t: J1, u: J2, v: J3, w: J4) => void
-            $.proxy((a: A, b: B, c: C, d: D, t: J1, u: J2, v: J3, w: J4) => { }, {}, a, b, c, d);
-
-            // $ExpectType (this: {}, t: J1, u: J2, v: J3, w: J4) => void
-            $.proxy((a: A, b: B, c: C, t: J1, u: J2, v: J3, w: J4) => { }, {}, a, b, c);
-
-            // $ExpectType (this: {}, t: J1, u: J2, v: J3, w: J4) => void
-            $.proxy((a: A, b: B, t: J1, u: J2, v: J3, w: J4) => { }, {}, a, b);
-
-            // $ExpectType (this: {}, t: J1, u: J2, v: J3, w: J4) => void
-            $.proxy((a: A, t: J1, u: J2, v: J3, w: J4) => { }, {}, a);
-
-            // $ExpectType (this: {}, t: J1, u: J2, v: J3, w: J4) => void
-            $.proxy((t: J1, u: J2, v: J3, w: J4) => { }, {});
-
-            // $ExpectType (this: {}, t: J1, u: J2, v: J3, w: J4, x: J5) => void
-            $.proxy((a: A, b: B, c: C, d: D, e: E, f: F, g: G, t: J1, u: J2, v: J3, w: J4, x: J5) => { }, {}, a, b, c, d, e, f, g);
-
-            // $ExpectType (this: {}, t: J1, u: J2, v: J3, w: J4, x: J5) => void
-            $.proxy((a: A, b: B, c: C, d: D, e: E, f: F, t: J1, u: J2, v: J3, w: J4, x: J5) => { }, {}, a, b, c, d, e, f);
-
-            // $ExpectType (this: {}, t: J1, u: J2, v: J3, w: J4, x: J5) => void
-            $.proxy((a: A, b: B, c: C, d: D, e: E, t: J1, u: J2, v: J3, w: J4, x: J5) => { }, {}, a, b, c, d, e);
-
-            // $ExpectType (this: {}, t: J1, u: J2, v: J3, w: J4, x: J5) => void
-            $.proxy((a: A, b: B, c: C, d: D, t: J1, u: J2, v: J3, w: J4, x: J5) => { }, {}, a, b, c, d);
-
-            // $ExpectType (this: {}, t: J1, u: J2, v: J3, w: J4, x: J5) => void
-            $.proxy((a: A, b: B, c: C, t: J1, u: J2, v: J3, w: J4, x: J5) => { }, {}, a, b, c);
-
-            // $ExpectType (this: {}, t: J1, u: J2, v: J3, w: J4, x: J5) => void
-            $.proxy((a: A, b: B, t: J1, u: J2, v: J3, w: J4, x: J5) => { }, {}, a, b);
-
-            // $ExpectType (this: {}, t: J1, u: J2, v: J3, w: J4, x: J5) => void
-            $.proxy((a: A, t: J1, u: J2, v: J3, w: J4, x: J5) => { }, {}, a);
-
-            // $ExpectType (this: {}, t: J1, u: J2, v: J3, w: J4, x: J5) => void
-            $.proxy((t: J1, u: J2, v: J3, w: J4, x: J5) => { }, {});
-
-            // $ExpectType (this: {}, t: J1, u: J2, v: J3, w: J4, x: J5, y: J6) => void
-            $.proxy((a: A, b: B, c: C, d: D, e: E, f: F, g: G, t: J1, u: J2, v: J3, w: J4, x: J5, y: J6) => { }, {}, a, b, c, d, e, f, g);
-
-            // $ExpectType (this: {}, t: J1, u: J2, v: J3, w: J4, x: J5, y: J6) => void
-            $.proxy((a: A, b: B, c: C, d: D, e: E, f: F, t: J1, u: J2, v: J3, w: J4, x: J5, y: J6) => { }, {}, a, b, c, d, e, f);
-
-            // $ExpectType (this: {}, t: J1, u: J2, v: J3, w: J4, x: J5, y: J6) => void
-            $.proxy((a: A, b: B, c: C, d: D, e: E, t: J1, u: J2, v: J3, w: J4, x: J5, y: J6) => { }, {}, a, b, c, d, e);
-
-            // $ExpectType (this: {}, t: J1, u: J2, v: J3, w: J4, x: J5, y: J6) => void
-            $.proxy((a: A, b: B, c: C, d: D, t: J1, u: J2, v: J3, w: J4, x: J5, y: J6) => { }, {}, a, b, c, d);
-
-            // $ExpectType (this: {}, t: J1, u: J2, v: J3, w: J4, x: J5, y: J6) => void
-            $.proxy((a: A, b: B, c: C, t: J1, u: J2, v: J3, w: J4, x: J5, y: J6) => { }, {}, a, b, c);
-
-            // $ExpectType (this: {}, t: J1, u: J2, v: J3, w: J4, x: J5, y: J6) => void
-            $.proxy((a: A, b: B, t: J1, u: J2, v: J3, w: J4, x: J5, y: J6) => { }, {}, a, b);
-
-            // $ExpectType (this: {}, t: J1, u: J2, v: J3, w: J4, x: J5, y: J6) => void
-            $.proxy((a: A, t: J1, u: J2, v: J3, w: J4, x: J5, y: J6) => { }, {}, a);
-
-            // $ExpectType (this: {}, t: J1, u: J2, v: J3, w: J4, x: J5, y: J6) => void
-            $.proxy((t: J1, u: J2, v: J3, w: J4, x: J5, y: J6) => { }, {});
-
-            // $ExpectType (this: {}, t: J1, u: J2, v: J3, w: J4, x: J5, y: J6, z: J7, ...args: any[]) => void
-            $.proxy((a: A, b: B, c: C, d: D, e: E, f: F, g: G, t: J1, u: J2, v: J3, w: J4, x: J5, y: J6, z: J7) => { }, {}, a, b, c, d, e, f, g);
-
-            // $ExpectType (this: {}, t: J1, u: J2, v: J3, w: J4, x: J5, y: J6, z: J7, ...args: any[]) => void
-            $.proxy((a: A, b: B, c: C, d: D, e: E, f: F, t: J1, u: J2, v: J3, w: J4, x: J5, y: J6, z: J7) => { }, {}, a, b, c, d, e, f);
-
-            // $ExpectType (this: {}, t: J1, u: J2, v: J3, w: J4, x: J5, y: J6, z: J7, ...args: any[]) => void
-            $.proxy((a: A, b: B, c: C, d: D, e: E, t: J1, u: J2, v: J3, w: J4, x: J5, y: J6, z: J7) => { }, {}, a, b, c, d, e);
-
-            // $ExpectType (this: {}, t: J1, u: J2, v: J3, w: J4, x: J5, y: J6, z: J7, ...args: any[]) => void
-            $.proxy((a: A, b: B, c: C, d: D, t: J1, u: J2, v: J3, w: J4, x: J5, y: J6, z: J7) => { }, {}, a, b, c, d);
-
-            // $ExpectType (this: {}, t: J1, u: J2, v: J3, w: J4, x: J5, y: J6, z: J7, ...args: any[]) => void
-            $.proxy((a: A, b: B, c: C, t: J1, u: J2, v: J3, w: J4, x: J5, y: J6, z: J7) => { }, {}, a, b, c);
-
-            // $ExpectType (this: {}, t: J1, u: J2, v: J3, w: J4, x: J5, y: J6, z: J7, ...args: any[]) => void
-            $.proxy((a: A, b: B, t: J1, u: J2, v: J3, w: J4, x: J5, y: J6, z: J7) => { }, {}, a, b);
-
-            // $ExpectType (this: {}, t: J1, u: J2, v: J3, w: J4, x: J5, y: J6, z: J7, ...args: any[]) => void
-            $.proxy((a: A, t: J1, u: J2, v: J3, w: J4, x: J5, y: J6, z: J7) => { }, {}, a);
-
-            // $ExpectType (this: {}, t: J1, u: J2, v: J3, w: J4, x: J5, y: J6, z: J7, ...args: any[]) => void
-            $.proxy((t: J1, u: J2, v: J3, w: J4, x: J5, y: J6, z: J7) => { }, {});
-
-            // $ExpectType (this: {}, t: J1, u: J2, v: J3, w: J4, x: J5, y: J6, z: J7, ...args: any[]) => void
-            $.proxy((a: A, b: B, c: C, d: D, e: E, f: F, g: G, t: J1, u: J2, v: J3, w: J4, x: J5, y: J6, z: J7, _: J8) => { }, {}, a, b, c, d, e, f, g);
-
-            // $ExpectType (this: {}, t: J1, u: J2, v: J3, w: J4, x: J5, y: J6, z: J7, ...args: any[]) => void
-            $.proxy((a: A, b: B, c: C, d: D, e: E, f: F, t: J1, u: J2, v: J3, w: J4, x: J5, y: J6, z: J7, _: J8) => { }, {}, a, b, c, d, e, f);
-
-            // $ExpectType (this: {}, t: J1, u: J2, v: J3, w: J4, x: J5, y: J6, z: J7, ...args: any[]) => void
-            $.proxy((a: A, b: B, c: C, d: D, e: E, t: J1, u: J2, v: J3, w: J4, x: J5, y: J6, z: J7, _: J8) => { }, {}, a, b, c, d, e);
-
-            // $ExpectType (this: {}, t: J1, u: J2, v: J3, w: J4, x: J5, y: J6, z: J7, ...args: any[]) => void
-            $.proxy((a: A, b: B, c: C, d: D, t: J1, u: J2, v: J3, w: J4, x: J5, y: J6, z: J7, _: J8) => { }, {}, a, b, c, d);
-
-            // $ExpectType (this: {}, t: J1, u: J2, v: J3, w: J4, x: J5, y: J6, z: J7, ...args: any[]) => void
-            $.proxy((a: A, b: B, c: C, t: J1, u: J2, v: J3, w: J4, x: J5, y: J6, z: J7, _: J8) => { }, {}, a, b, c);
-
-            // $ExpectType (this: {}, t: J1, u: J2, v: J3, w: J4, x: J5, y: J6, z: J7, ...args: any[]) => void
-            $.proxy((a: A, b: B, t: J1, u: J2, v: J3, w: J4, x: J5, y: J6, z: J7, _: J8) => { }, {}, a, b);
-
-            // $ExpectType (this: {}, t: J1, u: J2, v: J3, w: J4, x: J5, y: J6, z: J7, ...args: any[]) => void
-            $.proxy((a: A, t: J1, u: J2, v: J3, w: J4, x: J5, y: J6, z: J7, _: J8) => { }, {}, a);
-
-            // $ExpectType (this: {}, t: J1, u: J2, v: J3, w: J4, x: J5, y: J6, z: J7, ...args: any[]) => void
-            $.proxy((t: J1, u: J2, v: J3, w: J4, x: J5, y: J6, z: J7, _: J8) => { }, {});
-
-            // $ExpectType (this: {}, ...args: any[]) => void
-            $.proxy((a, b, c, d, e, f, g, h, t: J1, u: J2, v: J3, w: J4, x: J5, y: J6, z: J7, _: J8) => { }, {}, a, b, c, d, e, f, g, h);
+            // $ExpectType () => void
+            $.proxy(function(a, b, c, d, e, f, g) {
+                // $ExpectType JContext
+                this;
+            }, context, a, b, c, d, e, f, g);
+
+            // $ExpectType () => void
+            $.proxy(function(a, b, c, d, e, f) {
+                // $ExpectType JContext
+                this;
+            }, context, a, b, c, d, e, f);
+
+            // $ExpectType () => void
+            $.proxy(function(a, b, c, d, e) {
+                // $ExpectType JContext
+                this;
+            }, context, a, b, c, d, e);
+
+            // $ExpectType () => void
+            $.proxy(function(a, b, c, d) {
+                // $ExpectType JContext
+                this;
+            }, context, a, b, c, d);
+
+            // $ExpectType () => void
+            $.proxy(function(a, b, c) {
+                // $ExpectType JContext
+                this;
+            }, context, a, b, c);
+
+            // $ExpectType () => void
+            $.proxy(function(a, b) {
+                // $ExpectType JContext
+                this;
+            }, context, a, b);
+
+            // $ExpectType () => void
+            $.proxy(function(a) {
+                // $ExpectType JContext
+                this;
+            }, context, a);
+
+            // $ExpectType () => void
+            $.proxy(function() {
+                // $ExpectType JContext
+                this;
+            }, context);
+
+            // $ExpectType (t: J1) => void
+            $.proxy(function(a: A, b: B, c: C, d: D, e: E, f: F, g: G, t: J1) {
+                // $ExpectType JContext
+                this;
+            }, context, a, b, c, d, e, f, g);
+
+            // $ExpectType (t: J1) => void
+            $.proxy(function(a: A, b: B, c: C, d: D, e: E, f: F, t: J1) {
+                // $ExpectType JContext
+                this;
+            }, context, a, b, c, d, e, f);
+
+            // $ExpectType (t: J1) => void
+            $.proxy(function(a: A, b: B, c: C, d: D, e: E, t: J1) {
+                // $ExpectType JContext
+                this;
+            }, context, a, b, c, d, e);
+
+            // $ExpectType (t: J1) => void
+            $.proxy(function(a: A, b: B, c: C, d: D, t: J1) {
+                // $ExpectType JContext
+                this;
+            }, context, a, b, c, d);
+
+            // $ExpectType (t: J1) => void
+            $.proxy(function(a: A, b: B, c: C, t: J1) {
+                // $ExpectType JContext
+                this;
+            }, context, a, b, c);
+
+            // $ExpectType (t: J1) => void
+            $.proxy(function(a: A, b: B, t: J1) {
+                // $ExpectType JContext
+                this;
+            }, context, a, b);
+
+            // $ExpectType (t: J1) => void
+            $.proxy(function(a: A, t: J1) {
+                // $ExpectType JContext
+                this;
+            }, context, a);
+
+            // $ExpectType (t: J1) => void
+            $.proxy(function(t: J1) {
+                // $ExpectType JContext
+                this;
+            }, context);
+
+            // $ExpectType (t: J1, u: J2) => void
+            $.proxy(function(a: A, b: B, c: C, d: D, e: E, f: F, g: G, t: J1, u: J2) {
+                // $ExpectType JContext
+                this;
+            }, context, a, b, c, d, e, f, g);
+
+            // $ExpectType (t: J1, u: J2) => void
+            $.proxy(function(a: A, b: B, c: C, d: D, e: E, f: F, t: J1, u: J2) {
+                // $ExpectType JContext
+                this;
+            }, context, a, b, c, d, e, f);
+
+            // $ExpectType (t: J1, u: J2) => void
+            $.proxy(function(a: A, b: B, c: C, d: D, e: E, t: J1, u: J2) {
+                // $ExpectType JContext
+                this;
+            }, context, a, b, c, d, e);
+
+            // $ExpectType (t: J1, u: J2) => void
+            $.proxy(function(a: A, b: B, c: C, d: D, t: J1, u: J2) {
+                // $ExpectType JContext
+                this;
+            }, context, a, b, c, d);
+
+            // $ExpectType (t: J1, u: J2) => void
+            $.proxy(function(a: A, b: B, c: C, t: J1, u: J2) {
+                // $ExpectType JContext
+                this;
+            }, context, a, b, c);
+
+            // $ExpectType (t: J1, u: J2) => void
+            $.proxy(function(a: A, b: B, t: J1, u: J2) {
+                // $ExpectType JContext
+                this;
+            }, context, a, b);
+
+            // $ExpectType (t: J1, u: J2) => void
+            $.proxy(function(a: A, t: J1, u: J2) {
+                // $ExpectType JContext
+                this;
+            }, context, a);
+
+            // $ExpectType (t: J1, u: J2) => void
+            $.proxy(function(t: J1, u: J2) {
+                // $ExpectType JContext
+                this;
+            }, context);
+
+            // $ExpectType (t: J1, u: J2, v: J3) => void
+            $.proxy(function(a: A, b: B, c: C, d: D, e: E, f: F, g: G, t: J1, u: J2, v: J3) {
+                // $ExpectType JContext
+                this;
+            }, context, a, b, c, d, e, f, g);
+
+            // $ExpectType (t: J1, u: J2, v: J3) => void
+            $.proxy(function(a: A, b: B, c: C, d: D, e: E, f: F, t: J1, u: J2, v: J3) {
+                // $ExpectType JContext
+                this;
+            }, context, a, b, c, d, e, f);
+
+            // $ExpectType (t: J1, u: J2, v: J3) => void
+            $.proxy(function(a: A, b: B, c: C, d: D, e: E, t: J1, u: J2, v: J3) {
+                // $ExpectType JContext
+                this;
+            }, context, a, b, c, d, e);
+
+            // $ExpectType (t: J1, u: J2, v: J3) => void
+            $.proxy(function(a: A, b: B, c: C, d: D, t: J1, u: J2, v: J3) {
+                // $ExpectType JContext
+                this;
+            }, context, a, b, c, d);
+
+            // $ExpectType (t: J1, u: J2, v: J3) => void
+            $.proxy(function(a: A, b: B, c: C, t: J1, u: J2, v: J3) {
+                // $ExpectType JContext
+                this;
+            }, context, a, b, c);
+
+            // $ExpectType (t: J1, u: J2, v: J3) => void
+            $.proxy(function(a: A, b: B, t: J1, u: J2, v: J3) {
+                // $ExpectType JContext
+                this;
+            }, context, a, b);
+
+            // $ExpectType (t: J1, u: J2, v: J3) => void
+            $.proxy(function(a: A, t: J1, u: J2, v: J3) {
+                // $ExpectType JContext
+                this;
+            }, context, a);
+
+            // $ExpectType (t: J1, u: J2, v: J3) => void
+            $.proxy(function(t: J1, u: J2, v: J3) {
+                // $ExpectType JContext
+                this;
+            }, context);
+
+            // $ExpectType (t: J1, u: J2, v: J3, w: J4) => void
+            $.proxy(function(a: A, b: B, c: C, d: D, e: E, f: F, g: G, t: J1, u: J2, v: J3, w: J4) {
+                // $ExpectType JContext
+                this;
+            }, context, a, b, c, d, e, f, g);
+
+            // $ExpectType (t: J1, u: J2, v: J3, w: J4) => void
+            $.proxy(function(a: A, b: B, c: C, d: D, e: E, f: F, t: J1, u: J2, v: J3, w: J4) {
+                // $ExpectType JContext
+                this;
+            }, context, a, b, c, d, e, f);
+
+            // $ExpectType (t: J1, u: J2, v: J3, w: J4) => void
+            $.proxy(function(a: A, b: B, c: C, d: D, e: E, t: J1, u: J2, v: J3, w: J4) {
+                // $ExpectType JContext
+                this;
+            }, context, a, b, c, d, e);
+
+            // $ExpectType (t: J1, u: J2, v: J3, w: J4) => void
+            $.proxy(function(a: A, b: B, c: C, d: D, t: J1, u: J2, v: J3, w: J4) {
+                // $ExpectType JContext
+                this;
+            }, context, a, b, c, d);
+
+            // $ExpectType (t: J1, u: J2, v: J3, w: J4) => void
+            $.proxy(function(a: A, b: B, c: C, t: J1, u: J2, v: J3, w: J4) {
+                // $ExpectType JContext
+                this;
+            }, context, a, b, c);
+
+            // $ExpectType (t: J1, u: J2, v: J3, w: J4) => void
+            $.proxy(function(a: A, b: B, t: J1, u: J2, v: J3, w: J4) {
+                // $ExpectType JContext
+                this;
+            }, context, a, b);
+
+            // $ExpectType (t: J1, u: J2, v: J3, w: J4) => void
+            $.proxy(function(a: A, t: J1, u: J2, v: J3, w: J4) {
+                // $ExpectType JContext
+                this;
+            }, context, a);
+
+            // $ExpectType (t: J1, u: J2, v: J3, w: J4) => void
+            $.proxy(function(t: J1, u: J2, v: J3, w: J4) {
+                // $ExpectType JContext
+                this;
+            }, context);
+
+            // $ExpectType (t: J1, u: J2, v: J3, w: J4, x: J5) => void
+            $.proxy(function(a: A, b: B, c: C, d: D, e: E, f: F, g: G, t: J1, u: J2, v: J3, w: J4, x: J5) {
+                // $ExpectType JContext
+                this;
+            }, context, a, b, c, d, e, f, g);
+
+            // $ExpectType (t: J1, u: J2, v: J3, w: J4, x: J5) => void
+            $.proxy(function(a: A, b: B, c: C, d: D, e: E, f: F, t: J1, u: J2, v: J3, w: J4, x: J5) {
+                // $ExpectType JContext
+                this;
+            }, context, a, b, c, d, e, f);
+
+            // $ExpectType (t: J1, u: J2, v: J3, w: J4, x: J5) => void
+            $.proxy(function(a: A, b: B, c: C, d: D, e: E, t: J1, u: J2, v: J3, w: J4, x: J5) {
+                // $ExpectType JContext
+                this;
+            }, context, a, b, c, d, e);
+
+            // $ExpectType (t: J1, u: J2, v: J3, w: J4, x: J5) => void
+            $.proxy(function(a: A, b: B, c: C, d: D, t: J1, u: J2, v: J3, w: J4, x: J5) {
+                // $ExpectType JContext
+                this;
+            }, context, a, b, c, d);
+
+            // $ExpectType (t: J1, u: J2, v: J3, w: J4, x: J5) => void
+            $.proxy(function(a: A, b: B, c: C, t: J1, u: J2, v: J3, w: J4, x: J5) {
+                // $ExpectType JContext
+                this;
+            }, context, a, b, c);
+
+            // $ExpectType (t: J1, u: J2, v: J3, w: J4, x: J5) => void
+            $.proxy(function(a: A, b: B, t: J1, u: J2, v: J3, w: J4, x: J5) {
+                // $ExpectType JContext
+                this;
+            }, context, a, b);
+
+            // $ExpectType (t: J1, u: J2, v: J3, w: J4, x: J5) => void
+            $.proxy(function(a: A, t: J1, u: J2, v: J3, w: J4, x: J5) {
+                // $ExpectType JContext
+                this;
+            }, context, a);
+
+            // $ExpectType (t: J1, u: J2, v: J3, w: J4, x: J5) => void
+            $.proxy(function(t: J1, u: J2, v: J3, w: J4, x: J5) {
+                // $ExpectType JContext
+                this;
+            }, context);
+
+            // $ExpectType (t: J1, u: J2, v: J3, w: J4, x: J5, y: J6) => void
+            $.proxy(function(a: A, b: B, c: C, d: D, e: E, f: F, g: G, t: J1, u: J2, v: J3, w: J4, x: J5, y: J6) {
+                // $ExpectType JContext
+                this;
+            }, context, a, b, c, d, e, f, g);
+
+            // $ExpectType (t: J1, u: J2, v: J3, w: J4, x: J5, y: J6) => void
+            $.proxy(function(a: A, b: B, c: C, d: D, e: E, f: F, t: J1, u: J2, v: J3, w: J4, x: J5, y: J6) {
+                // $ExpectType JContext
+                this;
+            }, context, a, b, c, d, e, f);
+
+            // $ExpectType (t: J1, u: J2, v: J3, w: J4, x: J5, y: J6) => void
+            $.proxy(function(a: A, b: B, c: C, d: D, e: E, t: J1, u: J2, v: J3, w: J4, x: J5, y: J6) {
+                // $ExpectType JContext
+                this;
+            }, context, a, b, c, d, e);
+
+            // $ExpectType (t: J1, u: J2, v: J3, w: J4, x: J5, y: J6) => void
+            $.proxy(function(a: A, b: B, c: C, d: D, t: J1, u: J2, v: J3, w: J4, x: J5, y: J6) {
+                // $ExpectType JContext
+                this;
+            }, context, a, b, c, d);
+
+            // $ExpectType (t: J1, u: J2, v: J3, w: J4, x: J5, y: J6) => void
+            $.proxy(function(a: A, b: B, c: C, t: J1, u: J2, v: J3, w: J4, x: J5, y: J6) {
+                // $ExpectType JContext
+                this;
+            }, context, a, b, c);
+
+            // $ExpectType (t: J1, u: J2, v: J3, w: J4, x: J5, y: J6) => void
+            $.proxy(function(a: A, b: B, t: J1, u: J2, v: J3, w: J4, x: J5, y: J6) {
+                // $ExpectType JContext
+                this;
+            }, context, a, b);
+
+            // $ExpectType (t: J1, u: J2, v: J3, w: J4, x: J5, y: J6) => void
+            $.proxy(function(a: A, t: J1, u: J2, v: J3, w: J4, x: J5, y: J6) {
+                // $ExpectType JContext
+                this;
+            }, context, a);
+
+            // $ExpectType (t: J1, u: J2, v: J3, w: J4, x: J5, y: J6) => void
+            $.proxy(function(t: J1, u: J2, v: J3, w: J4, x: J5, y: J6) {
+                // $ExpectType JContext
+                this;
+            }, context);
+
+            // $ExpectType (t: J1, u: J2, v: J3, w: J4, x: J5, y: J6, z: J7, ...args: any[]) => void
+            $.proxy(function(a: A, b: B, c: C, d: D, e: E, f: F, g: G, t: J1, u: J2, v: J3, w: J4, x: J5, y: J6, z: J7) {
+                // $ExpectType JContext
+                this;
+            }, context, a, b, c, d, e, f, g);
+
+            // $ExpectType (t: J1, u: J2, v: J3, w: J4, x: J5, y: J6, z: J7, ...args: any[]) => void
+            $.proxy(function(a: A, b: B, c: C, d: D, e: E, f: F, t: J1, u: J2, v: J3, w: J4, x: J5, y: J6, z: J7) {
+                // $ExpectType JContext
+                this;
+            }, context, a, b, c, d, e, f);
+
+            // $ExpectType (t: J1, u: J2, v: J3, w: J4, x: J5, y: J6, z: J7, ...args: any[]) => void
+            $.proxy(function(a: A, b: B, c: C, d: D, e: E, t: J1, u: J2, v: J3, w: J4, x: J5, y: J6, z: J7) {
+                // $ExpectType JContext
+                this;
+            }, context, a, b, c, d, e);
+
+            // $ExpectType (t: J1, u: J2, v: J3, w: J4, x: J5, y: J6, z: J7, ...args: any[]) => void
+            $.proxy(function(a: A, b: B, c: C, d: D, t: J1, u: J2, v: J3, w: J4, x: J5, y: J6, z: J7) {
+                // $ExpectType JContext
+                this;
+            }, context, a, b, c, d);
+
+            // $ExpectType (t: J1, u: J2, v: J3, w: J4, x: J5, y: J6, z: J7, ...args: any[]) => void
+            $.proxy(function(a: A, b: B, c: C, t: J1, u: J2, v: J3, w: J4, x: J5, y: J6, z: J7) {
+                // $ExpectType JContext
+                this;
+            }, context, a, b, c);
+
+            // $ExpectType (t: J1, u: J2, v: J3, w: J4, x: J5, y: J6, z: J7, ...args: any[]) => void
+            $.proxy(function(a: A, b: B, t: J1, u: J2, v: J3, w: J4, x: J5, y: J6, z: J7) {
+                // $ExpectType JContext
+                this;
+            }, context, a, b);
+
+            // $ExpectType (t: J1, u: J2, v: J3, w: J4, x: J5, y: J6, z: J7, ...args: any[]) => void
+            $.proxy(function(a: A, t: J1, u: J2, v: J3, w: J4, x: J5, y: J6, z: J7) {
+                // $ExpectType JContext
+                this;
+            }, context, a);
+
+            // $ExpectType (t: J1, u: J2, v: J3, w: J4, x: J5, y: J6, z: J7, ...args: any[]) => void
+            $.proxy(function(t: J1, u: J2, v: J3, w: J4, x: J5, y: J6, z: J7) {
+                // $ExpectType JContext
+                this;
+            }, context);
+
+            // $ExpectType (t: J1, u: J2, v: J3, w: J4, x: J5, y: J6, z: J7, ...args: any[]) => void
+            $.proxy(function(a: A, b: B, c: C, d: D, e: E, f: F, g: G, t: J1, u: J2, v: J3, w: J4, x: J5, y: J6, z: J7, _: J8) {
+                // $ExpectType JContext
+                this;
+            }, context, a, b, c, d, e, f, g);
+
+            // $ExpectType (t: J1, u: J2, v: J3, w: J4, x: J5, y: J6, z: J7, ...args: any[]) => void
+            $.proxy(function(a: A, b: B, c: C, d: D, e: E, f: F, t: J1, u: J2, v: J3, w: J4, x: J5, y: J6, z: J7, _: J8) {
+                // $ExpectType JContext
+                this;
+            }, context, a, b, c, d, e, f);
+
+            // $ExpectType (t: J1, u: J2, v: J3, w: J4, x: J5, y: J6, z: J7, ...args: any[]) => void
+            $.proxy(function(a: A, b: B, c: C, d: D, e: E, t: J1, u: J2, v: J3, w: J4, x: J5, y: J6, z: J7, _: J8) {
+                // $ExpectType JContext
+                this;
+            }, context, a, b, c, d, e);
+
+            // $ExpectType (t: J1, u: J2, v: J3, w: J4, x: J5, y: J6, z: J7, ...args: any[]) => void
+            $.proxy(function(a: A, b: B, c: C, d: D, t: J1, u: J2, v: J3, w: J4, x: J5, y: J6, z: J7, _: J8) {
+                // $ExpectType JContext
+                this;
+            }, context, a, b, c, d);
+
+            // $ExpectType (t: J1, u: J2, v: J3, w: J4, x: J5, y: J6, z: J7, ...args: any[]) => void
+            $.proxy(function(a: A, b: B, c: C, t: J1, u: J2, v: J3, w: J4, x: J5, y: J6, z: J7, _: J8) {
+                // $ExpectType JContext
+                this;
+            }, context, a, b, c);
+
+            // $ExpectType (t: J1, u: J2, v: J3, w: J4, x: J5, y: J6, z: J7, ...args: any[]) => void
+            $.proxy(function(a: A, b: B, t: J1, u: J2, v: J3, w: J4, x: J5, y: J6, z: J7, _: J8) {
+                // $ExpectType JContext
+                this;
+            }, context, a, b);
+
+            // $ExpectType (t: J1, u: J2, v: J3, w: J4, x: J5, y: J6, z: J7, ...args: any[]) => void
+            $.proxy(function(a: A, t: J1, u: J2, v: J3, w: J4, x: J5, y: J6, z: J7, _: J8) {
+                // $ExpectType JContext
+                this;
+            }, context, a);
+
+            // $ExpectType (t: J1, u: J2, v: J3, w: J4, x: J5, y: J6, z: J7, ...args: any[]) => void
+            $.proxy(function(t: J1, u: J2, v: J3, w: J4, x: J5, y: J6, z: J7, _: J8) {
+                // $ExpectType JContext
+                this;
+            }, context);
+
+            // $ExpectType (...args: any[]) => void
+            $.proxy(function(a, b, c, d, e, f, g, h, t: J1, u: J2, v: J3, w: J4, x: J5, y: J6, z: J7, _: J8) {
+                // $ExpectType JContext
+                this;
+            }, context, a, b, c, d, e, f, g, h);
         }
 
-        // $ExpectType (this: { myFunc: () => undefined; }, ...args: any[]) => any
+        // $ExpectType (...args: any[]) => any
         $.proxy({ myFunc: $.noop }, 'myFunc', 1, 2);
 
-        // $ExpectType (this: { myFunc: () => undefined; }, ...args: any[]) => any
+        // $ExpectType (...args: any[]) => any
         $.proxy({ myFunc: $.noop }, 'myFunc');
     }
 

--- a/types/jquery/jquery-tests.ts
+++ b/types/jquery/jquery-tests.ts
@@ -1060,7 +1060,7 @@ function JQueryStatic() {
         type G = typeof g;
         type H = typeof h;
 
-        // (fn, null)
+        // (funсtion, null)
         {
             // $ExpectType () => void
             $.proxy((a, b, c, d, e, f, g) => { }, null, a, b, c, d, e, f, g);
@@ -1282,7 +1282,7 @@ function JQueryStatic() {
             $.proxy((a, b, c, d, e, f, g, h, t: J1, u: J2, v: J3, w: J4, x: J5, y: J6, z: J7, _: J8) => { }, null, a, b, c, d, e, f, g, h);
         }
 
-        // (fn, undefined)
+        // (funсtion, undefined)
         {
             // $ExpectType () => void
             $.proxy((a, b, c, d, e, f, g) => { }, undefined, a, b, c, d, e, f, g);
@@ -1504,7 +1504,7 @@ function JQueryStatic() {
             $.proxy((a, b, c, d, e, f, g, h, t: J1, u: J2, v: J3, w: J4, x: J5, y: J6, z: J7, _: J8) => { }, undefined, a, b, c, d, e, f, g, h);
         }
 
-        // (fn, context)
+        // (funсtion, context)
         {
             // $ExpectType (this: {}) => void
             $.proxy((a, b, c, d, e, f, g) => { }, {}, a, b, c, d, e, f, g);


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
https://api.jquery.com/jQuery.proxy/
- ~~Increase the version number in the header if appropriate.~~
- ~~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.~~

---

#### Summary of changes

##### Fix `TContext` declaration of `jQuery.proxy` on wrong value's type and drop constraint from `TContext`. (7f9250d / b68c55b)

Removes `this: TContext` declaration from output function and adds it to the input function.

Declaring `this` as `TContext` on the input function ensures that it can handle having its context changed to `TContext`. Declaring `this` on the output function is not important because the function will already be defined. It can also get in the way when passing a callback to a function whose callback parameter has `this` declared.

The constraint on `TContext` has been dropped as it's not really necessary and it is possible to pass primitives as the context.

##### Documentation improvements for `jQuery.proxy`. (eac0b5c / e42803c)