### PR TITLE
[update-notifier] add missing type for shouldNotifyInNpmScript

### DIFF
--- a/types/update-notifier/index.d.ts
+++ b/types/update-notifier/index.d.ts
@@ -1,8 +1,9 @@
-// Type definitions for update-notifier 2.2
+// Type definitions for update-notifier 2.5
 // Project: https://github.com/yeoman/update-notifier
 // Definitions by: vvakame <https://github.com/vvakame>
 //                 Noah Chen <https://github.com/nchen63>
 //                 Jason Dreyzehner <https://github.com/bitjson>
+//                 Michael Grinich <https://github.com/grinich>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 export = UpdateNotifier;
@@ -27,6 +28,7 @@ declare namespace UpdateNotifier {
         packageName?: string;
         packageVersion?: string;
         updateCheckInterval?: number; // in milliseconds, default 1000 * 60 * 60 * 24 (1 day)
+        shouldNotifyInNpmScript?: boolean;
     }
 
     interface BoxenOptions {


### PR DESCRIPTION
Was added to update-notifier in v2.5.0

https://github.com/yeoman/update-notifier/commit/ac0d3cbf556c7a78f80e9dc91ddfeec46f9a663b

Also increase version number in header to 2.5