### PR TITLE
[Slate] Add Editor Definition

### DIFF
--- a/types/slate-base64-serializer/index.d.ts
+++ b/types/slate-base64-serializer/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/ianstormtaylor/slate
 // Definitions by: Brandon Shelton <https://github.com/YangusKhan>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 import { Value, Node } from "slate";
 
 export function deserialize(string: string, options?: object): Value;

--- a/types/slate-plain-serializer/index.d.ts
+++ b/types/slate-plain-serializer/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Brandon Shelton <https://github.com/YangusKhan>
 //                 Martin Kiefel <https://github.com/mkiefel>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 import { BlockProperties, MarkProperties, Value } from 'slate';
 
 export interface DeserializeOptions {

--- a/types/slate/index.d.ts
+++ b/types/slate/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for slate 0.40
+// Type definitions for slate 0.42
 // Project: https://github.com/ianstormtaylor/slate
 // Definitions by: Andy Kent <https://github.com/andykent>
 //                 Jamie Talbot <https://github.com/majelbstoat>

--- a/types/slate/index.d.ts
+++ b/types/slate/index.d.ts
@@ -1533,16 +1533,16 @@ export interface EditorProperties {
     plugins?: any[];
     readOnly?: boolean;
     value?: Value;
-  }
-  
-  export class Editor {
+}
+
+export class Editor {
     object: "editor";
     onChange: (change: Change) => void;
     plugins: any[];
     readOnly: boolean;
     value: Value;
     constructor(attributes: EditorProperties)
-  
+
     change(customChange: (change: Change, ...args: any[]) => Change): void;
     command(name: string, ...args: any[]): void;
     event(handler: string, event: Event): void;
@@ -1552,7 +1552,6 @@ export interface EditorProperties {
     run(key: string, ...args: any[]): any;
     setReadOnly(readOnly: boolean): Editor;
     setValue(value: Value, options?: object): Editor;
-  }
-  
+}
 
 export {};

--- a/types/slate/index.d.ts
+++ b/types/slate/index.d.ts
@@ -11,6 +11,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 import * as Immutable from "immutable";
+
 export class Data extends Immutable.Record({}) {
     [key: string]: any;
 

--- a/types/slate/index.d.ts
+++ b/types/slate/index.d.ts
@@ -11,6 +11,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 import * as Immutable from "immutable";
+import { SyntheticEvent } from "react";
 
 export class Data extends Immutable.Record({}) {
     [key: string]: any;
@@ -1545,7 +1546,7 @@ export class Editor {
 
     change(customChange: (change: Change, ...args: any[]) => Change): void;
     command(name: string, ...args: any[]): void;
-    event(handler: string, event: Event): void;
+    event(handler: string, event: Event | SyntheticEvent): void;
     query(query: string, ...args: any[]): any;
     registerCommand(command: string): void;
     registerQuery(query: string): void;

--- a/types/slate/index.d.ts
+++ b/types/slate/index.d.ts
@@ -1528,22 +1528,31 @@ export interface PathUtils {
     ): Immutable.List<number>;
 }
 
-export class Editor extends Immutable.Record({}) {
+export interface EditorProperties {
+    onChange?: (change: Change) => void;
+    plugins?: any[];
+    readOnly?: boolean;
+    value?: Value;
+  }
+  
+  export class Editor {
     object: "editor";
     onChange: (change: Change) => void;
     plugins: any[];
     readOnly: boolean;
     value: Value;
-
+    constructor(attributes: EditorProperties)
+  
     change(customChange: (change: Change, ...args: any[]) => Change): void;
     command(name: string, ...args: any[]): void;
-    event(handler: string, event: any): void;
+    event(handler: string, event: Event): void;
     query(query: string, ...args: any[]): any;
     registerCommand(command: string): void;
     registerQuery(query: string): void;
     run(key: string, ...args: any[]): any;
     setReadOnly(readOnly: boolean): Editor;
     setValue(value: Value, options?: object): Editor;
-}
+  }
+  
 
 export {};

--- a/types/slate/index.d.ts
+++ b/types/slate/index.d.ts
@@ -1529,21 +1529,21 @@ export interface PathUtils {
 }
 
 export class Editor extends Immutable.Record({}) {
-  object: "editor";
-  onChange: (change: Change) => void;
-  plugins: any[];
-  readOnly: boolean;
-  value: Value;
+    object: "editor";
+    onChange: (change: Change) => void;
+    plugins: any[];
+    readOnly: boolean;
+    value: Value;
 
-  change(customChange: (change: Change, ...args: any[]) => Change): void;
-  command(name: string, ...args: any[]): void;
-  event(handler: string, event: any): void;
-  query(query: string, ...args: any[]): any;
-  registerCommand(command: string): void;
-  registerQuery(query: string): void;
-  run(key: string, ...args: any[]): any;
-  setReadOnly(readOnly: boolean): Editor;
-  setValue(value: Value, options?: object): Editor;
+    change(customChange: (change: Change, ...args: any[]) => Change): void;
+    command(name: string, ...args: any[]): void;
+    event(handler: string, event: any): void;
+    query(query: string, ...args: any[]): any;
+    registerCommand(command: string): void;
+    registerQuery(query: string): void;
+    run(key: string, ...args: any[]): any;
+    setReadOnly(readOnly: boolean): Editor;
+    setValue(value: Value, options?: object): Editor;
 }
 
 export {};

--- a/types/slate/index.d.ts
+++ b/types/slate/index.d.ts
@@ -9,7 +9,7 @@
 //                 Irwan Fario Subastian <https://github.com/isubasti>
 //                 Sebastian Greaves <https://github.com/sgreav>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 import * as Immutable from "immutable";
 import { SyntheticEvent } from "react";
 

--- a/types/slate/index.d.ts
+++ b/types/slate/index.d.ts
@@ -7,10 +7,10 @@
 //                 Kalley Powell <https://github.com/kalley>
 //                 Francesco Agnoletto <https://github.com/Kornil>
 //                 Irwan Fario Subastian <https://github.com/isubasti>
+//                 Sebastian Greaves <https://github.com/sgreav>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 import * as Immutable from "immutable";
-
 export class Data extends Immutable.Record({}) {
     [key: string]: any;
 
@@ -1525,6 +1525,24 @@ export interface PathUtils {
         a: Immutable.List<number>,
         b: Immutable.List<number>
     ): Immutable.List<number>;
+}
+
+export class Editor extends Immutable.Record({}) {
+  object: "editor";
+  onChange: (change: Change) => void;
+  plugins: any[];
+  readOnly: boolean;
+  value: Value;
+
+  change(customChange: (change: Change, ...args: any[]) => Change): void;
+  command(name: string, ...args: any[]): void;
+  event(handler: string, event: any): void;
+  query(query: string, ...args: any[]): any;
+  registerCommand(command: string): void;
+  registerQuery(query: string): void;
+  run(key: string, ...args: any[]): any;
+  setReadOnly(readOnly: boolean): Editor;
+  setValue(value: Value, options?: object): Editor;
 }
 
 export {};

--- a/types/slate/slate-tests.ts
+++ b/types/slate/slate-tests.ts
@@ -1,4 +1,4 @@
-import { Value, Data, BlockJSON, Document } from "slate";
+import { Value, Data, BlockJSON, Document, Editor, Change } from "slate";
 
 const data = Data.create({ foo: "bar " });
 const value = Value.create({ data });
@@ -45,3 +45,16 @@ const doc = Document.fromJSON({
 	data: {},
 	nodes: [node]
 });
+
+const editor = new Editor({ value });
+editor.change((change: Change) => {
+	return change.insertText("test");
+});
+
+editor.registerQuery("testQuery");
+editor.registerCommand("testCommand");
+editor.setReadOnly(true).setValue(value);
+editor.command("testCommand");
+editor.query("testQuery");
+editor.run("testCommand");
+editor.event("mouseDown", () => { });

--- a/types/slate/slate-tests.ts
+++ b/types/slate/slate-tests.ts
@@ -57,4 +57,4 @@ editor.setReadOnly(true).setValue(value);
 editor.command("testCommand");
 editor.query("testQuery");
 editor.run("testCommand");
-editor.event("mouseDown", () => { });
+editor.event("mouseDown", new Event("mouseDown"));


### PR DESCRIPTION
Add previously absent definition for `Editor` from `slate` package.
Required by users who do not wish to use the React mounted `Editor` component from `slate-react` (defined in [@types/slate-react](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/eb16e1790c80c5add37da0fe579655b979f39fe2/types/slate-react/index.d.ts#L128))

Please fill in this template:

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [Editor definition from slate docs](https://docs.slatejs.org/slate-core/editor#change)
- [x] Increase the version number in the header if appropriate.
- ~~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.~~
