### PR TITLE
Add support for RTCDTMFSender in RTCPeerConnection

### DIFF
--- a/types/webrtc/RTCPeerConnection.d.ts
+++ b/types/webrtc/RTCPeerConnection.d.ts
@@ -163,11 +163,21 @@ interface RTCRtcCapabilities {
     headerExtensions: RTCRtpHeaderExtensionCapability[];
 }
 
+// https://www.w3.org/TR/webrtc/#rtcdtmfsender
+interface RTCDTMFSender extends EventTarget {
+    readonly canInsertDTMF: boolean;
+    readonly toneBuffer: string;
+    ontonechange: EventHandler;
+    insertDTMF(tones: String, duration?: number, interToneGap?: number): void;
+}
+
 // https://www.w3.org/TR/webrtc/#dom-rtcrtpsender
 interface RTCRtpSender {
     //readonly track?: MediaStreamTrack;
     //readonly transport?: RTCDtlsTransport;
     //readonly rtcpTransport?: RTCDtlsTransport;
+    // Extension: https://www.w3.org/TR/webrtc/#rtcrtpsender-interface-extensions
+    readonly dtmf?: RTCDTMFSender;
     setParameters(parameters?: RTCRtpParameters): Promise<void>;
     getParameters(): RTCRtpParameters;
     replaceTrack(withTrack: MediaStreamTrack): Promise<void>;
@@ -276,6 +286,11 @@ interface RTCTrackEvent extends Event {
     readonly track: MediaStreamTrack;
     readonly streams: MediaStream[];
     readonly transceiver: RTCRtpTransceiver;
+}
+
+// https://www.w3.org/TR/webrtc/#dom-rtcdtmftonechangeevent
+interface RTCDTMFToneChangeEvent {
+    readonly tone: string;
 }
 
 // https://www.w3.org/TR/webrtc/#h-rtcpeerconnectioniceevent


### PR DESCRIPTION
Add RTCDTMFSender and events as per https://www.w3.org/TR/webrtc/#rtcdtmfsender

Adding dtmf attribute to RTCRtpSender as per https://www.w3.org/TR/webrtc/#rtcrtpsender-interface-extensions

- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.w3.org/TR/webrtc/#rtcdtmfsender
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.