### PR TITLE
Add rudimentary typings with mtgjson-raw for for working with the json from the mtgjson project

### DIFF
--- a/types/mtgjson-raw/card.d.ts
+++ b/types/mtgjson-raw/card.d.ts
@@ -1,0 +1,286 @@
+/// <reference path="lib/game.d.ts" />
+/// <reference path="lib/meta.d.ts" />
+/// <reference path="lib/physical.d.ts" />
+
+declare namespace mtgjson {
+
+  /**
+   * Snippet of data about alternate languages found on cards.
+   */
+  export interface ForeignDataEntry {
+    /**
+     * Flavor text in foreign language.
+     */
+    flavorText?: string
+
+    /**
+     * Foreign language of card.
+     */
+    language: ForeignLanguage
+
+    /**
+     * Multiverse ID of the card.
+     */
+    multiverseId: MultiverseID
+
+    /**
+     * Name of the card in foreign language.
+     */
+    name: string
+
+    /**
+     * Rules text of the card in foreign language.
+     */
+    text?: string
+
+    /**
+     * Type in foreign language.
+     */
+    type: string
+  }
+
+  /**
+   * Representation of an MTG Card
+   * @see https://mtgjson.com/v4/docs.html
+   */
+  export interface Card {
+    /**
+     * Name of artist
+     */
+    artist: string
+
+    /**
+     * Color of the card border
+     */
+    borderColor: BorderColor
+
+    /**
+     * List of all colors in card's mana cost, rules text,
+     * and any color indicator
+     */
+    colorIdentity: ColorCode[]
+
+    /**
+     * List of all colors in color indicator.
+     *
+     * Only found in cards without mana costs or other special cards.
+     */
+    colorIndicator?: ColorCode[]
+
+    /**
+     * List of colors in card's mana cost and any color indicator.
+     * Some cards are special (such as Devoid card or other cards with unique rules text)
+     */
+    colors: ColorCode[]
+
+    /**
+     * Converted mana cost.
+     *
+     * Is a float due to unhinged stuff costing 1.5 mana
+     */
+    convertedManaCost: number
+
+    /**
+     * Italicized text found below the rules text that has no game function
+     */
+    flavorText?: string
+
+    /**
+     * Can the card be only found in foil?
+     * @default false
+     */
+    isFoilOnly?: boolean
+
+    /**
+     * List of data about cards written in foreign languages.
+     *
+     * In mtg the "true rules" are all in English
+     */
+    foreignData: ForeignDataEntry[]
+
+    /**
+     * Style of the card frame
+     */
+    frameVersion: FrameVersion
+
+    /**
+     * Can the card be found in foil? Typically omitted if false
+     *
+     * @default true
+     */
+    hasFoil?: boolean
+
+    /**
+     * Can the card be found in non-foil? Typically omitted if false
+     *
+     * @default true
+     */
+    hasNonFoil?: boolean
+
+    /**
+     * Is the card only avilable online? Typically omitted if false
+     * @default false
+     */
+    isOnlineOnly?: boolean
+
+    /**
+     * Is the card oversized? Typically omitted if false
+     * @default false
+     */
+    isOversized?: boolean
+
+    /**
+     * Is the card on the Reserved List? Typically omitted if false
+     * @default false
+     */
+    isReserved: boolean
+
+    /**
+     * Type of card. Typically omitted if "normal"
+     * @default "normal"
+     */
+    layout: Layout
+
+    /**
+     * Map of play formats to the ability to play them in that format.
+     *
+     * If a format is missing, it is assumed the card is legal in that format.
+     * @default "Legal"
+     */
+    legalities: Partial<Record<Format, Legality>>
+
+    /**
+     * Planeswalker loyalty value.
+     *
+     * @example "7", or "X"
+     */
+    loyalty?: string
+
+    /**
+     * Mana cost in "symbol" notation
+     *
+     * @example "{1}{U}{B}{R}"
+     */
+    manaCost?: string
+
+    /**
+     * An integer most cards have which Wizards uses as a card identifier.
+     */
+    multiverseId?: MultiverseID
+
+    /**
+     * Name of the card
+     */
+    name: string
+
+    /**
+     * Names of each face on the card. If the card doesn't have multiple faces this is typically omitted.
+     *
+     * For flip cards, the first card is the front face.
+     *
+     * For meld cards it SHOULD go something like:
+     *
+     * The first card is the top side (left), the seond card the back side (melded), and the third card is the bottom (right) side.
+     */
+    names?: string[]
+
+    /**
+     * The collector's number of the card. Can be 345a or larger than the number of cards in the set.
+     */
+    number: string
+
+    /**
+     * Text on the card as originally printed, rather than it's oracle text.
+     *
+     * Can be \r\n seperated rather than \n seperated
+     */
+    originalText: string
+
+    /**
+     * Type as originally printed. Includes any supertypes and subtypes.
+     */
+    originalType: string
+
+    /**
+     * List of sets the card was printed in in uppercase. promo sets are prefexed with P
+     *
+     * @example ["M19", "PM19"]
+     */
+    printings: UppercaseSetCode[]
+
+    /**
+     * Power of a creature
+     * @example "4" or "X"
+     */
+    power: string
+
+    /**
+     * Rarity of the card
+     */
+    rarity: Rarity
+
+    /**
+     * The rulings on this card if any
+     */
+    rulings: Ruling[]
+
+    /**
+     * List of card subtypes found after em-dash
+     * @example ["Elder", "Dragon"]
+     */
+    subtypes: string[]
+
+    /**
+     * List of card supertypes found before the em-dash
+     */
+    supertypes: string[]
+
+    /**
+     * Rules text of the card. Also known as the "Oracle Text" and is the official rules text
+     *
+     * Can be \r\n seperated rather than \n seperated
+     */
+    text: string
+
+    /**
+     * Is this card timeshifted? (future or past). If omitted it is just a "normal" card.
+     * @default false
+     */
+    timeshifted?: boolean
+
+    /**
+     * Toughness of the card
+     * @example "4" or "X"
+     */
+    toughness: string
+
+    /**
+     * Full typeline of the card
+     *
+     * @example "Legendary Creature — Elder Dragon"
+     */
+    type: string
+
+    /**
+     * List of types of the card
+     *
+     * @example ["Creature"]
+     */
+    types: string[]
+
+    /**
+     * A universal unique id generated for the card.
+     *
+     * @example "7b215968-93a6-4278-ac61-4e3e8c3c3943"
+     */
+    uuid: UUID
+
+    /**
+     * Name of the watermark on the card. Can be one of many different values, including:
+     * a guild name, clan name, wotc for the shooting star.
+     *
+     * (If there isn’t one, it can be an empty string, but it is usually omitted.)
+     */
+    watermark?: string
+  }
+}

