### PR TITLE
Updated dhtmlxgantt type to properly export the types

### DIFF
--- a/types/dhtmlxgantt/index.d.ts
+++ b/types/dhtmlxgantt/index.d.ts
@@ -1731,3 +1731,11 @@ interface GanttStatic {
 
 declare var gantt: GanttStatic;
 declare var Gantt: GanttEnterprise;
+
+declare module "gantt" {
+    export = gantt;
+}
+
+declare module "Gantt" {
+    export = GanttEnterprise;
+}


### PR DESCRIPTION
Added modules declaration exporting the types to fix importing issues on ts 3.0+ (and angular 7 ecosystem) for dhtmlxgantt type(s).

No explicit import needed anymore (previously used `import "@types/dhtmlxgantt";` on ts 2.3.X)