### PR TITLE
add string-replace-webpack-plugin types

### DIFF
--- a/types/string-replace-webpack-plugin/index.d.ts
+++ b/types/string-replace-webpack-plugin/index.d.ts
@@ -1,0 +1,47 @@
+// Type definitions for string-replace-webpack-plugin 0.1.3
+// Project: https://github.com/jamesandersen/string-replace-webpack-plugin
+// Definitions by: Rongjian Zhang <https://github.com/pd4d10>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import { Plugin, RuleSetUse } from 'webpack';
+
+export = StringReplacePlugin;
+
+declare class StringReplacePlugin extends Plugin {
+    static replace(
+        options: StringReplacePlugin.Options,
+        /**
+         * loaders to follow the replacement
+         */
+        nextLoaders?: string
+    ): RuleSetUse;
+    static replace(
+        /**
+         * loaders to apply prior to the replacement
+         */
+        prevLoaders: string,
+        options: StringReplacePlugin.Options,
+        /**
+         * loaders to follow the replacement
+         */
+        nextLoaders?: string
+    ): RuleSetUse;
+}
+
+declare namespace StringReplacePlugin {
+    interface Options {
+        replacements: ReplacementItem[];
+    }
+
+    interface ReplacementItem {
+        /**
+         * a regex to match against the file contents
+         */
+        pattern: RegExp;
+        /**
+         * an ECMAScript string replacement function
+         * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#Specifying_a_function_as_a_parameter
+         */
+        replacement: (substring: string, ...args: any[]) => string;
+    }
+}

--- a/types/string-replace-webpack-plugin/index.d.ts
+++ b/types/string-replace-webpack-plugin/index.d.ts
@@ -1,9 +1,10 @@
-// Type definitions for string-replace-webpack-plugin 0.1.3
+// Type definitions for string-replace-webpack-plugin 0.1
 // Project: https://github.com/jamesandersen/string-replace-webpack-plugin
 // Definitions by: Rongjian Zhang <https://github.com/pd4d10>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
 
-import { Plugin, RuleSetUse } from 'webpack';
+import { Plugin, RuleSetUse } from "webpack";
 
 export = StringReplacePlugin;
 

--- a/types/string-replace-webpack-plugin/string-replace-webpack-plugin-tests.ts
+++ b/types/string-replace-webpack-plugin/string-replace-webpack-plugin-tests.ts
@@ -1,4 +1,4 @@
-import * as StringReplacePlugin from 'string-replace-webpack-plugin';
+import StringReplacePlugin = require('string-replace-webpack-plugin');
 
 StringReplacePlugin.replace('babel-loader', {
     replacements: [

--- a/types/string-replace-webpack-plugin/string-replace-webpack-plugin-tests.ts
+++ b/types/string-replace-webpack-plugin/string-replace-webpack-plugin-tests.ts
@@ -1,0 +1,17 @@
+import * as StringReplacePlugin from 'string-replace-webpack-plugin';
+
+StringReplacePlugin.replace('babel-loader', {
+    replacements: [
+        {
+            // Taken from:
+            // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#Specifying_a_function_as_a_parameter
+            pattern: /([^\d]*)(\d*)([^\w]*)/,
+            replacement: (match, p1, p2, p3, offset, string) => {
+                // p1 is nondigits, p2 digits, and p3 non-alphanumerics
+                return [p1, p2, p3].join(' - ');
+            }
+        }
+    ]
+});
+
+new StringReplacePlugin();

--- a/types/string-replace-webpack-plugin/tsconfig.json
+++ b/types/string-replace-webpack-plugin/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": false,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": ["index.d.ts", "string-replace-webpack-plugin-tests.ts"]
+}

--- a/types/string-replace-webpack-plugin/tslint.json
+++ b/types/string-replace-webpack-plugin/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
