### PR TITLE
Add missing type to constructor argument of ProgressPlugin in "webpack"

### DIFF
--- a/types/webpack/index.d.ts
+++ b/types/webpack/index.d.ts
@@ -1405,7 +1405,20 @@ declare namespace webpack {
     }
 
     class ProgressPlugin extends Plugin {
-        constructor(options?: (percentage: number, msg: string, moduleProgress?: string, activeModules?: string, moduleName?: string) => void);
+        constructor(options?: ProgressPlugin.Handler | ProgressPlugin.Options);
+    }
+
+    namespace ProgressPlugin {
+        type Handler = (percentage: number, msg: string, moduleProgress?: string, activeModules?: string, moduleName?: string) => void;
+
+        interface Options {
+            profile?: boolean;
+            handler: Handler;
+            modulesCount?: number;
+            entries?: boolean;
+            modules?: boolean;
+            activeModules?: boolean;
+        }
     }
 
     class EnvironmentPlugin extends Plugin {

--- a/types/webpack/webpack-tests.ts
+++ b/types/webpack/webpack-tests.ts
@@ -440,6 +440,20 @@ plugin = new webpack.EnvironmentPlugin(['a', 'b']);
 plugin = new webpack.EnvironmentPlugin({ a: true, b: 'c' });
 plugin = new webpack.ProgressPlugin((percent: number, message: string) => { });
 plugin = new webpack.ProgressPlugin((percent: number, message: string, moduleProgress?: string, activeModules?: string, moduleName?: string) => { });
+plugin = new webpack.ProgressPlugin({
+    handler: (percent: number, message: string) => { }
+});
+plugin = new webpack.ProgressPlugin({
+    handler: (percent: number, message: string, moduleProgress?: string, activeModules?: string, moduleName?: string) => { }
+});
+plugin = new webpack.ProgressPlugin({
+    profile: true,
+    handler: (percent: number, message: string) => { },
+    modulesCount: 500,
+    entries: false,
+    modules: false,
+    activeModules: false
+});
 plugin = new webpack.HashedModuleIdsPlugin();
 plugin = new webpack.HashedModuleIdsPlugin({
     hashFunction: 'sha256',


### PR DESCRIPTION
The constructor of `webpack.ProgressPlugin` accepts object as well as function.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - https://github.com/webpack/webpack/blob/master/lib/ProgressPlugin.js#L82
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
