### PR TITLE
types definitions for async-mkdirp were added

### DIFF
--- a/types/async-mkdirp/async-mkdirp-tests.ts
+++ b/types/async-mkdirp/async-mkdirp-tests.ts
@@ -1,0 +1,9 @@
+import mkdirp = require("async-mkdirp");
+
+mkdirp('str')
+  .then(() => { /* ... */ })
+  .catch(() => { /* ... */ });
+
+mkdirp('str', 0o777)
+  .then(() => { /* ... */ })
+  .catch(() => { /* ... */ });

--- a/types/async-mkdirp/index.d.ts
+++ b/types/async-mkdirp/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for async-mkdirp v.1.2.4
+// Type definitions for async-mkdirp 1.2.4
 // Project: https://github.com/simonlc/async-mkdirp
 // Definitions by: Andrey Sakharov <https://github.com/muturgan>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/async-mkdirp/index.d.ts
+++ b/types/async-mkdirp/index.d.ts
@@ -1,0 +1,12 @@
+// Type definitions for async-mkdirp v.1.2.4
+// Project: https://github.com/simonlc/async-mkdirp
+// Definitions by: Andrey Sakharov <https://github.com/muturgan>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types="node" />
+
+import fs = require('fs');
+
+declare function mkdirp(path: fs.PathLike, mode?: number): Promise<void>;
+
+export = mkdirp;

--- a/types/async-mkdirp/tsconfig.json
+++ b/types/async-mkdirp/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "target": "es6",
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "async-mkdirp-tests.ts"
+    ]
+}

--- a/types/async-mkdirp/tslint.json
+++ b/types/async-mkdirp/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "dtslint/dt.json"
+}


### PR DESCRIPTION
If adding a new definition:
- The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- This NPM package is 'async-mkdirp'.
