### PR TITLE
Remove workarounds for Microsoft/TypeScript#28394

### DIFF
--- a/types/reactstrap/reactstrap-tests.tsx
+++ b/types/reactstrap/reactstrap-tests.tsx
@@ -281,10 +281,7 @@ const Example13 = (
 interface CustomButtonProps extends ButtonProps {
   customProp: string;
 }
-// NOTE: not adding the <{}> causes the generic parameter to be a spread type of CustomButtonProps,
-// for some reason this causes children to be inferred as being 'ReactNode & {}' which makes the spread
-// invalid. TS3.2 bug?
-const CustomButton: React.SFC<CustomButtonProps> = props => <Button<{}> {...props}/>;
+const CustomButton: React.SFC<CustomButtonProps> = props => <Button {...props}/>;
 
 class Example14 extends React.Component<any, any> {
   state: any;

--- a/types/redux-form/index.d.ts
+++ b/types/redux-form/index.d.ts
@@ -12,7 +12,7 @@
 //                 Maddi Joyce <https://github.com/maddijoyce>
 //                 Kamil Wojcik <https://github.com/smifun>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.9
+// TypeScript Version: 2.8
 import {
   ComponentClass,
   StatelessComponent,

--- a/types/redux-form/redux-form-tests.tsx
+++ b/types/redux-form/redux-form-tests.tsx
@@ -316,7 +316,7 @@ const Test = reduxForm<TestFormData>({
                                 foo="bar"
                             />
 
-                            <FieldArray<{}>
+                            <FieldArray
                                 name="field9"
                                 component={ MyArrayField }
                             />


### PR DESCRIPTION
This removes workarounds added to make tests pass until the fix for https://github.com/Microsoft/TypeScript/issues/28394 is available on nightlies.

If everything goes well, just rerunning tests after the relevant nightly is published should make them pass 😄

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
