### PR TITLE
Refine swagger-schema-official parameter types

### DIFF
--- a/types/swagger-schema-official/index.d.ts
+++ b/types/swagger-schema-official/index.d.ts
@@ -87,7 +87,7 @@ export interface Path {
   options?: Operation;
   head?: Operation;
   patch?: Operation;
-  parameters?: Parameter[] | Reference[];
+  parameters?: Array<Parameter | Reference>;
 }
 
 // ----------------------------- Operation -----------------------------------
@@ -99,7 +99,7 @@ export interface Operation {
   operationId?: string;
   produces?: string[];
   consumes?: string[];
-  parameters?: Parameter[] | Reference[];
+  parameters?: Array<Parameter | Reference>;
   schemes?: string[];
   deprecated?: boolean;
   security?: Security[];

--- a/types/swagger-schema-official/swagger-schema-official-tests.ts
+++ b/types/swagger-schema-official/swagger-schema-official-tests.ts
@@ -1365,7 +1365,13 @@ const reference_support: swagger.Spec = {
         "/path": {
             "get": {
                 "parameters": [
-                    {"$ref": "#/parameters/operationParameter"}
+                    {"$ref": "#/parameters/operationParameter"},
+                    {
+                        "in": "body",
+                        "name": "bodyParameter",
+                        "type": "string",
+                        "description": "The body parameter"
+                    }
                 ],
                 "responses": {
                     "200": {
@@ -1380,7 +1386,13 @@ const reference_support: swagger.Spec = {
                 }
             },
             "parameters": [
-                {"$ref": "#/parameters/pathParameter"}
+                {"$ref": "#/parameters/pathParameter"},
+                {
+                    "in": "query",
+                    "name": "queryParameter",
+                    "type": "string",
+                    "description": "Another query parameter"
+                }
             ]
         }
     },


### PR DESCRIPTION
Refining the parameter definition for swagger-schema-official in `PathItem` and `Operation`, as they are actually arrays of either parameters or references instead of arrays of parameters or arrays of references.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
-- https://swagger.io/specification/v2/#pathItemObject
-- https://swagger.io/specification/v2/#operationObject
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.