### PR TITLE
ckeditor5-utils: add new definition

### DIFF
--- a/types/ckeditor__ckeditor5-utils/ckeditor__ckeditor5-utils-tests.ts
+++ b/types/ckeditor__ckeditor5-utils/ckeditor__ckeditor5-utils-tests.ts
@@ -1,0 +1,594 @@
+import * as utils from "ckeditor__ckeditor5-utils";
+
+declare const document: Document;
+declare const locale: utils.Locale;
+declare let bool: boolean;
+declare let changes: utils.Change[];
+declare let emitter: utils.Emitter;
+declare let htmlElement: HTMLElement;
+declare let map: Map<string, number>;
+declare let num: number;
+declare let rect: utils.Rect;
+declare let rectOrNull: utils.Rect | null;
+declare let str: string;
+
+// utils/dom
+
+utils.createElement(document, "p");
+utils.createElement(document, "p", {class: "foo"});
+utils.createElement(document, "p", null, "foo");
+utils.createElement(document, "p", null, ["foo", utils.createElement(document, "img")]);
+
+// TODO? utils/dom/emittermixin
+
+utils.getAncestors(htmlElement);
+
+utils.getBorderWidths(htmlElement);
+
+utils.getCommonAncestor(htmlElement, htmlElement);
+
+str = utils.getDataFromElement(htmlElement);
+
+let strNull: HTMLElement | null = utils.getPositionedAncestor();
+strNull = utils.getPositionedAncestor(htmlElement);
+
+num = utils.indexOf(htmlElement);
+
+utils.insertAt(htmlElement, 2, htmlElement);
+
+bool = utils.isNode(htmlElement);
+bool = utils.isNode(new Date());
+
+bool = utils.isRange(new Range());
+bool = utils.isRange(new Date());
+
+bool = utils.isText(new Text("foo"));
+bool = utils.isText(new Date());
+
+bool = utils.isWindow(window);
+bool = utils.isWindow(new Date());
+
+let position: utils.Position;
+
+position = utils.getOptimalPosition({
+    element: htmlElement,
+    target: () => htmlElement,
+    positions: [(targetRect, elementRect) => ({
+        top: targetRect.top,
+        left: targetRect.left + elementRect.width,
+        name: "right"
+    })]
+});
+
+position = utils.getOptimalPosition({
+    element: htmlElement,
+    target: htmlElement,
+    positions: [
+        (targetRect) => ({
+            top: targetRect.bottom,
+            left: targetRect.left,
+            name: "mySouthEastPosition"
+        }),
+        (targetRect, elementRect) => ({
+            top: targetRect.top - elementRect.height,
+            left: targetRect.left,
+            name: "myNorthEastPosition"
+        })
+    ],
+    limiter: document.body,
+    fitInViewport: true,
+});
+
+rect = new utils.Rect(document.body);
+rect = new utils.Rect(document.getSelection()!.getRangeAt(0));
+rect = new utils.Rect(window);
+rect = new utils.Rect({top: 0, right: 10, bottom: 10, left: 0, width: 10, height: 10});
+rect = new utils.Rect(rect);
+rect = new utils.Rect(document.body.getClientRects().item(0)!);
+
+rect = rect.clone();
+bool = rect.contains(rect);
+rect = rect.excludeScrollbarsAndBorders();
+num = rect.getArea();
+rect = rect.getIntersection(rect);
+num = rect.getIntersectionArea(rect);
+rectOrNull = rect.getVisible();
+bool = rect.isEqual(rect);
+rect = rect.moveBy(1, 1);
+rect = rect.moveTo(1, 1);
+
+utils.remove(htmlElement);
+
+utils.scrollAncestorsToShowTarget(new Range());
+utils.scrollAncestorsToShowTarget(htmlElement);
+
+utils.scrollViewportToShowTarget({target: new Range()});
+utils.scrollViewportToShowTarget({target: htmlElement});
+utils.scrollViewportToShowTarget({target: new Range(), viewportOffset: 30});
+utils.scrollViewportToShowTarget({target: htmlElement, viewportOffset: 30});
+
+utils.setDataInElement(htmlElement, "<b>foo</b>");
+
+str = utils.toUnit("rem")(10);
+
+// utils/ckeditorerror ========================================================
+
+const regularError = new Error("foo");
+let ckeditorError: utils.CKEditorError;
+
+const data = {bar: 1};
+ckeditorError = new utils.CKEditorError("foo");
+ckeditorError = new utils.CKEditorError("foo", data);
+
+utils.CKEditorError.isCKEditorError(ckeditorError);
+utils.CKEditorError.isCKEditorError(regularError);
+
+// utils/collection ===========================================================
+
+interface Foo {
+    foo: number;
+}
+
+interface Props {
+    id: string;
+}
+
+interface PropsStr {
+    id: string;
+    name: string;
+}
+
+declare let foo: Foo;
+let items: PropsStr[];
+let itemOrNull: Props | null;
+let itemOrUndef: Props | undefined;
+
+const item1 = {id: "id1"};
+const item2 = {id: "id2"};
+const itemStr1 = {id: "foo", name: "yy"};
+const itemStr2 = {id: "foo", name: "xx"};
+
+const coll = new utils.Collection<Props>();
+const collStr = new utils.Collection<PropsStr>({idProperty: "name"});
+
+coll.add(item1);
+coll.add(item2);
+collStr.add(itemStr1);
+collStr.add(itemStr2);
+
+coll.add(item1, 0);
+coll.add(item1).add(item2);
+
+coll.clear();
+
+items = collStr.filter((item) => item.name === "yy");
+items = collStr.filter((_, idx) => idx > 0);
+items = collStr.filter(function(this: Foo, _, idx) {return this.foo > 0 && idx === 0; }, foo);
+
+itemOrUndef = collStr.find((item) => item.name === "yy");
+itemOrUndef = collStr.find((_, idx) => idx === 3);
+itemOrUndef = collStr.find(function(this: Foo, _, idx) {return this.foo > 0 && idx === 0; }, foo);
+
+itemOrNull = coll.get(0);
+itemOrNull = coll.get("id1");
+
+num = coll.getIndex("id1");
+num = coll.getIndex(item1);
+
+coll.remove(0);
+coll.remove("id1");
+coll.remove(item1);
+
+const strings: string[] = collStr.map((item) => item.name);
+const nums: number[] = collStr.map((_, idx) => idx);
+const bools: boolean[] = collStr.map(function(this: Foo, _, idx) {return this.foo === idx; }, foo);
+
+// collection#bindTo
+
+interface LabelObj {
+    label: string;
+}
+
+interface LabelValueObj {
+    label: {value: string};
+}
+
+interface HiddenObj {
+    hidden: boolean;
+}
+
+class FactoryClass {
+    factoryLabel: string;
+    constructor(data: LabelObj) {
+        this.factoryLabel = data.label;
+    }
+}
+
+const source1 = new utils.Collection<LabelObj>({idProperty: "label"});
+const target1 = new utils.Collection<FactoryClass>();
+
+target1.bindTo(source1).as(FactoryClass);
+
+source1.add({label: "foo"});
+source1.add({label: "bar"});
+
+source1.remove(0);
+console.log(target1.length);
+console.log(target1.get(0)!.factoryLabel);
+
+class FooClass {
+    fooLabel: string;
+    constructor(data: LabelObj) {
+        this.fooLabel = data.label;
+    }
+}
+
+class BarClass {
+    barLabel: string;
+    constructor(data: LabelObj) {
+        this.barLabel = data.label;
+    }
+}
+
+const source2 = new utils.Collection<LabelObj>({idProperty: "label"});
+const target2 = new utils.Collection<FooClass | BarClass>();
+
+target2.bindTo(source2).using((item) => {
+    if (item.label === "foo") {
+        return new FooClass(item);
+    } else {
+        return new BarClass(item);
+    }
+});
+
+source2.add({label: "foo"});
+source2.add({label: "bar"});
+
+console.log(target2.length);
+console.log(target2.get(0)! instanceof FooClass);
+console.log(target2.get(1)! instanceof BarClass);
+
+const source3 = new utils.Collection<LabelValueObj>({idProperty: "label"});
+const target3 = new utils.Collection<LabelValueObj["label"]>();
+
+target3.bindTo(source2).using("label");
+
+source3.add({label: {value: "foo"}});
+source3.add({label: {value: "bar"}});
+
+console.log(target3.length);
+console.log(target3.get(0)!.value);
+console.log(target3.get(1)!.value);
+
+const source4 = new utils.Collection<HiddenObj>();
+const target4 = new utils.Collection<HiddenObj | null>();
+
+target4.bindTo(source4).using(item => {
+    if (item.hidden) {
+        return null;
+    }
+
+    return item;
+});
+
+source4.add({hidden: true});
+source4.add({hidden: false});
+
+// utils/comparearrays ========================================================
+
+utils.compareArrays([0, 2], [0, 2, 1]);
+utils.compareArrays(["abc", 0 ], ["abc", 0, 3]);
+
+// utils/config ===============================================================
+
+let strOrUndef: string | undefined;
+let config: utils.Config;
+const defaultConfig = {
+    foo: 1, bar: 2,
+};
+
+config = new utils.Config();
+config = new utils.Config({foo: 10});
+config = new utils.Config({}, defaultConfig);
+config = new utils.Config({foo: 10}, defaultConfig);
+
+config.define({
+    resize: {
+        minHeight: 400,
+        hidden: true
+    }
+});
+
+config.define("resize", {minHeight: 400, hidden: true});
+config.define("language", "en");
+config.define("resize.minHeight", 400);
+
+str = config.get("language");
+num = config.get("resize.minHeight");
+
+config.define("language", undefined);
+strOrUndef = config.get("language");
+
+// utils/count ================================================================
+
+num = utils.count([1, 2, 3, 4, 5]);
+
+// utils/diff =================================================================
+
+changes = utils.diff("aba", "acca");
+changes = utils.diff(Array.from("aba"), Array.from("acca"));
+
+// utils/difftochanges ========================================================
+
+const input = Array.from("abc");
+const output = Array.from("xaby");
+const allChanges = utils.diffToChanges(utils.diff(input, output), output);
+allChanges.forEach(change => {
+    if (change.type === "insert") {
+        input.splice(change.index, 0, ...change.values);
+    } else if (change.type === "delete") {
+        input.splice(change.index, change.howMany);
+    }
+});
+
+// utils/elementreplacer ======================================================
+
+const replacer = new utils.ElementReplacer();
+
+replacer.replace(htmlElement, htmlElement);
+replacer.replace(htmlElement);
+
+replacer.restore();
+
+// utils/emittermixin
+
+emitter = utils.EmitterMixin;
+emitter = Object.create(utils.EmitterMixin);
+
+emitter.delegate("foo") ;
+emitter.delegate("foo", "bar");
+emitter.delegate("foo").to(emitter);
+emitter.delegate("foo").to(emitter, "bar");
+emitter.delegate("foo").to(emitter, name => name + "-delegated");
+
+emitter.fire("foo");
+emitter.fire("foo", 1, "b", true);
+emitter.fire("getSelectedContent", (evt: utils.EventInfo<any>) => {
+    evt.return = new DocumentFragment();
+    evt.stop();
+});
+
+emitter.listenTo(emitter, "foo", () => {});
+emitter.listenTo(emitter, "foo", () => {}, {priority: 10});
+emitter.listenTo(emitter, "foo", () => {}, {priority: "highest"});
+
+emitter.off("foo");
+emitter.off("foo", () => {});
+
+emitter.on("foo", () => {});
+emitter.on("foo", () => {}, {priority: 10});
+emitter.on("foo", () => {}, {priority: "normal"});
+
+emitter.once("foo", () => {});
+emitter.once("foo", () => {}, {priority: 10});
+emitter.once("foo", () => {}, {priority: "lowest"});
+
+emitter.stopDelegating();
+emitter.stopDelegating("foo");
+emitter.stopDelegating("foo", emitter);
+
+emitter.stopListening();
+emitter.stopListening(emitter);
+emitter.stopListening(emitter, "foo");
+emitter.stopListening(emitter, "foo", () => {});
+
+// utils/env ==================================================================
+
+bool = utils.env.isEdge;
+bool = utils.env.isMac;
+
+// utils/eventinfo ============================================================
+
+const event = new utils.EventInfo({a: 1}, "test");
+num = event.source.a;
+str = event.name;
+
+event.path[0];
+
+event.stop();
+event.off();
+
+bool = event.stop.called;
+bool = event.off.called;
+
+// utils/fastdiff =============================================================
+
+utils.fastDiff(str, "2ab").forEach(change => {
+    if (change.type === "insert") {
+        str = str.substring(0, change.index) + change.values.join("") + str.substring(change.index);
+    } else if (change.type === "delete") {
+        str = str.substring(0, change.index) + str.substring(change.index + change.howMany);
+    }
+});
+
+// utils/first ================================================================
+
+const collection = [ 11, 22 ];
+const iterator = collection[Symbol.iterator]();
+
+utils.first(iterator);
+
+// utils/focustracker =========================================================
+
+const focusTracker = new utils.FocusTracker();
+htmlElement = focusTracker.focusedElement;
+bool = focusTracker.isFocused;
+focusTracker.add(htmlElement);
+focusTracker.remove(htmlElement);
+
+// utils/isiterable ===========================================================
+
+bool = utils.isIterable(str);
+bool = utils.isIterable([1, 2, 3]);
+
+// utils/keyboard =============================================================
+
+num = utils.keyCodes.a;
+num = utils.keyCodes["a"];
+
+num = utils.getCode("0");
+num = utils.getCode({keyCode: 48}) ;
+num = utils.getCode({keyCode: 48, altKey: true, ctrlKey: true, shiftKey: true});
+
+str = utils.getEnvKeystrokeText("alt+A");
+
+num = utils.parseKeystroke("Ctrl+A");
+num = utils.parseKeystroke(["ctrl", "a"]);
+num = utils.parseKeystroke(["shift", 33]);
+
+// utils/keystrokehandler =====================================================
+
+declare const keystroke: utils.KeystrokeInfo;
+const keystrokes = new utils.KeystrokeHandler();
+
+const spy = utils.spy();
+keystrokes.set("Ctrl+A", spy);
+keystrokes.set(["Ctrl", "A"], spy);
+keystrokes.set(["Ctrl", "A"], spy, {priority: "high"});
+keystrokes.set(["Ctrl", 33], spy, {priority: 10});
+
+const emitterMixxin = Object.create(utils.EmitterMixin) as utils.Emitter;
+keystrokes.listenTo(emitterMixxin);
+
+bool = keystrokes.press(keystroke);
+
+keystrokes.destroy();
+
+// utils/locale ===============================================================
+
+locale.t("Label");
+locale.t('Created file "%0" in %1ms.', ["fileName", "100"]);
+
+// utils/log ==================================================================
+
+utils.log.warn("message");
+utils.log.warn('plugin-load: It was not possible to load the "{$pluginName}" plugin in module "{$moduleName}', {
+    pluginName: "foo",
+    moduleName: "bar"
+});
+
+utils.log.error("message");
+utils.log.error('plugin-load: It was not possible to load the "{$pluginName}" plugin in module "{$moduleName}', {
+    pluginName: "foo",
+    moduleName: "bar"
+});
+
+// utils/mapsequal ============================================================
+
+utils.mapsEqual(map, map);
+
+// utils/mix ==================================================================
+
+class Editor {
+    b: () => number;
+}
+
+interface SomeMixin {
+    a: () => string;
+}
+
+const SomeMixin = {
+    a() {
+        return "a";
+    }
+};
+
+utils.mix(Editor, SomeMixin);
+const mixEditor = new Editor() as Editor & SomeMixin;
+mixEditor.a();
+mixEditor.b();
+
+// utils/nth ==================================================================
+
+function* getGenerator() {
+    yield 11;
+    yield 22;
+    yield 33;
+}
+
+utils.nth(2, getGenerator());
+
+// utils/objecttomap ==========================================================
+
+const objMap: Map<string, number> = utils.objectToMap({foo: 1, bar: 2});
+num = objMap.get("foo")!;
+
+// utils/observablemixin ======================================================
+
+const observable: utils.Observable = utils.ObservableMixin;
+
+const vehicle = Object.create(utils.ObservableMixin) as utils.Observable;
+const car = Object.create(utils.ObservableMixin) as utils.Observable;
+
+vehicle.bind("color");
+vehicle.bind("color", "year");
+vehicle.bind("color", "year").to(car);
+vehicle.bind("color", "year").to(car, "color");
+vehicle.bind("color", "year").to(car, "color", car, "year");
+vehicle.bind("year").to(car, "color", car, "year", (a: string, b: number) => a + b);
+vehicle.bind("custom").to(car, "color", car, "year", car, "hue", (...args: Array<string | number>) => args.join("/")); // TS 3.0: [string, number, string]
+vehicle.bind("color").toMany([car, car], "color", () => {});
+
+vehicle.decorate("method");
+
+car.set("color", "red");
+car.set("seats", undefined);
+car.set({
+    color: "blue",
+    wheels: 4,
+    seats: 5,
+});
+
+vehicle.unbind();
+vehicle.unbind("color");
+vehicle.unbind("color", "year");
+
+// utils/priorities ===========================================================
+
+num = utils.priorities.get(2);
+num = utils.priorities.get("normal");
+
+// utils/spy
+
+const fn1 = utils.spy();
+fn1();
+bool = fn1.called;
+
+// utils/tomap
+
+map = utils.toMap({foo: 1, bar: 2});
+map = utils.toMap([["foo", 1], ["bar", 2]]);
+map = utils.toMap(map);
+
+// utils/translation-service ==================================================
+
+utils.add("pl", {
+    OK: "OK",
+    "Cancel [context: reject]": "Anuluj"
+});
+
+utils.translate("pl", "Cancel [context: reject]");
+
+// utils/uid ==================================================================
+
+str = utils.uid();
+
+// utils/unicode ==============================================================
+
+bool = utils.isCombiningMark("a");
+bool = utils.isHighSurrogateHalf("a");
+bool = utils.isInsideCombinedSymbol(str, 2);
+bool = utils.isInsideSurrogatePair(str, 2);
+bool = utils.isLowSurrogateHalf(String.fromCharCode(57166));
+
+// utils/version ==============================================================

