### PR TITLE
Expose globalHistory field as @reach/router does

### DIFF
--- a/types/reach__router/index.d.ts
+++ b/types/reach__router/index.d.ts
@@ -8,17 +8,18 @@ import * as React from "react";
 import { Location as HLocation } from "history";
 export type WindowLocation = Window["location"] & HLocation;
 
+export type HistoryActionType = "PUSH" | "POP";
+export type HistoryLocation = WindowLocation & { state?: any };
+export type HistoryListenerParameter = { location: HistoryLocation, action: HistoryActionType };
+export type HistoryListener = (parameter: HistoryListenerParameter) => void;
+export type HistoryUnsubscribe = () => void;
+
 export interface History {
-    readonly location: string;
+    readonly location: HistoryLocation;
     readonly transitioning: boolean;
     listen: (listener: HistoryListener) => HistoryUnsubscribe;
     navigate: NavigateFn;
 }
-
-export type HistoryListenerLocation = WindowLocation & { state?: any };
-export type HistoryListenerParameter = { location: HistoryListenerLocation, action: "PUSH" | "POP" };
-export type HistoryListener = (parameter: HistoryListenerParameter) => void;
-export type HistoryUnsubscribe = () => void;
 
 export class Router extends React.Component<RouterProps> { }
 

--- a/types/reach__router/index.d.ts
+++ b/types/reach__router/index.d.ts
@@ -15,7 +15,9 @@ export interface History {
     navigate: NavigateFn;
 }
 
-export type HistoryListener = () => void;
+export type HistoryListenerLocation = WindowLocation & { state?: any };
+export type HistoryListenerParameter = { location: HistoryListenerLocation, action: "PUSH" | "POP" };
+export type HistoryListener = (parameter: HistoryListenerParameter) => void;
 export type HistoryUnsubscribe = () => void;
 
 export class Router extends React.Component<RouterProps> { }

--- a/types/reach__router/index.d.ts
+++ b/types/reach__router/index.d.ts
@@ -147,3 +147,5 @@ export interface RedirectRequest {
 export function isRedirect(error: any): error is RedirectRequest;
 
 export function redirectTo(uri: string): void;
+
+export const globalHistory: History;

--- a/types/reach__router/index.d.ts
+++ b/types/reach__router/index.d.ts
@@ -10,7 +10,10 @@ export type WindowLocation = Window["location"] & HLocation;
 
 export type HistoryActionType = "PUSH" | "POP";
 export type HistoryLocation = WindowLocation & { state?: any };
-export type HistoryListenerParameter = { location: HistoryLocation, action: HistoryActionType };
+export interface HistoryListenerParameter {
+	location: HistoryLocation;
+	action: HistoryActionType;
+}
 export type HistoryListener = (parameter: HistoryListenerParameter) => void;
 export type HistoryUnsubscribe = () => void;
 


### PR DESCRIPTION
Please fill in this template.

- [ x ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ x ] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ x ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ x ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

- [ x ] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/reach/router/blob/master/src/index.js#L544
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
