### PR TITLE
[@types/amqplib] fix wrong Message/MessageFields 

### DIFF
--- a/types/amqplib/index.d.ts
+++ b/types/amqplib/index.d.ts
@@ -8,7 +8,7 @@
 
 import * as Promise from 'bluebird';
 import * as events from 'events';
-import { Replies, Options, Message } from './properties';
+import { Replies, Options, Message, GetMessage, ConsumeMessage } from './properties';
 export * from './properties';
 
 export interface Connection extends events.EventEmitter {
@@ -40,10 +40,10 @@ export interface Channel extends events.EventEmitter {
     publish(exchange: string, routingKey: string, content: Buffer, options?: Options.Publish): boolean;
     sendToQueue(queue: string, content: Buffer, options?: Options.Publish): boolean;
 
-    consume(queue: string, onMessage: (msg: Message | null) => any, options?: Options.Consume): Promise<Replies.Consume>;
+    consume(queue: string, onMessage: (msg: ConsumeMessage | null) => any, options?: Options.Consume): Promise<Replies.Consume>;
 
     cancel(consumerTag: string): Promise<Replies.Empty>;
-    get(queue: string, options?: Options.Get): Promise<Message | false>;
+    get(queue: string, options?: Options.Get): Promise<GetMessage | false>;
 
     ack(message: Message, allUpTo?: boolean): void;
     ackAll(): void;

--- a/types/amqplib/properties.d.ts
+++ b/types/amqplib/properties.d.ts
@@ -145,12 +145,32 @@ export interface Message {
     properties: MessageProperties;
 }
 
-export interface MessageFields {
+export interface GetMessage extends Message {
+    fields: GetMessageFields;
+}
+
+export interface ConsumeMessage extends Message {
+    fields: ConsumeMessageFields;
+}
+
+export interface CommonMessageFields {
     deliveryTag: number;
     redelivered: boolean;
     exchange: string;
     routingKey: string;
-    messageCount: string;
+}
+
+export interface MessageFields extends CommonMessageFields {
+    messageCount?: number;
+    consumerTag?: string;
+}
+
+export interface GetMessageFields extends CommonMessageFields {
+    messageCount: number;
+}
+
+export interface ConsumeMessageFields extends CommonMessageFields {
+    deliveryTag: number;
 }
 
 export interface MessageProperties {


### PR DESCRIPTION
The current interface assumes the same message interface is returned on `Channel.consume` and `Channel.get` methods, which is wrong as `Message.fields` property interface varies between them.

This pull request adds the proper specific interfaces, maintaining both current `Message` and `MessageFields` as generic/compatible ones for parameters and existing code.

### Rationale

I found a bit weird the `MessageFields.messageCount` property being `string` instead of `number`, so I dug into documentation and found nothing about the existence (or type) `messageCount` property on `MessageFields`, so I ran a quick test:

```js
(async () => {
  const amqplib = require('amqplib');
  const uuid4 = require('uuid/v4');
  const connection = await amqplib.connect('amqp://localhost');
  const channel = await connection.createConfirmChannel();
  const assertion = await channel.assertQueue('test', {});

  channel.publish('', 'test', Buffer.from('ok'));
  const consumeMessage = await new Promise((resolve, reject) => {
    const consumerTag = uuid4();
    channel
      .consume('test', (message) => {
        channel.cancel(consumerTag);
        resolve(message);
      }, { consumerTag })
      .catch(reject);
  });

  channel.publish('', 'test', Buffer.from('ok'));
  const getMessage = await channel.get('test');
 
  console.log(JSON.stringify({ consumeMessage, getMessage }, null, '  '));
})();
```
Which logs:

```json
{
  "consumeMessage": {
    "fields": {
      "consumerTag": "5f43da79-afd4-4b48-b891-e28f9ad26b04",
      "deliveryTag": 1,
      "redelivered": true,
      "exchange": "",
      "routingKey": "test"
    },
    "properties": {
      "headers": {}
    },
    "content": {
      "type": "Buffer",
      "data": [
        111,
        107
      ]
    }
  },
  "getMessage": {
    "fields": {
      "deliveryTag": 10,
      "redelivered": false,
      "exchange": "",
      "routingKey": "test",
      "messageCount": 0
    },
    "properties": {
      "headers": {}
    },
    "content": {
      "type": "Buffer",
      "data": [
        111,
        107
      ]
    }
  }
}
```

It looks like different message fields are returned by `Channel.get` and `Channel.consume`, so specific message interfaces has to be defined, along with a generic message where specific fields are optional for `Channel` methods accepting `Message` objects.

### Changes

The existing message interface will be used as generic input, and two new specific interfaces, `GetMessage` and `ConsumeMessage`, will be used for returned messages on `Channel.get` and `Channel.consume` respectively.

The generic `Message` interface will be kept compatible with those specific interfaces, maintaining its interface name, preventing break of existing code.

The only breaking change is the `MessageFields.messageCount` type change (from `string` to `number`) as it was wrong anyway.
