### PR TITLE
Add typings for node-gamepad

### DIFF
--- a/types/node-gamepad/index.d.ts
+++ b/types/node-gamepad/index.d.ts
@@ -1,0 +1,33 @@
+// Type definitions for node-gamepad 1.5
+// Project: https://github.com/creationix/node-gamepad#readme
+// Definitions by: Alex Van Camp <https://github.com/Lange>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.4
+
+import { EventEmitter } from 'events';
+
+declare const nodeGamepad: NodeGamepad;
+export = nodeGamepad;
+
+interface NodeGamepad extends EventEmitter {
+    init(): void;
+    shutdown(): void;
+    numDevices(): number;
+    deviceAtIndex(deviceIndex: number): GamepadInstance;
+    detectDevices(): void;
+    processEvents(): void;
+
+    on(event: 'attach', listener: (deviceID: number, device: GamepadInstance) => void): this;
+    on(event: 'remove', listener: (deviceID: number) => void): this;
+    on(event: 'down' | 'up', listener: (deviceID: number, buttonID: number, timestamp: number) => void): this;
+    on(event: 'move', listener: (deviceID: number, axisID: number, value: number, lastValue: number, timestamp: number) => void): this;
+}
+
+interface GamepadInstance {
+    deviceID: number;
+    description: string;
+    vendorID: number;
+    productID: number;
+    axisStates: number[];
+    buttonStates: boolean[];
+}

--- a/types/node-gamepad/node-gamepad-tests.ts
+++ b/types/node-gamepad/node-gamepad-tests.ts
@@ -1,0 +1,69 @@
+/// <reference types="node" />
+import gamepad = require('node-gamepad');
+
+// Initialize the library
+gamepad.init();
+
+// List the state of all currently attached devices
+for (let i = 0, l = gamepad.numDevices(); i < l; i++) {
+    console.log(i, gamepad.deviceAtIndex(i));
+}
+
+// Create a game loop and poll for events
+setInterval(gamepad.processEvents, 16);
+// Scan for new gamepads as a slower rate
+setInterval(gamepad.detectDevices, 500);
+
+// Listen for new gamepads being attached
+gamepad.on('attach', (deviceID, device) => {
+    console.log('attach', {
+        deviceID,
+        device: {
+            deviceID: device.deviceID,
+            description: device.description,
+            vendorID: device.vendorID,
+            productID: device.productID,
+            axisStates: device.axisStates,
+            buttonStates: device.buttonStates,
+        }
+    });
+});
+
+// Listen for new gamepads being removed
+gamepad.on('remove', deviceID => {
+    console.log('remove', {
+        deviceID
+    });
+});
+
+// Listen for button down events on all gamepads
+gamepad.on('up', (deviceID, buttonID, timestamp) => {
+    console.log('up', {
+        deviceID,
+        buttonID,
+        timestamp
+    });
+});
+
+// Listen for button down events on all gamepads
+gamepad.on('down', (deviceID, buttonID, timestamp) => {
+    console.log('down', {
+        deviceID,
+        buttonID,
+        timestamp
+    });
+});
+
+// Listen for move events on all gamepads
+gamepad.on('move', (deviceID, axisID, value, lastValue, timestamp) => {
+    console.log('move', {
+        deviceID,
+        axisID,
+        value,
+        lastValue,
+        timestamp
+    });
+});
+
+// Shutdown the library
+gamepad.shutdown();

--- a/types/node-gamepad/tsconfig.json
+++ b/types/node-gamepad/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "node-gamepad-tests.ts"
+    ]
+}

--- a/types/node-gamepad/tslint.json
+++ b/types/node-gamepad/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "dtslint/dt.json"
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

## Problems to resolve before merging
The published name of this package on npm is [`gamepad`](https://www.npmjs.com/package/gamepad), not `node-gamepad`. However, there [already exists a set of typings under that name, for the native browser gamepad API](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/gamepad). I am unsure how to resolve this conflict.