### PR TITLE
[@types/react] Add JSX.ElementProps<T>

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -2324,6 +2324,7 @@ declare global {
         // tslint:disable-next-line:no-empty-interface
         interface IntrinsicClassAttributes<T> extends React.ClassAttributes<T> { }
 
+        type ElementAttributes<K extends keyof IntrinsicElements> = IntrinsicElements[K]
         interface IntrinsicElements {
             // HTML
             a: React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>;

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -2324,7 +2324,7 @@ declare global {
         // tslint:disable-next-line:no-empty-interface
         interface IntrinsicClassAttributes<T> extends React.ClassAttributes<T> { }
 
-        type ElementAttributes<K extends keyof IntrinsicElements> = IntrinsicElements[K]
+        type ElementAttributes<K extends keyof IntrinsicElements> = IntrinsicElements[K];
         interface IntrinsicElements {
             // HTML
             a: React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>;

--- a/types/react/v15/index.d.ts
+++ b/types/react/v15/index.d.ts
@@ -3633,6 +3633,7 @@ declare global {
         // tslint:disable-next-line:no-empty-interface
         interface IntrinsicClassAttributes<T> extends React.ClassAttributes<T> { }
 
+        type ElementAttributes<K extends keyof IntrinsicElements> = IntrinsicElements[K]
         interface IntrinsicElements {
             // HTML
             a: React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>;
@@ -3810,7 +3811,5 @@ declare global {
             view: React.SVGProps<SVGViewElement>;
         }
 
-        type IntrinsicElement = keyof IntrinsicElements;
-        type ElementProps<K extends IntrinsicElement> = IntrinsicElements[K];
     }
 }

--- a/types/react/v15/index.d.ts
+++ b/types/react/v15/index.d.ts
@@ -3633,7 +3633,7 @@ declare global {
         // tslint:disable-next-line:no-empty-interface
         interface IntrinsicClassAttributes<T> extends React.ClassAttributes<T> { }
 
-        type ElementAttributes<K extends keyof IntrinsicElements> = IntrinsicElements[K]
+        type ElementAttributes<K extends keyof IntrinsicElements> = IntrinsicElements[K];
         interface IntrinsicElements {
             // HTML
             a: React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>;

--- a/types/react/v15/index.d.ts
+++ b/types/react/v15/index.d.ts
@@ -3809,5 +3809,8 @@ declare global {
             use: React.SVGProps<SVGUseElement>;
             view: React.SVGProps<SVGViewElement>;
         }
+
+        type IntrinsicElement = keyof IntrinsicElements
+        type ElementProps<K extends IntrinsicElement> = IntrinsicElements[K]
     }
 }

--- a/types/react/v15/index.d.ts
+++ b/types/react/v15/index.d.ts
@@ -3810,7 +3810,7 @@ declare global {
             view: React.SVGProps<SVGViewElement>;
         }
 
-        type IntrinsicElement = keyof IntrinsicElements
-        type ElementProps<K extends IntrinsicElement> = IntrinsicElements[K]
+        type IntrinsicElement = keyof IntrinsicElements;
+        type ElementProps<K extends IntrinsicElement> = IntrinsicElements[K];
     }
 }


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 

When your write components that are essentially an extension around `JSX.IntrinsicElement`, your first intuition is to do something like the following

```jsx
interface MyProps extends JSX.IntrinsicElement["div"] {
  color: string
}

export const MyComponent: React.SFC<MyProps> = ({color, style, ...props}) => {
  return (
    <div {...props} style={{...style, color}} />
  )
}

```

Which is not possible.

Instead you must do something like this...

```jsx
interface MyProps {
  color: string
}

export const MyComponent: MyProps & React.SFC<JSX.IntrinsicElement["div"]> = ({color, style, ...props}) => {
  return (
    <div {...props} style={{...style, color}} />
  )
}
```

Which is ugly and explodes the tooltips in editors such as visual studio code.

![image](https://user-images.githubusercontent.com/7560635/47623888-8b033d00-dad3-11e8-8f63-e8e8073d40c2.png)

This adds the `JSX.ElementProps<T>` generic to extend off of which results in what I believe is prettier, more intuitive, and also results in better tooltips in visual studio code.

```jsx
interface MyProps extends JSX.ElementProps<"div"> {
  color: string
}

export const MyComponent: React.SFC<MyProps> = ({color, style, ...props}) => {
  return (
    <div {...props} style={{...style, color}} />
  )
}
```

![image](https://user-images.githubusercontent.com/7560635/47623899-99e9ef80-dad3-11e8-80a0-1a5e7d8cb963.png)
