### PR TITLE
Add typings for glue v4

### DIFF
--- a/types/glue/v4/glue-tests.ts
+++ b/types/glue/v4/glue-tests.ts
@@ -1,0 +1,69 @@
+import * as glue from "glue";
+import * as hapi from "hapi";
+
+const manifest: glue.Manifest = {
+  server: {
+    debug: false,
+  },
+  connections: [
+    {
+      port: 8000,
+      labels: ['web']
+    },
+    {
+      port: 8001,
+      labels: ['admin']
+    }
+  ],
+  registrations: [
+    {
+      plugin: {
+        register: './assets',
+        options: {
+          uglify: true
+        }
+      }
+    },
+    {
+      plugin: './ui-user',
+      options: {
+        select: ['web']
+      }
+    },
+    {
+      plugin: {
+        register: './ui-admin',
+        options: {
+          sessiontime: 500
+        }
+      },
+      options: {
+        select: ['admin'],
+        routes: {
+          prefix: '/admin'
+        }
+      }
+    },
+    {
+      plugin: {
+        register: require('./awesome-plugin.js'),
+        options: {
+          whyNot: true
+        }
+      }
+    },
+  ]
+};
+
+const options: glue.Options = {
+  relativeTo: `${__dirname}/modules`
+};
+
+glue.compose(manifest, options, (err, server) => {
+  if (err) {
+    throw err;
+  }
+  server.start(() => {
+    console.log('hapi days!');
+  });
+});

--- a/types/glue/v4/glue-tests.ts
+++ b/types/glue/v4/glue-tests.ts
@@ -1,0 +1,34 @@
+import * as glue from "glue";
+import * as hapi from "hapi";
+
+const serverOptions: hapi.ServerOptions = {
+  debug: false
+};
+
+const serverConnectionOptions: hapi.ServerConnectionOptions = {
+  port: 3000
+};
+
+const manifest: glue.Manifest = {
+  server: serverOptions,
+  connections: [ serverConnectionOptions ],
+  registrations: [
+    {
+      plugin: "./test.js",
+    },
+    {
+      plugin: {
+	register: "test",
+	options: {
+	  foo: "bar"
+	}
+      }
+    }
+  ],
+};
+
+const options: glue.Options = {
+  relativeTo: `${__dirname}/modules`
+};
+
+glue.compose(manifest, options);

--- a/types/glue/v4/index.d.ts
+++ b/types/glue/v4/index.d.ts
@@ -1,8 +1,8 @@
-// Type definitions for glue 4.0
+// Type definitions for glue 4.2
 // Project: https://github.com/hapijs/glue
 // Definitions by: Greg Jednaszewski <https://github.com/gjednaszewski>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.8
+// TypeScript Version: 2.4
 
 import { Server, ServerConnectionOptions, ServerOptions } from "hapi";
 

--- a/types/glue/v4/index.d.ts
+++ b/types/glue/v4/index.d.ts
@@ -1,0 +1,31 @@
+// Type definitions for glue 4.0
+// Project: https://github.com/hapijs/glue
+// Definitions by: Greg Jednaszewski <https://github.com/gjednaszewski>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.8
+
+import { Server, ServerConnectionOptions, ServerOptions } from "hapi";
+
+export interface Options {
+  relativeTo: string;
+  preConnections?: (Server: Server, next: (err: any) => void) => void;
+  preRegister?: (Server: Server, next: (err: any) => void) => void;
+}
+
+export interface Plugin {
+  plugin: string | {
+      register: string;
+      options?: any;
+  };
+  options?: any;
+}
+
+export interface Manifest {
+  server: ServerOptions;
+  connections: ServerConnectionOptions[];
+  registrations?: Plugin[];
+}
+
+export function compose(manifest: Manifest,
+                        options?: Options,
+                        callback?: (err?: any, server?: Server) => void): Promise<Server>;

--- a/types/glue/v4/tsconfig.json
+++ b/types/glue/v4/tsconfig.json
@@ -1,0 +1,29 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": false,
+        "strictFunctionTypes": true,
+        "baseUrl": "../../",
+        "typeRoots": [
+            "../../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "paths": {
+            "boom": [ "boom/v4" ],
+            "catbox": [ "catbox/v7" ],
+            "hapi": [ "hapi/v16" ],
+            "glue": [ "glue/v4" ]
+        }
+    },
+    "files": [
+        "index.d.ts",
+        "glue-tests.ts"
+    ]
+}

--- a/types/glue/v4/tslint.json
+++ b/types/glue/v4/tslint.json
@@ -1,0 +1,3 @@
+{
+  "extends": "dtslint/dt.json"
+}


### PR DESCRIPTION
Add typings for glue v4, which goes with hapi v16.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/hapijs/glue/blob/v4.2.1/API.md
- [X] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