--- a/types/ckeditor__ckeditor5-utils/index.d.ts
+++ b/types/ckeditor__ckeditor5-utils/index.d.ts
@@ -1,0 +1,471 @@
+// Type definitions for @ckeditor/ckeditor5-utils 10.2
+// Project: https://github.com/ckeditor/ckeditor5-utils
+// Definitions by: denisname <https://github.com/denisname>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
+
+// Helpers
+
+export interface DeleteChange {
+    index: number;
+    type: "delete";
+    howMany: number;
+}
+
+export interface InsertChange {
+    index: number;
+    type: "insert";
+    values: string[];
+}
+
+export interface BindChain {
+    to(observable: Observable, ...bindProperties: Array<Observable | string | Function>): void;
+    toMany(observable: Observable[], ...bindProperties: Array<Observable | string | Function>): void;
+}
+
+export interface CollectionBindTo<T, K> {
+    as: (Class: {new(item: T): K}) => void;
+    using: (callbackOrProperty: keyof T | ((item: T) => K)) => void;
+}
+
+// utils/dom
+
+export function createElement(doc: Document, name: string, attributes?: object | null, children?: Node | string | Array<Node | string>): Element;
+
+// TODO? utils/dom/emittermixin
+
+export function getAncestors(node: Node): Array<Node | DocumentFragment>;
+
+export function getBorderWidths(element: HTMLElement): {top: number, right: number, bottom: number, left: number};
+
+export function getCommonAncestor(nodeA: Node, nodeB: Node): Node | DocumentFragment | Document | null;
+
+export function getDataFromElement(el: HTMLElement): string;
+
+export function getPositionedAncestor(element?: HTMLElement): HTMLElement | null;
+
+export function indexOf(node: Node): number;
+
+export function insertAt(parentElement: Element, index: number, nodeToInsert: Node): void;
+
+export function isNode(obj: any): obj is Node;
+
+export function isRange(obj: any): obj is Range;
+
+export function isText(obj: any): obj is Text;
+
+export function isWindow(obj: any): obj is Window;
+
+export interface Options {
+    element: HTMLElement;
+    fitInViewport?: boolean;
+    limiter?: HTMLElement | Range | ClientRect | Rect | (() => HTMLElement | Range | ClientRect | Rect);
+    positions: Array<(targetRect: Rect, elementRect: Rect) => Position>;
+    target: HTMLElement | Range | ClientRect | Rect | (() => HTMLElement | Range | ClientRect | Rect);
+}
+
+export interface Position {
+    left: number;
+    name: string;
+    top: number;
+}
+
+export function getOptimalPosition(options: Options): Position;
+
+export class Rect {
+    readonly bottom: number;
+    readonly height: number;
+    readonly left: number;
+    readonly right: number;
+    readonly top: number;
+    readonly width: number;
+
+    constructor(source: HTMLElement | Range | Window | ClientRect | Rect | object);
+    clone(): Rect;
+    contains(anotherRect: Rect): boolean;
+    excludeScrollbarsAndBorders(): Rect;
+    getArea(): number;
+    getIntersection(anotherRect: Rect): Rect;
+    getIntersectionArea(anotherRect: Rect): number;
+    getVisible(): Rect | null;
+    isEqual(rect: Rect): boolean;
+    moveBy(x: number, y: number): Rect;
+    moveTo(x: number, y: number): Rect;
+
+    static getDomRangeRects(range: Range): Rect[];
+}
+
+export function remove(node: Node): void;
+
+export function scrollAncestorsToShowTarget(target: HTMLElement | Range): void;
+
+export function scrollViewportToShowTarget(options: {target: HTMLElement | Range, viewportOffset?: number}): void;
+
+export function setDataInElement(el: HTMLElement, data: string): void;
+
+export function toUnit(unit: string): (value: number) => string;
+
+// utils/ckeditorerror
+
+export const DOCUMENTATION_URL: string;
+
+export class CKEditorError extends Error {
+    data: object | undefined;
+    name: string;
+
+    constructor(message: string, data?: object);
+
+    static isCKEditorError(error: Error): boolean;
+}
+
+export function attachLinkToDocumentation(message: string): string;
+
+// utils/collection
+
+export function as(Class: Function): void;
+export function using(callbackOrProperty: Function | string): void;
+
+export class Collection<T> implements Iterable<T>, Emitter {
+    first: T | null;
+    last: T | null;
+    length: number;
+
+    constructor(options?: {idProperty?: keyof T});
+    add(item: T, index?: number): this;
+    bindTo<S>(externalCollection: Collection<S>): CollectionBindTo<S, T>;
+    clear(): void;
+    filter(callbackfn: (item: T, index: number) => boolean, thisArg?: any): T[];
+    find(predicate: (item: T, index: number) => boolean, thisArg?: any): T | undefined;
+    get(idOrIndex: string | number): T | null;
+    getIndex(idOrItem: string | T): number;
+    map<U>(callbackfn: (item: T, index: number) => U, thisArg?: any): U[];
+    remove(subject: T | number | string): T;
+
+    // Iterable<T>
+    [Symbol.iterator](): Iterator<T>;
+
+    // Emitter
+    delegate(...events: string[]): EmitterMixinDelegateChain;
+    fire(eventOrInfo: string | EventInfo<Emitter>, ...args: any[]): any;
+    listenTo(emitter: Emitter, event: string, callback: Function, options?: {priority?: PriorityString | number }): void;
+    off(event: string, callback?: Function): void;
+    on(event: string, callback: Function, options?: {priority: PriorityString | number}): void;
+    once(event: string, callback: Function, options?: {priority: PriorityString | number}): void;
+    stopDelegating(event?: string, emitter?: Emitter): void;
+    stopListening(emitter?: Emitter, event?: string, callback?: Function): void;
+}
+
+// utils/comparearrays
+
+export type ArrayRelation = "extension" | "same" | "prefix";
+
+export function compareArrays<T>(a: ReadonlyArray<T>, b: ReadonlyArray<T>): number | ArrayRelation;
+
+// utils/config
+
+export class Config {
+    constructor(configurations?: object, defaultConfigurations?: object);
+    define(name: object): void;
+    define(name: string, value: any): void;
+    get(name: string): any | undefined;
+    set(name: string, value: any | undefined): void;
+}
+
+// utils/count
+
+export function count(iterator: Iterable<any>): number;
+
+// utils/diff
+
+export type Change = "equal" | "insert" | "delete";
+
+export function diff(a: string, b: string, cmp?: (a: string, b: string) => boolean): Change[];
+export function diff(a: ReadonlyArray<string>, b: ReadonlyArray<string>, cmp?: (a: string, b: string) => boolean): Change[];
+
+// utils/difftochanges
+
+export function diffToChanges(diff: Change[], output: string | string[]): Array<DeleteChange | InsertChange>;
+
+// utils/elementreplacer
+
+export class ElementReplacer {
+    replace(element: HTMLElement, newElement?: HTMLElement): void;
+    restore(): void;
+}
+
+// utils/emittermixin
+
+export const EmitterMixin: Emitter;
+
+export interface Emitter {
+    delegate(...events: string[]): EmitterMixinDelegateChain;
+    fire(eventOrInfo: string | EventInfo<Emitter>, ...args: any[]): any;
+    listenTo(emitter: Emitter, event: string, callback: Function, options?: {priority?: PriorityString | number }): void;
+    off(event: string, callback?: Function): void;
+    on(event: string, callback: Function, options?: {priority: PriorityString | number}): void;
+    once(event: string, callback: Function, options?: {priority: PriorityString | number}): void;
+    stopDelegating(event?: string, emitter?: Emitter): void;
+    stopListening(emitter?: Emitter, event?: string, callback?: Function): void;
+}
+
+export interface EmitterMixinDelegateChain {
+    to(emitter: Emitter, nameOrFunction?: string | ((name: string) => string)): void;
+}
+
+// utils/env
+
+export namespace env {
+    const isEdge: boolean;
+    const isMac: boolean;
+}
+
+// utils/eventinfo
+
+export class EventInfo<T> {
+    readonly name: string;
+    readonly path: object[];
+    return: any | undefined;
+    readonly source: T;
+
+    constructor(source: T, name: string);
+    off: {
+        (): void;
+        called: boolean;
+    };
+    stop: {
+        (): void;
+        called: boolean;
+    };
+}
+
+// utils/fastdiff
+
+export function fastDiff(oldText: string, newText: string): Array<DeleteChange | InsertChange>;
+
+// utils/first
+
+export function first<T>(iterable: Iterable<T>): T;
+
+// utils/focustracker
+
+export class FocusTracker implements Observable {
+    readonly focusedElement: HTMLElement;
+    readonly isFocused: boolean;
+
+    add(element: HTMLElement): void;
+    remove(element: HTMLElement): void;
+
+    // Observable
+    bind(...bindProperties: string[]): BindChain;
+    decorate(methodName: string): void;
+    set(name: object): void;
+    set(name: string, value: any): void;
+    unbind(...unbindProperties: string[]): void;
+
+    // Observable (Emitter)
+    delegate(...events: string[]): EmitterMixinDelegateChain;
+    fire(eventOrInfo: string | EventInfo<Emitter>, ...args: any[]): any;
+    listenTo(emitter: Emitter, event: string, callback: Function, options?: {priority?: PriorityString | number }): void;
+    off(event: string, callback?: Function): void;
+    on(event: string, callback: Function, options?: {priority: PriorityString | number}): void;
+    once(event: string, callback: Function, options?: {priority: PriorityString | number}): void;
+    stopDelegating(event?: string, emitter?: Emitter): void;
+    stopListening(emitter?: Emitter, event?: string, callback?: Function): void;
+}
+
+// utils/isiterable
+
+export function isIterable(value: any): value is Iterable<any>;
+
+// utils/keyboard
+
+export const keyCodes: {
+    a: 65,
+    b: 66,
+    c: 67;
+    d: 68;
+    e: 69;
+    f: 70;
+    g: 71;
+    h: 72;
+    i: 73;
+    j: 74;
+    k: 75;
+    l: 76;
+    m: 77;
+    n: 78;
+    o: 79;
+    p: 80;
+    q: 81;
+    r: 82;
+    s: 83;
+    t: 84;
+    u: 85;
+    v: 86;
+    w: 87;
+    x: 88;
+    y: 89;
+    z: 90;
+
+    0: 48;
+    1: 49;
+    2: 50;
+    3: 51;
+    4: 52;
+    5: 53;
+    6: 54;
+    7: 55;
+    8: 56;
+    9: 57;
+
+    f1: 112;
+    f2: 113;
+    f3: 114;
+    f4: 115;
+    f5: 116;
+    f6: 117;
+    f7: 118;
+    f8: 118;
+    f9: 120;
+    f10: 121;
+    f11: 122;
+    f12: 123;
+
+    arrowleft: 37,
+    arrowup: 38,
+    arrowright: 39,
+    arrowdown: 40,
+    backspace: 8,
+    "delete": 46,
+    enter: 13,
+    space: 32,
+    esc: 27,
+    tab: 9,
+    ctrl: 0x110000,
+    cmd: 0x110000,
+    shift: 0x220000,
+    alt: 0x440000
+};
+
+export interface KeystrokeInfo {
+    altKey?: boolean;
+    ctrlKey?: boolean;
+    keyCode: number;
+    shiftKey?: boolean;
+}
+
+export function getCode(key: string | KeystrokeInfo): number;
+
+export function getEnvKeystrokeText(keystroke: string): string;
+
+export function parseKeystroke(keystroke: string | Array<number | string>): number;
+
+// utils/keystrokehandler
+
+export class KeystrokeHandler {
+    constructor();
+    destroy(): void;
+    listenTo(emitter: Emitter): void;
+    press(keyEvtData: KeystrokeInfo): boolean;
+    set(keystroke: string | Array<string | number>, callback: Function, options?: {priority?: PriorityString | number}): void;
+}
+
+// utils/locale
+
+export class Locale {
+    readonly language: string;
+
+    constructor(language?: string);
+    t(str: string, values?: string[]): string;
+}
+
+// utils/log
+
+export namespace log {
+    function error(message: string, data?: object): void;
+    function warn(message: string, data?: object): void;
+}
+
+// utils/mapsequal
+
+export function mapsEqual<K, V>(mapsA: Map<K, V>, mapsB: Map<K, V>): boolean;
+
+// utils/mix
+
+export function mix(baseClass: {new(): any}, ...mixins: any[]): void;
+
+// utils/nth
+
+export function nth<T>(index: number, iterable: Iterable<T>): T;
+
+// utils/objecttomap
+
+export function objectToMap<T extends object>(obj: T): Map<keyof T, T[keyof T]>;
+
+// utils/observablemixin
+
+export const ObservableMixin: Observable;
+
+export interface Observable extends Emitter {
+    bind(...bindProperties: string[]): BindChain;
+    decorate(methodName: string): void;
+    set(name: object): void;
+    set(name: string, value: any): void;
+    unbind(...unbindProperties: string[]): void;
+
+    // Emitter
+    delegate(...events: string[]): EmitterMixinDelegateChain;
+    fire(eventOrInfo: string | EventInfo<Emitter>, ...args: any[]): any;
+    listenTo(emitter: Emitter, event: string, callback: Function, options?: {priority?: PriorityString | number }): void;
+    off(event: string, callback?: Function): void;
+    on(event: string, callback: Function, options?: {priority: PriorityString | number}): void;
+    once(event: string, callback: Function, options?: {priority: PriorityString | number}): void;
+    stopDelegating(event?: string, emitter?: Emitter): void;
+    stopListening(emitter?: Emitter, event?: string, callback?: Function): void;
+}
+
+// utils/priorities
+
+export namespace priorities {
+    function get(priority: PriorityString | number): number;
+}
+
+export type PriorityString = "highest" | "high" | "normal" | "low" | "lowest";
+
+// utils/spy
+
+export function spy(): {(): void; called: boolean};
+
+// utils/tomap
+
+export function toMap<K, V>(data: Map<K, V>): Map<K, V>;
+export function toMap<K extends string, V = any>(data: ReadonlyArray<[K, V]>): Map<K, V>;
+export function toMap<T extends object>(data: T): Map<keyof T, T[keyof T]>;
+
+// utils/translation-service
+
+export function add(language: string, translations: {[key: string]: string}): void;
+
+export function translate(language: string, translationKey: string): string;
+
+// TODO: CKEDITOR_TRANSLATIONS
+
+// utils/uid
+
+export function uid(): string;
+
+// utils/unicode
+
+export function isCombiningMark(character: string): boolean;
+
+export function isHighSurrogateHalf(character: string): boolean;
+
+export function isInsideCombinedSymbol(string: string, offset: number): boolean;
+
+export function isInsideSurrogatePair(string: string, offset: number): boolean;
+
+export function isLowSurrogateHalf(character: string): boolean;
+
+// utils/version
+
+// TODO: CKEDITOR_VERSION;

