### PR TITLE
[react-stripe-elements] Fix wrong types for onReady method

### DIFF
--- a/types/react-stripe-elements/index.d.ts
+++ b/types/react-stripe-elements/index.d.ts
@@ -5,6 +5,7 @@
 //                 sonnysangha <https://github.com/sonnysangha>
 //                 Andrew Goh Yisheng <https://github.com/9y5>
 //                 Thomas Chia <https://github.com/thchia>
+//                 Piotr Dabrowski <github.com/yhnavein>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 

--- a/types/react-stripe-elements/index.d.ts
+++ b/types/react-stripe-elements/index.d.ts
@@ -59,7 +59,7 @@ export namespace ReactStripeElements {
 
 		onFocus?(event: ElementChangeResponse): void;
 
-		onReady?(el: any): void;
+		onReady?(el: HTMLElement): void;
 	}
 }
 

--- a/types/react-stripe-elements/index.d.ts
+++ b/types/react-stripe-elements/index.d.ts
@@ -59,7 +59,7 @@ export namespace ReactStripeElements {
 
 		onFocus?(event: ElementChangeResponse): void;
 
-		onReady?(): void;
+		onReady?(el: any): void;
 	}
 }
 

--- a/types/react-stripe-elements/index.d.ts
+++ b/types/react-stripe-elements/index.d.ts
@@ -5,7 +5,7 @@
 //                 sonnysangha <https://github.com/sonnysangha>
 //                 Andrew Goh Yisheng <https://github.com/9y5>
 //                 Thomas Chia <https://github.com/thchia>
-//                 Piotr Dabrowski <github.com/yhnavein>
+//                 Piotr Dabrowski <https://github.com/yhnavein>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 

--- a/types/react-stripe-elements/react-stripe-elements-tests.tsx
+++ b/types/react-stripe-elements/react-stripe-elements-tests.tsx
@@ -69,35 +69,35 @@ const ElementsWithPropsTest: React.SFC = () => (
             {...cardElementProps}
             onChange={(event: ElementChangeResponse) => void 0}
             onBlur={(event: ElementChangeResponse) => void 0}
-            onReady={() => void 0}
+            onReady={(el: HTMLElement) => void 0}
             onFocus={(event: ElementChangeResponse) => void 0}
         />
         <CardNumberElement
             {...cardElementProps}
             onChange={(event: ElementChangeResponse) => void 0}
             onBlur={(event: ElementChangeResponse) => void 0}
-            onReady={() => void 0}
+            onReady={(el: HTMLElement) => void 0}
             onFocus={(event: ElementChangeResponse) => void 0}
         />
         <CardExpiryElement
             {...cardElementProps}
             onChange={(event: ElementChangeResponse) => void 0}
             onBlur={(event: ElementChangeResponse) => void 0}
-            onReady={() => void 0}
+            onReady={(el: HTMLElement) => void 0}
             onFocus={(event: ElementChangeResponse) => void 0}
         />
         <CardCVCElement
             {...cardElementProps}
             onChange={(event: ElementChangeResponse) => void 0}
             onBlur={(event: ElementChangeResponse) => void 0}
-            onReady={() => void 0}
+            onReady={(el: HTMLElement) => void 0}
             onFocus={(event: ElementChangeResponse) => void 0}
         />
         <PostalCodeElement
             {...cardElementProps}
             onChange={(event: ElementChangeResponse) => void 0}
             onBlur={(event: ElementChangeResponse) => void 0}
-            onReady={() => void 0}
+            onReady={(el: HTMLElement) => void 0}
             onFocus={(event: ElementChangeResponse) => void 0}
         />
     </div>


### PR DESCRIPTION
In Stripe docs there are examples like `<CardElement onReady={(el) => el.focus()} />`
This PR fixes issue with missing method parameters for `onReady` function.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/stripe/react-stripe-elements#using-onready
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
