### PR TITLE
[@types/rebass] rearrange types to match rebass hierachy, remove unnecessary properties

### DIFF
--- a/types/rebass/index.d.ts
+++ b/types/rebass/index.d.ts
@@ -1,31 +1,36 @@
-// Type definitions for Rebass 0.3.7
+// Type definitions for Rebass 0.3.8
 // Project: https://github.com/jxnblk/rebass
 // Definitions by: rhysd <https://rhysd.github.io>
 //                 ryee-dev <https://github.com/ryee-dev>
+//                 jamesmckenzie <https://github.com/jamesmckenzie>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
 import * as React from "react";
 
 export interface BaseProps<C> extends React.ClassAttributes<C> {
-  className?: string;
-  m?: number;
-  mt?: number;
-  mr?: number;
-  mb?: number;
-  ml?: number;
-  mx?: number;
-  my?: number;
-  p?: number;
-  pt?: number;
-  pr?: number;
-  pb?: number;
-  pl?: number;
-  px?: number;
-  py?: number;
+    className?: string;
+    as?: string;
 }
 
-export interface BoxProps extends BaseProps<BoxClass> {
+export interface SpaceProps<C> extends BaseProps<C> {
+    m?: number;
+    mt?: number;
+    mr?: number;
+    mb?: number;
+    ml?: number;
+    mx?: number;
+    my?: number;
+    p?: number;
+    pt?: number;
+    pr?: number;
+    pb?: number;
+    pl?: number;
+    px?: number;
+    py?: number;
+}
+
+export interface BoxProps extends SpaceProps<BoxClass> {
     className?: string;
     width?: number | number[];
     fontSize?: number | number[];
@@ -36,82 +41,67 @@ export interface BoxProps extends BaseProps<BoxClass> {
 type BoxClass = React.StatelessComponent<BoxProps>;
 export declare const Box: BoxClass;
 
-export interface ButtonProps extends BaseProps<ButtonClass> {
-  fontWeight?: string;
-  border?: number;
-  borderColor?: string;
-  borderRadius?: number;
-  variant?: string;
-  bg?: string;
-  color?: string;
+export interface ButtonProps extends BoxProps {
+    fontWeight?: string;
+    border?: number;
+    borderColor?: string;
+    borderRadius?: number;
+    variant?: string;
 }
 type ButtonClass = React.StatelessComponent<ButtonProps>;
 export declare const Button: ButtonClass;
 
-export interface CardProps extends BaseProps<CardClass> {
-  border?: number;
-  borderColor?: string;
-  borderRadius?: number;
-  boxShadow?: string;
-  bg?: string;
-  backgroundImage?: string;
-  backgroundSize?: string;
-  backgroundPosition?: string;
-  backgroundRepeat?: string;
-  opacity?: number;
-  fontSize?: number | number[];
-  fontWeight?: string;
-  width?: number | number[];
+export interface CardProps extends BoxProps {
+    border?: number;
+    borderColor?: string;
+    borderRadius?: number;
+    boxShadow?: string;
+    backgroundImage?: string;
+    backgroundSize?: string;
+    backgroundPosition?: string;
+    backgroundRepeat?: string;
+    opacity?: number;
+    variant?: string;
 }
 type CardClass = React.StatelessComponent<CardProps>;
 export declare const Card: CardClass;
 
-export interface FlexProps extends BaseProps<FlexClass> {
-  alignItems?: string;
-  justifyContent?: string,
-  flexDirection?: string,
-  flexWrap?: string,
-  width?: number | number[];
+export interface FlexProps extends BoxProps {
+    alignItems?: string;
+    justifyContent?: string;
+    flexDirection?: string;
+    flexWrap?: string;
 }
-type FlexClass = React.StatelessComponent<FlexProps>
+type FlexClass = React.StatelessComponent<FlexProps>;
 export declare const Flex: FlexClass;
 
-export interface HeadingProps extends BaseProps<ImageClass> {
-  fontSize?: number | number[];
-  fontWeight?: string;
-  color?: string;
-  fontFamily?: string;
-  textAlign?: string;
-  lineHeight?: number;
-  letterSpacing?: number;
-}
-type HeadingClass = React.StatelessComponent<HeadingProps>
-export declare const Heading: HeadingClass;
-
-export interface ImageProps extends BaseProps<ImageClass> {
+export interface ImageProps extends BoxProps {
     height?: number;
     borderRadius?: number;
     src?: string;
     alt?: string;
-    width?: number | number[];
 }
-type ImageClass = React.StatelessComponent<ImageProps>
+type ImageClass = React.StatelessComponent<ImageProps>;
 export declare const Image: ImageClass;
 
-export interface LinkProps extends BaseProps<LinkClass> {
-  href?: string;
+export interface LinkProps extends BoxProps {
+    href?: string;
 }
-type LinkClass = React.StatelessComponent<LinkProps>
+type LinkClass = React.StatelessComponent<LinkProps>;
 export declare const Link: LinkClass;
 
-export interface TextProps extends BaseProps<ImageClass> {
-  fontSize?: number | number[];
-  fontWeight?: string;
-  color?: string;
-  fontFamily?: string;
-  textAlign?: string;
-  lineHeight?: number;
-  letterSpacing?: number;
+export interface TextProps extends BoxProps {
+    fontSize?: number | number[];
+    fontWeight?: string;
+    color?: string;
+    fontFamily?: string;
+    textAlign?: string;
+    lineHeight?: number;
+    letterSpacing?: number;
 }
-type TextClass = React.StatelessComponent<TextProps>
+type TextClass = React.StatelessComponent<TextProps>;
 export declare const Text: TextClass;
+
+export interface HeadingProps extends TextProps {}
+type HeadingClass = React.StatelessComponent<HeadingProps>;
+export declare const Heading: HeadingClass;

--- a/types/rebass/rebass-tests.tsx
+++ b/types/rebass/rebass-tests.tsx
@@ -8,7 +8,6 @@ const RebassTests = () => (
       <Text fontSize={3}>Hi, I'm text.</Text>
       <Card
         fontSize={6}
-        fontWeight='bold'
         width={[ 1, 1, 1/2 ]}
         p={5}
         my={5}


### PR DESCRIPTION
I've rearranged the Types to match Rebass's internal hierachy (most components extend Box). There were also a couple of properties that are unnecessary (e.g. fontWeight on Card). 

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Increase the version number in the header if appropriate.
