### PR TITLE
auth0: remove dependency on Bluebird

### DIFF
--- a/types/auth0/index.d.ts
+++ b/types/auth0/index.d.ts
@@ -4,8 +4,6 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
-import * as Promise from 'bluebird';
-
 export interface ManagementClientOptions {
   token?: string;
   domain: string;


### PR DESCRIPTION
Not everybody uses Bluebird for their Promises and coupling this so tightly to Bluebird causes us problems