### PR TITLE
styled-system: Minor Fix, remove the true as an option to flexWrap

### DIFF
--- a/types/styled-system/dist/styles.d.ts
+++ b/types/styled-system/dist/styles.d.ts
@@ -299,7 +299,7 @@ export interface JustifyContentProps {
 
 export function justifyContent(...args: any[]): any;
 
-export type FlexWrapValue = true | "nowrap" | "wrap" | "wrap-reverse";
+export type FlexWrapValue = "nowrap" | "wrap" | "wrap-reverse";
 export type ResponsiveFlexWrapValue = ResponsiveValue<FlexWrapValue>;
 
 export interface FlexWrapProps {


### PR DESCRIPTION
`true` is not a valid option for set flexWrap to [in browsers](https://developer.mozilla.org/en-US/docs/Web/CSS/flex-wrap), we had accidentally set a bunch of these values.

/cc @iskounen

----

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.mozilla.org/en-US/docs/Web/CSS/flex-wrap
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
