### PR TITLE
[@types/babylon] typescript plugin name support

### DIFF
--- a/types/babylon/index.d.ts
+++ b/types/babylon/index.d.ts
@@ -46,6 +46,7 @@ export type PluginName =
     'estree' |
     'jsx' |
     'flow' |
+    'typescript' |
     'classConstructorCall' |
     'doExpressions' |
     'objectRestSpread' |


### PR DESCRIPTION
If changing an existing definition:
- [*] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/babel/babel/blob/master/packages/babel-parser/src/plugins/typescript.js
