### PR TITLE
BN.js: Constructor accepts 'hex' as a base

### DIFF
--- a/types/bn.js/index.d.ts
+++ b/types/bn.js/index.d.ts
@@ -45,7 +45,7 @@ interface ReductionContext {
 declare class BN {
     constructor(
         number: number | string | number[] | Buffer | BN,
-        base?: number,
+        base?: number | 'hex',
         endian?: Endianness
     );
     constructor(


### PR DESCRIPTION
Currently the typings say base can only be a number, but it also accepts the word hex.

https://github.com/indutny/bn.js/blob/24cc2dd51b58694088a637a314689f61c9ba65a4/lib/bn.js#L85
