### PR TITLE
Express and Socket.io : Setup class constructor function as a default export

### DIFF
--- a/types/socket.io/index.d.ts
+++ b/types/socket.io/index.d.ts
@@ -11,7 +11,7 @@
 ///<reference types="node" />
 
 declare const SocketIO: SocketIOStatic;
-export = SocketIO;
+export default SocketIO;
 /** @deprecated Available as a global for backwards-compatibility. */
 export as namespace SocketIO;
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: 
**I can't provide any documentation to explain this change but I saw that when I used `import * as express from "express"`. I would receive the error `express is not a function` but I was able to fix it by importing the default using `import express from "express"`. Problem is, I can only use that import statement if the export is marked as default. The same problem occurs for socket.io**
- [ ] Increase the version number in the header if appropriate. **(n.a)**
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. **(n.a)**
