### PR TITLE
Add changed method on TextMarker

### DIFF
--- a/types/codemirror/index.d.ts
+++ b/types/codemirror/index.d.ts
@@ -4,6 +4,7 @@
 //                 nrbernard <https://github.com/nrbernard>
 //                 Pr1st0n <https://github.com/Pr1st0n>
 //                 rileymiller <https://github.com/rileymiller>
+//                 toddself <https://github.com/toddself>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 export = CodeMirror;
@@ -706,8 +707,27 @@ declare namespace CodeMirror {
         or undefined if the marker is no longer in the document. */
         find(): {from: CodeMirror.Position, to: CodeMirror.Position};
 
+        /**  Called when you've done something that might change the size of the marker and want to cheaply update the display*/
+        changed(): void;
+
         /**  Returns an object representing the options for the marker. If copyWidget is given true, it will clone the value of the replacedWith option, if any. */
         getOptions(copyWidget: boolean): CodeMirror.TextMarkerOptions;
+
+        /** Fired when the cursor enters the marked range */
+        on(eventName: 'beforeCursorEnter', handler: () =>  void) : void;
+        off(eventName: 'beforeCursorEnter', handler: () => void) : void;
+
+        /** Fired when the range is cleared, either through cursor movement in combination with clearOnEnter or through a call to its clear() method */
+        on(eventName: 'clear', handler: (from: Position, to: Position) => void) : void;
+        off(eventName: 'clear', handler: () => void) : void;
+
+        /** Fired when the last part of the marker is removed from the document by editing operations */
+        on(eventName: 'hide', handler: () => void) : void;
+        off(eventname: 'hide', handler: () => void) : void;
+
+        /** Fired when, after the marker was removed by editing, a undo operation brough the marker back */
+        on(eventName: 'unhide', handler: () => void) : void;
+        off(eventname: 'unhide', handler: () => void) : void;
     }
 
     interface LineWidget {


### PR DESCRIPTION
The TextMarker definition is missing the `changed` method as defined [here](https://github.com/codemirror/CodeMirror/blob/master/src/model/mark_text.js#L111-L131), as well as it's specific event handlers.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
    - https://github.com/codemirror/CodeMirror/blob/master/src/model/mark_text.js#L111-L131
    - https://github.com/codemirror/CodeMirror/blob/master/src/model/mark_text.js#L150
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.