### PR TITLE
Add final function for pino 5.8

### DIFF
--- a/types/pino/index.d.ts
+++ b/types/pino/index.d.ts
@@ -98,6 +98,23 @@ declare namespace P {
      */
     function extreme(fileDescriptor?: string | number): SonicBoom;
 
+    /**
+     * The pino.final method can be used to create an exit listener function.
+     * This listener function can be supplied to process exit events.
+     * The exit listener function will cal the handler with
+     * @param [logger]: pino logger that serves as reference for the final logger
+     * @param [handler]: Function that will be called by the handler returned from this function
+     * @returns Exit listener function that can be supplied to process exit events and will call the supplied handler function
+     */
+    function final(logger: Logger, handler: (error: Error, finalLogger: Logger, ...args: any[]) => void): (error: Error | null, ...args: any[]) => void;
+
+    /**
+     * The pino.final method can be used to acquire a final logger instance that synchronously flushes on every write.
+     * @param [logger]: pino logger that serves as reference for the final logger
+     * @returns Final, synchronous logger
+     */
+    function final(logger: Logger): Logger;
+
     interface LevelMapping {
         /**
          * Returns the mappings of level names to their respective internal number representation.

--- a/types/pino/pino-tests.ts
+++ b/types/pino/pino-tests.ts
@@ -7,9 +7,9 @@ const error = log.error;
 info('hello world');
 error('this is at error level');
 info('the answer is %d', 42);
-info({obj: 42}, 'hello world');
-info({obj: 42, b: 2}, 'hello world');
-info({obj: {aa: 'bbb'}}, 'another');
+info({ obj: 42 }, 'hello world');
+info({ obj: 42, b: 2 }, 'hello world');
+info({ obj: { aa: 'bbb' } }, 'another');
 setImmediate(info, 'after setImmediate');
 error(new Error('an error'));
 
@@ -41,27 +41,27 @@ pino({
 });
 
 pino({ base: null });
-pino({ base: { foo: 'bar' } , changeLevelName: 'severity' });
+pino({ base: { foo: 'bar' }, changeLevelName: 'severity' });
 
 if ('pino' in log) console.log(`pino version: ${log.pino}`);
 
-log.child({a: 'property'}).info('hello child!');
+log.child({ a: 'property' }).info('hello child!');
 log.level = 'error';
 log.info('nope');
-const child = log.child({foo: 'bar'});
+const child = log.child({ foo: 'bar' });
 child.info('nope again');
 child.level = 'info';
 child.info('hooray');
 log.info('nope nope nope');
-log.child({foo: 'bar', level: 'debug'}).debug('debug!');
+log.child({ foo: 'bar', level: 'debug' }).debug('debug!');
 const customSerializers = {
     test() {
         return 'this is my serializer';
     }
 };
-pino().child({serializers: customSerializers}).info({test: 'should not show up'});
-const child2 = log.child({father: true});
-const childChild = child2.child({baby: true});
+pino().child({ serializers: customSerializers }).info({ test: 'should not show up' });
+const child2 = log.child({ father: true });
+const childChild = child2.child({ baby: true });
 
 log.level = 'info';
 if (log.levelVal === 30) {
@@ -91,3 +91,14 @@ logstderr.error('on stderr instead of stdout');
 log.useLevelLabels = true;
 log.info('lol');
 log.level === 'info';
+
+const extremeDest = pino.extreme();
+const logExtreme = pino(extremeDest);
+
+const handler = pino.final(logExtreme, (err: Error, finalLogger: pino.BaseLogger) => {
+    if (err) {
+        finalLogger.error(err, 'error caused exit');
+    }
+});
+
+handler(new Error('error'));


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ X Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: http://getpino.io/#/docs/api?id=pino-final
- [X] Increase the version number in the header if appropriate.
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

This PR adds the definition for the pino.final functions, as seen here: http://getpino.io/#/docs/api?id=pino-final

This one's been somewhat tricky because of incomplete / not entirely accurate documentation, but by looking at the code I'd say the definition matches what the code does:
http://getpino.io/#/docs/extreme?id=log-loss-prevention
https://github.com/pinojs/pino/blob/master/lib/tools.js#L305
