### PR TITLE
Add types for express-version-route

### DIFF
--- a/types/express-version-route/express-version-route-tests.ts
+++ b/types/express-version-route/express-version-route-tests.ts
@@ -1,0 +1,19 @@
+import * as express from 'express';
+import * as versionRouter from 'express-version-route';
+
+const app = express();
+
+const routesMap = new Map<string, express.Handler>([
+    ["1.0", respondV1],
+    ["2.0", respondV2]
+]);
+
+app.get('/test', versionRouter.route(routesMap));
+
+function respondV1(req: express.Request, res: express.Response, next: express.NextFunction) {
+    res.status(200).send('ok v1');
+}
+
+function respondV2(req: express.Request, res: express.Response, next: express.NextFunction) {
+    res.status(200).send('ok v2');
+}

--- a/types/express-version-route/index.d.ts
+++ b/types/express-version-route/index.d.ts
@@ -1,0 +1,9 @@
+// Type definitions for express-version-route 1.0
+// Project: https://github.com/lirantal/express-version-route
+// Definitions by: Rogelio Negrete <https://github.com/weffe>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.2
+
+import { Handler } from 'express';
+
+export function route(versionsMap: Map<string, Handler>): Handler;

--- a/types/express-version-route/tsconfig.json
+++ b/types/express-version-route/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "express-version-route-tests.ts"
+    ]
+}

--- a/types/express-version-route/tslint.json
+++ b/types/express-version-route/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.