--- a/types/mtgjson-raw/index.d.ts
+++ b/types/mtgjson-raw/index.d.ts
@@ -1,0 +1,20 @@
+// Type definitions for mtgjson (the json project not the npm package) 4.x
+// Project: https://mtgjson.com/v4/
+// Definitions by: Everspace <https://github.com/Everspace>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.0
+
+/**
+ * mtgjson types
+ * @see https://mtgjson.com/v4/docs.html
+ */
+declare namespace mtgjson {
+
+}
+
+/// <reference path="./lib/game" />
+/// <reference path="./lib/meta" />
+/// <reference path="./lib/physical" />
+
+/// <reference path="./card" />
+/// <reference path="./set" />

--- a/types/mtgjson-raw/lib/game.d.ts
+++ b/types/mtgjson-raw/lib/game.d.ts
@@ -1,0 +1,18 @@
+declare namespace mtgjson {
+  /**
+   * Place for "game mechanically important" things
+   * like color or subtypes
+   */
+
+  /**
+   * Single letter for a color
+   */
+  export type ColorCode = "W" | "U" | "B" | "R" | "G"
+
+  /**
+   * An attribute after the emdash on a card
+   *
+   * @example "Goblin"
+   */
+  export type SubType = string
+}

--- a/types/mtgjson-raw/lib/meta.d.ts
+++ b/types/mtgjson-raw/lib/meta.d.ts
@@ -1,0 +1,96 @@
+declare namespace mtgjson {
+  /**
+   * For stuff about the game itself or stuff that doesn't
+   * nessisarily relate to the card.
+   */
+
+  /**
+   * mtgjson unique id for a card
+   */
+  export type UUID = string
+
+  /**
+   * WOTC set codename like "M19" for "Core Set 2019"
+   * @example "M19" "RTR"
+   */
+  export type SetCode = string
+
+  /**
+   * mtgjson Date formated date. YYYY-MM-DD
+   * "An ODBC standard date"
+   *
+   * @example "2018-10-13"
+   */
+
+  export type mtgjsonDate = string
+
+  /**
+   * @example "m19" "rtr"
+   */
+  export type LowercaseSetCode = SetCode
+
+  /**
+   * @example "M19" "RTR"
+   */
+  export type UppercaseSetCode = SetCode
+
+  /**
+   * WOTC card rulings.
+   */
+  export interface Ruling {
+    date: mtgjsonDate
+    text: string
+  }
+
+  /**
+   * WOTC set number that is used as an identifier in thier DB
+   *
+   * may or may not be present for every card.
+   */
+  export type MultiverseID = number
+
+  /**
+   * What number is this card in the set?
+   *
+   * It is ordered by "Non-colored Non-Artifact" WUBRG Gold Hybrid Artifact
+   *
+   * a or b signifies the side of the card
+   *
+   *
+   *
+   * For meld cards, both front sides get "a", and the backside is the the bottom half's "b"
+   *
+   *
+   * Bruna: 7a
+   * Brisela: 7b
+   */
+  export type CollectorNumber = string
+
+  /**
+   * Printed rarities
+   */
+  export type Rarity = "common" | "uncommon" | "rare" | "mythic" | "Special"
+
+  /**
+   * Play formats
+   */
+  export type Format =
+    | "1v1"
+    | "brawl"
+    | "commander"
+    | "duel"
+    | "frontier"
+    | "future"
+    | "legacy"
+    | "modern"
+    | "pauper"
+    | "penny"
+    | "standard"
+    | "vintage"
+
+  /**
+   * States of ability to play the card in a format
+   * "Future" is used for a revision of the format in which the card will be legal soon.
+   */
+  export type Legality = "Banned" | "Future" | "Legal" | "Restricted"
+}

