### PR TITLE
[slate-react] Add a 'next' arg to slate-react render methods

### DIFF
--- a/types/slate-react/index.d.ts
+++ b/types/slate-react/index.d.ts
@@ -93,9 +93,9 @@ export interface Plugin {
     renderEditor?: (props: RenderAttributes, editor?: Editor) => object | void;
     schema?: Schema;
     decorateNode?: (node: Node) => Range[] | void;
-    renderMark?: (props: RenderMarkProps) => any;
-    renderNode?: (props: RenderNodeProps) => any;
-    renderPlaceholder?: (props: RenderAttributes) => any;
+    renderMark?: (props: RenderMarkProps, next: () => void) => any;
+    renderNode?: (props: RenderNodeProps, next: () => void) => any;
+    renderPlaceholder?: (props: RenderAttributes, next: () => void) => any;
     renderPortal?: (props: RenderAttributes) => any;
     validateNode?: (node: Node) => any;
 }

--- a/types/slate-react/slate-react-tests.tsx
+++ b/types/slate-react/slate-react-tests.tsx
@@ -3,7 +3,7 @@ import { Change, Value } from "slate";
 import * as React from "react";
 
 class MyPlugin implements Plugin {
-    renderNode(props: RenderNodeProps) {
+    renderNode(props: RenderNodeProps, next: () => void) {
         const { node } = props;
         if (node) {
             switch (node.object) {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

    Tried this, but getting this error:

    ```shell
    $ npm run lint slate-react                                                    (16s 710ms)

    > definitely-typed@0.0.3 lint /Users/spencerelliott/Dev/elliottsj/DefinitelyTyped
    > dtslint types "slate-react"

    TypeError: fs.pathExists is not a function
        at /Users/spencerelliott/Dev/elliottsj/DefinitelyTyped/node_modules/dtslint/bin/installer.js:28:24
        at Generator.next (<anonymous>)
        at /Users/spencerelliott/Dev/elliottsj/DefinitelyTyped/node_modules/dtslint/bin/installer.js:7:71
        at new Promise (<anonymous>)
        at __awaiter (/Users/spencerelliott/Dev/elliottsj/DefinitelyTyped/node_modules/dtslint/bin/installer.js:3:12)
        at install (/Users/spencerelliott/Dev/elliottsj/DefinitelyTyped/node_modules/dtslint/bin/installer.js:26:12)
        at Object.<anonymous> (/Users/spencerelliott/Dev/elliottsj/DefinitelyTyped/node_modules/dtslint/bin/installer.js:19:19)
        at Generator.next (<anonymous>)
        at /Users/spencerelliott/Dev/elliottsj/DefinitelyTyped/node_modules/dtslint/bin/installer.js:7:71
        at new Promise (<anonymous>)
    ```

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.slatejs.org/guides/rendering
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
