### PR TITLE
[yazl] ZipFile#outputStream should be Readable

### DIFF
--- a/types/yazl/index.d.ts
+++ b/types/yazl/index.d.ts
@@ -1,12 +1,13 @@
 // Type definitions for yazl 2.4
 // Project: https://github.com/thejoshwolfe/yazl
 // Definitions by: taoqf <https://github.com/taoqf>
+//                 Sean Marvi Oliver Genabe <https://github.com/seangenabe>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.1
 
 /// <reference types="node" />
 
-import { Readable, Writable } from 'stream';
+import { Readable } from 'stream';
 import { Buffer } from 'buffer';
 
 export interface Options {
@@ -36,7 +37,7 @@ export interface DosDateTime {
 
 export class ZipFile {
     addFile(realPath: string, metadataPath: string, options?: Partial<Options>): void;
-    outputStream: Writable;
+    outputStream: Readable;
     addReadStream(input: Readable, metadataPath: string, options?: Partial<ReadStreamOptions>): void;
     addBuffer(buffer: Buffer, metadataPath: string, options?: Partial<Options>): void;
     end(optoins?: EndOptions, finalSizeCallback?: () => void): void;

--- a/types/yazl/yazl-tests.ts
+++ b/types/yazl/yazl-tests.ts
@@ -1,4 +1,5 @@
 import { ZipFile } from "yazl";
+import { Readable } from "stream";
 import fs = require('fs');
 
 const zipfile = new ZipFile();
@@ -6,6 +7,8 @@ zipfile.addFile("file1.txt", "file1.txt");
 // (add only files, not directories)
 zipfile.addFile("path/to/file.txt", "path/in/zipfile.txt");
 // pipe() can be called any time after the constructor
+// $ExpectType Readable
+zipfile.outputStream;
 zipfile.outputStream.pipe(fs.createWriteStream("output.zip")).on("close", () => {
 	console.log("done");
 });


### PR DESCRIPTION
`ZipFile#outputStream` should be `Readable`, not `Writable`, according to the documentation: "A readable stream that will produce the contents of the zip file." Internally, the stream is a `PassThrough` but is intended to be consumed as a `Readable`.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/thejoshwolfe/yazl#outputstream>>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