--- a/types/mtgjson-raw/lib/physical.d.ts
+++ b/types/mtgjson-raw/lib/physical.d.ts
@@ -1,0 +1,59 @@
+declare namespace mtgjson {
+  /**
+   * For things about the card itself like what is written on it
+   * or what shape it is
+   */
+
+  /**
+   * Border format
+   */
+  export type BorderColor = "black" | "borderless" | "gold" | "silver" | "white"
+
+  /**
+   * Valid card frame styles
+   */
+  export type FrameVersion = "1993" | "1997" | "2003" | "2015" | "future"
+
+  /**
+   * Describes all possible card layouts
+   */
+  export type Layout =
+    | "normal"
+    | "split"
+    | "flip"
+    | "transform"
+    | "meld"
+    | "vanguard"
+    | "token"
+    | "double_faced_token"
+    | "emblem"
+    | "augment"
+    | "host"
+
+  /**
+   * The full foreign language name in English for ForeignDataEntry
+   *
+   * Includes promo language ones like Arabic and Phyrexian
+   *
+   * @see ForeignDataEntry
+   */
+  export type ForeignLanguage =
+    | "English"
+    | "Spanish"
+    | "French"
+    | "German"
+    | "Italian"
+    | "Portuguese (Brazil)"
+    | "Japanese"
+    | "Korean"
+    | "Russian"
+    | "Chinese Simplified"
+    | "Chinese Traditional"
+    // Promo cards
+    | "Hebrew"
+    | "Latin"
+    | "Ancient Greek"
+    | "Arabic"
+    | "Sanskrit"
+    | "Phyrexian"
+}

