### PR TITLE
dd-trace: Fix incorrect typings for TracerOptions interface

### DIFF
--- a/types/dd-trace/dd-trace-tests.ts
+++ b/types/dd-trace/dd-trace-tests.ts
@@ -9,6 +9,7 @@ tracer.init({
         debug: msg => {},
         error: err => {},
     },
+    tags: { tracerEnv: 'dev'}
 });
 
 function useWebFrameworkPlugin(plugin: "express" | "hapi" | "koa" | "restify") {

--- a/types/dd-trace/index.d.ts
+++ b/types/dd-trace/index.d.ts
@@ -110,6 +110,11 @@ interface TracerOptions {
         debug: (message: string) => void;
         error: (err: Error) => void;
     };
+
+    /**
+     * Global tags that should be assigned to every span.
+     */
+    tags?: { [key: string]: any };
 }
 
 interface ExperimentalOptions {}


### PR DESCRIPTION
**Why:**
There was a missing property for the `TracerOptions` interface.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes:
This property exists in the javascript package but is missing in the typings see [here](https://github.com/DataDog/dd-trace-js/blob/v0.6.1/src/config.js#L25)
