### PR TITLE
[koa-bodyparser] textLimit property missing in types

### DIFF
--- a/types/koa-bodyparser/index.d.ts
+++ b/types/koa-bodyparser/index.d.ts
@@ -46,7 +46,7 @@ declare namespace bodyParser {
          * limit of the json body. Default is 1mb
          */
         jsonLimit?: string;
-        
+
         /**
          * limit of the text body. Default is 1mb.
          */

--- a/types/koa-bodyparser/index.d.ts
+++ b/types/koa-bodyparser/index.d.ts
@@ -46,6 +46,11 @@ declare namespace bodyParser {
          * limit of the json body. Default is 1mb
          */
         jsonLimit?: string;
+        
+        /**
+         * limit of the text body. Default is 1mb.
+         */
+        textLimit?: string;
 
         /**
          * when set to true, JSON parser will only accept arrays and objects. Default is true


### PR DESCRIPTION
The property 'textLimit' similar to jsonLimit is missing in the types :)

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/koajs/bodyparser (textLimit is a property as well as can be seen very clearly in their readme)

