### PR TITLE
@types/cli-table2 fixed header parameter types

### DIFF
--- a/types/cli-table2/cli-table2-tests.ts
+++ b/types/cli-table2/cli-table2-tests.ts
@@ -230,3 +230,24 @@ table26.push(
 // feel free to use colors in your content strings, column widths will be calculated correctly
 const table27 = new Table({ colWidths: [5], style: { head: [], border: [] } }) as Table.HorizontalTable;
 table27.push([/*colors.red(*/'hello'/*)*/]);
+
+// Header as text
+const table28 = new Table({ head: ["Top Header 1", "Top Header 2"] }) as Table.HorizontalTable;
+table28.push(
+    ['Value Row 1 Col 1', 'Value Row 1 Col 2'],
+    ['Value Row 2 Col 1', 'Value Row 2 Col 2']
+);
+
+// Header as Cells
+const table29 = new Table({ head: [{content: "Top Header 1"}, {content: "Top Header 2"}] }) as Table.HorizontalTable;
+table29.push(
+    ['Value Row 1 Col 1', 'Value Row 1 Col 2'],
+    ['Value Row 2 Col 1', 'Value Row 2 Col 2']
+);
+
+// ColSpan in header
+const table30 = new Table({ head: [{content: "Top Header 1", colSpan: 2}, {content: "Top Header 3"}] }) as Table.HorizontalTable;
+table30.push(
+    ['Value Row 1 Col 1', 'Value Row 1 Col 2', 'Value Row 1 Col 3'],
+    ['Value Row 2 Col 1', 'Value Row 2 Col 2', 'Value Row 2 Col 3']
+);

--- a/types/cli-table2/index.d.ts
+++ b/types/cli-table2/index.d.ts
@@ -31,7 +31,7 @@ declare namespace CliTable2 {
         rowHeights: Array<number | null>;
         colAligns: HorizontalAlignment[];
         rowAligns: VerticalAlignment[];
-        head: string[];
+        head: Cell[];
         wordWrap: boolean;
     }
 


### PR DESCRIPTION
Though it is not currently documented, `head` prop accepts `Cell[]`, not
`string[]`.
I've made PR to cli-table2 regarding this
(URL HERE: https://github.com/jamestalmage/cli-table2/pull/53), but I guess it should probably
be fixed whether it is gonna be merged soon or not.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

@mgroenhoff 
