### PR TITLE
reactVirtualizedListProps can by only partial

### DIFF
--- a/types/react-sortable-tree/index.d.ts
+++ b/types/react-sortable-tree/index.d.ts
@@ -158,7 +158,7 @@ export interface TreeRendererProps {
 export interface ThemeProps {
     style?: { [index: string]: any };
     innerStyle?: { [index: string]: any };
-    reactVirtualizedListProps?: ListProps;
+    reactVirtualizedListProps?: Partial<ListProps>;
     scaffoldBlockPxWidth?: number;
     slideRegionSize?: number;
     rowHeight?: ((info: Index) => number) | number;
@@ -184,7 +184,7 @@ export interface ReactSortableTreeProps {
     onVisibilityToggle?(data: OnVisibilityToggleData): void;
     canDrag?: ((data: ExtendedNodeData) => boolean) | boolean;
     canDrop?(data: OnDragPreviousAndNextLocation & NodeData): boolean;
-    reactVirtualizedListProps?: ListProps;
+    reactVirtualizedListProps?: Partial<ListProps>;
     rowHeight?: ((info: Index) => number) | number;
     slideRegionSize?: number;
     scaffoldBlockPxWidth?: number;


### PR DESCRIPTION
Please fill in this template.

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/frontend-collective/react-sortable-tree/blob/master/src/react-sortable-tree.js#L44-L46
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
