### PR TITLE
better error typings for auth0-js

### DIFF
--- a/types/auth0-js/index.d.ts
+++ b/types/auth0-js/index.d.ts
@@ -4,6 +4,7 @@
 //                 Matt Durrant <https://github.com/mdurrant>
 //                 Peter Blazejewicz <https://github.com/peterblazejewicz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
 
 export as namespace auth0;
 

--- a/types/auth0-js/index.d.ts
+++ b/types/auth0-js/index.d.ts
@@ -172,7 +172,7 @@ export class WebAuth {
      *
      * @param callback: any(err, token_payload)
      */
-    parseHash(callback: Auth0Callback<Auth0DecodedHash>): void;
+    parseHash(callback: Auth0Callback<Auth0DecodedHash | null, Auth0ParseHashError>): void;
 
     /**
      * Parse the url hash and extract the returned tokens depending on the transaction.
@@ -183,7 +183,7 @@ export class WebAuth {
      *
      * @param callback: any(err, token_payload)
      */
-    parseHash(options: ParseHashOptions, callback: Auth0Callback<Auth0DecodedHash>): void;
+    parseHash(options: ParseHashOptions, callback: Auth0Callback<Auth0DecodedHash | null, Auth0ParseHashError>): void;
 
     /**
      * Decodes the id_token and verifies  the nonce.
@@ -482,7 +482,7 @@ export class CrossOriginAuthentication {
     callback(): void;
 }
 
-export type Auth0Callback<T> = (error: null | Auth0Error, result: T) => void;
+export type Auth0Callback<T, E = Auth0Error> = (error: null | E, result: T) => void;
 
 export interface TokenProvider {
     enableCache?: boolean;
@@ -522,16 +522,49 @@ export interface PasswordlessAuthOptions {
     email: string;
 }
 
+/**
+ * These are error codes defined by the auth0-js lib.
+ */
+export type LibErrorCodes = 'timeout' | 'request_error' | 'invalid_token';
+
+/**
+ * The user was not logged in at Auth0, so silent authentication is not possible.
+ */
+export type LoginRequiredErrorCode = 'login_required';
+
+/**
+ * The user was logged in at Auth0 and has authorized the application, but needs to
+ * be redirected elsewhere before authentication can be completed; for example, when
+ * using a redirect rule.
+ */
+export type InteractionRequiredErrorCode = 'interaction_required';
+
+/**
+ * The user was logged in at Auth0, but needs to give consent to authorize the application.
+ */
+export type ConsentRequiredErrorCode = 'consent_required';
+
+/**
+ * These are error codes defined by the OpenID Connect specification.
+ */
+export type SpecErrorCodes =
+    LoginRequiredErrorCode |
+    InteractionRequiredErrorCode |
+    ConsentRequiredErrorCode |
+    'account_selection_required' |
+    'invalid_request_uri' |
+    'invalid_request_object' |
+    'request_not_supported' |
+    'request_uri_not_supported' |
+    'registration_not_supported';
+
 export interface Auth0Error {
-    error?: any;
-    errorDescription?: string;
-    code?: string;
-    description?: string;
-    name?: string;
-    policy?: string;
-    original?: any;
-    statusCode?: number;
-    statusText?: string;
+    error: LibErrorCodes | SpecErrorCodes | string;
+    errorDescription: string;
+}
+
+export type Auth0ParseHashError = Auth0Error & {
+    state?: string;
 }
 
 /**

--- a/types/auth0-js/index.d.ts
+++ b/types/auth0-js/index.d.ts
@@ -566,7 +566,7 @@ export interface Auth0Error {
 
 export type Auth0ParseHashError = Auth0Error & {
     state?: string;
-}
+};
 
 /**
  * The contents of the authResult object returned by {@link WebAuth#parseHash }

--- a/types/auth0-lock/auth0-lock-tests.ts
+++ b/types/auth0-lock/auth0-lock-tests.ts
@@ -235,7 +235,7 @@ const checkboxFieldOptions : Auth0LockConstructorOptions = {
       type: "checkbox",
       name: "remember",
       placeholder: "Remember Me",
-      prefill: "false" as 'false'
+      prefill: "false"
     }]
   };
 

--- a/types/auth0-lock/auth0-lock-tests.ts
+++ b/types/auth0-lock/auth0-lock-tests.ts
@@ -1,4 +1,3 @@
-// TypeScript Version: 2.7
 import * as auth0 from 'auth0-js';
 import Auth0Lock from 'auth0-lock';
 
@@ -236,7 +235,7 @@ const checkboxFieldOptions : Auth0LockConstructorOptions = {
       type: "checkbox",
       name: "remember",
       placeholder: "Remember Me",
-      prefill: "false"
+      prefill: "false" as 'false'
     }]
   };
 

--- a/types/auth0-lock/auth0-lock-tests.ts
+++ b/types/auth0-lock/auth0-lock-tests.ts
@@ -1,3 +1,4 @@
+// TypeScript Version: 2.7
 import * as auth0 from 'auth0-js';
 import Auth0Lock from 'auth0-lock';
 

--- a/types/auth0-lock/index.d.ts
+++ b/types/auth0-lock/index.d.ts
@@ -5,6 +5,7 @@
 //                 Larry Faudree <https://github.com/lfaudreejr>
 //                 Will Caulfield <https://github.com/willcaul>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
 
 /// <reference types="auth0-js" />
 

--- a/types/auth0-lock/index.d.ts
+++ b/types/auth0-lock/index.d.ts
@@ -5,7 +5,7 @@
 //                 Larry Faudree <https://github.com/lfaudreejr>
 //                 Will Caulfield <https://github.com/willcaul>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.7
 
 /// <reference types="auth0-js" />
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: See explanation below.
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

---

This PR tries to fix the errors which can be returned by `auth0-js`. I gathered all information in this issue: https://github.com/auth0/auth0.js/issues/861
I also added `null` as a possible return type for `parseHash` (this was documented here: https://github.com/auth0/auth0.js/issues/766).

I added some inline documentation for some of the error codes which I took from here: https://auth0.com/docs/api-auth/tutorials/silent-authentication#error-response.