### PR TITLE
[next] Allow any key/value on __NEXT_DATA__

### DIFF
--- a/types/next/document.d.ts
+++ b/types/next/document.d.ts
@@ -55,6 +55,7 @@ export interface DocumentProps<Q extends DefaultQuery = DefaultQuery> {
         runtimeConfig?: any;
         nextExport?: boolean;
         err?: any;
+        [key: string]: any;
     };
     dev: boolean;
     dir?: string;

--- a/types/next/test/next-document-tests.tsx
+++ b/types/next/test/next-document-tests.tsx
@@ -1,4 +1,5 @@
 import Document, {
+    DocumentProps,
     Enhancer,
     Head,
     Main,
@@ -48,6 +49,14 @@ class MyDoc extends Document<WithUrlProps> {
         const url = req!.url;
 
         return { html, head, buildManifest, styles, url };
+    }
+
+    constructor(props: WithUrlProps & DocumentProps) {
+        super(props);
+        const { __NEXT_DATA__, url } = props;
+
+        // Custom __NEXT_DATA__ attribute
+        __NEXT_DATA__.url = url;
     }
 
     render() {


### PR DESCRIPTION
Setting arbitrary properties on `__NEXT_DATA__` is a common pattern for server-side rendering of styles. For example: https://github.com/zeit/next.js/blob/c95abc209bbb56d72a8564e7bcc59a588d34f7e1/examples/with-emotion/pages/_document.js#L15

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

This error occurs:

```
> definitely-typed@0.0.3 lint /Users/spencerelliott/Dev/elliottsj/DefinitelyTyped
> dtslint types "next"

TypeError: Cannot read property 'isDeclarationFile' of undefined
    at walk (/Users/spencerelliott/Dev/elliottsj/DefinitelyTyped/node_modules/dtslint/bin/rules/expectRule.js:93:20)
    at applyWithFunction.ctx (/Users/spencerelliott/Dev/elliottsj/DefinitelyTyped/node_modules/dtslint/bin/rules/expectRule.js:22:62)
    at Rule.AbstractRule.applyWithFunction (/Users/spencerelliott/Dev/elliottsj/DefinitelyTyped/node_modules/tslint/lib/language/rule/abstractRule.js:39:9)
    at getFailures (/Users/spencerelliott/Dev/elliottsj/DefinitelyTyped/node_modules/dtslint/bin/rules/expectRule.js:22:25)
    at Rule.applyWithProgram (/Users/spencerelliott/Dev/elliottsj/DefinitelyTyped/node_modules/dtslint/bin/rules/expectRule.js:24:29)
    at Linter.applyRule (/Users/spencerelliott/Dev/elliottsj/DefinitelyTyped/node_modules/tslint/lib/linter.js:194:29)
    at /Users/spencerelliott/Dev/elliottsj/DefinitelyTyped/node_modules/tslint/lib/linter.js:139:85
    at Object.flatMap (/Users/spencerelliott/Dev/elliottsj/DefinitelyTyped/node_modules/tslint/lib/utils.js:151:29)
    at Linter.getAllFailures (/Users/spencerelliott/Dev/elliottsj/DefinitelyTyped/node_modules/tslint/lib/linter.js:139:32)
    at Linter.lint (/Users/spencerelliott/Dev/elliottsj/DefinitelyTyped/node_modules/tslint/lib/linter.js:99:33)
Error: /Users/spencerelliott/Dev/elliottsj/DefinitelyTyped/types/next/test/next-app-tests.tsx:76:21
ERROR: 76:21  expect  TypeScript@next compile error:
Type 'Readonly<{ children?: ReactNode; }> & Readonly<P & AppProps<Record<string, string | string[] | undefined>> & WithExampleHocProps> & { example: string; }' is not assignable to type 'IntrinsicAttributes & P & WithExampleProps & AppProps<Record<string, string | string[] | undefined>> & { children?: ReactNode; }'.
  Type 'Readonly<{ children?: ReactNode; }> & Readonly<P & AppProps<Record<string, string | string[] | undefined>> & WithExampleHocProps> & { example: string; }' is not assignable to type 'P'.
ERROR: 92:21  expect  TypeScript@next compile error:
Type 'Readonly<{ children?: ReactNode; }> & Readonly<P & AppProps<Record<string, string | string[] | undefined>>>' is not assignable to type 'IntrinsicAttributes & P & AppProps<Record<string, string | string[] | undefined>> & { children?: ReactNode; }'.
  Type 'Readonly<{ children?: ReactNode; }> & Readonly<P & AppProps<Record<string, string | string[] | undefined>>>' is not assignable to type 'P'.

/Users/spencerelliott/Dev/elliottsj/DefinitelyTyped/types/next/test/next-component-tests.tsx:72:21
ERROR: 72:21  expect  TypeScript@next compile error:
Type 'Readonly<{ children?: ReactNode; }> & Readonly<P & WithExampleHocProps> & { example: string; }' is not assignable to type 'IntrinsicAttributes & P & WithExampleProps & { children?: ReactNode; }'.
  Type 'Readonly<{ children?: ReactNode; }> & Readonly<P & WithExampleHocProps> & { example: string; }' is not assignable to type 'P'.

/Users/spencerelliott/Dev/elliottsj/DefinitelyTyped/types/react/index.d.ts:27:22
ERROR: 27:22  expect  TypeScript@next compile error:
Cannot find module 'csstype'.

    at /Users/spencerelliott/Dev/elliottsj/DefinitelyTyped/node_modules/dtslint/bin/index.js:158:19
    at Generator.next (<anonymous>)
    at fulfilled (/Users/spencerelliott/Dev/elliottsj/DefinitelyTyped/node_modules/dtslint/bin/index.js:5:58)
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! definitely-typed@0.0.3 lint: `dtslint types "next"`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the definitely-typed@0.0.3 lint script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/spencerelliott/.npm/_logs/2018-11-01T17_34_00_902Z-debug.log
```

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/zeit/next.js/blob/c95abc209bbb56d72a8564e7bcc59a588d34f7e1/examples/with-emotion/pages/_document.js#L15
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
