### PR TITLE
d3-dsv: TypesScript 2.3

### DIFF
--- a/types/d3-dsv/d3-dsv-tests.ts
+++ b/types/d3-dsv/d3-dsv-tests.ts
@@ -5,6 +5,7 @@
  * in the sense of typing and call signature consistency. They
  * are not intended as functional tests.
  */
+/* tslint:disable:no-unnecessary-type-assertion */
 
 import * as d3Dsv from 'd3-dsv';
 
@@ -16,9 +17,9 @@ const csvTestString = '1997,Ford,E350,2.34\n2000,Mercury,Cougar,2.38';
 const tsvTestString = '1997\tFord\tE350\t2.34\n2000\tMercury\tCougar\t2.38';
 const pipedTestString = '1997|Ford|E350|2.34\n2000|Mercury|Cougar|2.38';
 
-const csvTestStringWithHeader = 'Year,Make,Model,Length\n1997,Ford,E350,2.34\n2000,Mercury,Cougar,2.38';
-const tsvTestStringWithHeader = 'Year\tMake\tModel\tLength\n1997\tFord\tE350\t2.34\n2000\tMercury\tCougar\t2.38';
-const pipedTestStringWithHeader = 'Year|Make|Model|Length\n1997|Ford|E350|2.34\n2000|Mercury|Cougar|2.38';
+const csvTestStringWithHeader = `Year,Make,Model,Length\n${csvTestString}`;
+const tsvTestStringWithHeader = `Year\tMake\tModel\tLength\n${tsvTestString}`;
+const pipedTestStringWithHeader = `Year|Make|Model|Length\n${pipedTestString}`;
 
 interface ParsedTestObject {
     year: Date | null;
@@ -33,9 +34,8 @@ let parseMappedArray: d3Dsv.DSVParsedArray<ParsedTestObject>;
 let parseRowsArray: string[][];
 let parseRowsMappedArray: ParsedTestObject[];
 
+let parsedTestObject: ParsedTestObject;
 let columns: string[];
-let num: number;
-let dateNull: Date | null;
 let str: string;
 let strMaybe: string | undefined;
 
@@ -48,12 +48,8 @@ let strMaybe: string | undefined;
 // without row mapper -----------------------------------------------------------------------
 
 parseArray = d3Dsv.csvParse(csvTestStringWithHeader);
-
 columns = parseArray.columns;
-
-strMaybe = parseArray[0]['Year'];
-// $ExpectError
-date = parseArray[0]['Year']; // fails, return value is string
+strMaybe = parseArray[0].Year;
 
 // with row mapper ---------------------------------------------------------------------------
 
@@ -61,28 +57,15 @@ parseMappedArray = d3Dsv.csvParse(csvTestStringWithHeader, (rawRow, index, colum
     const rr: d3Dsv.DSVRowString = rawRow;
     const i: number = index;
     const c: string[] = columns;
-    const pr: ParsedTestObject = {
-        year: rr['Year'] ? new Date(+rr['Year']!, 0, 1) : null,
-        make: rr['Make'] ? rr['Make']! : "Missing Value",
-        model: rr['Model'] ? rr['Model']! : "Missing Value",
-        length: rr['Length'] ? +rr['Length']! : NaN
-    };
-    return pr;
-});
-
-parseMappedArray = d3Dsv.csvParse(csvTestStringWithHeader, (rawRow, index, columns) => {
-    const rr: d3Dsv.DSVRowString = rawRow;
-    const i: number = index;
-    const c: string[] = columns;
-    const d: number | null = rr['Year'] ? +rr['Year']! : null;
+    const d: number | null = rr.Year ? +rr.Year! : null;
     const pr: ParsedTestObject | null | undefined = d !== null
         ? (
             d > 1997
                 ? {
                     year: new Date(d, 0, 1),
-                    make: rr['Make'] ? rr['Make']! : "Missing Value",
-                    model: rr['Model'] ? rr['Model']! : "Missing Value",
-                    length: rr['Length'] ? +rr['Length']! : NaN
+                    make: rr.Make ? rr.Make! : "Missing Value",
+                    model: rr.Model ? rr.Model! : "Missing Value",
+                    length: rr.Length ? +rr.Length! : NaN
                 }
                 : undefined
         )
@@ -91,21 +74,14 @@ parseMappedArray = d3Dsv.csvParse(csvTestStringWithHeader, (rawRow, index, colum
 });
 
 columns = parseMappedArray.columns;
-
-dateNull = parseMappedArray[0].year;
-strMaybe = parseMappedArray[0].make;
-strMaybe = parseMappedArray[0].model;
-num = parseMappedArray[0].length;
+parsedTestObject = parseMappedArray[0];
 
 // csvParseRows(...) ============================================================================
 
 // without row mapper -----------------------------------------------------------------------
 
 parseRowsArray = d3Dsv.csvParseRows(csvTestString);
-
 strMaybe = parseRowsArray[0][0]; // 'Year' of first row
-// $ExpectError
-date = parseRowsArray[0][0]; // fails, return value is string
 
 // with row mapper ---------------------------------------------------------------------------
 
@@ -128,15 +104,12 @@ parseRowsMappedArray = d3Dsv.csvParseRows(csvTestString, (rawRow, index) => {
     return pr;
 });
 
-dateNull = parseRowsMappedArray[0].year;
-strMaybe = parseRowsMappedArray[0].make;
-strMaybe = parseRowsMappedArray[0].model;
-num = parseRowsMappedArray[0].length;
-
 // csvFormat(...) ============================================================================
 
 str = d3Dsv.csvFormat(parseRowsMappedArray);
-str = d3Dsv.csvFormat(parseRowsMappedArray, columns);
+str = d3Dsv.csvFormat(parseRowsMappedArray, ["year", "length"]);
+// $ExpectError
+str = d3Dsv.csvFormat(parseRowsMappedArray, ["year", "unknown"]);
 
 // csvFormatRows(...) ========================================================================
 
@@ -156,12 +129,8 @@ str = d3Dsv.csvFormatRows(parseRowsMappedArray.map((d, i) => [
 // without row mapper -----------------------------------------------------------------------
 
 parseArray = d3Dsv.tsvParse(tsvTestStringWithHeader);
-
 columns = parseArray.columns;
-
-strMaybe = parseArray[0]['Year'];
-// $ExpectError
-date = parseArray[0]['Year']; // fails, return value is string
+strMaybe = parseArray[0].Year;
 
 // with row mapper ---------------------------------------------------------------------------
 
@@ -169,15 +138,15 @@ parseMappedArray = d3Dsv.tsvParse(tsvTestStringWithHeader, (rawRow, index, colum
     const rr: d3Dsv.DSVRowString = rawRow;
     const i: number = index;
     const c: string[] = columns;
-    const d: number | null = rr['Year'] ? +rr['Year']! : null;
+    const d: number | null = rr.Year ? +rr.Year! : null;
     const pr: ParsedTestObject | null | undefined = d !== null
         ? (
             d > 1997
                 ? {
                     year: new Date(d, 0, 1),
-                    make: rr['Make'] ? rr['Make']! : "Missing Value",
-                    model: rr['Model'] ? rr['Model']! : "Missing Value",
-                    length: rr['Length'] ? +rr['Length']! : NaN
+                    make: rr.Make ? rr.Make! : "Missing Value",
+                    model: rr.Model ? rr.Model! : "Missing Value",
+                    length: rr.Length ? +rr.Length! : NaN
                 }
                 : undefined
         )
@@ -186,21 +155,14 @@ parseMappedArray = d3Dsv.tsvParse(tsvTestStringWithHeader, (rawRow, index, colum
 });
 
 columns = parseMappedArray.columns;
-
-dateNull = parseMappedArray[0].year;
-strMaybe = parseMappedArray[0].make;
-strMaybe = parseMappedArray[0].model;
-num = parseMappedArray[0].length;
+parsedTestObject = parseMappedArray[0];
 
 // tsvParseRows(...) ============================================================================
 
 // without row mapper -----------------------------------------------------------------------
 
 parseRowsArray = d3Dsv.tsvParseRows(tsvTestString);
-
 strMaybe = parseRowsArray[0][0]; // 'Year' of first row
-// $ExpectError
-date = parseRowsArray[0][0]; // fails, return value is string
 
 // with row mapper ---------------------------------------------------------------------------
 
@@ -223,15 +185,12 @@ parseRowsMappedArray = d3Dsv.tsvParseRows(tsvTestString, (rawRow, index) => {
     return pr;
 });
 
-dateNull = parseRowsMappedArray[0].year;
-strMaybe = parseRowsMappedArray[0].make;
-strMaybe = parseRowsMappedArray[0].model;
-num = parseRowsMappedArray[0].length;
-
 // tsvFormat(...) ============================================================================
 
 str = d3Dsv.tsvFormat(parseRowsMappedArray);
-str = d3Dsv.tsvFormat(parseRowsMappedArray, columns);
+str = d3Dsv.tsvFormat(parseRowsMappedArray, ["year", "length"]);
+// $ExpectError
+str = d3Dsv.tsvFormat(parseRowsMappedArray, ["year", "unknown"]);
 
 // tsvFormatRows(...) ========================================================================
 
@@ -256,12 +215,8 @@ dsv = d3Dsv.dsvFormat('|');
 // without row mapper -----------------------------------------------------------------------
 
 parseArray = dsv.parse(pipedTestStringWithHeader);
-
 columns = parseArray.columns;
-
-strMaybe = parseArray[0]['Year'];
-// $ExpectError
-date = parseArray[0]['Year']; // fails, return value is string
+strMaybe = parseArray[0].Year;
 
 // with row mapper ---------------------------------------------------------------------------
 
@@ -269,15 +224,15 @@ parseMappedArray = dsv.parse(pipedTestStringWithHeader, (rawRow, index, columns)
     const rr: d3Dsv.DSVRowString = rawRow;
     const i: number = index;
     const c: string[] = columns;
-    const d: number | null = rr['Year'] ? +rr['Year']! : null;
+    const d: number | null = rr.Year ? +rr.Year! : null;
     const pr: ParsedTestObject | null | undefined = d !== null
         ? (
             d > 1997
                 ? {
                     year: new Date(d, 0, 1),
-                    make: rr['Make'] ? rr['Make']! : "Missing Value",
-                    model: rr['Model'] ? rr['Model']! : "Missing Value",
-                    length: rr['Length'] ? +rr['Length']! : NaN
+                    make: rr.Make ? rr.Make! : "Missing Value",
+                    model: rr.Model ? rr.Model! : "Missing Value",
+                    length: rr.Length ? +rr.Length! : NaN
                 }
                 : undefined
         )
@@ -286,21 +241,14 @@ parseMappedArray = dsv.parse(pipedTestStringWithHeader, (rawRow, index, columns)
 });
 
 columns = parseMappedArray.columns;
-
-dateNull = parseMappedArray[0].year;
-strMaybe = parseMappedArray[0].make;
-strMaybe = parseMappedArray[0].model;
-num = parseMappedArray[0].length;
+parsedTestObject = parseMappedArray[0];
 
 // parseRows(...) ============================================================================
 
 // without row mapper -----------------------------------------------------------------------
 
 parseRowsArray = dsv.parseRows(pipedTestString);
-
 strMaybe = parseRowsArray[0][0]; // 'Year' of first row
-// $ExpectError
-date = parseRowsArray[0][0]; // fails, return value is string
 
 // with row mapper ---------------------------------------------------------------------------
 
@@ -323,15 +271,12 @@ parseRowsMappedArray = dsv.parseRows(pipedTestString, (rawRow, index) => {
     return pr;
 });
 
-dateNull = parseRowsMappedArray[0].year;
-strMaybe = parseRowsMappedArray[0].make;
-strMaybe = parseRowsMappedArray[0].model;
-num = parseRowsMappedArray[0].length;
-
 // format(...) ============================================================================
 
 str = dsv.format(parseRowsMappedArray);
-str = dsv.format(parseRowsMappedArray, columns);
+str = dsv.format(parseRowsMappedArray, ["year", "length"]);
+// $ExpectError
+str = dsv.format(parseRowsMappedArray, ["year", "unknown"]);
 
 // formatRows(...) ========================================================================
 

--- a/types/d3-dsv/index.d.ts
+++ b/types/d3-dsv/index.d.ts
@@ -1,9 +1,13 @@
 // Type definitions for D3JS d3-dsv module 1.0
 // Project: https://github.com/d3/d3-dsv/
-// Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
+// Definitions by: Tom Wanzek <https://github.com/tomwanzek>
+//                 Alex Ford <https://github.com/gustavderdrache>
+//                 Boris Yankov <https://github.com/borisyankov>
+//                 denisname <https://github.com/denisname>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
 
-// Last module patch version validated against: 1.0.8
+// Last module patch version validated against: 1.0.10
 
 // ------------------------------------------------------------------------------------------
 // Shared Types and Interfaces
@@ -19,10 +23,10 @@ export interface DSVRowString {
 /**
  * An object representing a DSV parsed row with values represented as an arbitrary datatype, depending
  * on the performed parsed row mapping.
+ *
+ * @deprecated
  */
-export interface DSVRowAny {
-    [key: string]: any;
-}
+export type DSVRowAny = object;
 
 /**
  * An array object representing all parsed rows. The array is enhanced with a property listing
@@ -70,7 +74,7 @@ export function csvParse(csvString: string): DSVParsedArray<DSVRowString>;
  * the row is skipped and will be omitted from the array returned by dsv.parse; otherwise, the returned value defines the corresponding row object.
  * In effect, row is similar to applying a map and filter operator to the returned rows.
  */
-export function csvParse<ParsedRow extends DSVRowAny>(
+export function csvParse<ParsedRow extends object>(
     csvString: string,
     row: (rawRow: DSVRowString, index: number, columns: string[]) => ParsedRow | undefined | null
 ): DSVParsedArray<ParsedRow>;
@@ -105,7 +109,7 @@ export function csvParseRows(csvString: string): string[][];
  * the row is skipped and will be omitted from the array returned by dsv.parse; otherwise, the returned value defines the corresponding row object.
  * In effect, row is similar to applying a map and filter operator to the returned rows.
  */
-export function csvParseRows<ParsedRow extends DSVRowAny>(
+export function csvParseRows<ParsedRow extends object>(
     csvString: string,
     row: (rawRow: string[], index: number) => ParsedRow | undefined | null
 ): ParsedRow[];
@@ -126,7 +130,7 @@ export function csvParseRows<ParsedRow extends DSVRowAny>(
  * @param rows Array of object rows.
  * @param columns An array of strings representing the column names.
  */
-export function csvFormat(rows: DSVRowAny[], columns?: string[]): string;
+export function csvFormat<T extends object>(rows: T[], columns?: Array<keyof T>): string;
 
 // csvFormatRows(...) ========================================================================
 
@@ -180,7 +184,7 @@ export function tsvParse(tsvString: string): DSVParsedArray<DSVRowString>;
  * the row is skipped and will be omitted from the array returned by dsv.parse; otherwise, the returned value defines the corresponding row object.
  * In effect, row is similar to applying a map and filter operator to the returned rows.
  */
-export function tsvParse<MappedRow extends DSVRowAny>(
+export function tsvParse<MappedRow extends object>(
     tsvString: string,
     row: (rawRow: DSVRowString, index: number, columns: string[]) => MappedRow | undefined | null
 ): DSVParsedArray<MappedRow>;
@@ -215,7 +219,7 @@ export function tsvParseRows(tsvString: string): string[][];
  * the row is skipped and will be omitted from the array returned by dsv.parse; otherwise, the returned value defines the corresponding row object.
  * In effect, row is similar to applying a map and filter operator to the returned rows.
  */
-export function tsvParseRows<MappedRow extends DSVRowAny>(
+export function tsvParseRows<MappedRow extends object>(
     tsvString: string,
     row: (rawRow: string[], index: number) => MappedRow | undefined | null
 ): MappedRow[];
@@ -236,7 +240,7 @@ export function tsvParseRows<MappedRow extends DSVRowAny>(
  * @param rows Array of object rows.
  * @param columns An array of strings representing the column names.
  */
-export function tsvFormat(rows: DSVRowAny[], columns?: string[]): string;
+export function tsvFormat<T extends object>(rows: T[], columns?: Array<keyof T>): string;
 
 // tsvFormatRows(...) ========================================================================
 
@@ -288,7 +292,7 @@ export interface DSV {
      * the row is skipped and will be omitted from the array returned by dsv.parse; otherwise, the returned value defines the corresponding row object.
      * In effect, row is similar to applying a map and filter operator to the returned rows.
      */
-    parse<ParsedRow extends DSVRowAny>(
+    parse<ParsedRow extends object>(
         dsvString: string,
         row: (rawRow: DSVRowString, index: number, columns: string[]) => ParsedRow | undefined | null
     ): DSVParsedArray<ParsedRow>;
@@ -317,7 +321,7 @@ export interface DSV {
      * the row is skipped and will be omitted from the array returned by dsv.parse; otherwise, the returned value defines the corresponding row object.
      * In effect, row is similar to applying a map and filter operator to the returned rows.
      */
-    parseRows<ParsedRow extends DSVRowAny>(
+    parseRows<ParsedRow extends object>(
         dsvString: string,
         row: (rawRow: string[], index: number) => ParsedRow | undefined | null
     ): ParsedRow[];
@@ -334,7 +338,7 @@ export interface DSV {
      * @param rows Array of object rows.
      * @param columns An array of strings representing the column names.
      */
-    format(rows: DSVRowAny[], columns?: string[]): string;
+    format<T extends object>(rows: T[], columns?: Array<keyof T>): string;
 
     /**
      * Formats the specified array of array of string rows as delimiter-separated values, returning a string.

--- a/types/d3-dsv/index.d.ts
+++ b/types/d3-dsv/index.d.ts
@@ -26,7 +26,9 @@ export interface DSVRowString {
  *
  * @deprecated
  */
-export type DSVRowAny = object;
+export interface DSVRowAny {
+    [key: string]: any;
+}
 
 /**
  * An array object representing all parsed rows. The array is enhanced with a property listing

--- a/types/d3-fetch/index.d.ts
+++ b/types/d3-fetch/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://d3js.org/d3-fetch/
 // Definitions by: Hugues Stefanski <https://github.com/ledragon>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 // Last module patch version validated against: 1.1.0
 


### PR DESCRIPTION
Add a generic to `tsvFormat`, `csvFormat` and `dsv#format` functions for better `columns` typing. Same can be done to some other functions. I will do that in a next PR, still think on it...

Use TypeScript 2.2 `object` type instead of DSVRowAny.

Remove useless expectError. Testing if someting is not a `Date` is useless, if before we test if it is a `string | undefined`

Remove a useless/duplicate csvParse test.

Replace properties `year`, `make`, ... tests for an interface test. If a `foo` is of type `ParsedTestObject`, `foo.year` is obviuosly of type `Date | null`. Same for `make`, `model` and `length`.

Change `rr['Foo']` to `rr.Foo`.
When, `bar`, is a `string | undefined`, TS 2.6- does not infer the type of the second bar in `bar ? bar : "undef"` as `string`. So it needs a `!` to compile. But TS 2.7+ does infer `bar` correctly, so it complain about  `no-unnecessary-type-assertion`. This is why I had to add a `tslint:disable` rule. It can be removed once we will be using TS 2.7+ only.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
