### PR TITLE
Added definitions for crpc

### DIFF
--- a/types/crpc/crpc-tests.ts
+++ b/types/crpc/crpc-tests.ts
@@ -1,0 +1,3 @@
+import crpc from 'crpc';
+
+const client = crpc('https://example.com/');

--- a/types/crpc/index.d.ts
+++ b/types/crpc/index.d.ts
@@ -1,0 +1,9 @@
+// Type definitions for crpc 0.2
+// Project: https://github.com/billinghamj/crpc
+// Definitions by: Alexander Forbes-Reed <https://github.com/0xdeafcafe>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.9
+
+export type Client = <TReq, TRes>(path: string, body: TReq, options?: {} | null) => Promise<TRes>;
+
+export default function crpc(baseUrl: string, options?: {}): Client;

--- a/types/crpc/index.d.ts
+++ b/types/crpc/index.d.ts
@@ -4,6 +4,6 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.9
 
-export type Client = <TReq, TRes>(path: string, body: TReq, options?: {} | null) => Promise<TRes>;
+export type Client = <TRes>(path: string, body: any, options?: {} | null) => Promise<TRes>;
 
 export default function crpc(baseUrl: string, options?: {}): Client;

--- a/types/crpc/tsconfig.json
+++ b/types/crpc/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/crpc/tsconfig.json
+++ b/types/crpc/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": [
             "es6"
         ],
+        "esModuleInterop": true,
         "noImplicitAny": true,
         "noImplicitThis": true,
         "strictFunctionTypes": true,

--- a/types/crpc/tsconfig.json
+++ b/types/crpc/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "crpc-tests.ts"
+    ]
+}

--- a/types/crpc/tslint.json
+++ b/types/crpc/tslint.json
@@ -1,0 +1,6 @@
+{
+	"extends": "dtslint/dt.json",
+	"rules": {
+		"no-unnecessary-generics": false
+	}
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

The `no-unnecessary-generics` rule was thrown, however the generic is sort of needed in this function, so I updated the lint file to ignore it. Is this allowed?