### PR TITLE
TargetLocator.frame - Should accept null type.

### DIFF
--- a/types/selenium-webdriver/index.d.ts
+++ b/types/selenium-webdriver/index.d.ts
@@ -3448,7 +3448,7 @@ export class TargetLocator {
    * @return {!promise.Promise<void>} A promise that will be resolved
    *     when the driver has changed focus to the specified frame.
    */
-  frame(nameOrIndex: number | WebElement): promise.Promise<void>;
+  frame(nameOrIndex: number | WebElement | null): promise.Promise<void>;
 
   /**
    * Schedules a command to switch the focus of all future commands to another


### PR DESCRIPTION
This change (adding null to TargetLocator.frame) is documented in the comments just above the change.
The behavior 

http://go/gh/DefinitelyTyped/DefinitelyTyped/blob/5344bfc80508c53a23dae37b860fb0c905ff7b24/types/selenium-webdriver/index.d.ts#L3447