--- a/types/ckeditor__ckeditor5-utils/index.d.ts
+++ b/types/ckeditor__ckeditor5-utils/index.d.ts
@@ -167,8 +167,8 @@ export class Config {
     constructor(configurations?: object, defaultConfigurations?: object);
     define(name: object): void;
     define(name: string, value: any): void;
-    get(name: string): any | undefined;
-    set(name: string, value: any | undefined): void;
+    get(name: string): any /*| undefined*/;
+    set(name: string, value: any /*| undefined*/): void;
 }
 
 // utils/count
@@ -224,7 +224,7 @@ export namespace env {
 export class EventInfo<T> {
     readonly name: string;
     readonly path: object[];
-    return: any | undefined;
+    return: any /*| undefined*/;
     readonly source: T;
 
     constructor(source: T, name: string);

--- a/types/ckeditor__ckeditor5-utils/tsconfig.json
+++ b/types/ckeditor__ckeditor5-utils/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "ckeditor__ckeditor5-utils-tests.ts"
+    ]
+}

--- a/types/ckeditor__ckeditor5-utils/tslint.json
+++ b/types/ckeditor__ckeditor5-utils/tslint.json
@@ -1,0 +1,20 @@
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "ban-types": {
+            "options": [
+                ["Object", "Avoid using the `Object` type. Did you mean `object`?"],
+                ["Boolean", "Avoid using the `Boolean` type. Did you mean `boolean`?"],
+                ["Number", "Avoid using the `Number` type. Did you mean `number`?"],
+                ["String", "Avoid using the `String` type. Did you mean `string`?"],
+                ["Symbol", "Avoid using the `Symbol` type. Did you mean `symbol`?"]
+            ]
+        },
+        "quotemark": [
+            true,
+            "double",
+            "avoid-escape",
+            "avoid-template"
+        ]
+    }
+}

--- a/types/ckeditor__ckeditor5-utils/tslint.json
+++ b/types/ckeditor__ckeditor5-utils/tslint.json
@@ -10,7 +10,6 @@
                 ["Symbol", "Avoid using the `Symbol` type. Did you mean `symbol`?"]
             ]
         },
-        "no-any-union": false,
         "quotemark": [
             true,
             "double",

--- a/types/ckeditor__ckeditor5-utils/tslint.json
+++ b/types/ckeditor__ckeditor5-utils/tslint.json
@@ -10,6 +10,7 @@
                 ["Symbol", "Avoid using the `Symbol` type. Did you mean `symbol`?"]
             ]
         },
+        "no-any-union": false,
         "quotemark": [
             true,
             "double",


### PR DESCRIPTION
Add [ckeditor5-utils](https://github.com/ckeditor/ckeditor5-utils) type definition. This is far from enough to use the CKEditor5 editors. But it is a first step in that direction.

Documentation: https://ckeditor.com/docs/ckeditor5/latest/api/utils.html

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
