### PR TITLE
fix chai-jquery added enabled

### DIFF
--- a/types/chai-jquery/chai-jquery-tests.ts
+++ b/types/chai-jquery/chai-jquery-tests.ts
@@ -67,6 +67,10 @@ function test_disabled() {
     expect($('#foo')).to.be.disabled;
 }
 
+function test_enabled() {
+    expect($('#foo')).to.be.enabled;
+}
+
 function test_empty() {
     $('.empty').should.be.empty;
     expect($('body')).not.to.be.empty;

--- a/types/chai-jquery/index.d.ts
+++ b/types/chai-jquery/index.d.ts
@@ -25,6 +25,7 @@ declare namespace Chai {
         selected(): Assertion;
         checked(): Assertion;
         disabled(): Assertion;
+        enabled(): Assertion;
         (selector: string): Assertion;
     }
 


### PR DESCRIPTION
According to https://www.chaijs.com/plugins/chai-jquery/ `enabled` was missing so far

@kazimanzurrashid