### PR TITLE
React Navigation - NavigationRouteConfig.drawerLockMode

### DIFF
--- a/types/react-navigation/index.d.ts
+++ b/types/react-navigation/index.d.ts
@@ -554,6 +554,8 @@ export interface NavigationBottomTabScreenOptions
   ) => void;
 }
 
+export type DrawerLockMode = 'unlocked' | 'locked-closed' | 'locked-open';
+
 export interface NavigationDrawerScreenOptions {
   title?: string;
   drawerIcon?:
@@ -567,7 +569,7 @@ export interface NavigationDrawerScreenOptions {
   | ((
     options: { tintColor: string | null; focused: boolean }
   ) => React.ReactElement<any> | null);
-  drawerLockMode?: 'unlocked' | 'locked-closed' | 'locked-open';
+  drawerLockMode?: DrawerLockMode;
 }
 
 export interface NavigationRouteConfigMap {
@@ -899,6 +901,7 @@ export interface DrawerNavigatorConfig
     style?: StyleProp<ViewStyle>;
     labelStyle?: StyleProp<TextStyle>;
   };
+  drawerLockMode?: DrawerLockMode;
 }
 
 export function DrawerNavigator(

--- a/types/react-navigation/react-navigation-tests.tsx
+++ b/types/react-navigation/react-navigation-tests.tsx
@@ -323,6 +323,7 @@ const drawerNavigatorConfig: DrawerNavigatorConfig = {
         activeTintColor: '#7A9B49',
         inactiveTintColor: '#FFFFFF',
     },
+    drawerLockMode: 'locked-open',
 };
 
 const BasicDrawerNavigator = createDrawerNavigator(


### PR DESCRIPTION
Fixed missing optional "drawerLockMode" property in "NavigationRouteConfig" interface, values for "drawerLockMode" as a separate exported type.