### PR TITLE
fix: fix react fragment and strict type

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -148,8 +148,7 @@ declare namespace React {
     type ReactChild = ReactElement<any> | ReactText;
 
     interface ReactNodeArray extends Array<ReactNode> {}
-    type ReactFragment = {} | ReactNodeArray;
-    type ReactNode = ReactChild | ReactFragment | ReactPortal | boolean | null | undefined;
+    type ReactNode = ReactChild | ReactNodeArray | ReactPortal | boolean | null | undefined;
 
     //
     // Top Level API
@@ -269,8 +268,8 @@ declare namespace React {
     function isValidElement<P>(object: {} | null | undefined): object is ReactElement<P>;
 
     const Children: ReactChildren;
-    const Fragment: ComponentType;
-    const StrictMode: ComponentType;
+    const Fragment: StatelessComponent;
+    const StrictMode: StatelessComponent;
     const version: string;
 
     //


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).


- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [render return type](https://reactjs.org/docs/react-component.html#render), [React.Fragment](https://reactjs.org/docs/fragments.html), [React.StrictMode](https://reactjs.org/docs/strict-mode.html)
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

Not entirely sure about these changes, but reading through docs and actual flow types suggests that it should be right.
Fixes https://github.com/DefinitelyTyped/DefinitelyTyped/issues/29307
