### PR TITLE
Jasmine: Adds withContext method on Matcher<T>

### DIFF
--- a/types/jasmine/index.d.ts
+++ b/types/jasmine/index.d.ts
@@ -448,6 +448,12 @@ declare namespace jasmine {
         toThrowError(message?: string | RegExp): boolean;
         toThrowError(expected?: new (...args: any[]) => Error, message?: string | RegExp): boolean;
 
+        /**
+         * Add some context for an expect.
+         * @param message - Additional context to show when the matcher fails
+         */
+        withContext(message: string): Matchers<T>;
+
         not: Matchers<T>;
 
         Any: Any;

--- a/types/jasmine/jasmine-tests.ts
+++ b/types/jasmine/jasmine-tests.ts
@@ -246,6 +246,12 @@ describe("A spec", () => {
     });
 });
 
+describe("withContext", () => {
+    it("can be used after an expectation", () => {
+        expect(1).withContext('context message').toBe(1);
+    });
+});
+
 xdescribe("A spec", () => {
     var foo: number;
 


### PR DESCRIPTION
Jasmine 3.3.0 introduced a new method called `withContext` to provide additional context to an expectation.
See https://github.com/jasmine/jasmine/blob/master/release_notes/3.3.0.md and https://github.com/jasmine/jasmine/blob/552420765833d5bef141d541d224c90f7eacdaba/src/core/Expectation.js#L20-L28

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/jasmine/jasmine/blob/552420765833d5bef141d541d224c90f7eacdaba/src/core/Expectation.js#L20-L28
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.