### PR TITLE
Papaparse: Fix Papa.parse() return value when called with Papa.NODE_STREAM_INPUT

### DIFF
--- a/types/papaparse/index.d.ts
+++ b/types/papaparse/index.d.ts
@@ -7,6 +7,7 @@
 //                 Alberto Restifo <https://github.com/albertorestifo>
 //                 Behind The Math <https://github.com/BehindTheMath>
 //                 3af <https://github.com/3af>
+//                 Janne Liuhtonen <https://github.com/jliuhtonen>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
@@ -23,7 +24,7 @@ export function parse(file: File, config?: ParseConfig): ParseResult;
 
 export function parse(stream: NodeJS.ReadableStream, config?: ParseConfig): ParseResult;
 
-export function parse(stream: typeof NODE_STREAM_INPUT, config?: ParseConfig): NodeJS.ReadableStream;
+export function parse(stream: typeof NODE_STREAM_INPUT, config?: ParseConfig): NodeJS.ReadWriteStream;
 
 /**
  * Unparses javascript data objects and returns a csv string

--- a/types/papaparse/papaparse-tests.ts
+++ b/types/papaparse/papaparse-tests.ts
@@ -9,6 +9,7 @@ import {
 	ParseMeta,
 	ParseResult
 } from "papaparse";
+import { Readable } from "stream";
 
 /**
  * Parsing
@@ -40,8 +41,19 @@ Papa.parse(file, {
 	}
 });
 
+const readable = new Readable()
+const rows = [
+	"1,2,3",
+	"4,5,6"
+]
 
-Papa.parse(Papa.NODE_STREAM_INPUT);
+rows.forEach(r => {
+	readable.push(r);
+});
+
+const papaStream: NodeJS.ReadWriteStream = Papa.parse(Papa.NODE_STREAM_INPUT);
+
+readable.pipe(papaStream);
 
 /**
  * Unparsing


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/mholt/PapaParse#papa-parse-for-node
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
