### PR TITLE
consul: Add near parameter to ServiceOptions

### DIFF
--- a/types/consul/index.d.ts
+++ b/types/consul/index.d.ts
@@ -625,6 +625,7 @@ declare namespace Consul {
             dc?: string;
             tag?: string;
             passing?: boolean;
+            near?: string;
         }
 
         interface StateOptions extends CommonOptions {


### PR DESCRIPTION
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: See https://www.consul.io/api/health.html#near-1 and https://github.com/silas/node-consul#common-method-call-options
- [x] Increase the version number in the header if appropriate. (I don't think this is needed here but please let me know if it is)