### PR TITLE
[react-virtualized] List calls `rowRenderer` with `index` prop instead of `rowIndex`

### DIFF
--- a/types/react-virtualized/dist/es/List.d.ts
+++ b/types/react-virtualized/dist/es/List.d.ts
@@ -8,9 +8,8 @@ import {
 import { Index, IndexRange, Alignment } from "../../index";
 import { CellMeasurerCache, CellPosition } from "./CellMeasurer";
 
-export type ListRowProps = GridCellProps & {
-    index: number;
-    style: React.CSSProperties;
+export type ListRowProps = Pick<GridCellProps, Exclude<keyof GridCellProps, 'rowIndex'>> & {
+    index: GridCellProps['rowIndex'];
 };
 
 export type ListRowRenderer = (props: ListRowProps) => React.ReactNode;

--- a/types/react-virtualized/index.d.ts
+++ b/types/react-virtualized/index.d.ts
@@ -8,6 +8,7 @@
 //                 Steve Zhang <https://github.com/Stevearzh>
 //                 Maciej Goszczycki <https://github.com/mgoszcz2>
 //                 Brandon Hall <https://github.com/brandonhall>
+//                 Sebastian Busch <https://github.com/sbusch>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 


### PR DESCRIPTION
Changes to `ListRowProps`, which is the type of the argument to `List` `rowRenderer` prop:

* `List` calls `rowRenderer` with `index` prop, which is a renamed `rowIndex` (see links below)
* `style` should not be included as it's already inherited from `GridCellProps`

---
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] ~Add or edit tests to reflect the change. (Run with `npm test`.)~ Didn't know how to make "negative tests"
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  * <https://github.com/bvaughn/react-virtualized/blob/master/source/List/types.js>
  * <https://github.com/bvaughn/react-virtualized/blob/master/source/List/List.js>
  * <https://github.com/bvaughn/react-virtualized/blob/master/docs/List.md#rowrenderer>
- [ ] ~Increase the version number in the header if appropriate.~ version is 9.18, so it seems to follow react-virtualized releases. Since I did not make changes that support new features of 9.19 and later, I wont edit the version
- [ ] ~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.~ already included
