### PR TITLE
[Luxon] toSQL opts and fromFormatExplain result.

### DIFF
--- a/types/luxon/index.d.ts
+++ b/types/luxon/index.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: Colby DeHart <https://github.com/colbydehart>
 //                 Hyeonseok Yang <https://github.com/FourwingsY>
 //                 Jonathan Siebern <https://github.com/jsiebern>
+//                 Matt R. Wilson <https://github.com/mastermatt>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
@@ -20,6 +21,11 @@ declare module 'luxon' {
 
         type ToFormatOptions = DateTimeFormatOptions & {
             round?: boolean;
+        };
+
+        type ToSQLOptions = {
+            includeOffset?: boolean;
+            includeZone?: boolean;
         };
 
         type ISOTimeOptions = {
@@ -65,6 +71,17 @@ declare module 'luxon' {
             conversionAccuracy?: string;
         };
 
+        type ExplainedFormat = {
+            input: string;
+            tokens: Array<{ literal: boolean, val: string }>,
+            regex?: RegExp;
+            rawMatches?: RegExpMatchArray | null;
+            matches?: {[k: string]: any};
+            result?: {[k: string]: any} | null;
+            zone?: Zone | null;
+            invalidReason?: string;
+        };
+
         class DateTime {
             static readonly DATETIME_FULL: DateTimeFormatOptions;
             static readonly DATETIME_FULL_WITH_SECONDS: DateTimeFormatOptions;
@@ -108,7 +125,7 @@ declare module 'luxon' {
                 text: string,
                 format: string,
                 opts?: DateTimeOptions
-            ): object;
+            ): ExplainedFormat;
             /**
              * @deprecated since 0.3.0. Use fromFormat instead
              */
@@ -124,7 +141,7 @@ declare module 'luxon' {
                 text: string,
                 format: string,
                 options?: DateTimeOptions
-            ): object;
+            ): ExplainedFormat;
             static invalid(reason: any): DateTime;
             static local(
                 year?: number,
@@ -213,9 +230,9 @@ declare module 'luxon' {
             toMillis(): number;
             toObject(options?: { includeConfig?: boolean }): DateObject;
             toRFC2822(): string;
-            toSQL(options?: Object): string;
+            toSQL(options?: ToSQLOptions): string;
             toSQLDate(): string;
-            toSQLTime(options?: Object): string;
+            toSQLTime(options?: ToSQLOptions): string;
             toString(): string;
             toUTC(offset?: number, options?: ZoneOptions): DateTime;
             until(other: DateTime): Interval;

--- a/types/luxon/luxon-tests.ts
+++ b/types/luxon/luxon-tests.ts
@@ -39,6 +39,11 @@ dt.toLocaleString();
 dt.toLocaleString(DateTime.DATE_MED);
 dt.toISO();
 dt.toISO({includeOffset: true});
+dt.toSQL();
+dt.toSQL({includeOffset: false, includeZone: true});
+dt.toSQLDate();
+dt.toSQLTime();
+dt.toSQLTime({includeOffset: false, includeZone: true});
 
 dt.plus({ hours: 3, minutes: 2 });
 dt.minus({ days: 7 });
@@ -61,6 +66,8 @@ DateTime.local().toUTC();
 DateTime.utc().toLocal();
 
 DateTime.fromMillis(1527780819458).toMillis();
+
+const {input, result, zone} = DateTime.fromFormatExplain("Aug 6 1982", "MMMM d yyyy");
 
 /* Duration */
 const dur = Duration.fromObject({ hours: 2, minutes: 7 });

--- a/types/luxon/tslint.json
+++ b/types/luxon/tslint.json
@@ -1,7 +1,6 @@
 {
     "extends": "dtslint/dt.json",
     "rules": {
-        "ban-types": false,
         "no-single-declare-module": false,
         "interface-over-type-literal": false,
         "no-declare-current-package": false


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
  - [`toSQL` docs](https://moment.github.io/luxon/docs/class/src/datetime.js~DateTime.html#instance-method-toSQL)
  - [Write up on debugger using `fromFormatExplain`](https://moment.github.io/luxon/docs/manual/parsing.html#debugging). It calls [`explainFromTokens`](https://github.com/moment/luxon/blob/master/src/impl/tokenParser.js#L271-L286) which does the heavy lifting. 

