### PR TITLE
@types/react-dates Add openDirection on single date range picker

### DIFF
--- a/types/react-dates/index.d.ts
+++ b/types/react-dates/index.d.ts
@@ -181,6 +181,7 @@ declare namespace ReactDates {
           ) => string | JSX.Element,
         orientation?: OrientationShape,
         anchorDirection?: AnchorDirectionShape,
+        openDirection?: OpenDirectionShape,
         horizontalMargin?: number,
         withPortal?: boolean,
         withFullScreenPortal?: boolean,


### PR DESCRIPTION
openDirection is missing as a prop for SingleDatePickerShape

Please fill in this template.

- [ Done ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ Done ] Test the change in your own code. (Compile and run.)
- [ Done ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ Done ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ Done  ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ Done ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ Done ] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/airbnb/react-dates/blob/master/src/components/SingleDatePicker.jsx
- [ Not required ] Increase the version number in the header if appropriate.
- [ Done ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

