### PR TITLE
[styled-components] Fix #30042

### DIFF
--- a/types/styled-components/index.d.ts
+++ b/types/styled-components/index.d.ts
@@ -82,7 +82,7 @@ export interface ThemedStyledFunction<P, T, O = P> {
         strings: TemplateStringsArray,
         ...interpolations: Array<Interpolation<ThemedStyledProps<P & U, T>>>
     ): StyledComponentClass<P & U, T, O & U>;
-    attrs<U, A extends Partial<P & U> & { [others: string]: unknown; } = {}>(
+    attrs<U, A extends Partial<P & U> & { [others: string]: any; } = {}>(
         attrs: Attrs<P & U, A, T>,
     ): ThemedStyledFunction<DiffBetween<A, P & U>, T, DiffBetween<A, O & U>>;
 }

--- a/types/styled-components/index.d.ts
+++ b/types/styled-components/index.d.ts
@@ -82,7 +82,7 @@ export interface ThemedStyledFunction<P, T, O = P> {
         strings: TemplateStringsArray,
         ...interpolations: Array<Interpolation<ThemedStyledProps<P & U, T>>>
     ): StyledComponentClass<P & U, T, O & U>;
-    attrs<U, A extends Partial<P & U> = {}>(
+    attrs<U, A extends Partial<P & U> & { [others: string]: unknown; } = {}>(
         attrs: Attrs<P & U, A, T>,
     ): ThemedStyledFunction<DiffBetween<A, P & U>, T, DiffBetween<A, O & U>>;
 }

--- a/types/styled-components/test/index.tsx
+++ b/types/styled-components/test/index.tsx
@@ -312,6 +312,12 @@ const AttrsInput = styled.input.attrs({
     padding: ${props => props.padding};
 `;
 
+// https://github.com/DefinitelyTyped/DefinitelyTyped/issues/30042
+const AttrsWithOnlyNewProps = styled.h2.attrs({ as: 'h1' })`
+    color: ${props => props.as === 'h1' ? 'red' : 'blue'};
+    font-size: ${props => props.as === 'h1' ? 2 : 1};
+`;
+
 /**
  * component type
  */


### PR DESCRIPTION
Fix #30042

- allow `attrs`'s `A` type parameter to accept exceed properties

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes:
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