--- a/types/mtgjson-raw/set.d.ts
+++ b/types/mtgjson-raw/set.d.ts
@@ -1,0 +1,91 @@
+declare namespace mtgjson {
+  /**
+   * mtgjson release info
+   */
+  export interface SetMetadata {
+    /**
+     * OBDC Date of build (YYYY-MM-DD)
+     */
+    date: mtgjsonDate
+
+    /**
+     * mtgjson release version
+     */
+    version: string
+  }
+
+  /**
+   * All possible set types
+   */
+  export type SetType =
+    | "archenemy"
+    | "box"
+    | "commander"
+    | "core"
+    | "draft_innovation"
+    | "duel_deck"
+    | "expansion"
+    | "from_the_vault"
+    | "funny"
+    | "masterpiece"
+    | "masters"
+    | "memorabilia"
+    | "planechase"
+    | "premium_deck"
+    | "promo"
+    | "spellbook"
+    | "starter"
+    | "token"
+    | "vanguard"
+
+  /**
+   * Representation of an MTG Set
+   * @see https://mtgjson.com/v4/docs.html
+   */
+  export interface Set {
+    /**
+     * Block the set was in. Sometimes blocks are their own set.
+     */
+    block: string
+
+    /**
+     * List of cards
+     */
+    cards: Card[]
+
+    /**
+     * Set code for the set.
+     */
+    code: LowercaseSetCode
+
+    /**
+     * Info about MTJSON publishing
+     */
+    meta: SetMetadata
+
+    /**
+     * Set code for the set as it appears on Magic: The Gathering Online.
+     */
+    mtgoCode: LowercaseSetCode
+
+    /**
+     * Name of set
+     */
+    name: string
+
+    /**
+     * Release date
+     */
+    releaseDate: mtgjsonDate
+
+    /**
+     * Type of set
+     */
+    type: SetType
+
+    /**
+     * Tokens in the set
+     */
+    tokens: {}[]
+  }
+}

--- a/types/mtgjson-raw/tests/BladeOfSixthPride.test.ts
+++ b/types/mtgjson-raw/tests/BladeOfSixthPride.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Blade of the Sixth Pride has:
+ * - No flavour/card text
+ * - Uses the future frame
+ * - Has the "Special" rarity
+ */
+
+let Blade: mtgjson.Card = {
+  "artist": "Justin Sweet",
+  "borderColor": "black",
+  "colorIdentity": [
+    "W"
+  ],
+  "colors": [
+    "W"
+  ],
+  "convertedManaCost": 2,
+  "foreignData": [
+    {
+      "language": "German",
+      "multiverseId": 144956,
+      "name": "Säbel des sechsten Rudels",
+      "type": "Kreatur — Katze, Rebell"
+    },
+    {
+      "language": "Spanish",
+      "multiverseId": 145280,
+      "name": "Espada de la Sexta Manada",
+      "type": "Criatura — Felino rebelde"
+    },
+    {
+      "language": "French",
+      "multiverseId": 145361,
+      "name": "Scramasaxe de la Sixième bande",
+      "type": "Créature : chat et rebelle"
+    },
+    {
+      "language": "Italian",
+      "multiverseId": 144875,
+      "name": "Lama del Sesto Branco",
+      "type": "Creatura — Ribelle Felino"
+    },
+    {
+      "language": "Japanese",
+      "multiverseId": 145442,
+      "name": "第六隊の刃",
+      "type": "クリーチャー — 猫・レベル"
+    },
+    {
+      "language": "Portuguese (Brazil)",
+      "multiverseId": 145118,
+      "name": "Lâmina do Sexto Orgulho",
+      "type": "Criatura — Felino Rebelde"
+    },
+    {
+      "language": "Russian",
+      "multiverseId": 157478,
+      "name": "Клинок Шестого Прайда",
+      "type": "(none)"
+    },
+    {
+      "language": "Chinese Simplified",
+      "multiverseId": 145199,
+      "name": "六战群之刃",
+      "type": "生物～猫／反抗军"
+    }
+  ],
+  "frameVersion": "future",
+  "hasFoil": true,
+  "hasNonFoil": true,
+  "isReserved": false,
+  "layout": "normal",
+  "legalities": {
+    "1v1": "Legal",
+    "commander": "Legal",
+    "duel": "Legal",
+    "legacy": "Legal",
+    "modern": "Legal",
+    "pauper": "Legal",
+    "penny": "Legal",
+    "vintage": "Legal"
+  },
+  "manaCost": "{1}{W}",
+  "multiverseId": 130676,
+  "name": "Blade of the Sixth Pride",
+  "number": "19",
+  "originalText": "",
+  "originalType": "Creature - Cat Rebel",
+  "power": "3",
+  "printings": [
+    "FUT"
+  ],
+  "rarity": "Special",
+  "rulings": [],
+  "subtypes": [
+    "Cat",
+    "Rebel"
+  ],
+  "supertypes": [],
+  "text": "",
+  "timeshifted": true,
+  "toughness": "1",
+  "type": "Creature — Cat Rebel",
+  "types": [
+    "Creature"
+  ],
+  "uuid": "f6ccfe28-ec08-4751-b65c-c40b2bafa955"
+}

