### PR TITLE
storybook__react: Add support for addons options object

### DIFF
--- a/types/storybook__react/index.d.ts
+++ b/types/storybook__react/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/storybooks/storybook
 // Definitions by: Joscha Feth <https://github.com/joscha>
 //                 Anton Izmailov <https://github.com/wapgear>
+//                 Keith Wade <https://github.com/keawade>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -16,7 +17,7 @@ export type StoryDecorator = (story: RenderFunction, context: { kind: string, st
 
 export interface Story {
     readonly kind: string;
-    add(storyName: string, callback: RenderFunction): this;
+    add(storyName: string, callback: RenderFunction, options?: { [key: string]: any }): this;
     addDecorator(decorator: StoryDecorator): this;
 }
 

--- a/types/storybook__react/storybook__react-tests.tsx
+++ b/types/storybook__react/storybook__react-tests.tsx
@@ -9,7 +9,8 @@ storiesOf('Welcome', module)
     // local addDecorator
     .addDecorator(Decorator)
     .add('to Storybook', () => <div/>)
-    .add('to Storybook as Array', () => [<div />, <div />]);
+    .add('to Storybook as Array', () => [<div />, <div />])
+    .add('to Storybook with options', () => <div/>, { test: 'Hurray'});
 
 // global addDecorator
 addDecorator(Decorator);


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - https://medium.com/storybookjs/storybook-4-0-is-here-10b9857fc7de#531d
  - https://github.com/storybooks/storybook/tree/562794e65bb4bead1fdfca923df5c2ab41d63de7/addons/notes#getting-started
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

Storybook `.add` can take an optional options object with arbitrary key value pairs to configure the addons per story.