### PR TITLE
Types for JQuery FormatDateTime

### DIFF
--- a/types/jquery-formatdatetime/index.d.ts
+++ b/types/jquery-formatdatetime/index.d.ts
@@ -1,0 +1,64 @@
+// Type definitions for JQuery formatDateTime 1.1
+// Project: https://github.com/agschwender/jquery.formatDateTime
+// Definitions by: Anderson Friaça <https://github.com/AndersonFriaca>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
+
+/// <reference types="jquery" />
+
+export type Options = Partial<{
+    /**
+     * Names of the months, e.g. January
+     */
+    monthNames: string[];
+
+    /**
+     * Shortened names of the months, e.g. Jan
+     */
+    monthNamesShort: string[];
+
+    /**
+     * Names of the days, e.g. Sunday
+     */
+    dayNames: string[];
+
+    /**
+     * Shortened names of the days, e.g. Sun
+     */
+    dayNamesShort: string[];
+
+    /**
+     * Names of the 12-hour clock periods, e.g. AM
+     */
+    ampmNames: string[];
+
+    /**
+     * Callback to convert number to ordinal suffix, e.g. 1 to st
+     */
+    getSuffix: ((num: number) => string);
+
+    /**
+     * Attribute which contains the datetime
+     */
+    attribute: string;
+
+    /**
+     * Attribute which contains the datetime format
+     */
+    formatAttribute: string;
+
+    /**
+     * Render dates in UTC instead of local timezone
+     */
+    utc: boolean;
+}>;
+
+declare global {
+    interface JQuery {
+        formatDateTime(format: string, options?: Options): JQuery;
+    }
+
+    interface JQueryStatic {
+        formatDateTime(format: string, date: Date, options?: Options): string;
+    }
+}

--- a/types/jquery-formatdatetime/jquery-formatdatetime-tests.ts
+++ b/types/jquery-formatdatetime/jquery-formatdatetime-tests.ts
@@ -1,0 +1,40 @@
+import { Options } from "jquery-formatdatetime";
+
+// basic usage
+$('#example').formatDateTime('mm/dd/y g:ii a');
+
+const date = new Date('2012/07/05 09:55:03');
+
+$.formatDateTime('mm/dd/y g:ii a', date);
+
+// with options
+const options: Options = {
+    monthNames: [
+        'Janeiro',
+        'Fevereiro',
+        'Março',
+        'Abril',
+        'Maio',
+        'Junho',
+        'Julho',
+        'Agosto',
+        'Setembro',
+        'Outubro',
+        'Novembro',
+        'Dezembro'
+    ],
+    dayNames: [
+        'Domingo',
+        'Segunda-Feira',
+        'Terça-Feira',
+        'Quarta-Feira',
+        'Quinta-Feira',
+        'Sexta-Feira',
+        'Sábado'
+    ],
+    ampmNames: ['AM', 'PM']
+};
+
+$.formatDateTime('mm/dd/y g:ii a', date, options);
+
+$('#example').formatDateTime('mm/dd/y g:ii a', options);

--- a/types/jquery-formatdatetime/tsconfig.json
+++ b/types/jquery-formatdatetime/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "jquery-formatdatetime-tests.ts"
+    ]
+}

--- a/types/jquery-formatdatetime/tslint.json
+++ b/types/jquery-formatdatetime/tslint.json
@@ -1,0 +1,1 @@
+{"extends": "dtslint/dt.json"}


### PR DESCRIPTION
Types creation of [https://github.com/agschwender/jquery.formatDateTime](https://github.com/agschwender/jquery.formatDateTime)
NPM: [https://www.npmjs.com/package/jquery-formatdatetime](https://www.npmjs.com/package/jquery-formatdatetime)

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- [X] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [X] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [X] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.