### PR TITLE
[@types/mathjs] Fix wrong return type of callback of map function

### DIFF
--- a/types/mathjs/index.d.ts
+++ b/types/mathjs/index.d.ts
@@ -1345,7 +1345,7 @@ declare namespace math {
          * the Matrix/array being traversed.
          * @returns Transformed map of x
          */
-        map(x: Matrix | MathArray, callback: ((value: any, index: any, matrix: Matrix | MathArray) => Matrix | MathArray)): Matrix | MathArray;
+        map(x: Matrix | MathArray, callback: ((value: any, index: any, matrix: Matrix | MathArray) => MathType | string)): Matrix | MathArray;
 
         /**
          * Create a matrix filled with ones. The created matrix can have one or

--- a/types/mathjs/mathjs-tests.ts
+++ b/types/mathjs/mathjs-tests.ts
@@ -270,6 +270,13 @@ Matrices examples
 		math.range('2:-1:-3');
 		math.factorial(math.range('1:6'));
 	}
+
+	// map matrix
+	{
+  	math.map([1, 2, 3], function(value) {
+      return value * value;
+	  });  // returns [1, 4, 9]
+	}
 }
 
 /*


### PR DESCRIPTION
fix #30192 

I changed to return type as `MathType | string` because matrix can contain various types (mentioned in [official docs](http://mathjs.org/docs/datatypes/matrices.html))


> Matrices can contain different types of values: numbers, complex numbers, units, or strings. Different types can be mixed together in a single matrix.


- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
