### PR TITLE
Update events option in types/jquery.contextmenu/index.d.ts

### DIFF
--- a/types/jquery.contextmenu/index.d.ts
+++ b/types/jquery.contextmenu/index.d.ts
@@ -22,8 +22,8 @@ interface JQueryContextMenuOptions {
         hide?: string;
     };
     events?: {
-        show?: (options?: any) => any;
-        hide?: (options?: any) => any;
+        show?: (options: any) => boolean;
+        hide?: (options: any) => boolean;
     };
     callback?: (key: any, options: any) => any;
     items?: any;

--- a/types/jquery.contextmenu/index.d.ts
+++ b/types/jquery.contextmenu/index.d.ts
@@ -22,8 +22,8 @@ interface JQueryContextMenuOptions {
         hide?: string;
     };
     events?: {
-        show?: () => void;
-        hide?: () => void;
+        show?: (options?: any) => any;
+        hide?: (options?: any) => any;
     };
     callback?: (key: any, options: any) => any;
     items?: any;


### PR DESCRIPTION
The events show/hide options allow options to be passed and may return false to prevent the event occurring.  Note that later versions have an activated event also.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: https://swisnl.github.io/jQuery-contextMenu/docs.html#events

