### PR TITLE
[Jest] - Fix returning message as string for custom matchers

### DIFF
--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -345,7 +345,14 @@ declare namespace jest {
     }
 
     interface ExpectExtendMap {
-        [key: string]: (this: MatcherUtils, received: any, ...actual: any[]) => { message(): string | (() => string), pass: boolean } | Promise<{ message(): string, pass: boolean }>;
+        [key: string]: CustomMatcher;
+    }
+
+    type CustomMatcher = (this: MatcherUtils, received: any, ...actual: any[]) => CustomMatcherResult | Promise<CustomMatcherResult>;
+
+    interface CustomMatcherResult {
+        pass: boolean;
+        message: string | (() => string);
     }
 
     interface SnapshotSerializerOptions {

--- a/types/jest/jest-tests.ts
+++ b/types/jest/jest-tests.ts
@@ -434,10 +434,26 @@ expect.extend({
     }
 });
 expect.extend({
+    foo(this: jest.MatcherUtils, received: {}, ...actual: Array<{}>) {
+        return {
+            message: JSON.stringify(received),
+            pass: false,
+        };
+    }
+});
+expect.extend({
     async foo(this: jest.MatcherUtils, received: {}, ...actual: Array<{}>) {
         return {
             message: () => JSON.stringify(received),
             pass: false,
+        };
+    }
+});
+expect.extend({
+    async foo(this: jest.MatcherUtils, received: {}, ...actual: Array<{}>) {
+        return {
+            message: JSON.stringify(received),
+            pass: false
         };
     }
 });


### PR DESCRIPTION
Previous definition was:
```ts
message(): string | () => string
```
which is wrong because message is a string or a function that returns a string. It was written as a function that returns a string or returns _another_ function that returns a string.

I'm not sure what the protocol is here when mixing jest and jasmine namespaces. The return type matches jasmine's `CustomMatcherResult`. I created a `jest.CustomMatcherResult` which just aliases to jasmine's. Happy to adjust as desired.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

