### PR TITLE
Add correct overloading to `get` method

### DIFF
--- a/types/cheerio/index.d.ts
+++ b/types/cheerio/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for Cheerio v0.22.0
 // Project: https://github.com/cheeriojs/cheerio
-// Definitions by: Bret Little <https://github.com/blittle>, VILIC VANE <http://vilic.info>, Wayne Maurer <https://github.com/wmaurer>, Umar Nizamani <https://github.com/umarniz>, LiJinyao <https://github.com/LiJinyao>, Chennakrishna <https://github.com/chennakrishna8>
+// Definitions by: Bret Little <https://github.com/blittle>, VILIC VANE <http://vilic.info>, Wayne Maurer <https://github.com/wmaurer>, Umar Nizamani <https://github.com/umarniz>, LiJinyao <https://github.com/LiJinyao>, Chennakrishna <https://github.com/chennakrishna8>, AzSiAz <https://github.com/AzSiAz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 interface Cheerio {
@@ -112,8 +112,10 @@ interface Cheerio {
     eq(index: number): Cheerio;
 
     get(): string[];
+    get<T>(): T[];
     get(): CheerioElement[];
     get(index: number): CheerioElement;
+    get<T>(index: number): T;
 
     index(): number;
     index(selector: string): number;

--- a/types/cheerio/index.d.ts
+++ b/types/cheerio/index.d.ts
@@ -111,10 +111,8 @@ interface Cheerio {
 
     eq(index: number): Cheerio;
 
-	get(): any[]
-    get(): string[];
-    get(): CheerioElement[];
-    get(index: number): CheerioElement;
+    get(): any[];
+    get(index: number): any;
 
     index(): number;
     index(selector: string): number;

--- a/types/cheerio/index.d.ts
+++ b/types/cheerio/index.d.ts
@@ -111,6 +111,7 @@ interface Cheerio {
 
     eq(index: number): Cheerio;
 
+	get(): any[]
     get(): string[];
     get(): CheerioElement[];
     get(index: number): CheerioElement;

--- a/types/cheerio/index.d.ts
+++ b/types/cheerio/index.d.ts
@@ -112,10 +112,8 @@ interface Cheerio {
     eq(index: number): Cheerio;
 
     get(): string[];
-    get<T>(): T[];
     get(): CheerioElement[];
     get(index: number): CheerioElement;
-    get<T>(index: number): T;
 
     index(): number;
     index(selector: string): number;


### PR DESCRIPTION
issue #28125
If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/cheeriojs/cheerio/#map-functionindex-element-

ex (or from #28125 : https://runkit.com/gaspardip/5b73a04f4e7a6100115dd595) :
```ts
type custom = {
    text: string
    href: string
}
$("a").map((index, element) => { text: $(element).text(), href: $(element).attr("href") }).get() as custom[];
```
return an array of type custom