--- a/types/mtgjson-raw/tests/Brisela.test.ts
+++ b/types/mtgjson-raw/tests/Brisela.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Brisela is a meld card
+ */
+
+let Brisela: mtgjson.Card = {
+  "artist": "Clint Cearley",
+  "borderColor": "black",
+  "colorIdentity": [
+    "W"
+  ],
+  "colors": [],
+  "convertedManaCost": 11,
+  "flavorText": "Upon discovering what had become of her sisters, Sigarda could only weep.",
+  "foreignData": [
+    {
+      "flavorText": "Nachdem sie herausfand, was aus ihren Schwestern geworden war, konnte Sigarda nur noch weinen. Nachdem sie herausfand, was aus ihren Schwestern geworden war, konnte Sigarda nur noch weinen.",
+      "language": "German",
+      "multiverseId": 414974,
+      "name": "Brisela, Stimme der Albträume",
+      "text": "Fliegend, Erstschlag, Wachsamkeit, Lebensverknüpfung\nDeine Gegner können keine Zaubersprüche mit umgewandelten Manakosten von 3 oder weniger wirken.",
+      "type": "Legendäre Kreatur — Eldrazi, Engel"
+    },
+    {
+      "flavorText": "Al descubrir lo que había sido de sus hermanas, Sigarda no pudo más que prorrumpir en llanto. Al descubrir lo que había sido de sus hermanas, Sigarda no pudo más que prorrumpir en llanto.",
+      "language": "Spanish",
+      "multiverseId": 416535,
+      "name": "Brisela, Voz de las Pesadillas",
+      "text": "Vuela, daña primero, vigilancia, vínculo vital.\nTus oponentes no pueden lanzar hechizos con coste de maná convertido de 3 o menos.",
+      "type": "Criatura legendaria — Ángel eldrazi"
+    },
+    {
+      "flavorText": "En découvrant ce qu'étaient devenues ses sœurs, Sigarda fut réduite en larmes. En découvrant ce qu'étaient devenues ses sœurs, Sigarda fut réduite en larmes.",
+      "language": "French",
+      "multiverseId": 415197,
+      "name": "Brisela, voix des cauchemars",
+      "text": "Vol, initiative, vigilance, lien de vie\nVos adversaires ne peuvent pas lancer de sorts ayant un coût converti de mana inférieur ou égal à 3.",
+      "type": "Créature légendaire : eldrazi et ange"
+    },
+    {
+      "flavorText": "Quando scoprì ciò che era accaduto alle sue sorelle, Sigarda non poté che piangere. Quando scoprì ciò che era accaduto alle sue sorelle, Sigarda non poté che piangere.",
+      "language": "Italian",
+      "multiverseId": 415420,
+      "name": "Brisela, Voce degli Incubi",
+      "text": "Volare, attacco improvviso, cautela, legame vitale\nI tuoi avversari non possono lanciare magie con costo di mana convertito pari o inferiore a 3.",
+      "type": "Creatura Leggendaria — Angelo Eldrazi"
+    },
+    {
+      "flavorText": "姉妹のなれの果てを知ったシガルダは、ただ咽び泣くことしかできなかった。 姉妹のなれの果てを知ったシガルダは、ただ咽び泣くことしかできなかった。",
+      "language": "Japanese",
+      "multiverseId": 415643,
+      "name": "悪夢の声、ブリセラ",
+      "text": "飛行、先制攻撃、警戒、絆魂\n対戦相手は、点数で見たマナ・コストが３以下の呪文を唱えられない。",
+      "type": "伝説のクリーチャー — エルドラージ・天使"
+    },
+    {
+      "flavorText": "그녀의 자매들에게 생긴 일을 보자, 시가르다는 눈물밖에 나오지 않았다. 그녀의 자매들에게 생긴 일을 보자, 시가르다는 눈물밖에 나오지 않았다.",
+      "language": "Korean",
+      "multiverseId": 415866,
+      "name": "악몽의 목소리 브리셀라",
+      "text": "비행, 선제공격, 경계, 생명연결\n당신의 상대는 전환마나비용이 3 이하인 주문을 발동할 수 없다.",
+      "type": "전설적 생물 — 엘드라지 천사"
+    },
+    {
+      "flavorText": "Ao descobrir o que suas irmãs haviam se tornado, Sigarda pôde apenas chorar. Ao descobrir o que suas irmãs haviam se tornado, Sigarda pôde apenas chorar.",
+      "language": "Portuguese (Brazil)",
+      "multiverseId": 416089,
+      "name": "Brisela, Voz dos Pesadelos",
+      "text": "Voar, iniciativa, vigilância, vínculo com a vida\nSeus oponentes não podem conjurar mágicas com custo de mana convertido igual ou inferior a 3.",
+      "type": "Criatura Lendária — Eldrazi Anjo"
+    },
+    {
+      "flavorText": "Когда Сигарда узнала, в кого превратились ее сестры, ей оставалось только плакать. Когда Сигарда узнала, в кого превратились ее сестры, ей оставалось только плакать.",
+      "language": "Russian",
+      "multiverseId": 416312,
+      "name": "Бризела, Голос Кошмаров",
+      "text": "Полет, Первый удар, Бдительность, Цепь жизни\nВаши оппоненты не могут разыгрывать заклинания с конвертированной мана-стоимостью 3 или меньше.",
+      "type": "Легендарное Существо — Эльдрази Ангел"
+    },
+    {
+      "flavorText": "眼见姐妹落此凄惨境地，只余席嘉妲空自悲切。 眼见姐妹落此凄惨境地，只余席嘉妲空自悲切。",
+      "language": "Chinese Simplified",
+      "multiverseId": 414528,
+      "name": "梦魇异音布瑟拉",
+      "text": "飞行，先攻，警戒，系命\n所有对手都不能施放总法术力费用等于或小于3的咒语。",
+      "type": "传奇生物～奥札奇／天使"
+    },
+    {
+      "flavorText": "眼見姐妹落此淒慘境地，只餘席嘉妲空自悲切。 眼見姐妹落此淒慘境地，只餘席嘉妲空自悲切。",
+      "language": "Chinese Traditional",
+      "multiverseId": 414751,
+      "name": "夢魘異音布瑟拉",
+      "text": "飛行，先攻，警戒，繫命\n所有對手都不能施放總魔法力費用等於或小於3的咒語。",
+      "type": "傳奇生物～奧札奇／天使"
+    }
+  ],
+  "frameVersion": "2015",
+  "hasFoil": true,
+  "hasNonFoil": true,
+  "isReserved": false,
+  "layout": "meld",
+  "legalities": {
+    "1v1": "Legal",
+    "commander": "Legal",
+    "duel": "Legal",
+    "frontier": "Legal",
+    "legacy": "Legal",
+    "modern": "Legal",
+    "vintage": "Legal"
+  },
+  "multiverseId": 414305,
+  "name": "Brisela, Voice of Nightmares",
+  "names": [
+    "Bruna, the Fading Light",
+    "Brisela, Voice of Nightmares",
+    "Gisela, the Broken Blade"
+  ],
+  "number": "15b",
+  "originalText": "When you cast Bruna, the Fading Light, you may return target Angel or Human creature card from your graveyard to the battlefield.\r\nFlying, vigilance\r\n(Melds with Gisela, the Broken Blade.)",
+  "originalType": "Legendary Creature — Angel Horror",
+  "power": "9",
+  "printings": [
+    "EMN",
+    "PEMN",
+    "V17"
+  ],
+  "rarity": "mythic",
+  "rulings": [
+    {
+      "date": "2016-07-13",
+      "text": "In a Commander game, your commander may be Bruna, the Fading Light or Gisela, the Broken Blade, and the other may be in your deck. If they meld into Brisela, Voice of Nightmares, Brisela will also be your commander; but if Brisela leaves the battlefield, only the card chosen as your commander at the start of the game may be put into the command zone."
+    },
+    {
+      "date": "2016-07-13",
+      "text": "A “when you cast” triggered ability resolves before the original spell resolves. It resolves even if the original spell is countered, and the original spell resolves even if the triggered ability is countered."
+    },
+    {
+      "date": "2016-07-13",
+      "text": "Effects that increase or reduce the cost to cast a spell (such as those of escalate and emerge) don’t affect the spell’s converted mana cost, so they won’t change whether Brisela’s last ability restricts that spell from being cast."
+    },
+    {
+      "date": "2016-07-13",
+      "text": "For spells with {X} in their mana costs, use the value chosen for X to determine if the spell’s converted mana cost is 3 or less. For example, your opponent could cast Burn from Within (a spell with mana cost {X}{R}) with X equal to 3, but not with X equal to 2."
+    },
+    {
+      "date": "2016-07-13",
+      "text": "For more information on meld cards, see the Eldritch Moon mechanics article (http://magic.wizards.com/en/articles/archive/feature/eldritch-moon-mechanics)."
+    }
+  ],
+  "subtypes": [
+    "Eldrazi",
+    "Angel"
+  ],
+  "supertypes": [
+    "Legendary"
+  ],
+  "text": "Flying, first strike, vigilance, lifelink\nYour opponents can't cast spells with converted mana cost 3 or less.",
+  "toughness": "10",
+  "type": "Legendary Creature — Eldrazi Angel",
+  "types": [
+    "Creature"
+  ],
+  "uuid": "5a7a212e-e0b6-4f12-a95c-173cae023f93"
+}

