### PR TITLE
validator: add options for isISO8601

### DIFF
--- a/types/validator/index.d.ts
+++ b/types/validator/index.d.ts
@@ -341,7 +341,7 @@ declare namespace ValidatorJS {
     gt?: number;
   }
 
-  // options for isISO8601Options
+  // options for isISO8601
   interface IsISO8601Options {
     strict?: boolean;
   }

--- a/types/validator/index.d.ts
+++ b/types/validator/index.d.ts
@@ -122,7 +122,7 @@ declare namespace ValidatorJS {
     isISIN(str: string): boolean;
 
     // check if the string is a valid ISO 8601 (https://en.wikipedia.org/wiki/ISO_8601) date.
-    isISO8601(str: string): boolean;
+    isISO8601(str: string, options?: IsISO8601Options): boolean;
 
     // check if the string is a valid ISO 3166-1 alpha-2 (https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) officially assigned
     // country code.
@@ -339,6 +339,11 @@ declare namespace ValidatorJS {
     allow_leading_zeroes?: boolean;
     lt?: number;
     gt?: number;
+  }
+
+  // options for isISO8601Options
+  interface IsISO8601Options {
+    strict?: boolean;
   }
 
   // options for IsLength

--- a/types/validator/validator-tests.ts
+++ b/types/validator/validator-tests.ts
@@ -469,7 +469,9 @@ let any: any;
 
   result = validator.isISIN('sample');
 
+  let isISO8601Options: ValidatorJS.IsISO8601Options = {};
   result = validator.isISO8601('sample');
+  result = validator.isISO8601('sample', isISO8601Options);
 
   result = validator.isISO31661Alpha2('sample');
 


### PR DESCRIPTION
Please fill in this template.

- [ X ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ X ] Test the change in your own code. (Compile and run.)
- [ X ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ X ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ X ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ X ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ X ] Provide a URL to documentation or source code which provides context for the suggested changes: 
https://github.com/chriso/validator.js#validators (search for `isISO8601`)
- [ N/A ] Increase the version number in the header if appropriate.
- [ N/A ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

Summary: I added an `options` object for the `isISO8601` function, as documented on the project’s Github, see link above.