### PR TITLE
dockerode: Fix typo in dockerode DeviceMapping interface

### DIFF
--- a/types/dockerode/index.d.ts
+++ b/types/dockerode/index.d.ts
@@ -6,6 +6,7 @@
 //                 Ray Fang <https://github.com/lazarusx>
 //                 Marius Meisenzahl <https://github.com/meisenzahl>
 //                 Rob Moran <https://github.com/thegecko>
+//                 Cameron Diver <https://github.com/CameronDiver>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
@@ -626,7 +627,7 @@ declare namespace Dockerode {
 
   interface DeviceMapping {
     PathOnHost: string;
-    PathinContainer: string;
+    PathInContainer: string;
     CgroupPermissions: string;
   }
 


### PR DESCRIPTION
Changed the interface to reflect the actual field name from the docker documentation: https://docs.docker.com/engine/api/v1.30/#operation/ContainerCreate

Signed-off-by: Cameron Diver <cameron@balena.io>

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
 https://docs.docker.com/engine/api/v1.30/#operation/ContainerCreate
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
