### PR TITLE
[react-jsonschema-form] Fix onBlur/onFocus signature for (custom) widgets

### DIFF
--- a/types/react-jsonschema-form/index.d.ts
+++ b/types/react-jsonschema-form/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-jsonschema-form 1.0.0
+// Type definitions for react-jsonschema-form 1.0.1
 // Project: https://github.com/mozilla-services/react-jsonschema-form
 // Definitions by: Dan Fox <https://github.com/iamdanfox>
 //                 Ivan Jiang <https://github.com/iplus26>
@@ -6,6 +6,7 @@
 //                 Philippe Bourdages <https://github.com/phbou72>
 //                 Lucian Buzzo <https://github.com/LucianBuzzo>
 //                 Sylvain Thénault <https://github.com/sthenault>
+//                 Sebastian Busch <https://github.com/sbusch>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -68,7 +69,12 @@ declare module "react-jsonschema-form" {
         [key: string]: FieldId;
     };
 
-    export interface WidgetProps extends React.HTMLAttributes<HTMLElement> {
+    export interface WidgetProps extends Pick<
+        React.HTMLAttributes<HTMLElement>,
+        Exclude<
+            keyof React.HTMLAttributes<HTMLElement>,
+            "onBlur"|"onFocus">
+    > {
         id: string;
         schema: JSONSchema6;
         value: any;
@@ -79,6 +85,8 @@ declare module "react-jsonschema-form" {
         onChange: (value: any) => void;
         options: object;
         formContext: any;
+        onBlur: (id: string, value: string) => void;
+        onFocus: (id: string, value: string) => void;
     }
 
     export type Widget =

--- a/types/react-jsonschema-form/react-jsonschema-form-tests.tsx
+++ b/types/react-jsonschema-form/react-jsonschema-form-tests.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import Form, { UiSchema, ErrorListProps } from "react-jsonschema-form";
+import Form, { UiSchema, ErrorListProps, WidgetProps } from "react-jsonschema-form";
 import { JSONSchema6 } from "json-schema";
 
 // example taken from the react-jsonschema-form playground:
@@ -108,3 +108,9 @@ export class Example extends React.Component<any, IExampleState> {
         );
     }
 }
+
+export const CustomWidget: React.SFC<WidgetProps> = (props) =>
+    <input
+        onFocus={()=> props.onFocus('id', 'value')}
+        onBlur={()=> props.onFocus('id', 'value')}
+    />


### PR DESCRIPTION
`react-jsonschema-form` unfortunately uses for its (custom) widgets a custom, non-standard signature for `onBlur` and `onFocus` props which is incompatible with HTMLElement (custom signature is documented [here](https://github.com/mozilla-services/react-jsonschema-form/blob/master/README.md#custom-widget-components))

My change fixes the definition just for the two affected props, which still using all other props of HTMLElement.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/mozilla-services/react-jsonschema-form/blob/master/README.md#custom-widget-components>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

