### PR TITLE
Update chrome.pageAction with optional callbacks for show/hide

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -4525,12 +4525,12 @@ declare namespace chrome.pageAction {
      * Shows the page action. The page action is shown whenever the tab is selected.
      * @param tabId The id of the tab for which you want to modify the page action.
      */
-    export function hide(tabId: number): void;
+    export function hide(tabId: number, callback?: () => void): void;
     /**
      * Shows the page action. The page action is shown whenever the tab is selected.
      * @param tabId The id of the tab for which you want to modify the page action.
      */
-    export function show(tabId: number): void;
+    export function show(tabId: number, callback?: () => void): void;
     /** Sets the title of the page action. This is displayed in a tooltip over the page action. */
     export function setTitle(details: TitleDetails): void;
     /** Sets the html document to be opened as a popup when the user clicks on the page action's icon. */


### PR DESCRIPTION
Add missing callback parameter to chrome.pageAction.show and chrome.pageAction.hide per https://developer.chrome.com/extensions/pageAction#method-show

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.) (not covered by test)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.chrome.com/extensions/pageAction#method-show
- [ ] Increase the version number in the header if appropriate. (not sure if this warrants a new version)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. (minor change)
