### PR TITLE
Added type definitions for git-rev-sync

### DIFF
--- a/types/git-rev-sync/git-rev-sync-tests.ts
+++ b/types/git-rev-sync/git-rev-sync-tests.ts
@@ -1,0 +1,13 @@
+import * as gitRevSync from "git-rev-sync";
+
+gitRevSync.branch();
+gitRevSync.count();
+gitRevSync.date();
+gitRevSync.isDirty();
+gitRevSync.isTagDirty();
+gitRevSync.long();
+gitRevSync.message();
+gitRevSync.remoteUrl();
+gitRevSync.short();
+gitRevSync.short();
+gitRevSync.tag();

--- a/types/git-rev-sync/index.d.ts
+++ b/types/git-rev-sync/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for git-rev-sync 1.12
-// Project: https://github.com/tblobaum/git-rev
-// Definitions by: Khoi Nguyen <http://hellokhoi.com>
+// Project: https://github.com/kurttheviking/git-rev-sync-js
+// Definitions by: khoi-fish <https://github.com/khoi-fish>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 export function short(filePath?: string, length?: number): string;

--- a/types/git-rev-sync/index.d.ts
+++ b/types/git-rev-sync/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for git-rev-sync 1.12.0
+// Type definitions for git-rev-sync 1.12
 // Project: https://github.com/tblobaum/git-rev
 // Definitions by: Khoi Nguyen <http://hellokhoi.com>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/git-rev-sync/index.d.ts
+++ b/types/git-rev-sync/index.d.ts
@@ -1,0 +1,15 @@
+// Type definitions for git-rev-sync 1.12.0
+// Project: https://github.com/tblobaum/git-rev
+// Definitions by: Khoi Nguyen <http://hellokhoi.com>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export function short(filePath?: string, length?: number): string;
+export function long(filePath?: string): string;
+export function branch(branch?: string): void;
+export function count(): number;
+export function date(): Date;
+export function isDirty(): boolean;
+export function isTagDirty(): boolean;
+export function message(): string;
+export function remoteUrl(): string;
+export function tag(makeDirty?: boolean): string;

--- a/types/git-rev-sync/tsconfig.json
+++ b/types/git-rev-sync/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": ["index.d.ts", "git-rev-sync-tests.ts"]
+}

--- a/types/git-rev-sync/tslint.json
+++ b/types/git-rev-sync/tslint.json
@@ -1,0 +1,6 @@
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "dt-header": false
+    }
+}

--- a/types/git-rev-sync/tslint.json
+++ b/types/git-rev-sync/tslint.json
@@ -1,6 +1,6 @@
 {
     "extends": "dtslint/dt.json",
     "rules": {
-        "dt-header": false
+        "dt-header": true
     }
 }


### PR DESCRIPTION
- [ ✅ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ✅ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ✅ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ✅ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.