### PR TITLE
[pbf] Add ArrayBuffer to the constructor argument type

### DIFF
--- a/types/pbf/index.d.ts
+++ b/types/pbf/index.d.ts
@@ -9,7 +9,7 @@ declare class Pbf {
     type: number;
     length: number;
 
-    constructor(buffer?: Uint8Array);
+    constructor(buffer?: Uint8Array|ArrayBuffer);
 
     destroy(): void;
     readFields<T>(readField: (tag: number, result?: T, pbf?: Pbf) => void, result?: T, end?: number): T;

--- a/types/pbf/pbf-tests.ts
+++ b/types/pbf/pbf-tests.ts
@@ -2,6 +2,7 @@ import Pbf = require('pbf');
 
 const pbf = new Pbf(new Uint8Array(1));
 new Pbf();
+new Pbf(new ArrayBuffer(8));
 pbf.buf;
 pbf.pos;
 pbf.type;


### PR DESCRIPTION
In addition to `Uint8Array`, the `buffer` can be an `ArrayBuffer`.

See: https://github.com/mapbox/pbf/blob/v3.0.0/index.js#L8
And in the [README](https://github.com/mapbox/pbf#api):
```
Create a Pbf object, optionally given a Buffer or Uint8Array as input data
```


Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
https://github.com/mapbox/pbf/blob/v3.0.0/index.js#L8
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
