### PR TITLE
Update openpgp type definitions to support async functions

### DIFF
--- a/types/openpgp/index.d.ts
+++ b/types/openpgp/index.d.ts
@@ -1,8 +1,9 @@
-// Type definitions for openpgp 4.0.0
+// Type definitions for openpgp 4.0.1
 // Project: http://openpgpjs.org/
 // Definitions by: Guillaume Lacasa <https://blog.lacasa.fr>
 //                 Errietta Kostala <https://github.com/errietta>
 //                 Daniel Montesinos <https://github.com/damonpam>
+//                 Carlos Villavicencio <https://github.com/po5i>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 export as namespace openpgp;
@@ -269,7 +270,17 @@ export namespace cleartext {
         verify(keys: Array<key.Key>): Array<VerifiedMessage>;
     }
 
-    function readArmored(armoredText: string): CleartextMessage;
+    /** creates new message object from binary data
+        @param bytes
+     */
+    function fromBinary(bytes: string): CleartextMessage;
+
+    /** creates new message object from text
+        @param text
+     */
+    function fromText(text: string): CleartextMessage;
+
+    function readArmored(armoredText: string): Promise<CleartextMessage>;
 }
 
 export namespace config {
@@ -514,7 +525,7 @@ export namespace key {
 
         @param armoredText text to be parsed
      */
-    function readArmored(armoredText: string): KeyResult;
+    function readArmored(armoredText: string): Promise<KeyResult>;
 }
 
 export namespace message {
@@ -580,7 +591,7 @@ export namespace message {
 
         @param armoredText text to be parsed
      */
-    function readArmored(armoredText: string): Message;
+    function readArmored(armoredText: string): Promise<Message>;
 
     /**
      * reads an OpenPGP message as byte array and returns a message object

--- a/types/openpgp/openpgp-tests.ts
+++ b/types/openpgp/openpgp-tests.ts
@@ -19,27 +19,51 @@ openpgp.generateKey(options).then(function (keypair) {
 
 
 var spubkey = '-----BEGIN PGP PUBLIC KEY BLOCK ... END PGP PUBLIC KEY BLOCK-----';
-var publicKey = openpgp.key.readArmored(spubkey);
 
-openpgp.encrypt({
-    message: openpgp.message.fromText('Hello, World!'),
-    publicKeys: publicKey.keys
-}).then(function (pgpMessage) {
+openpgp.key.readArmored(spubkey)
+    .then(function (publicKey) {
+        return {
+            message: openpgp.message.fromText('Hello, World!'),
+            publicKeys: publicKey.keys
+        };
+    })
+    .then(openpgp.encrypt)
+    .then(function (pgpMessage) {
+        // success
+    })
+    .catch(function (error) {
+        // failure
+    });
+
+var sprivkey = '-----BEGIN PGP PRIVATE KEY BLOCK ... END PGP PRIVATE KEY BLOCK-----';
+var pgpMessageStr = '-----BEGIN PGP MESSAGE ... END PGP MESSAGE-----';
+
+openpgp.message.readArmored(pgpMessageStr).then(function(pgpMessage) {
+    const options = {
+        message: pgpMessage
+    };
+    return openpgp.decrypt(options);
+}).then(function (plaintext) {
     // success
 }).catch(function (error) {
     // failure
 });
 
-var sprivkey = '-----BEGIN PGP PRIVATE KEY BLOCK ... END PGP PRIVATE KEY BLOCK-----';
-var privateKey = openpgp.key.readArmored(sprivkey).keys[0];
-privateKey.decrypt('passphrase');
+const promises: [Promise<openpgp.key.KeyResult>, Promise<openpgp.message.Message>] = [
+    openpgp.key.readArmored(sprivkey),
+    openpgp.message.readArmored(pgpMessageStr)
+];
 
-var pgpMessageStr = '-----BEGIN PGP MESSAGE ... END PGP MESSAGE-----';
-var pgpMessage = openpgp.message.readArmored(pgpMessageStr);
-
-openpgp.decrypt({
-    privateKeys: privateKey,
-    message: pgpMessage
+Promise.all(promises).then(function (values) {
+    const keyObject: openpgp.key.KeyResult = values[0];
+    const pgpMessage: openpgp.message.Message = values[1];
+    const privateKey = keyObject.keys[0];
+    privateKey.decrypt('passphrase');
+    const options = {
+        privateKeys: privateKey,
+        message: pgpMessage
+    };
+    return openpgp.decrypt(options);
 }).then(function (plaintext) {
     // success
 }).catch(function (error) {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URLs to documentation or source code which provides context for the suggested changes:
  - https://github.com/openpgpjs/openpgpjs#encrypt-and-decrypt-string-data-with-pgp-keys
  - https://github.com/openpgpjs/openpgpjs/releases/tag/v3.0.0
  - https://github.com/openpgpjs/openpgpjs/blob/master/src/key.js#L1270
  - https://github.com/openpgpjs/openpgpjs/blob/master/src/cleartext.js#L155
  - https://github.com/openpgpjs/openpgpjs/blob/master/src/cleartext.js#L218
  - https://github.com/openpgpjs/openpgpjs/blob/master/src/message.js#L697
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
