### PR TITLE
Make slideNext function params optional.

### DIFF
--- a/types/swiper/index.d.ts
+++ b/types/swiper/index.d.ts
@@ -1,6 +1,10 @@
 // Type definitions for Swiper 4.2
 // Project: https://github.com/nolimits4web/Swiper
-// Definitions by: Sebastián Galiano <https://github.com/sgaliano>, Luca Trazzi <https://github.com/lucax88x>, Eugene Matseruk <https://github.com/ematseruk>, Luiz M. <https://github.com/odahcam>
+// Definitions by: Sebastián Galiano <https://github.com/sgaliano>
+//                 Luca Trazzi <https://github.com/lucax88x>
+//                 Eugene Matseruk <https://github.com/ematseruk>
+//                 Luiz M. <https://github.com/odahcam>
+//                 Justin Abene <https://github.com/jmca>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.9
 
@@ -1047,7 +1051,7 @@ export default class Swiper {
      * @param runCallbacks Set it to false (by default it is true) and transition will
      *  not produce transition events.
      */
-    slideNext(speed: number, runCallbacks: boolean): void;
+    slideNext(speed?: number, runCallbacks?: boolean): void;
 
     /**
      * Run transition to previous slide.


### PR DESCRIPTION
`slideNext` method params are optional according to the docs @ [https://idangero.us/swiper/api/#methods](https://idangero.us/swiper/api/#methods).

