### PR TITLE
feat(catbox-memory): add v4

### DIFF
--- a/types/catbox-memory/catbox-memory-tests.ts
+++ b/types/catbox-memory/catbox-memory-tests.ts
@@ -1,0 +1,8 @@
+import * as CatboxMemory from 'catbox-memory';
+
+const client = new CatboxMemory<string>({
+    allowMixedContent: true,
+    cloneBuffersOnGet: false,
+    maxByteSize: 1024,
+    minCleanupIntervalMsec: 1000,
+});

--- a/types/catbox-memory/index.d.ts
+++ b/types/catbox-memory/index.d.ts
@@ -1,0 +1,47 @@
+// Type definitions for catbox-memory 4.0
+// Project: https://github.com/hapijs/catbox-memory#readme
+// Definitions by: Simon Schick <https://github.com/SimonSchick>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.8
+
+import { ClientApi } from 'catbox';
+
+interface CatboxMemory<T> extends ClientApi<T> {}
+
+// tslint:disable-next-line:no-unnecessary-class
+declare class CatboxMemory<T> implements ClientApi<T> {
+    constructor(options?: CatboxMemory.Options);
+}
+
+declare namespace CatboxMemory {
+    interface Options {
+        /**
+         * Sets an upper limit on the number of bytes that can be stored in the cache.
+         * Once this limit is reached no additional items will be added to the cache until some expire.
+         * The utilized memory calculation is a rough approximation and must not be relied on.
+         * @default 104857600 (100MB).
+         */
+        maxByteSize?: number;
+        /**
+         * The minimum number of milliseconds in between each cache cleanup.
+         * @default 1000 (1 second)
+         */
+        minCleanupIntervalMsec?: number;
+        /**
+         * by default, all data is cached as JSON strings, and converted to an object using JSON.parse() on retrieval.
+         * By setting this option to true, Buffer data can be stored alongside the stringified data.
+         * Buffers are not stringified, and are copied before storage to prevent the value from changing while in the cache.
+         * @default false
+         */
+        allowMixedContent?: boolean;
+        /**
+         * by default, buffers stored in the cache with allowMixedContent set to true are copied when they are set but not when they are retrieved.
+         * This means a change to the buffer returned by a get() will change the value in the cache. To prevent this,
+         * set cloneBuffersOnGet to true to always return a copy of the cached buffer.
+         * @default false
+         */
+        cloneBuffersOnGet?: boolean;
+    }
+}
+
+export = CatboxMemory;

--- a/types/catbox-memory/tsconfig.json
+++ b/types/catbox-memory/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "catbox-memory-tests.ts"
+    ]
+}

--- a/types/catbox-memory/tslint.json
+++ b/types/catbox-memory/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "dtslint/dt.json"
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

@andy-ms 2 things:
As mentioned in https://github.com/Microsoft/dtslint/issues/156 I have some trouble with understanding the rule and fixing the resulting errors, so I disabled the rule.

I'm trying not to re-declare all interface methods that the class implements so I tried using declaration merging, however this yields:
```
The 'no-unnecessary-generics' rule threw an error in 'vendor/DefinitelyTyped/types/catbox-memory/index.d.ts':
TypeError: sig.parameters is not iterable
    at getSoleUse (vendor/DefinitelyTyped/node_modules/dtslint/bin/rules/noUnnecessaryGenericsRule.js:67:33)
    at checkSignature (vendor/DefinitelyTyped/node_modules/dtslint/bin/rules/noUnnecessaryGenericsRule.js:40:25)
    at cb (vendor/DefinitelyTyped/node_modules/dtslint/bin/rules/noUnnecessaryGenericsRule.js:30:13)
    at visitNodes (vendor/DefinitelyTyped/node_modules/typescript/lib/typescript.js:15240:30)
    at Object.forEachChild (vendor/DefinitelyTyped/node_modules/typescript/lib/typescript.js:15466:24)
    at SourceFileObject.NodeObject.forEachChild (vendor/DefinitelyTyped/node_modules/typescript/lib/typescript.js:111085:23)
    at walk (vendor/DefinitelyTyped/node_modules/dtslint/bin/rules/noUnnecessaryGenericsRule.js:28:16)
    at applyWithFunction.ctx (vendor/DefinitelyTyped/node_modules/dtslint/bin/rules/noUnnecessaryGenericsRule.js:14:58)
    at Rule.AbstractRule.applyWithFunction (vendor/DefinitelyTyped/node_modules/tslint/lib/language/rule/abstractRule.js:39:9)
    at Rule.applyWithProgram (vendor/DefinitelyTyped/node_modules/dtslint/bin/rules/noUnnecessaryGenericsRule.js:14:21)
```
