### PR TITLE
feat: Add fastify-accepts typings

### DIFF
--- a/types/fastify-accepts/fastify-accepts-tests.ts
+++ b/types/fastify-accepts/fastify-accepts-tests.ts
@@ -1,0 +1,47 @@
+import fastify = require("fastify");
+import fastifyAccepts = require("fastify-accepts");
+
+const app = fastify();
+
+app.register<fastifyAccepts.FastifyAcceptsOptions>(fastifyAccepts, {
+    decorateReplyToo: true
+});
+
+app.post("/", (req, reply) => {
+    const accept = req.accepts(); // Accepts object
+    switch (accept.type(["json", "html"])) {
+        case "json":
+            reply.type("application/json").send({ hello: "world" });
+            break;
+        case "html":
+            reply.type("text/html").send("<b>hello, world!</b>");
+            break;
+        default:
+            reply.send("unacceptable");
+            break;
+    }
+});
+
+app.post("/", (req, reply) => {
+    req.charset(["utf-8"]);
+    req.charsets();
+    req.encoding(["gzip", "compress"]);
+    req.encodings();
+    req.language(["es", "en"]);
+    req.languages();
+    req.type(["image/png", "image/tiff"]);
+    req.types();
+});
+
+app.post("/", (req, reply) => {
+    reply.requestAccepts();
+
+    reply.requestCharset(["utf-8"]);
+    reply.requestCharsets();
+    reply.requestEncoding(["gzip", "compress"]);
+    reply.requestEncodings();
+    reply.requestLanguage(["es", "en"]);
+    reply.requestLanguages();
+    reply.requestType(["image/png", "image/tiff"]);
+    reply.requestTypes();
+});

--- a/types/fastify-accepts/index.d.ts
+++ b/types/fastify-accepts/index.d.ts
@@ -1,0 +1,45 @@
+// Type definitions for fastify-accepts 0.5
+// Project: https://github.com/fastify/fastify-accepts#readme
+// Definitions by: Leonhard Melzer <https://github.com/leomelzer>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.4
+
+import fastify = require("fastify");
+
+import { Accepts } from "accepts";
+
+declare module "fastify" {
+    interface FastifyRequest<HttpRequest> {
+        accepts(): Accepts;
+        charset: Accepts["charset"];
+        charsets: Accepts["charsets"];
+        encoding: Accepts["encoding"];
+        encodings: Accepts["charsets"];
+        language: Accepts["language"];
+        languages: Accepts["languages"];
+        type: Accepts["type"];
+        types: Accepts["types"];
+    }
+
+    interface FastifyReply<HttpResponse> {
+        requestAccepts(): Accepts;
+        requestCharset: Accepts["charset"];
+        requestCharsets: Accepts["charsets"];
+        requestEncoding: Accepts["encoding"];
+        requestEncodings: Accepts["charsets"];
+        requestLanguage: Accepts["language"];
+        requestLanguages: Accepts["languages"];
+        requestType: Accepts["type"];
+        requestTypes: Accepts["types"];
+    }
+}
+
+declare function fastifyAccepts(): void;
+
+declare namespace fastifyAccepts {
+    interface FastifyAcceptsOptions {
+        decorateReplyToo?: boolean;
+    }
+}
+
+export = fastifyAccepts;

--- a/types/fastify-accepts/package.json
+++ b/types/fastify-accepts/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "fastify": "^1.11.2"
+    }
+}

--- a/types/fastify-accepts/tsconfig.json
+++ b/types/fastify-accepts/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": ["index.d.ts", "fastify-accepts-tests.ts"]
+}

--- a/types/fastify-accepts/tslint.json
+++ b/types/fastify-accepts/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Hi there,
this PR adds typings for the [fastify-accepts](https://github.com/fastify/fastify-accepts) plugin. The plugin in turn exposes some ([but not all](https://github.com/fastify/fastify-accepts/blob/master/index.js#L9-L14)) methods of the [accepts](https://github.com/jshttp/accepts) NPM package which has existing types. Hence I based the PR on those. I hope that is fine.

Thanks, Leo


- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.