### PR TITLE
Fix the signature of @storybook/react .add() method

### DIFF
--- a/types/storybook__react/index.d.ts
+++ b/types/storybook__react/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for @storybook/react 3.4
+// Type definitions for @storybook/react 4.0
 // Project: https://github.com/storybooks/storybook
 // Definitions by: Joscha Feth <https://github.com/joscha>
 //                 Anton Izmailov <https://github.com/wapgear>
@@ -13,15 +13,21 @@ import * as React from 'react';
 export type Renderable = React.ComponentType | JSX.Element;
 export type RenderFunction = () => Renderable | Renderable[];
 
+export interface DecoratorParameters {
+    [key: string]: any;
+}
 export type StoryDecorator = (story: RenderFunction, context: { kind: string, story: string }) => Renderable | null;
 
 export interface Story {
     readonly kind: string;
-    add(storyName: string, callback: RenderFunction, parameters?: { [key: string]: any }): this;
+    add(storyName: string, callback: RenderFunction, parameters?: DecoratorParameters): this;
     addDecorator(decorator: StoryDecorator): this;
+    addParameters(parameters: DecoratorParameters): this;
 }
 
 export function addDecorator(decorator: StoryDecorator): void;
+export function addParameters(parameters: DecoratorParameters): void;
+export function clearDecorators(): void;
 export function configure(fn: () => void, module: NodeModule): void;
 export function setAddon(addon: object): void;
 export function storiesOf(name: string, module: NodeModule): Story;

--- a/types/storybook__react/index.d.ts
+++ b/types/storybook__react/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/storybooks/storybook
 // Definitions by: Joscha Feth <https://github.com/joscha>
 //                 Anton Izmailov <https://github.com/wapgear>
+//                 Dan Dean <https://github.com/dandean>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -16,7 +17,7 @@ export type StoryDecorator = (story: RenderFunction, context: { kind: string, st
 
 export interface Story {
     readonly kind: string;
-    add(storyName: string, callback: RenderFunction): this;
+    add(storyName: string, callback: RenderFunction, parameters?: { [key: string]: any }): this;
     addDecorator(decorator: StoryDecorator): this;
 }
 

--- a/types/storybook__react/index.d.ts
+++ b/types/storybook__react/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for @storybook/react 3.0
+// Type definitions for @storybook/react 3.4
 // Project: https://github.com/storybooks/storybook
 // Definitions by: Joscha Feth <https://github.com/joscha>
 //                 Anton Izmailov <https://github.com/wapgear>

--- a/types/storybook__react/storybook__react-tests.tsx
+++ b/types/storybook__react/storybook__react-tests.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
-import { storiesOf, setAddon, addDecorator, configure, getStorybook, RenderFunction, Story, forceReRender } from '@storybook/react';
+import { storiesOf, setAddon, addDecorator, addParameters, configure, getStorybook, RenderFunction, Story, forceReRender, DecoratorParameters, clearDecorators } from '@storybook/react';
 
 const Decorator = (story: RenderFunction) => <div>{story()}</div>;
+const Parameters: DecoratorParameters = { parameter: 'foo' };
 
 forceReRender();
 
@@ -9,10 +10,13 @@ storiesOf('Welcome', module)
     // local addDecorator
     .addDecorator(Decorator)
     .add('to Storybook', () => <div/>)
-    .add('to Storybook as Array', () => [<div />, <div />]);
+    .add('to Storybook as Array', () => [<div />, <div />])
+    .add('and a story with additional parameters', () => <div/>, Parameters);
 
 // global addDecorator
 addDecorator(Decorator);
+addParameters(Parameters);
+clearDecorators();
 
 // setAddon
 interface AnyAddon {
@@ -30,7 +34,7 @@ storiesOf<AnyAddon>('withAnyAddon', module)
     .addWithSideEffect('more', () => <div/>)
     .add('another story', () => <div/>)
     .add('to Storybook as Array', () => [<div />, <div />])
-    .add('and a story with additional parameters', () => <div/>, { parameter: 'foo' })
+    .add('and a story with additional parameters', () => <div/>, Parameters)
     .addWithSideEffect('even more', () => <div/>);
 
 // configure

--- a/types/storybook__react/storybook__react-tests.tsx
+++ b/types/storybook__react/storybook__react-tests.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { storiesOf, setAddon, addDecorator, addParameters, configure, getStorybook, RenderFunction, Story, forceReRender, DecoratorParameters, clearDecorators } from '@storybook/react';
 
 const Decorator = (story: RenderFunction) => <div>{story()}</div>;
-const Parameters: DecoratorParameters = { parameter: 'foo' };
+const parameters: DecoratorParameters = { parameter: 'foo' };
 
 forceReRender();
 
@@ -11,11 +11,11 @@ storiesOf('Welcome', module)
     .addDecorator(Decorator)
     .add('to Storybook', () => <div/>)
     .add('to Storybook as Array', () => [<div />, <div />])
-    .add('and a story with additional parameters', () => <div/>, Parameters);
+    .add('and a story with additional parameters', () => <div/>, parameters);
 
 // global addDecorator
 addDecorator(Decorator);
-addParameters(Parameters);
+addParameters(parameters);
 clearDecorators();
 
 // setAddon
@@ -34,7 +34,7 @@ storiesOf<AnyAddon>('withAnyAddon', module)
     .addWithSideEffect('more', () => <div/>)
     .add('another story', () => <div/>)
     .add('to Storybook as Array', () => [<div />, <div />])
-    .add('and a story with additional parameters', () => <div/>, Parameters)
+    .add('and a story with additional parameters', () => <div/>, parameters)
     .addWithSideEffect('even more', () => <div/>);
 
 // configure

--- a/types/storybook__react/storybook__react-tests.tsx
+++ b/types/storybook__react/storybook__react-tests.tsx
@@ -30,6 +30,7 @@ storiesOf<AnyAddon>('withAnyAddon', module)
     .addWithSideEffect('more', () => <div/>)
     .add('another story', () => <div/>)
     .add('to Storybook as Array', () => [<div />, <div />])
+    .add('and a story with additional parameters', () => <div/>, { parameter: 'foo' })
     .addWithSideEffect('even more', () => <div/>);
 
 // configure


### PR DESCRIPTION
Since `@storybook/react@3.4` the `add` method takes an optional 3rd `parameters` argument which is used to configure globally installed addons for the current story.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: _See comments inline with each addition/change_
- [x] Increase the version number in the header if appropriate.
