### PR TITLE
[jquery] Improve declaration of Events API.

### DIFF
--- a/types/angular-agility/tslint.json
+++ b/types/angular-agility/tslint.json
@@ -74,6 +74,7 @@
         "typedef-whitespace": false,
         "unified-signatures": false,
         "void-return": false,
-        "whitespace": false
+        "whitespace": false,
+        "no-angle-bracket-type-assertion": false
     }
 }

--- a/types/angular-locker/tslint.json
+++ b/types/angular-locker/tslint.json
@@ -74,6 +74,7 @@
         "typedef-whitespace": false,
         "unified-signatures": false,
         "void-return": false,
-        "whitespace": false
+        "whitespace": false,
+        "no-angle-bracket-type-assertion": false
     }
 }

--- a/types/angular-odata-resources/tslint.json
+++ b/types/angular-odata-resources/tslint.json
@@ -74,6 +74,7 @@
         "typedef-whitespace": false,
         "unified-signatures": false,
         "void-return": false,
-        "whitespace": false
+        "whitespace": false,
+        "no-angle-bracket-type-assertion": false
     }
 }

--- a/types/angular-ui-tree/tslint.json
+++ b/types/angular-ui-tree/tslint.json
@@ -74,6 +74,7 @@
         "typedef-whitespace": false,
         "unified-signatures": false,
         "void-return": false,
-        "whitespace": false
+        "whitespace": false,
+        "no-angle-bracket-type-assertion": false
     }
 }

--- a/types/angular/test/jquery3-merging-tests.ts
+++ b/types/angular/test/jquery3-merging-tests.ts
@@ -94,19 +94,9 @@ function JQuery() {
     }
 
     function bind() {
-        interface I1 { kind: 'I1'; }
-
         // $ExpectType JQuery<HTMLElement>
         $('p').bind('myEvent', 'myData', function(event) {
             // TODO: $ExpectType HTMLElement
-            this;
-            // TODO: $ExpectType Event<HTMLElement, string>
-            event;
-        });
-
-        // $ExpectType JQuery<HTMLElement>
-        $('p').bind('myEvent', 'myData', function(this: I1, event) {
-            // $ExpectType I1
             this;
             // TODO: $ExpectType Event<HTMLElement, string>
             event;
@@ -121,14 +111,6 @@ function JQuery() {
         });
 
         // $ExpectType JQuery<HTMLElement>
-        $('p').bind('myEvent', function(this: I1, event) {
-            // $ExpectType I1
-            this;
-            // TODO: $ExpectType Event<HTMLElement, null>
-            event;
-        });
-
-        // $ExpectType JQuery<HTMLElement>
         $('p').bind('myEvent', false);
 
         // $ExpectType JQuery<HTMLElement>
@@ -136,12 +118,6 @@ function JQuery() {
             myEvent1: false,
             myEvent2(event) {
                 // TODO: $ExpectType HTMLElement
-                this;
-                // TODO: $ExpectType Event<HTMLElement, null>
-                event;
-            },
-            myEvent3(this: I1, event) {
-                // $ExpectType I1
                 this;
                 // TODO: $ExpectType Event<HTMLElement, null>
                 event;
@@ -164,27 +140,15 @@ function JQuery() {
     }
 
     function off() {
-        function defaultContext_defaultData(this: HTMLElement, event: JQueryEventObject) { }
+        function defaultData(this: HTMLElement, event: JQueryEventObject) { }
 
-        function defaultContext_customData(this: HTMLElement, event: JQueryEventObject) { }
-
-        function customContext_defaultData(this: I1, event: JQueryEventObject) { }
-
-        function customContext_customData(this: I1, event: JQueryEventObject) { }
-
-        interface I1 { kind: 'I1'; }
+        function customData(this: HTMLElement, event: JQueryEventObject) { }
 
         // $ExpectType JQuery<HTMLElement>
-        $('table').off('myEvent', 'td', defaultContext_defaultData);
+        $('table').off('myEvent', 'td', defaultData);
 
         // $ExpectType JQuery<HTMLElement>
-        $('table').off('myEvent', 'td', defaultContext_customData);
-
-        // $ExpectType JQuery<HTMLElement>
-        $('table').off('myEvent', 'td', customContext_defaultData);
-
-        // $ExpectType JQuery<HTMLElement>
-        $('table').off('myEvent', 'td', customContext_customData);
+        $('table').off('myEvent', 'td', customData);
 
         // $ExpectType JQuery<HTMLElement>
         $('table').off('myEvent', 'td', false);
@@ -193,16 +157,10 @@ function JQuery() {
         $('table').off('myEvent', 'td');
 
         // $ExpectType JQuery<HTMLElement>
-        $('table').off('myEvent', defaultContext_defaultData);
+        $('table').off('myEvent', defaultData);
 
         // $ExpectType JQuery<HTMLElement>
-        $('table').off('myEvent', defaultContext_customData);
-
-        // $ExpectType JQuery<HTMLElement>
-        $('table').off('myEvent', customContext_defaultData);
-
-        // $ExpectType JQuery<HTMLElement>
-        $('table').off('myEvent', customContext_customData);
+        $('table').off('myEvent', customData);
 
         // $ExpectType JQuery<HTMLElement>
         $('table').off('myEvent', false);
@@ -213,19 +171,15 @@ function JQuery() {
         // $ExpectType JQuery<HTMLElement>
         $('table').off({
             myEvent1: false,
-            defaultContext_defaultData,
-            defaultContext_customData,
-            customContext_defaultData,
-            customContext_customData
+            defaultData,
+            customData
         }, 'td');
 
         // $ExpectType JQuery<HTMLElement>
         $('table').off({
             myEvent1: false,
-            defaultContext_defaultData,
-            defaultContext_customData,
-            customContext_defaultData,
-            customContext_customData
+            defaultData,
+            customData
         });
 
         // $ExpectType JQuery<HTMLElement>
@@ -236,19 +190,9 @@ function JQuery() {
     }
 
     function on() {
-        interface I1 { kind: 'I1'; }
-
         // $ExpectType JQuery<HTMLElement>
         $('table').on('myEvent', 'td', 'myData', function(event) {
             // TODO: $ExpectType HTMLElement
-            this;
-            // TODO: $ExpectType Event<HTMLElement, string>
-            event;
-        });
-
-        // $ExpectType JQuery<HTMLElement>
-        $('table').on('myEvent', 'td', 'myData', function(this: I1, event) {
-            // $ExpectType I1
             this;
             // TODO: $ExpectType Event<HTMLElement, string>
             event;
@@ -263,24 +207,8 @@ function JQuery() {
         });
 
         // $ExpectType JQuery<HTMLElement>
-        $('table').on('myEvent', null, 'myData', function(this: I1, event) {
-            // $ExpectType I1
-            this;
-            // TODO: $ExpectType Event<HTMLElement, string>
-            event;
-        });
-
-        // $ExpectType JQuery<HTMLElement>
         $('table').on('myEvent', 'td', function(event) {
             // TODO: $ExpectType HTMLElement
-            this;
-            // TODO: $ExpectType Event<HTMLElement, null>
-            event;
-        });
-
-        // $ExpectType JQuery<HTMLElement>
-        $('table').on('myEvent', 'td', function(this: I1, event) {
-            // $ExpectType I1
             this;
             // TODO: $ExpectType Event<HTMLElement, null>
             event;
@@ -298,24 +226,8 @@ function JQuery() {
         });
 
         // $ExpectType JQuery<HTMLElement>
-        $('table').on('myEvent', 3, function(this: I1, event) {
-            // $ExpectType I1
-            this;
-            // TODO: $ExpectType Event<HTMLElement, number>
-            event;
-        });
-
-        // $ExpectType JQuery<HTMLElement>
         $('table').on('myEvent', function(event) {
             // TODO: $ExpectType HTMLElement
-            this;
-            // TODO: $ExpectType Event<HTMLElement, null>
-            event;
-        });
-
-        // $ExpectType JQuery<HTMLElement>
-        $('table').on('myEvent', function(this: I1, event) {
-            // $ExpectType I1
             this;
             // TODO: $ExpectType Event<HTMLElement, null>
             event;
@@ -332,12 +244,6 @@ function JQuery() {
                 this;
                 // TODO: $ExpectType Event<HTMLElement, string>
                 event;
-            },
-            myEvent3(this: I1, event) {
-                // $ExpectType I1
-                this;
-                // TODO: $ExpectType Event<HTMLElement, string>
-                event;
             }
         }, 'td', 'myData');
 
@@ -346,12 +252,6 @@ function JQuery() {
             myEvent1: false,
             myEvent2(event) {
                 // TODO: $ExpectType HTMLElement
-                this;
-                // TODO: $ExpectType Event<HTMLElement, string>
-                event;
-            },
-            myEvent3(this: I1, event) {
-                // $ExpectType I1
                 this;
                 // TODO: $ExpectType Event<HTMLElement, string>
                 event;
@@ -366,12 +266,6 @@ function JQuery() {
                 this;
                 // TODO: $ExpectType Event<HTMLElement, null>
                 event;
-            },
-            myEvent3(this: I1, event) {
-                // $ExpectType I1
-                this;
-                // TODO: $ExpectType Event<HTMLElement, null>
-                event;
             }
         }, 'td');
 
@@ -380,12 +274,6 @@ function JQuery() {
             myEvent1: false,
             myEvent2(event) {
                 // TODO: $ExpectType HTMLElement
-                this;
-                // TODO: $ExpectType Event<HTMLElement, number>
-                event;
-            },
-            myEvent3(this: I1, event) {
-                // $ExpectType I1
                 this;
                 // TODO: $ExpectType Event<HTMLElement, number>
                 event;
@@ -400,30 +288,14 @@ function JQuery() {
                 this;
                 // TODO: $ExpectType Event<HTMLElement, null>
                 event;
-            },
-            myEvent3(this: I1, event) {
-                // $ExpectType I1
-                this;
-                // TODO: $ExpectType Event<HTMLElement, null>
-                event;
             }
         });
     }
 
     function one() {
-        interface I1 { kind: 'I1'; }
-
         // $ExpectType JQuery<HTMLElement>
         $('table').one('myEvent', 'td', 'myData', function(event) {
             // TODO: $ExpectType HTMLElement
-            this;
-            // TODO: $ExpectType Event<HTMLElement, string>
-            event;
-        });
-
-        // $ExpectType JQuery<HTMLElement>
-        $('table').one('myEvent', 'td', 'myData', function(this: I1, event) {
-            // $ExpectType I1
             this;
             // TODO: $ExpectType Event<HTMLElement, string>
             event;
@@ -438,24 +310,8 @@ function JQuery() {
         });
 
         // $ExpectType JQuery<HTMLElement>
-        $('table').one('myEvent', null, 'myData', function(this: I1, event) {
-            // $ExpectType I1
-            this;
-            // TODO: $ExpectType Event<HTMLElement, string>
-            event;
-        });
-
-        // $ExpectType JQuery<HTMLElement>
         $('table').one('myEvent', 'td', function(event) {
             // TODO: $ExpectType HTMLElement
-            this;
-            // TODO: $ExpectType Event<HTMLElement, null>
-            event;
-        });
-
-        // $ExpectType JQuery<HTMLElement>
-        $('table').one('myEvent', 'td', function(this: I1, event) {
-            // $ExpectType I1
             this;
             // TODO: $ExpectType Event<HTMLElement, null>
             event;
@@ -473,24 +329,8 @@ function JQuery() {
         });
 
         // $ExpectType JQuery<HTMLElement>
-        $('table').one('myEvent', 3, function(this: I1, event) {
-            // $ExpectType I1
-            this;
-            // TODO: $ExpectType Event<HTMLElement, number>
-            event;
-        });
-
-        // $ExpectType JQuery<HTMLElement>
         $('table').one('myEvent', function(event) {
             // TODO: $ExpectType HTMLElement
-            this;
-            // TODO: $ExpectType Event<HTMLElement, null>
-            event;
-        });
-
-        // $ExpectType JQuery<HTMLElement>
-        $('table').one('myEvent', function(this: I1, event) {
-            // $ExpectType I1
             this;
             // TODO: $ExpectType Event<HTMLElement, null>
             event;
@@ -507,12 +347,6 @@ function JQuery() {
                 this;
                 // TODO: $ExpectType Event<HTMLElement, string>
                 event;
-            },
-            myEvent3(this: I1, event) {
-                // $ExpectType I1
-                this;
-                // TODO: $ExpectType Event<HTMLElement, string>
-                event;
             }
         }, 'td', 'myData');
 
@@ -521,12 +355,6 @@ function JQuery() {
             myEvent1: false,
             myEvent2(event) {
                 // TODO: $ExpectType HTMLElement
-                this;
-                // TODO: $ExpectType Event<HTMLElement, string>
-                event;
-            },
-            myEvent3(this: I1, event) {
-                // $ExpectType I1
                 this;
                 // TODO: $ExpectType Event<HTMLElement, string>
                 event;
@@ -541,12 +369,6 @@ function JQuery() {
                 this;
                 // TODO: $ExpectType Event<HTMLElement, null>
                 event;
-            },
-            myEvent3(this: I1, event) {
-                // $ExpectType I1
-                this;
-                // TODO: $ExpectType Event<HTMLElement, null>
-                event;
             }
         }, 'td');
 
@@ -558,12 +380,6 @@ function JQuery() {
                 this;
                 // TODO: $ExpectType Event<HTMLElement, number>
                 event;
-            },
-            myEvent3(this: I1, event) {
-                // $ExpectType I1
-                this;
-                // TODO: $ExpectType Event<HTMLElement, number>
-                event;
             }
         }, 3);
 
@@ -572,12 +388,6 @@ function JQuery() {
             myEvent1: false,
             myEvent2(event) {
                 // TODO: $ExpectType HTMLElement
-                this;
-                // TODO: $ExpectType Event<HTMLElement, null>
-                event;
-            },
-            myEvent3(this: I1, event) {
-                // $ExpectType I1
                 this;
                 // TODO: $ExpectType Event<HTMLElement, null>
                 event;

--- a/types/angularfire/tslint.json
+++ b/types/angularfire/tslint.json
@@ -74,6 +74,7 @@
         "typedef-whitespace": false,
         "unified-signatures": false,
         "void-return": false,
-        "whitespace": false
+        "whitespace": false,
+        "no-angle-bracket-type-assertion": false
     }
 }

--- a/types/backbone/index.d.ts
+++ b/types/backbone/index.d.ts
@@ -92,7 +92,7 @@ declare namespace Backbone {
     }
 
     interface EventsHash {
-        [selector: string]: string | {(eventObject: JQueryEventObject): void};
+        [selector: string]: string | {(eventObject: JQuery.TriggeredEvent): void};
     }
 
     export const Events: Events;

--- a/types/bootstrap-slider/bootstrap-slider-tests.ts
+++ b/types/bootstrap-slider/bootstrap-slider-tests.ts
@@ -42,7 +42,7 @@ $(() => {
 
     $('#ex7').slider();
 
-    $('#ex7-enabled').click(function(this: HTMLInputElement) {
+    $<HTMLInputElement>('#ex7-enabled').click(function() {
         if (this.checked) {
             // With JQuery
             $('#ex7').slider('enable');

--- a/types/bootstrap-slider/tslint.json
+++ b/types/bootstrap-slider/tslint.json
@@ -1,3 +1,6 @@
 {
-    "extends": "dtslint/dt.json"
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "no-angle-bracket-type-assertion": false
+    }
 }

--- a/types/bootstrap/index.d.ts
+++ b/types/bootstrap/index.d.ts
@@ -322,7 +322,7 @@ export interface TooltipOption {
 // Events
 // --------------------------------------------------------------------------------------
 
-export interface CarouselEventHandler<TElement> extends JQuery.Event<TElement, undefined> {
+export interface CarouselEventHandler<TElement> extends JQuery.TriggeredEvent<TElement, undefined> {
     /**
      * The direction in which the carousel is sliding.
      */
@@ -337,6 +337,10 @@ export interface CarouselEventHandler<TElement> extends JQuery.Event<TElement, u
      * The index of the next item.
      */
     to: number;
+}
+
+export interface TapEventHandler<TElement> extends JQuery.TriggeredEvent<TElement, undefined> {
+    relatedTarget: HTMLElement;
 }
 
 export type AlertEvent = "close.bs.alert" | "closed.bs.alert";
@@ -383,9 +387,10 @@ declare global {
         tooltip(options?: TooltipOption): this;
 
         on(events: CarouselEvent, handler: JQuery.EventHandlerBase<TElement, CarouselEventHandler<TElement>>): this;
+        on(events: TapEvent, handler: JQuery.EventHandlerBase<TElement, TapEventHandler<TElement>>): this;
         on(events:
             AlertEvent | CollapseEvent | DropdownEvent | ModalEvent |
-            PopoverEvent | ScrollspyEvent | TapEvent | TooltipEvent,
+            PopoverEvent | ScrollspyEvent | TooltipEvent,
             handler: JQuery.EventHandler<TElement>): this;
     }
 }

--- a/types/datatables.net/tslint.json
+++ b/types/datatables.net/tslint.json
@@ -1,1 +1,6 @@
-{ "extends": "dtslint/dt.json" }
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "no-angle-bracket-type-assertion": false
+    }
+}

--- a/types/devexpress-web/v172/tslint.json
+++ b/types/devexpress-web/v172/tslint.json
@@ -74,6 +74,7 @@
         "typedef-whitespace": false,
         "unified-signatures": false,
         "void-return": false,
-        "whitespace": false
+        "whitespace": false,
+        "no-angle-bracket-type-assertion": false
     }
 }

--- a/types/devexpress-web/v181/tslint.json
+++ b/types/devexpress-web/v181/tslint.json
@@ -74,6 +74,7 @@
         "typedef-whitespace": false,
         "unified-signatures": false,
         "void-return": false,
-        "whitespace": false
+        "whitespace": false,
+        "no-angle-bracket-type-assertion": false
     }
 }

--- a/types/ej.web.all/tslint.json
+++ b/types/ej.web.all/tslint.json
@@ -37,6 +37,7 @@
     "radix": false,
     "prefer-for-of": false,
     "one-line": false,
-    "no-unnecessary-type-assertion": false
+    "no-unnecessary-type-assertion": false,
+    "no-angle-bracket-type-assertion": false
   }
 }

--- a/types/gridstack/tslint.json
+++ b/types/gridstack/tslint.json
@@ -74,6 +74,7 @@
         "typedef-whitespace": false,
         "unified-signatures": false,
         "void-return": false,
-        "whitespace": false
+        "whitespace": false,
+        "no-angle-bracket-type-assertion": false
     }
 }

--- a/types/highcharts/tslint.json
+++ b/types/highcharts/tslint.json
@@ -9,6 +9,7 @@
         "no-declare-current-package": false,
         "no-object-literal-type-assertion": false,
         "no-self-import": false,
-        "no-unnecessary-generics": false
+        "no-unnecessary-generics": false,
+        "no-angle-bracket-type-assertion": false
     }
 }

--- a/types/intl-tel-input/v13/tslint.json
+++ b/types/intl-tel-input/v13/tslint.json
@@ -75,6 +75,7 @@
         "typedef-whitespace": false,
         "unified-signatures": false,
         "void-return": false,
-        "whitespace": false
+        "whitespace": false,
+        "no-angle-bracket-type-assertion": false
     }
 }

--- a/types/jquery-focus-exit/index.d.ts
+++ b/types/jquery-focus-exit/index.d.ts
@@ -14,7 +14,7 @@ export interface FocusElements {
 declare global {
     interface JQuery {
         focusExit(options?: { debug: boolean }): JQuery;
-        on(event: 'focusExit', handler: ((event: JQuery.Event<HTMLElement>, data: FocusElements) => void)): JQuery;
-        one(event: 'focusin', handler: ((event: JQuery.Event<HTMLElement>) => void)): JQuery;
+        on(event: 'focusExit', handler: ((event: JQuery.TriggeredEvent<HTMLElement>, data: FocusElements) => void)): JQuery;
+        one(event: 'focusin', handler: ((event: JQuery.TriggeredEvent<HTMLElement>) => void)): JQuery;
     }
 }

--- a/types/jquery-mouse-exit/index.d.ts
+++ b/types/jquery-mouse-exit/index.d.ts
@@ -18,6 +18,6 @@ export type FocusElements = Partial<{
 declare global {
     interface JQuery {
         mouseExit(options?: Options): JQuery;
-        on(event: 'mouseExit', handler: ((event: JQuery.Event<HTMLElement>, data: FocusElements) => void)): JQuery;
+        on(event: 'mouseExit', handler: ((event: JQuery.TriggeredEvent<HTMLElement>, data: FocusElements) => void)): JQuery;
     }
 }

--- a/types/jquery.colorpicker/tslint.json
+++ b/types/jquery.colorpicker/tslint.json
@@ -74,6 +74,7 @@
         "typedef-whitespace": false,
         "unified-signatures": false,
         "void-return": false,
-        "whitespace": false
+        "whitespace": false,
+        "no-angle-bracket-type-assertion": false
     }
 }

--- a/types/jquery.fancytree/tslint.json
+++ b/types/jquery.fancytree/tslint.json
@@ -74,6 +74,7 @@
         "typedef-whitespace": false,
         "unified-signatures": false,
         "void-return": false,
-        "whitespace": false
+        "whitespace": false,
+        "no-angle-bracket-type-assertion": false
     }
 }

--- a/types/jquery.pjax/tslint.json
+++ b/types/jquery.pjax/tslint.json
@@ -74,6 +74,7 @@
         "typedef-whitespace": false,
         "unified-signatures": false,
         "void-return": false,
-        "whitespace": false
+        "whitespace": false,
+        "no-angle-bracket-type-assertion": false
     }
 }

--- a/types/jquery/JQuery.d.ts
+++ b/types/jquery/JQuery.d.ts
@@ -530,7 +530,10 @@ $( document ).ajaxComplete(function( event, request, settings ) {
 });
 ```
      */
-    ajaxComplete(handler: (this: Document, event: JQuery.Event<Document>, jqXHR: JQuery.jqXHR, ajaxOptions: JQuery.AjaxSettings) => void | false): this;
+    ajaxComplete(handler: (this: Document,
+                           event: JQuery.TriggeredEvent<Document, undefined, Document, Document>,
+                           jqXHR: JQuery.jqXHR,
+                           ajaxOptions: JQuery.AjaxSettings) => void | false): this;
     /**
      * Register a handler to be called when Ajax requests complete with an error. This is an Ajax Event.
      * @param handler The function to be invoked.
@@ -543,7 +546,11 @@ $( document ).ajaxError(function( event, request, settings ) {
 });
 ```
      */
-    ajaxError(handler: (this: Document, event: JQuery.Event<Document>, jqXHR: JQuery.jqXHR, ajaxSettings: JQuery.AjaxSettings, thrownError: string) => void | false): this;
+    ajaxError(handler: (this: Document,
+                        event: JQuery.TriggeredEvent<Document, undefined, Document, Document>,
+                        jqXHR: JQuery.jqXHR,
+                        ajaxSettings: JQuery.AjaxSettings,
+                        thrownError: string) => void | false): this;
     /**
      * Attach a function to be executed before an Ajax request is sent. This is an Ajax Event.
      * @param handler The function to be invoked.
@@ -556,7 +563,10 @@ $( document ).ajaxSend(function( event, request, settings ) {
 });
 ```
      */
-    ajaxSend(handler: (this: Document, event: JQuery.Event<Document>, jqXHR: JQuery.jqXHR, ajaxOptions: JQuery.AjaxSettings) => void | false): this;
+    ajaxSend(handler: (this: Document,
+                       event: JQuery.TriggeredEvent<Document, undefined, Document, Document>,
+                       jqXHR: JQuery.jqXHR,
+                       ajaxOptions: JQuery.AjaxSettings) => void | false): this;
     /**
      * Register a handler to be called when the first Ajax request begins. This is an Ajax Event.
      * @param handler The function to be invoked.
@@ -595,7 +605,11 @@ $( document ).ajaxSuccess(function( event, request, settings ) {
 });
 ```
      */
-    ajaxSuccess(handler: (this: Document, event: JQuery.Event<Document>, jqXHR: JQuery.jqXHR, ajaxOptions: JQuery.AjaxSettings, data: JQuery.PlainObject) => void | false): this;
+    ajaxSuccess(handler: (this: Document,
+                          event: JQuery.TriggeredEvent<Document, undefined, Document, Document>,
+                          jqXHR: JQuery.jqXHR,
+                          ajaxOptions: JQuery.AjaxSettings,
+                          data: JQuery.PlainObject) => void | false): this;
     /**
      * Perform a custom animation of a set of CSS properties.
      * @param properties An object of CSS properties and values that the animation will move toward.
@@ -1329,9 +1343,12 @@ $( "p" ).before( $( "b" ) );
      *
      * **Solution**: Change the method call to use `.on()` or `.off()`, the documentation for the old methods include specific instructions. In general, the `.bind()` and `.unbind()` methods can be renamed directly to `.on()` and `.off()` respectively since the argument orders are identical.
      */
-    bind<TData>(eventType: string,
-                eventData: TData,
-                handler: JQuery.EventHandler<TElement, TData>): this;
+    bind<TType extends string,
+         TData>(
+        eventType: TType,
+        eventData: TData,
+        handler: JQuery.TypeEventHandler<TElement, TData, TElement, TElement, TElement, TType>
+    ): this;
     /**
      * Attach a handler to an event for the elements.
      * @param eventType A string containing one or more DOM event types, such as "click" or "submit," or custom event names.
@@ -1458,8 +1475,13 @@ $( "button" ).click(function() {
 </html>
 ```
      */
-    bind(eventType: string,
-         handler_preventBubble: JQuery.EventHandler<TElement> | false | null | undefined): this;
+    bind<TType extends string>(
+        eventType: TType,
+        handler_preventBubble: JQuery.TypeEventHandler<TElement, undefined, TElement, TElement, TElement, TType> |
+                               false |
+                               null |
+                               undefined
+    ): this;
     /**
      * Attach a handler to an event for the elements.
      * @param events An object containing one or more DOM event types and functions to execute for them.
@@ -1485,7 +1507,7 @@ $( "div.test" ).bind({
 });
 ```
      */
-    bind(events: JQuery.PlainObject<JQuery.EventHandler<TElement> | false>): this;
+    bind(events: JQuery.TypeEventHandlers<TElement, undefined, TElement, TElement, TElement>): this;
     /**
      * Bind an event handler to the "blur" JavaScript event, or trigger that event on an element.
      * @param eventData An object containing data that will be passed to the event handler.
@@ -2713,10 +2735,13 @@ $( "button" ).click(function() {
      *
      * **Solution**: Change the method call to use `.on()` or `.off()`, the documentation for the old methods include specific instructions. In general, the `.bind()` and `.unbind()` methods can be renamed directly to `.on()` and `.off()` respectively since the argument orders are identical.
      */
-    delegate<TData>(selector: JQuery.Selector,
-                    eventType: string,
-                    eventData: TData,
-                    handler: JQuery.EventHandler<TElement, TData>): this;
+    delegate<TType extends string,
+             TData>(
+        selector: JQuery.Selector,
+        eventType: TType,
+        eventData: TData,
+        handler: JQuery.TypeEventHandler<TElement, TData, any, any, any, TType>
+    ): this;
     /**
      * Attach a handler to one or more events for all elements that match the selector, now or in the future, based on a specific set of root elements.
      * @param selector A selector to filter the elements that trigger the event.
@@ -2828,9 +2853,12 @@ $( "button" ).click(function() {
 </html>
 ```
      */
-    delegate(selector: JQuery.Selector,
-             eventType: string,
-             handler: JQuery.EventHandler<TElement> | false): this;
+    delegate<TType extends string>(
+        selector: JQuery.Selector,
+        eventType: TType,
+        handler: JQuery.TypeEventHandler<TElement, undefined, any, any, any, TType> |
+                 false
+    ): this;
     /**
      * Attach a handler to one or more events for all elements that match the selector, now or in the future, based on a specific set of root elements.
      * @param selector A selector to filter the elements that trigger the event.
@@ -2844,7 +2872,8 @@ $( "button" ).click(function() {
      * **Solution**: Change the method call to use `.on()` or `.off()`, the documentation for the old methods include specific instructions. In general, the `.bind()` and `.unbind()` methods can be renamed directly to `.on()` and `.off()` respectively since the argument orders are identical.
      */
     delegate(selector: JQuery.Selector,
-             events: JQuery.PlainObject<JQuery.EventHandler<TElement> | false>): this;
+             events: JQuery.TypeEventHandlers<TElement, undefined, any, any, any>
+    ): this;
     /**
      * Execute the next function on the queue for the matched elements.
      * @param queueName A string containing the name of the queue. Defaults to fx, the standard effects queue.
@@ -7245,7 +7274,10 @@ $( "body" ).on( "click", "p", foo );
 $( "body" ).off( "click", "p", foo );
 ```
      */
-    off(events: string, selector: JQuery.Selector, handler: JQuery.EventHandlerBase<any, JQuery.Event<TElement, any>> | false): this;
+    off(events: string,
+        selector: JQuery.Selector,
+        handler: JQuery.TypeEventHandler<TElement, any, any, any, any, string> |
+                 false): this;
     /**
      * Remove an event handler.
      * @param events One or more space-separated event types and optional namespaces, or just namespaces, such as
@@ -7275,7 +7307,10 @@ $( "form" ).on( "keypress.validator", "input[type='text']", validate );
 $( "form" ).off( ".validator" );
 ```
      */
-    off(events: string, selector_handler?: JQuery.Selector | JQuery.EventHandlerBase<any, JQuery.Event<TElement, any>> | false): this;
+    off(events: string,
+        selector_handler?: JQuery.Selector |
+                           JQuery.TypeEventHandler<TElement, any, any, any, any, string> |
+                           false): this;
     /**
      * Remove an event handler.
      * @param events An object where the string keys represent one or more space-separated event types and optional
@@ -7284,7 +7319,8 @@ $( "form" ).off( ".validator" );
      * @see \`{@link https://api.jquery.com/off/ }\`
      * @since 1.7
      */
-    off(events: JQuery.PlainObject<JQuery.EventHandlerBase<any, JQuery.Event<TElement, any>> | false>, selector?: JQuery.Selector): this;
+    off(events: JQuery.TypeEventHandlers<TElement, any, any, any, any>,
+        selector?: JQuery.Selector): this;
     /**
      * Remove an event handler.
      * @param event A jQuery.Event object.
@@ -7295,7 +7331,7 @@ $( "form" ).off( ".validator" );
 $( "p" ).off();
 ```
      */
-    off(event?: JQuery.Event<TElement>): this;
+    off(event?: JQuery.TriggeredEvent<TElement>): this;
     /**
      * Set the current coordinates of every element in the set of matched elements, relative to the document.
      * @param coordinates_function _&#x40;param_ `coordinates_function`
@@ -7468,10 +7504,30 @@ $( "*", document.body ).click(function( event ) {
      * @see \`{@link https://api.jquery.com/on/ }\`
      * @since 1.7
      */
-    on<TData>(events: string,
-              selector: JQuery.Selector | null,
-              data: TData,
-              handler: JQuery.EventHandler<TElement, TData>): this;
+    on<TType extends string,
+       TData>(
+        events: TType,
+        selector: JQuery.Selector,
+        data: TData,
+        handler: JQuery.TypeEventHandler<TElement, TData, any, any, any, TType>
+    ): this;
+    /**
+     * Attach an event handler function for one or more events to the selected elements.
+     * @param events One or more space-separated event types and optional namespaces, such as "click" or "keydown.myPlugin".
+     * @param selector A selector string to filter the descendants of the selected elements that trigger the event. If the
+     *                 selector is null or omitted, the event is always triggered when it reaches the selected element.
+     * @param data Data to be passed to the handler in event.data when an event is triggered.
+     * @param handler A function to execute when the event is triggered.
+     * @see \`{@link https://api.jquery.com/on/ }\`
+     * @since 1.7
+     */
+    on<TType extends string,
+       TData>(
+        events: TType,
+        selector: null | undefined,
+        data: TData,
+        handler: JQuery.TypeEventHandler<TElement, TData, TElement, TElement, TElement, TType>
+    ): this;
     /**
      * Attach an event handler function for one or more events to the selected elements.
      * @param events One or more space-separated event types and optional namespaces, such as "click" or "keydown.myPlugin".
@@ -7484,7 +7540,7 @@ $( "*", document.body ).click(function( event ) {
      * @deprecated ​ Deprecated. Use \`{@link JQuery.Event }\` in place of \`{@link JQueryEventObject }\`.
      */
     on(events: string,
-       selector: JQuery.Selector | null,
+       selector: JQuery.Selector | null | undefined,
        data: any,
        handler: ((event: JQueryEventObject) => void)): this;
     /**
@@ -7547,14 +7603,41 @@ $( "body" ).on( "click", "a", function( event ) {
 });
 ```
      */
-    on(events: string,
-       selector: JQuery.Selector,
-       handler: JQuery.EventHandler<TElement> | false): this;
+    on<TType extends string>(
+        events: TType,
+        selector: JQuery.Selector,
+        handler: JQuery.TypeEventHandler<TElement, undefined, any, any, any, TType> |
+                 false
+    ): this;
     /**
      * Attach an event handler function for one or more events to the selected elements.
      * @param events One or more space-separated event types and optional namespaces, such as "click" or "keydown.myPlugin".
-     * @param selector A selector string to filter the descendants of the selected elements that trigger the event. If the
-     *                 selector is null or omitted, the event is always triggered when it reaches the selected element.
+     * @param data Data to be passed to the handler in event.data when an event is triggered.
+     * @param handler A function to execute when the event is triggered.
+     * @see \`{@link https://api.jquery.com/on/ }\`
+     * @since 1.7
+     * @example ​ ````Pass data to the event handler, which is specified here by name:
+```javascript
+function myHandler( event ) {
+  alert( event.data.foo );
+}
+$( "p" ).on( "click", { foo: "bar" }, myHandler );
+```
+     */
+    on<TType extends string,
+       TData>(
+        events: TType,
+        data: TData,
+        handler: JQuery.TypeEventHandler<TElement, TData, TElement, TElement, TElement, TType>
+    ): this;
+    /**
+     * Attach an event handler function for one or more events to the selected elements.
+     * @param events One or more space-separated event types and optional namespaces, such as "click" or "keydown.myPlugin".
+     * @param selector_data _&#x40;param_ `selector_data`
+     * <br>
+     * * `selector` — A selector string to filter the descendants of the selected elements that trigger the event. If the
+     *                selector is null or omitted, the event is always triggered when it reaches the selected element. <br>
+     * * `data` — Data to be passed to the handler in event.data when an event is triggered.
      * @param handler A function to execute when the event is triggered.
      * @see \`{@link https://api.jquery.com/on/ }\`
      * @since 1.7
@@ -7609,37 +7692,6 @@ $( "body" ).on( "click", "a", function( event ) {
   event.preventDefault();
 });
 ```
-     */
-    on(events: string,
-       selector: JQuery.Selector,
-       // tslint:disable-next-line:unified-signatures
-       handler: ((event: JQueryEventObject) => void)): this;
-    /**
-     * Attach an event handler function for one or more events to the selected elements.
-     * @param events One or more space-separated event types and optional namespaces, such as "click" or "keydown.myPlugin".
-     * @param data Data to be passed to the handler in event.data when an event is triggered.
-     * @param handler A function to execute when the event is triggered.
-     * @see \`{@link https://api.jquery.com/on/ }\`
-     * @since 1.7
-     * @example ​ ````Pass data to the event handler, which is specified here by name:
-```javascript
-function myHandler( event ) {
-  alert( event.data.foo );
-}
-$( "p" ).on( "click", { foo: "bar" }, myHandler );
-```
-     */
-    on<TData>(events: string,
-              data: TData,
-              handler: JQuery.EventHandler<TElement, TData>): this;
-    /**
-     * Attach an event handler function for one or more events to the selected elements.
-     * @param events One or more space-separated event types and optional namespaces, such as "click" or "keydown.myPlugin".
-     * @param data Data to be passed to the handler in event.data when an event is triggered.
-     * @param handler A function to execute when the event is triggered.
-     * @see \`{@link https://api.jquery.com/on/ }\`
-     * @since 1.7
-     * @deprecated ​ Deprecated. Use \`{@link JQuery.Event }\` in place of \`{@link JQueryEventObject }\`.
      * @example ​ ````Pass data to the event handler, which is specified here by name:
 ```javascript
 function myHandler( event ) {
@@ -7649,8 +7701,7 @@ $( "p" ).on( "click", { foo: "bar" }, myHandler );
 ```
      */
     on(events: string,
-       // tslint:disable-next-line:unified-signatures
-       data: any,
+       selector_data: any,
        handler: ((event: JQueryEventObject) => void)): this;
     /**
      * Attach an event handler function for one or more events to the selected elements.
@@ -7743,8 +7794,11 @@ $( "#cart" ).on( "mouseenter mouseleave", function( event ) {
 });
 ```
      */
-    on(events: string,
-       handler: JQuery.EventHandler<TElement> | false): this;
+    on<TType extends string>(
+        events: TType,
+        handler: JQuery.TypeEventHandler<TElement, undefined, TElement, TElement, TElement, TType> |
+                 false
+    ): this;
     /**
      * Attach an event handler function for one or more events to the selected elements.
      * @param events One or more space-separated event types and optional namespaces, such as "click" or "keydown.myPlugin".
@@ -7837,7 +7891,6 @@ $( "#cart" ).on( "mouseenter mouseleave", function( event ) {
 ```
      */
     on(events: string,
-       // tslint:disable-next-line:unified-signatures
        handler: ((event: JQueryEventObject) => void)): this;
     /**
      * Attach an event handler function for one or more events to the selected elements.
@@ -7849,9 +7902,26 @@ $( "#cart" ).on( "mouseenter mouseleave", function( event ) {
      * @see \`{@link https://api.jquery.com/on/ }\`
      * @since 1.7
      */
-    on<TData>(events: JQuery.PlainObject<JQuery.EventHandler<TElement, TData> | false>,
-              selector: JQuery.Selector | null,
-              data: TData): this;
+    on<TData>(
+        events: JQuery.TypeEventHandlers<TElement, TData, any, any, any>,
+        selector: JQuery.Selector,
+        data: TData
+    ): this;
+    /**
+     * Attach an event handler function for one or more events to the selected elements.
+     * @param events An object in which the string keys represent one or more space-separated event types and optional
+     *               namespaces, and the values represent a handler function to be called for the event(s).
+     * @param selector A selector string to filter the descendants of the selected elements that will call the handler. If
+     *                 the selector is null or omitted, the handler is always called when it reaches the selected element.
+     * @param data Data to be passed to the handler in event.data when an event occurs.
+     * @see \`{@link https://api.jquery.com/on/ }\`
+     * @since 1.7
+     */
+    on<TData>(
+        events: JQuery.TypeEventHandlers<TElement, TData, TElement, TElement, TElement>,
+        selector: null | undefined,
+        data: TData
+    ): this;
     /**
      * Attach an event handler function for one or more events to the selected elements.
      * @param events An object in which the string keys represent one or more space-separated event types and optional
@@ -7861,9 +7931,9 @@ $( "#cart" ).on( "mouseenter mouseleave", function( event ) {
      * @see \`{@link https://api.jquery.com/on/ }\`
      * @since 1.7
      */
-    on(events: JQuery.PlainObject<JQuery.EventHandler<TElement> | false>,
-       // tslint:disable-next-line:unified-signatures
-       selector: JQuery.Selector): this;
+    on(events: JQuery.TypeEventHandlers<TElement, undefined, any, any, any>,
+       selector: JQuery.Selector
+    ): this;
     /**
      * Attach an event handler function for one or more events to the selected elements.
      * @param events An object in which the string keys represent one or more space-separated event types and optional
@@ -7872,8 +7942,10 @@ $( "#cart" ).on( "mouseenter mouseleave", function( event ) {
      * @see \`{@link https://api.jquery.com/on/ }\`
      * @since 1.7
      */
-    on<TData>(events: JQuery.PlainObject<JQuery.EventHandler<TElement, TData> | false>,
-              data: TData): this;
+    on<TData>(
+        events: JQuery.TypeEventHandlers<TElement, TData, TElement, TElement, TElement>,
+        data: TData
+    ): this;
     /**
      * Attach an event handler function for one or more events to the selected elements.
      * @param events An object in which the string keys represent one or more space-separated event types and optional
@@ -7922,7 +7994,7 @@ $( "div.test" ).on({
 </html>
 ```
      */
-    on(events: JQuery.PlainObject<JQuery.EventHandler<TElement> | false>): this;
+    on(events: JQuery.TypeEventHandlers<TElement, undefined, TElement, TElement, TElement>): this;
     /**
      * Attach a handler to an event for the elements. The handler is executed at most once per element per event type.
      * @param events One or more space-separated event types and optional namespaces, such as "click" or "keydown.myPlugin".
@@ -7933,10 +8005,30 @@ $( "div.test" ).on({
      * @see \`{@link https://api.jquery.com/one/ }\`
      * @since 1.7
      */
-    one<TData>(events: string,
-               selector: JQuery.Selector | null,
-               data: TData,
-               handler: JQuery.EventHandler<TElement, TData>): this;
+    one<TType extends string,
+        TData>(
+        events: TType,
+        selector: JQuery.Selector,
+        data: TData,
+        handler: JQuery.TypeEventHandler<TElement, TData, any, any, any, TType>
+    ): this;
+    /**
+     * Attach a handler to an event for the elements. The handler is executed at most once per element per event type.
+     * @param events One or more space-separated event types and optional namespaces, such as "click" or "keydown.myPlugin".
+     * @param selector A selector string to filter the descendants of the selected elements that trigger the event. If the
+     *                 selector is null or omitted, the event is always triggered when it reaches the selected element.
+     * @param data Data to be passed to the handler in event.data when an event is triggered.
+     * @param handler A function to execute when the event is triggered.
+     * @see \`{@link https://api.jquery.com/one/ }\`
+     * @since 1.7
+     */
+    one<TType extends string,
+        TData>(
+        events: TType,
+        selector: null | undefined,
+        data: TData,
+        handler: JQuery.TypeEventHandler<TElement, TData, TElement, TElement, TElement, TType>
+    ): this;
     /**
      * Attach a handler to an event for the elements. The handler is executed at most once per element per event type.
      * @param events One or more space-separated event types and optional namespaces, such as "click" or "keydown.myPlugin".
@@ -7947,9 +8039,12 @@ $( "div.test" ).on({
      * @see \`{@link https://api.jquery.com/one/ }\`
      * @since 1.7
      */
-    one(events: string,
+    one<TType extends string>(
+        events: TType,
         selector: JQuery.Selector,
-        handler: JQuery.EventHandler<TElement> | false): this;
+        handler: JQuery.TypeEventHandler<TElement, undefined, any, any, any, TType> |
+                 false
+    ): this;
     /**
      * Attach a handler to an event for the elements. The handler is executed at most once per element per event type.
      * @param events One or more space-separated event types and optional namespaces, such as "click" or "keydown.myPlugin".
@@ -7958,9 +8053,12 @@ $( "div.test" ).on({
      * @see \`{@link https://api.jquery.com/one/ }\`
      * @since 1.7
      */
-    one<TData>(events: string,
-               data: TData,
-               handler: JQuery.EventHandler<TElement, TData>): this;
+    one<TType extends string,
+        TData>(
+        events: TType,
+        data: TData,
+        handler: JQuery.TypeEventHandler<TElement, TData, TElement, TElement, TElement, TType>
+    ): this;
     /**
      * Attach a handler to an event for the elements. The handler is executed at most once per element per event type.
      * @param events One or more space-separated event types and optional namespaces, such as "click" or "keydown.myPlugin".
@@ -8049,8 +8147,11 @@ $(".target").one("click mouseenter", function() {
 </html>
 ```
      */
-    one(events: string,
-        handler: JQuery.EventHandler<TElement> | false): this;
+    one<TType extends string>(
+        events: TType,
+        handler: JQuery.TypeEventHandler<TElement, undefined, TElement, TElement, TElement, TType>|
+                 false
+    ): this;
     /**
      * Attach a handler to an event for the elements. The handler is executed at most once per element per event type.
      * @param events An object in which the string keys represent one or more space-separated event types and optional
@@ -8061,9 +8162,26 @@ $(".target").one("click mouseenter", function() {
      * @see \`{@link https://api.jquery.com/one/ }\`
      * @since 1.7
      */
-    one<TData>(events: JQuery.PlainObject<JQuery.EventHandler<TElement, TData> | false>,
-               selector: JQuery.Selector | null,
-               data: TData): this;
+    one<TData>(
+        events: JQuery.TypeEventHandlers<TElement, TData, any, any, any>,
+        selector: JQuery.Selector,
+        data: TData
+    ): this;
+    /**
+     * Attach a handler to an event for the elements. The handler is executed at most once per element per event type.
+     * @param events An object in which the string keys represent one or more space-separated event types and optional
+     *               namespaces, and the values represent a handler function to be called for the event(s).
+     * @param selector A selector string to filter the descendants of the selected elements that will call the handler. If
+     *                 the selector is null or omitted, the handler is always called when it reaches the selected element.
+     * @param data Data to be passed to the handler in event.data when an event occurs.
+     * @see \`{@link https://api.jquery.com/one/ }\`
+     * @since 1.7
+     */
+    one<TData>(
+        events: JQuery.TypeEventHandlers<TElement, TData, TElement, TElement, TElement>,
+        selector: null | undefined,
+        data: TData
+    ): this;
     /**
      * Attach a handler to an event for the elements. The handler is executed at most once per element per event type.
      * @param events An object in which the string keys represent one or more space-separated event types and optional
@@ -8073,8 +8191,7 @@ $(".target").one("click mouseenter", function() {
      * @see \`{@link https://api.jquery.com/one/ }\`
      * @since 1.7
      */
-    one(events: JQuery.PlainObject<JQuery.EventHandler<TElement> | false>,
-        // tslint:disable-next-line:unified-signatures
+    one(events: JQuery.TypeEventHandlers<TElement, undefined, any, any, any>,
         selector: JQuery.Selector): this;
     /**
      * Attach a handler to an event for the elements. The handler is executed at most once per element per event type.
@@ -8084,8 +8201,10 @@ $(".target").one("click mouseenter", function() {
      * @see \`{@link https://api.jquery.com/one/ }\`
      * @since 1.7
      */
-    one<TData>(events: JQuery.PlainObject<JQuery.EventHandler<TElement, TData> | false>,
-               data: TData): this;
+    one<TData>(
+        events: JQuery.TypeEventHandlers<TElement, TData, TElement, TElement, TElement>,
+        data: TData
+    ): this;
     /**
      * Attach a handler to an event for the elements. The handler is executed at most once per element per event type.
      * @param events An object in which the string keys represent one or more space-separated event types and optional
@@ -8093,7 +8212,7 @@ $(".target").one("click mouseenter", function() {
      * @see \`{@link https://api.jquery.com/one/ }\`
      * @since 1.7
      */
-    one(events: JQuery.PlainObject<JQuery.EventHandler<TElement> | false>): this;
+    one(events: JQuery.TypeEventHandlers<TElement, undefined, TElement, TElement, TElement>): this;
     /**
      * Set the CSS outer height of each element in the set of matched elements.
      * @param value_function _&#x40;param_ `value_function`
@@ -11704,7 +11823,7 @@ $( "body" ).trigger({
 });
 ```
      */
-    trigger(eventType_event: string | JQuery.Event<TElement>, extraParameters?: any[] | JQuery.PlainObject | string | number | boolean): this;
+    trigger(eventType_event: string | JQuery.Event, extraParameters?: any[] | JQuery.PlainObject | string | number | boolean): this;
     /**
      * Execute all handlers attached to an element for an event.
      * @param eventType_event _&#x40;param_ `eventType_event`
@@ -11747,7 +11866,7 @@ $( "input" ).focus(function() {
 </html>
 ```
      */
-    triggerHandler(eventType_event: string | JQuery.Event<TElement>, extraParameters?: any[] | JQuery.PlainObject | string | number | boolean): any;
+    triggerHandler(eventType_event: string | JQuery.Event, extraParameters?: any[] | JQuery.PlainObject | string | number | boolean): any;
     /**
      * Remove a previously-attached event handler from the elements.
      * @param event A string containing one or more DOM event types, such as "click" or "submit," or custom event names.
@@ -11815,7 +11934,10 @@ $( "p" ).bind( "click", foo ); // ... Now foo will be called when paragraphs are
 $( "p" ).unbind( "click", foo ); // ... foo will no longer be called.
 ```
      */
-    unbind(event: string, handler: JQuery.EventHandlerBase<any, JQuery.Event<TElement, any>> | false): this;
+    unbind(event: string,
+           handler: JQuery.TypeEventHandler<TElement, any, TElement, TElement, TElement, string> |
+                    false
+    ): this;
     /**
      * Remove a previously-attached event handler from the elements.
      * @param event A string containing one or more DOM event types, such as "click" or "submit," or custom event names.
@@ -11836,7 +11958,7 @@ $( "p" ).unbind();
 $( "p" ).unbind( "click" );
 ```
      */
-    unbind(event?: string | JQuery.Event<TElement>): this;
+    unbind(event?: string | JQuery.TriggeredEvent<TElement>): this;
     /**
      * Remove a handler from the event for all elements which match the current selector, based upon a specific set of root elements.
      * @param selector A selector which will be used to filter the event results.
@@ -11906,12 +12028,18 @@ $( "body" ).delegate( "p", "click", foo );
 $( "body" ).undelegate( "p", "click", foo );
 ```
      */
-    undelegate(selector: JQuery.Selector, eventType: string, handler: JQuery.EventHandlerBase<any, JQuery.Event<TElement, any>> | false): this;
+    undelegate(selector: JQuery.Selector,
+               eventType: string,
+               handler: JQuery.TypeEventHandler<TElement, any, any, any, any, string> |
+                        false
+    ): this;
     /**
      * Remove a handler from the event for all elements which match the current selector, based upon a specific set of root elements.
      * @param selector A selector which will be used to filter the event results.
-     * @param eventTypes A string containing a JavaScript event type, such as "click" or "keydown"
-     *                   An object of one or more event types and previously bound functions to unbind from them.
+     * @param eventType_events _&#x40;param_ `eventType_events`
+     * <br>
+     * * `eventType` — A string containing a JavaScript event type, such as "click" or "keydown" <br>
+     * * `events` — An object of one or more event types and previously bound functions to unbind from them.
      * @see \`{@link https://api.jquery.com/undelegate/ }\`
      * @since 1.4.2
      * @since 1.4.3
@@ -11921,7 +12049,9 @@ $( "body" ).undelegate( "p", "click", foo );
      *
      * **Solution**: Change the method call to use `.on()` or `.off()`, the documentation for the old methods include specific instructions. In general, the `.bind()` and `.unbind()` methods can be renamed directly to `.on()` and `.off()` respectively since the argument orders are identical.
      */
-    undelegate(selector: JQuery.Selector, eventTypes: string | JQuery.PlainObject<JQuery.EventHandlerBase<any, JQuery.Event<TElement, any>> | false>): this;
+    undelegate(selector: JQuery.Selector,
+               eventType_events: string |
+                                 JQuery.TypeEventHandlers<TElement, any, any, any, any>): this;
     /**
      * Remove a handler from the event for all elements which match the current selector, based upon a specific set of root elements.
      * @param namespace A selector which will be used to filter the event results.

--- a/types/jquery/JQuery.d.ts
+++ b/types/jquery/JQuery.d.ts
@@ -1331,7 +1331,7 @@ $( "p" ).before( $( "b" ) );
      */
     bind<TData>(eventType: string,
                 eventData: TData,
-                handler: JQuery.EventHandler<TElement, TData> | JQuery.EventHandlerBase<any, JQuery.Event<TElement, TData>>): this;
+                handler: JQuery.EventHandler<TElement, TData>): this;
     /**
      * Attach a handler to an event for the elements.
      * @param eventType A string containing one or more DOM event types, such as "click" or "submit," or custom event names.
@@ -1459,7 +1459,7 @@ $( "button" ).click(function() {
 ```
      */
     bind(eventType: string,
-         handler_preventBubble: JQuery.EventHandler<TElement> | JQuery.EventHandlerBase<any, JQuery.Event<TElement>> | false | null | undefined): this;
+         handler_preventBubble: JQuery.EventHandler<TElement> | false | null | undefined): this;
     /**
      * Attach a handler to an event for the elements.
      * @param events An object containing one or more DOM event types and functions to execute for them.
@@ -1485,7 +1485,7 @@ $( "div.test" ).bind({
 });
 ```
      */
-    bind(events: JQuery.PlainObject<JQuery.EventHandler<TElement> | JQuery.EventHandlerBase<any, JQuery.Event<TElement>> | false>): this;
+    bind(events: JQuery.PlainObject<JQuery.EventHandler<TElement> | false>): this;
     /**
      * Bind an event handler to the "blur" JavaScript event, or trigger that event on an element.
      * @param eventData An object containing data that will be passed to the event handler.
@@ -1499,7 +1499,7 @@ $( "div.test" ).bind({
      * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
      */
     blur<TData>(eventData: TData,
-                handler: JQuery.EventHandler<TElement, TData> | JQuery.EventHandlerBase<any, JQuery.Event<TElement, TData>>): this;
+                handler: JQuery.EventHandler<TElement, TData>): this;
     /**
      * Bind an event handler to the "blur" JavaScript event, or trigger that event on an element.
      * @param handler A function to execute each time the event is triggered.
@@ -1515,7 +1515,7 @@ $( "div.test" ).bind({
 $( "p" ).blur();
 ```
      */
-    blur(handler?: JQuery.EventHandler<TElement> | JQuery.EventHandlerBase<any, JQuery.Event<TElement>> | false): this;
+    blur(handler?: JQuery.EventHandler<TElement> | false): this;
     /**
      * Bind an event handler to the "change" JavaScript event, or trigger that event on an element.
      * @param eventData An object containing data that will be passed to the event handler.
@@ -1529,7 +1529,7 @@ $( "p" ).blur();
      * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
      */
     change<TData>(eventData: TData,
-                  handler: JQuery.EventHandler<TElement, TData> | JQuery.EventHandlerBase<any, JQuery.Event<TElement, TData>>): this;
+                  handler: JQuery.EventHandler<TElement, TData>): this;
     /**
      * Bind an event handler to the "change" JavaScript event, or trigger that event on an element.
      * @param handler A function to execute each time the event is triggered.
@@ -1588,7 +1588,7 @@ $( "input[type='text']" ).change(function() {
 });
 ```
      */
-    change(handler?: JQuery.EventHandler<TElement> | JQuery.EventHandlerBase<any, JQuery.Event<TElement>> | false): this;
+    change(handler?: JQuery.EventHandler<TElement> | false): this;
     /**
      * Get the children of each element in the set of matched elements, optionally filtered by a selector.
      * @param selector A string containing a selector expression to match elements against.
@@ -1841,7 +1841,7 @@ $( "#stop" ).click(function() {
      * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
      */
     click<TData>(eventData: TData,
-                 handler: JQuery.EventHandler<TElement, TData> | JQuery.EventHandlerBase<any, JQuery.Event<TElement, TData>>): this;
+                 handler: JQuery.EventHandler<TElement, TData>): this;
     /**
      * Bind an event handler to the "click" JavaScript event, or trigger that event on an element.
      * @param handler A function to execute each time the event is triggered.
@@ -1891,7 +1891,7 @@ $( "p" ).click(function() {
 $( "p" ).click();
 ```
      */
-    click(handler?: JQuery.EventHandler<TElement> | JQuery.EventHandlerBase<any, JQuery.Event<TElement>> | false): this;
+    click(handler?: JQuery.EventHandler<TElement> | false): this;
     /**
      * Create a deep copy of the set of matched elements.
      * @param withDataAndEvents A Boolean indicating whether event handlers and data should be copied along with the elements. The
@@ -2079,7 +2079,7 @@ $( "#frameDemo" ).contents().find( "a" ).css( "background-color", "#BADA55" );
      * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
      */
     contextmenu<TData>(eventData: TData,
-                       handler: JQuery.EventHandler<TElement, TData> | JQuery.EventHandlerBase<any, JQuery.Event<TElement, TData>>): this;
+                       handler: JQuery.EventHandler<TElement, TData>): this;
     /**
      * Bind an event handler to the "contextmenu" JavaScript event, or trigger that event on an element.
      * @param handler A function to execute each time the event is triggered.
@@ -2133,7 +2133,7 @@ div.contextmenu(function() {
 </html>
 ```
      */
-    contextmenu(handler?: JQuery.EventHandler<TElement> | JQuery.EventHandlerBase<any, JQuery.Event<TElement>> | false): this;
+    contextmenu(handler?: JQuery.EventHandler<TElement> | false): this;
     /**
      * Set one or more CSS properties for the set of matched elements.
      * @param propertyName A CSS property name.
@@ -2594,7 +2594,7 @@ $( "button" ).click(function() {
      * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
      */
     dblclick<TData>(eventData: TData,
-                    handler: JQuery.EventHandler<TElement, TData> | JQuery.EventHandlerBase<any, JQuery.Event<TElement, TData>>): this;
+                    handler: JQuery.EventHandler<TElement, TData>): this;
     /**
      * Bind an event handler to the "dblclick" JavaScript event, or trigger that event on an element.
      * @param handler A function to execute each time the event is triggered.
@@ -2648,7 +2648,7 @@ divdbl.dblclick(function() {
 </html>
 ```
      */
-    dblclick(handler?: JQuery.EventHandler<TElement> | JQuery.EventHandlerBase<any, JQuery.Event<TElement>> | false): this;
+    dblclick(handler?: JQuery.EventHandler<TElement> | false): this;
     /**
      * Set a timer to delay execution of subsequent items in the queue.
      * @param duration An integer indicating the number of milliseconds to delay execution of the next item in the queue.
@@ -2716,7 +2716,7 @@ $( "button" ).click(function() {
     delegate<TData>(selector: JQuery.Selector,
                     eventType: string,
                     eventData: TData,
-                    handler: JQuery.EventHandler<TElement, TData> | JQuery.EventHandlerBase<any, JQuery.Event<TElement, TData>>): this;
+                    handler: JQuery.EventHandler<TElement, TData>): this;
     /**
      * Attach a handler to one or more events for all elements that match the selector, now or in the future, based on a specific set of root elements.
      * @param selector A selector to filter the elements that trigger the event.
@@ -2830,7 +2830,7 @@ $( "button" ).click(function() {
      */
     delegate(selector: JQuery.Selector,
              eventType: string,
-             handler: JQuery.EventHandler<TElement> | JQuery.EventHandlerBase<any, JQuery.Event<TElement>> | false): this;
+             handler: JQuery.EventHandler<TElement> | false): this;
     /**
      * Attach a handler to one or more events for all elements that match the selector, now or in the future, based on a specific set of root elements.
      * @param selector A selector to filter the elements that trigger the event.
@@ -2844,7 +2844,7 @@ $( "button" ).click(function() {
      * **Solution**: Change the method call to use `.on()` or `.off()`, the documentation for the old methods include specific instructions. In general, the `.bind()` and `.unbind()` methods can be renamed directly to `.on()` and `.off()` respectively since the argument orders are identical.
      */
     delegate(selector: JQuery.Selector,
-             events: JQuery.PlainObject<JQuery.EventHandler<TElement> | JQuery.EventHandlerBase<any, JQuery.Event<TElement>> | false>): this;
+             events: JQuery.PlainObject<JQuery.EventHandler<TElement> | false>): this;
     /**
      * Execute the next function on the queue for the matched elements.
      * @param queueName A string containing the name of the queue. Defaults to fx, the standard effects queue.
@@ -4264,7 +4264,7 @@ $( "p span" ).first().addClass( "highlight" );
      * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
      */
     focus<TData>(eventData: TData,
-                 handler: JQuery.EventHandler<TElement, TData> | JQuery.EventHandlerBase<any, JQuery.Event<TElement, TData>>): this;
+                 handler: JQuery.EventHandler<TElement, TData>): this;
     /**
      * Bind an event handler to the "focus" JavaScript event, or trigger that event on an element.
      * @param handler A function to execute each time the event is triggered.
@@ -4316,7 +4316,7 @@ $( document ).ready(function() {
 });
 ```
      */
-    focus(handler?: JQuery.EventHandler<TElement> | JQuery.EventHandlerBase<any, JQuery.Event<TElement>> | false): this;
+    focus(handler?: JQuery.EventHandler<TElement> | false): this;
     /**
      * Bind an event handler to the "focusin" event.
      * @param eventData An object containing data that will be passed to the event handler.
@@ -4330,7 +4330,7 @@ $( document ).ready(function() {
      * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
      */
     focusin<TData>(eventData: TData,
-                   handler: JQuery.EventHandler<TElement, TData> | JQuery.EventHandlerBase<any, JQuery.Event<TElement, TData>>): this;
+                   handler: JQuery.EventHandler<TElement, TData>): this;
     /**
      * Bind an event handler to the "focusin" event.
      * @param handler A function to execute each time the event is triggered.
@@ -4370,7 +4370,7 @@ $( "p" ).focusin(function() {
 </html>
 ```
      */
-    focusin(handler?: JQuery.EventHandler<TElement> | JQuery.EventHandlerBase<any, JQuery.Event<TElement>> | false): this;
+    focusin(handler?: JQuery.EventHandler<TElement> | false): this;
     /**
      * Bind an event handler to the "focusout" JavaScript event.
      * @param eventData An object containing data that will be passed to the event handler.
@@ -4384,7 +4384,7 @@ $( "p" ).focusin(function() {
      * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
      */
     focusout<TData>(eventData: TData,
-                    handler: JQuery.EventHandler<TElement, TData> | JQuery.EventHandlerBase<any, JQuery.Event<TElement, TData>>): this;
+                    handler: JQuery.EventHandler<TElement, TData>): this;
     /**
      * Bind an event handler to the "focusout" JavaScript event.
      * @param handler A function to execute each time the event is triggered.
@@ -4445,7 +4445,7 @@ $( "p" )
 </html>
 ```
      */
-    focusout(handler?: JQuery.EventHandler<TElement> | JQuery.EventHandlerBase<any, JQuery.Event<TElement>> | false): this;
+    focusout(handler?: JQuery.EventHandler<TElement> | false): this;
     /**
      * Retrieve one of the elements matched by the jQuery object.
      * @param index A zero-based integer indicating which element to retrieve.
@@ -5018,8 +5018,8 @@ $( "li" )
      */
     // HACK: The type parameter T is not used but ensures the 'event' callback parameter is typed correctly.
     // tslint:disable-next-line:no-unnecessary-generics
-    hover<T>(handlerInOut: JQuery.EventHandler<TElement> | JQuery.EventHandlerBase<any, JQuery.Event<TElement>> | false,
-             handlerOut?: JQuery.EventHandler<TElement> | JQuery.EventHandlerBase<any, JQuery.Event<TElement>> | false): this;
+    hover<T>(handlerInOut: JQuery.EventHandler<TElement> | false,
+             handlerOut?: JQuery.EventHandler<TElement> | false): this;
     /**
      * Set the HTML contents of each element in the set of matched elements.
      * @param htmlString_function _&#x40;param_ `htmlString_function`
@@ -5833,7 +5833,7 @@ $( "li" ).click(function() {
      * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
      */
     keydown<TData>(eventData: TData,
-                   handler: JQuery.EventHandler<TElement, TData> | JQuery.EventHandlerBase<any, JQuery.Event<TElement, TData>>): this;
+                   handler: JQuery.EventHandler<TElement, TData>): this;
     /**
      * Bind an event handler to the "keydown" JavaScript event, or trigger that event on an element.
      * @param handler A function to execute each time the event is triggered.
@@ -5905,7 +5905,7 @@ $( "#other" ).click(function() {
 </html>
 ```
      */
-    keydown(handler?: JQuery.EventHandler<TElement> | JQuery.EventHandlerBase<any, JQuery.Event<TElement>> | false): this;
+    keydown(handler?: JQuery.EventHandler<TElement> | false): this;
     /**
      * Bind an event handler to the "keypress" JavaScript event, or trigger that event on an element.
      * @param eventData An object containing data that will be passed to the event handler.
@@ -5919,7 +5919,7 @@ $( "#other" ).click(function() {
      * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
      */
     keypress<TData>(eventData: TData,
-                    handler: JQuery.EventHandler<TElement, TData> | JQuery.EventHandlerBase<any, JQuery.Event<TElement, TData>>): this;
+                    handler: JQuery.EventHandler<TElement, TData>): this;
     /**
      * Bind an event handler to the "keypress" JavaScript event, or trigger that event on an element.
      * @param handler A function to execute each time the event is triggered.
@@ -5991,7 +5991,7 @@ $( "#other" ).click(function() {
 </html>
 ```
      */
-    keypress(handler?: JQuery.EventHandler<TElement> | JQuery.EventHandlerBase<any, JQuery.Event<TElement>> | false): this;
+    keypress(handler?: JQuery.EventHandler<TElement> | false): this;
     /**
      * Bind an event handler to the "keyup" JavaScript event, or trigger that event on an element.
      * @param eventData An object containing data that will be passed to the event handler.
@@ -6005,7 +6005,7 @@ $( "#other" ).click(function() {
      * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
      */
     keyup<TData>(eventData: TData,
-                 handler: JQuery.EventHandler<TElement, TData> | JQuery.EventHandlerBase<any, JQuery.Event<TElement, TData>>): this;
+                 handler: JQuery.EventHandler<TElement, TData>): this;
     /**
      * Bind an event handler to the "keyup" JavaScript event, or trigger that event on an element.
      * @param handler A function to execute each time the event is triggered.
@@ -6078,7 +6078,7 @@ $( "#other").click(function() {
 </html>
 ```
      */
-    keyup(handler?: JQuery.EventHandler<TElement> | JQuery.EventHandlerBase<any, JQuery.Event<TElement>> | false): this;
+    keyup(handler?: JQuery.EventHandler<TElement> | false): this;
     /**
      * Reduce the set of matched elements to the final one in the set.
      * @see \`{@link https://api.jquery.com/last/ }\`
@@ -6367,7 +6367,7 @@ $( "input" ).click(function() {
      * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
      */
     mousedown<TData>(eventData: TData,
-                     handler: JQuery.EventHandler<TElement, TData> | JQuery.EventHandlerBase<any, JQuery.Event<TElement, TData>>): this;
+                     handler: JQuery.EventHandler<TElement, TData>): this;
     /**
      * Bind an event handler to the "mousedown" JavaScript event, or trigger that event on an element.
      * @param handler A function to execute each time the event is triggered.
@@ -6405,7 +6405,7 @@ $( "p" )
 </html>
 ```
      */
-    mousedown(handler?: JQuery.EventHandler<TElement> | JQuery.EventHandlerBase<any, JQuery.Event<TElement>> | false): this;
+    mousedown(handler?: JQuery.EventHandler<TElement> | false): this;
     /**
      * Bind an event handler to be fired when the mouse enters an element, or trigger that handler on an element.
      * @param eventData An object containing data that will be passed to the event handler.
@@ -6419,7 +6419,7 @@ $( "p" )
      * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
      */
     mouseenter<TData>(eventData: TData,
-                      handler: JQuery.EventHandler<TElement, TData> | JQuery.EventHandlerBase<any, JQuery.Event<TElement, TData>>): this;
+                      handler: JQuery.EventHandler<TElement, TData>): this;
     /**
      * Bind an event handler to be fired when the mouse enters an element, or trigger that handler on an element.
      * @param handler A function to execute each time the event is triggered.
@@ -6500,7 +6500,7 @@ $( "div.enterleave" )
 </html>
 ```
      */
-    mouseenter(handler?: JQuery.EventHandler<TElement> | JQuery.EventHandlerBase<any, JQuery.Event<TElement>> | false): this;
+    mouseenter(handler?: JQuery.EventHandler<TElement> | false): this;
     /**
      * Bind an event handler to be fired when the mouse leaves an element, or trigger that handler on an element.
      * @param eventData An object containing data that will be passed to the event handler.
@@ -6514,7 +6514,7 @@ $( "div.enterleave" )
      * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
      */
     mouseleave<TData>(eventData: TData,
-                      handler: JQuery.EventHandler<TElement, TData> | JQuery.EventHandlerBase<any, JQuery.Event<TElement, TData>>): this;
+                      handler: JQuery.EventHandler<TElement, TData>): this;
     /**
      * Bind an event handler to be fired when the mouse leaves an element, or trigger that handler on an element.
      * @param handler A function to execute each time the event is triggered.
@@ -6593,7 +6593,7 @@ $( "div.enterleave" )
 </html>
 ```
      */
-    mouseleave(handler?: JQuery.EventHandler<TElement> | JQuery.EventHandlerBase<any, JQuery.Event<TElement>> | false): this;
+    mouseleave(handler?: JQuery.EventHandler<TElement> | false): this;
     /**
      * Bind an event handler to the "mousemove" JavaScript event, or trigger that event on an element.
      * @param eventData An object containing data that will be passed to the event handler.
@@ -6607,7 +6607,7 @@ $( "div.enterleave" )
      * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
      */
     mousemove<TData>(eventData: TData,
-                     handler: JQuery.EventHandler<TElement, TData> | JQuery.EventHandlerBase<any, JQuery.Event<TElement, TData>>): this;
+                     handler: JQuery.EventHandler<TElement, TData>): this;
     /**
      * Bind an event handler to the "mousemove" JavaScript event, or trigger that event on an element.
      * @param handler A function to execute each time the event is triggered.
@@ -6671,7 +6671,7 @@ $( "div" ).mousemove(function( event ) {
 </html>
 ```
      */
-    mousemove(handler?: JQuery.EventHandler<TElement> | JQuery.EventHandlerBase<any, JQuery.Event<TElement>> | false): this;
+    mousemove(handler?: JQuery.EventHandler<TElement> | false): this;
     /**
      * Bind an event handler to the "mouseout" JavaScript event, or trigger that event on an element.
      * @param eventData An object containing data that will be passed to the event handler.
@@ -6685,7 +6685,7 @@ $( "div" ).mousemove(function( event ) {
      * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
      */
     mouseout<TData>(eventData: TData,
-                    handler: JQuery.EventHandler<TElement, TData> | JQuery.EventHandlerBase<any, JQuery.Event<TElement, TData>>): this;
+                    handler: JQuery.EventHandler<TElement, TData>): this;
     /**
      * Bind an event handler to the "mouseout" JavaScript event, or trigger that event on an element.
      * @param handler A function to execute each time the event is triggered.
@@ -6766,7 +6766,7 @@ $( "div.enterleave" )
 </html>
 ```
      */
-    mouseout(handler?: JQuery.EventHandler<TElement> | JQuery.EventHandlerBase<any, JQuery.Event<TElement>> | false): this;
+    mouseout(handler?: JQuery.EventHandler<TElement> | false): this;
     /**
      * Bind an event handler to the "mouseover" JavaScript event, or trigger that event on an element.
      * @param eventData An object containing data that will be passed to the event handler.
@@ -6780,7 +6780,7 @@ $( "div.enterleave" )
      * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
      */
     mouseover<TData>(eventData: TData,
-                     handler: JQuery.EventHandler<TElement, TData> | JQuery.EventHandlerBase<any, JQuery.Event<TElement, TData>>): this;
+                     handler: JQuery.EventHandler<TElement, TData>): this;
     /**
      * Bind an event handler to the "mouseover" JavaScript event, or trigger that event on an element.
      * @param handler A function to execute each time the event is triggered.
@@ -6861,7 +6861,7 @@ $( "div.enterleave" )
 </html>
 ```
      */
-    mouseover(handler?: JQuery.EventHandler<TElement> | JQuery.EventHandlerBase<any, JQuery.Event<TElement>> | false): this;
+    mouseover(handler?: JQuery.EventHandler<TElement> | false): this;
     /**
      * Bind an event handler to the "mouseup" JavaScript event, or trigger that event on an element.
      * @param eventData An object containing data that will be passed to the event handler.
@@ -6875,7 +6875,7 @@ $( "div.enterleave" )
      * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
      */
     mouseup<TData>(eventData: TData,
-                   handler: JQuery.EventHandler<TElement, TData> | JQuery.EventHandlerBase<any, JQuery.Event<TElement, TData>>): this;
+                   handler: JQuery.EventHandler<TElement, TData>): this;
     /**
      * Bind an event handler to the "mouseup" JavaScript event, or trigger that event on an element.
      * @param handler A function to execute each time the event is triggered.
@@ -6913,7 +6913,7 @@ $( "p" )
 </html>
 ```
      */
-    mouseup(handler?: JQuery.EventHandler<TElement> | JQuery.EventHandlerBase<any, JQuery.Event<TElement>> | false): this;
+    mouseup(handler?: JQuery.EventHandler<TElement> | false): this;
     /**
      * Get the immediately following sibling of each element in the set of matched elements. If a selector is provided, it retrieves the next sibling only if it matches that selector.
      * @param selector A string containing a selector expression to match elements against.
@@ -7471,7 +7471,7 @@ $( "*", document.body ).click(function( event ) {
     on<TData>(events: string,
               selector: JQuery.Selector | null,
               data: TData,
-              handler: JQuery.EventHandler<TElement, TData> | JQuery.EventHandlerBase<any, JQuery.Event<TElement, TData>>): this;
+              handler: JQuery.EventHandler<TElement, TData>): this;
     /**
      * Attach an event handler function for one or more events to the selected elements.
      * @param events One or more space-separated event types and optional namespaces, such as "click" or "keydown.myPlugin".
@@ -7549,7 +7549,7 @@ $( "body" ).on( "click", "a", function( event ) {
      */
     on(events: string,
        selector: JQuery.Selector,
-       handler: JQuery.EventHandler<TElement> | JQuery.EventHandlerBase<any, JQuery.Event<TElement>> | false): this;
+       handler: JQuery.EventHandler<TElement> | false): this;
     /**
      * Attach an event handler function for one or more events to the selected elements.
      * @param events One or more space-separated event types and optional namespaces, such as "click" or "keydown.myPlugin".
@@ -7631,7 +7631,7 @@ $( "p" ).on( "click", { foo: "bar" }, myHandler );
      */
     on<TData>(events: string,
               data: TData,
-              handler: JQuery.EventHandler<TElement, TData> | JQuery.EventHandlerBase<any, JQuery.Event<TElement, TData>>): this;
+              handler: JQuery.EventHandler<TElement, TData>): this;
     /**
      * Attach an event handler function for one or more events to the selected elements.
      * @param events One or more space-separated event types and optional namespaces, such as "click" or "keydown.myPlugin".
@@ -7744,7 +7744,7 @@ $( "#cart" ).on( "mouseenter mouseleave", function( event ) {
 ```
      */
     on(events: string,
-       handler: JQuery.EventHandler<TElement> | JQuery.EventHandlerBase<any, JQuery.Event<TElement>> | false): this;
+       handler: JQuery.EventHandler<TElement> | false): this;
     /**
      * Attach an event handler function for one or more events to the selected elements.
      * @param events One or more space-separated event types and optional namespaces, such as "click" or "keydown.myPlugin".
@@ -7849,7 +7849,7 @@ $( "#cart" ).on( "mouseenter mouseleave", function( event ) {
      * @see \`{@link https://api.jquery.com/on/ }\`
      * @since 1.7
      */
-    on<TData>(events: JQuery.PlainObject<JQuery.EventHandler<TElement, TData> | JQuery.EventHandlerBase<any, JQuery.Event<TElement, TData>> | false>,
+    on<TData>(events: JQuery.PlainObject<JQuery.EventHandler<TElement, TData> | false>,
               selector: JQuery.Selector | null,
               data: TData): this;
     /**
@@ -7861,7 +7861,7 @@ $( "#cart" ).on( "mouseenter mouseleave", function( event ) {
      * @see \`{@link https://api.jquery.com/on/ }\`
      * @since 1.7
      */
-    on(events: JQuery.PlainObject<JQuery.EventHandler<TElement> | JQuery.EventHandlerBase<any, JQuery.Event<TElement>> | false>,
+    on(events: JQuery.PlainObject<JQuery.EventHandler<TElement> | false>,
        // tslint:disable-next-line:unified-signatures
        selector: JQuery.Selector): this;
     /**
@@ -7872,7 +7872,7 @@ $( "#cart" ).on( "mouseenter mouseleave", function( event ) {
      * @see \`{@link https://api.jquery.com/on/ }\`
      * @since 1.7
      */
-    on<TData>(events: JQuery.PlainObject<JQuery.EventHandler<TElement, TData> | JQuery.EventHandlerBase<any, JQuery.Event<TElement, TData>> | false>,
+    on<TData>(events: JQuery.PlainObject<JQuery.EventHandler<TElement, TData> | false>,
               data: TData): this;
     /**
      * Attach an event handler function for one or more events to the selected elements.
@@ -7922,7 +7922,7 @@ $( "div.test" ).on({
 </html>
 ```
      */
-    on(events: JQuery.PlainObject<JQuery.EventHandler<TElement> | JQuery.EventHandlerBase<any, JQuery.Event<TElement>> | false>): this;
+    on(events: JQuery.PlainObject<JQuery.EventHandler<TElement> | false>): this;
     /**
      * Attach a handler to an event for the elements. The handler is executed at most once per element per event type.
      * @param events One or more space-separated event types and optional namespaces, such as "click" or "keydown.myPlugin".
@@ -7936,7 +7936,7 @@ $( "div.test" ).on({
     one<TData>(events: string,
                selector: JQuery.Selector | null,
                data: TData,
-               handler: JQuery.EventHandler<TElement, TData> | JQuery.EventHandlerBase<any, JQuery.Event<TElement, TData>>): this;
+               handler: JQuery.EventHandler<TElement, TData>): this;
     /**
      * Attach a handler to an event for the elements. The handler is executed at most once per element per event type.
      * @param events One or more space-separated event types and optional namespaces, such as "click" or "keydown.myPlugin".
@@ -7949,7 +7949,7 @@ $( "div.test" ).on({
      */
     one(events: string,
         selector: JQuery.Selector,
-        handler: JQuery.EventHandler<TElement> | JQuery.EventHandlerBase<any, JQuery.Event<TElement>> | false): this;
+        handler: JQuery.EventHandler<TElement> | false): this;
     /**
      * Attach a handler to an event for the elements. The handler is executed at most once per element per event type.
      * @param events One or more space-separated event types and optional namespaces, such as "click" or "keydown.myPlugin".
@@ -7960,7 +7960,7 @@ $( "div.test" ).on({
      */
     one<TData>(events: string,
                data: TData,
-               handler: JQuery.EventHandler<TElement, TData> | JQuery.EventHandlerBase<any, JQuery.Event<TElement, TData>>): this;
+               handler: JQuery.EventHandler<TElement, TData>): this;
     /**
      * Attach a handler to an event for the elements. The handler is executed at most once per element per event type.
      * @param events One or more space-separated event types and optional namespaces, such as "click" or "keydown.myPlugin".
@@ -8050,7 +8050,7 @@ $(".target").one("click mouseenter", function() {
 ```
      */
     one(events: string,
-        handler: JQuery.EventHandler<TElement> | JQuery.EventHandlerBase<any, JQuery.Event<TElement>> | false): this;
+        handler: JQuery.EventHandler<TElement> | false): this;
     /**
      * Attach a handler to an event for the elements. The handler is executed at most once per element per event type.
      * @param events An object in which the string keys represent one or more space-separated event types and optional
@@ -8061,7 +8061,7 @@ $(".target").one("click mouseenter", function() {
      * @see \`{@link https://api.jquery.com/one/ }\`
      * @since 1.7
      */
-    one<TData>(events: JQuery.PlainObject<JQuery.EventHandler<TElement, TData> | JQuery.EventHandlerBase<any, JQuery.Event<TElement, TData>> | false>,
+    one<TData>(events: JQuery.PlainObject<JQuery.EventHandler<TElement, TData> | false>,
                selector: JQuery.Selector | null,
                data: TData): this;
     /**
@@ -8073,7 +8073,7 @@ $(".target").one("click mouseenter", function() {
      * @see \`{@link https://api.jquery.com/one/ }\`
      * @since 1.7
      */
-    one(events: JQuery.PlainObject<JQuery.EventHandler<TElement> | JQuery.EventHandlerBase<any, JQuery.Event<TElement>> | false>,
+    one(events: JQuery.PlainObject<JQuery.EventHandler<TElement> | false>,
         // tslint:disable-next-line:unified-signatures
         selector: JQuery.Selector): this;
     /**
@@ -8084,7 +8084,7 @@ $(".target").one("click mouseenter", function() {
      * @see \`{@link https://api.jquery.com/one/ }\`
      * @since 1.7
      */
-    one<TData>(events: JQuery.PlainObject<JQuery.EventHandler<TElement, TData> | JQuery.EventHandlerBase<any, JQuery.Event<TElement, TData>> | false>,
+    one<TData>(events: JQuery.PlainObject<JQuery.EventHandler<TElement, TData> | false>,
                data: TData): this;
     /**
      * Attach a handler to an event for the elements. The handler is executed at most once per element per event type.
@@ -8093,7 +8093,7 @@ $(".target").one("click mouseenter", function() {
      * @see \`{@link https://api.jquery.com/one/ }\`
      * @since 1.7
      */
-    one(events: JQuery.PlainObject<JQuery.EventHandler<TElement> | JQuery.EventHandlerBase<any, JQuery.Event<TElement>> | false>): this;
+    one(events: JQuery.PlainObject<JQuery.EventHandler<TElement> | false>): this;
     /**
      * Set the CSS outer height of each element in the set of matched elements.
      * @param value_function _&#x40;param_ `value_function`
@@ -9851,7 +9851,7 @@ $( "button" ).on( "click", function() {
      * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
      */
     resize<TData>(eventData: TData,
-                  handler: JQuery.EventHandler<TElement, TData> | JQuery.EventHandlerBase<any, JQuery.Event<TElement, TData>>): this;
+                  handler: JQuery.EventHandler<TElement, TData>): this;
     /**
      * Bind an event handler to the "resize" JavaScript event, or trigger that event on an element.
      * @param handler A function to execute each time the event is triggered.
@@ -9869,7 +9869,7 @@ $( window ).resize(function() {
 });
 ```
      */
-    resize(handler?: JQuery.EventHandler<TElement> | JQuery.EventHandlerBase<any, JQuery.Event<TElement>> | false): this;
+    resize(handler?: JQuery.EventHandler<TElement> | false): this;
     /**
      * Bind an event handler to the "scroll" JavaScript event, or trigger that event on an element.
      * @param eventData An object containing data that will be passed to the event handler.
@@ -9883,7 +9883,7 @@ $( window ).resize(function() {
      * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
      */
     scroll<TData>(eventData: TData,
-                  handler: JQuery.EventHandler<TElement, TData> | JQuery.EventHandlerBase<any, JQuery.Event<TElement, TData>>): this;
+                  handler: JQuery.EventHandler<TElement, TData>): this;
     /**
      * Bind an event handler to the "scroll" JavaScript event, or trigger that event on an element.
      * @param handler A function to execute each time the event is triggered.
@@ -9933,7 +9933,7 @@ $( window ).scroll(function() {
 </html>
 ```
      */
-    scroll(handler?: JQuery.EventHandler<TElement> | JQuery.EventHandlerBase<any, JQuery.Event<TElement>> | false): this;
+    scroll(handler?: JQuery.EventHandler<TElement> | false): this;
     /**
      * Set the current horizontal position of the scroll bar for each of the set of matched elements.
      * @param value An integer indicating the new position to set the scroll bar to.
@@ -10107,7 +10107,7 @@ $( "p:last" ).text( "scrollTop:" + p.scrollTop() );
      * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
      */
     select<TData>(eventData: TData,
-                  handler: JQuery.EventHandler<TElement, TData> | JQuery.EventHandlerBase<any, JQuery.Event<TElement, TData>>): this;
+                  handler: JQuery.EventHandler<TElement, TData>): this;
     /**
      * Bind an event handler to the "select" JavaScript event, or trigger that event on an element.
      * @param handler A function to execute each time the event is triggered.
@@ -10156,7 +10156,7 @@ $( ":input" ).select(function() {
 $( "input" ).select();
 ```
      */
-    select(handler?: JQuery.EventHandler<TElement> | JQuery.EventHandlerBase<any, JQuery.Event<TElement>> | false): this;
+    select(handler?: JQuery.EventHandler<TElement> | false): this;
     /**
      * Encode a set of form elements as a string for submission.
      * @see \`{@link https://api.jquery.com/serialize/ }\`
@@ -11127,7 +11127,7 @@ $( "#toggle" ).on( "click", function() {
      * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
      */
     submit<TData>(eventData: TData,
-                  handler: JQuery.EventHandler<TElement, TData> | JQuery.EventHandlerBase<any, JQuery.Event<TElement, TData>>): this;
+                  handler: JQuery.EventHandler<TElement, TData>): this;
     /**
      * Bind an event handler to the "submit" JavaScript event, or trigger that event on an element.
      * @param handler A function to execute each time the event is triggered.
@@ -11196,7 +11196,7 @@ $( "form" ).submit(function() {
 $( "form:first" ).submit();
 ```
      */
-    submit(handler?: JQuery.EventHandler<TElement> | JQuery.EventHandlerBase<any, JQuery.Event<TElement>> | false): this;
+    submit(handler?: JQuery.EventHandler<TElement> | false): this;
     /**
      * Set the content of each element in the set of matched elements to the specified text.
      * @param text_function _&#x40;param_ `text_function`

--- a/types/jquery/JQuery.d.ts
+++ b/types/jquery/JQuery.d.ts
@@ -1347,7 +1347,7 @@ $( "p" ).before( $( "b" ) );
          TData>(
         eventType: TType,
         eventData: TData,
-        handler: JQuery.TypeEventHandler<TElement, TData, TElement, TElement, TElement, TType>
+        handler: JQuery.TypeEventHandler<TElement, TData, TElement, TElement, TType>
     ): this;
     /**
      * Attach a handler to an event for the elements.
@@ -1477,7 +1477,7 @@ $( "button" ).click(function() {
      */
     bind<TType extends string>(
         eventType: TType,
-        handler_preventBubble: JQuery.TypeEventHandler<TElement, undefined, TElement, TElement, TElement, TType> |
+        handler_preventBubble: JQuery.TypeEventHandler<TElement, undefined, TElement, TElement, TType> |
                                false |
                                null |
                                undefined
@@ -1507,7 +1507,7 @@ $( "div.test" ).bind({
 });
 ```
      */
-    bind(events: JQuery.TypeEventHandlers<TElement, undefined, TElement, TElement, TElement>): this;
+    bind(events: JQuery.TypeEventHandlers<TElement, undefined, TElement, TElement>): this;
     /**
      * Bind an event handler to the "blur" JavaScript event, or trigger that event on an element.
      * @param eventData An object containing data that will be passed to the event handler.
@@ -1521,7 +1521,7 @@ $( "div.test" ).bind({
      * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
      */
     blur<TData>(eventData: TData,
-                handler: JQuery.TypeEventHandler<TElement, TData, TElement, TElement, TElement, 'blur'>): this;
+                handler: JQuery.TypeEventHandler<TElement, TData, TElement, TElement, 'blur'>): this;
     /**
      * Bind an event handler to the "blur" JavaScript event, or trigger that event on an element.
      * @param handler A function to execute each time the event is triggered.
@@ -1537,7 +1537,7 @@ $( "div.test" ).bind({
 $( "p" ).blur();
 ```
      */
-    blur(handler?: JQuery.TypeEventHandler<TElement, null, TElement, TElement, TElement, 'blur'> |
+    blur(handler?: JQuery.TypeEventHandler<TElement, null, TElement, TElement, 'blur'> |
                    false): this;
     /**
      * Bind an event handler to the "change" JavaScript event, or trigger that event on an element.
@@ -1552,7 +1552,7 @@ $( "p" ).blur();
      * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
      */
     change<TData>(eventData: TData,
-                  handler: JQuery.TypeEventHandler<TElement, TData, TElement, TElement, TElement, 'change'>): this;
+                  handler: JQuery.TypeEventHandler<TElement, TData, TElement, TElement, 'change'>): this;
     /**
      * Bind an event handler to the "change" JavaScript event, or trigger that event on an element.
      * @param handler A function to execute each time the event is triggered.
@@ -1611,7 +1611,7 @@ $( "input[type='text']" ).change(function() {
 });
 ```
      */
-    change(handler?: JQuery.TypeEventHandler<TElement, null, TElement, TElement, TElement, 'change'> |
+    change(handler?: JQuery.TypeEventHandler<TElement, null, TElement, TElement, 'change'> |
                      false): this;
     /**
      * Get the children of each element in the set of matched elements, optionally filtered by a selector.
@@ -1865,7 +1865,7 @@ $( "#stop" ).click(function() {
      * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
      */
     click<TData>(eventData: TData,
-                 handler: JQuery.TypeEventHandler<TElement, TData, TElement, TElement, TElement, 'click'>): this;
+                 handler: JQuery.TypeEventHandler<TElement, TData, TElement, TElement, 'click'>): this;
     /**
      * Bind an event handler to the "click" JavaScript event, or trigger that event on an element.
      * @param handler A function to execute each time the event is triggered.
@@ -1915,7 +1915,7 @@ $( "p" ).click(function() {
 $( "p" ).click();
 ```
      */
-    click(handler?: JQuery.TypeEventHandler<TElement, null, TElement, TElement, TElement, 'click'> |
+    click(handler?: JQuery.TypeEventHandler<TElement, null, TElement, TElement, 'click'> |
                     false): this;
     /**
      * Create a deep copy of the set of matched elements.
@@ -2104,7 +2104,7 @@ $( "#frameDemo" ).contents().find( "a" ).css( "background-color", "#BADA55" );
      * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
      */
     contextmenu<TData>(eventData: TData,
-                       handler: JQuery.TypeEventHandler<TElement, TData, TElement, TElement, TElement, 'contextmenu'>): this;
+                       handler: JQuery.TypeEventHandler<TElement, TData, TElement, TElement, 'contextmenu'>): this;
     /**
      * Bind an event handler to the "contextmenu" JavaScript event, or trigger that event on an element.
      * @param handler A function to execute each time the event is triggered.
@@ -2158,7 +2158,7 @@ div.contextmenu(function() {
 </html>
 ```
      */
-    contextmenu(handler?: JQuery.TypeEventHandler<TElement, null, TElement, TElement, TElement, 'contextmenu'> |
+    contextmenu(handler?: JQuery.TypeEventHandler<TElement, null, TElement, TElement, 'contextmenu'> |
                           false): this;
     /**
      * Set one or more CSS properties for the set of matched elements.
@@ -2620,7 +2620,7 @@ $( "button" ).click(function() {
      * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
      */
     dblclick<TData>(eventData: TData,
-                    handler: JQuery.TypeEventHandler<TElement, TData, TElement, TElement, TElement, 'dblclick'>): this;
+                    handler: JQuery.TypeEventHandler<TElement, TData, TElement, TElement, 'dblclick'>): this;
     /**
      * Bind an event handler to the "dblclick" JavaScript event, or trigger that event on an element.
      * @param handler A function to execute each time the event is triggered.
@@ -2674,7 +2674,7 @@ divdbl.dblclick(function() {
 </html>
 ```
      */
-    dblclick(handler?: JQuery.TypeEventHandler<TElement, null, TElement, TElement, TElement, 'dblclick'> |
+    dblclick(handler?: JQuery.TypeEventHandler<TElement, null, TElement, TElement, 'dblclick'> |
                        false): this;
     /**
      * Set a timer to delay execution of subsequent items in the queue.
@@ -2745,7 +2745,7 @@ $( "button" ).click(function() {
         selector: JQuery.Selector,
         eventType: TType,
         eventData: TData,
-        handler: JQuery.TypeEventHandler<TElement, TData, any, any, any, TType>
+        handler: JQuery.TypeEventHandler<TElement, TData, any, any, TType>
     ): this;
     /**
      * Attach a handler to one or more events for all elements that match the selector, now or in the future, based on a specific set of root elements.
@@ -2861,7 +2861,7 @@ $( "button" ).click(function() {
     delegate<TType extends string>(
         selector: JQuery.Selector,
         eventType: TType,
-        handler: JQuery.TypeEventHandler<TElement, undefined, any, any, any, TType> |
+        handler: JQuery.TypeEventHandler<TElement, undefined, any, any, TType> |
                  false
     ): this;
     /**
@@ -2877,7 +2877,7 @@ $( "button" ).click(function() {
      * **Solution**: Change the method call to use `.on()` or `.off()`, the documentation for the old methods include specific instructions. In general, the `.bind()` and `.unbind()` methods can be renamed directly to `.on()` and `.off()` respectively since the argument orders are identical.
      */
     delegate(selector: JQuery.Selector,
-             events: JQuery.TypeEventHandlers<TElement, undefined, any, any, any>
+             events: JQuery.TypeEventHandlers<TElement, undefined, any, any>
     ): this;
     /**
      * Execute the next function on the queue for the matched elements.
@@ -4298,7 +4298,7 @@ $( "p span" ).first().addClass( "highlight" );
      * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
      */
     focus<TData>(eventData: TData,
-                 handler: JQuery.TypeEventHandler<TElement, TData, TElement, TElement, TElement, 'focus'>): this;
+                 handler: JQuery.TypeEventHandler<TElement, TData, TElement, TElement, 'focus'>): this;
     /**
      * Bind an event handler to the "focus" JavaScript event, or trigger that event on an element.
      * @param handler A function to execute each time the event is triggered.
@@ -4350,7 +4350,7 @@ $( document ).ready(function() {
 });
 ```
      */
-    focus(handler?: JQuery.TypeEventHandler<TElement, null, TElement, TElement, TElement, 'focus'> |
+    focus(handler?: JQuery.TypeEventHandler<TElement, null, TElement, TElement, 'focus'> |
                     false): this;
     /**
      * Bind an event handler to the "focusin" event.
@@ -4365,7 +4365,7 @@ $( document ).ready(function() {
      * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
      */
     focusin<TData>(eventData: TData,
-                   handler: JQuery.TypeEventHandler<TElement, TData, TElement, TElement, TElement, 'focusin'>): this;
+                   handler: JQuery.TypeEventHandler<TElement, TData, TElement, TElement, 'focusin'>): this;
     /**
      * Bind an event handler to the "focusin" event.
      * @param handler A function to execute each time the event is triggered.
@@ -4405,7 +4405,7 @@ $( "p" ).focusin(function() {
 </html>
 ```
      */
-    focusin(handler?: JQuery.TypeEventHandler<TElement, null, TElement, TElement, TElement, 'focusin'> |
+    focusin(handler?: JQuery.TypeEventHandler<TElement, null, TElement, TElement, 'focusin'> |
                       false): this;
     /**
      * Bind an event handler to the "focusout" JavaScript event.
@@ -4420,7 +4420,7 @@ $( "p" ).focusin(function() {
      * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
      */
     focusout<TData>(eventData: TData,
-                    handler: JQuery.TypeEventHandler<TElement, TData, TElement, TElement, TElement, 'focusout'>): this;
+                    handler: JQuery.TypeEventHandler<TElement, TData, TElement, TElement, 'focusout'>): this;
     /**
      * Bind an event handler to the "focusout" JavaScript event.
      * @param handler A function to execute each time the event is triggered.
@@ -4481,7 +4481,7 @@ $( "p" )
 </html>
 ```
      */
-    focusout(handler?: JQuery.TypeEventHandler<TElement, null, TElement, TElement, TElement, 'focusout'> |
+    focusout(handler?: JQuery.TypeEventHandler<TElement, null, TElement, TElement, 'focusout'> |
                        false): this;
     /**
      * Retrieve one of the elements matched by the jQuery object.
@@ -4998,9 +4998,9 @@ $( "td" ).hover(
 $( "td" ).off( "mouseenter mouseleave" );
 ```
      */
-    hover(handlerIn: JQuery.TypeEventHandler<TElement, null, TElement, TElement, TElement, 'mouseenter'> |
+    hover(handlerIn: JQuery.TypeEventHandler<TElement, null, TElement, TElement, 'mouseenter'> |
                      false,
-          handlerOut: JQuery.TypeEventHandler<TElement, null, TElement, TElement, TElement, 'mouseleave'> |
+          handlerOut: JQuery.TypeEventHandler<TElement, null, TElement, TElement, 'mouseleave'> |
                       false): this;
     /**
      * Bind a single handler to the matched elements, to be executed when the mouse pointer enters or leaves the elements.
@@ -5067,7 +5067,7 @@ $( "li" )
 </html>
 ```
      */
-    hover(handlerInOut: JQuery.TypeEventHandler<TElement, null, TElement, TElement, TElement, 'mouseenter' | 'mouseleave'> |
+    hover(handlerInOut: JQuery.TypeEventHandler<TElement, null, TElement, TElement, 'mouseenter' | 'mouseleave'> |
                         false): this;
     /**
      * Set the HTML contents of each element in the set of matched elements.
@@ -5882,7 +5882,7 @@ $( "li" ).click(function() {
      * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
      */
     keydown<TData>(eventData: TData,
-                   handler: JQuery.TypeEventHandler<TElement, TData, TElement, TElement, TElement, 'keydown'>): this;
+                   handler: JQuery.TypeEventHandler<TElement, TData, TElement, TElement, 'keydown'>): this;
     /**
      * Bind an event handler to the "keydown" JavaScript event, or trigger that event on an element.
      * @param handler A function to execute each time the event is triggered.
@@ -5954,7 +5954,7 @@ $( "#other" ).click(function() {
 </html>
 ```
      */
-    keydown(handler?: JQuery.TypeEventHandler<TElement, null, TElement, TElement, TElement, 'keydown'> |
+    keydown(handler?: JQuery.TypeEventHandler<TElement, null, TElement, TElement, 'keydown'> |
                       false): this;
     /**
      * Bind an event handler to the "keypress" JavaScript event, or trigger that event on an element.
@@ -5969,7 +5969,7 @@ $( "#other" ).click(function() {
      * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
      */
     keypress<TData>(eventData: TData,
-                    handler: JQuery.TypeEventHandler<TElement, TData, TElement, TElement, TElement, 'keypress'>): this;
+                    handler: JQuery.TypeEventHandler<TElement, TData, TElement, TElement, 'keypress'>): this;
     /**
      * Bind an event handler to the "keypress" JavaScript event, or trigger that event on an element.
      * @param handler A function to execute each time the event is triggered.
@@ -6041,7 +6041,7 @@ $( "#other" ).click(function() {
 </html>
 ```
      */
-    keypress(handler?: JQuery.TypeEventHandler<TElement, null, TElement, TElement, TElement, 'keypress'> |
+    keypress(handler?: JQuery.TypeEventHandler<TElement, null, TElement, TElement, 'keypress'> |
                        false): this;
     /**
      * Bind an event handler to the "keyup" JavaScript event, or trigger that event on an element.
@@ -6056,7 +6056,7 @@ $( "#other" ).click(function() {
      * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
      */
     keyup<TData>(eventData: TData,
-                 handler: JQuery.TypeEventHandler<TElement, TData, TElement, TElement, TElement, 'keyup'>): this;
+                 handler: JQuery.TypeEventHandler<TElement, TData, TElement, TElement, 'keyup'>): this;
     /**
      * Bind an event handler to the "keyup" JavaScript event, or trigger that event on an element.
      * @param handler A function to execute each time the event is triggered.
@@ -6129,7 +6129,7 @@ $( "#other").click(function() {
 </html>
 ```
      */
-    keyup(handler?: JQuery.TypeEventHandler<TElement, null, TElement, TElement, TElement, 'keyup'> |
+    keyup(handler?: JQuery.TypeEventHandler<TElement, null, TElement, TElement, 'keyup'> |
                     false): this;
     /**
      * Reduce the set of matched elements to the final one in the set.
@@ -6419,7 +6419,7 @@ $( "input" ).click(function() {
      * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
      */
     mousedown<TData>(eventData: TData,
-                     handler: JQuery.TypeEventHandler<TElement, TData, TElement, TElement, TElement, 'mousedown'>): this;
+                     handler: JQuery.TypeEventHandler<TElement, TData, TElement, TElement, 'mousedown'>): this;
     /**
      * Bind an event handler to the "mousedown" JavaScript event, or trigger that event on an element.
      * @param handler A function to execute each time the event is triggered.
@@ -6457,7 +6457,7 @@ $( "p" )
 </html>
 ```
      */
-    mousedown(handler?: JQuery.TypeEventHandler<TElement, null, TElement, TElement, TElement, 'mousedown'> |
+    mousedown(handler?: JQuery.TypeEventHandler<TElement, null, TElement, TElement, 'mousedown'> |
                         false): this;
     /**
      * Bind an event handler to be fired when the mouse enters an element, or trigger that handler on an element.
@@ -6472,7 +6472,7 @@ $( "p" )
      * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
      */
     mouseenter<TData>(eventData: TData,
-                      handler: JQuery.TypeEventHandler<TElement, TData, TElement, TElement, TElement, 'mouseenter'>): this;
+                      handler: JQuery.TypeEventHandler<TElement, TData, TElement, TElement, 'mouseenter'>): this;
     /**
      * Bind an event handler to be fired when the mouse enters an element, or trigger that handler on an element.
      * @param handler A function to execute each time the event is triggered.
@@ -6553,7 +6553,7 @@ $( "div.enterleave" )
 </html>
 ```
      */
-    mouseenter(handler?: JQuery.TypeEventHandler<TElement, null, TElement, TElement, TElement, 'mouseenter'> |
+    mouseenter(handler?: JQuery.TypeEventHandler<TElement, null, TElement, TElement, 'mouseenter'> |
                          false): this;
     /**
      * Bind an event handler to be fired when the mouse leaves an element, or trigger that handler on an element.
@@ -6568,7 +6568,7 @@ $( "div.enterleave" )
      * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
      */
     mouseleave<TData>(eventData: TData,
-                      handler: JQuery.TypeEventHandler<TElement, TData, TElement, TElement, TElement, 'mouseleave'>): this;
+                      handler: JQuery.TypeEventHandler<TElement, TData, TElement, TElement, 'mouseleave'>): this;
     /**
      * Bind an event handler to be fired when the mouse leaves an element, or trigger that handler on an element.
      * @param handler A function to execute each time the event is triggered.
@@ -6647,7 +6647,7 @@ $( "div.enterleave" )
 </html>
 ```
      */
-    mouseleave(handler?: JQuery.TypeEventHandler<TElement, null, TElement, TElement, TElement, 'mouseleave'> |
+    mouseleave(handler?: JQuery.TypeEventHandler<TElement, null, TElement, TElement, 'mouseleave'> |
                          false): this;
     /**
      * Bind an event handler to the "mousemove" JavaScript event, or trigger that event on an element.
@@ -6662,7 +6662,7 @@ $( "div.enterleave" )
      * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
      */
     mousemove<TData>(eventData: TData,
-                     handler: JQuery.TypeEventHandler<TElement, TData, TElement, TElement, TElement, 'mousemove'>): this;
+                     handler: JQuery.TypeEventHandler<TElement, TData, TElement, TElement, 'mousemove'>): this;
     /**
      * Bind an event handler to the "mousemove" JavaScript event, or trigger that event on an element.
      * @param handler A function to execute each time the event is triggered.
@@ -6726,7 +6726,7 @@ $( "div" ).mousemove(function( event ) {
 </html>
 ```
      */
-    mousemove(handler?: JQuery.TypeEventHandler<TElement, null, TElement, TElement, TElement, 'mousemove'> |
+    mousemove(handler?: JQuery.TypeEventHandler<TElement, null, TElement, TElement, 'mousemove'> |
                         false): this;
     /**
      * Bind an event handler to the "mouseout" JavaScript event, or trigger that event on an element.
@@ -6741,7 +6741,7 @@ $( "div" ).mousemove(function( event ) {
      * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
      */
     mouseout<TData>(eventData: TData,
-                    handler: JQuery.TypeEventHandler<TElement, TData, TElement, TElement, TElement, 'mouseout'>): this;
+                    handler: JQuery.TypeEventHandler<TElement, TData, TElement, TElement, 'mouseout'>): this;
     /**
      * Bind an event handler to the "mouseout" JavaScript event, or trigger that event on an element.
      * @param handler A function to execute each time the event is triggered.
@@ -6822,7 +6822,7 @@ $( "div.enterleave" )
 </html>
 ```
      */
-    mouseout(handler?: JQuery.TypeEventHandler<TElement, null, TElement, TElement, TElement, 'mouseout'> |
+    mouseout(handler?: JQuery.TypeEventHandler<TElement, null, TElement, TElement, 'mouseout'> |
                        false): this;
     /**
      * Bind an event handler to the "mouseover" JavaScript event, or trigger that event on an element.
@@ -6837,7 +6837,7 @@ $( "div.enterleave" )
      * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
      */
     mouseover<TData>(eventData: TData,
-                     handler: JQuery.TypeEventHandler<TElement, TData, TElement, TElement, TElement, 'mouseover'>): this;
+                     handler: JQuery.TypeEventHandler<TElement, TData, TElement, TElement, 'mouseover'>): this;
     /**
      * Bind an event handler to the "mouseover" JavaScript event, or trigger that event on an element.
      * @param handler A function to execute each time the event is triggered.
@@ -6918,7 +6918,7 @@ $( "div.enterleave" )
 </html>
 ```
      */
-    mouseover(handler?: JQuery.TypeEventHandler<TElement, null, TElement, TElement, TElement, 'mouseover'> |
+    mouseover(handler?: JQuery.TypeEventHandler<TElement, null, TElement, TElement, 'mouseover'> |
                         false): this;
     /**
      * Bind an event handler to the "mouseup" JavaScript event, or trigger that event on an element.
@@ -6933,7 +6933,7 @@ $( "div.enterleave" )
      * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
      */
     mouseup<TData>(eventData: TData,
-                   handler: JQuery.TypeEventHandler<TElement, TData, TElement, TElement, TElement, 'mouseup'>): this;
+                   handler: JQuery.TypeEventHandler<TElement, TData, TElement, TElement, 'mouseup'>): this;
     /**
      * Bind an event handler to the "mouseup" JavaScript event, or trigger that event on an element.
      * @param handler A function to execute each time the event is triggered.
@@ -6971,7 +6971,7 @@ $( "p" )
 </html>
 ```
      */
-    mouseup(handler?: JQuery.TypeEventHandler<TElement, null, TElement, TElement, TElement, 'mouseup'> |
+    mouseup(handler?: JQuery.TypeEventHandler<TElement, null, TElement, TElement, 'mouseup'> |
                       false): this;
     /**
      * Get the immediately following sibling of each element in the set of matched elements. If a selector is provided, it retrieves the next sibling only if it matches that selector.
@@ -7306,7 +7306,7 @@ $( "body" ).off( "click", "p", foo );
      */
     off(events: string,
         selector: JQuery.Selector,
-        handler: JQuery.TypeEventHandler<TElement, any, any, any, any, string> |
+        handler: JQuery.TypeEventHandler<TElement, any, any, any, string> |
                  false): this;
     /**
      * Remove an event handler.
@@ -7339,7 +7339,7 @@ $( "form" ).off( ".validator" );
      */
     off(events: string,
         selector_handler?: JQuery.Selector |
-                           JQuery.TypeEventHandler<TElement, any, any, any, any, string> |
+                           JQuery.TypeEventHandler<TElement, any, any, any, string> |
                            false): this;
     /**
      * Remove an event handler.
@@ -7349,7 +7349,7 @@ $( "form" ).off( ".validator" );
      * @see \`{@link https://api.jquery.com/off/ }\`
      * @since 1.7
      */
-    off(events: JQuery.TypeEventHandlers<TElement, any, any, any, any>,
+    off(events: JQuery.TypeEventHandlers<TElement, any, any, any>,
         selector?: JQuery.Selector): this;
     /**
      * Remove an event handler.
@@ -7539,7 +7539,7 @@ $( "*", document.body ).click(function( event ) {
         events: TType,
         selector: JQuery.Selector,
         data: TData,
-        handler: JQuery.TypeEventHandler<TElement, TData, any, any, any, TType>
+        handler: JQuery.TypeEventHandler<TElement, TData, any, any, TType>
     ): this;
     /**
      * Attach an event handler function for one or more events to the selected elements.
@@ -7556,7 +7556,7 @@ $( "*", document.body ).click(function( event ) {
         events: TType,
         selector: null | undefined,
         data: TData,
-        handler: JQuery.TypeEventHandler<TElement, TData, TElement, TElement, TElement, TType>
+        handler: JQuery.TypeEventHandler<TElement, TData, TElement, TElement, TType>
     ): this;
     /**
      * Attach an event handler function for one or more events to the selected elements.
@@ -7636,7 +7636,7 @@ $( "body" ).on( "click", "a", function( event ) {
     on<TType extends string>(
         events: TType,
         selector: JQuery.Selector,
-        handler: JQuery.TypeEventHandler<TElement, undefined, any, any, any, TType> |
+        handler: JQuery.TypeEventHandler<TElement, undefined, any, any, TType> |
                  false
     ): this;
     /**
@@ -7658,7 +7658,7 @@ $( "p" ).on( "click", { foo: "bar" }, myHandler );
        TData>(
         events: TType,
         data: TData,
-        handler: JQuery.TypeEventHandler<TElement, TData, TElement, TElement, TElement, TType>
+        handler: JQuery.TypeEventHandler<TElement, TData, TElement, TElement, TType>
     ): this;
     /**
      * Attach an event handler function for one or more events to the selected elements.
@@ -7826,7 +7826,7 @@ $( "#cart" ).on( "mouseenter mouseleave", function( event ) {
      */
     on<TType extends string>(
         events: TType,
-        handler: JQuery.TypeEventHandler<TElement, undefined, TElement, TElement, TElement, TType> |
+        handler: JQuery.TypeEventHandler<TElement, undefined, TElement, TElement, TType> |
                  false
     ): this;
     /**
@@ -7933,7 +7933,7 @@ $( "#cart" ).on( "mouseenter mouseleave", function( event ) {
      * @since 1.7
      */
     on<TData>(
-        events: JQuery.TypeEventHandlers<TElement, TData, any, any, any>,
+        events: JQuery.TypeEventHandlers<TElement, TData, any, any>,
         selector: JQuery.Selector,
         data: TData
     ): this;
@@ -7948,7 +7948,7 @@ $( "#cart" ).on( "mouseenter mouseleave", function( event ) {
      * @since 1.7
      */
     on<TData>(
-        events: JQuery.TypeEventHandlers<TElement, TData, TElement, TElement, TElement>,
+        events: JQuery.TypeEventHandlers<TElement, TData, TElement, TElement>,
         selector: null | undefined,
         data: TData
     ): this;
@@ -7961,7 +7961,7 @@ $( "#cart" ).on( "mouseenter mouseleave", function( event ) {
      * @see \`{@link https://api.jquery.com/on/ }\`
      * @since 1.7
      */
-    on(events: JQuery.TypeEventHandlers<TElement, undefined, any, any, any>,
+    on(events: JQuery.TypeEventHandlers<TElement, undefined, any, any>,
        selector: JQuery.Selector
     ): this;
     /**
@@ -7973,7 +7973,7 @@ $( "#cart" ).on( "mouseenter mouseleave", function( event ) {
      * @since 1.7
      */
     on<TData>(
-        events: JQuery.TypeEventHandlers<TElement, TData, TElement, TElement, TElement>,
+        events: JQuery.TypeEventHandlers<TElement, TData, TElement, TElement>,
         data: TData
     ): this;
     /**
@@ -8024,7 +8024,7 @@ $( "div.test" ).on({
 </html>
 ```
      */
-    on(events: JQuery.TypeEventHandlers<TElement, undefined, TElement, TElement, TElement>): this;
+    on(events: JQuery.TypeEventHandlers<TElement, undefined, TElement, TElement>): this;
     /**
      * Attach a handler to an event for the elements. The handler is executed at most once per element per event type.
      * @param events One or more space-separated event types and optional namespaces, such as "click" or "keydown.myPlugin".
@@ -8040,7 +8040,7 @@ $( "div.test" ).on({
         events: TType,
         selector: JQuery.Selector,
         data: TData,
-        handler: JQuery.TypeEventHandler<TElement, TData, any, any, any, TType>
+        handler: JQuery.TypeEventHandler<TElement, TData, any, any, TType>
     ): this;
     /**
      * Attach a handler to an event for the elements. The handler is executed at most once per element per event type.
@@ -8057,7 +8057,7 @@ $( "div.test" ).on({
         events: TType,
         selector: null | undefined,
         data: TData,
-        handler: JQuery.TypeEventHandler<TElement, TData, TElement, TElement, TElement, TType>
+        handler: JQuery.TypeEventHandler<TElement, TData, TElement, TElement, TType>
     ): this;
     /**
      * Attach a handler to an event for the elements. The handler is executed at most once per element per event type.
@@ -8072,7 +8072,7 @@ $( "div.test" ).on({
     one<TType extends string>(
         events: TType,
         selector: JQuery.Selector,
-        handler: JQuery.TypeEventHandler<TElement, undefined, any, any, any, TType> |
+        handler: JQuery.TypeEventHandler<TElement, undefined, any, any, TType> |
                  false
     ): this;
     /**
@@ -8087,7 +8087,7 @@ $( "div.test" ).on({
         TData>(
         events: TType,
         data: TData,
-        handler: JQuery.TypeEventHandler<TElement, TData, TElement, TElement, TElement, TType>
+        handler: JQuery.TypeEventHandler<TElement, TData, TElement, TElement, TType>
     ): this;
     /**
      * Attach a handler to an event for the elements. The handler is executed at most once per element per event type.
@@ -8179,7 +8179,7 @@ $(".target").one("click mouseenter", function() {
      */
     one<TType extends string>(
         events: TType,
-        handler: JQuery.TypeEventHandler<TElement, undefined, TElement, TElement, TElement, TType>|
+        handler: JQuery.TypeEventHandler<TElement, undefined, TElement, TElement, TType>|
                  false
     ): this;
     /**
@@ -8193,7 +8193,7 @@ $(".target").one("click mouseenter", function() {
      * @since 1.7
      */
     one<TData>(
-        events: JQuery.TypeEventHandlers<TElement, TData, any, any, any>,
+        events: JQuery.TypeEventHandlers<TElement, TData, any, any>,
         selector: JQuery.Selector,
         data: TData
     ): this;
@@ -8208,7 +8208,7 @@ $(".target").one("click mouseenter", function() {
      * @since 1.7
      */
     one<TData>(
-        events: JQuery.TypeEventHandlers<TElement, TData, TElement, TElement, TElement>,
+        events: JQuery.TypeEventHandlers<TElement, TData, TElement, TElement>,
         selector: null | undefined,
         data: TData
     ): this;
@@ -8221,7 +8221,7 @@ $(".target").one("click mouseenter", function() {
      * @see \`{@link https://api.jquery.com/one/ }\`
      * @since 1.7
      */
-    one(events: JQuery.TypeEventHandlers<TElement, undefined, any, any, any>,
+    one(events: JQuery.TypeEventHandlers<TElement, undefined, any, any>,
         selector: JQuery.Selector): this;
     /**
      * Attach a handler to an event for the elements. The handler is executed at most once per element per event type.
@@ -8232,7 +8232,7 @@ $(".target").one("click mouseenter", function() {
      * @since 1.7
      */
     one<TData>(
-        events: JQuery.TypeEventHandlers<TElement, TData, TElement, TElement, TElement>,
+        events: JQuery.TypeEventHandlers<TElement, TData, TElement, TElement>,
         data: TData
     ): this;
     /**
@@ -8242,7 +8242,7 @@ $(".target").one("click mouseenter", function() {
      * @see \`{@link https://api.jquery.com/one/ }\`
      * @since 1.7
      */
-    one(events: JQuery.TypeEventHandlers<TElement, undefined, TElement, TElement, TElement>): this;
+    one(events: JQuery.TypeEventHandlers<TElement, undefined, TElement, TElement>): this;
     /**
      * Set the CSS outer height of each element in the set of matched elements.
      * @param value_function _&#x40;param_ `value_function`
@@ -10000,7 +10000,7 @@ $( "button" ).on( "click", function() {
      * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
      */
     resize<TData>(eventData: TData,
-                  handler: JQuery.TypeEventHandler<TElement, TData, TElement, TElement, TElement, 'resize'>): this;
+                  handler: JQuery.TypeEventHandler<TElement, TData, TElement, TElement, 'resize'>): this;
     /**
      * Bind an event handler to the "resize" JavaScript event, or trigger that event on an element.
      * @param handler A function to execute each time the event is triggered.
@@ -10018,7 +10018,7 @@ $( window ).resize(function() {
 });
 ```
      */
-    resize(handler?: JQuery.TypeEventHandler<TElement, null, TElement, TElement, TElement, 'resize'> |
+    resize(handler?: JQuery.TypeEventHandler<TElement, null, TElement, TElement, 'resize'> |
                      false): this;
     /**
      * Bind an event handler to the "scroll" JavaScript event, or trigger that event on an element.
@@ -10033,7 +10033,7 @@ $( window ).resize(function() {
      * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
      */
     scroll<TData>(eventData: TData,
-                  handler: JQuery.TypeEventHandler<TElement, TData, TElement, TElement, TElement, 'scroll'>): this;
+                  handler: JQuery.TypeEventHandler<TElement, TData, TElement, TElement, 'scroll'>): this;
     /**
      * Bind an event handler to the "scroll" JavaScript event, or trigger that event on an element.
      * @param handler A function to execute each time the event is triggered.
@@ -10083,7 +10083,7 @@ $( window ).scroll(function() {
 </html>
 ```
      */
-    scroll(handler?: JQuery.TypeEventHandler<TElement, null, TElement, TElement, TElement, 'scroll'> |
+    scroll(handler?: JQuery.TypeEventHandler<TElement, null, TElement, TElement, 'scroll'> |
                      false): this;
     /**
      * Set the current horizontal position of the scroll bar for each of the set of matched elements.
@@ -10258,7 +10258,7 @@ $( "p:last" ).text( "scrollTop:" + p.scrollTop() );
      * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
      */
     select<TData>(eventData: TData,
-                  handler: JQuery.TypeEventHandler<TElement, TData, TElement, TElement, TElement, 'select'>): this;
+                  handler: JQuery.TypeEventHandler<TElement, TData, TElement, TElement, 'select'>): this;
     /**
      * Bind an event handler to the "select" JavaScript event, or trigger that event on an element.
      * @param handler A function to execute each time the event is triggered.
@@ -10307,7 +10307,7 @@ $( ":input" ).select(function() {
 $( "input" ).select();
 ```
      */
-    select(handler?: JQuery.TypeEventHandler<TElement, null, TElement, TElement, TElement, 'select'> |
+    select(handler?: JQuery.TypeEventHandler<TElement, null, TElement, TElement, 'select'> |
                      false): this;
     /**
      * Encode a set of form elements as a string for submission.
@@ -11279,7 +11279,7 @@ $( "#toggle" ).on( "click", function() {
      * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
      */
     submit<TData>(eventData: TData,
-                  handler: JQuery.TypeEventHandler<TElement, TData, TElement, TElement, TElement, 'submit'>): this;
+                  handler: JQuery.TypeEventHandler<TElement, TData, TElement, TElement, 'submit'>): this;
     /**
      * Bind an event handler to the "submit" JavaScript event, or trigger that event on an element.
      * @param handler A function to execute each time the event is triggered.
@@ -11348,7 +11348,7 @@ $( "form" ).submit(function() {
 $( "form:first" ).submit();
 ```
      */
-    submit(handler?: JQuery.TypeEventHandler<TElement, null, TElement, TElement, TElement, 'submit'> |
+    submit(handler?: JQuery.TypeEventHandler<TElement, null, TElement, TElement, 'submit'> |
                      false): this;
     /**
      * Set the content of each element in the set of matched elements to the specified text.
@@ -11969,7 +11969,7 @@ $( "p" ).unbind( "click", foo ); // ... foo will no longer be called.
 ```
      */
     unbind(event: string,
-           handler: JQuery.TypeEventHandler<TElement, any, TElement, TElement, TElement, string> |
+           handler: JQuery.TypeEventHandler<TElement, any, TElement, TElement, string> |
                     false
     ): this;
     /**
@@ -12064,7 +12064,7 @@ $( "body" ).undelegate( "p", "click", foo );
      */
     undelegate(selector: JQuery.Selector,
                eventType: string,
-               handler: JQuery.TypeEventHandler<TElement, any, any, any, any, string> |
+               handler: JQuery.TypeEventHandler<TElement, any, any, any, string> |
                         false
     ): this;
     /**
@@ -12085,7 +12085,7 @@ $( "body" ).undelegate( "p", "click", foo );
      */
     undelegate(selector: JQuery.Selector,
                eventType_events: string |
-                                 JQuery.TypeEventHandlers<TElement, any, any, any, any>): this;
+                                 JQuery.TypeEventHandlers<TElement, any, any, any>): this;
     /**
      * Remove a handler from the event for all elements which match the current selector, based upon a specific set of root elements.
      * @param namespace A selector which will be used to filter the event results.

--- a/types/jquery/JQuery.d.ts
+++ b/types/jquery/JQuery.d.ts
@@ -1521,7 +1521,7 @@ $( "div.test" ).bind({
      * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
      */
     blur<TData>(eventData: TData,
-                handler: JQuery.EventHandler<TElement, TData>): this;
+                handler: JQuery.TypeEventHandler<TElement, TData, TElement, TElement, TElement, 'blur'>): this;
     /**
      * Bind an event handler to the "blur" JavaScript event, or trigger that event on an element.
      * @param handler A function to execute each time the event is triggered.
@@ -1537,7 +1537,8 @@ $( "div.test" ).bind({
 $( "p" ).blur();
 ```
      */
-    blur(handler?: JQuery.EventHandler<TElement> | false): this;
+    blur(handler?: JQuery.TypeEventHandler<TElement, null, TElement, TElement, TElement, 'blur'> |
+                   false): this;
     /**
      * Bind an event handler to the "change" JavaScript event, or trigger that event on an element.
      * @param eventData An object containing data that will be passed to the event handler.
@@ -1551,7 +1552,7 @@ $( "p" ).blur();
      * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
      */
     change<TData>(eventData: TData,
-                  handler: JQuery.EventHandler<TElement, TData>): this;
+                  handler: JQuery.TypeEventHandler<TElement, TData, TElement, TElement, TElement, 'change'>): this;
     /**
      * Bind an event handler to the "change" JavaScript event, or trigger that event on an element.
      * @param handler A function to execute each time the event is triggered.
@@ -1610,7 +1611,8 @@ $( "input[type='text']" ).change(function() {
 });
 ```
      */
-    change(handler?: JQuery.EventHandler<TElement> | false): this;
+    change(handler?: JQuery.TypeEventHandler<TElement, null, TElement, TElement, TElement, 'change'> |
+                     false): this;
     /**
      * Get the children of each element in the set of matched elements, optionally filtered by a selector.
      * @param selector A string containing a selector expression to match elements against.
@@ -1863,7 +1865,7 @@ $( "#stop" ).click(function() {
      * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
      */
     click<TData>(eventData: TData,
-                 handler: JQuery.EventHandler<TElement, TData>): this;
+                 handler: JQuery.TypeEventHandler<TElement, TData, TElement, TElement, TElement, 'click'>): this;
     /**
      * Bind an event handler to the "click" JavaScript event, or trigger that event on an element.
      * @param handler A function to execute each time the event is triggered.
@@ -1913,7 +1915,8 @@ $( "p" ).click(function() {
 $( "p" ).click();
 ```
      */
-    click(handler?: JQuery.EventHandler<TElement> | false): this;
+    click(handler?: JQuery.TypeEventHandler<TElement, null, TElement, TElement, TElement, 'click'> |
+                    false): this;
     /**
      * Create a deep copy of the set of matched elements.
      * @param withDataAndEvents A Boolean indicating whether event handlers and data should be copied along with the elements. The
@@ -2101,7 +2104,7 @@ $( "#frameDemo" ).contents().find( "a" ).css( "background-color", "#BADA55" );
      * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
      */
     contextmenu<TData>(eventData: TData,
-                       handler: JQuery.EventHandler<TElement, TData>): this;
+                       handler: JQuery.TypeEventHandler<TElement, TData, TElement, TElement, TElement, 'contextmenu'>): this;
     /**
      * Bind an event handler to the "contextmenu" JavaScript event, or trigger that event on an element.
      * @param handler A function to execute each time the event is triggered.
@@ -2155,7 +2158,8 @@ div.contextmenu(function() {
 </html>
 ```
      */
-    contextmenu(handler?: JQuery.EventHandler<TElement> | false): this;
+    contextmenu(handler?: JQuery.TypeEventHandler<TElement, null, TElement, TElement, TElement, 'contextmenu'> |
+                          false): this;
     /**
      * Set one or more CSS properties for the set of matched elements.
      * @param propertyName A CSS property name.
@@ -2616,7 +2620,7 @@ $( "button" ).click(function() {
      * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
      */
     dblclick<TData>(eventData: TData,
-                    handler: JQuery.EventHandler<TElement, TData>): this;
+                    handler: JQuery.TypeEventHandler<TElement, TData, TElement, TElement, TElement, 'dblclick'>): this;
     /**
      * Bind an event handler to the "dblclick" JavaScript event, or trigger that event on an element.
      * @param handler A function to execute each time the event is triggered.
@@ -2670,7 +2674,8 @@ divdbl.dblclick(function() {
 </html>
 ```
      */
-    dblclick(handler?: JQuery.EventHandler<TElement> | false): this;
+    dblclick(handler?: JQuery.TypeEventHandler<TElement, null, TElement, TElement, TElement, 'dblclick'> |
+                       false): this;
     /**
      * Set a timer to delay execution of subsequent items in the queue.
      * @param duration An integer indicating the number of milliseconds to delay execution of the next item in the queue.
@@ -4293,7 +4298,7 @@ $( "p span" ).first().addClass( "highlight" );
      * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
      */
     focus<TData>(eventData: TData,
-                 handler: JQuery.EventHandler<TElement, TData>): this;
+                 handler: JQuery.TypeEventHandler<TElement, TData, TElement, TElement, TElement, 'focus'>): this;
     /**
      * Bind an event handler to the "focus" JavaScript event, or trigger that event on an element.
      * @param handler A function to execute each time the event is triggered.
@@ -4345,7 +4350,8 @@ $( document ).ready(function() {
 });
 ```
      */
-    focus(handler?: JQuery.EventHandler<TElement> | false): this;
+    focus(handler?: JQuery.TypeEventHandler<TElement, null, TElement, TElement, TElement, 'focus'> |
+                    false): this;
     /**
      * Bind an event handler to the "focusin" event.
      * @param eventData An object containing data that will be passed to the event handler.
@@ -4359,7 +4365,7 @@ $( document ).ready(function() {
      * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
      */
     focusin<TData>(eventData: TData,
-                   handler: JQuery.EventHandler<TElement, TData>): this;
+                   handler: JQuery.TypeEventHandler<TElement, TData, TElement, TElement, TElement, 'focusin'>): this;
     /**
      * Bind an event handler to the "focusin" event.
      * @param handler A function to execute each time the event is triggered.
@@ -4399,7 +4405,8 @@ $( "p" ).focusin(function() {
 </html>
 ```
      */
-    focusin(handler?: JQuery.EventHandler<TElement> | false): this;
+    focusin(handler?: JQuery.TypeEventHandler<TElement, null, TElement, TElement, TElement, 'focusin'> |
+                      false): this;
     /**
      * Bind an event handler to the "focusout" JavaScript event.
      * @param eventData An object containing data that will be passed to the event handler.
@@ -4413,7 +4420,7 @@ $( "p" ).focusin(function() {
      * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
      */
     focusout<TData>(eventData: TData,
-                    handler: JQuery.EventHandler<TElement, TData>): this;
+                    handler: JQuery.TypeEventHandler<TElement, TData, TElement, TElement, TElement, 'focusout'>): this;
     /**
      * Bind an event handler to the "focusout" JavaScript event.
      * @param handler A function to execute each time the event is triggered.
@@ -4474,7 +4481,8 @@ $( "p" )
 </html>
 ```
      */
-    focusout(handler?: JQuery.EventHandler<TElement> | false): this;
+    focusout(handler?: JQuery.TypeEventHandler<TElement, null, TElement, TElement, TElement, 'focusout'> |
+                       false): this;
     /**
      * Retrieve one of the elements matched by the jQuery object.
      * @param index A zero-based integer indicating which element to retrieve.
@@ -4917,12 +4925,11 @@ $( "button" ).click(function() {
      */
     hide(duration_complete_options?: JQuery.Duration | ((this: TElement) => void) | JQuery.EffectsOptions<TElement>): this;
     /**
-     * Bind one or two handlers to the matched elements, to be executed when the mouse pointer enters and leaves the elements.
-     * @param handlerInOut A function to execute when the mouse pointer enters or leaves the element.
+     * Bind two handlers to the matched elements, to be executed when the mouse pointer enters and leaves the elements.
+     * @param handlerIn A function to execute when the mouse pointer enters the element.
      * @param handlerOut A function to execute when the mouse pointer leaves the element.
      * @see \`{@link https://api.jquery.com/hover/ }\`
      * @since 1.0
-     * @since 1.4
      * @deprecated ​ Deprecated.
      *
      * **Cause**: The `.hover()` method is a shorthand for the use of the `mouseover`/`mouseout` events. It is often a poor user interface choice because it does not allow for any small amounts of delay between when the mouse enters or exits an area and when the event fires. This can make it quite difficult to use with UI widgets such as drop-down menus. For more information on the problems of hovering, see the \`{@link http://cherne.net/brian/resources/jquery.hoverIntent.html hoverIntent plugin}\`.
@@ -4990,6 +4997,21 @@ $( "td" ).hover(
 ```javascript
 $( "td" ).off( "mouseenter mouseleave" );
 ```
+     */
+    hover(handlerIn: JQuery.TypeEventHandler<TElement, null, TElement, TElement, TElement, 'mouseenter'> |
+                     false,
+          handlerOut: JQuery.TypeEventHandler<TElement, null, TElement, TElement, TElement, 'mouseleave'> |
+                      false): this;
+    /**
+     * Bind a single handler to the matched elements, to be executed when the mouse pointer enters or leaves the elements.
+     * @param handlerInOut A function to execute when the mouse pointer enters or leaves the element.
+     * @see \`{@link https://api.jquery.com/hover/ }\`
+     * @since 1.4
+     * @deprecated ​ Deprecated.
+     *
+     * **Cause**: The `.hover()` method is a shorthand for the use of the `mouseover`/`mouseout` events. It is often a poor user interface choice because it does not allow for any small amounts of delay between when the mouse enters or exits an area and when the event fires. This can make it quite difficult to use with UI widgets such as drop-down menus. For more information on the problems of hovering, see the \`{@link http://cherne.net/brian/resources/jquery.hoverIntent.html hoverIntent plugin}\`.
+     *
+     * **Solution**: Review uses of `.hover()` to determine if they are appropriate, and consider use of plugins such as `hoverIntent` as an alternative. The direct replacement for `.hover(fn1, fn2)`, is `.on("mouseenter", fn1).on("mouseleave", fn2)`.
      * @example ​ ````Slide the next sibling LI up or down on hover, and toggle a class.
 ```html
 <!doctype html>
@@ -5045,10 +5067,8 @@ $( "li" )
 </html>
 ```
      */
-    // HACK: The type parameter T is not used but ensures the 'event' callback parameter is typed correctly.
-    // tslint:disable-next-line:no-unnecessary-generics
-    hover<T>(handlerInOut: JQuery.EventHandler<TElement> | false,
-             handlerOut?: JQuery.EventHandler<TElement> | false): this;
+    hover(handlerInOut: JQuery.TypeEventHandler<TElement, null, TElement, TElement, TElement, 'mouseenter' | 'mouseleave'> |
+                        false): this;
     /**
      * Set the HTML contents of each element in the set of matched elements.
      * @param htmlString_function _&#x40;param_ `htmlString_function`
@@ -5862,7 +5882,7 @@ $( "li" ).click(function() {
      * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
      */
     keydown<TData>(eventData: TData,
-                   handler: JQuery.EventHandler<TElement, TData>): this;
+                   handler: JQuery.TypeEventHandler<TElement, TData, TElement, TElement, TElement, 'keydown'>): this;
     /**
      * Bind an event handler to the "keydown" JavaScript event, or trigger that event on an element.
      * @param handler A function to execute each time the event is triggered.
@@ -5934,7 +5954,8 @@ $( "#other" ).click(function() {
 </html>
 ```
      */
-    keydown(handler?: JQuery.EventHandler<TElement> | false): this;
+    keydown(handler?: JQuery.TypeEventHandler<TElement, null, TElement, TElement, TElement, 'keydown'> |
+                      false): this;
     /**
      * Bind an event handler to the "keypress" JavaScript event, or trigger that event on an element.
      * @param eventData An object containing data that will be passed to the event handler.
@@ -5948,7 +5969,7 @@ $( "#other" ).click(function() {
      * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
      */
     keypress<TData>(eventData: TData,
-                    handler: JQuery.EventHandler<TElement, TData>): this;
+                    handler: JQuery.TypeEventHandler<TElement, TData, TElement, TElement, TElement, 'keypress'>): this;
     /**
      * Bind an event handler to the "keypress" JavaScript event, or trigger that event on an element.
      * @param handler A function to execute each time the event is triggered.
@@ -6020,7 +6041,8 @@ $( "#other" ).click(function() {
 </html>
 ```
      */
-    keypress(handler?: JQuery.EventHandler<TElement> | false): this;
+    keypress(handler?: JQuery.TypeEventHandler<TElement, null, TElement, TElement, TElement, 'keypress'> |
+                       false): this;
     /**
      * Bind an event handler to the "keyup" JavaScript event, or trigger that event on an element.
      * @param eventData An object containing data that will be passed to the event handler.
@@ -6034,7 +6056,7 @@ $( "#other" ).click(function() {
      * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
      */
     keyup<TData>(eventData: TData,
-                 handler: JQuery.EventHandler<TElement, TData>): this;
+                 handler: JQuery.TypeEventHandler<TElement, TData, TElement, TElement, TElement, 'keyup'>): this;
     /**
      * Bind an event handler to the "keyup" JavaScript event, or trigger that event on an element.
      * @param handler A function to execute each time the event is triggered.
@@ -6107,7 +6129,8 @@ $( "#other").click(function() {
 </html>
 ```
      */
-    keyup(handler?: JQuery.EventHandler<TElement> | false): this;
+    keyup(handler?: JQuery.TypeEventHandler<TElement, null, TElement, TElement, TElement, 'keyup'> |
+                    false): this;
     /**
      * Reduce the set of matched elements to the final one in the set.
      * @see \`{@link https://api.jquery.com/last/ }\`
@@ -6396,7 +6419,7 @@ $( "input" ).click(function() {
      * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
      */
     mousedown<TData>(eventData: TData,
-                     handler: JQuery.EventHandler<TElement, TData>): this;
+                     handler: JQuery.TypeEventHandler<TElement, TData, TElement, TElement, TElement, 'mousedown'>): this;
     /**
      * Bind an event handler to the "mousedown" JavaScript event, or trigger that event on an element.
      * @param handler A function to execute each time the event is triggered.
@@ -6434,7 +6457,8 @@ $( "p" )
 </html>
 ```
      */
-    mousedown(handler?: JQuery.EventHandler<TElement> | false): this;
+    mousedown(handler?: JQuery.TypeEventHandler<TElement, null, TElement, TElement, TElement, 'mousedown'> |
+                        false): this;
     /**
      * Bind an event handler to be fired when the mouse enters an element, or trigger that handler on an element.
      * @param eventData An object containing data that will be passed to the event handler.
@@ -6448,7 +6472,7 @@ $( "p" )
      * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
      */
     mouseenter<TData>(eventData: TData,
-                      handler: JQuery.EventHandler<TElement, TData>): this;
+                      handler: JQuery.TypeEventHandler<TElement, TData, TElement, TElement, TElement, 'mouseenter'>): this;
     /**
      * Bind an event handler to be fired when the mouse enters an element, or trigger that handler on an element.
      * @param handler A function to execute each time the event is triggered.
@@ -6529,7 +6553,8 @@ $( "div.enterleave" )
 </html>
 ```
      */
-    mouseenter(handler?: JQuery.EventHandler<TElement> | false): this;
+    mouseenter(handler?: JQuery.TypeEventHandler<TElement, null, TElement, TElement, TElement, 'mouseenter'> |
+                         false): this;
     /**
      * Bind an event handler to be fired when the mouse leaves an element, or trigger that handler on an element.
      * @param eventData An object containing data that will be passed to the event handler.
@@ -6543,7 +6568,7 @@ $( "div.enterleave" )
      * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
      */
     mouseleave<TData>(eventData: TData,
-                      handler: JQuery.EventHandler<TElement, TData>): this;
+                      handler: JQuery.TypeEventHandler<TElement, TData, TElement, TElement, TElement, 'mouseleave'>): this;
     /**
      * Bind an event handler to be fired when the mouse leaves an element, or trigger that handler on an element.
      * @param handler A function to execute each time the event is triggered.
@@ -6622,7 +6647,8 @@ $( "div.enterleave" )
 </html>
 ```
      */
-    mouseleave(handler?: JQuery.EventHandler<TElement> | false): this;
+    mouseleave(handler?: JQuery.TypeEventHandler<TElement, null, TElement, TElement, TElement, 'mouseleave'> |
+                         false): this;
     /**
      * Bind an event handler to the "mousemove" JavaScript event, or trigger that event on an element.
      * @param eventData An object containing data that will be passed to the event handler.
@@ -6636,7 +6662,7 @@ $( "div.enterleave" )
      * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
      */
     mousemove<TData>(eventData: TData,
-                     handler: JQuery.EventHandler<TElement, TData>): this;
+                     handler: JQuery.TypeEventHandler<TElement, TData, TElement, TElement, TElement, 'mousemove'>): this;
     /**
      * Bind an event handler to the "mousemove" JavaScript event, or trigger that event on an element.
      * @param handler A function to execute each time the event is triggered.
@@ -6700,7 +6726,8 @@ $( "div" ).mousemove(function( event ) {
 </html>
 ```
      */
-    mousemove(handler?: JQuery.EventHandler<TElement> | false): this;
+    mousemove(handler?: JQuery.TypeEventHandler<TElement, null, TElement, TElement, TElement, 'mousemove'> |
+                        false): this;
     /**
      * Bind an event handler to the "mouseout" JavaScript event, or trigger that event on an element.
      * @param eventData An object containing data that will be passed to the event handler.
@@ -6714,7 +6741,7 @@ $( "div" ).mousemove(function( event ) {
      * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
      */
     mouseout<TData>(eventData: TData,
-                    handler: JQuery.EventHandler<TElement, TData>): this;
+                    handler: JQuery.TypeEventHandler<TElement, TData, TElement, TElement, TElement, 'mouseout'>): this;
     /**
      * Bind an event handler to the "mouseout" JavaScript event, or trigger that event on an element.
      * @param handler A function to execute each time the event is triggered.
@@ -6795,7 +6822,8 @@ $( "div.enterleave" )
 </html>
 ```
      */
-    mouseout(handler?: JQuery.EventHandler<TElement> | false): this;
+    mouseout(handler?: JQuery.TypeEventHandler<TElement, null, TElement, TElement, TElement, 'mouseout'> |
+                       false): this;
     /**
      * Bind an event handler to the "mouseover" JavaScript event, or trigger that event on an element.
      * @param eventData An object containing data that will be passed to the event handler.
@@ -6809,7 +6837,7 @@ $( "div.enterleave" )
      * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
      */
     mouseover<TData>(eventData: TData,
-                     handler: JQuery.EventHandler<TElement, TData>): this;
+                     handler: JQuery.TypeEventHandler<TElement, TData, TElement, TElement, TElement, 'mouseover'>): this;
     /**
      * Bind an event handler to the "mouseover" JavaScript event, or trigger that event on an element.
      * @param handler A function to execute each time the event is triggered.
@@ -6890,7 +6918,8 @@ $( "div.enterleave" )
 </html>
 ```
      */
-    mouseover(handler?: JQuery.EventHandler<TElement> | false): this;
+    mouseover(handler?: JQuery.TypeEventHandler<TElement, null, TElement, TElement, TElement, 'mouseover'> |
+                        false): this;
     /**
      * Bind an event handler to the "mouseup" JavaScript event, or trigger that event on an element.
      * @param eventData An object containing data that will be passed to the event handler.
@@ -6904,7 +6933,7 @@ $( "div.enterleave" )
      * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
      */
     mouseup<TData>(eventData: TData,
-                   handler: JQuery.EventHandler<TElement, TData>): this;
+                   handler: JQuery.TypeEventHandler<TElement, TData, TElement, TElement, TElement, 'mouseup'>): this;
     /**
      * Bind an event handler to the "mouseup" JavaScript event, or trigger that event on an element.
      * @param handler A function to execute each time the event is triggered.
@@ -6942,7 +6971,8 @@ $( "p" )
 </html>
 ```
      */
-    mouseup(handler?: JQuery.EventHandler<TElement> | false): this;
+    mouseup(handler?: JQuery.TypeEventHandler<TElement, null, TElement, TElement, TElement, 'mouseup'> |
+                      false): this;
     /**
      * Get the immediately following sibling of each element in the set of matched elements. If a selector is provided, it retrieves the next sibling only if it matches that selector.
      * @param selector A string containing a selector expression to match elements against.
@@ -9970,7 +10000,7 @@ $( "button" ).on( "click", function() {
      * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
      */
     resize<TData>(eventData: TData,
-                  handler: JQuery.EventHandler<TElement, TData>): this;
+                  handler: JQuery.TypeEventHandler<TElement, TData, TElement, TElement, TElement, 'resize'>): this;
     /**
      * Bind an event handler to the "resize" JavaScript event, or trigger that event on an element.
      * @param handler A function to execute each time the event is triggered.
@@ -9988,7 +10018,8 @@ $( window ).resize(function() {
 });
 ```
      */
-    resize(handler?: JQuery.EventHandler<TElement> | false): this;
+    resize(handler?: JQuery.TypeEventHandler<TElement, null, TElement, TElement, TElement, 'resize'> |
+                     false): this;
     /**
      * Bind an event handler to the "scroll" JavaScript event, or trigger that event on an element.
      * @param eventData An object containing data that will be passed to the event handler.
@@ -10002,7 +10033,7 @@ $( window ).resize(function() {
      * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
      */
     scroll<TData>(eventData: TData,
-                  handler: JQuery.EventHandler<TElement, TData>): this;
+                  handler: JQuery.TypeEventHandler<TElement, TData, TElement, TElement, TElement, 'scroll'>): this;
     /**
      * Bind an event handler to the "scroll" JavaScript event, or trigger that event on an element.
      * @param handler A function to execute each time the event is triggered.
@@ -10052,7 +10083,8 @@ $( window ).scroll(function() {
 </html>
 ```
      */
-    scroll(handler?: JQuery.EventHandler<TElement> | false): this;
+    scroll(handler?: JQuery.TypeEventHandler<TElement, null, TElement, TElement, TElement, 'scroll'> |
+                     false): this;
     /**
      * Set the current horizontal position of the scroll bar for each of the set of matched elements.
      * @param value An integer indicating the new position to set the scroll bar to.
@@ -10226,7 +10258,7 @@ $( "p:last" ).text( "scrollTop:" + p.scrollTop() );
      * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
      */
     select<TData>(eventData: TData,
-                  handler: JQuery.EventHandler<TElement, TData>): this;
+                  handler: JQuery.TypeEventHandler<TElement, TData, TElement, TElement, TElement, 'select'>): this;
     /**
      * Bind an event handler to the "select" JavaScript event, or trigger that event on an element.
      * @param handler A function to execute each time the event is triggered.
@@ -10275,7 +10307,8 @@ $( ":input" ).select(function() {
 $( "input" ).select();
 ```
      */
-    select(handler?: JQuery.EventHandler<TElement> | false): this;
+    select(handler?: JQuery.TypeEventHandler<TElement, null, TElement, TElement, TElement, 'select'> |
+                     false): this;
     /**
      * Encode a set of form elements as a string for submission.
      * @see \`{@link https://api.jquery.com/serialize/ }\`
@@ -11246,7 +11279,7 @@ $( "#toggle" ).on( "click", function() {
      * **Solution**: Instead of `.click(fn)` use `.on("click", fn)`. Instead of `.click()` use `.trigger("click")`.
      */
     submit<TData>(eventData: TData,
-                  handler: JQuery.EventHandler<TElement, TData>): this;
+                  handler: JQuery.TypeEventHandler<TElement, TData, TElement, TElement, TElement, 'submit'>): this;
     /**
      * Bind an event handler to the "submit" JavaScript event, or trigger that event on an element.
      * @param handler A function to execute each time the event is triggered.
@@ -11315,7 +11348,8 @@ $( "form" ).submit(function() {
 $( "form:first" ).submit();
 ```
      */
-    submit(handler?: JQuery.EventHandler<TElement> | false): this;
+    submit(handler?: JQuery.TypeEventHandler<TElement, null, TElement, TElement, TElement, 'submit'> |
+                     false): this;
     /**
      * Set the content of each element in the set of matched elements to the specified text.
      * @param text_function _&#x40;param_ `text_function`

--- a/types/jquery/jquery-tests.ts
+++ b/types/jquery/jquery-tests.ts
@@ -2430,7 +2430,7 @@ function JQuery() {
             $(document).ajaxComplete(function(event, jqXHR, ajaxOptions) {
                 // $ExpectType Document
                 this;
-                // $ExpectType Event<Document, null>
+                // $ExpectType TriggeredEvent<Document, undefined, Document, Document>
                 event;
                 // $ExpectType jqXHR<any>
                 jqXHR;
@@ -2446,7 +2446,7 @@ function JQuery() {
             $(document).ajaxError(function(event, jqXHR, ajaxSettings, thrownError) {
                 // $ExpectType Document
                 this;
-                // $ExpectType Event<Document, null>
+                // $ExpectType TriggeredEvent<Document, undefined, Document, Document>
                 event;
                 // $ExpectType jqXHR<any>
                 jqXHR;
@@ -2464,7 +2464,7 @@ function JQuery() {
             $(document).ajaxSend(function(event, jqXHR, ajaxOptions) {
                 // $ExpectType Document
                 this;
-                // $ExpectType Event<Document, null>
+                // $ExpectType TriggeredEvent<Document, undefined, Document, Document>
                 event;
                 // $ExpectType jqXHR<any>
                 jqXHR;
@@ -2500,7 +2500,7 @@ function JQuery() {
             $(document).ajaxSuccess(function(event, jqXHR, ajaxOptions, data) {
                 // $ExpectType Document
                 this;
-                // $ExpectType Event<Document, null>
+                // $ExpectType TriggeredEvent<Document, undefined, Document, Document>
                 event;
                 // $ExpectType jqXHR<any>
                 jqXHR;
@@ -3887,7 +3887,7 @@ function JQuery() {
             $('p').bind('myEvent', 'myData', function(event) {
                 // $ExpectType HTMLElement
                 this;
-                // $ExpectType Event<HTMLElement, string>
+                // $ExpectType TriggeredEvent<HTMLElement, string, HTMLElement, HTMLElement>
                 event;
             });
 
@@ -3895,7 +3895,7 @@ function JQuery() {
             $('p').bind('myEvent', function(event) {
                 // $ExpectType HTMLElement
                 this;
-                // $ExpectType Event<HTMLElement, null>
+                // $ExpectType TriggeredEvent<HTMLElement, undefined, HTMLElement, HTMLElement>
                 event;
             });
 
@@ -3903,37 +3903,37 @@ function JQuery() {
             $('p').bind('myEvent', false);
 
             // $ExpectType JQuery<HTMLElement>
+            $('p').bind('myEvent', null);
+
+            // $ExpectType JQuery<HTMLElement>
+            $('p').bind('myEvent', undefined);
+
+            // $ExpectType JQuery<HTMLElement>
             $('p').bind({
                 myEvent1: false,
                 myEvent2(event) {
                     // $ExpectType HTMLElement
                     this;
-                    // $ExpectType Event<HTMLElement, null>
+                    // $ExpectType TriggeredEvent<HTMLElement, undefined, HTMLElement, HTMLElement>
                     event;
                 }
             });
-
-            // $ExpectType JQuery<HTMLElement>
-            $('p').bind('myEvent', null);
-
-            // $ExpectType JQuery<HTMLElement>
-            $('p').bind('myEvent', undefined);
-        }
+       }
 
         function delegate() {
             // $ExpectType JQuery<HTMLElement>
             $('table').delegate('td', 'myEvent', 'myData', function(event) {
-                // $ExpectType HTMLElement
+                // $ExpectType any
                 this;
-                // $ExpectType Event<HTMLElement, string>
+                // $ExpectType TriggeredEvent<HTMLElement, string, any, any>
                 event;
             });
 
             // $ExpectType JQuery<HTMLElement>
             $('table').delegate('td', 'myEvent', function(event) {
-                // $ExpectType HTMLElement
+                // $ExpectType any
                 this;
-                // $ExpectType Event<HTMLElement, null>
+                // $ExpectType TriggeredEvent<HTMLElement, undefined, any, any>
                 event;
             });
 
@@ -3942,20 +3942,20 @@ function JQuery() {
 
             // $ExpectType JQuery<HTMLElement>
             $('table').delegate('td', {
-                myEvent1(event) {
-                    // $ExpectType HTMLElement
+                myEvent1: false,
+                myEvent2(event) {
+                    // $ExpectType any
                     this;
-                    // $ExpectType Event<HTMLElement, null>
+                    // $ExpectType TriggeredEvent<HTMLElement, undefined, any, any>
                     event;
-                },
-                myEvent2: false
+                }
             });
         }
 
         function off() {
-            function defaultData(this: HTMLElement, event: JQuery.Event<HTMLElement>) { }
+            function defaultData(this: HTMLElement, event: JQuery.TriggeredEvent<HTMLElement>) { }
 
-            function customData(this: HTMLElement, event: JQuery.Event<HTMLElement, string>) { }
+            function customData(this: HTMLElement, event: JQuery.TriggeredEvent<HTMLElement, string>) { }
 
             // $ExpectType JQuery<HTMLElement>
             $('table').off('myEvent', 'td', defaultData);
@@ -3995,27 +3995,19 @@ function JQuery() {
                 customData
             });
 
+            const ev: JQuery.TriggeredEvent<HTMLElement> = undefined!;
             // $ExpectType JQuery<HTMLElement>
-            $('table').off($.Event('myEvent'));
+            $('table').off(ev);
 
             // $ExpectType JQuery<HTMLElement>
             $('table').off();
         }
 
         function on() {
-            // $ExpectType JQuery<HTMLElement>
             $('table').on('myEvent', 'td', 'myData', function(event) {
-                // $ExpectType HTMLElement
+                // $ExpectType any
                 this;
-                // $ExpectType Event<HTMLElement, string>
-                event;
-            });
-
-            // $ExpectType JQuery<HTMLElement>
-            $('table').on('myEvent', 'td', 'myData', function(event: JQueryEventObject) {
-                // $ExpectType HTMLElement
-                this;
-                // $ExpectType JQueryEventObject
+                // $ExpectType TriggeredEvent<HTMLElement, string, any, any>
                 event;
             });
 
@@ -4023,12 +4015,38 @@ function JQuery() {
             $('table').on('myEvent', null, 'myData', function(event) {
                 // $ExpectType HTMLElement
                 this;
-                // $ExpectType Event<HTMLElement, string>
+                // $ExpectType TriggeredEvent<HTMLElement, string, HTMLElement, HTMLElement>
+                event;
+            });
+
+            // $ExpectType JQuery<HTMLElement>
+            $('table').on('myEvent', undefined, 'myData', function(event) {
+                // $ExpectType HTMLElement
+                this;
+                // $ExpectType TriggeredEvent<HTMLElement, string, HTMLElement, HTMLElement>
+                event;
+            });
+
+            // $ExpectType JQuery<HTMLElement>
+            $('table').on('myEvent', 'td', 'myData', function(event: JQueryEventObject) {
+                // $ExpectType any
+                this;
+                // $ExpectType JQueryEventObject
                 event;
             });
 
             // $ExpectType JQuery<HTMLElement>
             $('table').on('myEvent', null, 'myData', function(event: JQueryEventObject) {
+                // TODO: Why is this HTMLElement? The callback signature doesn't even have `this` declared.
+                // $ExpectType HTMLElement
+                this;
+                // $ExpectType JQueryEventObject
+                event;
+            });
+
+            // $ExpectType JQuery<HTMLElement>
+            $('table').on('myEvent', undefined, 'myData', function(event: JQueryEventObject) {
+                // TODO: Why is this HTMLElement? The callback signature doesn't even have `this` declared.
                 // $ExpectType HTMLElement
                 this;
                 // $ExpectType JQueryEventObject
@@ -4037,17 +4055,9 @@ function JQuery() {
 
             // $ExpectType JQuery<HTMLElement>
             $('table').on('myEvent', 'td', function(event) {
-                // $ExpectType HTMLElement
+                // $ExpectType any
                 this;
-                // $ExpectType Event<HTMLElement, null>
-                event;
-            });
-
-            // $ExpectType JQuery<HTMLElement>
-            $('table').on('myEvent', 'td', function(event: JQueryEventObject) {
-                // $ExpectType HTMLElement
-                this;
-                // $ExpectType JQueryEventObject
+                // $ExpectType TriggeredEvent<HTMLElement, undefined, any, any>
                 event;
             });
 
@@ -4058,7 +4068,15 @@ function JQuery() {
             $('table').on('myEvent', 3, function(event) {
                 // $ExpectType HTMLElement
                 this;
-                // $ExpectType Event<HTMLElement, number>
+                // $ExpectType TriggeredEvent<HTMLElement, number, HTMLElement, HTMLElement>
+                event;
+            });
+
+            // $ExpectType JQuery<HTMLElement>
+            $('table').on('myEvent', 'td', function(event: JQueryEventObject) {
+                // $ExpectType any
+                this;
+                // $ExpectType JQueryEventObject
                 event;
             });
 
@@ -4074,9 +4092,12 @@ function JQuery() {
             $('table').on('myEvent', function(event) {
                 // $ExpectType HTMLElement
                 this;
-                // $ExpectType Event<HTMLElement, null>
+                // $ExpectType TriggeredEvent<HTMLElement, undefined, HTMLElement, HTMLElement>
                 event;
             });
+
+            // $ExpectType JQuery<HTMLElement>
+            $('table').on('myEvent', false);
 
             // $ExpectType JQuery<HTMLElement>
             $('table').on('myEvent', function(event: JQueryEventObject) {
@@ -4111,15 +4132,12 @@ function JQuery() {
             });
 
             // $ExpectType JQuery<HTMLElement>
-            $('table').on('myEvent', false);
-
-            // $ExpectType JQuery<HTMLElement>
             $('table').on({
                 myEvent1: false,
                 myEvent2(event) {
-                    // $ExpectType HTMLElement
+                    // $ExpectType any
                     this;
-                    // $ExpectType Event<HTMLElement, string>
+                    // $ExpectType TriggeredEvent<HTMLElement, string, any, any>
                     event;
                 }
             }, 'td', 'myData');
@@ -4130,7 +4148,7 @@ function JQuery() {
                 myEvent2(event) {
                     // $ExpectType HTMLElement
                     this;
-                    // $ExpectType Event<HTMLElement, string>
+                    // $ExpectType TriggeredEvent<HTMLElement, string, HTMLElement, HTMLElement>
                     event;
                 }
             }, null, 'myData');
@@ -4141,7 +4159,18 @@ function JQuery() {
                 myEvent2(event) {
                     // $ExpectType HTMLElement
                     this;
-                    // $ExpectType Event<HTMLElement, null>
+                    // $ExpectType TriggeredEvent<HTMLElement, string, HTMLElement, HTMLElement>
+                    event;
+                }
+            }, undefined, 'myData');
+
+            // $ExpectType JQuery<HTMLElement>
+            $('table').on({
+                myEvent1: false,
+                myEvent2(event) {
+                    // $ExpectType any
+                    this;
+                    // $ExpectType TriggeredEvent<HTMLElement, undefined, any, any>
                     event;
                 }
             }, 'td');
@@ -4152,7 +4181,7 @@ function JQuery() {
                 myEvent2(event) {
                     // $ExpectType HTMLElement
                     this;
-                    // $ExpectType Event<HTMLElement, number>
+                    // $ExpectType TriggeredEvent<HTMLElement, number, HTMLElement, HTMLElement>
                     event;
                 }
             }, 3);
@@ -4163,7 +4192,7 @@ function JQuery() {
                 myEvent2(event) {
                     // $ExpectType HTMLElement
                     this;
-                    // $ExpectType Event<HTMLElement, null>
+                    // $ExpectType TriggeredEvent<HTMLElement, undefined, HTMLElement, HTMLElement>
                     event;
                 }
             });
@@ -4172,9 +4201,9 @@ function JQuery() {
         function one() {
             // $ExpectType JQuery<HTMLElement>
             $('table').one('myEvent', 'td', 'myData', function(event) {
-                // $ExpectType HTMLElement
+                // $ExpectType any
                 this;
-                // $ExpectType Event<HTMLElement, string>
+                // $ExpectType TriggeredEvent<HTMLElement, string, any, any>
                 event;
             });
 
@@ -4182,15 +4211,23 @@ function JQuery() {
             $('table').one('myEvent', null, 'myData', function(event) {
                 // $ExpectType HTMLElement
                 this;
-                // $ExpectType Event<HTMLElement, string>
+                // $ExpectType TriggeredEvent<HTMLElement, string, HTMLElement, HTMLElement>
+                event;
+            });
+
+            // $ExpectType JQuery<HTMLElement>
+            $('table').one('myEvent', undefined, 'myData', function(event) {
+                // $ExpectType HTMLElement
+                this;
+                // $ExpectType TriggeredEvent<HTMLElement, string, HTMLElement, HTMLElement>
                 event;
             });
 
             // $ExpectType JQuery<HTMLElement>
             $('table').one('myEvent', 'td', function(event) {
-                // $ExpectType HTMLElement
+                // $ExpectType any
                 this;
-                // $ExpectType Event<HTMLElement, null>
+                // $ExpectType TriggeredEvent<HTMLElement, undefined, any, any>
                 event;
             });
 
@@ -4201,7 +4238,7 @@ function JQuery() {
             $('table').one('myEvent', 3, function(event) {
                 // $ExpectType HTMLElement
                 this;
-                // $ExpectType Event<HTMLElement, number>
+                // $ExpectType TriggeredEvent<HTMLElement, number, HTMLElement, HTMLElement>
                 event;
             });
 
@@ -4209,7 +4246,7 @@ function JQuery() {
             $('table').one('myEvent', function(event) {
                 // $ExpectType HTMLElement
                 this;
-                // $ExpectType Event<HTMLElement, null>
+                // $ExpectType TriggeredEvent<HTMLElement, undefined, HTMLElement, HTMLElement>
                 event;
             });
 
@@ -4220,9 +4257,9 @@ function JQuery() {
             $('table').one({
                 myEvent1: false,
                 myEvent2(event) {
-                    // $ExpectType HTMLElement
+                    // $ExpectType any
                     this;
-                    // $ExpectType Event<HTMLElement, string>
+                    // $ExpectType TriggeredEvent<HTMLElement, string, any, any>
                     event;
                 }
             }, 'td', 'myData');
@@ -4233,7 +4270,7 @@ function JQuery() {
                 myEvent2(event) {
                     // $ExpectType HTMLElement
                     this;
-                    // $ExpectType Event<HTMLElement, string>
+                    // $ExpectType TriggeredEvent<HTMLElement, string, HTMLElement, HTMLElement>
                     event;
                 }
             }, null, 'myData');
@@ -4244,7 +4281,18 @@ function JQuery() {
                 myEvent2(event) {
                     // $ExpectType HTMLElement
                     this;
-                    // $ExpectType Event<HTMLElement, null>
+                    // $ExpectType TriggeredEvent<HTMLElement, string, HTMLElement, HTMLElement>
+                    event;
+                }
+            }, undefined, 'myData');
+
+            // $ExpectType JQuery<HTMLElement>
+            $('table').one({
+                myEvent1: false,
+                myEvent2(event) {
+                    // $ExpectType any
+                    this;
+                    // $ExpectType TriggeredEvent<HTMLElement, undefined, any, any>
                     event;
                 }
             }, 'td');
@@ -4255,7 +4303,7 @@ function JQuery() {
                 myEvent2(event) {
                     // $ExpectType HTMLElement
                     this;
-                    // $ExpectType Event<HTMLElement, number>
+                    // $ExpectType TriggeredEvent<HTMLElement, number, HTMLElement, HTMLElement>
                     event;
                 }
             }, 3);
@@ -4266,7 +4314,7 @@ function JQuery() {
                 myEvent2(event) {
                     // $ExpectType HTMLElement
                     this;
-                    // $ExpectType Event<HTMLElement, null>
+                    // $ExpectType TriggeredEvent<HTMLElement, undefined, HTMLElement, HTMLElement>
                     event;
                 }
             });
@@ -4337,9 +4385,9 @@ function JQuery() {
         }
 
         function unbind() {
-            function defaultData(this: HTMLElement, event: JQuery.Event<HTMLElement>) { }
+            function defaultData(this: HTMLElement, event: JQuery.TriggeredEvent<HTMLElement>) { }
 
-            function customData(this: HTMLElement, event: JQuery.Event<HTMLElement, string>) { }
+            function customData(this: HTMLElement, event: JQuery.TriggeredEvent<HTMLElement, string>) { }
 
             // $ExpectType JQuery<HTMLElement>
             $('p').unbind('myEvent', defaultData);
@@ -4353,17 +4401,18 @@ function JQuery() {
             // $ExpectType JQuery<HTMLElement>
             $('p').unbind('myEvent');
 
+            const ev: JQuery.TriggeredEvent<HTMLElement> = undefined!;
             // $ExpectType JQuery<HTMLElement>
-            $('p').unbind($.Event('myEvent'));
+            $('p').unbind(ev);
 
             // $ExpectType JQuery<HTMLElement>
             $('p').unbind();
         }
 
         function undelegate() {
-            function defaultData(this: HTMLElement, event: JQuery.Event<HTMLElement>) { }
+            function defaultData(this: HTMLElement, event: JQuery.TriggeredEvent<HTMLElement>) { }
 
-            function customData(this: HTMLElement, event: JQuery.Event<HTMLElement, string>) { }
+            function customData(this: HTMLElement, event: JQuery.TriggeredEvent<HTMLElement, string>) { }
 
             // $ExpectType JQuery<HTMLElement>
             $('table').undelegate('td', 'click', defaultData);
@@ -7696,18 +7745,18 @@ function JQuery_Effects() {
 
 function JQuery_Event() {
     function call_signature() {
-        // $ExpectType Event<HTMLElement, null> & Coordinates
+        // $ExpectType Event & Coordinates
         $.Event('keydown', $('p').offset());
     }
 
     function constructor() {
-        // $ExpectType Event<HTMLElement, null> & Coordinates
+        // $ExpectType Event & Coordinates
         new $.Event('keydown', $('p').offset());
     }
 
     // https://stackoverflow.com/questions/49892574/trigger-a-jquery-3-event-with-ctrlkey-set
     function stackoverflow_49892574() {
-        const event = $.Event<object, Window>("keydown");
+        const event = $.Event("keydown");
         event.which = 77;
         event.ctrlKey = true;
         $(window).trigger(event);
@@ -7727,7 +7776,7 @@ function JQuery_EventExtensions() {
                 data;
                 // $ExpectType string
                 namespaces;
-                // $ExpectType EventHandler<EventTarget, any>
+                // $ExpectType EventHandlerBase<EventTarget, TriggeredEvent<EventTarget, any, any, any>>
                 eventHandle;
 
                 return false;
@@ -7753,7 +7802,7 @@ function JQuery_EventExtensions() {
             trigger(event, data) {
                 // $ExpectType EventTarget
                 this;
-                // $ExpectType Event<EventTarget, any>
+                // $ExpectType Event
                 event;
                 // $ExpectType any
                 data;
@@ -7761,7 +7810,7 @@ function JQuery_EventExtensions() {
                 return false;
             },
             _default(event, data) {
-                // $ExpectType Event<EventTarget, any>
+                // $ExpectType TriggeredEvent<EventTarget, any, any, any>
                 event;
                 // $ExpectType any
                 data;
@@ -7769,7 +7818,7 @@ function JQuery_EventExtensions() {
                 return false;
             },
             handle(event, data) {
-                // $ExpectType Event<EventTarget, any> & { handleObj: HandleObject<EventTarget, any>; }
+                // $ExpectType TriggeredEvent<EventTarget, any, any, any> & { handleObj: HandleObject<EventTarget, any>; }
                 event;
                 // $ExpectType any
                 data;
@@ -7777,7 +7826,7 @@ function JQuery_EventExtensions() {
             preDispatch(event) {
                 // $ExpectType EventTarget
                 this;
-                // $ExpectType Event<EventTarget, any>
+                // $ExpectType Event
                 event;
 
                 return false;
@@ -7785,7 +7834,7 @@ function JQuery_EventExtensions() {
             postDispatch(event) {
                 // $ExpectType EventTarget
                 this;
-                // $ExpectType Event<EventTarget, any>
+                // $ExpectType Event
                 event;
             }
         };

--- a/types/jquery/jquery-tests.ts
+++ b/types/jquery/jquery-tests.ts
@@ -3916,6 +3916,12 @@ function JQuery() {
                     this;
                     // $ExpectType TriggeredEvent<HTMLElement, undefined, HTMLElement, HTMLElement>
                     event;
+                },
+                click(event) {
+                    // $ExpectType HTMLElement
+                    this;
+                    // $ExpectType ClickEvent<HTMLElement, undefined, HTMLElement, HTMLElement>
+                    event;
                 }
             });
        }
@@ -3947,6 +3953,12 @@ function JQuery() {
                     // $ExpectType any
                     this;
                     // $ExpectType TriggeredEvent<HTMLElement, undefined, any, any>
+                    event;
+                },
+                click(event) {
+                    // $ExpectType any
+                    this;
+                    // $ExpectType ClickEvent<HTMLElement, undefined, any, any>
                     event;
                 }
             });
@@ -4139,6 +4151,12 @@ function JQuery() {
                     this;
                     // $ExpectType TriggeredEvent<HTMLElement, string, any, any>
                     event;
+                },
+                click(event) {
+                    // $ExpectType any
+                    this;
+                    // $ExpectType ClickEvent<HTMLElement, string, any, any>
+                    event;
                 }
             }, 'td', 'myData');
 
@@ -4149,6 +4167,12 @@ function JQuery() {
                     // $ExpectType HTMLElement
                     this;
                     // $ExpectType TriggeredEvent<HTMLElement, string, HTMLElement, HTMLElement>
+                    event;
+                },
+                click(event) {
+                    // $ExpectType HTMLElement
+                    this;
+                    // $ExpectType ClickEvent<HTMLElement, string, HTMLElement, HTMLElement>
                     event;
                 }
             }, null, 'myData');
@@ -4161,6 +4185,12 @@ function JQuery() {
                     this;
                     // $ExpectType TriggeredEvent<HTMLElement, string, HTMLElement, HTMLElement>
                     event;
+                },
+                click(event) {
+                    // $ExpectType HTMLElement
+                    this;
+                    // $ExpectType ClickEvent<HTMLElement, string, HTMLElement, HTMLElement>
+                    event;
                 }
             }, undefined, 'myData');
 
@@ -4171,6 +4201,12 @@ function JQuery() {
                     // $ExpectType any
                     this;
                     // $ExpectType TriggeredEvent<HTMLElement, undefined, any, any>
+                    event;
+                },
+                click(event) {
+                    // $ExpectType any
+                    this;
+                    // $ExpectType ClickEvent<HTMLElement, undefined, any, any>
                     event;
                 }
             }, 'td');
@@ -4183,6 +4219,12 @@ function JQuery() {
                     this;
                     // $ExpectType TriggeredEvent<HTMLElement, number, HTMLElement, HTMLElement>
                     event;
+                },
+                click(event) {
+                    // $ExpectType HTMLElement
+                    this;
+                    // $ExpectType ClickEvent<HTMLElement, number, HTMLElement, HTMLElement>
+                    event;
                 }
             }, 3);
 
@@ -4193,6 +4235,12 @@ function JQuery() {
                     // $ExpectType HTMLElement
                     this;
                     // $ExpectType TriggeredEvent<HTMLElement, undefined, HTMLElement, HTMLElement>
+                    event;
+                },
+                click(event) {
+                    // $ExpectType HTMLElement
+                    this;
+                    // $ExpectType ClickEvent<HTMLElement, undefined, HTMLElement, HTMLElement>
                     event;
                 }
             });
@@ -4261,6 +4309,12 @@ function JQuery() {
                     this;
                     // $ExpectType TriggeredEvent<HTMLElement, string, any, any>
                     event;
+                },
+                click(event) {
+                    // $ExpectType any
+                    this;
+                    // $ExpectType ClickEvent<HTMLElement, string, any, any>
+                    event;
                 }
             }, 'td', 'myData');
 
@@ -4271,6 +4325,12 @@ function JQuery() {
                     // $ExpectType HTMLElement
                     this;
                     // $ExpectType TriggeredEvent<HTMLElement, string, HTMLElement, HTMLElement>
+                    event;
+                },
+                click(event) {
+                    // $ExpectType HTMLElement
+                    this;
+                    // $ExpectType ClickEvent<HTMLElement, string, HTMLElement, HTMLElement>
                     event;
                 }
             }, null, 'myData');
@@ -4283,6 +4343,12 @@ function JQuery() {
                     this;
                     // $ExpectType TriggeredEvent<HTMLElement, string, HTMLElement, HTMLElement>
                     event;
+                },
+                click(event) {
+                    // $ExpectType HTMLElement
+                    this;
+                    // $ExpectType ClickEvent<HTMLElement, string, HTMLElement, HTMLElement>
+                    event;
                 }
             }, undefined, 'myData');
 
@@ -4293,6 +4359,12 @@ function JQuery() {
                     // $ExpectType any
                     this;
                     // $ExpectType TriggeredEvent<HTMLElement, undefined, any, any>
+                    event;
+                },
+                click(event) {
+                    // $ExpectType any
+                    this;
+                    // $ExpectType ClickEvent<HTMLElement, undefined, any, any>
                     event;
                 }
             }, 'td');
@@ -4305,6 +4377,12 @@ function JQuery() {
                     this;
                     // $ExpectType TriggeredEvent<HTMLElement, number, HTMLElement, HTMLElement>
                     event;
+                },
+                click(event) {
+                    // $ExpectType HTMLElement
+                    this;
+                    // $ExpectType ClickEvent<HTMLElement, number, HTMLElement, HTMLElement>
+                    event;
                 }
             }, 3);
 
@@ -4315,6 +4393,12 @@ function JQuery() {
                     // $ExpectType HTMLElement
                     this;
                     // $ExpectType TriggeredEvent<HTMLElement, undefined, HTMLElement, HTMLElement>
+                    event;
+                },
+                click(event) {
+                    // $ExpectType HTMLElement
+                    this;
+                    // $ExpectType ClickEvent<HTMLElement, undefined, HTMLElement, HTMLElement>
                     event;
                 }
             });
@@ -4445,7 +4529,7 @@ function JQuery() {
             $('p').blur('myData', function(event) {
                 // $ExpectType HTMLElement
                 this;
-                // $ExpectType Event<HTMLElement, string>
+                // $ExpectType BlurEvent<HTMLElement, string, HTMLElement, HTMLElement>
                 event;
             });
 
@@ -4453,7 +4537,7 @@ function JQuery() {
             $('p').blur(function(event) {
                 // $ExpectType HTMLElement
                 this;
-                // $ExpectType Event<HTMLElement, null>
+                // $ExpectType BlurEvent<HTMLElement, null, HTMLElement, HTMLElement>
                 event;
             });
 
@@ -4469,7 +4553,7 @@ function JQuery() {
             $('p').change('myData', function(event) {
                 // $ExpectType HTMLElement
                 this;
-                // $ExpectType Event<HTMLElement, string>
+                // $ExpectType ChangeEvent<HTMLElement, string, HTMLElement, HTMLElement>
                 event;
             });
 
@@ -4477,7 +4561,7 @@ function JQuery() {
             $('p').change(function(event) {
                 // $ExpectType HTMLElement
                 this;
-                // $ExpectType Event<HTMLElement, null>
+                // $ExpectType ChangeEvent<HTMLElement, null, HTMLElement, HTMLElement>
                 event;
             });
 
@@ -4493,7 +4577,7 @@ function JQuery() {
             $('p').click('myData', function(event) {
                 // $ExpectType HTMLElement
                 this;
-                // $ExpectType Event<HTMLElement, string>
+                // $ExpectType ClickEvent<HTMLElement, string, HTMLElement, HTMLElement>
                 event;
             });
 
@@ -4501,7 +4585,7 @@ function JQuery() {
             $('p').click(function(event) {
                 // $ExpectType HTMLElement
                 this;
-                // $ExpectType Event<HTMLElement, null>
+                // $ExpectType ClickEvent<HTMLElement, null, HTMLElement, HTMLElement>
                 event;
             });
 
@@ -4517,7 +4601,7 @@ function JQuery() {
             $('p').contextmenu('myData', function(event) {
                 // $ExpectType HTMLElement
                 this;
-                // $ExpectType Event<HTMLElement, string>
+                // $ExpectType ContextMenuEvent<HTMLElement, string, HTMLElement, HTMLElement>
                 event;
             });
 
@@ -4525,7 +4609,7 @@ function JQuery() {
             $('p').contextmenu(function(event) {
                 // $ExpectType HTMLElement
                 this;
-                // $ExpectType Event<HTMLElement, null>
+                // $ExpectType ContextMenuEvent<HTMLElement, null, HTMLElement, HTMLElement>
                 event;
             });
 
@@ -4541,7 +4625,7 @@ function JQuery() {
             $('p').dblclick('myData', function(event) {
                 // $ExpectType HTMLElement
                 this;
-                // $ExpectType Event<HTMLElement, string>
+                // $ExpectType DoubleClickEvent<HTMLElement, string, HTMLElement, HTMLElement>
                 event;
             });
 
@@ -4549,7 +4633,7 @@ function JQuery() {
             $('p').dblclick(function(event) {
                 // $ExpectType HTMLElement
                 this;
-                // $ExpectType Event<HTMLElement, null>
+                // $ExpectType DoubleClickEvent<HTMLElement, null, HTMLElement, HTMLElement>
                 event;
             });
 
@@ -4565,7 +4649,7 @@ function JQuery() {
             $('p').focus('myData', function(event) {
                 // $ExpectType HTMLElement
                 this;
-                // $ExpectType Event<HTMLElement, string>
+                // $ExpectType FocusEvent<HTMLElement, string, HTMLElement, HTMLElement>
                 event;
             });
 
@@ -4573,7 +4657,7 @@ function JQuery() {
             $('p').focus(function(event) {
                 // $ExpectType HTMLElement
                 this;
-                // $ExpectType Event<HTMLElement, null>
+                // $ExpectType FocusEvent<HTMLElement, null, HTMLElement, HTMLElement>
                 event;
             });
 
@@ -4589,7 +4673,7 @@ function JQuery() {
             $('p').focusin('myData', function(event) {
                 // $ExpectType HTMLElement
                 this;
-                // $ExpectType Event<HTMLElement, string>
+                // $ExpectType FocusInEvent<HTMLElement, string, HTMLElement, HTMLElement>
                 event;
             });
 
@@ -4597,7 +4681,7 @@ function JQuery() {
             $('p').focusin(function(event) {
                 // $ExpectType HTMLElement
                 this;
-                // $ExpectType Event<HTMLElement, null>
+                // $ExpectType FocusInEvent<HTMLElement, null, HTMLElement, HTMLElement>
                 event;
             });
 
@@ -4613,7 +4697,7 @@ function JQuery() {
             $('p').focusout('myData', function(event) {
                 // $ExpectType HTMLElement
                 this;
-                // $ExpectType Event<HTMLElement, string>
+                // $ExpectType FocusOutEvent<HTMLElement, string, HTMLElement, HTMLElement>
                 event;
             });
 
@@ -4621,7 +4705,7 @@ function JQuery() {
             $('p').focusout(function(event) {
                 // $ExpectType HTMLElement
                 this;
-                // $ExpectType Event<HTMLElement, null>
+                // $ExpectType FocusOutEvent<HTMLElement, null, HTMLElement, HTMLElement>
                 event;
             });
 
@@ -4637,7 +4721,7 @@ function JQuery() {
             $('p').keydown('myData', function(event) {
                 // $ExpectType HTMLElement
                 this;
-                // $ExpectType Event<HTMLElement, string>
+                // $ExpectType KeyDownEvent<HTMLElement, string, HTMLElement, HTMLElement>
                 event;
             });
 
@@ -4645,7 +4729,7 @@ function JQuery() {
             $('p').keydown(function(event) {
                 // $ExpectType HTMLElement
                 this;
-                // $ExpectType Event<HTMLElement, null>
+                // $ExpectType KeyDownEvent<HTMLElement, null, HTMLElement, HTMLElement>
                 event;
             });
 
@@ -4661,7 +4745,7 @@ function JQuery() {
             $('p').keypress('myData', function(event) {
                 // $ExpectType HTMLElement
                 this;
-                // $ExpectType Event<HTMLElement, string>
+                // $ExpectType KeyPressEvent<HTMLElement, string, HTMLElement, HTMLElement>
                 event;
             });
 
@@ -4669,7 +4753,7 @@ function JQuery() {
             $('p').keypress(function(event) {
                 // $ExpectType HTMLElement
                 this;
-                // $ExpectType Event<HTMLElement, null>
+                // $ExpectType KeyPressEvent<HTMLElement, null, HTMLElement, HTMLElement>
                 event;
             });
 
@@ -4685,7 +4769,7 @@ function JQuery() {
             $('p').keyup('myData', function(event) {
                 // $ExpectType HTMLElement
                 this;
-                // $ExpectType Event<HTMLElement, string>
+                // $ExpectType KeyUpEvent<HTMLElement, string, HTMLElement, HTMLElement>
                 event;
             });
 
@@ -4693,7 +4777,7 @@ function JQuery() {
             $('p').keyup(function(event) {
                 // $ExpectType HTMLElement
                 this;
-                // $ExpectType Event<HTMLElement, null>
+                // $ExpectType KeyUpEvent<HTMLElement, null, HTMLElement, HTMLElement>
                 event;
             });
 
@@ -4709,7 +4793,7 @@ function JQuery() {
             $('p').mousedown('myData', function(event) {
                 // $ExpectType HTMLElement
                 this;
-                // $ExpectType Event<HTMLElement, string>
+                // $ExpectType MouseDownEvent<HTMLElement, string, HTMLElement, HTMLElement>
                 event;
             });
 
@@ -4717,7 +4801,7 @@ function JQuery() {
             $('p').mousedown(function(event) {
                 // $ExpectType HTMLElement
                 this;
-                // $ExpectType Event<HTMLElement, null>
+                // $ExpectType MouseDownEvent<HTMLElement, null, HTMLElement, HTMLElement>
                 event;
             });
 
@@ -4733,7 +4817,7 @@ function JQuery() {
             $('p').mouseenter('myData', function(event) {
                 // $ExpectType HTMLElement
                 this;
-                // $ExpectType Event<HTMLElement, string>
+                // $ExpectType MouseEnterEvent<HTMLElement, string, HTMLElement, HTMLElement>
                 event;
             });
 
@@ -4741,7 +4825,7 @@ function JQuery() {
             $('p').mouseenter(function(event) {
                 // $ExpectType HTMLElement
                 this;
-                // $ExpectType Event<HTMLElement, null>
+                // $ExpectType MouseEnterEvent<HTMLElement, null, HTMLElement, HTMLElement>
                 event;
             });
 
@@ -4757,7 +4841,7 @@ function JQuery() {
             $('p').mouseleave('myData', function(event) {
                 // $ExpectType HTMLElement
                 this;
-                // $ExpectType Event<HTMLElement, string>
+                // $ExpectType MouseLeaveEvent<HTMLElement, string, HTMLElement, HTMLElement>
                 event;
             });
 
@@ -4765,7 +4849,7 @@ function JQuery() {
             $('p').mouseleave(function(event) {
                 // $ExpectType HTMLElement
                 this;
-                // $ExpectType Event<HTMLElement, null>
+                // $ExpectType MouseLeaveEvent<HTMLElement, null, HTMLElement, HTMLElement>
                 event;
             });
 
@@ -4781,7 +4865,7 @@ function JQuery() {
             $('p').mousemove('myData', function(event) {
                 // $ExpectType HTMLElement
                 this;
-                // $ExpectType Event<HTMLElement, string>
+                // $ExpectType MouseMoveEvent<HTMLElement, string, HTMLElement, HTMLElement>
                 event;
             });
 
@@ -4789,7 +4873,7 @@ function JQuery() {
             $('p').mousemove(function(event) {
                 // $ExpectType HTMLElement
                 this;
-                // $ExpectType Event<HTMLElement, null>
+                // $ExpectType MouseMoveEvent<HTMLElement, null, HTMLElement, HTMLElement>
                 event;
             });
 
@@ -4805,7 +4889,7 @@ function JQuery() {
             $('p').mouseout('myData', function(event) {
                 // $ExpectType HTMLElement
                 this;
-                // $ExpectType Event<HTMLElement, string>
+                // $ExpectType MouseOutEvent<HTMLElement, string, HTMLElement, HTMLElement>
                 event;
             });
 
@@ -4813,7 +4897,7 @@ function JQuery() {
             $('p').mouseout(function(event) {
                 // $ExpectType HTMLElement
                 this;
-                // $ExpectType Event<HTMLElement, null>
+                // $ExpectType MouseOutEvent<HTMLElement, null, HTMLElement, HTMLElement>
                 event;
             });
 
@@ -4829,7 +4913,7 @@ function JQuery() {
             $('p').mouseover('myData', function(event) {
                 // $ExpectType HTMLElement
                 this;
-                // $ExpectType Event<HTMLElement, string>
+                // $ExpectType MouseOverEvent<HTMLElement, string, HTMLElement, HTMLElement>
                 event;
             });
 
@@ -4837,7 +4921,7 @@ function JQuery() {
             $('p').mouseover(function(event) {
                 // $ExpectType HTMLElement
                 this;
-                // $ExpectType Event<HTMLElement, null>
+                // $ExpectType MouseOverEvent<HTMLElement, null, HTMLElement, HTMLElement>
                 event;
             });
 
@@ -4853,7 +4937,7 @@ function JQuery() {
             $('p').mouseup('myData', function(event) {
                 // $ExpectType HTMLElement
                 this;
-                // $ExpectType Event<HTMLElement, string>
+                // $ExpectType MouseUpEvent<HTMLElement, string, HTMLElement, HTMLElement>
                 event;
             });
 
@@ -4861,7 +4945,7 @@ function JQuery() {
             $('p').mouseup(function(event) {
                 // $ExpectType HTMLElement
                 this;
-                // $ExpectType Event<HTMLElement, null>
+                // $ExpectType MouseUpEvent<HTMLElement, null, HTMLElement, HTMLElement>
                 event;
             });
 
@@ -4877,7 +4961,7 @@ function JQuery() {
             $('p').resize('myData', function(event) {
                 // $ExpectType HTMLElement
                 this;
-                // $ExpectType Event<HTMLElement, string>
+                // $ExpectType ResizeEvent<HTMLElement, string, HTMLElement, HTMLElement>
                 event;
             });
 
@@ -4885,7 +4969,7 @@ function JQuery() {
             $('p').resize(function(event) {
                 // $ExpectType HTMLElement
                 this;
-                // $ExpectType Event<HTMLElement, null>
+                // $ExpectType ResizeEvent<HTMLElement, null, HTMLElement, HTMLElement>
                 event;
             });
 
@@ -4901,7 +4985,7 @@ function JQuery() {
             $('p').scroll('myData', function(event) {
                 // $ExpectType HTMLElement
                 this;
-                // $ExpectType Event<HTMLElement, string>
+                // $ExpectType ScrollEvent<HTMLElement, string, HTMLElement, HTMLElement>
                 event;
             });
 
@@ -4909,7 +4993,7 @@ function JQuery() {
             $('p').scroll(function(event) {
                 // $ExpectType HTMLElement
                 this;
-                // $ExpectType Event<HTMLElement, null>
+                // $ExpectType ScrollEvent<HTMLElement, null, HTMLElement, HTMLElement>
                 event;
             });
 
@@ -4925,7 +5009,7 @@ function JQuery() {
             $('p').select('myData', function(event) {
                 // $ExpectType HTMLElement
                 this;
-                // $ExpectType Event<HTMLElement, string>
+                // $ExpectType SelectEvent<HTMLElement, string, HTMLElement, HTMLElement>
                 event;
             });
 
@@ -4933,7 +5017,7 @@ function JQuery() {
             $('p').select(function(event) {
                 // $ExpectType HTMLElement
                 this;
-                // $ExpectType Event<HTMLElement, null>
+                // $ExpectType SelectEvent<HTMLElement, null, HTMLElement, HTMLElement>
                 event;
             });
 
@@ -4949,7 +5033,7 @@ function JQuery() {
             $('p').submit('myData', function(event) {
                 // $ExpectType HTMLElement
                 this;
-                // $ExpectType Event<HTMLElement, string>
+                // $ExpectType SubmitEvent<HTMLElement, string, HTMLElement, HTMLElement>
                 event;
             });
 
@@ -4957,7 +5041,7 @@ function JQuery() {
             $('p').submit(function(event) {
                 // $ExpectType HTMLElement
                 this;
-                // $ExpectType Event<HTMLElement, null>
+                // $ExpectType SubmitEvent<HTMLElement, null, HTMLElement, HTMLElement>
                 event;
             });
 
@@ -4973,12 +5057,12 @@ function JQuery() {
             $('p').hover(function(event) {
                 // $ExpectType HTMLElement
                 this;
-                // $ExpectType Event<HTMLElement, null>
+                // $ExpectType MouseEnterEvent<HTMLElement, null, HTMLElement, HTMLElement>
                 event;
             }, function(event) {
                 // $ExpectType HTMLElement
                 this;
-                // $ExpectType Event<HTMLElement, null>
+                // $ExpectType MouseLeaveEvent<HTMLElement, null, HTMLElement, HTMLElement>
                 event;
             });
 
@@ -4986,7 +5070,7 @@ function JQuery() {
             $('p').hover(function(event) {
                 // $ExpectType HTMLElement
                 this;
-                // $ExpectType Event<HTMLElement, null>
+                // $ExpectType MouseEnterEvent<HTMLElement, null, HTMLElement, HTMLElement>
                 event;
             }, false);
 
@@ -4994,7 +5078,7 @@ function JQuery() {
             $('p').hover(false, function(event) {
                 // $ExpectType HTMLElement
                 this;
-                // $ExpectType Event<HTMLElement, null>
+                // $ExpectType MouseLeaveEvent<HTMLElement, null, HTMLElement, HTMLElement>
                 event;
             });
 
@@ -5005,8 +5089,23 @@ function JQuery() {
             $('p').hover(function(event) {
                 // $ExpectType HTMLElement
                 this;
-                // $ExpectType Event<HTMLElement, null>
+                // $ExpectType MouseEnterEvent<HTMLElement, null, HTMLElement, HTMLElement> | MouseLeaveEvent<HTMLElement, null, HTMLElement, HTMLElement>
                 event;
+
+                switch (event.type) {
+                    case 'mouseover':
+                        // $ExpectType MouseEnterEvent<HTMLElement, null, HTMLElement, HTMLElement>
+                        event;
+                        break;
+                    case 'mouseout':
+                        // $ExpectType MouseLeaveEvent<HTMLElement, null, HTMLElement, HTMLElement>
+                        event;
+                        break;
+                    default:
+                        // $ExpectType never
+                        event;
+                        break;
+                }
             });
 
             // $ExpectType JQuery<HTMLElement>

--- a/types/jquery/jquery-tests.ts
+++ b/types/jquery/jquery-tests.ts
@@ -8400,21 +8400,11 @@ function JQuery_Event() {
     function call_signature() {
         // $ExpectType Event<HTMLElement, null> & Coordinates
         $.Event('keydown', $('p').offset());
-
-        // $ExpectType Event<HTMLElement, null> & { type: string; }
-        $.Event({
-            type: 'keydown'
-        });
     }
 
     function constructor() {
         // $ExpectType Event<HTMLElement, null> & Coordinates
         new $.Event('keydown', $('p').offset());
-
-        // $ExpectType Event<HTMLElement, null> & { type: string; }
-        new $.Event({
-            type: 'keydown'
-        });
     }
 
     // https://stackoverflow.com/questions/49892574/trigger-a-jquery-3-event-with-ctrlkey-set

--- a/types/jquery/jquery-tests.ts
+++ b/types/jquery/jquery-tests.ts
@@ -8427,22 +8427,6 @@ function JQuery_Event() {
 }
 
 function JQuery_EventExtensions() {
-    function fixHooks() {
-        jQuery.event.fixHooks.drop = {
-            props: ['dataTransfer'],
-            filter(event, originalEvent) {
-                // $ExpectType Event<EventTarget, null>
-                event;
-                // $ExpectType Event
-                originalEvent;
-            },
-        };
-
-        // Weak type test. This may be removed if the TypeScript requirement is increased to 2.4+.
-        // $ExpectError
-        jQuery.event.fixHooks.drop = ['dataTransfer'];
-    }
-
     function special() {
         jQuery.event.special.multiclick = {
             noBubble: true,

--- a/types/jquery/jquery-tests.ts
+++ b/types/jquery/jquery-tests.ts
@@ -3883,8 +3883,6 @@ function JQuery() {
     function events() {
         // [bind() overloads] https://github.com/jquery/api.jquery.com/issues/1048
         function bind() {
-            interface J1 { kind: 'J1'; }
-
             // $ExpectType JQuery<HTMLElement>
             $('p').bind('myEvent', 'myData', function(event) {
                 // $ExpectType HTMLElement
@@ -3894,24 +3892,8 @@ function JQuery() {
             });
 
             // $ExpectType JQuery<HTMLElement>
-            $('p').bind('myEvent', 'myData', function(this: J1, event) {
-                // $ExpectType J1
-                this;
-                // $ExpectType Event<HTMLElement, string>
-                event;
-            });
-
-            // $ExpectType JQuery<HTMLElement>
             $('p').bind('myEvent', function(event) {
                 // $ExpectType HTMLElement
-                this;
-                // $ExpectType Event<HTMLElement, null>
-                event;
-            });
-
-            // $ExpectType JQuery<HTMLElement>
-            $('p').bind('myEvent', function(this: J1, event) {
-                // $ExpectType J1
                 this;
                 // $ExpectType Event<HTMLElement, null>
                 event;
@@ -3928,12 +3910,6 @@ function JQuery() {
                     this;
                     // $ExpectType Event<HTMLElement, null>
                     event;
-                },
-                myEvent3(this: J1, event) {
-                    // $ExpectType J1
-                    this;
-                    // $ExpectType Event<HTMLElement, null>
-                    event;
                 }
             });
 
@@ -3945,8 +3921,6 @@ function JQuery() {
         }
 
         function delegate() {
-            interface J1 { kind: 'J1'; }
-
             // $ExpectType JQuery<HTMLElement>
             $('table').delegate('td', 'myEvent', 'myData', function(event) {
                 // $ExpectType HTMLElement
@@ -3956,24 +3930,8 @@ function JQuery() {
             });
 
             // $ExpectType JQuery<HTMLElement>
-            $('table').delegate('td', 'myEvent', 'myData', function(this: J1, event) {
-                // $ExpectType J1
-                this;
-                // $ExpectType Event<HTMLElement, string>
-                event;
-            });
-
-            // $ExpectType JQuery<HTMLElement>
             $('table').delegate('td', 'myEvent', function(event) {
                 // $ExpectType HTMLElement
-                this;
-                // $ExpectType Event<HTMLElement, null>
-                event;
-            });
-
-            // $ExpectType JQuery<HTMLElement>
-            $('table').delegate('td', 'myEvent', function(this: J1, event) {
-                // $ExpectType J1
                 this;
                 // $ExpectType Event<HTMLElement, null>
                 event;
@@ -3990,38 +3948,20 @@ function JQuery() {
                     // $ExpectType Event<HTMLElement, null>
                     event;
                 },
-                myEvent2: false,
-                myEvent3(this: J1, event) {
-                    // $ExpectType J1
-                    this;
-                    // $ExpectType Event<HTMLElement, null>
-                    event;
-                }
+                myEvent2: false
             });
         }
 
         function off() {
-            function defaultContext_defaultData(this: HTMLElement, event: JQuery.Event<HTMLElement>) { }
+            function defaultData(this: HTMLElement, event: JQuery.Event<HTMLElement>) { }
 
-            function defaultContext_customData(this: HTMLElement, event: JQuery.Event<HTMLElement, string>) { }
-
-            function customContext_defaultData(this: J1, event: JQuery.Event<HTMLElement>) { }
-
-            function customContext_customData(this: J1, event: JQuery.Event<HTMLElement, string>) { }
-
-            interface J1 { kind: 'J1'; }
+            function customData(this: HTMLElement, event: JQuery.Event<HTMLElement, string>) { }
 
             // $ExpectType JQuery<HTMLElement>
-            $('table').off('myEvent', 'td', defaultContext_defaultData);
+            $('table').off('myEvent', 'td', defaultData);
 
             // $ExpectType JQuery<HTMLElement>
-            $('table').off('myEvent', 'td', defaultContext_customData);
-
-            // $ExpectType JQuery<HTMLElement>
-            $('table').off('myEvent', 'td', customContext_defaultData);
-
-            // $ExpectType JQuery<HTMLElement>
-            $('table').off('myEvent', 'td', customContext_customData);
+            $('table').off('myEvent', 'td', customData);
 
             // $ExpectType JQuery<HTMLElement>
             $('table').off('myEvent', 'td', false);
@@ -4030,16 +3970,10 @@ function JQuery() {
             $('table').off('myEvent', 'td');
 
             // $ExpectType JQuery<HTMLElement>
-            $('table').off('myEvent', defaultContext_defaultData);
+            $('table').off('myEvent', defaultData);
 
             // $ExpectType JQuery<HTMLElement>
-            $('table').off('myEvent', defaultContext_customData);
-
-            // $ExpectType JQuery<HTMLElement>
-            $('table').off('myEvent', customContext_defaultData);
-
-            // $ExpectType JQuery<HTMLElement>
-            $('table').off('myEvent', customContext_customData);
+            $('table').off('myEvent', customData);
 
             // $ExpectType JQuery<HTMLElement>
             $('table').off('myEvent', false);
@@ -4050,19 +3984,15 @@ function JQuery() {
             // $ExpectType JQuery<HTMLElement>
             $('table').off({
                 myEvent1: false,
-                defaultContext_defaultData,
-                defaultContext_customData,
-                customContext_defaultData,
-                customContext_customData
+                defaultData,
+                customData
             }, 'td');
 
             // $ExpectType JQuery<HTMLElement>
             $('table').off({
                 myEvent1: false,
-                defaultContext_defaultData,
-                defaultContext_customData,
-                customContext_defaultData,
-                customContext_customData
+                defaultData,
+                customData
             });
 
             // $ExpectType JQuery<HTMLElement>
@@ -4073,8 +4003,6 @@ function JQuery() {
         }
 
         function on() {
-            interface J1 { kind: 'J1'; }
-
             // $ExpectType JQuery<HTMLElement>
             $('table').on('myEvent', 'td', 'myData', function(event) {
                 // $ExpectType HTMLElement
@@ -4088,14 +4016,6 @@ function JQuery() {
                 // $ExpectType HTMLElement
                 this;
                 // $ExpectType JQueryEventObject
-                event;
-            });
-
-            // $ExpectType JQuery<HTMLElement>
-            $('table').on('myEvent', 'td', 'myData', function(this: J1, event) {
-                // $ExpectType J1
-                this;
-                // $ExpectType Event<HTMLElement, string>
                 event;
             });
 
@@ -4116,14 +4036,6 @@ function JQuery() {
             });
 
             // $ExpectType JQuery<HTMLElement>
-            $('table').on('myEvent', null, 'myData', function(this: J1, event) {
-                // $ExpectType J1
-                this;
-                // $ExpectType Event<HTMLElement, string>
-                event;
-            });
-
-            // $ExpectType JQuery<HTMLElement>
             $('table').on('myEvent', 'td', function(event) {
                 // $ExpectType HTMLElement
                 this;
@@ -4136,14 +4048,6 @@ function JQuery() {
                 // $ExpectType HTMLElement
                 this;
                 // $ExpectType JQueryEventObject
-                event;
-            });
-
-            // $ExpectType JQuery<HTMLElement>
-            $('table').on('myEvent', 'td', function(this: J1, event) {
-                // $ExpectType J1
-                this;
-                // $ExpectType Event<HTMLElement, null>
                 event;
             });
 
@@ -4163,14 +4067,6 @@ function JQuery() {
                 // $ExpectType HTMLElement
                 this;
                 // $ExpectType JQueryEventObject
-                event;
-            });
-
-            // $ExpectType JQuery<HTMLElement>
-            $('table').on('myEvent', 3, function(this: J1, event) {
-                // $ExpectType J1
-                this;
-                // $ExpectType Event<HTMLElement, number>
                 event;
             });
 
@@ -4215,14 +4111,6 @@ function JQuery() {
             });
 
             // $ExpectType JQuery<HTMLElement>
-            $('table').on('myEvent', function(this: J1, event) {
-                // $ExpectType J1
-                this;
-                // $ExpectType Event<HTMLElement, null>
-                event;
-            });
-
-            // $ExpectType JQuery<HTMLElement>
             $('table').on('myEvent', false);
 
             // $ExpectType JQuery<HTMLElement>
@@ -4230,12 +4118,6 @@ function JQuery() {
                 myEvent1: false,
                 myEvent2(event) {
                     // $ExpectType HTMLElement
-                    this;
-                    // $ExpectType Event<HTMLElement, string>
-                    event;
-                },
-                myEvent3(this: J1, event) {
-                    // $ExpectType J1
                     this;
                     // $ExpectType Event<HTMLElement, string>
                     event;
@@ -4250,12 +4132,6 @@ function JQuery() {
                     this;
                     // $ExpectType Event<HTMLElement, string>
                     event;
-                },
-                myEvent3(this: J1, event) {
-                    // $ExpectType J1
-                    this;
-                    // $ExpectType Event<HTMLElement, string>
-                    event;
                 }
             }, null, 'myData');
 
@@ -4264,12 +4140,6 @@ function JQuery() {
                 myEvent1: false,
                 myEvent2(event) {
                     // $ExpectType HTMLElement
-                    this;
-                    // $ExpectType Event<HTMLElement, null>
-                    event;
-                },
-                myEvent3(this: J1, event) {
-                    // $ExpectType J1
                     this;
                     // $ExpectType Event<HTMLElement, null>
                     event;
@@ -4284,12 +4154,6 @@ function JQuery() {
                     this;
                     // $ExpectType Event<HTMLElement, number>
                     event;
-                },
-                myEvent3(this: J1, event) {
-                    // $ExpectType J1
-                    this;
-                    // $ExpectType Event<HTMLElement, number>
-                    event;
                 }
             }, 3);
 
@@ -4301,30 +4165,14 @@ function JQuery() {
                     this;
                     // $ExpectType Event<HTMLElement, null>
                     event;
-                },
-                myEvent3(this: J1, event) {
-                    // $ExpectType J1
-                    this;
-                    // $ExpectType Event<HTMLElement, null>
-                    event;
                 }
             });
         }
 
         function one() {
-            interface J1 { kind: 'J1'; }
-
             // $ExpectType JQuery<HTMLElement>
             $('table').one('myEvent', 'td', 'myData', function(event) {
                 // $ExpectType HTMLElement
-                this;
-                // $ExpectType Event<HTMLElement, string>
-                event;
-            });
-
-            // $ExpectType JQuery<HTMLElement>
-            $('table').one('myEvent', 'td', 'myData', function(this: J1, event) {
-                // $ExpectType J1
                 this;
                 // $ExpectType Event<HTMLElement, string>
                 event;
@@ -4339,24 +4187,8 @@ function JQuery() {
             });
 
             // $ExpectType JQuery<HTMLElement>
-            $('table').one('myEvent', null, 'myData', function(this: J1, event) {
-                // $ExpectType J1
-                this;
-                // $ExpectType Event<HTMLElement, string>
-                event;
-            });
-
-            // $ExpectType JQuery<HTMLElement>
             $('table').one('myEvent', 'td', function(event) {
                 // $ExpectType HTMLElement
-                this;
-                // $ExpectType Event<HTMLElement, null>
-                event;
-            });
-
-            // $ExpectType JQuery<HTMLElement>
-            $('table').one('myEvent', 'td', function(this: J1, event) {
-                // $ExpectType J1
                 this;
                 // $ExpectType Event<HTMLElement, null>
                 event;
@@ -4374,24 +4206,8 @@ function JQuery() {
             });
 
             // $ExpectType JQuery<HTMLElement>
-            $('table').one('myEvent', 3, function(this: J1, event) {
-                // $ExpectType J1
-                this;
-                // $ExpectType Event<HTMLElement, number>
-                event;
-            });
-
-            // $ExpectType JQuery<HTMLElement>
             $('table').one('myEvent', function(event) {
                 // $ExpectType HTMLElement
-                this;
-                // $ExpectType Event<HTMLElement, null>
-                event;
-            });
-
-            // $ExpectType JQuery<HTMLElement>
-            $('table').one('myEvent', function(this: J1, event) {
-                // $ExpectType J1
                 this;
                 // $ExpectType Event<HTMLElement, null>
                 event;
@@ -4408,12 +4224,6 @@ function JQuery() {
                     this;
                     // $ExpectType Event<HTMLElement, string>
                     event;
-                },
-                myEvent3(this: J1, event) {
-                    // $ExpectType J1
-                    this;
-                    // $ExpectType Event<HTMLElement, string>
-                    event;
                 }
             }, 'td', 'myData');
 
@@ -4422,12 +4232,6 @@ function JQuery() {
                 myEvent1: false,
                 myEvent2(event) {
                     // $ExpectType HTMLElement
-                    this;
-                    // $ExpectType Event<HTMLElement, string>
-                    event;
-                },
-                myEvent3(this: J1, event) {
-                    // $ExpectType J1
                     this;
                     // $ExpectType Event<HTMLElement, string>
                     event;
@@ -4442,12 +4246,6 @@ function JQuery() {
                     this;
                     // $ExpectType Event<HTMLElement, null>
                     event;
-                },
-                myEvent3(this: J1, event) {
-                    // $ExpectType J1
-                    this;
-                    // $ExpectType Event<HTMLElement, null>
-                    event;
                 }
             }, 'td');
 
@@ -4459,12 +4257,6 @@ function JQuery() {
                     this;
                     // $ExpectType Event<HTMLElement, number>
                     event;
-                },
-                myEvent3(this: J1, event) {
-                    // $ExpectType J1
-                    this;
-                    // $ExpectType Event<HTMLElement, number>
-                    event;
                 }
             }, 3);
 
@@ -4473,12 +4265,6 @@ function JQuery() {
                 myEvent1: false,
                 myEvent2(event) {
                     // $ExpectType HTMLElement
-                    this;
-                    // $ExpectType Event<HTMLElement, null>
-                    event;
-                },
-                myEvent3(this: J1, event) {
-                    // $ExpectType J1
                     this;
                     // $ExpectType Event<HTMLElement, null>
                     event;
@@ -4551,27 +4337,15 @@ function JQuery() {
         }
 
         function unbind() {
-            function defaultContext_defaultData(this: HTMLElement, event: JQuery.Event<HTMLElement>) { }
+            function defaultData(this: HTMLElement, event: JQuery.Event<HTMLElement>) { }
 
-            function defaultContext_customData(this: HTMLElement, event: JQuery.Event<HTMLElement, string>) { }
-
-            function customContext_defaultData(this: J1, event: JQuery.Event<HTMLElement>) { }
-
-            function customContext_customData(this: J1, event: JQuery.Event<HTMLElement, string>) { }
-
-            interface J1 { kind: 'J1'; }
+            function customData(this: HTMLElement, event: JQuery.Event<HTMLElement, string>) { }
 
             // $ExpectType JQuery<HTMLElement>
-            $('p').unbind('myEvent', defaultContext_defaultData);
+            $('p').unbind('myEvent', defaultData);
 
             // $ExpectType JQuery<HTMLElement>
-            $('p').unbind('myEvent', defaultContext_customData);
-
-            // $ExpectType JQuery<HTMLElement>
-            $('p').unbind('myEvent', customContext_defaultData);
-
-            // $ExpectType JQuery<HTMLElement>
-            $('p').unbind('myEvent', customContext_customData);
+            $('p').unbind('myEvent', customData);
 
             // $ExpectType JQuery<HTMLElement>
             $('p').unbind('myEvent', false);
@@ -4587,27 +4361,15 @@ function JQuery() {
         }
 
         function undelegate() {
-            function defaultContext_defaultData(this: HTMLElement, event: JQuery.Event<HTMLElement>) { }
+            function defaultData(this: HTMLElement, event: JQuery.Event<HTMLElement>) { }
 
-            function defaultContext_customData(this: HTMLElement, event: JQuery.Event<HTMLElement, string>) { }
-
-            function customContext_defaultData(this: J1, event: JQuery.Event<HTMLElement>) { }
-
-            function customContext_customData(this: J1, event: JQuery.Event<HTMLElement, string>) { }
-
-            interface J1 { kind: 'J1'; }
+            function customData(this: HTMLElement, event: JQuery.Event<HTMLElement, string>) { }
 
             // $ExpectType JQuery<HTMLElement>
-            $('table').undelegate('td', 'click', defaultContext_defaultData);
+            $('table').undelegate('td', 'click', defaultData);
 
             // $ExpectType JQuery<HTMLElement>
-            $('table').undelegate('td', 'click', defaultContext_customData);
-
-            // $ExpectType JQuery<HTMLElement>
-            $('table').undelegate('td', 'click', customContext_defaultData);
-
-            // $ExpectType JQuery<HTMLElement>
-            $('table').undelegate('td', 'click', customContext_customData);
+            $('table').undelegate('td', 'click', customData);
 
             // $ExpectType JQuery<HTMLElement>
             $('table').undelegate('td', 'click', false);
@@ -4618,10 +4380,8 @@ function JQuery() {
             // $ExpectType JQuery<HTMLElement>
             $('table').undelegate('td', {
                 myEvent1: false,
-                defaultContext_defaultData,
-                defaultContext_customData,
-                customContext_defaultData,
-                customContext_customData
+                defaultData,
+                customData
             });
 
             // $ExpectType JQuery<HTMLElement>
@@ -4632,19 +4392,9 @@ function JQuery() {
         }
 
         function blur() {
-            interface J1 { kind: 'J1'; }
-
             // $ExpectType JQuery<HTMLElement>
             $('p').blur('myData', function(event) {
                 // $ExpectType HTMLElement
-                this;
-                // $ExpectType Event<HTMLElement, string>
-                event;
-            });
-
-            // $ExpectType JQuery<HTMLElement>
-            $('p').blur('myData', function(this: J1, event) {
-                // $ExpectType J1
                 this;
                 // $ExpectType Event<HTMLElement, string>
                 event;
@@ -4659,14 +4409,6 @@ function JQuery() {
             });
 
             // $ExpectType JQuery<HTMLElement>
-            $('p').blur(function(this: J1, event) {
-                // $ExpectType J1
-                this;
-                // $ExpectType Event<HTMLElement, null>
-                event;
-            });
-
-            // $ExpectType JQuery<HTMLElement>
             $('p').blur(false);
 
             // $ExpectType JQuery<HTMLElement>
@@ -4674,19 +4416,9 @@ function JQuery() {
         }
 
         function change() {
-            interface J1 { kind: 'J1'; }
-
             // $ExpectType JQuery<HTMLElement>
             $('p').change('myData', function(event) {
                 // $ExpectType HTMLElement
-                this;
-                // $ExpectType Event<HTMLElement, string>
-                event;
-            });
-
-            // $ExpectType JQuery<HTMLElement>
-            $('p').change('myData', function(this: J1, event) {
-                // $ExpectType J1
                 this;
                 // $ExpectType Event<HTMLElement, string>
                 event;
@@ -4701,14 +4433,6 @@ function JQuery() {
             });
 
             // $ExpectType JQuery<HTMLElement>
-            $('p').change(function(this: J1, event) {
-                // $ExpectType J1
-                this;
-                // $ExpectType Event<HTMLElement, null>
-                event;
-            });
-
-            // $ExpectType JQuery<HTMLElement>
             $('p').change(false);
 
             // $ExpectType JQuery<HTMLElement>
@@ -4716,19 +4440,9 @@ function JQuery() {
         }
 
         function click() {
-            interface J1 { kind: 'J1'; }
-
             // $ExpectType JQuery<HTMLElement>
             $('p').click('myData', function(event) {
                 // $ExpectType HTMLElement
-                this;
-                // $ExpectType Event<HTMLElement, string>
-                event;
-            });
-
-            // $ExpectType JQuery<HTMLElement>
-            $('p').click('myData', function(this: J1, event) {
-                // $ExpectType J1
                 this;
                 // $ExpectType Event<HTMLElement, string>
                 event;
@@ -4743,14 +4457,6 @@ function JQuery() {
             });
 
             // $ExpectType JQuery<HTMLElement>
-            $('p').click(function(this: J1, event) {
-                // $ExpectType J1
-                this;
-                // $ExpectType Event<HTMLElement, null>
-                event;
-            });
-
-            // $ExpectType JQuery<HTMLElement>
             $('p').click(false);
 
             // $ExpectType JQuery<HTMLElement>
@@ -4758,19 +4464,9 @@ function JQuery() {
         }
 
         function contextmenu() {
-            interface J1 { kind: 'J1'; }
-
             // $ExpectType JQuery<HTMLElement>
             $('p').contextmenu('myData', function(event) {
                 // $ExpectType HTMLElement
-                this;
-                // $ExpectType Event<HTMLElement, string>
-                event;
-            });
-
-            // $ExpectType JQuery<HTMLElement>
-            $('p').contextmenu('myData', function(this: J1, event) {
-                // $ExpectType J1
                 this;
                 // $ExpectType Event<HTMLElement, string>
                 event;
@@ -4785,14 +4481,6 @@ function JQuery() {
             });
 
             // $ExpectType JQuery<HTMLElement>
-            $('p').contextmenu(function(this: J1, event) {
-                // $ExpectType J1
-                this;
-                // $ExpectType Event<HTMLElement, null>
-                event;
-            });
-
-            // $ExpectType JQuery<HTMLElement>
             $('p').contextmenu(false);
 
             // $ExpectType JQuery<HTMLElement>
@@ -4800,19 +4488,9 @@ function JQuery() {
         }
 
         function dblclick() {
-            interface J1 { kind: 'J1'; }
-
             // $ExpectType JQuery<HTMLElement>
             $('p').dblclick('myData', function(event) {
                 // $ExpectType HTMLElement
-                this;
-                // $ExpectType Event<HTMLElement, string>
-                event;
-            });
-
-            // $ExpectType JQuery<HTMLElement>
-            $('p').dblclick('myData', function(this: J1, event) {
-                // $ExpectType J1
                 this;
                 // $ExpectType Event<HTMLElement, string>
                 event;
@@ -4827,14 +4505,6 @@ function JQuery() {
             });
 
             // $ExpectType JQuery<HTMLElement>
-            $('p').dblclick(function(this: J1, event) {
-                // $ExpectType J1
-                this;
-                // $ExpectType Event<HTMLElement, null>
-                event;
-            });
-
-            // $ExpectType JQuery<HTMLElement>
             $('p').dblclick(false);
 
             // $ExpectType JQuery<HTMLElement>
@@ -4842,19 +4512,9 @@ function JQuery() {
         }
 
         function focus() {
-            interface J1 { kind: 'J1'; }
-
             // $ExpectType JQuery<HTMLElement>
             $('p').focus('myData', function(event) {
                 // $ExpectType HTMLElement
-                this;
-                // $ExpectType Event<HTMLElement, string>
-                event;
-            });
-
-            // $ExpectType JQuery<HTMLElement>
-            $('p').focus('myData', function(this: J1, event) {
-                // $ExpectType J1
                 this;
                 // $ExpectType Event<HTMLElement, string>
                 event;
@@ -4869,14 +4529,6 @@ function JQuery() {
             });
 
             // $ExpectType JQuery<HTMLElement>
-            $('p').focus(function(this: J1, event) {
-                // $ExpectType J1
-                this;
-                // $ExpectType Event<HTMLElement, null>
-                event;
-            });
-
-            // $ExpectType JQuery<HTMLElement>
             $('p').focus(false);
 
             // $ExpectType JQuery<HTMLElement>
@@ -4884,19 +4536,9 @@ function JQuery() {
         }
 
         function focusin() {
-            interface J1 { kind: 'J1'; }
-
             // $ExpectType JQuery<HTMLElement>
             $('p').focusin('myData', function(event) {
                 // $ExpectType HTMLElement
-                this;
-                // $ExpectType Event<HTMLElement, string>
-                event;
-            });
-
-            // $ExpectType JQuery<HTMLElement>
-            $('p').focusin('myData', function(this: J1, event) {
-                // $ExpectType J1
                 this;
                 // $ExpectType Event<HTMLElement, string>
                 event;
@@ -4911,14 +4553,6 @@ function JQuery() {
             });
 
             // $ExpectType JQuery<HTMLElement>
-            $('p').focusin(function(this: J1, event) {
-                // $ExpectType J1
-                this;
-                // $ExpectType Event<HTMLElement, null>
-                event;
-            });
-
-            // $ExpectType JQuery<HTMLElement>
             $('p').focusin(false);
 
             // $ExpectType JQuery<HTMLElement>
@@ -4926,19 +4560,9 @@ function JQuery() {
         }
 
         function focusout() {
-            interface J1 { kind: 'J1'; }
-
             // $ExpectType JQuery<HTMLElement>
             $('p').focusout('myData', function(event) {
                 // $ExpectType HTMLElement
-                this;
-                // $ExpectType Event<HTMLElement, string>
-                event;
-            });
-
-            // $ExpectType JQuery<HTMLElement>
-            $('p').focusout('myData', function(this: J1, event) {
-                // $ExpectType J1
                 this;
                 // $ExpectType Event<HTMLElement, string>
                 event;
@@ -4953,14 +4577,6 @@ function JQuery() {
             });
 
             // $ExpectType JQuery<HTMLElement>
-            $('p').focusout(function(this: J1, event) {
-                // $ExpectType J1
-                this;
-                // $ExpectType Event<HTMLElement, null>
-                event;
-            });
-
-            // $ExpectType JQuery<HTMLElement>
             $('p').focusout(false);
 
             // $ExpectType JQuery<HTMLElement>
@@ -4968,19 +4584,9 @@ function JQuery() {
         }
 
         function keydown() {
-            interface J1 { kind: 'J1'; }
-
             // $ExpectType JQuery<HTMLElement>
             $('p').keydown('myData', function(event) {
                 // $ExpectType HTMLElement
-                this;
-                // $ExpectType Event<HTMLElement, string>
-                event;
-            });
-
-            // $ExpectType JQuery<HTMLElement>
-            $('p').keydown('myData', function(this: J1, event) {
-                // $ExpectType J1
                 this;
                 // $ExpectType Event<HTMLElement, string>
                 event;
@@ -4995,14 +4601,6 @@ function JQuery() {
             });
 
             // $ExpectType JQuery<HTMLElement>
-            $('p').keydown(function(this: J1, event) {
-                // $ExpectType J1
-                this;
-                // $ExpectType Event<HTMLElement, null>
-                event;
-            });
-
-            // $ExpectType JQuery<HTMLElement>
             $('p').keydown(false);
 
             // $ExpectType JQuery<HTMLElement>
@@ -5010,19 +4608,9 @@ function JQuery() {
         }
 
         function keypress() {
-            interface J1 { kind: 'J1'; }
-
             // $ExpectType JQuery<HTMLElement>
             $('p').keypress('myData', function(event) {
                 // $ExpectType HTMLElement
-                this;
-                // $ExpectType Event<HTMLElement, string>
-                event;
-            });
-
-            // $ExpectType JQuery<HTMLElement>
-            $('p').keypress('myData', function(this: J1, event) {
-                // $ExpectType J1
                 this;
                 // $ExpectType Event<HTMLElement, string>
                 event;
@@ -5037,14 +4625,6 @@ function JQuery() {
             });
 
             // $ExpectType JQuery<HTMLElement>
-            $('p').keypress(function(this: J1, event) {
-                // $ExpectType J1
-                this;
-                // $ExpectType Event<HTMLElement, null>
-                event;
-            });
-
-            // $ExpectType JQuery<HTMLElement>
             $('p').keypress(false);
 
             // $ExpectType JQuery<HTMLElement>
@@ -5052,19 +4632,9 @@ function JQuery() {
         }
 
         function keyup() {
-            interface J1 { kind: 'J1'; }
-
             // $ExpectType JQuery<HTMLElement>
             $('p').keyup('myData', function(event) {
                 // $ExpectType HTMLElement
-                this;
-                // $ExpectType Event<HTMLElement, string>
-                event;
-            });
-
-            // $ExpectType JQuery<HTMLElement>
-            $('p').keyup('myData', function(this: J1, event) {
-                // $ExpectType J1
                 this;
                 // $ExpectType Event<HTMLElement, string>
                 event;
@@ -5079,14 +4649,6 @@ function JQuery() {
             });
 
             // $ExpectType JQuery<HTMLElement>
-            $('p').keyup(function(this: J1, event) {
-                // $ExpectType J1
-                this;
-                // $ExpectType Event<HTMLElement, null>
-                event;
-            });
-
-            // $ExpectType JQuery<HTMLElement>
             $('p').keyup(false);
 
             // $ExpectType JQuery<HTMLElement>
@@ -5094,19 +4656,9 @@ function JQuery() {
         }
 
         function mousedown() {
-            interface J1 { kind: 'J1'; }
-
             // $ExpectType JQuery<HTMLElement>
             $('p').mousedown('myData', function(event) {
                 // $ExpectType HTMLElement
-                this;
-                // $ExpectType Event<HTMLElement, string>
-                event;
-            });
-
-            // $ExpectType JQuery<HTMLElement>
-            $('p').mousedown('myData', function(this: J1, event) {
-                // $ExpectType J1
                 this;
                 // $ExpectType Event<HTMLElement, string>
                 event;
@@ -5121,14 +4673,6 @@ function JQuery() {
             });
 
             // $ExpectType JQuery<HTMLElement>
-            $('p').mousedown(function(this: J1, event) {
-                // $ExpectType J1
-                this;
-                // $ExpectType Event<HTMLElement, null>
-                event;
-            });
-
-            // $ExpectType JQuery<HTMLElement>
             $('p').mousedown(false);
 
             // $ExpectType JQuery<HTMLElement>
@@ -5136,19 +4680,9 @@ function JQuery() {
         }
 
         function mouseenter() {
-            interface J1 { kind: 'J1'; }
-
             // $ExpectType JQuery<HTMLElement>
             $('p').mouseenter('myData', function(event) {
                 // $ExpectType HTMLElement
-                this;
-                // $ExpectType Event<HTMLElement, string>
-                event;
-            });
-
-            // $ExpectType JQuery<HTMLElement>
-            $('p').mouseenter('myData', function(this: J1, event) {
-                // $ExpectType J1
                 this;
                 // $ExpectType Event<HTMLElement, string>
                 event;
@@ -5163,14 +4697,6 @@ function JQuery() {
             });
 
             // $ExpectType JQuery<HTMLElement>
-            $('p').mouseenter(function(this: J1, event) {
-                // $ExpectType J1
-                this;
-                // $ExpectType Event<HTMLElement, null>
-                event;
-            });
-
-            // $ExpectType JQuery<HTMLElement>
             $('p').mouseenter(false);
 
             // $ExpectType JQuery<HTMLElement>
@@ -5178,19 +4704,9 @@ function JQuery() {
         }
 
         function mouseleave() {
-            interface J1 { kind: 'J1'; }
-
             // $ExpectType JQuery<HTMLElement>
             $('p').mouseleave('myData', function(event) {
                 // $ExpectType HTMLElement
-                this;
-                // $ExpectType Event<HTMLElement, string>
-                event;
-            });
-
-            // $ExpectType JQuery<HTMLElement>
-            $('p').mouseleave('myData', function(this: J1, event) {
-                // $ExpectType J1
                 this;
                 // $ExpectType Event<HTMLElement, string>
                 event;
@@ -5205,14 +4721,6 @@ function JQuery() {
             });
 
             // $ExpectType JQuery<HTMLElement>
-            $('p').mouseleave(function(this: J1, event) {
-                // $ExpectType J1
-                this;
-                // $ExpectType Event<HTMLElement, null>
-                event;
-            });
-
-            // $ExpectType JQuery<HTMLElement>
             $('p').mouseleave(false);
 
             // $ExpectType JQuery<HTMLElement>
@@ -5220,19 +4728,9 @@ function JQuery() {
         }
 
         function mousemove() {
-            interface J1 { kind: 'J1'; }
-
             // $ExpectType JQuery<HTMLElement>
             $('p').mousemove('myData', function(event) {
                 // $ExpectType HTMLElement
-                this;
-                // $ExpectType Event<HTMLElement, string>
-                event;
-            });
-
-            // $ExpectType JQuery<HTMLElement>
-            $('p').mousemove('myData', function(this: J1, event) {
-                // $ExpectType J1
                 this;
                 // $ExpectType Event<HTMLElement, string>
                 event;
@@ -5247,14 +4745,6 @@ function JQuery() {
             });
 
             // $ExpectType JQuery<HTMLElement>
-            $('p').mousemove(function(this: J1, event) {
-                // $ExpectType J1
-                this;
-                // $ExpectType Event<HTMLElement, null>
-                event;
-            });
-
-            // $ExpectType JQuery<HTMLElement>
             $('p').mousemove(false);
 
             // $ExpectType JQuery<HTMLElement>
@@ -5262,19 +4752,9 @@ function JQuery() {
         }
 
         function mouseout() {
-            interface J1 { kind: 'J1'; }
-
             // $ExpectType JQuery<HTMLElement>
             $('p').mouseout('myData', function(event) {
                 // $ExpectType HTMLElement
-                this;
-                // $ExpectType Event<HTMLElement, string>
-                event;
-            });
-
-            // $ExpectType JQuery<HTMLElement>
-            $('p').mouseout('myData', function(this: J1, event) {
-                // $ExpectType J1
                 this;
                 // $ExpectType Event<HTMLElement, string>
                 event;
@@ -5289,14 +4769,6 @@ function JQuery() {
             });
 
             // $ExpectType JQuery<HTMLElement>
-            $('p').mouseout(function(this: J1, event) {
-                // $ExpectType J1
-                this;
-                // $ExpectType Event<HTMLElement, null>
-                event;
-            });
-
-            // $ExpectType JQuery<HTMLElement>
             $('p').mouseout(false);
 
             // $ExpectType JQuery<HTMLElement>
@@ -5304,19 +4776,9 @@ function JQuery() {
         }
 
         function mouseover() {
-            interface J1 { kind: 'J1'; }
-
             // $ExpectType JQuery<HTMLElement>
             $('p').mouseover('myData', function(event) {
                 // $ExpectType HTMLElement
-                this;
-                // $ExpectType Event<HTMLElement, string>
-                event;
-            });
-
-            // $ExpectType JQuery<HTMLElement>
-            $('p').mouseover('myData', function(this: J1, event) {
-                // $ExpectType J1
                 this;
                 // $ExpectType Event<HTMLElement, string>
                 event;
@@ -5331,14 +4793,6 @@ function JQuery() {
             });
 
             // $ExpectType JQuery<HTMLElement>
-            $('p').mouseover(function(this: J1, event) {
-                // $ExpectType J1
-                this;
-                // $ExpectType Event<HTMLElement, null>
-                event;
-            });
-
-            // $ExpectType JQuery<HTMLElement>
             $('p').mouseover(false);
 
             // $ExpectType JQuery<HTMLElement>
@@ -5346,19 +4800,9 @@ function JQuery() {
         }
 
         function mouseup() {
-            interface J1 { kind: 'J1'; }
-
             // $ExpectType JQuery<HTMLElement>
             $('p').mouseup('myData', function(event) {
                 // $ExpectType HTMLElement
-                this;
-                // $ExpectType Event<HTMLElement, string>
-                event;
-            });
-
-            // $ExpectType JQuery<HTMLElement>
-            $('p').mouseup('myData', function(this: J1, event) {
-                // $ExpectType J1
                 this;
                 // $ExpectType Event<HTMLElement, string>
                 event;
@@ -5373,14 +4817,6 @@ function JQuery() {
             });
 
             // $ExpectType JQuery<HTMLElement>
-            $('p').mouseup(function(this: J1, event) {
-                // $ExpectType J1
-                this;
-                // $ExpectType Event<HTMLElement, null>
-                event;
-            });
-
-            // $ExpectType JQuery<HTMLElement>
             $('p').mouseup(false);
 
             // $ExpectType JQuery<HTMLElement>
@@ -5388,19 +4824,9 @@ function JQuery() {
         }
 
         function resize() {
-            interface J1 { kind: 'J1'; }
-
             // $ExpectType JQuery<HTMLElement>
             $('p').resize('myData', function(event) {
                 // $ExpectType HTMLElement
-                this;
-                // $ExpectType Event<HTMLElement, string>
-                event;
-            });
-
-            // $ExpectType JQuery<HTMLElement>
-            $('p').resize('myData', function(this: J1, event) {
-                // $ExpectType J1
                 this;
                 // $ExpectType Event<HTMLElement, string>
                 event;
@@ -5415,14 +4841,6 @@ function JQuery() {
             });
 
             // $ExpectType JQuery<HTMLElement>
-            $('p').resize(function(this: J1, event) {
-                // $ExpectType J1
-                this;
-                // $ExpectType Event<HTMLElement, null>
-                event;
-            });
-
-            // $ExpectType JQuery<HTMLElement>
             $('p').resize(false);
 
             // $ExpectType JQuery<HTMLElement>
@@ -5430,19 +4848,9 @@ function JQuery() {
         }
 
         function scroll() {
-            interface J1 { kind: 'J1'; }
-
             // $ExpectType JQuery<HTMLElement>
             $('p').scroll('myData', function(event) {
                 // $ExpectType HTMLElement
-                this;
-                // $ExpectType Event<HTMLElement, string>
-                event;
-            });
-
-            // $ExpectType JQuery<HTMLElement>
-            $('p').scroll('myData', function(this: J1, event) {
-                // $ExpectType J1
                 this;
                 // $ExpectType Event<HTMLElement, string>
                 event;
@@ -5457,14 +4865,6 @@ function JQuery() {
             });
 
             // $ExpectType JQuery<HTMLElement>
-            $('p').scroll(function(this: J1, event) {
-                // $ExpectType J1
-                this;
-                // $ExpectType Event<HTMLElement, null>
-                event;
-            });
-
-            // $ExpectType JQuery<HTMLElement>
             $('p').scroll(false);
 
             // $ExpectType JQuery<HTMLElement>
@@ -5472,19 +4872,9 @@ function JQuery() {
         }
 
         function select() {
-            interface J1 { kind: 'J1'; }
-
             // $ExpectType JQuery<HTMLElement>
             $('p').select('myData', function(event) {
                 // $ExpectType HTMLElement
-                this;
-                // $ExpectType Event<HTMLElement, string>
-                event;
-            });
-
-            // $ExpectType JQuery<HTMLElement>
-            $('p').select('myData', function(this: J1, event) {
-                // $ExpectType J1
                 this;
                 // $ExpectType Event<HTMLElement, string>
                 event;
@@ -5499,14 +4889,6 @@ function JQuery() {
             });
 
             // $ExpectType JQuery<HTMLElement>
-            $('p').select(function(this: J1, event) {
-                // $ExpectType J1
-                this;
-                // $ExpectType Event<HTMLElement, null>
-                event;
-            });
-
-            // $ExpectType JQuery<HTMLElement>
             $('p').select(false);
 
             // $ExpectType JQuery<HTMLElement>
@@ -5514,19 +4896,9 @@ function JQuery() {
         }
 
         function submit() {
-            interface J1 { kind: 'J1'; }
-
             // $ExpectType JQuery<HTMLElement>
             $('p').submit('myData', function(event) {
                 // $ExpectType HTMLElement
-                this;
-                // $ExpectType Event<HTMLElement, string>
-                event;
-            });
-
-            // $ExpectType JQuery<HTMLElement>
-            $('p').submit('myData', function(this: J1, event) {
-                // $ExpectType J1
                 this;
                 // $ExpectType Event<HTMLElement, string>
                 event;
@@ -5541,14 +4913,6 @@ function JQuery() {
             });
 
             // $ExpectType JQuery<HTMLElement>
-            $('p').submit(function(this: J1, event) {
-                // $ExpectType J1
-                this;
-                // $ExpectType Event<HTMLElement, null>
-                event;
-            });
-
-            // $ExpectType JQuery<HTMLElement>
             $('p').submit(false);
 
             // $ExpectType JQuery<HTMLElement>
@@ -5556,9 +4920,6 @@ function JQuery() {
         }
 
         function hover() {
-            interface J1 { kind: 'J1'; }
-            interface J2 { kind: 'J2'; }
-
             // $ExpectType JQuery<HTMLElement>
             $('p').hover(function(event) {
                 // $ExpectType HTMLElement
@@ -5573,55 +4934,8 @@ function JQuery() {
             });
 
             // $ExpectType JQuery<HTMLElement>
-            $('p').hover(function(this: J1, event) {
-                // $ExpectType J1
-                this;
-                // $ExpectType Event<HTMLElement, null>
-                event;
-            }, function(event) {
-                // $ExpectType HTMLElement
-                this;
-                // $ExpectType Event<HTMLElement, null>
-                event;
-            });
-
-            // $ExpectType JQuery<HTMLElement>
             $('p').hover(function(event) {
                 // $ExpectType HTMLElement
-                this;
-                // $ExpectType Event<HTMLElement, null>
-                event;
-            }, function(this: J1, event) {
-                // $ExpectType J1
-                this;
-                // $ExpectType Event<HTMLElement, null>
-                event;
-            });
-
-            // $ExpectType JQuery<HTMLElement>
-            $('p').hover(function(this: J1, event) {
-                // $ExpectType J1
-                this;
-                // $ExpectType Event<HTMLElement, null>
-                event;
-            }, function(this: J2, event) {
-                // $ExpectType J2
-                this;
-                // $ExpectType Event<HTMLElement, null>
-                event;
-            });
-
-            // $ExpectType JQuery<HTMLElement>
-            $('p').hover(function(event) {
-                // $ExpectType HTMLElement
-                this;
-                // $ExpectType Event<HTMLElement, null>
-                event;
-            }, false);
-
-            // $ExpectType JQuery<HTMLElement>
-            $('p').hover(function(this: J1, event) {
-                // $ExpectType J1
                 this;
                 // $ExpectType Event<HTMLElement, null>
                 event;
@@ -5636,27 +4950,11 @@ function JQuery() {
             });
 
             // $ExpectType JQuery<HTMLElement>
-            $('p').hover(false, function(this: J1, event) {
-                // $ExpectType J1
-                this;
-                // $ExpectType Event<HTMLElement, null>
-                event;
-            });
-
-            // $ExpectType JQuery<HTMLElement>
             $('p').hover(false, false);
 
             // $ExpectType JQuery<HTMLElement>
             $('p').hover(function(event) {
                 // $ExpectType HTMLElement
-                this;
-                // $ExpectType Event<HTMLElement, null>
-                event;
-            });
-
-            // $ExpectType JQuery<HTMLElement>
-            $('p').hover(function(this: J1, event) {
-                // $ExpectType J1
                 this;
                 // $ExpectType Event<HTMLElement, null>
                 event;

--- a/types/jquery/jquery-tests.ts
+++ b/types/jquery/jquery-tests.ts
@@ -7862,6 +7862,167 @@ function JQuery_Event() {
     }
 }
 
+function JQuery_TypeEventHandlers() {
+    const events: JQuery.TypeEventHandlers<HTMLElement, undefined, HTMLElement, HTMLElement> = {
+        change(event) {
+            // $ExpectType HTMLElement
+            this;
+            // $ExpectType ChangeEvent<HTMLElement, undefined, HTMLElement, HTMLElement>
+            event;
+        },
+        resize(event) {
+            // $ExpectType HTMLElement
+            this;
+            // $ExpectType ResizeEvent<HTMLElement, undefined, HTMLElement, HTMLElement>
+            event;
+        },
+        scroll(event) {
+            // $ExpectType HTMLElement
+            this;
+            // $ExpectType ScrollEvent<HTMLElement, undefined, HTMLElement, HTMLElement>
+            event;
+        },
+        select(event) {
+            // $ExpectType HTMLElement
+            this;
+            // $ExpectType SelectEvent<HTMLElement, undefined, HTMLElement, HTMLElement>
+            event;
+        },
+        submit(event) {
+            // $ExpectType HTMLElement
+            this;
+            // $ExpectType SubmitEvent<HTMLElement, undefined, HTMLElement, HTMLElement>
+            event;
+        },
+        click(event) {
+            // $ExpectType HTMLElement
+            this;
+            // $ExpectType ClickEvent<HTMLElement, undefined, HTMLElement, HTMLElement>
+            event;
+        },
+        contextmenu(event) {
+            // $ExpectType HTMLElement
+            this;
+            // $ExpectType ContextMenuEvent<HTMLElement, undefined, HTMLElement, HTMLElement>
+            event;
+        },
+        dblclick(event) {
+            // $ExpectType HTMLElement
+            this;
+            // $ExpectType DoubleClickEvent<HTMLElement, undefined, HTMLElement, HTMLElement>
+            event;
+        },
+        mousedown(event) {
+            // $ExpectType HTMLElement
+            this;
+            // $ExpectType MouseDownEvent<HTMLElement, undefined, HTMLElement, HTMLElement>
+            event;
+        },
+        mouseenter(event) {
+            // $ExpectType HTMLElement
+            this;
+            // $ExpectType MouseEnterEvent<HTMLElement, undefined, HTMLElement, HTMLElement>
+            event;
+        },
+        mouseleave(event) {
+            // $ExpectType HTMLElement
+            this;
+            // $ExpectType MouseLeaveEvent<HTMLElement, undefined, HTMLElement, HTMLElement>
+            event;
+        },
+        mousemove(event) {
+            // $ExpectType HTMLElement
+            this;
+            // $ExpectType MouseMoveEvent<HTMLElement, undefined, HTMLElement, HTMLElement>
+            event;
+        },
+        mouseout(event) {
+            // $ExpectType HTMLElement
+            this;
+            // $ExpectType MouseOutEvent<HTMLElement, undefined, HTMLElement, HTMLElement>
+            event;
+        },
+        mouseover(event) {
+            // $ExpectType HTMLElement
+            this;
+            // $ExpectType MouseOverEvent<HTMLElement, undefined, HTMLElement, HTMLElement>
+            event;
+        },
+        mouseup(event) {
+            // $ExpectType HTMLElement
+            this;
+            // $ExpectType MouseUpEvent<HTMLElement, undefined, HTMLElement, HTMLElement>
+            event;
+        },
+        keydown(event) {
+            // $ExpectType HTMLElement
+            this;
+            // $ExpectType KeyDownEvent<HTMLElement, undefined, HTMLElement, HTMLElement>
+            event;
+        },
+        keypress(event) {
+            // $ExpectType HTMLElement
+            this;
+            // $ExpectType KeyPressEvent<HTMLElement, undefined, HTMLElement, HTMLElement>
+            event;
+        },
+        keyup(event) {
+            // $ExpectType HTMLElement
+            this;
+            // $ExpectType KeyUpEvent<HTMLElement, undefined, HTMLElement, HTMLElement>
+            event;
+        },
+        touchcancel(event) {
+            // $ExpectType HTMLElement
+            this;
+            // $ExpectType TouchCancelEvent<HTMLElement, undefined, HTMLElement, HTMLElement>
+            event;
+        },
+        touchend(event) {
+            // $ExpectType HTMLElement
+            this;
+            // $ExpectType TouchEndEvent<HTMLElement, undefined, HTMLElement, HTMLElement>
+            event;
+        },
+        touchmove(event) {
+            // $ExpectType HTMLElement
+            this;
+            // $ExpectType TouchMoveEvent<HTMLElement, undefined, HTMLElement, HTMLElement>
+            event;
+        },
+        touchstart(event) {
+            // $ExpectType HTMLElement
+            this;
+            // $ExpectType TouchStartEvent<HTMLElement, undefined, HTMLElement, HTMLElement>
+            event;
+        },
+        blur(event) {
+            // $ExpectType HTMLElement
+            this;
+            // $ExpectType BlurEvent<HTMLElement, undefined, HTMLElement, HTMLElement>
+            event;
+        },
+        focus(event) {
+            // $ExpectType HTMLElement
+            this;
+            // $ExpectType FocusEvent<HTMLElement, undefined, HTMLElement, HTMLElement>
+            event;
+        },
+        focusin(event) {
+            // $ExpectType HTMLElement
+            this;
+            // $ExpectType FocusInEvent<HTMLElement, undefined, HTMLElement, HTMLElement>
+            event;
+        },
+        focusout(event) {
+            // $ExpectType HTMLElement
+            this;
+            // $ExpectType FocusOutEvent<HTMLElement, undefined, HTMLElement, HTMLElement>
+            event;
+        }
+    };
+}
+
 function JQuery_EventExtensions() {
     function special() {
         jQuery.event.special.multiclick = {

--- a/types/jquery/misc.d.ts
+++ b/types/jquery/misc.d.ts
@@ -5722,8 +5722,9 @@ $( "#checkMetaKey" ).click(function( event ) {
     interface TouchEventBase<
         TDelegateTarget = any,
         TData = any,
-        TCurrentTarget = any
-    > extends UIEventBase<TDelegateTarget, TData, TCurrentTarget> {
+        TCurrentTarget = any,
+        TTarget = any
+    > extends UIEventBase<TDelegateTarget, TData, TCurrentTarget, TTarget> {
         /**
          * The other DOM element involved in the event, if any.
          * @see \`{@link https://api.jquery.com/event.relatedTarget/ }\`
@@ -5948,32 +5949,36 @@ $( "#checkMetaKey" ).click(function( event ) {
     interface TouchCancelEvent<
         TDelegateTarget = any,
         TData = any,
-        TCurrentTarget = any
-    > extends TouchEventBase<TDelegateTarget, TData, TCurrentTarget> {
+        TCurrentTarget = any,
+        TTarget = any
+    > extends TouchEventBase<TDelegateTarget, TData, TCurrentTarget, TTarget> {
         type: 'touchcancel';
     }
 
     interface TouchEndEvent<
         TDelegateTarget = any,
         TData = any,
-        TCurrentTarget = any
-    > extends TouchEventBase<TDelegateTarget, TData, TCurrentTarget> {
+        TCurrentTarget = any,
+        TTarget = any
+    > extends TouchEventBase<TDelegateTarget, TData, TCurrentTarget, TTarget> {
         type: 'touchend';
     }
 
     interface TouchMoveEvent<
         TDelegateTarget = any,
         TData = any,
-        TCurrentTarget = any
-    > extends TouchEventBase<TDelegateTarget, TData, TCurrentTarget> {
+        TCurrentTarget = any,
+        TTarget = any
+    > extends TouchEventBase<TDelegateTarget, TData, TCurrentTarget, TTarget> {
         type: 'touchmove';
     }
 
     interface TouchStartEvent<
         TDelegateTarget = any,
         TData = any,
-        TCurrentTarget = any
-    > extends TouchEventBase<TDelegateTarget, TData, TCurrentTarget> {
+        TCurrentTarget = any,
+        TTarget = any
+    > extends TouchEventBase<TDelegateTarget, TData, TCurrentTarget, TTarget> {
         type: 'touchstart';
     }
 
@@ -6286,10 +6291,10 @@ $( "#checkMetaKey" ).click(function( event ) {
 
         // TouchEvent
 
-        touchcancel: TouchCancelEvent<TDelegateTarget, TData, TCurrentTarget>;
-        touchend: TouchEndEvent<TDelegateTarget, TData, TCurrentTarget>;
-        touchmove: TouchMoveEvent<TDelegateTarget, TData, TCurrentTarget>;
-        touchstart: TouchStartEvent<TDelegateTarget, TData, TCurrentTarget>;
+        touchcancel: TouchCancelEvent<TDelegateTarget, TData, TCurrentTarget, TTarget>;
+        touchend: TouchEndEvent<TDelegateTarget, TData, TCurrentTarget, TTarget>;
+        touchmove: TouchMoveEvent<TDelegateTarget, TData, TCurrentTarget, TTarget>;
+        touchstart: TouchStartEvent<TDelegateTarget, TData, TCurrentTarget, TTarget>;
 
         // FocusEvent
 

--- a/types/jquery/misc.d.ts
+++ b/types/jquery/misc.d.ts
@@ -4305,6 +4305,7 @@ $( "a" ).click(function( event ) {
          * For key or mouse events, this property indicates the specific key or button that was pressed.
          * @see \`{@link https://api.jquery.com/event.which/ }\`
          * @since 1.1.3
+         * @deprecated ​ Deprecated since 3.3. See \`{@link https://github.com/jquery/api.jquery.com/issues/821 }\`.
          * @example ​ ````Log which key was depressed.
 ```html
 <!doctype html>

--- a/types/jquery/misc.d.ts
+++ b/types/jquery/misc.d.ts
@@ -4728,13 +4728,6 @@ $( "ul" ).click( handler ).find( "ul" ).hide();
 
     interface EventExtensions {
         /**
-         * jQuery defines an \`{@link https://api.jquery.com/category/events/event-object/ Event object}\` that represents a cross-browser subset of the information available when an event occurs. The `jQuery.event.props` property is an array of string names for properties that are always copied when jQuery processes a native browser event. (Events fired in code by `.trigger()` do not use this list, since the code can construct a `jQuery.Event` object with the needed values and trigger using that object.)
-         *
-         * To add a property name to this list, use `jQuery.event.props.push( "newPropertyName" )`. However, be aware that every event processed by jQuery will now attempt to copy this property name from the native browser event to jQuery's constructed event. If the property does not exist for that event type, it will get an undefined value. Adding many properties to this list can significantly reduce event delivery performance, so for infrequently-needed properties it is more efficient to use the value directly from `event.originalEvent` instead. If properties must be copied, you are strongly advised to use `jQuery.event.fixHooks` as of version 1.7.
-         * @see \`{@link https://learn.jquery.com/events/event-extensions/#jquery-event-props-array }\`
-         */
-        props: string[];
-        /**
          * The jQuery special event hooks are a set of per-event-name functions and properties that allow code to control the behavior of event processing within jQuery. The mechanism is similar to `fixHooks` in that the special event information is stored in `jQuery.event.special.NAME`, where `NAME` is the name of the special event. Event names are case sensitive.
          *
          * As with `fixHooks`, the special event hooks design assumes it will be very rare that two unrelated pieces of code want to process the same event name. Special event authors who need to modify events with existing hooks will need to take precautions to avoid introducing unwanted side-effects by clobbering those hooks.

--- a/types/jquery/misc.d.ts
+++ b/types/jquery/misc.d.ts
@@ -4744,12 +4744,1290 @@ $( "button" ).click(function( event ) {
         result?: any;
     }
 
+    // region Event
+    // #region Event
+
+    interface EventBase<
+        TDelegateTarget = any,
+        TData = any,
+        TCurrentTarget = any,
+        TTarget = any
+    > extends TriggeredEvent<TDelegateTarget, TData, TCurrentTarget, TTarget> {
+        /**
+         * The other DOM element involved in the event, if any.
+         * @see \`{@link https://api.jquery.com/event.relatedTarget/ }\`
+         * @since 1.1.4
+         * @example ​ ````On mouseout of anchors, alert the element type being entered.
+```javascript
+$( "a" ).mouseout(function( event ) {
+  alert( event.relatedTarget.nodeName ); // "DIV"
+});
+```
+        */
+        relatedTarget?: undefined;
+
+        // Event
+
+        bubbles: boolean;
+        cancelable: boolean;
+        eventPhase: number;
+
+        // UIEvent
+
+        detail: undefined;
+        view: undefined;
+
+        // MouseEvent
+
+        button: undefined;
+        buttons: undefined;
+        clientX: undefined;
+        clientY: undefined;
+        offsetX: undefined;
+        offsetY: undefined;
+        /**
+         * The mouse position relative to the left edge of the document.
+         * @see \`{@link https://api.jquery.com/event.pageX/ }\`
+         * @since 1.0.4
+         * @example ​ ````Show the mouse position relative to the left and top edges of the document (within this iframe).
+```html
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>event.pageX demo</title>
+  <style>
+  body {
+    background-color: #eef;
+  }
+  div {
+    padding: 20px;
+  }
+  </style>
+  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
+</head>
+<body>
+​
+<div id="log"></div>
+​
+<script>
+$( document ).on( "mousemove", function( event ) {
+  $( "#log" ).text( "pageX: " + event.pageX + ", pageY: " + event.pageY );
+});
+</script>
+​
+</body>
+</html>
+```
+         */
+        pageX: undefined;
+        /**
+         * The mouse position relative to the top edge of the document.
+         * @see \`{@link https://api.jquery.com/event.pageY/ }\`
+         * @since 1.0.4
+         * @example ​ ````Show the mouse position relative to the left and top edges of the document (within this iframe).
+```html
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>event.pageY demo</title>
+  <style>
+  body {
+    background-color: #eef;
+  }
+  div {
+    padding: 20px;
+  }
+  </style>
+  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
+</head>
+<body>
+​
+<div id="log"></div>
+​
+<script>
+$( document ).on( "mousemove", function( event ) {
+  $( "#log" ).text( "pageX: " + event.pageX + ", pageY: " + event.pageY );
+});
+</script>
+​
+</body>
+</html>
+```
+         */
+        pageY: undefined;
+        screenX: undefined;
+        screenY: undefined;
+        /** @deprecated */
+        toElement: undefined;
+
+        // PointerEvent
+
+        pointerId: undefined;
+        pointerType: undefined;
+
+        // KeyboardEvent
+
+        /** @deprecated */
+        char: undefined;
+        /** @deprecated */
+        charCode: undefined;
+        key: undefined;
+        /** @deprecated */
+        keyCode: undefined;
+
+        // TouchEvent
+
+        changedTouches: undefined;
+        targetTouches: undefined;
+        touches: undefined;
+
+        // MouseEvent, KeyboardEvent
+
+        /**
+         * For key or mouse events, this property indicates the specific key or button that was pressed.
+         * @see \`{@link https://api.jquery.com/event.which/ }\`
+         * @since 1.1.3
+         * @deprecated ​ Deprecated since 3.3. See \`{@link https://github.com/jquery/api.jquery.com/issues/821 }\`.
+         * @example ​ ````Log which key was depressed.
+```html
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>event.which demo</title>
+  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
+</head>
+<body>
+​
+<input id="whichkey" value="type something">
+<div id="log"></div>
+​
+<script>
+$( "#whichkey" ).on( "keydown", function( event ) {
+  $( "#log" ).html( event.type + ": " +  event.which );
+});
+</script>
+​
+</body>
+</html>
+```
+         * @example ​ ````Log which mouse button was depressed.
+```html
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>event.which demo</title>
+  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
+</head>
+<body>
+​
+<input id="whichkey" value="click here">
+<div id="log"></div>
+​
+<script>
+$( "#whichkey" ).on( "mousedown", function( event ) {
+  $( "#log" ).html( event.type + ": " +  event.which );
+});
+</script>
+​
+</body>
+</html>
+```
+         */
+        which: undefined;
+
+        // MouseEvent, KeyboardEvent, TouchEvent
+
+        altKey: undefined;
+        ctrlKey: undefined;
+        /**
+         * Indicates whether the META key was pressed when the event fired.
+         * @see \`{@link https://api.jquery.com/event.metaKey/ }\`
+         * @since 1.0.4
+         * @example ​ ````Determine whether the META key was pressed when the event fired.
+```html
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>event.metaKey demo</title>
+  <style>
+  body {
+    background-color: #eef;
+  }
+  div {
+    padding: 20px;
+  }
+  </style>
+  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
+</head>
+<body>
+​
+<button value="Test" name="Test" id="checkMetaKey">Click me!</button>
+<div id="display"></div>
+​
+<script>
+$( "#checkMetaKey" ).click(function( event ) {
+  $( "#display" ).text( event.metaKey );
+});
+</script>
+​
+</body>
+</html>
+```
+         */
+        metaKey: undefined;
+        shiftKey: undefined;
+
+        originalEvent?: _Event;
+    }
+
+    interface ChangeEvent<
+        TDelegateTarget = any,
+        TData = any,
+        TCurrentTarget = any,
+        TTarget = any
+    > extends EventBase<TDelegateTarget, TData, TCurrentTarget, TTarget> {
+        type: 'change';
+    }
+
+    interface ResizeEvent<
+        TDelegateTarget = any,
+        TData = any,
+        TCurrentTarget = any,
+        TTarget = any
+    > extends EventBase<TDelegateTarget, TData, TCurrentTarget, TTarget> {
+        type: 'resize';
+    }
+
+    interface ScrollEvent<
+        TDelegateTarget = any,
+        TData = any,
+        TCurrentTarget = any,
+        TTarget = any
+    > extends EventBase<TDelegateTarget, TData, TCurrentTarget, TTarget> {
+        type: 'scroll';
+    }
+
+    interface SelectEvent<
+        TDelegateTarget = any,
+        TData = any,
+        TCurrentTarget = any,
+        TTarget = any
+    > extends EventBase<TDelegateTarget, TData, TCurrentTarget, TTarget> {
+        type: 'select';
+    }
+
+    interface SubmitEvent<
+        TDelegateTarget = any,
+        TData = any,
+        TCurrentTarget = any,
+        TTarget = any
+    > extends EventBase<TDelegateTarget, TData, TCurrentTarget, TTarget> {
+        type: 'submit';
+    }
+
+    // #endregion
+
+    // region UIEvent
+    // #region UIEvent
+
+    interface UIEventBase<
+        TDelegateTarget = any,
+        TData = any,
+        TCurrentTarget = any,
+        TTarget = any
+    > extends TriggeredEvent<TDelegateTarget, TData, TCurrentTarget, TTarget> {
+        // Event
+
+        bubbles: boolean;
+        cancelable: boolean;
+        eventPhase: number;
+
+        // UIEvent
+
+        detail: number;
+        view: Window;
+
+        originalEvent?: _UIEvent;
+    }
+
+    // region MouseEvent
+    // #region MouseEvent
+
+    interface MouseEventBase<
+        TDelegateTarget = any,
+        TData = any,
+        TCurrentTarget = any,
+        TTarget = any
+    > extends UIEventBase<TDelegateTarget, TData, TCurrentTarget, TTarget> {
+        /**
+         * The other DOM element involved in the event, if any.
+         * @see \`{@link https://api.jquery.com/event.relatedTarget/ }\`
+         * @since 1.1.4
+         * @example ​ ````On mouseout of anchors, alert the element type being entered.
+```javascript
+$( "a" ).mouseout(function( event ) {
+  alert( event.relatedTarget.nodeName ); // "DIV"
+});
+```
+        */
+        relatedTarget?: EventTarget | null;
+
+        // MouseEvent
+
+        button: number;
+        buttons: number;
+        clientX: number;
+        clientY: number;
+        offsetX: number;
+        offsetY: number;
+        /**
+         * The mouse position relative to the left edge of the document.
+         * @see \`{@link https://api.jquery.com/event.pageX/ }\`
+         * @since 1.0.4
+         * @example ​ ````Show the mouse position relative to the left and top edges of the document (within this iframe).
+```html
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>event.pageX demo</title>
+  <style>
+  body {
+    background-color: #eef;
+  }
+  div {
+    padding: 20px;
+  }
+  </style>
+  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
+</head>
+<body>
+​
+<div id="log"></div>
+​
+<script>
+$( document ).on( "mousemove", function( event ) {
+  $( "#log" ).text( "pageX: " + event.pageX + ", pageY: " + event.pageY );
+});
+</script>
+​
+</body>
+</html>
+```
+         */
+        pageX: number;
+        /**
+         * The mouse position relative to the top edge of the document.
+         * @see \`{@link https://api.jquery.com/event.pageY/ }\`
+         * @since 1.0.4
+         * @example ​ ````Show the mouse position relative to the left and top edges of the document (within this iframe).
+```html
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>event.pageY demo</title>
+  <style>
+  body {
+    background-color: #eef;
+  }
+  div {
+    padding: 20px;
+  }
+  </style>
+  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
+</head>
+<body>
+​
+<div id="log"></div>
+​
+<script>
+$( document ).on( "mousemove", function( event ) {
+  $( "#log" ).text( "pageX: " + event.pageX + ", pageY: " + event.pageY );
+});
+</script>
+​
+</body>
+</html>
+```
+         */
+        pageY: number;
+        screenX: number;
+        screenY: number;
+        /** @deprecated */
+        toElement: Element;
+
+        // PointerEvent
+
+        pointerId: undefined;
+        pointerType: undefined;
+
+        // KeyboardEvent
+
+        /** @deprecated */
+        char: undefined;
+        /** @deprecated */
+        charCode: undefined;
+        key: undefined;
+        /** @deprecated */
+        keyCode: undefined;
+
+        // TouchEvent
+
+        changedTouches: undefined;
+        targetTouches: undefined;
+        touches: undefined;
+
+        // MouseEvent, KeyboardEvent
+
+        /**
+         * For key or mouse events, this property indicates the specific key or button that was pressed.
+         * @see \`{@link https://api.jquery.com/event.which/ }\`
+         * @since 1.1.3
+         * @deprecated ​ Deprecated since 3.3. See \`{@link https://github.com/jquery/api.jquery.com/issues/821 }\`.
+         * @example ​ ````Log which key was depressed.
+```html
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>event.which demo</title>
+  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
+</head>
+<body>
+​
+<input id="whichkey" value="type something">
+<div id="log"></div>
+​
+<script>
+$( "#whichkey" ).on( "keydown", function( event ) {
+  $( "#log" ).html( event.type + ": " +  event.which );
+});
+</script>
+​
+</body>
+</html>
+```
+         * @example ​ ````Log which mouse button was depressed.
+```html
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>event.which demo</title>
+  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
+</head>
+<body>
+​
+<input id="whichkey" value="click here">
+<div id="log"></div>
+​
+<script>
+$( "#whichkey" ).on( "mousedown", function( event ) {
+  $( "#log" ).html( event.type + ": " +  event.which );
+});
+</script>
+​
+</body>
+</html>
+```
+         */
+        which: number;
+
+        // MouseEvent, KeyboardEvent, TouchEvent
+
+        altKey: boolean;
+        ctrlKey: boolean;
+        /**
+         * Indicates whether the META key was pressed when the event fired.
+         * @see \`{@link https://api.jquery.com/event.metaKey/ }\`
+         * @since 1.0.4
+         * @example ​ ````Determine whether the META key was pressed when the event fired.
+```html
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>event.metaKey demo</title>
+  <style>
+  body {
+    background-color: #eef;
+  }
+  div {
+    padding: 20px;
+  }
+  </style>
+  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
+</head>
+<body>
+​
+<button value="Test" name="Test" id="checkMetaKey">Click me!</button>
+<div id="display"></div>
+​
+<script>
+$( "#checkMetaKey" ).click(function( event ) {
+  $( "#display" ).text( event.metaKey );
+});
+</script>
+​
+</body>
+</html>
+```
+         */
+        metaKey: boolean;
+        shiftKey: boolean;
+
+        originalEvent?: _MouseEvent;
+    }
+
+    interface ClickEvent<
+        TDelegateTarget = any,
+        TData = any,
+        TCurrentTarget = any,
+        TTarget = any
+    > extends MouseEventBase<TDelegateTarget, TData, TCurrentTarget, TTarget> {
+        /**
+         * The other DOM element involved in the event, if any.
+         * @see \`{@link https://api.jquery.com/event.relatedTarget/ }\`
+         * @since 1.1.4
+         * @example ​ ````On mouseout of anchors, alert the element type being entered.
+ ```javascript
+ $( "a" ).mouseout(function( event ) {
+  alert( event.relatedTarget.nodeName ); // "DIV"
+ });
+ ```
+        */
+        relatedTarget?: null;
+
+        type: 'click';
+    }
+
+    interface ContextMenuEvent<
+        TDelegateTarget = any,
+        TData = any,
+        TCurrentTarget = any,
+        TTarget = any
+    > extends MouseEventBase<TDelegateTarget, TData, TCurrentTarget, TTarget> {
+        /**
+         * The other DOM element involved in the event, if any.
+         * @see \`{@link https://api.jquery.com/event.relatedTarget/ }\`
+         * @since 1.1.4
+         * @example ​ ````On mouseout of anchors, alert the element type being entered.
+ ```javascript
+ $( "a" ).mouseout(function( event ) {
+  alert( event.relatedTarget.nodeName ); // "DIV"
+ });
+ ```
+        */
+        relatedTarget?: null;
+
+        type: 'contextmenu';
+    }
+
+    interface DoubleClickEvent<
+        TDelegateTarget = any,
+        TData = any,
+        TCurrentTarget = any,
+        TTarget = any
+    > extends MouseEventBase<TDelegateTarget, TData, TCurrentTarget, TTarget> {
+        /**
+         * The other DOM element involved in the event, if any.
+         * @see \`{@link https://api.jquery.com/event.relatedTarget/ }\`
+         * @since 1.1.4
+         * @example ​ ````On mouseout of anchors, alert the element type being entered.
+ ```javascript
+ $( "a" ).mouseout(function( event ) {
+  alert( event.relatedTarget.nodeName ); // "DIV"
+ });
+ ```
+        */
+        relatedTarget?: null;
+
+        type: 'dblclick';
+    }
+
+    interface MouseDownEvent<
+        TDelegateTarget = any,
+        TData = any,
+        TCurrentTarget = any,
+        TTarget = any
+    > extends MouseEventBase<TDelegateTarget, TData, TCurrentTarget, TTarget> {
+        /**
+         * The other DOM element involved in the event, if any.
+         * @see \`{@link https://api.jquery.com/event.relatedTarget/ }\`
+         * @since 1.1.4
+         * @example ​ ````On mouseout of anchors, alert the element type being entered.
+ ```javascript
+ $( "a" ).mouseout(function( event ) {
+  alert( event.relatedTarget.nodeName ); // "DIV"
+ });
+ ```
+        */
+        relatedTarget?: null;
+
+        type: 'mousedown';
+    }
+
+    interface MouseEnterEvent<
+        TDelegateTarget = any,
+        TData = any,
+        TCurrentTarget = any,
+        TTarget = any
+    > extends MouseEventBase<TDelegateTarget, TData, TCurrentTarget, TTarget> {
+        // Special handling by jQuery.
+        type: 'mouseover';
+    }
+
+    interface MouseLeaveEvent<
+        TDelegateTarget = any,
+        TData = any,
+        TCurrentTarget = any,
+        TTarget = any
+    > extends MouseEventBase<TDelegateTarget, TData, TCurrentTarget, TTarget> {
+        // Special handling by jQuery.
+        type: 'mouseout';
+    }
+
+    interface MouseMoveEvent<
+        TDelegateTarget = any,
+        TData = any,
+        TCurrentTarget = any,
+        TTarget = any
+    > extends MouseEventBase<TDelegateTarget, TData, TCurrentTarget, TTarget> {
+        /**
+         * The other DOM element involved in the event, if any.
+         * @see \`{@link https://api.jquery.com/event.relatedTarget/ }\`
+         * @since 1.1.4
+         * @example ​ ````On mouseout of anchors, alert the element type being entered.
+ ```javascript
+ $( "a" ).mouseout(function( event ) {
+  alert( event.relatedTarget.nodeName ); // "DIV"
+ });
+ ```
+        */
+        relatedTarget?: null;
+
+        type: 'mousemove';
+    }
+
+    interface MouseOutEvent<
+        TDelegateTarget = any,
+        TData = any,
+        TCurrentTarget = any,
+        TTarget = any
+    > extends MouseEventBase<TDelegateTarget, TData, TCurrentTarget, TTarget> {
+        type: 'mouseout';
+    }
+
+    interface MouseOverEvent<
+        TDelegateTarget = any,
+        TData = any,
+        TCurrentTarget = any,
+        TTarget = any
+    > extends MouseEventBase<TDelegateTarget, TData, TCurrentTarget, TTarget> {
+        type: 'mouseover';
+    }
+
+    interface MouseUpEvent<
+        TDelegateTarget = any,
+        TData = any,
+        TCurrentTarget = any,
+        TTarget = any
+    > extends MouseEventBase<TDelegateTarget, TData, TCurrentTarget, TTarget> {
+        /**
+         * The other DOM element involved in the event, if any.
+         * @see \`{@link https://api.jquery.com/event.relatedTarget/ }\`
+         * @since 1.1.4
+         * @example ​ ````On mouseout of anchors, alert the element type being entered.
+ ```javascript
+ $( "a" ).mouseout(function( event ) {
+  alert( event.relatedTarget.nodeName ); // "DIV"
+ });
+ ```
+        */
+        relatedTarget?: null;
+
+        type: 'mouseup';
+    }
+
+    // #endregion
+
+    // region KeyboardEvent
+    // #region KeyboardEvent
+
+    interface KeyboardEventBase<
+        TDelegateTarget = any,
+        TData = any,
+        TCurrentTarget = any,
+        TTarget = any
+    > extends UIEventBase<TDelegateTarget, TData, TCurrentTarget, TTarget> {
+        /**
+         * The other DOM element involved in the event, if any.
+         * @see \`{@link https://api.jquery.com/event.relatedTarget/ }\`
+         * @since 1.1.4
+         * @example ​ ````On mouseout of anchors, alert the element type being entered.
+```javascript
+$( "a" ).mouseout(function( event ) {
+  alert( event.relatedTarget.nodeName ); // "DIV"
+});
+```
+        */
+        relatedTarget?: undefined;
+
+        // MouseEvent
+
+        button: undefined;
+        buttons: undefined;
+        clientX: undefined;
+        clientY: undefined;
+        offsetX: undefined;
+        offsetY: undefined;
+        /**
+         * The mouse position relative to the left edge of the document.
+         * @see \`{@link https://api.jquery.com/event.pageX/ }\`
+         * @since 1.0.4
+         * @example ​ ````Show the mouse position relative to the left and top edges of the document (within this iframe).
+```html
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>event.pageX demo</title>
+  <style>
+  body {
+    background-color: #eef;
+  }
+  div {
+    padding: 20px;
+  }
+  </style>
+  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
+</head>
+<body>
+​
+<div id="log"></div>
+​
+<script>
+$( document ).on( "mousemove", function( event ) {
+  $( "#log" ).text( "pageX: " + event.pageX + ", pageY: " + event.pageY );
+});
+</script>
+​
+</body>
+</html>
+```
+         */
+        pageX: undefined;
+        /**
+         * The mouse position relative to the top edge of the document.
+         * @see \`{@link https://api.jquery.com/event.pageY/ }\`
+         * @since 1.0.4
+         * @example ​ ````Show the mouse position relative to the left and top edges of the document (within this iframe).
+```html
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>event.pageY demo</title>
+  <style>
+  body {
+    background-color: #eef;
+  }
+  div {
+    padding: 20px;
+  }
+  </style>
+  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
+</head>
+<body>
+​
+<div id="log"></div>
+​
+<script>
+$( document ).on( "mousemove", function( event ) {
+  $( "#log" ).text( "pageX: " + event.pageX + ", pageY: " + event.pageY );
+});
+</script>
+​
+</body>
+</html>
+```
+         */
+        pageY: undefined;
+        screenX: undefined;
+        screenY: undefined;
+        /** @deprecated */
+        toElement: undefined;
+
+        // PointerEvent
+
+        pointerId: undefined;
+        pointerType: undefined;
+
+        // KeyboardEvent
+
+        /** @deprecated */
+        char: string | undefined;
+        /** @deprecated */
+        charCode: number;
+        key: string;
+        /** @deprecated */
+        keyCode: number;
+
+        // TouchEvent
+
+        changedTouches: undefined;
+        targetTouches: undefined;
+        touches: undefined;
+
+        // MouseEvent, KeyboardEvent
+
+        /**
+         * For key or mouse events, this property indicates the specific key or button that was pressed.
+         * @see \`{@link https://api.jquery.com/event.which/ }\`
+         * @since 1.1.3
+         * @deprecated ​ Deprecated since 3.3. See \`{@link https://github.com/jquery/api.jquery.com/issues/821 }\`.
+         * @example ​ ````Log which key was depressed.
+```html
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>event.which demo</title>
+  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
+</head>
+<body>
+​
+<input id="whichkey" value="type something">
+<div id="log"></div>
+​
+<script>
+$( "#whichkey" ).on( "keydown", function( event ) {
+  $( "#log" ).html( event.type + ": " +  event.which );
+});
+</script>
+​
+</body>
+</html>
+```
+         * @example ​ ````Log which mouse button was depressed.
+```html
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>event.which demo</title>
+  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
+</head>
+<body>
+​
+<input id="whichkey" value="click here">
+<div id="log"></div>
+​
+<script>
+$( "#whichkey" ).on( "mousedown", function( event ) {
+  $( "#log" ).html( event.type + ": " +  event.which );
+});
+</script>
+​
+</body>
+</html>
+```
+         */
+        which: number;
+
+        // MouseEvent, KeyboardEvent, TouchEvent
+
+        altKey: boolean;
+        ctrlKey: boolean;
+        /**
+         * Indicates whether the META key was pressed when the event fired.
+         * @see \`{@link https://api.jquery.com/event.metaKey/ }\`
+         * @since 1.0.4
+         * @example ​ ````Determine whether the META key was pressed when the event fired.
+```html
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>event.metaKey demo</title>
+  <style>
+  body {
+    background-color: #eef;
+  }
+  div {
+    padding: 20px;
+  }
+  </style>
+  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
+</head>
+<body>
+​
+<button value="Test" name="Test" id="checkMetaKey">Click me!</button>
+<div id="display"></div>
+​
+<script>
+$( "#checkMetaKey" ).click(function( event ) {
+  $( "#display" ).text( event.metaKey );
+});
+</script>
+​
+</body>
+</html>
+```
+         */
+        metaKey: boolean;
+        shiftKey: boolean;
+
+        originalEvent?: _KeyboardEvent;
+    }
+
+    interface KeyDownEvent<
+        TDelegateTarget = any,
+        TData = any,
+        TCurrentTarget = any,
+        TTarget = any
+    > extends KeyboardEventBase<TDelegateTarget, TData, TCurrentTarget, TTarget> {
+        type: 'keydown';
+    }
+
+    interface KeyPressEvent<
+        TDelegateTarget = any,
+        TData = any,
+        TCurrentTarget = any,
+        TTarget = any
+    > extends KeyboardEventBase<TDelegateTarget, TData, TCurrentTarget, TTarget> {
+        type: 'keypress';
+    }
+
+    interface KeyUpEvent<
+        TDelegateTarget = any,
+        TData = any,
+        TCurrentTarget = any,
+        TTarget = any
+    > extends KeyboardEventBase<TDelegateTarget, TData, TCurrentTarget, TTarget> {
+        type: 'keyup';
+    }
+
+    // #endregion
+
+    // region FocusEvent
+    // #region FocusEvent
+
+    interface FocusEventBase<
+        TDelegateTarget = any,
+        TData = any,
+        TCurrentTarget = any,
+        TTarget = any
+    > extends UIEventBase<TDelegateTarget, TData, TCurrentTarget, TTarget> {
+        /**
+         * The other DOM element involved in the event, if any.
+         * @see \`{@link https://api.jquery.com/event.relatedTarget/ }\`
+         * @since 1.1.4
+         * @example ​ ````On mouseout of anchors, alert the element type being entered.
+```javascript
+$( "a" ).mouseout(function( event ) {
+  alert( event.relatedTarget.nodeName ); // "DIV"
+});
+```
+        */
+        relatedTarget?: EventTarget | null;
+
+        // MouseEvent
+
+        button: undefined;
+        buttons: undefined;
+        clientX: undefined;
+        clientY: undefined;
+        offsetX: undefined;
+        offsetY: undefined;
+        /**
+         * The mouse position relative to the left edge of the document.
+         * @see \`{@link https://api.jquery.com/event.pageX/ }\`
+         * @since 1.0.4
+         * @example ​ ````Show the mouse position relative to the left and top edges of the document (within this iframe).
+```html
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>event.pageX demo</title>
+  <style>
+  body {
+    background-color: #eef;
+  }
+  div {
+    padding: 20px;
+  }
+  </style>
+  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
+</head>
+<body>
+​
+<div id="log"></div>
+​
+<script>
+$( document ).on( "mousemove", function( event ) {
+  $( "#log" ).text( "pageX: " + event.pageX + ", pageY: " + event.pageY );
+});
+</script>
+​
+</body>
+</html>
+```
+         */
+        pageX: undefined;
+        /**
+         * The mouse position relative to the top edge of the document.
+         * @see \`{@link https://api.jquery.com/event.pageY/ }\`
+         * @since 1.0.4
+         * @example ​ ````Show the mouse position relative to the left and top edges of the document (within this iframe).
+```html
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>event.pageY demo</title>
+  <style>
+  body {
+    background-color: #eef;
+  }
+  div {
+    padding: 20px;
+  }
+  </style>
+  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
+</head>
+<body>
+​
+<div id="log"></div>
+​
+<script>
+$( document ).on( "mousemove", function( event ) {
+  $( "#log" ).text( "pageX: " + event.pageX + ", pageY: " + event.pageY );
+});
+</script>
+​
+</body>
+</html>
+```
+         */
+        pageY: undefined;
+        screenX: undefined;
+        screenY: undefined;
+        /** @deprecated */
+        toElement: undefined;
+
+        // PointerEvent
+
+        pointerId: undefined;
+        pointerType: undefined;
+
+        // KeyboardEvent
+
+        /** @deprecated */
+        char: undefined;
+        /** @deprecated */
+        charCode: undefined;
+        key: undefined;
+        /** @deprecated */
+        keyCode: undefined;
+
+        // TouchEvent
+
+        changedTouches: undefined;
+        targetTouches: undefined;
+        touches: undefined;
+
+        // MouseEvent, KeyboardEvent
+
+        /**
+         * For key or mouse events, this property indicates the specific key or button that was pressed.
+         * @see \`{@link https://api.jquery.com/event.which/ }\`
+         * @since 1.1.3
+         * @deprecated ​ Deprecated since 3.3. See \`{@link https://github.com/jquery/api.jquery.com/issues/821 }\`.
+         * @example ​ ````Log which key was depressed.
+```html
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>event.which demo</title>
+  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
+</head>
+<body>
+​
+<input id="whichkey" value="type something">
+<div id="log"></div>
+​
+<script>
+$( "#whichkey" ).on( "keydown", function( event ) {
+  $( "#log" ).html( event.type + ": " +  event.which );
+});
+</script>
+​
+</body>
+</html>
+```
+         * @example ​ ````Log which mouse button was depressed.
+```html
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>event.which demo</title>
+  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
+</head>
+<body>
+​
+<input id="whichkey" value="click here">
+<div id="log"></div>
+​
+<script>
+$( "#whichkey" ).on( "mousedown", function( event ) {
+  $( "#log" ).html( event.type + ": " +  event.which );
+});
+</script>
+​
+</body>
+</html>
+```
+         */
+        which: undefined;
+
+        // MouseEvent, KeyboardEvent, TouchEvent
+
+        altKey: undefined;
+        ctrlKey: undefined;
+        /**
+         * Indicates whether the META key was pressed when the event fired.
+         * @see \`{@link https://api.jquery.com/event.metaKey/ }\`
+         * @since 1.0.4
+         * @example ​ ````Determine whether the META key was pressed when the event fired.
+```html
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>event.metaKey demo</title>
+  <style>
+  body {
+    background-color: #eef;
+  }
+  div {
+    padding: 20px;
+  }
+  </style>
+  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
+</head>
+<body>
+​
+<button value="Test" name="Test" id="checkMetaKey">Click me!</button>
+<div id="display"></div>
+​
+<script>
+$( "#checkMetaKey" ).click(function( event ) {
+  $( "#display" ).text( event.metaKey );
+});
+</script>
+​
+</body>
+</html>
+```
+         */
+        metaKey: undefined;
+        shiftKey: undefined;
+
+        originalEvent?: _FocusEvent;
+    }
+
+    interface BlurEvent<
+        TDelegateTarget = any,
+        TData = any,
+        TCurrentTarget = any,
+        TTarget = any
+    > extends FocusEventBase<TDelegateTarget, TData, TCurrentTarget, TTarget> {
+        type: 'blur';
+    }
+
+    interface FocusEvent<
+        TDelegateTarget = any,
+        TData = any,
+        TCurrentTarget = any,
+        TTarget = any
+    > extends FocusEventBase<TDelegateTarget, TData, TCurrentTarget, TTarget> {
+        type: 'focus';
+    }
+
+    interface FocusInEvent<
+        TDelegateTarget = any,
+        TData = any,
+        TCurrentTarget = any,
+        TTarget = any
+    > extends FocusEventBase<TDelegateTarget, TData, TCurrentTarget, TTarget> {
+        type: 'focusin';
+    }
+
+    interface FocusOutEvent<
+        TDelegateTarget = any,
+        TData = any,
+        TCurrentTarget = any,
+        TTarget = any
+    > extends FocusEventBase<TDelegateTarget, TData, TCurrentTarget, TTarget> {
+        type: 'focusout';
+    }
+
+    // #endregion
+
+    // #endregion
+
     interface TypeToTriggeredEventMap<
         TDelegateTarget,
         TData,
         TCurrentTarget,
         TTarget
     > {
+        // Event
+
+        change: ChangeEvent<TDelegateTarget, TData, TCurrentTarget, TTarget>;
+        resize: ResizeEvent<TDelegateTarget, TData, TCurrentTarget, TTarget>;
+        scroll: ScrollEvent<TDelegateTarget, TData, TCurrentTarget, TTarget>;
+        select: SelectEvent<TDelegateTarget, TData, TCurrentTarget, TTarget>;
+        submit: SubmitEvent<TDelegateTarget, TData, TCurrentTarget, TTarget>;
+
+        // UIEvent
+
+        // MouseEvent
+
+        click: ClickEvent<TDelegateTarget, TData, TCurrentTarget, TTarget>;
+        contextmenu: ContextMenuEvent<TDelegateTarget, TData, TCurrentTarget, TTarget>;
+        dblclick: DoubleClickEvent<TDelegateTarget, TData, TCurrentTarget, TTarget>;
+        mousedown: MouseDownEvent<TDelegateTarget, TData, TCurrentTarget, TTarget>;
+        mouseenter: MouseEnterEvent<TDelegateTarget, TData, TCurrentTarget, TTarget>;
+        mouseleave: MouseLeaveEvent<TDelegateTarget, TData, TCurrentTarget, TTarget>;
+        mousemove: MouseMoveEvent<TDelegateTarget, TData, TCurrentTarget, TTarget>;
+        mouseout: MouseOutEvent<TDelegateTarget, TData, TCurrentTarget, TTarget>;
+        mouseover: MouseOverEvent<TDelegateTarget, TData, TCurrentTarget, TTarget>;
+        mouseup: MouseUpEvent<TDelegateTarget, TData, TCurrentTarget, TTarget>;
+
+        // KeyboardEvent
+
+        keydown: KeyDownEvent<TDelegateTarget, TData, TCurrentTarget, TTarget>;
+        keypress: KeyPressEvent<TDelegateTarget, TData, TCurrentTarget, TTarget>;
+        keyup: KeyUpEvent<TDelegateTarget, TData, TCurrentTarget, TTarget>;
+
+        // FocusEvent
+
+        blur: BlurEvent<TDelegateTarget, TData, TCurrentTarget, TTarget>;
+        focus: FocusEvent<TDelegateTarget, TData, TCurrentTarget, TTarget>;
+        focusin: FocusInEvent<TDelegateTarget, TData, TCurrentTarget, TTarget>;
+        focusout: FocusOutEvent<TDelegateTarget, TData, TCurrentTarget, TTarget>;
+
         [type: string]: TriggeredEvent<TDelegateTarget, TData, TCurrentTarget, TTarget>;
     }
 
@@ -4985,6 +6263,10 @@ declare const jQuery: JQueryStatic;
 declare const $: JQueryStatic;
 
 type _Event = Event;
+type _UIEvent = UIEvent;
+type _MouseEvent = MouseEvent;
+type _KeyboardEvent = KeyboardEvent;
+type _FocusEvent = FocusEvent;
 
 // region ES5 compatibility
 // #region ES5 compatibility

--- a/types/jquery/misc.d.ts
+++ b/types/jquery/misc.d.ts
@@ -5716,6 +5716,269 @@ $( "#checkMetaKey" ).click(function( event ) {
 
     // #endregion
 
+    // region TouchEvent
+    // #region TouchEvent
+
+    interface TouchEventBase<
+        TDelegateTarget = any,
+        TData = any,
+        TCurrentTarget = any
+    > extends UIEventBase<TDelegateTarget, TData, TCurrentTarget> {
+        /**
+         * The other DOM element involved in the event, if any.
+         * @see \`{@link https://api.jquery.com/event.relatedTarget/ }\`
+         * @since 1.1.4
+         * @example ​ ````On mouseout of anchors, alert the element type being entered.
+```javascript
+$( "a" ).mouseout(function( event ) {
+  alert( event.relatedTarget.nodeName ); // "DIV"
+});
+```
+        */
+        relatedTarget?: undefined;
+
+        // MouseEvent
+
+        button: undefined;
+        buttons: undefined;
+        clientX: undefined;
+        clientY: undefined;
+        offsetX: undefined;
+        offsetY: undefined;
+        /**
+         * The mouse position relative to the left edge of the document.
+         * @see \`{@link https://api.jquery.com/event.pageX/ }\`
+         * @since 1.0.4
+         * @example ​ ````Show the mouse position relative to the left and top edges of the document (within this iframe).
+```html
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>event.pageX demo</title>
+  <style>
+  body {
+    background-color: #eef;
+  }
+  div {
+    padding: 20px;
+  }
+  </style>
+  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
+</head>
+<body>
+​
+<div id="log"></div>
+​
+<script>
+$( document ).on( "mousemove", function( event ) {
+  $( "#log" ).text( "pageX: " + event.pageX + ", pageY: " + event.pageY );
+});
+</script>
+​
+</body>
+</html>
+```
+         */
+        pageX: undefined;
+        /**
+         * The mouse position relative to the top edge of the document.
+         * @see \`{@link https://api.jquery.com/event.pageY/ }\`
+         * @since 1.0.4
+         * @example ​ ````Show the mouse position relative to the left and top edges of the document (within this iframe).
+```html
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>event.pageY demo</title>
+  <style>
+  body {
+    background-color: #eef;
+  }
+  div {
+    padding: 20px;
+  }
+  </style>
+  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
+</head>
+<body>
+​
+<div id="log"></div>
+​
+<script>
+$( document ).on( "mousemove", function( event ) {
+  $( "#log" ).text( "pageX: " + event.pageX + ", pageY: " + event.pageY );
+});
+</script>
+​
+</body>
+</html>
+```
+         */
+        pageY: undefined;
+        screenX: undefined;
+        screenY: undefined;
+        /** @deprecated */
+        toElement: undefined;
+
+        // PointerEvent
+
+        pointerId: undefined;
+        pointerType: undefined;
+
+        // KeyboardEvent
+
+        /** @deprecated */
+        char: undefined;
+        /** @deprecated */
+        charCode: undefined;
+        key: undefined;
+        /** @deprecated */
+        keyCode: undefined;
+
+        // TouchEvent
+
+        changedTouches: TouchList;
+        targetTouches: TouchList;
+        touches: TouchList;
+
+        // MouseEvent, KeyboardEvent
+
+        /**
+         * For key or mouse events, this property indicates the specific key or button that was pressed.
+         * @see \`{@link https://api.jquery.com/event.which/ }\`
+         * @since 1.1.3
+         * @deprecated ​ Deprecated since 3.3. See \`{@link https://github.com/jquery/api.jquery.com/issues/821 }\`.
+         * @example ​ ````Log which key was depressed.
+```html
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>event.which demo</title>
+  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
+</head>
+<body>
+​
+<input id="whichkey" value="type something">
+<div id="log"></div>
+​
+<script>
+$( "#whichkey" ).on( "keydown", function( event ) {
+  $( "#log" ).html( event.type + ": " +  event.which );
+});
+</script>
+​
+</body>
+</html>
+```
+         * @example ​ ````Log which mouse button was depressed.
+```html
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>event.which demo</title>
+  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
+</head>
+<body>
+​
+<input id="whichkey" value="click here">
+<div id="log"></div>
+​
+<script>
+$( "#whichkey" ).on( "mousedown", function( event ) {
+  $( "#log" ).html( event.type + ": " +  event.which );
+});
+</script>
+​
+</body>
+</html>
+```
+         */
+        which: undefined;
+
+        // MouseEvent, KeyboardEvent, TouchEvent
+
+        altKey: boolean;
+        ctrlKey: boolean;
+        /**
+         * Indicates whether the META key was pressed when the event fired.
+         * @see \`{@link https://api.jquery.com/event.metaKey/ }\`
+         * @since 1.0.4
+         * @example ​ ````Determine whether the META key was pressed when the event fired.
+```html
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>event.metaKey demo</title>
+  <style>
+  body {
+    background-color: #eef;
+  }
+  div {
+    padding: 20px;
+  }
+  </style>
+  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
+</head>
+<body>
+​
+<button value="Test" name="Test" id="checkMetaKey">Click me!</button>
+<div id="display"></div>
+​
+<script>
+$( "#checkMetaKey" ).click(function( event ) {
+  $( "#display" ).text( event.metaKey );
+});
+</script>
+​
+</body>
+</html>
+```
+         */
+        metaKey: boolean;
+        shiftKey: boolean;
+
+        originalEvent?: _TouchEvent;
+    }
+
+    interface TouchCancelEvent<
+        TDelegateTarget = any,
+        TData = any,
+        TCurrentTarget = any
+    > extends TouchEventBase<TDelegateTarget, TData, TCurrentTarget> {
+        type: 'touchcancel';
+    }
+
+    interface TouchEndEvent<
+        TDelegateTarget = any,
+        TData = any,
+        TCurrentTarget = any
+    > extends TouchEventBase<TDelegateTarget, TData, TCurrentTarget> {
+        type: 'touchend';
+    }
+
+    interface TouchMoveEvent<
+        TDelegateTarget = any,
+        TData = any,
+        TCurrentTarget = any
+    > extends TouchEventBase<TDelegateTarget, TData, TCurrentTarget> {
+        type: 'touchmove';
+    }
+
+    interface TouchStartEvent<
+        TDelegateTarget = any,
+        TData = any,
+        TCurrentTarget = any
+    > extends TouchEventBase<TDelegateTarget, TData, TCurrentTarget> {
+        type: 'touchstart';
+    }
+
+    // #endregion
+
     // region FocusEvent
     // #region FocusEvent
 
@@ -6021,6 +6284,13 @@ $( "#checkMetaKey" ).click(function( event ) {
         keypress: KeyPressEvent<TDelegateTarget, TData, TCurrentTarget, TTarget>;
         keyup: KeyUpEvent<TDelegateTarget, TData, TCurrentTarget, TTarget>;
 
+        // TouchEvent
+
+        touchcancel: TouchCancelEvent<TDelegateTarget, TData, TCurrentTarget>;
+        touchend: TouchEndEvent<TDelegateTarget, TData, TCurrentTarget>;
+        touchmove: TouchMoveEvent<TDelegateTarget, TData, TCurrentTarget>;
+        touchstart: TouchStartEvent<TDelegateTarget, TData, TCurrentTarget>;
+
         // FocusEvent
 
         blur: BlurEvent<TDelegateTarget, TData, TCurrentTarget, TTarget>;
@@ -6266,6 +6536,7 @@ type _Event = Event;
 type _UIEvent = UIEvent;
 type _MouseEvent = MouseEvent;
 type _KeyboardEvent = KeyboardEvent;
+type _TouchEvent = TouchEvent;
 type _FocusEvent = FocusEvent;
 
 // region ES5 compatibility

--- a/types/jquery/misc.d.ts
+++ b/types/jquery/misc.d.ts
@@ -4735,11 +4735,6 @@ $( "ul" ).click( handler ).find( "ul" ).hide();
          */
         props: string[];
         /**
-         * The `fixHooks` interface provides a per-event-type way to extend or normalize the event object that jQuery creates when it processes a _native_ browser event.
-         * @see \`{@link https://learn.jquery.com/events/event-extensions/#jquery-event-fixhooks-object }\`
-         */
-        fixHooks: FixHooks;
-        /**
          * The jQuery special event hooks are a set of per-event-name functions and properties that allow code to control the behavior of event processing within jQuery. The mechanism is similar to `fixHooks` in that the special event information is stored in `jQuery.event.special.NAME`, where `NAME` is the name of the special event. Event names are case sensitive.
          *
          * As with `fixHooks`, the special event hooks design assumes it will be very rare that two unrelated pieces of code want to process the same event name. Special event authors who need to modify events with existing hooks will need to take precautions to avoid introducing unwanted side-effects by clobbering those hooks.
@@ -4747,75 +4742,6 @@ $( "ul" ).click( handler ).find( "ul" ).hide();
          */
         special: SpecialEventHooks;
     }
-
-    // region Fix hooks
-    // #region Fix hooks
-
-    // Workaround for TypeScript 2.3 which does not have support for weak types handling.
-    type FixHook = {
-        /**
-         * Strings representing properties that should be copied from the browser's event object to the jQuery event object. If omitted, no additional properties are copied beyond the standard ones that jQuery copies and normalizes (e.g. `event.target` and `event.relatedTarget`).
-         */
-        props: string[];
-    } | {
-        /**
-         * jQuery calls this function after it constructs the `jQuery.Event` object, copies standard properties from `jQuery.event.props`, and copies the `fixHooks`-specific props (if any) specified above. The function can create new properties on the event object or modify existing ones. The second argument is the browser's native event object, which is also available in `event.originalEvent`.
-         *
-         * Note that for all events, the browser's native event object is available in `event.originalEvent`; if the jQuery event handler examines the properties there instead of jQuery's normalized `event` object, there is no need to create a `fixHooks` entry to copy or modify the properties.
-         * @example ​ ````For example, to set a hook for the "drop" event that copies the `dataTransfer` property, assign an object to `jQuery.event.fixHooks.drop`:
-```javascript
-jQuery.event.fixHooks.drop = {
-    props: [ "dataTransfer" ]
-};
-```
-
-Since fixHooks is an advanced feature and rarely used externally, jQuery does not include code or
-interfaces to deal with conflict resolution. If there is a chance that some other code may be assigning
-`fixHooks` to the same events, the code should check for an existing hook and take appropriate measures.
-A simple solution might look like this:
-
-```javascript
-if ( jQuery.event.fixHooks.drop ) {
-    throw new Error( "Someone else took the jQuery.event.fixHooks.drop hook!" );
-}
-
-jQuery.event.fixHooks.drop = {
-    props: [ "dataTransfer" ]
-};
-```
-
-When there are known cases of different plugins wanting to attach to the drop hook, this solution might be more appropriate:
-
-```javascript
-var existingHook = jQuery.event.fixHooks.drop;
-
-if ( !existingHook ) {
-    jQuery.event.fixHooks.drop = {
-        props: [ "dataTransfer" ]
-    };
-} else {
-    if ( existingHook.props ) {
-        existingHook.props.push( "dataTransfer" );
-    } else {
-        existingHook.props = [ "dataTransfer" ];
-    }
-}
-```
-         */
-        filter(event: Event, originalEvent: _Event): void;
-    } | {
-        [key: string]: never;
-    };
-
-    /**
-     * The `fixHooks` interface provides a per-event-type way to extend or normalize the event object that jQuery creates when it processes a _native_ browser event.
-     * @see \`{@link https://learn.jquery.com/events/event-extensions/#jquery-event-fixhooks-object }\`
-     */
-    interface FixHooks {
-        [event: string]: FixHook;
-    }
-
-    // #endregion
 
     // region Special event hooks
     // #region Special event hooks

--- a/types/jquery/misc.d.ts
+++ b/types/jquery/misc.d.ts
@@ -6314,20 +6314,18 @@ $( "#checkMetaKey" ).click(function( event ) {
         TData,
         TCurrentTarget,
         TTarget,
-        TContext,
         TType extends keyof TypeToTriggeredEventMap<TDelegateTarget, TData, TCurrentTarget, TTarget>
-    > = EventHandlerBase<TContext, TypeToTriggeredEventMap<TDelegateTarget, TData, TCurrentTarget, TTarget>[TType]>;
+    > = EventHandlerBase<TCurrentTarget, TypeToTriggeredEventMap<TDelegateTarget, TData, TCurrentTarget, TTarget>[TType]>;
 
     interface TypeEventHandlers<
         TDelegateTarget,
         TData,
         TCurrentTarget,
-        TTarget,
-        TContext
-    > extends _TypeEventHandlers<TDelegateTarget, TData, TCurrentTarget, TTarget, TContext> {
+        TTarget
+    > extends _TypeEventHandlers<TDelegateTarget, TData, TCurrentTarget, TTarget> {
         // No idea why it's necessary to include `object` in the union but otherwise TypeScript complains that
         // derived types of Event are not assignable to Event.
-        [type: string]: TypeEventHandler<TDelegateTarget, TData, TCurrentTarget, TTarget, TContext, string> |
+        [type: string]: TypeEventHandler<TDelegateTarget, TData, TCurrentTarget, TTarget, string> |
                         false |
                         undefined |
                         object;
@@ -6337,11 +6335,10 @@ $( "#checkMetaKey" ).click(function( event ) {
         TDelegateTarget,
         TData,
         TCurrentTarget,
-        TTarget,
-        TContext
+        TTarget
     > = {
         [TType in keyof TypeToTriggeredEventMap<TDelegateTarget, TData, TCurrentTarget, TTarget>]?:
-            TypeEventHandler<TDelegateTarget, TData, TCurrentTarget, TTarget, TContext, TType> |
+            TypeEventHandler<TDelegateTarget, TData, TCurrentTarget, TTarget, TType> |
             false |
             object;
     };

--- a/types/jquery/misc.d.ts
+++ b/types/jquery/misc.d.ts
@@ -3981,45 +3981,97 @@ $( "input" ).click(function() {
 
     // This should be a class but doesn't work correctly under the JQuery namespace. Event should be an inner class of jQuery.
 
-    // Static members
+    /**
+     * jQuery's event system normalizes the event object according to W3C standards. The event object is guaranteed to be passed to the event handler (no checks for window.event required). It normalizes the target, relatedTarget, which, metaKey and pageX/Y properties and provides both stopPropagation() and preventDefault() methods.
+     *
+     * Those properties are all documented, and accompanied by examples, on the \`{@link http://api.jquery.com/category/events/event-object/ Event object}\` page.
+     *
+     * The standard events in the Document Object Model are: `blur`, `focus`, `load`, `resize`, `scroll`, `unload`, `beforeunload`, `click`, `dblclick`, `mousedown`, `mouseup`, `mousemove`, `mouseover`, `mouseout`, `mouseenter`, `mouseleave`, `change`, `select`, `submit`, `keydown`, `keypress`, and `keyup`. Since the DOM event names have predefined meanings for some elements, using them for other purposes is not recommended. jQuery's event model can trigger an event by any name on an element, and it is propagated up the DOM tree to which that element belongs, if any.
+     * @see \`{@link https://api.jquery.com/category/events/event-object/ }\`
+     */
     interface EventStatic {
-        // tslint:disable-next-line:no-unnecessary-generics
-        <T extends object, TTarget extends EventTarget = HTMLElement>(event: string, properties?: T): Event<TTarget> & T;
-        // tslint:disable-next-line:no-unnecessary-generics
-        new <T extends object, TTarget extends EventTarget = HTMLElement>(event: string, properties?: T): Event<TTarget> & T;
+        /**
+         * The jQuery.Event constructor is exposed and can be used when calling trigger. The new operator is optional.
+         *
+         * Check \`{@link https://api.jquery.com/trigger/ trigger}\`'s documentation to see how to combine it with your own event object.
+         * @see \`{@link https://api.jquery.com/category/events/event-object/ }\`
+         * @since 1.6
+         * @example
+```javascript
+//Create a new jQuery.Event object without the "new" operator.
+var e = jQuery.Event( "click" );
+​
+// trigger an artificial click event
+jQuery( "body" ).trigger( e );
+```
+         * @example
+```javascript
+// Create a new jQuery.Event object with specified event properties.
+var e = jQuery.Event( "keydown", { keyCode: 64 } );
+​
+// trigger an artificial keydown event with keyCode 64
+jQuery( "body" ).trigger( e );
+```
+         */
+        <T extends object>(event: string, properties?: T): Event & T;
+        /**
+         * The jQuery.Event constructor is exposed and can be used when calling trigger. The new operator is optional.
+         *
+         * Check \`{@link https://api.jquery.com/trigger/ trigger}\`'s documentation to see how to combine it with your own event object.
+         * @see \`{@link https://api.jquery.com/category/events/event-object/ }\`
+         * @since 1.6
+         * @example
+```javascript
+//Create a new jQuery.Event object without the "new" operator.
+var e = jQuery.Event( "click" );
+​
+// trigger an artificial click event
+jQuery( "body" ).trigger( e );
+```
+         * @example
+```javascript
+// Create a new jQuery.Event object with specified event properties.
+var e = jQuery.Event( "keydown", { keyCode: 64 } );
+​
+// trigger an artificial keydown event with keyCode 64
+jQuery( "body" ).trigger( e );
+```
+         */
+        new <T extends object>(event: string, properties?: T): Event & T;
     }
 
-    // Instance members
+    /**
+     * jQuery's event system normalizes the event object according to W3C standards. The event object is guaranteed to be passed to the event handler (no checks for window.event required). It normalizes the target, relatedTarget, which, metaKey and pageX/Y properties and provides both stopPropagation() and preventDefault() methods.
+     *
+     * Those properties are all documented, and accompanied by examples, on the \`{@link http://api.jquery.com/category/events/event-object/ Event object}\` page.
+     *
+     * The standard events in the Document Object Model are: `blur`, `focus`, `load`, `resize`, `scroll`, `unload`, `beforeunload`, `click`, `dblclick`, `mousedown`, `mouseup`, `mousemove`, `mouseover`, `mouseout`, `mouseenter`, `mouseleave`, `change`, `select`, `submit`, `keydown`, `keypress`, and `keyup`. Since the DOM event names have predefined meanings for some elements, using them for other purposes is not recommended. jQuery's event model can trigger an event by any name on an element, and it is propagated up the DOM tree to which that element belongs, if any.
+     * @see \`{@link https://api.jquery.com/category/events/event-object/ }\`
+     * @see \`{@link TriggeredEvent }\`
+     */
     interface Event {
         // region Copied properties
         // #region Copied properties
 
-        // region Event
-        // #region Event
+        // Event
 
-        bubbles?: boolean;
-        cancelable?: boolean;
-        eventPhase?: number;
+        bubbles: boolean | undefined;
+        cancelable: boolean | undefined;
+        eventPhase: number | undefined;
 
-        // #endregion
+        // UIEvent
 
-        // region UIEvent
-        // #region UIEvent
+        detail: number | undefined;
+        view: Window | undefined;
 
-        detail?: number;
-        view?: Window;
+        // MouseEvent
 
-        // #endregion
-
-        // region MouseEvent
-        // #region MouseEvent
-
-        button?: number;
-        buttons?: number;
-        clientX?: number;
-        clientY?: number;
-        offsetX?: number;
-        offsetY?: number;
+        button: number | undefined;
+        buttons: number | undefined;
+        clientX: number | undefined;
+        clientY: number | undefined;
+        offsetX: number | undefined;
+        offsetY: number | undefined;
         /**
          * The mouse position relative to the left edge of the document.
          * @see \`{@link https://api.jquery.com/event.pageX/ }\`
@@ -4055,7 +4107,7 @@ $( document ).on( "mousemove", function( event ) {
 </html>
 ```
          */
-        pageX: number;
+        pageX: number | undefined;
         /**
          * The mouse position relative to the top edge of the document.
          * @see \`{@link https://api.jquery.com/event.pageY/ }\`
@@ -4091,49 +4143,93 @@ $( document ).on( "mousemove", function( event ) {
 </html>
 ```
          */
-        pageY: number;
-        screenX?: number;
-        screenY?: number;
+        pageY: number | undefined;
+        screenX: number | undefined;
+        screenY: number | undefined;
         /** @deprecated */
-        toElement?: Element;
+        toElement: Element | undefined;
 
-        // #endregion
+        // PointerEvent
 
-        // region PointerEvent
-        // #region PointerEvent
+        pointerId: number | undefined;
+        pointerType: string | undefined;
 
-        pointerId?: number;
-        pointerType?: string;
-
-        // #endregion
-
-        // region KeyboardEvent
-        // #region KeyboardEvent
+        // KeyboardEvent
 
         /** @deprecated */
-        char?: string;
+        char: string | undefined;
         /** @deprecated */
-        charCode?: number;
-        key?: string;
+        charCode: number | undefined;
+        key: string | undefined;
         /** @deprecated */
-        keyCode?: number;
+        keyCode: number | undefined;
 
-        // #endregion
+        // TouchEvent
 
-        // region TouchEvent
-        // #region TouchEvent
+        changedTouches: TouchList | undefined;
+        targetTouches: TouchList | undefined;
+        touches: TouchList | undefined;
 
-        changedTouches?: TouchList;
-        targetTouches?: TouchList;
-        touches?: TouchList;
+        // MouseEvent, KeyboardEvent
 
-        // #endregion
+        /**
+         * For key or mouse events, this property indicates the specific key or button that was pressed.
+         * @see \`{@link https://api.jquery.com/event.which/ }\`
+         * @since 1.1.3
+         * @deprecated ​ Deprecated since 3.3. See \`{@link https://github.com/jquery/api.jquery.com/issues/821 }\`.
+         * @example ​ ````Log which key was depressed.
+```html
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>event.which demo</title>
+  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
+</head>
+<body>
+​
+<input id="whichkey" value="type something">
+<div id="log"></div>
+​
+<script>
+$( "#whichkey" ).on( "keydown", function( event ) {
+  $( "#log" ).html( event.type + ": " +  event.which );
+});
+</script>
+​
+</body>
+</html>
+```
+         * @example ​ ````Log which mouse button was depressed.
+```html
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>event.which demo</title>
+  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
+</head>
+<body>
+​
+<input id="whichkey" value="click here">
+<div id="log"></div>
+​
+<script>
+$( "#whichkey" ).on( "mousedown", function( event ) {
+  $( "#log" ).html( event.type + ": " +  event.which );
+});
+</script>
+​
+</body>
+</html>
+```
+         */
+        which: number | undefined;
 
-        // region MouseEvent, KeyboardEvent, TouchEvent
-        // #region MouseEvent, KeyboardEvent, TouchEvent
+        // MouseEvent, KeyboardEvent, TouchEvent
 
-        altKey?: boolean;
-        ctrlKey?: boolean;
+        altKey: boolean | undefined;
+        ctrlKey: boolean | undefined;
         /**
          * Indicates whether the META key was pressed when the event fired.
          * @see \`{@link https://api.jquery.com/event.metaKey/ }\`
@@ -4170,77 +4266,11 @@ $( "#checkMetaKey" ).click(function( event ) {
 </html>
 ```
          */
-        metaKey: boolean;
-        shiftKey?: boolean;
+        metaKey: boolean | undefined;
+        shiftKey: boolean | undefined;
 
         // #endregion
 
-        // #endregion
-
-        /**
-         * The namespace specified when the event was triggered.
-         * @see \`{@link https://api.jquery.com/event.namespace/ }\`
-         * @since 1.4.3
-         * @example ​ ````Determine the event namespace used.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>event.namespace demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<button>display event.namespace</button>
-<p></p>
-​
-<script>
-$( "p" ).on( "test.something", function( event ) {
-  alert( event.namespace );
-});
-$( "button" ).click(function( event ) {
-  $( "p" ).trigger( "test.something" );
-});
-</script>
-​
-</body>
-</html>
-```
-         */
-        namespace: string;
-        /**
-         * The last value returned by an event handler that was triggered by this event, unless the value was undefined.
-         * @see \`{@link https://api.jquery.com/event.result/ }\`
-         * @since 1.3
-         * @example ​ ````Display previous handler&#39;s return value
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>event.result demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<button>display event.result</button>
-<p></p>
-​
-<script>
-$( "button" ).click(function( event ) {
-  return "hey";
-});
-$( "button" ).click(function( event ) {
-  $( "p" ).html( event.result );
-});
-</script>
-​
-</body>
-</html>
-```
-         */
-        result: any;
         /**
          * The difference in milliseconds between the time the browser created the event and January 1, 1970.
          * @see \`{@link https://api.jquery.com/event.timeStamp/ }\`
@@ -4297,59 +4327,6 @@ $( "a" ).click(function( event ) {
 ```
          */
         type: string;
-        /**
-         * For key or mouse events, this property indicates the specific key or button that was pressed.
-         * @see \`{@link https://api.jquery.com/event.which/ }\`
-         * @since 1.1.3
-         * @deprecated ​ Deprecated since 3.3. See \`{@link https://github.com/jquery/api.jquery.com/issues/821 }\`.
-         * @example ​ ````Log which key was depressed.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>event.which demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<input id="whichkey" value="type something">
-<div id="log"></div>
-​
-<script>
-$( "#whichkey" ).on( "keydown", function( event ) {
-  $( "#log" ).html( event.type + ": " +  event.which );
-});
-</script>
-​
-</body>
-</html>
-```
-         * @example ​ ````Log which mouse button was depressed.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>event.which demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<input id="whichkey" value="click here">
-<div id="log"></div>
-​
-<script>
-$( "#whichkey" ).on( "mousedown", function( event ) {
-  $( "#log" ).html( event.type + ": " +  event.which );
-});
-</script>
-​
-</body>
-</html>
-```
-         */
-        which: number;
         /**
          * Returns whether event.preventDefault() was ever called on this event object.
          * @see \`{@link https://api.jquery.com/event.isDefaultPrevented/ }\`
@@ -4542,11 +4519,17 @@ $( "p" ).click(function( event ) {
         stopPropagation(): void;
     }
 
-    // Generic members
-    interface Event<
-        TTarget = EventTarget,
-        TData = null
-    > {
+    // #endregion
+
+    /**
+     * Base type for jQuery events that have been triggered (including events triggered on plain objects).
+     */
+    interface TriggeredEvent<
+        TDelegateTarget = any,
+        TData = any,
+        TCurrentTarget = any,
+        TTarget = any
+    > extends Event {
         /**
          * The current DOM element within the event bubbling phase.
          * @see \`{@link https://api.jquery.com/event.currentTarget/ }\`
@@ -4557,51 +4540,8 @@ $( "p" ).click(function( event ) {
   alert( event.currentTarget === this ); // true
 });
 ```
-         */
-        currentTarget: TTarget;
-        /**
-         * An optional object of data passed to an event method when the current executing handler is bound.
-         * @see \`{@link https://api.jquery.com/event.data/ }\`
-         * @since 1.1
-         * @example ​ ````Within a for loop, pass the value of i to the .on() method so that the current iteration&#39;s value is preserved.
-```html
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>event.data demo</title>
-  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
-</head>
-<body>
-​
-<button> 0 </button>
-<button> 1 </button>
-<button> 2 </button>
-<button> 3 </button>
-<button> 4 </button>
-​
-<div id="log"></div>
-​
-<script>
-var logDiv = $( "#log" );
-​
-for ( var i = 0; i < 5; i++ ) {
-  $( "button" ).eq( i ).on( "click", { value: i }, function( event ) {
-    var msgs = [
-      "button = " + $( this ).index(),
-      "event.data.value = " + event.data.value,
-      "i = " + i
-    ];
-    logDiv.append( msgs.join( ", " ) + "<br>" );
-  });
-}
-</script>
-​
-</body>
-</html>
-```
-         */
-        data: TData;
+        */
+        currentTarget: TCurrentTarget;
         /**
          * The element where the currently-called jQuery event handler was attached.
          * @see \`{@link https://api.jquery.com/event.delegateTarget/ }\`
@@ -4612,21 +4552,8 @@ $( ".box" ).on( "click", "button", function( event ) {
   $( event.delegateTarget ).css( "background-color", "red" );
 });
 ```
-         */
-        delegateTarget: TTarget;
-        originalEvent: _Event;
-        /**
-         * The other DOM element involved in the event, if any.
-         * @see \`{@link https://api.jquery.com/event.relatedTarget/ }\`
-         * @since 1.1.4
-         * @example ​ ````On mouseout of anchors, alert the element type being entered.
-```javascript
-$( "a" ).mouseout(function( event ) {
-  alert( event.relatedTarget.nodeName ); // "DIV"
-});
-```
-         */
-        relatedTarget: TTarget | null;
+        */
+        delegateTarget: TDelegateTarget;
         /**
          * The DOM element that initiated the event.
          * @see \`{@link https://api.jquery.com/event.target/ }\`
@@ -4704,16 +4631,172 @@ $( "ul" ).click( handler ).find( "ul" ).hide();
 </body>
 </html>
 ```
-         */
+        */
         target: TTarget;
+
+        /**
+         * An optional object of data passed to an event method when the current executing handler is bound.
+         * @see \`{@link https://api.jquery.com/event.data/ }\`
+         * @since 1.1
+         * @example ​ ````Within a for loop, pass the value of i to the .on() method so that the current iteration&#39;s value is preserved.
+```html
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>event.data demo</title>
+  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
+</head>
+<body>
+​
+<button> 0 </button>
+<button> 1 </button>
+<button> 2 </button>
+<button> 3 </button>
+<button> 4 </button>
+​
+<div id="log"></div>
+​
+<script>
+var logDiv = $( "#log" );
+​
+for ( var i = 0; i < 5; i++ ) {
+  $( "button" ).eq( i ).on( "click", { value: i }, function( event ) {
+    var msgs = [
+      "button = " + $( this ).index(),
+      "event.data.value = " + event.data.value,
+      "i = " + i
+    ];
+    logDiv.append( msgs.join( ", " ) + "<br>" );
+  });
+}
+</script>
+​
+</body>
+</html>
+```
+        */
+        data: TData;
+
+        /**
+         * The namespace specified when the event was triggered.
+         * @see \`{@link https://api.jquery.com/event.namespace/ }\`
+         * @since 1.4.3
+         * @example ​ ````Determine the event namespace used.
+```html
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>event.namespace demo</title>
+  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
+</head>
+<body>
+​
+<button>display event.namespace</button>
+<p></p>
+​
+<script>
+$( "p" ).on( "test.something", function( event ) {
+  alert( event.namespace );
+});
+$( "button" ).click(function( event ) {
+  $( "p" ).trigger( "test.something" );
+});
+</script>
+​
+</body>
+</html>
+```
+         */
+        namespace?: string;
+        /**
+         * The last value returned by an event handler that was triggered by this event, unless the value was undefined.
+         * @see \`{@link https://api.jquery.com/event.result/ }\`
+         * @since 1.3
+         * @example ​ ````Display previous handler&#39;s return value
+```html
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>event.result demo</title>
+  <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
+</head>
+<body>
+​
+<button>display event.result</button>
+<p></p>
+​
+<script>
+$( "button" ).click(function( event ) {
+  return "hey";
+});
+$( "button" ).click(function( event ) {
+  $( "p" ).html( event.result );
+});
+</script>
+​
+</body>
+</html>
+```
+         */
+        result?: any;
     }
 
-    // #endregion
-
-    interface EventHandler<TCurrentTarget, TData = null> extends EventHandlerBase<TCurrentTarget, Event<TCurrentTarget, TData>> { }
+    interface TypeToTriggeredEventMap<
+        TDelegateTarget,
+        TData,
+        TCurrentTarget,
+        TTarget
+    > {
+        [type: string]: TriggeredEvent<TDelegateTarget, TData, TCurrentTarget, TTarget>;
+    }
 
     // Extra parameters can be passed from trigger()
     type EventHandlerBase<TContext, T> = (this: TContext, t: T, ...args: any[]) => any;
+
+    type EventHandler<
+        TCurrentTarget,
+        TData = undefined
+    > = EventHandlerBase<TCurrentTarget, TriggeredEvent<TCurrentTarget, TData>>;
+
+    type TypeEventHandler<
+        TDelegateTarget,
+        TData,
+        TCurrentTarget,
+        TTarget,
+        TContext,
+        TType extends keyof TypeToTriggeredEventMap<TDelegateTarget, TData, TCurrentTarget, TTarget>
+    > = EventHandlerBase<TContext, TypeToTriggeredEventMap<TDelegateTarget, TData, TCurrentTarget, TTarget>[TType]>;
+
+    interface TypeEventHandlers<
+        TDelegateTarget,
+        TData,
+        TCurrentTarget,
+        TTarget,
+        TContext
+    > extends _TypeEventHandlers<TDelegateTarget, TData, TCurrentTarget, TTarget, TContext> {
+        // No idea why it's necessary to include `object` in the union but otherwise TypeScript complains that
+        // derived types of Event are not assignable to Event.
+        [type: string]: TypeEventHandler<TDelegateTarget, TData, TCurrentTarget, TTarget, TContext, string> |
+                        false |
+                        undefined |
+                        object;
+    }
+
+    type _TypeEventHandlers<
+        TDelegateTarget,
+        TData,
+        TCurrentTarget,
+        TTarget,
+        TContext
+    > = {
+        [TType in keyof TypeToTriggeredEventMap<TDelegateTarget, TData, TCurrentTarget, TTarget>]?:
+            TypeEventHandler<TDelegateTarget, TData, TCurrentTarget, TTarget, TContext, TType> |
+            false |
+            object;
+    };
 
     // region Event extensions
     // #region Event extensions
@@ -4791,13 +4874,13 @@ $( "ul" ).click( handler ).find( "ul" ).hide();
          * The trigger hook is called early in the process of triggering an event, just after the `jQuery.Event` object is constructed and before any handlers have been called. It can process the triggered event in any way, for example by calling `event.stopPropagation()` or `event.preventDefault()` before returning. If the hook returns `false`, jQuery does not perform any further event triggering actions and returns immediately. Otherwise, it performs the normal trigger processing, calling any event handlers for the element and bubbling the event (unless propagation is stopped in advance or `noBubble` was specified for the special event) to call event handlers attached to parent elements.
          * @see \`{@link https://learn.jquery.com/events/event-extensions/#trigger-function-event-jquery-event-data-object }\`
          */
-        trigger(this: TTarget, event: Event<TTarget, TData>, data: TData): void | false;
+        trigger(this: TTarget, event: Event, data: TData): void | false;
     } | {
         /**
          * When the `.trigger()` method finishes running all the event handlers for an event, it also looks for and runs any method on the target object by the same name unless of the handlers called `event.preventDefault()`. So, `.trigger( "submit" )` will execute the `submit()` method on the element if one exists. When a `_default` hook is specified, the hook is called just prior to checking for and executing the element's default method. If this hook returns the value `false` the element's default method will be called; otherwise it is not.
          * @see \`{@link https://learn.jquery.com/events/event-extensions/#_default-function-event-jquery-event-data-object }\`
          */
-        _default(event: Event<TTarget, TData>, data: TData): void | false;
+        _default(event: TriggeredEvent<TTarget, TData>, data: TData): void | false;
     } | {
         /**
          * jQuery calls a handle hook when the event has occurred and jQuery would normally call the user's event handler specified by `.on()` or another event binding method. If the hook exists, jQuery calls it _instead_ of that event handler, passing it the event and any data passed from `.trigger()` if it was not a native event. The `this` keyword is the DOM element being handled, and `event.handleObj` property has the detailed event information.
@@ -4805,11 +4888,11 @@ $( "ul" ).click( handler ).find( "ul" ).hide();
          * Based in the information it has, the handle hook should decide whether to call the original handler function which is in `event.handleObj.handler`. It can modify information in the event object before calling the original handler, but _must restore_ that data before returning or subsequent unrelated event handlers may act unpredictably. In most cases, the handle hook should return the result of the original handler, but that is at the discretion of the hook. The handle hook is unique in that it is the only special event function hook that is called under its original special event name when the type is mapped using `bindType` and `delegateType`. For that reason, it is almost always an error to have anything other than a handle hook present if the special event defines a `bindType` and `delegateType`, since those other hooks will never be called.
          * @see \`{@link https://learn.jquery.com/events/event-extensions/#handle-function-event-jquery-event-data-object }\`
          */
-        handle(this: TTarget, event: Event<TTarget, TData> & { handleObj: HandleObject<TTarget, TData>; }, ...data: TData[]): void;
+        handle(this: TTarget, event: TriggeredEvent<TTarget, TData> & { handleObj: HandleObject<TTarget, TData>; }, ...data: TData[]): void;
     } | {
-        preDispatch(this: TTarget, event: Event<TTarget, TData>): false | void;
+        preDispatch(this: TTarget, event: Event): false | void;
     } | {
-        postDispatch(this: TTarget, event: Event<TTarget, TData>): void;
+        postDispatch(this: TTarget, event: Event): void;
     } | {
         [key: string]: never;
     };
@@ -4901,7 +4984,6 @@ $( "ul" ).click( handler ).find( "ul" ).hide();
 declare const jQuery: JQueryStatic;
 declare const $: JQueryStatic;
 
-// Used by JQuery.Event
 type _Event = Event;
 
 // region ES5 compatibility

--- a/types/jquery/misc.d.ts
+++ b/types/jquery/misc.d.ts
@@ -3986,11 +3986,7 @@ $( "input" ).click(function() {
         // tslint:disable-next-line:no-unnecessary-generics
         <T extends object, TTarget extends EventTarget = HTMLElement>(event: string, properties?: T): Event<TTarget> & T;
         // tslint:disable-next-line:no-unnecessary-generics
-        <T extends EventLike, TTarget extends EventTarget = HTMLElement>(properties: T): Event<TTarget> & T;
-        // tslint:disable-next-line:no-unnecessary-generics
         new <T extends object, TTarget extends EventTarget = HTMLElement>(event: string, properties?: T): Event<TTarget> & T;
-        // tslint:disable-next-line:no-unnecessary-generics
-        new <T extends EventLike, TTarget extends EventTarget = HTMLElement>(properties: T): Event<TTarget> & T;
     }
 
     // Instance members
@@ -4710,10 +4706,6 @@ $( "ul" ).click( handler ).find( "ul" ).hide();
 ```
          */
         target: TTarget;
-    }
-
-    interface EventLike {
-        type: string;
     }
 
     // #endregion

--- a/types/jquery/test/example-tests.ts
+++ b/types/jquery/test/example-tests.ts
@@ -384,7 +384,7 @@ function examples() {
     }
 
     function bind_2() {
-        function handler(event: JQuery.Event<HTMLElement, any>) {
+        function handler(event: JQuery.TriggeredEvent<HTMLElement>) {
             alert(event.data.foo);
         }
 
@@ -830,7 +830,7 @@ function examples() {
             var len = kids.addClass('hilite').length;
 
             $('#results span:first').text(len);
-            $('#results span:last').text(event.target.tagName);
+            $('#results span:last').text((event.target as Element).tagName);
 
             event.preventDefault();
         });
@@ -1614,12 +1614,12 @@ function examples() {
 
     function event_target_0() {
         $('body').click(function(event) {
-            $('#log').html('clicked: ' + event.target.nodeName);
+            $('#log').html('clicked: ' + (event.target as Node).nodeName);
         });
     }
 
     function event_target_1() {
-        function handler(event: JQuery.Event) {
+        function handler(event: JQuery.TriggeredEvent) {
             var target = $(event.target);
             if (target.is('li')) {
                 target.children().toggle();
@@ -3018,10 +3018,10 @@ function examples() {
     function jQuery_proxy_0() {
         var me = {
             type: 'zombie',
-            test: function(event: JQuery.Event) {
+            test: function(event: JQuery.TriggeredEvent) {
                 // Without proxy, `this` would refer to the event target
                 // use event.target to reference that element.
-                var element = event.target;
+                var element = event.target as Element;
                 $(element).css('background-color', 'red');
 
                 // With proxy, `this` refers to the me object encapsulating
@@ -3033,7 +3033,7 @@ function examples() {
 
         var you = {
             type: 'person',
-            test: function(event: JQuery.Event) {
+            test: function(event: JQuery.TriggeredEvent) {
                 $('#log').append(this.type + ' ');
             },
         };
@@ -3075,7 +3075,7 @@ function examples() {
             type: 'dog',
 
             // Note that event comes *after* one and two
-            test: function(one: typeof you, two: typeof they, event: JQuery.Event<HTMLElement>) {
+            test: function(one: typeof you, two: typeof they, event: JQuery.TriggeredEvent<HTMLElement>) {
                 $('#log')
 
                 // `one` maps to `you`, the 1st additional
@@ -3796,7 +3796,7 @@ function examples() {
     }
 
     function on_1() {
-        function myHandler(event: JQuery.Event<HTMLElement, { foo: string; }>) {
+        function myHandler(event: JQuery.TriggeredEvent<HTMLElement, { foo: string; }>) {
             alert(event.data.foo);
         }
 

--- a/types/jquery/test/example-tests.ts
+++ b/types/jquery/test/example-tests.ts
@@ -1578,7 +1578,7 @@ function examples() {
 
     function event_related_target_0() {
         $('a').mouseout(function(event) {
-            alert((<HTMLElement> event.relatedTarget).nodeName); // "DIV"
+            alert((event.relatedTarget as HTMLElement).nodeName); // "DIV"
         });
     }
 

--- a/types/jquery/test/learn-tests.ts
+++ b/types/jquery/test/learn-tests.ts
@@ -21,24 +21,6 @@ jQuery("a").greenify(); // Makes all the links green.
 
 // Events
 
-function fixHooks() {
-    function setHook() {
-        jQuery.event.fixHooks.drop = {
-            props: ["dataTransfer"]
-        };
-    }
-
-    function conflictResolution() {
-        if (jQuery.event.fixHooks.drop) {
-            throw new Error("Someone else took the jQuery.event.fixHooks.drop hook!");
-        }
-
-        jQuery.event.fixHooks.drop = {
-            props: ["dataTransfer"]
-        };
-    }
-}
-
 function special() {
     function defineSpecialEvent() {
         jQuery.event.special.pushy = {

--- a/types/jquery/test/learn-tests.ts
+++ b/types/jquery/test/learn-tests.ts
@@ -35,7 +35,7 @@ function special() {
             bindType: "click",
             handle(event) {
                 const handleObj = event.handleObj;
-                const targetData = jQuery.data(event.target);
+                const targetData = jQuery.data(event.target as Element);
                 let ret = null;
 
                 // If a multiple of the click count, run the handler

--- a/types/jquery/test/longdesc-tests.ts
+++ b/types/jquery/test/longdesc-tests.ts
@@ -538,7 +538,7 @@ function longdesc() {
         $('#foo').slideUp(300).delay(800).fadeIn(400);
     }
 
-    function delegate_0(elements: HTMLElement[], selector: string, events: string, data: any, handler: JQuery.TypeEventHandler<HTMLElement, any, any, any, any, string>) {
+    function delegate_0(elements: HTMLElement[], selector: string, events: string, data: any, handler: JQuery.TypeEventHandler<HTMLElement, any, any, any, string>) {
         // jQuery 1.4.3+
         $(elements).delegate(selector, events, data, handler);
         // jQuery 1.7+

--- a/types/jquery/test/longdesc-tests.ts
+++ b/types/jquery/test/longdesc-tests.ts
@@ -538,7 +538,7 @@ function longdesc() {
         $('#foo').slideUp(300).delay(800).fadeIn(400);
     }
 
-    function delegate_0(elements: HTMLElement[], selector: string, events: any, data: any, handler: JQuery.EventHandler<HTMLElement>) {
+    function delegate_0(elements: HTMLElement[], selector: string, events: string, data: any, handler: JQuery.TypeEventHandler<HTMLElement, any, any, any, any, string>) {
         // jQuery 1.4.3+
         $(elements).delegate(selector, events, data, handler);
         // jQuery 1.7+
@@ -2016,7 +2016,7 @@ function longdesc() {
     }
 
     function on_3() {
-        function greet(event: JQuery.Event<HTMLElement, { name: string; }>) {
+        function greet(event: JQuery.TriggeredEvent<HTMLElement, { name: string; }>) {
             alert('Hello ' + event.data.name);
         }
 

--- a/types/jquery/test/longdesc-tests.ts
+++ b/types/jquery/test/longdesc-tests.ts
@@ -886,7 +886,7 @@ function longdesc() {
         var currentRequests: JQuery.PlainObject = {};
 
         $.ajaxPrefilter(function(options, originalOptions, jqXHR) {
-            if ((<any> options).abortOnRetry) {
+            if ((options as any).abortOnRetry) {
                 if (currentRequests[options.url!]) {
                     currentRequests[options.url!].abort();
                 }
@@ -1297,7 +1297,7 @@ function longdesc() {
                         return $.css(elem, borderRadius!);
                     },
                     set: function(elem, value) {
-                        (<any> elem.style)[borderRadius!] = value;
+                        (elem.style as any)[borderRadius!] = value;
                     },
                 };
             }

--- a/types/kendo-ui/tslint.json
+++ b/types/kendo-ui/tslint.json
@@ -74,6 +74,7 @@
         "typedef-whitespace": false,
         "unified-signatures": false,
         "void-return": false,
-        "whitespace": false
+        "whitespace": false,
+        "no-angle-bracket-type-assertion": false
     }
 }

--- a/types/ng-cordova/tslint.json
+++ b/types/ng-cordova/tslint.json
@@ -74,6 +74,7 @@
         "typedef-whitespace": false,
         "unified-signatures": false,
         "void-return": false,
-        "whitespace": false
+        "whitespace": false,
+        "no-angle-bracket-type-assertion": false
     }
 }

--- a/types/ng-flow/tslint.json
+++ b/types/ng-flow/tslint.json
@@ -74,6 +74,7 @@
         "typedef-whitespace": false,
         "unified-signatures": false,
         "void-return": false,
-        "whitespace": false
+        "whitespace": false,
+        "no-angle-bracket-type-assertion": false
     }
 }

--- a/types/ng-grid/tslint.json
+++ b/types/ng-grid/tslint.json
@@ -74,6 +74,7 @@
         "typedef-whitespace": false,
         "unified-signatures": false,
         "void-return": false,
-        "whitespace": false
+        "whitespace": false,
+        "no-angle-bracket-type-assertion": false
     }
 }

--- a/types/openui5/tslint.json
+++ b/types/openui5/tslint.json
@@ -74,6 +74,7 @@
         "typedef-whitespace": false,
         "unified-signatures": false,
         "void-return": false,
-        "whitespace": false
+        "whitespace": false,
+        "no-angle-bracket-type-assertion": false
     }
 }

--- a/types/q/tslint.json
+++ b/types/q/tslint.json
@@ -7,6 +7,7 @@
     "no-unnecessary-type-assertion": false,
     "prefer-declare-function": false,
     "strict-export-declare-modifiers": false,
-    "unified-signatures": false
+    "unified-signatures": false,
+    "no-angle-bracket-type-assertion": false
   }
 }

--- a/types/q/v0/tslint.json
+++ b/types/q/v0/tslint.json
@@ -74,6 +74,7 @@
         "typedef-whitespace": false,
         "unified-signatures": false,
         "void-return": false,
-        "whitespace": false
+        "whitespace": false,
+        "no-angle-bracket-type-assertion": false
     }
 }

--- a/types/qtip2/tslint.json
+++ b/types/qtip2/tslint.json
@@ -74,6 +74,7 @@
         "typedef-whitespace": false,
         "unified-signatures": false,
         "void-return": false,
-        "whitespace": false
+        "whitespace": false,
+        "no-angle-bracket-type-assertion": false
     }
 }

--- a/types/sammy/tslint.json
+++ b/types/sammy/tslint.json
@@ -74,6 +74,7 @@
         "typedef-whitespace": false,
         "unified-signatures": false,
         "void-return": false,
-        "whitespace": false
+        "whitespace": false,
+        "no-angle-bracket-type-assertion": false
     }
 }

--- a/types/segment-analytics/tslint.json
+++ b/types/segment-analytics/tslint.json
@@ -74,6 +74,7 @@
         "typedef-whitespace": false,
         "unified-signatures": false,
         "void-return": false,
-        "whitespace": false
+        "whitespace": false,
+        "no-angle-bracket-type-assertion": false
     }
 }

--- a/types/selectize/tslint.json
+++ b/types/selectize/tslint.json
@@ -74,6 +74,7 @@
         "typedef-whitespace": false,
         "unified-signatures": false,
         "void-return": false,
-        "whitespace": false
+        "whitespace": false,
+        "no-angle-bracket-type-assertion": false
     }
 }

--- a/types/semantic-ui-form/global.d.ts
+++ b/types/semantic-ui-form/global.d.ts
@@ -212,7 +212,7 @@ declare namespace SemanticUI {
             /**
              * Callback if a form is all valid
              */
-            onSuccess(this: JQuery, event: JQuery.Event<HTMLElement>, fields: any): void;
+            onSuccess(this: JQuery, event: JQuery.TriggeredEvent<HTMLElement>, fields: any): void;
             /**
              * Callback if any form field is invalid
              */

--- a/types/semantic-ui-form/semantic-ui-form-tests.ts
+++ b/types/semantic-ui-form/semantic-ui-form-tests.ts
@@ -144,7 +144,7 @@ function test_form() {
         },
         onSuccess(event, fields) {
             this; // $ExpectType JQuery<HTMLElement>
-            event; // $ExpectType Event<HTMLElement, null>
+            event; // $ExpectType TriggeredEvent<HTMLElement, any, any, any>
             fields; // $ExpectType any
         },
         onFailure(formErrors, fields) {

--- a/types/sharepoint/sharepoint-tests.ts
+++ b/types/sharepoint/sharepoint-tests.ts
@@ -2038,7 +2038,7 @@ namespace _ {
     // do is retrieve a reference to the term set with the same ID as the div, and
     // then add the term  that belong to that term set under the div that was clicked.
 
-    function showTerms(event: JQuery.Event, groupID: SP.Guid, termSetID: SP.Guid) {
+    function showTerms(event: JQuery.ClickEvent, groupID: SP.Guid, termSetID: SP.Guid) {
         // First, cancel the bubble so that the group div click handler does not also fire
         // because that removes all term set divs and we don't want that here.
         event.originalEvent.cancelBubble = true;

--- a/types/space-pen/tslint.json
+++ b/types/space-pen/tslint.json
@@ -74,6 +74,7 @@
         "typedef-whitespace": false,
         "unified-signatures": false,
         "void-return": false,
-        "whitespace": false
+        "whitespace": false,
+        "no-angle-bracket-type-assertion": false
     }
 }

--- a/types/toastr/tslint.json
+++ b/types/toastr/tslint.json
@@ -74,6 +74,7 @@
         "typedef-whitespace": false,
         "unified-signatures": false,
         "void-return": false,
-        "whitespace": false
+        "whitespace": false,
+        "no-angle-bracket-type-assertion": false
     }
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- ~~Provide a URL to documentation or source code which provides context for the suggested changes:~~
- ~~Increase the version number in the header if appropriate.~~
- ~~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.~~

---

#### Summary of changes

##### Improve declaration of Events API. (f13af8b / 00c5463 / 3a54bad0684cc88f91cfeac115d57554fc494c62 / db83bc7)

The `*Target` properties (`currentTarget`, `delegateTarget`, `relatedTarget`, and `target`) were all set to the same type parameter (`TTarget`). API methods passed the type of selected elements (`TElement`) to `TTarget`. This is only guaranteed to be correct for directly bound event handlers (excluding `relatedTarget`, which varies based on event type instead of binding type). This PR fixes this issue by replacing `TTarget` with `TDelegateTarget` for `delegateTarget`, `TCurrentTarget` for `currentTarget`, and `TTarget` for `target`. Methods that bind directly bound event handlers pass in `TElement` for all target-related type parameters as they are guaranteed to be the same object. Methods that bind delegate bound event handlers pass in `TElement` for `TDelegateTarget` and `any` for the rest of the target-related parameters. `unknown` would be better here but requires TypeScript 3.0. As the types of `currentTarget`, `relatedTarget`, and `target` cannot be known until run time, consumers will still need type assertions when accessing these properties but they are no longer presented with a type that could be outright wrong.

This PR also introduces the concept of a triggered event. A triggered event is a jQuery event that has been triggered (either manually by `.trigger()`/`.triggerHandler()` or automatically by the user agent). Many properties on a jQuery event are not set until it has been triggered. In particular, the `*Target` properties are not set on a freshly constructed `jQuery.Event` object. `JQuery.Event` now represents the object returned from the `jQuery.Event` constructor and serves as the base type for all jQuery events. This means that the `*Target` properties (and their type parameters) were removed from `JQuery.Event` and added to a new triggered event type ([`JQuery.TriggeredEvent`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/f13af8beb0b54f71d8a070c99fdf76cf5601433b/types/jquery/misc.d.ts#L4527)).

This PR also introduces event type-specific types for known events. When binding an event handler for a known event type, the event handler will receive an event type-specific type for that event type. For example, when binding to a "click" event, the event handler will receive a [`ClickEvent`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/00c546398c4d3d98655a4bce525a077dd52c83c1/types/jquery/misc.d.ts#L5288) event that has all properties copied from `MouseEvent` (`button`, `ctrlKey`, `shiftKey`, etc) declared as non-nullable and `originalEvent` declared as `MouseEvent`. This should reduce the need for type assertions for consumers. Types have been added for event types that have an associated shorthand method and for touch events. Types for the rest of the DOM events may be added at a later point.

###### Migration notes

As a general note, there are many cases where the correct type can be inferred but consumers have annotated their code with an incorrect type. In these cases, it's best to just drop the annotation and let inference do its work.

Most breaks will be due to splitting `JQuery.Event` into `JQuery.TriggeredEvent`. As code that references `JQuery.Event` will typically be event handlers (and therefore dealing with a triggered event), the fix is to simply change the declaration from `JQuery.Event` to `JQuery.TriggeredEvent`. In cases where code actually wants to reference a base event type, the fix is to remove the type arguments from the declaration (the declaration will be simply `JQuery.Event`).

Fixes #17377
Fixes https://github.com/DefinitelyTyped/DefinitelyTyped/pull/26674#pullrequestreview-130294320
Fixes #30705 

##### Add deprecation notice for `Event.which`. (16770fa)

Deprecated since 3.3. See https://github.com/jquery/api.jquery.com/issues/821.

##### Remove `jQuery.event.props` and `jQuery.event.fixHooks`. (50b56a1 / e64bea6)

Removed since 3.0. See https://jquery.com/upgrade-guide/3.0/#breaking-change-jquery-event-props-and-jquery-event-fixhooks-removed.

##### Remove `jQuery.Event(EventLike)` signatures and `EventLike` interface. (32e0482)

These are undocumented and don't appear to be intended to be public.

###### Migration notes

If consumers still require the `EventLike` interface, they may add this declaration to their project.

```typescript
declare namespace JQuery {
    interface EventLike {
        type: string;
    }
}
```

##### Remove `JQuery.EventHandlerBase<TContext = any, JQuery.Event>` from handler types. (c1ec1c2)

Handler types previously included `JQuery.EventHandlerBase<TContext = any, JQuery.Event>`. This was a fix to what turned out to be a problem with `jQuery.proxy`. That issue was properly fixed by #29930.

---

Fixes 5 violations of `no-unnecessary-generics`.
Fixes 5 violations of `unified-signatures`.

---

Pinging @Kovensky @HolgerJeromin as they have expressed interest in this before.

---

@zhamid @nvivo @sventschui @razorness @confususs

The change to `@types/backbone` (68c38a8) was to fix a conflict with the [`EventsHash`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/9f9f6430117d025aef62ed56128deb65508edc86/types/backbone.marionette/index.d.ts#L261-L267) declaration in `@types/backbone.marionette`. You may wish to review that the change is appropriate.

---

The addition of touch events was to fix [test failures with `@types/viewporter`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/9f9f6430117d025aef62ed56128deb65508edc86/types/viewporter/viewporter-tests.ts#L119-L162). Not going to bother mentioning authors of `@types/viewporter` here as this was simply a matter of extending support.