### PR TITLE
Fix jest-each:  each describe cannot be used with parameters

### DIFF
--- a/types/jest-each/index.d.ts
+++ b/types/jest-each/index.d.ts
@@ -24,7 +24,7 @@ declare namespace JestEach {
 	}
 
 	interface DescribeObj {
-		(name: string, fn: DescribeFn): void;
+		(name: string, fn: SyncCallback): void;
 		only: DescribeFn;
 		skip: DescribeFn;
 	}

--- a/types/jest-each/index.d.ts
+++ b/types/jest-each/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/mattphillips/jest-each
 // Definitions by: Michael Utz <https://github.com/theutz>, Nick McCurdy <https://github.com/nickmccurdy>
 // Definitions: <https://github.com/DefinitelyTyped/DefinitelyTyped>
-// TypeScript Version: 2.1
+// TypeScript Version: 2.2
 
 export default JestEach;
 

--- a/types/jest-each/jest-each-tests.ts
+++ b/types/jest-each/jest-each-tests.ts
@@ -17,3 +17,19 @@ each(params).describe.only('', () => {});
 each(params).fdescribe('', () => {});
 each(params).describe.skip('', () => {});
 each(params).xdescribe('', () => {});
+
+each(params).test('', (a: number, b: string, c: object) => {});
+each(params).it('', (a: number, b: string, c: object) => {});
+each(params).test.only('', (a: number, b: string, c: object) => {});
+each(params).it.only('', (a: number, b: string, c: object) => {});
+each(params).fit('', (a: number, b: string, c: object) => {});
+each(params).test.skip('', (a: number, b: string, c: object) => {});
+each(params).it.skip('', (a: number, b: string, c: object) => {});
+each(params).xit('', (a: number, b: string, c: object) => {});
+each(params).xtest('', (a: number, b: string, c: object) => {});
+
+each(params).describe('', (a: number, b: string, c: object) => {});
+each(params).describe.only('', (a: number, b: string, c: object) => {});
+each(params).fdescribe('', (a: number, b: string, c: object) => {});
+each(params).describe.skip('', (a: number, b: string, c: object) => {});
+each(params).xdescribe('', (a: number, b: string, c: object) => {});


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.npmjs.com/package/jest-each#describename-fn
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