--- a/types/mtgjson-raw/tests/NivMizzet.test.ts
+++ b/types/mtgjson-raw/tests/NivMizzet.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Example of normal card
+ */
+
+let GRN_Niv_Mizzet: mtgjson.Card = {
+  "artist": "Svetlin Velinov",
+  "borderColor": "black",
+  "colorIdentity": [
+    "R",
+    "U"
+  ],
+  "colors": [
+    "R",
+    "U"
+  ],
+  "convertedManaCost": 6.0,
+  "foreignData": [],
+  "frameVersion": "2015",
+  "hasFoil": true,
+  "hasNonFoil": true,
+  "isReserved": false,
+  "layout": "normal",
+  "legalities": {
+    "1v1": "Legal",
+    "brawl": "Legal",
+    "commander": "Legal",
+    "duel": "Legal",
+    "frontier": "Legal",
+    "future": "Legal",
+    "legacy": "Legal",
+    "modern": "Legal",
+    "standard": "Legal",
+    "vintage": "Legal"
+  },
+  "manaCost": "{U}{U}{U}{R}{R}{R}",
+  "multiverseId": 452942,
+  "name": "Niv-Mizzet, Parun",
+  "number": "192",
+  "originalText": "This spell can't be countered.\nFlying\nWhenever you draw a card, Niv-Mizzet, Parun deals 1 damage to any target.\nWhenever a player casts an instant or sorcery spell, you draw a card.",
+  "originalType": "Legendary Creature — Dragon Wizard",
+  "power": "5",
+  "printings": [
+    "GRN",
+    "PGRN"
+  ],
+  "rarity": "rare",
+  "rulings": [
+    {
+      "date": "2018-10-05",
+      "text": "If an effect instructs you to draw multiple cards, Niv-Mizzet’s first triggered ability triggers that many times. You choose targets for those abilities after you’ve drawn all of the cards."
+    },
+    {
+      "date": "2018-10-05",
+      "text": "If a spell or ability causes you to put cards into your hand without specifically using the word “draw,” Niv-Mizzet’s first triggered ability won’t trigger."
+    },
+    {
+      "date": "2018-10-05",
+      "text": "Niv-Mizzet’s second triggered ability resolves before the spell that caused it to trigger. It resolves even if that spell is countered. This causes its first triggered ability to trigger, and that also resolves before the spell."
+    },
+    {
+      "date": "2018-10-05",
+      "text": "Players can cast spells and activate abilities after Niv-Mizzet’s second triggered ability resolves but before the spell that caused it to trigger does. Notably, the card you draw may be able to counter that spell."
+    }
+  ],
+  "subtypes": [
+    "Dragon",
+    "Wizard"
+  ],
+  "supertypes": [
+    "Legendary"
+  ],
+  "text": "This spell can't be countered.\nFlying\nWhenever you draw a card, Niv-Mizzet, Parun deals 1 damage to any target.\nWhenever a player casts an instant or sorcery spell, you draw a card.",
+  "toughness": "5",
+  "type": "Legendary Creature — Dragon Wizard",
+  "types": [
+    "Creature"
+  ],
+  "uuid": "6f3d2dc5-7b9d-4af6-9f3b-4de90fbf63c9",
+  "watermark": "izzet"
+}

