### PR TITLE
[jasmine] make SpyObjMethodNames more strongly-typed

### DIFF
--- a/types/angular-wizard/index.d.ts
+++ b/types/angular-wizard/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/mgonto/angular-wizard
 // Definitions by: Marko Jurisic <https://github.com/mjurisic>, Ronald Wildenberg <https://github.com/rwwilden>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 import * as angular from 'angular';
 

--- a/types/frisby/index.d.ts
+++ b/types/frisby/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Christopher E. Woodland <https://github.com/cwoodland>
 //                 Johnny Li <https://github.com/johnny4753>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 /// <reference types='jasmine'/>
 

--- a/types/frisby/v0/index.d.ts
+++ b/types/frisby/v0/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/vlucas/frisby
 // Definitions by: Johnny Li <https://github.com/johnny4753>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 ///<reference types="jasmine"/>
 

--- a/types/gulp-jasmine/index.d.ts
+++ b/types/gulp-jasmine/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/sindresorhus/gulp-jasmine#readme
 // Definitions by: Andrey Lalev <https://github.com/andypyrope>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 /// <reference types="node" />
 /// <reference types="jasmine" />

--- a/types/jasmine-ajax/index.d.ts
+++ b/types/jasmine-ajax/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/jasmine/jasmine-ajax
 // Definitions by: Louis Grignon <https://github.com/lgrignon>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 interface JasmineAjaxResponse {
 	status?: number;

--- a/types/jasmine-data_driven_tests/index.d.ts
+++ b/types/jasmine-data_driven_tests/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/gburghardt/jasmine-data_driven_tests
 // Definitions by: Anthony MacKinnon <https://github.com/AnthonyMacKinnon>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 declare var all: JasmineDataDrivenTest;
 declare var xall: JasmineDataDrivenTest;

--- a/types/jasmine-es6-promise-matchers/index.d.ts
+++ b/types/jasmine-es6-promise-matchers/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/bvaughn/jasmine-es6-promise-matchers
 // Definitions by: Stephen Lautier <https://github.com/stephenlautier>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 /// <reference types="jasmine" />
 

--- a/types/jasmine-fixture/index.d.ts
+++ b/types/jasmine-fixture/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/searls/jasmine-fixture
 // Definitions by: Craig Brett <https://github.com/craigbrett17>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 /// <reference types="jasmine" />
 

--- a/types/jasmine-jquery/index.d.ts
+++ b/types/jasmine-jquery/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/velesin/jasmine-jquery
 // Definitions by: Gregor Stamac <https://github.com/gstamac>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 /// <reference types="jasmine"/>
 /// <reference types="jquery"/>

--- a/types/jasmine-matchers/index.d.ts
+++ b/types/jasmine-matchers/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/uxebu/jasmine-matchers
 // Definitions by: Bart van der Schoor <https://github.com/Bartvds>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 /*
 Typings 2013 Bart van der Schoor

--- a/types/jasmine-node/index.d.ts
+++ b/types/jasmine-node/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/mhevery/jasmine-node
 // Definitions by: Sven Reglitzki <https://github.com/svi3c>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 ///<reference types="jasmine"/>
 

--- a/types/jasmine-promise-matchers/index.d.ts
+++ b/types/jasmine-promise-matchers/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/bvaughn/jasmine-promise-matchers
 // Definitions by: Matthew Hill <https://github.com/matthewjh>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 /// <reference types="jasmine" />
 

--- a/types/jasmine/index.d.ts
+++ b/types/jasmine/index.d.ts
@@ -1,8 +1,14 @@
 // Type definitions for Jasmine 2.8.0
 // Project: http://jasmine.github.io/
-// Definitions by: Boris Yankov <https://github.com/borisyankov>, Theodore Brown <https://github.com/theodorejb>, David Pärsson <https://github.com/davidparsson>, Gabe Moothart <https://github.com/gmoothart>, Lukas Zech <https://github.com/lukas-zech-software>, Boris Breuer <https://github.com/Engineer2B>
+// Definitions by: Boris Yankov <https://github.com/borisyankov>
+//                 Theodore Brown <https://github.com/theodorejb>
+//                 David Pärsson <https://github.com/davidparsson>
+//                 Gabe Moothart <https://github.com/gmoothart>
+//                 Lukas Zech <https://github.com/lukas-zech-software>
+//                 Boris Breuer <https://github.com/Engineer2B>
+//                 Chris Yungmann <https://github.com/cyungmann>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 // For ddescribe / iit use : https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/karma-jasmine/karma-jasmine.d.ts
 
 /**
@@ -129,7 +135,7 @@ declare function waits(timeout?: number): void;
 
 declare namespace jasmine {
     type Expected<T> = T | ObjectContaining<T> | Any | Spy;
-    type SpyObjMethodNames<T = {}> = string[] | {[methodName: string]: any} | Array<keyof T>;
+    type SpyObjMethodNames<T = undefined> = T extends undefined ? (ReadonlyArray<string> | {[methodName: string]: any}) : (ReadonlyArray<keyof T> | {[P in keyof T]?: ReturnType<T[P] extends (...args: any[]) => any ? T[P] : any>});
 
     var clock: () => Clock;
 

--- a/types/jasmine_dom_matchers/index.d.ts
+++ b/types/jasmine_dom_matchers/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/charleshansen/jasmine_dom_matchers
 // Definitions by: Yaroslav Admin <https://github.com/devoto13>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 /// <reference types="jasmine" />
 

--- a/types/jasminewd2/index.d.ts
+++ b/types/jasminewd2/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Sammy Jelin <https://github.com/sjelin>
 //                 George Kalpakas <https://github.com/gkalpak>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 /// <reference types="jasmine" />
 

--- a/types/karma-jasmine/index.d.ts
+++ b/types/karma-jasmine/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/karma-runner/karma-jasmine
 // Definitions by: Michel Salib <https://github.com/michelsalib>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 /// <reference types="jasmine" />
 

--- a/types/protractor-helpers/index.d.ts
+++ b/types/protractor-helpers/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/wix/protractor-helpers
 // Definitions by: John Cant <https://github.com/johncant>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 import * as webdriver from "selenium-webdriver";
 

--- a/types/saywhen/index.d.ts
+++ b/types/saywhen/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/pushtechnology/saywhen
 // Definitions by: Sean Sobey <https://github.com/SeanSobey>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 /// <reference types="jasmine" />
 


### PR DESCRIPTION
When a generic type argument is provided, require the method names array
to only include keys of the generic type argument and for the object
syntax, additionally require that the setup returned type matches the
return type of the method. Requires TS 2.8 for conditional types.

Addresses my comments here: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/29325#issuecomment-432764890

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/29325#issuecomment-432764890
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
