### PR TITLE
[@types/react] RefForwardingComponent argument type doesn't correspond to actual type

### DIFF
--- a/types/react-is/react-is-tests.tsx
+++ b/types/react-is/react-is-tests.tsx
@@ -6,7 +6,7 @@ import * as ReactIs from 'react-is';
 // Determining if a Component is Valid
 
 interface CompProps {
-    forwardedRef?: React.Ref<any>;
+    forwardedRef: React.Ref<any> | null;
     children?: React.ReactNode;
 }
 

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -348,7 +348,7 @@ declare namespace React {
     }
 
     interface RefForwardingComponent<T, P = {}> {
-        (props: P & { children?: ReactNode }, ref?: Ref<T>): ReactElement<any> | null;
+        (props: P & { children?: ReactNode }, ref: Ref<T> | null): ReactElement<any> | null;
         propTypes?: ValidationMap<P>;
         contextTypes?: ValidationMap<any>;
         defaultProps?: Partial<P>;


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/facebook/react/blob/3ff2c7ccd4d174786aed0f16cc0dd784816ae977/packages/react-reconciler/src/ReactFiber.js#L131 - one can see that `ref` can definitely be null and I reproduced that successfully. Though I didn't find any evidence of `ref`being `undefined`.
- [ ] Increase the version number in the header if appropriate. - **I'm not sure if the version should be increased. The change is very small though it can break one's code. It already broke code in different type definition package that I had to change.**
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.