### PR TITLE
Rename React's SFC / StatelessComponent to FunctionComponent

### DIFF
--- a/types/react-share/react-share-tests.ts
+++ b/types/react-share/react-share-tests.ts
@@ -1,25 +1,25 @@
 import {
-    FacebookShareCount, // $ExpectType StatelessComponent<ShareCountComponentProps>
-    GooglePlusShareCount, // $ExpectType StatelessComponent<ShareCountComponentProps>
-    LinkedinShareCount, // $ExpectType StatelessComponent<ShareCountComponentProps>
-    PinterestShareCount, // $ExpectType StatelessComponent<ShareCountComponentProps>
-    VKShareCount, // $ExpectType StatelessComponent<ShareCountComponentProps>
-    OKShareCount, // $ExpectType StatelessComponent<ShareCountComponentProps>
-    RedditShareCount, // $ExpectType StatelessComponent<ShareCountComponentProps>
-    TumblrShareCount, // $ExpectType StatelessComponent<ShareCountComponentProps>
+    FacebookShareCount, // $ExpectType FunctionComponent<ShareCountComponentProps>
+    GooglePlusShareCount, // $ExpectType FunctionComponent<ShareCountComponentProps>
+    LinkedinShareCount, // $ExpectType FunctionComponent<ShareCountComponentProps>
+    PinterestShareCount, // $ExpectType FunctionComponent<ShareCountComponentProps>
+    VKShareCount, // $ExpectType FunctionComponent<ShareCountComponentProps>
+    OKShareCount, // $ExpectType FunctionComponent<ShareCountComponentProps>
+    RedditShareCount, // $ExpectType FunctionComponent<ShareCountComponentProps>
+    TumblrShareCount, // $ExpectType FunctionComponent<ShareCountComponentProps>
 
-    FacebookIcon, // $ExpectType StatelessComponent<IconComponentProps>
-    TwitterIcon, // $ExpectType StatelessComponent<IconComponentProps>
-    TelegramIcon, // $ExpectType StatelessComponent<IconComponentProps>
-    WhatsappIcon, // $ExpectType StatelessComponent<IconComponentProps>
-    GooglePlusIcon, // $ExpectType StatelessComponent<IconComponentProps>
-    LinkedinIcon, // $ExpectType StatelessComponent<IconComponentProps>
-    PinterestIcon, // $ExpectType StatelessComponent<IconComponentProps>
-    VKIcon, // $ExpectType StatelessComponent<IconComponentProps>
-    OKIcon, // $ExpectType StatelessComponent<IconComponentProps>
-    RedditIcon, // $ExpectType StatelessComponent<IconComponentProps>
-    TumblrIcon, // $ExpectType StatelessComponent<IconComponentProps>
-    LivejournalIcon, // $ExpectType StatelessComponent<IconComponentProps>
-    MailruIcon, // $ExpectType StatelessComponent<IconComponentProps>
-    EmailIcon, // $ExpectType StatelessComponent<IconComponentProps>
+    FacebookIcon, // $ExpectType FunctionComponent<IconComponentProps>
+    TwitterIcon, // $ExpectType FunctionComponent<IconComponentProps>
+    TelegramIcon, // $ExpectType FunctionComponent<IconComponentProps>
+    WhatsappIcon, // $ExpectType FunctionComponent<IconComponentProps>
+    GooglePlusIcon, // $ExpectType FunctionComponent<IconComponentProps>
+    LinkedinIcon, // $ExpectType FunctionComponent<IconComponentProps>
+    PinterestIcon, // $ExpectType FunctionComponent<IconComponentProps>
+    VKIcon, // $ExpectType FunctionComponent<IconComponentProps>
+    OKIcon, // $ExpectType FunctionComponent<IconComponentProps>
+    RedditIcon, // $ExpectType FunctionComponent<IconComponentProps>
+    TumblrIcon, // $ExpectType FunctionComponent<IconComponentProps>
+    LivejournalIcon, // $ExpectType FunctionComponent<IconComponentProps>
+    MailruIcon, // $ExpectType FunctionComponent<IconComponentProps>
+    EmailIcon, // $ExpectType FunctionComponent<IconComponentProps>
 } from 'react-share';

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -50,7 +50,7 @@ declare namespace React {
     // ----------------------------------------------------------------------
 
     type ReactType<P = any> = string | ComponentType<P>;
-    type ComponentType<P = {}> = ComponentClass<P> | StatelessComponent<P>;
+    type ComponentType<P = {}> = ComponentClass<P> | FunctionComponent<P>;
 
     type Key = string | number;
 
@@ -70,13 +70,18 @@ declare namespace React {
     }
 
     interface ReactElement<P> {
-        type: string | ComponentClass<P> | SFC<P>;
+        type: string | ComponentClass<P> | FunctionComponent<P>;
         props: P;
         key: Key | null;
     }
 
-    interface SFCElement<P> extends ReactElement<P> {
-        type: SFC<P>;
+    /**
+     * @deprecated Please use `FunctionComponentElement`
+     */
+    type SFCElement<P> = FunctionComponentElement<P>;
+
+    interface FunctionComponentElement<P> extends ReactElement<P> {
+        type: FunctionComponent<P>;
     }
 
     type CElement<P, T extends Component<P, ComponentState>> = ComponentElement<P, T>;
@@ -117,7 +122,12 @@ declare namespace React {
 
     type Factory<P> = (props?: Attributes & P, ...children: ReactNode[]) => ReactElement<P>;
 
-    type SFCFactory<P> = (props?: Attributes & P, ...children: ReactNode[]) => SFCElement<P>;
+    /**
+     * @deprecated Please use `FunctionComponentFactory`
+     */
+    type SFCFactory<P> = FunctionComponentFactory<P>;
+
+    type FunctionComponentFactory<P> = (props?: Attributes & P, ...children: ReactNode[]) => FunctionComponentElement<P>;
 
     type ComponentFactory<P, T extends Component<P, ComponentState>> =
         (props?: ClassAttributes<T> & P, ...children: ReactNode[]) => CElement<P, T>;
@@ -164,7 +174,7 @@ declare namespace React {
         type: string): DOMFactory<P, T>;
 
     // Custom components
-    function createFactory<P>(type: SFC<P>): SFCFactory<P>;
+    function createFactory<P>(type: FunctionComponent<P>): FunctionComponentFactory<P>;
     function createFactory<P>(
         type: ClassType<P, ClassicComponent<P, ComponentState>, ClassicComponentClass<P>>): CFactory<P, ClassicComponent<P, ComponentState>>;
     function createFactory<P, T extends Component<P, ComponentState>, C extends ComponentClass<P>>(
@@ -192,9 +202,9 @@ declare namespace React {
 
     // Custom components
     function createElement<P>(
-        type: SFC<P>,
+        type: FunctionComponent<P>,
         props?: Attributes & P | null,
-        ...children: ReactNode[]): SFCElement<P>;
+        ...children: ReactNode[]): FunctionComponentElement<P>;
     function createElement<P>(
         type: ClassType<P, ClassicComponent<P, ComponentState>, ClassicComponentClass<P>>,
         props?: ClassAttributes<ClassicComponent<P, ComponentState>> & P | null,
@@ -204,7 +214,7 @@ declare namespace React {
         props?: ClassAttributes<T> & P | null,
         ...children: ReactNode[]): CElement<P, T>;
     function createElement<P>(
-        type: SFC<P> | ComponentClass<P> | string,
+        type: FunctionComponent<P> | ComponentClass<P> | string,
         props?: Attributes & P | null,
         ...children: ReactNode[]): ReactElement<P>;
 
@@ -232,9 +242,9 @@ declare namespace React {
 
     // Custom components
     function cloneElement<P>(
-        element: SFCElement<P>,
+        element: FunctionComponentElement<P>,
         props?: Partial<P> & Attributes,
-        ...children: ReactNode[]): SFCElement<P>;
+        ...children: ReactNode[]): FunctionComponentElement<P>;
     function cloneElement<P, T extends Component<P, ComponentState>>(
         element: CElement<P, T>,
         props?: Partial<P> & ClassAttributes<T>,
@@ -338,8 +348,17 @@ declare namespace React {
     // Class Interfaces
     // ----------------------------------------------------------------------
 
-    type SFC<P = {}> = StatelessComponent<P>;
-    interface StatelessComponent<P = {}> {
+    /**
+     * @deprecated Please use `FunctionComponent`
+     */
+    type SFC<P = {}> = FunctionComponent<P>;
+
+    /**
+     * @deprecated Please use `FunctionComponent`
+     */
+    type StatelessComponent<P = {}> = FunctionComponent<P>;
+
+    interface FunctionComponent<P = {}> {
         (props: P & { children?: ReactNode }, context?: any): ReactElement<any> | null;
         propTypes?: ValidationMap<P>;
         contextTypes?: ValidationMap<any>;

--- a/types/react/test/index.ts
+++ b/types/react/test/index.ts
@@ -194,31 +194,31 @@ interface SCProps {
     foo?: number;
 }
 
-function StatelessComponent(props: SCProps) {
+function FunctionComponent(props: SCProps) {
     return props.foo ? DOM.div(null, props.foo) : null;
 }
 
 // tslint:disable-next-line:no-namespace
-namespace StatelessComponent {
-    export const displayName = "StatelessComponent";
+namespace FunctionComponent {
+    export const displayName = "FunctionComponent";
     export const defaultProps = { foo: 42 };
 }
 
-const StatelessComponent2: React.SFC<SCProps> =
+const FunctionComponent2: React.FunctionComponent<SCProps> =
     // props is contextually typed
     props => DOM.div(null, props.foo);
-StatelessComponent2.displayName = "StatelessComponent2";
-StatelessComponent2.defaultProps = {
+FunctionComponent2.displayName = "FunctionComponent2";
+FunctionComponent2.defaultProps = {
     foo: 42
 };
 
-const StatelessComponent3: React.SFC<SCProps> =
+const FunctionComponent3: React.FunctionComponent<SCProps> =
     // allows usage of props.children
     // allows null return
     props => props.foo ? DOM.div(null, props.foo, props.children) : null;
 
 // allows null as props
-const StatelessComponent4: React.SFC = props => null;
+const FunctionComponent4: React.FunctionComponent = props => null;
 
 // React.createFactory
 const factory: React.CFactory<Props, ModernComponent> =
@@ -226,10 +226,10 @@ const factory: React.CFactory<Props, ModernComponent> =
 const factoryElement: React.CElement<Props, ModernComponent> =
     factory(props);
 
-const statelessFactory: React.SFCFactory<SCProps> =
-    React.createFactory(StatelessComponent);
-const statelessFactoryElement: React.SFCElement<SCProps> =
-    statelessFactory(props);
+const functionComponentFactory: React.FunctionComponentFactory<SCProps> =
+    React.createFactory(FunctionComponent);
+const functionComponentFactoryElement: React.FunctionComponentElement<SCProps> =
+    functionComponentFactory(props);
 
 const domFactory: React.DOMFactory<React.DOMAttributes<{}>, Element> =
     React.createFactory("div");
@@ -240,8 +240,8 @@ const domFactoryElement: React.DOMElement<React.DOMAttributes<{}>, Element> =
 const element: React.CElement<Props, ModernComponent> = React.createElement(ModernComponent, props);
 const elementNoState: React.CElement<Props, ModernComponentNoState> = React.createElement(ModernComponentNoState, props);
 const elementNullProps: React.CElement<{}, ModernComponentNoPropsAndState> = React.createElement(ModernComponentNoPropsAndState, null);
-const statelessElement: React.SFCElement<SCProps> = React.createElement(StatelessComponent, props);
-const statelessElementNullProps: React.SFCElement<SCProps> = React.createElement(StatelessComponent4, null);
+const functionComponentElement: React.FunctionComponentElement<SCProps> = React.createElement(FunctionComponent, props);
+const functionComponentElementNullProps: React.FunctionComponentElement<SCProps> = React.createElement(FunctionComponent4, null);
 const domElement: React.DOMElement<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement> = React.createElement("div");
 const domElementNullProps = React.createElement("div", null);
 const htmlElement = React.createElement("input", { type: "text" });
@@ -258,7 +258,7 @@ const customDomElementNullProps = React.createElement(customDomElement, null);
 
 // https://github.com/Microsoft/TypeScript/issues/15019
 
-function foo3(child: React.ComponentClass<{ name: string }> | React.StatelessComponent<{ name: string }> | string) {
+function foo3(child: React.ComponentClass<{ name: string }> | React.FunctionComponent<{ name: string }> | string) {
     React.createElement(child, { name: "bar" });
 }
 
@@ -277,8 +277,8 @@ const clonedElement3: React.CElement<Props, ModernComponent> =
         key: "8eac7",
         foo: 55
     });
-const clonedStatelessElement: React.SFCElement<SCProps> =
-    React.cloneElement(statelessElement, { foo: 44 });
+const clonedfunctionComponentElement: React.FunctionComponentElement<SCProps> =
+    React.cloneElement(functionComponentElement, { foo: 44 });
 // Clone base DOMElement
 const clonedDOMElement: React.DOMElement<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement> =
     React.cloneElement(domElement, {
@@ -605,11 +605,11 @@ const foundComponents: ModernComponent[] = TestUtils.scryRenderedComponentsWithT
 // ReactTestUtils custom type guards
 
 const emptyElement1: React.ReactElement<{}> = React.createElement(ModernComponent);
-if (TestUtils.isElementOfType(emptyElement1, StatelessComponent)) {
+if (TestUtils.isElementOfType(emptyElement1, FunctionComponent)) {
     emptyElement1.props.foo;
 }
-const emptyElement2: React.ReactElement<{}> = React.createElement(StatelessComponent);
-if (TestUtils.isElementOfType(emptyElement2, StatelessComponent)) {
+const emptyElement2: React.ReactElement<{}> = React.createElement(FunctionComponent);
+if (TestUtils.isElementOfType(emptyElement2, FunctionComponent)) {
     emptyElement2.props.foo;
 }
 

--- a/types/react/test/tsx.tsx
+++ b/types/react/test/tsx.tsx
@@ -3,23 +3,23 @@ import * as React from "react";
 interface SCProps {
     foo?: number;
 }
-const StatelessComponent: React.SFC<SCProps> = ({ foo }: SCProps) => {
+const FunctionComponent: React.FunctionComponent<SCProps> = ({ foo }: SCProps) => {
     return <div>{foo}</div>;
 };
-StatelessComponent.displayName = "StatelessComponent3";
-StatelessComponent.defaultProps = {
+FunctionComponent.displayName = "FunctionComponent3";
+FunctionComponent.defaultProps = {
     foo: 42
 };
-<StatelessComponent />;
+<FunctionComponent />;
 
-const StatelessComponent2: React.SFC<SCProps> = ({ foo, children }) => {
+const FunctionComponent2: React.FunctionComponent<SCProps> = ({ foo, children }) => {
     return <div>{foo}{children}</div>;
 };
-StatelessComponent2.displayName = "StatelessComponent4";
-StatelessComponent2.defaultProps = {
+FunctionComponent2.displayName = "FunctionComponent4";
+FunctionComponent2.defaultProps = {
     foo: 42
 };
-<StatelessComponent2>24</StatelessComponent2>;
+<FunctionComponent2>24</FunctionComponent2>;
 
 // svg sanity check
 <svg viewBox="0 0 1000 1000">
@@ -70,10 +70,10 @@ class ComponentWithoutPropsAndState extends React.Component {
 }
 <ComponentWithoutPropsAndState />;
 
-const StatelessComponentWithoutProps: React.SFC = (props) => {
+const FunctionComponentWithoutProps: React.FunctionComponent = (props) => {
     return <div />;
 };
-<StatelessComponentWithoutProps />;
+<FunctionComponentWithoutProps />;
 
 // React.createContext
 const ContextWithRenderProps = React.createContext('defaultValue');


### PR DESCRIPTION
This PR renames `React.SFC` and `React.StatelessComponent` to `React.FunctionComponent`, while introducing deprecated aliases for the old names. The motivation for this is twofold: firstly the addition of hooks means function components can have state, and secondly the term "stateless component" can equally apply to class components which don't use any state, causing some confusion.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
    - The hooks docs at https://reactjs.org/docs/hooks-state.html#hooks-and-function-components
      
      > You might have previously known these as “stateless components”. We’re now introducing the ability to use React state from these, so we prefer the name “function components”.

    - Dan Abramov's tweet on the subject https://twitter.com/dan_abramov/status/1057625147216220162

      ![screen shot 2018-11-01 at 12 03 27 pm](https://user-images.githubusercontent.com/320910/47826811-2f37fd00-ddce-11e8-8bff-574843e265e4.png)
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
