### PR TITLE
[graphql-relay] Change toGlobalId ID parameter to be either string or number

### DIFF
--- a/types/graphql-relay/index.d.ts
+++ b/types/graphql-relay/index.d.ts
@@ -290,7 +290,7 @@ export interface ResolvedGlobalId {
  * Takes a type name and an ID specific to that type name, and returns a
  * "global ID" that is unique among all types.
  */
-export function toGlobalId(type: string, id: string): string;
+export function toGlobalId(type: string, id: string | number): string;
 
 /**
  * Takes the "global ID" created by toGlobalID, and returns the type name and ID


### PR DESCRIPTION
Related issue: https://github.com/graphql/graphql-relay-js/issues/218
Related pull: https://github.com/graphql/graphql-relay-js/pull/219

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