--- a/types/mtgjson-raw/token.d.ts
+++ b/types/mtgjson-raw/token.d.ts
@@ -1,0 +1,5 @@
+declare namespace mtgjson {
+  export interface Token {
+    // TODO
+  }
+}

--- a/types/mtgjson-raw/tsconfig.json
+++ b/types/mtgjson-raw/tsconfig.json
@@ -23,7 +23,7 @@
         "lib/game.d.ts",
         "lib/meta.d.ts",
         "lib/physical.d.ts",
-        "tests/BladeOfSithPride.test.ts",
+        "tests/BladeOfSixthPride.test.ts",
         "tests/Brisela.test.ts",
         "tests/NivMizzet.test.ts"
     ]

--- a/types/mtgjson-raw/tsconfig.json
+++ b/types/mtgjson-raw/tsconfig.json
@@ -1,0 +1,30 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "include": [
+        "./**/*.test.ts"
+    ],
+    "files": [
+        "index.d.ts",
+        "card.d.ts",
+        "set.d.ts",
+        "token.d.ts",
+        "lib/game.d.ts",
+        "lib/meta.d.ts",
+        "lib/physical.d.ts"
+    ]
+}

--- a/types/mtgjson-raw/tsconfig.json
+++ b/types/mtgjson-raw/tsconfig.json
@@ -15,9 +15,6 @@
         "noEmit": true,
         "forceConsistentCasingInFileNames": true
     },
-    "include": [
-        "./**/*.test.ts"
-    ],
     "files": [
         "index.d.ts",
         "card.d.ts",
@@ -25,6 +22,9 @@
         "token.d.ts",
         "lib/game.d.ts",
         "lib/meta.d.ts",
-        "lib/physical.d.ts"
+        "lib/physical.d.ts",
+        "tests/BladeOfSithPride.test.ts",
+        "tests/Brisela.test.ts",
+        "tests/NivMizzet.test.ts"
     ]
 }

--- a/types/mtgjson-raw/tslint.json
+++ b/types/mtgjson-raw/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
This is specifically typing for https://mtgjson.com/v4/ . The `mtgjson` project isn't being maintained, and it provides a different thing. These typing could also be useful for general development between client and servers exchanging card data.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
