### PR TITLE
[ember] Polyfill: allow assign to take in more than 4 args

### DIFF
--- a/types/ember__polyfills/ember__polyfills-tests.ts
+++ b/types/ember__polyfills/ember__polyfills-tests.ts
@@ -11,6 +11,7 @@ import { assign, merge } from '@ember/polyfills';
     assign({ a: 'hello' }, { b: 6 }, { a: true }).a; // $ExpectType boolean
     assign({ a: 'hello' }, '', { a: true }).a; // $ExpectError
     assign({ d: ['gobias industries'] }, { a: 'hello' }, { b: 6 }, { a: true }).d; // $ExpectType string[]
+    assign({}, { a: 0 }, { b: 1 }, { c: 2 }, { d: 3 }).a; // $ExpectType any
 })();
 
 (() => { /* merge */

--- a/types/ember__polyfills/ember__polyfills-tests.ts
+++ b/types/ember__polyfills/ember__polyfills-tests.ts
@@ -11,7 +11,6 @@ import { assign, merge } from '@ember/polyfills';
     assign({ a: 'hello' }, { b: 6 }, { a: true }).a; // $ExpectType boolean
     assign({ a: 'hello' }, '', { a: true }).a; // $ExpectError
     assign({ d: ['gobias industries'] }, { a: 'hello' }, { b: 6 }, { a: true }).d; // $ExpectType string[]
-    assign({}, { a: 0 }, { b: 1 }, { c: 2 }, { d: 3 }); // $ExpectType object
     assign({}, { a: 0 }, { b: 1 }, { c: 2 }, { d: 3 }).a; // $ExpectType any
 })();
 

--- a/types/ember__polyfills/ember__polyfills-tests.ts
+++ b/types/ember__polyfills/ember__polyfills-tests.ts
@@ -11,6 +11,7 @@ import { assign, merge } from '@ember/polyfills';
     assign({ a: 'hello' }, { b: 6 }, { a: true }).a; // $ExpectType boolean
     assign({ a: 'hello' }, '', { a: true }).a; // $ExpectError
     assign({ d: ['gobias industries'] }, { a: 'hello' }, { b: 6 }, { a: true }).d; // $ExpectType string[]
+    assign({}, { a: 0 }, { b: 1 }, { c: 2 }, { d: 3 }); // $ExpectType object
     assign({}, { a: 0 }, { b: 1 }, { c: 2 }, { d: 3 }).a; // $ExpectType any
 })();
 

--- a/types/ember__polyfills/index.d.ts
+++ b/types/ember__polyfills/index.d.ts
@@ -13,6 +13,7 @@ import { Mix, Mix3, Mix4 } from './types';
 export function assign<T extends object, U extends object>(target: T, source: U): Mix<T, U>;
 export function assign<T extends object, U extends object, V extends object>(target: T, source1: U, source2: V): Mix3<T, U, V>;
 export function assign<T extends object, U extends object, V extends object, W extends object>(target: T, source1: U, source2: V, source3: W): Mix4<T, U, V, W>;
+export function assign(target: object, ...sources: object[]): any;
 
 /**
  * Merge the contents of two objects together into the first object.

--- a/types/ember__polyfills/index.d.ts
+++ b/types/ember__polyfills/index.d.ts
@@ -13,7 +13,7 @@ import { Mix, Mix3, Mix4 } from './types';
 export function assign<T extends object, U extends object>(target: T, source: U): Mix<T, U>;
 export function assign<T extends object, U extends object, V extends object>(target: T, source1: U, source2: V): Mix3<T, U, V>;
 export function assign<T extends object, U extends object, V extends object, W extends object>(target: T, source1: U, source2: V, source3: W): Mix4<T, U, V, W>;
-export function assign(target: object, ...sources: object[]): object;
+export function assign(target: object, ...sources: object[]): any;
 
 /**
  * Merge the contents of two objects together into the first object.

--- a/types/ember__polyfills/index.d.ts
+++ b/types/ember__polyfills/index.d.ts
@@ -13,7 +13,7 @@ import { Mix, Mix3, Mix4 } from './types';
 export function assign<T extends object, U extends object>(target: T, source: U): Mix<T, U>;
 export function assign<T extends object, U extends object, V extends object>(target: T, source1: U, source2: V): Mix3<T, U, V>;
 export function assign<T extends object, U extends object, V extends object, W extends object>(target: T, source1: U, source2: V, source3: W): Mix4<T, U, V, W>;
-export function assign(target: object, ...sources: object[]): any;
+export function assign(target: object, ...sources: object[]): object;
 
 /**
  * Merge the contents of two objects together into the first object.


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/emberjs/ember.js/blob/v3.5.1/packages/%40ember/polyfills/lib/assign.ts#L8
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

This PR allows the ember polyfill for object assign to take in more than 4 objects, which more closely aligns with the ember source code's definition: https://github.com/emberjs/ember.js/blob/v3.5.1/packages/%40ember/polyfills/lib/assign.ts#L8