### PR TITLE
Fix react-date-range CommonCalendarProps

### DIFF
--- a/types/react-date-range/index.d.ts
+++ b/types/react-date-range/index.d.ts
@@ -60,9 +60,9 @@ export interface CommonCalendarProps {
 	/** default: none */
 	onChange?: (range: Range) => void;
 	/** default: none */
-	minDate?: DateInputType;
+	minDate?: DateInputType | Date;
 	/** default: none */
-	maxDate?: DateInputType;
+	maxDate?: DateInputType | Date;
 	/**
 	 * Calendar languages.
 	 * ('cn' - Chinese, 'jp' - Japanese,


### PR DESCRIPTION
The documentation at https://github.com/Adphorus/react-date-range lists
the type of minDate and maxDate as Date. Everything works as expected
when passing a Date in these props, but causes a runtime error when using
any of the types listed in this package.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

