### PR TITLE
next-server: makes router optional

### DIFF
--- a/types/next-server/router.d.ts
+++ b/types/next-server/router.d.ts
@@ -79,7 +79,7 @@ export interface SingletonRouter<Q = DefaultQuery> extends RouterProps<Q> {
 }
 
 export interface WithRouterProps<Q = DefaultQuery> {
-    router: SingletonRouter<Q>;
+    router?: SingletonRouter<Q>;
 }
 
 /**

--- a/types/next-server/test/next-server-router-tests.tsx
+++ b/types/next-server/test/next-server-router-tests.tsx
@@ -79,16 +79,18 @@ class TestComponent extends React.Component<TestComponentProps> {
 
     constructor(props: TestComponentProps) {
         super(props);
-        props.router.ready(() => {
-            this.setState({ ready: true });
-        });
+        if (props.router) {
+            props.router.ready(() => {
+                this.setState({ ready: true });
+            });
+        }
     }
 
     render() {
         return (
             <div>
                 <h1>{this.state.ready ? 'Ready' : 'Not Ready'}</h1>
-                <h2>Route: {this.props.router.route}</h2>
+                <h2>Route: {this.props.router ? this.props.router.route : ""}</h2>
                 <p>Another prop: {this.props.testValue}</p>
             </div>
         );
@@ -106,16 +108,18 @@ class TestComponent2 extends React.Component<TestComponent2Props> {
 
     constructor(props: TestComponent2Props) {
         super(props);
-        props.router.ready(() => {
-            this.setState({ ready: true });
-        });
+        if (props.router) {
+            props.router.ready(() => {
+                this.setState({ ready: true });
+            });
+        }
     }
 
     render() {
         return (
             <div>
                 <h1>{this.state.ready ? 'Ready' : 'Not Ready'}</h1>
-                <h2>Route: {this.props.router.route}</h2>
+                <h2>Route: {this.props.router ? this.props.router.route : ""}</h2>
                 <p>Another prop: {this.props.testValue}</p>
             </div>
         );
@@ -134,20 +138,20 @@ interface TestSFCProps extends WithRouterProps<TestSFCQuery> {
 }
 
 const TestSFC: React.SFC<TestSFCProps> = ({ router }) => {
-    return <div>{router.query && router.query.test}</div>;
+    return <div>{router && router.query && router.query.test}</div>;
 };
 const TestSFCComponent = withRouter(TestSFC);
 
 const res2 = <TestSFCComponent testProp="asdf"/>;
 
 const TestSFC2 = withRouter<TestSFCProps>(({ router }) => {
-    return <div>{router.query && router.query.test}</div>;
+    return <div>{router && router.query && router.query.test}</div>;
 });
 
 const res3 = <TestSFC2 testProp="asdf" />;
 
 const TestSFC3 = withRouter(({ router }) => {
-    return <div>{router.query && router.query.test}</div>;
+    return <div>{router && router.query && router.query.test}</div>;
 });
 
 const res4 = <TestSFC3 />;

--- a/types/next/test/next-router-tests.tsx
+++ b/types/next/test/next-router-tests.tsx
@@ -79,16 +79,18 @@ class TestComponent extends React.Component<TestComponentProps & WithRouterProps
 
     constructor(props: TestComponentProps & WithRouterProps) {
         super(props);
-        props.router.ready(() => {
-            this.setState({ ready: true });
-        });
+        if (props.router) {
+            props.router.ready(() => {
+                this.setState({ ready: true });
+            });
+        }
     }
 
     render() {
         return (
             <div>
                 <h1>{this.state.ready ? 'Ready' : 'Not Ready'}</h1>
-                <h2>Route: {this.props.router.route}</h2>
+                <h2>Route: {this.props.router ? this.props.router.route : ""}</h2>
                 <p>Another prop: {this.props.testValue}</p>
             </div>
         );
@@ -104,5 +106,5 @@ interface TestSFCQuery {
 interface TestSFCProps extends WithRouterProps<TestSFCQuery> { }
 
 const TestSFC: React.SFC<TestSFCProps> = ({ router }) => {
-    return <div>{router.query && router.query.test}</div>;
+    return <div>{router && router.query && router.query.test}</div>;
 };

--- a/types/next/test/next-router-tests.tsx
+++ b/types/next/test/next-router-tests.tsx
@@ -90,7 +90,7 @@ class TestComponent extends React.Component<TestComponentProps & WithRouterProps
         return (
             <div>
                 <h1>{this.state.ready ? 'Ready' : 'Not Ready'}</h1>
-                <h2>Route: {this.props.router ? this.props.router.route : ""}</h2>
+                <h2>Route: { this.props.router ? this.props.router.route : "" }</h2>
                 <p>Another prop: {this.props.testValue}</p>
             </div>
         );

--- a/types/next/test/next-router-tests.tsx
+++ b/types/next/test/next-router-tests.tsx
@@ -90,7 +90,7 @@ class TestComponent extends React.Component<TestComponentProps & WithRouterProps
         return (
             <div>
                 <h1>{this.state.ready ? 'Ready' : 'Not Ready'}</h1>
-                <h2>Route: { this.props.router ? this.props.router.route : "" }</h2>
+                <h2>Route: {this.props.router ? this.props.router.route : ""}</h2>
                 <p>Another prop: {this.props.testValue}</p>
             </div>
         );


### PR DESCRIPTION
This makes router optional as explained in first comment of #24077 . Tested with my local project. 

Unfortunately this is a breaking change (tsc will start requiring null checks on router after this) but AFACT the current types are currently incorrect wrong. For some context:

I'm using this on a class as follows:
```
interface MyProps {
  router?: SingletonRouter<MyQuery> // Only optional/nullable after the changes in this PR
  baseUrl: string
  coin: string
}

class Page extends React.Component<MyProps, MyState> {
...
```

Using the current current types I get forced down one of two paths:
1: Don't declare `router` on `MyProps`: This sort of works, as `router` _is there at runtime_, but leads to me having to do ugly casting to access `this.props.router` (e.g. in render).
2: Declare the router on `MyProps` (as required):  This leads to my being forced to return props with router specified in `getInitialProps` and if I return it as `null` from there, then the behavior of `withRouter` breaks where I get a null router on my props at runtime instead of the actual route.

Making it optional resolves the behavioral issue but will start requiring users to check the `router` for null in their components (as seen in the tests after this PR). This seems legit because as was called out in #24077, users of the component don't want to have to supply `router` as a prop value on the component either!


- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/24077
- [x] Increase the version number in the header if appropriate. _**n/a - this is a fix to the existing types not updating to a new package version**_
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. - _**n/a - not substantial changes, lint already exists**_
