### PR TITLE
react-stripe-elements - Allows for inaccessible types inside of index.d.ts to be accessed from other files.

### DIFF
--- a/types/react-stripe-elements/index.d.ts
+++ b/types/react-stripe-elements/index.d.ts
@@ -12,12 +12,12 @@
 import * as React from 'react';
 
 export namespace ReactStripeElements {
-	import ElementChangeResponse = stripe.elements.ElementChangeResponse;
-	import ElementsOptions = stripe.elements.ElementsOptions;
-	import TokenOptions = stripe.TokenOptions;
-	import TokenResponse = stripe.TokenResponse;
-	import SourceResponse = stripe.SourceResponse;
-	import SourceOptions = stripe.SourceOptions;
+	type ElementChangeResponse = stripe.elements.ElementChangeResponse;
+	type ElementsOptions = stripe.elements.ElementsOptions;
+	type TokenOptions = stripe.TokenOptions;
+	type TokenResponse = stripe.TokenResponse;
+	type SourceResponse = stripe.SourceResponse;
+	type SourceOptions = stripe.SourceOptions;
 
 	/**
 	 * There's a bug in @types/stripe which defines the property as


### PR DESCRIPTION
Allows for these types to be accessed from `ReactStripeElements` export.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react-stripe-elements/index.d.ts
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
