### PR TITLE
sonic-boom.reopen file descriptor should be optional

### DIFF
--- a/types/sonic-boom/index.d.ts
+++ b/types/sonic-boom/index.d.ts
@@ -31,7 +31,7 @@ declare class SonicBoom extends EventEmitter {
     /**
      * Reopen the file in place, useful for log rotation.
      */
-    reopen(file: string): void;
+    reopen(fileDescriptor?: string | number): void;
 
     /**
      * Flushes the buffered data synchronously. This is a costly operation.

--- a/types/sonic-boom/sonic-boom-tests.ts
+++ b/types/sonic-boom/sonic-boom-tests.ts
@@ -7,6 +7,8 @@ sonic.flush();
 
 sonic.flushSync();
 
+sonic.reopen();
+
 sonic.end();
 
 sonic.destroy();


### PR DESCRIPTION
When adding this definition, I forgot to make the file descriptor parameter for the reopen method optional.

This PR attempts to fix that

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/mcollina/sonic-boom#sonicboomreopenfile and https://github.com/mcollina/sonic-boom/blob/master/index.js#L118
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
