### PR TITLE
d3-selection: better type inference for append, insert, create and creator

### DIFF
--- a/types/d3-brush/d3-brush-tests.ts
+++ b/types/d3-brush/d3-brush-tests.ts
@@ -98,7 +98,7 @@ brush.on('end', function(d, i, g) {
 // -----------------------------------------------------------------------------
 
 const g = select<SVGSVGElement, any>('svg')
-    .append<SVGGElement>('g')
+    .append('g')
     .classed('brush', true)
     .datum<BrushDatum>({
         extent: [[0, 0], [300, 200]],
@@ -108,7 +108,7 @@ const g = select<SVGSVGElement, any>('svg')
 g.call(brush);
 
 const gX = select<SVGSVGElement, any>('svg')
-    .append<SVGGElement>('g')
+    .append('g')
     .classed('brush', true)
     .datum<BrushDatum>({
         extent: [[0, 0], [300, 200]],

--- a/types/d3-chord/d3-chord-tests.ts
+++ b/types/d3-chord/d3-chord-tests.ts
@@ -193,5 +193,5 @@ ribbonPaths = select<SVGGElement, any>('g')
     .datum(chords)
     .selectAll()
     .data(chords => chords)
-    .enter().append<SVGPathElement>('path')
+    .enter().append('path')
     .attr('d', svgRibbon);

--- a/types/d3-drag/index.d.ts
+++ b/types/d3-drag/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/d3/d3-drag/
 // Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
 
 // Last module patch version validated against: 1.2.1
 

--- a/types/d3-sankey/index.d.ts
+++ b/types/d3-sankey/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/d3/d3-sankey/
 // Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
 
 // Last module patch version validated against: 0.7.1
 

--- a/types/d3-selection/d3-selection-tests.ts
+++ b/types/d3-selection/d3-selection-tests.ts
@@ -810,19 +810,24 @@ nRow = td2.data(); // flattened matrix (Array[16] of number)
 
 // append(...), creator(...) and create(...) ---------------------------------------------
 
-// without append<...> typing returned selection has group element of type BaseType
-let newDiv: d3Selection.Selection<d3Selection.BaseType, BodyDatum, HTMLElement, any>;
+let newCircle: d3Selection.Selection<SVGCircleElement, BodyDatum, HTMLElement, any>;
+newCircle = body.append('circle');
+
+let newDiv: d3Selection.Selection<HTMLDivElement, BodyDatum, HTMLElement, any>;
 newDiv = body.append('div');
 
-let newDiv2: d3Selection.Selection<HTMLDivElement, BodyDatum, HTMLElement, any>;
-newDiv2 = body.append<HTMLDivElement>('div');
+newDiv = body.append<HTMLDivElement>('div');
 
 // using creator
-newDiv2 = body.append(d3Selection.creator<HTMLDivElement>('div'));
+newCircle = body.append(d3Selection.creator('circle'));
+newDiv = body.append(d3Selection.creator('div'));
+newDiv = body.append(d3Selection.creator<HTMLDivElement>('custom_div_elem'));
 // $ExpectError
-newDiv2 = body.append(d3Selection.creator('div')); // fails, as creator returns BaseType element, but HTMLDivElement is expected.
+newDiv = body.append(d3Selection.creator('a'));
+// $ExpectError
+newDiv = body.append(d3Selection.creator<HTMLAnchorElement>('a'));
 
-newDiv2 = body.append(function(d, i, g) {
+newDiv = body.append(function(d, i, g) {
     const that: HTMLBodyElement = this;
     // $ExpectError
     const that2: SVGElement  = this; // fails, type mismatch
@@ -834,29 +839,29 @@ newDiv2 = body.append(function(d, i, g) {
 });
 
 // $ExpectError
-newDiv2 = body.append<HTMLDivElement>(function(d) {
+newDiv = body.append<HTMLDivElement>(function(d) {
     return this.ownerDocument!.createElement('a'); // fails, HTMLDivElement expected by type parameter, HTMLAnchorElement returned
 });
 
 // $ExpectError
-newDiv2 = body.append(function(d) {
+newDiv = body.append(function(d) {
     return this.ownerDocument!.createElement('a'); // fails, HTMLDivElement expected by inference, HTMLAnchorElement returned
 });
 
 // create a detached element
 
+let detachedCircle: d3Selection.Selection<SVGCircleElement, undefined, null, undefined>;
+
+detachedCircle = d3Selection.create('circle');
+
 let detachedDiv: d3Selection.Selection<HTMLDivElement, undefined, null, undefined>;
 
-detachedDiv = d3Selection.create<HTMLDivElement>('div');
+detachedDiv = d3Selection.create('div');
+detachedDiv = d3Selection.create<HTMLDivElement>('custom_div_elem');
 
 // insert(...) ---------------------------------------------------------------------------
 
-// without insert<...> typing returned selection has group element of type BaseType
-let newParagraph: d3Selection.Selection<d3Selection.BaseType, BodyDatum, HTMLElement, any>;
-newParagraph = body.insert('p', 'p.second-paragraph');
-newParagraph = body.insert('p');
-
-// Two arguments; the first can be string, selection , or a
+// Two arguments; the first can be string, selection, or a
 
 const typeValueFunction = function(
   this: HTMLBodyElement,
@@ -876,32 +881,37 @@ const beforeValueFunction = function(
     return this.children[0];
 };
 
-let newParagraph2: d3Selection.Selection<HTMLParagraphElement, BodyDatum, HTMLElement, any>;
+let newParagraph: d3Selection.Selection<HTMLParagraphElement, BodyDatum, HTMLElement, any>;
+
+// 1 args, with 3 possibilities each, makes 3 possible combinations:
+newParagraph = body.insert('p', 'p.second-paragraph');
+newParagraph = body.insert('p', beforeValueFunction);
+newParagraph = body.insert('p');
 
 // 2 args, with 3 possibilities each, makes 9 possible combinations:
-newParagraph2 = body.insert<HTMLParagraphElement>('p', 'p.second-paragraph');
-newParagraph2 = body.insert<HTMLParagraphElement>('p', beforeValueFunction);
-newParagraph2 = body.insert<HTMLParagraphElement>('p');
+newParagraph = body.insert<HTMLParagraphElement>('p', 'p.second-paragraph');
+newParagraph = body.insert<HTMLParagraphElement>('p', beforeValueFunction);
+newParagraph = body.insert<HTMLParagraphElement>('p');
 
-newParagraph2 = body.insert(d3Selection.creator<HTMLParagraphElement>('p'), 'p.second-paragraph');
-newParagraph2 = body.insert(d3Selection.creator<HTMLParagraphElement>('p'), beforeValueFunction);
-newParagraph2 = body.insert(d3Selection.creator<HTMLParagraphElement>('p'));
+newParagraph = body.insert(d3Selection.creator<HTMLParagraphElement>('p'), 'p.second-paragraph');
+newParagraph = body.insert(d3Selection.creator<HTMLParagraphElement>('p'), beforeValueFunction);
+newParagraph = body.insert(d3Selection.creator<HTMLParagraphElement>('p'));
 
-newParagraph2 = body.insert(typeValueFunction, 'p.second-paragraph');
-newParagraph2 = body.insert(typeValueFunction, beforeValueFunction);
-newParagraph2 = body.insert(typeValueFunction);
+newParagraph = body.insert(typeValueFunction, 'p.second-paragraph');
+newParagraph = body.insert(typeValueFunction, beforeValueFunction);
+newParagraph = body.insert(typeValueFunction);
 
 // clone(...) ----------------------------------------------------------------------------
 
 let clonedParagraph: d3Selection.Selection<HTMLParagraphElement, BodyDatum, HTMLElement, any>;
 
 // shallow clone
-clonedParagraph = newParagraph2.clone();
+clonedParagraph = newParagraph.clone();
 
 // deep clone
 
 newParagraph.append('span');
-clonedParagraph = newParagraph2.clone(true);
+clonedParagraph = newParagraph.clone(true);
 
 // sort(...) -----------------------------------------------------------------------------
 

--- a/types/d3-selection/d3-selection-tests.ts
+++ b/types/d3-selection/d3-selection-tests.ts
@@ -685,7 +685,7 @@ circles2 = d3Selection.select<SVGSVGElement, any>('#svg2')
     .selectAll() // create empty Selection
     .data(startCircleData) // assign data for circles to be added (no previous circles)
     .enter() // obtain enter selection
-    .append<SVGCircleElement>('circle');
+    .append('circle');
 
 // UPDATE-selection with continuation in data type ---------------------------------
 
@@ -705,7 +705,7 @@ let enterElements: d3Selection.Selection<d3Selection.EnterElement, CircleDatumAl
 enterElements = circles2.enter(); // enter selection
 
 const enterCircles = enterElements
-    .append<SVGCircleElement>('circle') // enter selection with materialized DOM elements (svg circles)
+    .append('circle') // enter selection with materialized DOM elements (svg circles)
     .attr('cx', d => d.cx)
     .attr('cy', d => d.cy)
     .attr('r', d => d.r)
@@ -763,19 +763,19 @@ let nRow: number[];
 
 let tr: d3Selection.Selection<HTMLTableRowElement, number[], HTMLTableElement, any>;
 tr = d3Selection.select('body')
-    .append<HTMLTableElement>('table')
+    .append('table')
     .selectAll()
     .data(matrix)
     // $ExpectError
     .data<number[]>([{test: 1}, {test: 2}]) // fails, using this data statement instead, would fail because of its type parameter not being met by input
-    .enter().append<HTMLTableRowElement>('tr');
+    .enter().append('tr');
 
 nMatrix = tr.data(); // i.e. matrix
 
 let td: d3Selection.Selection<HTMLTableDataCellElement, number, HTMLTableRowElement, number[]>;
 td = tr.selectAll()
     .data(d => d) // d : Array<number> inferred (Array[4] of number per parent <tr>)
-    .enter().append<HTMLTableDataCellElement>('td')
+    .enter().append('td')
     .text(function(d, i, g) {
         const that: HTMLTableDataCellElement = this;
         const datum: number = d;

--- a/types/d3-selection/index.d.ts
+++ b/types/d3-selection/index.d.ts
@@ -5,6 +5,7 @@
 //                 Boris Yankov <https://github.com/borisyankov>
 //                 denisname <https://github.com/denisname>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
 
 // Last module patch version validated against: 1.3.0
 
@@ -474,6 +475,19 @@ export interface Selection<GElement extends BaseType, Datum, PElement extends Ba
      * This method returns a new selection containing the appended elements.
      * Each new element inherits the data of the current elements, if any.
      *
+     * @param type A string representing the tag name.
+     */
+    append<K extends keyof ElementTagNameMap>(type: K): Selection<ElementTagNameMap[K], Datum, PElement, PDatum>;
+    /**
+     * Appends a new element of this type (tag name) as the last child of each selected element,
+     * or before the next following sibling in the update selection if this is an enter selection.
+     * The latter behavior for enter selections allows you to insert elements into the DOM in an order consistent with the new bound data;
+     * however, note that selection.order may still be required if updating elements change order
+     * (i.e., if the order of new data is inconsistent with old data).
+     *
+     * This method returns a new selection containing the appended elements.
+     * Each new element inherits the data of the current elements, if any.
+     *
      * The generic refers to the type of the child element to be appended.
      *
      * @param type A string representing the tag name. The specified name may have a namespace prefix, such as svg:text
@@ -482,6 +496,7 @@ export interface Selection<GElement extends BaseType, Datum, PElement extends Ba
      * (for example, svg implies svg:svg)
      */
     append<ChildElement extends BaseType>(type: string): Selection<ChildElement, Datum, PElement, PDatum>;
+
     /**
      * Appends a new element of the type provided by the element creator function as the last child of each selected element,
      * or before the next following sibling in the update selection if this is an enter selection.
@@ -510,6 +525,27 @@ export interface Selection<GElement extends BaseType, Datum, PElement extends Ba
      *
      * The generic refers to the type of the child element to be appended.
      *
+     * @param type A string representing the tag name for the element type to be inserted.
+     * @param before One of:
+     *   * A CSS selector string for the element before which the insertion should occur.
+     *   * A child selector function which is evaluated for each selected element, in order, being passed the current datum (d),
+     *     the current index (i), and the current group (nodes), with this as the current DOM element (nodes[i]). This function should return the child element
+     *     before which the element should be inserted.
+     */
+    insert<K extends keyof ElementTagNameMap>(
+        type: K,
+        before?: string | ValueFn<GElement, Datum, BaseType>
+    ): Selection<ElementTagNameMap[K], Datum, PElement, PDatum>;
+    /**
+     * Inserts a new element of the specified type (tag name) before the first element matching the specified
+     * before selector for each selected element. For example, a before selector :first-child will prepend nodes before the first child.
+     * If before is not specified, it defaults to null. (To append elements in an order consistent with bound data, use selection.append.)
+     *
+     * This method returns a new selection containing the appended elements.
+     * Each new element inherits the data of the current elements, if any.
+     *
+     * The generic refers to the type of the child element to be appended.
+     *
      * @param type One of:
      *   * A string representing the tag name for the element type to be inserted. The specified name may have a namespace prefix,
      *     such as svg:text to specify a text attribute in the SVG namespace. If no namespace is specified, the namespace will be inherited
@@ -527,7 +563,7 @@ export interface Selection<GElement extends BaseType, Datum, PElement extends Ba
     insert<ChildElement extends BaseType>(
         type: string | ValueFn<GElement, Datum, ChildElement>,
         before?: string | ValueFn<GElement, Datum, BaseType>
-        ): Selection<ChildElement, Datum, PElement, PDatum>;
+    ): Selection<ChildElement, Datum, PElement, PDatum>;
 
     /**
      * Removes the selected elements from the document.
@@ -1119,11 +1155,25 @@ export function window(DOMNode: Window | Document | Element): Window;
  * Given the specified element name, returns a single-element selection containing
  * a detached element of the given name in the current document.
  *
+ * @param name tag name of the element to be added.
+ */
+export function create<K extends keyof ElementTagNameMap>(name: K): Selection<ElementTagNameMap[K], undefined, null, undefined>;
+/**
+ * Given the specified element name, returns a single-element selection containing
+ * a detached element of the given name in the current document.
+ *
  * @param name Tag name of the element to be added. See "namespace" for details on supported namespace prefixes,
  * such as for SVG elements.
  */
 export function create<NewGElement extends Element>(name: string): Selection<NewGElement, undefined, null, undefined>;
 
+/**
+ * Given the specified element name, returns a function which creates an element of the given name,
+ * assuming that "this" is the parent element.
+ *
+ * @param name Tag name of the element to be added.
+ */
+export function creator<K extends keyof ElementTagNameMap>(name: K): (this: BaseType) => ElementTagNameMap[K];
 /**
  * Given the specified element name, returns a function which creates an element of the given name,
  * assuming that "this" is the parent element.

--- a/types/d3-shape/index.d.ts
+++ b/types/d3-shape/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/d3/d3-shape/
 // Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
 
 // Last module patch version validated against: 1.2.0
 

--- a/types/d3-transition/d3-transition-tests.ts
+++ b/types/d3-transition/d3-transition-tests.ts
@@ -102,7 +102,7 @@ circles = select<SVGSVGElement, any>('svg')
     .selectAll()
     .data(startCircleData)
     .enter()
-    .append<SVGCircleElement>('circle')
+    .append('circle')
     .attr('cx', d => d.cx)
     .attr('cy', d => d.cy)
     .attr('r', d => d.r)
@@ -114,7 +114,7 @@ circles = circles
 
 const enterCircles = circles
     .enter()
-    .append<SVGCircleElement>('circle')
+    .append('circle')
     .classed('big', d => d.r > 10)
     .attr('cx', d => d.cx)
     .attr('cy', d => d.cy)

--- a/types/d3-zoom/d3-zoom-tests.ts
+++ b/types/d3-zoom/d3-zoom-tests.ts
@@ -65,11 +65,11 @@ const svg = select<SVGSVGElement, undefined>('svg')
     .attr('width', d => d.width)
     .attr('height', d => d.height);
 
-const g = svg.append<SVGGElement>('g');
+const g = svg.append('g');
 
 g.selectAll()
     .data<[number, number]>(points)
-    .enter().append<SVGCircleElement>('circle')
+    .enter().append('circle')
     .attr('cx', d => d[0])
     .attr('cy', d => d[1])
     .attr('r', 2.5);
@@ -280,7 +280,7 @@ canvas.call(canvasZoom);
 // SVG Example --------------------------------------------------------------
 
 // attach the zoom behavior to an overlay svg rectangle
-const svgOverlay: Selection<SVGRectElement, SVGDatum, HTMLElement, any> = svg.append<SVGRectElement>('rect')
+const svgOverlay: Selection<SVGRectElement, SVGDatum, HTMLElement, any> = svg.append('rect')
     .attr('width', d => d.width)
     .attr('height', d => d.height)
     .style('fill', 'none')


### PR DESCRIPTION
This PR improve type inference for some d3-selection methods. For example before we needed to do:

```typescript
selection.append<SVGCircleElement>('circle');
```

to get a _SVGCircleElement selection_. Now the same code without a generic will give the same result:

```typescript
selection.append('circle'); // => d3.Selection<SVGCircleElement, Data, HTMLElement, any>
```

It is easier to get your selection correctly typed. And changing an element type is also simpler. Finally, it's more user-friendly for beginners. For example, the code:

```typescript
g.append("g")
    .attr("transform", `translate(0,${height})`)
    .call(d3.axisBottom(x));
```
was giving a hard to undersand error about `d3.axisBottom`, because it is missing a genreic in `append`. Now it will just compile, as expected by beginners, and be strongly typed.