### PR TITLE
'file-saver' typedef: Added 'url' option to saveAs function.

### DIFF
--- a/types/file-saver/file-saver-tests.ts
+++ b/types/file-saver/file-saver-tests.ts
@@ -23,6 +23,17 @@ function testWindowSaveAs() {
 }
 
 /**
+ * @summary Test for "saveAs" function with URL as first argument.
+ */
+function testUrlSaveAs() {
+    const url = 'https://example.com/test.txt';
+    const filename = 'hello world.txt';
+    const disableAutoBOM = true;
+
+    window.saveAs(url, filename, disableAutoBOM);
+}
+
+/**
  * @summary Test for "saveAs" function with the 3rd parameter omitted
  */
 function testOptionalOneParamSaveAs() {

--- a/types/file-saver/index.d.ts
+++ b/types/file-saver/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for FileSaver.js 1.3
+// Type definitions for FileSaver.js 2.0
 // Project: https://github.com/eligrey/FileSaver.js/
 // Definitions by: Cyril Schumacher <https://github.com/cyrilschumacher>
 //                 Daniel Roth <https://github.com/DaIgeb>
@@ -8,11 +8,11 @@
 declare namespace FileSaver {
     /**
      * FileSaver.js implements the saveAs() FileSaver interface in browsers that do not natively support it.
-     * @param data - The actual file data blob.
+     * @param data - The actual file data blob or URL.
      * @param filename - The optional name of the file to be downloaded. If omitted, the name used in the file data will be used. If none is provided "download" will be used.
      * @param disableAutoBOM - Optional & defaults to `false`. Set to `true` if you want FileSaver.js to automatically provide Unicode text encoding hints
      */
-    function saveAs(data: Blob, filename?: string, disableAutoBOM?: boolean): void;
+    function saveAs(data: Blob | string, filename?: string, disableAutoBOM?: boolean): void;
 }
 
 declare global {


### PR DESCRIPTION
The 'file-saver' type definitions are slightly out of date. The latest version of the library supports saving files from external URLs in addition to saving Blob objects. 

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Changing exisiting:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [latest file-saver source code supports url](https://github.com/eligrey/FileSaver.js#saving-urls)
- [x] Increase the version number in the header if appropriate.
- [x] (tslint file alreadt exists)If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
