### PR TITLE
Ember: add deprecation note for `object/internals/copy`.

### DIFF
--- a/types/ember__object/internals.d.ts
+++ b/types/ember__object/internals.d.ts
@@ -1,4 +1,4 @@
-import { UnwrapComputedPropertyGetter } from '@ember/object/-private/types';
+import { UnwrapComputedPropertyGetter } from "@ember/object/-private/types";
 
 /**
  * Returns the cached value for a property, if one exists.
@@ -13,6 +13,11 @@ export function cacheFor<T, K extends keyof T>(
 /**
  * Creates a shallow copy of the passed object. A deep copy of the object is
  * returned if the optional `deep` argument is `true`.
+ *
+ * @deprecated as of Ember 3.3, to be removed in Ember 4.0. See how to migrate
+ * [here][deprecation].
+ *
+ * [deprecation]: https://emberjs.com/deprecations/v3.x#toc_ember-runtime-deprecate-copy-copyable
  */
 export function copy<T>(obj: T, deep: true): T;
 export function copy(obj: any, deep?: boolean): any;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- ~~Add or edit tests to reflect the change. (Run with `npm test`.)~~ (irrelevant)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://deprecations-app-prod.herokuapp.com/deprecations/v3.x/#toc_ember-runtime-deprecate-copy-copyable>
- ~~Increase the version number in the header if appropriate.~~ (irrelevant)
- ~~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.~~ (irrelevant)
