### PR TITLE
types/node: make util.inspect.custom a 'unique symbol', not only a 'symbol'

### DIFF
--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -6792,7 +6792,7 @@ declare module "util" {
             [style: string]: string | undefined
         }
         defaultOptions: InspectOptions;
-        custom: symbol;
+        custom: unique symbol;
     };
     /** @deprecated since v4.0.0 - use `Array.isArray()` instead. */
     function isArray(object: any): object is any[];

--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -6782,7 +6782,8 @@ declare module "util" {
     function print(...param: any[]): void;
     /** @deprecated since v0.11.3 - use a third party module instead. */
     function log(string: string): void;
-    const inspect: {
+    
+    interface Inspect {
         (object: any, showHidden?: boolean, depth?: number | null, color?: boolean): string;
         (object: any, options: InspectOptions): string;
         colors: {
@@ -6792,8 +6793,10 @@ declare module "util" {
             [style: string]: string | undefined
         }
         defaultOptions: InspectOptions;
-        custom: unique symbol;
-    };
+        readonly custom: unique symbol;
+    }
+    const inspect: Inspect;
+
     /** @deprecated since v4.0.0 - use `Array.isArray()` instead. */
     function isArray(object: any): object is any[];
     /** @deprecated since v4.0.0 - use `util.types.isRegExp()` instead. */


### PR DESCRIPTION
Need to have util.inspect.custom being a `unique symbol`, otherwise you can't define a field of your class by this symbol, then you get:

    error TS1169: A computed property name in an interface must refer to an expression whose type is a literal type or a 'unique symbol' type.

I believe `unique symbol` is the right type as of node 11, since now they use `Symbol.for`:
https://github.com/nodejs/node/commit/dadd6e16888baac8fd110432b81f3fd1237be3e1#diff-a43208147d795be6dd3517c53226e37dL402

I am not 100% that the previous value, which was `Symbol(<string>)` could also be a `unique symbol` though. I guess it must have been OK though, since people were expected to use that to customize the behaviour in their own code?