### PR TITLE
Add 'error' event to minio-js types' BucketStream

### DIFF
--- a/types/minio/index.d.ts
+++ b/types/minio/index.d.ts
@@ -61,6 +61,7 @@ export interface IncompleteUploadedBucketItem {
 
 export interface BucketStream<T> extends Stream {
     on(event: 'data', listener: (item: T) => void): this;
+    on(event: 'error', listener: (error: Error) => void): this;
 }
 
 export interface PostPolicyResult {


### PR DESCRIPTION
The current definition does not take into account that the returned `Stream` may emit events under the name `error`.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/minio/minio-js/blob/d18a76ac44c65ed06ca606c91745fa81e20ac3f7/src/main/minio.js#L1342
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
