### PR TITLE
[Slate] Correct definition for KeyUtils

### DIFF
--- a/types/slate/index.d.ts
+++ b/types/slate/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for slate 0.42
+// Type definitions for slate 0.43
 // Project: https://github.com/ianstormtaylor/slate
 // Definitions by: Andy Kent <https://github.com/andykent>
 //                 Jamie Talbot <https://github.com/majelbstoat>
@@ -1478,10 +1478,10 @@ export class SlateError extends Error {
     [key: string]: any;
 }
 
-export interface KeyUtils {
-    create(key: string): string;
-    setGenerator(func: () => any): void;
-    resetGenerator(): void;
+export namespace KeyUtils {
+    function create(key?: string): string;
+    function setGenerator(func: () => any): void;
+    function resetGenerator(): void;
 }
 
 export type useMemoization = () => void;

--- a/types/slate/slate-tests.ts
+++ b/types/slate/slate-tests.ts
@@ -1,4 +1,4 @@
-import { Value, Data, BlockJSON, Document, Editor, Change } from "slate";
+import { Value, Data, BlockJSON, Document, Editor, Change, KeyUtils } from "slate";
 
 const data = Data.create({ foo: "bar " });
 const value = Value.create({ data });
@@ -58,3 +58,7 @@ editor.command("testCommand");
 editor.query("testQuery");
 editor.run("testCommand");
 editor.event("mouseDown", new Event("mouseDown"));
+
+KeyUtils.setGenerator(() => 'Test');
+KeyUtils.create();
+KeyUtils.resetGenerator();

--- a/types/slate/slate-tests.ts
+++ b/types/slate/slate-tests.ts
@@ -59,6 +59,6 @@ editor.query("testQuery");
 editor.run("testCommand");
 editor.event("mouseDown", new Event("mouseDown"));
 
-KeyUtils.setGenerator(() => 'Test');
+KeyUtils.setGenerator(() => "Test");
 KeyUtils.create();
 KeyUtils.resetGenerator();


### PR DESCRIPTION
**`KeyUtils` was incorrectly defined as an `interface` rather than a `namespace`.**

In the [source material](https://github.com/ianstormtaylor/slate/blob/master/packages/slate/src/utils/key-utils.js) `KeyUtils` is defined as 3 exported functions, however we are treating it as an interface. Nowhere in our definitions nor in the source JS is this type of interface accepted, so it is essentially redundant in its current form. As such this change modifies the definition to be a namespace, from which users can call the functions directly in as intended in the original JS code.

Due to the fact that this interface was previously 'unusable' I have not made this a breaking change (i.e. have only incremented a minor version number, rather than a major one). Please feel free to argue this :) 

[Original bug on slate repo](https://github.com/ianstormtaylor/slate/issues/2189)

_N.b. If this pr looks good to everyone and is approved, I will provide the same treatment for `PathUtils` which currently has the same issue_

-----

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:  [Documentation](https://docs.slatejs.org/slate-core/utils)
- [x] Increase the version number in the header if appropriate.
~~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.~~
