### PR TITLE
[node] Fix typo in BasePrivateKeyEncodingOptions interface

### DIFF
--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -30,6 +30,7 @@
 //                 Wilco Bakker <https://github.com/WilcoBakker>
 //                 wwwy3y3 <https://github.com/wwwy3y3>
 //                 Zane Hannan AU <https://github.com/ZaneHannanAU>
+//                 Jeremie Rodriguez <https://github.com/jeremiergz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /** inspector module types */
@@ -6394,7 +6395,7 @@ declare module "crypto" {
 
     interface BasePrivateKeyEncodingOptions<T extends KeyFormat> {
         format: T;
-        ciper: string;
+        cipher: string;
         passphrase: string;
     }
 

--- a/types/node/node-tests.ts
+++ b/types/node/node-tests.ts
@@ -1513,7 +1513,7 @@ async function asyncStreamPipelineFinished() {
                 type: 'pkcs1',
             },
             privateKeyEncoding: {
-                ciper: 'some-cipher',
+                cipher: 'some-cipher',
                 format: 'pem',
                 passphrase: 'secret',
                 type: 'pkcs8',
@@ -1531,7 +1531,7 @@ async function asyncStreamPipelineFinished() {
                 type: 'spki',
             },
             privateKeyEncoding: {
-                ciper: 'some-cipher',
+                cipher: 'some-cipher',
                 format: 'der',
                 passphrase: 'secret',
                 type: 'pkcs8',
@@ -1548,7 +1548,7 @@ async function asyncStreamPipelineFinished() {
                 type: 'pkcs1',
             },
             privateKeyEncoding: {
-                ciper: 'some-cipher',
+                cipher: 'some-cipher',
                 format: 'pem',
                 passphrase: 'secret',
                 type: 'pkcs8',


### PR DESCRIPTION
Easy fix for a typo in BasePrivateKeyEncodingOptions interface used in generateKeyPairSync function.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
