### PR TITLE
Update Sequelize types

### DIFF
--- a/types/sequelize/index.d.ts
+++ b/types/sequelize/index.d.ts
@@ -5703,7 +5703,7 @@ declare namespace sequelize {
         /**
          * Set to `true` to enable connecting over SSL.
          *
-         * Defaults to false
+         * Defaults to undefined
          */
         ssl?: boolean;
     }

--- a/types/sequelize/index.d.ts
+++ b/types/sequelize/index.d.ts
@@ -14,6 +14,7 @@
 //                 Todd Bealmear <https://github.com/todd>
 //                 Nick Schultz <https://github.com/nrschultz>
 //                 Thomas Breleur <https://github.com/thomas-b>
+//                 Antoine Boisadam <https://github.com/Antoine38660>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -5698,6 +5699,13 @@ declare namespace sequelize {
          * Pass object to limit set of aliased operators or false to disable completely.
          */
         operatorsAliases?: boolean | OperatorsAliases;
+
+        /**
+         * Set to `true` to enable connecting over SSL.
+         *
+         * Defaults to false
+         */
+        ssl?: boolean;
     }
 
     /**


### PR DESCRIPTION
According to the official Sequelize documentation : [configuration-for-connecting-over-ssl](https://github.com/sequelize/cli/tree/master/docs#configuration-for-connecting-over-ssl) I'm adding a `ssl` key in options.

Cheers 😄 