### PR TITLE
N3: Made typings of prefixes consistent with behaviour of N3

### DIFF
--- a/types/n3/index.d.ts
+++ b/types/n3/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Fred Eisele <https://github.com/phreed>
 //                 Ruben Taelman <https://github.com/rubensworks>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.1
+// TypeScript Version: 2.3
 
 /// <reference types="node" />
 
@@ -12,9 +12,11 @@ import * as stream from "stream";
 import * as RDF from "rdf-js";
 import { EventEmitter } from "events";
 
-export interface Prefixes {
-    [key: string]: RDF.NamedNode;
+export interface Prefixes<I = RDF.NamedNode> {
+  [key: string]: I;
 }
+
+export type PrefixedToIri = (suffix: string) => RDF.NamedNode;
 
 export class Term implements RDF.Term {
     termType: "NamedNode" | "BlankNode" | "Literal" | "Variable" | "DefaultGraph";
@@ -139,7 +141,7 @@ export interface N3StreamParser extends RDF.Stream, NodeJS.WritableStream, RDF.S
 
 export interface WriterOptions {
     format?: string;
-    prefixes?: Prefixes;
+    prefixes?: Prefixes<RDF.NamedNode | string>;
     end?: boolean;
 }
 
@@ -157,8 +159,8 @@ export interface N3Writer {
     addQuad(subject: RDF.Term, predicate: RDF.Term, object: RDF.Term | RDF.Term[], graph?: RDF.Term, done?: () => void): void;
     addQuad(quad: RDF.Quad): void;
     addQuads(quads: RDF.Quad[]): void;
-    addPrefix(prefix: string, iri: string, done?: () => void): void;
-    addPrefixes(prefixes: Prefixes, done?: () => void): void;
+    addPrefix(prefix: string, iri: RDF.NamedNode | string , done?: () => void): void;
+    addPrefixes(prefixes: Prefixes<RDF.NamedNode | string>, done?: () => void): void;
     end(err?: ErrorCallback, result?: string): void;
     blank(predicate: RDF.Term, object: RDF.Term): RDF.Term;
     blank(triple: BlankTriple | RDF.Quad | BlankTriple[] | RDF.Quad[]): RDF.Term;
@@ -218,6 +220,9 @@ export namespace Util {
     function isVariable(value: RDF.Term | null): boolean;
     function isDefaultGraph(value: RDF.Term | null): boolean;
     function inDefaultGraph(value: RDF.Quad): boolean;
-    function prefix(iri: string, factory?: RDF.DataFactory): (suffix: string) => RDF.NamedNode;
-    function prefixes(defaultPrefixes: Prefixes, factory?: RDF.DataFactory): (iri: string) => (suffix: string) => RDF.NamedNode;
+    function prefix(iri: RDF.NamedNode|string, factory?: RDF.DataFactory): PrefixedToIri;
+    function prefixes(
+      defaultPrefixes: Prefixes<RDF.NamedNode|string>,
+      factory?: RDF.DataFactory
+    ): (prefix: string) => PrefixedToIri;
 }

--- a/types/n3/n3-tests.ts
+++ b/types/n3/n3-tests.ts
@@ -17,7 +17,8 @@ function test_add_prefixes() {
 
     writer.addPrefixes({
         freebase: N3.DataFactory.namedNode("http://rdf.freebase.com/ns/"),
-        xsd: N3.DataFactory.namedNode("http://www.w3.org/2001/XMLSchema#")
+        xsd: N3.DataFactory.namedNode("http://www.w3.org/2001/XMLSchema#"),
+        rdf: 'http://test'
     });
 
     writer.end((error, result) => {
@@ -31,7 +32,7 @@ function test_serialize() {
             format: "ttl",
             prefixes: {
                 foaf: "http://xmlns.com/foaf/0.1",
-                freebase: "http://rdf.freebase.com/ns/",
+                freebase: N3.DataFactory.namedNode("http://rdf.freebase.com/ns/"),
                 g: "http://base.google.com/ns/1.0"
             }
         });


### PR DESCRIPTION


Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/rdfjs/N3.js/blob/master/test/N3Util-test.js#L253
- [X] Increase the version number in the header if appropriate.
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.


Had to change the minimum typescript version to 2.3 to support default generics