### PR TITLE
SystemInformation module Name property added to ProcessesProcessData interface 

### DIFF
--- a/types/systeminformation/index.d.ts
+++ b/types/systeminformation/index.d.ts
@@ -367,7 +367,7 @@ export namespace Systeminformation {
         tty: string;
         user: string;
         command: string;
-        name:string;
+        name: string;
     }
 
     interface ProcessesProcessLoadData {

--- a/types/systeminformation/index.d.ts
+++ b/types/systeminformation/index.d.ts
@@ -367,6 +367,7 @@ export namespace Systeminformation {
         tty: string;
         user: string;
         command: string;
+        name:string;
     }
 
     interface ProcessesProcessLoadData {


### PR DESCRIPTION
name property added to ProcessesProcessData interface.
This allows reading the name of process.
https://github.com/sebhildebrandt/systeminformation
