### PR TITLE
[knex] Adding missing clearOrder() method

### DIFF
--- a/types/knex/index.d.ts
+++ b/types/knex/index.d.ts
@@ -5,6 +5,7 @@
 //                 Matt R. Wilson <https://github.com/mastermatt>
 //                 Satana Charuwichitratana <https://github.com/micksatana>
 //                 Shrey Jain <https://github.com/shreyjain1994>
+//                 Joel Shepherd <https://github.com/joelshepherd>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -129,6 +130,7 @@ declare namespace Knex {
         havingIn: HavingIn;
 
         // Clear
+        clearOrder(): QueryBuilder;
         clearSelect(): QueryBuilder;
         clearWhere(): QueryBuilder;
 

--- a/types/knex/knex-tests.ts
+++ b/types/knex/knex-tests.ts
@@ -738,6 +738,10 @@ knex.table('users').first(knex.raw('round(sum(products)) as p')).then((row) => {
   console.log(row);
 });
 
+knex.table('users').orderBy('name', 'desc').clearOrder().orderBy('id', 'asc').then((rows) => {
+  console.log(rows);
+});
+
 knex.table('users').select('*').clearSelect().select('id').then((rows) => {
   console.log(rows);
 });


### PR DESCRIPTION
Adding in missing clearOrder() method on the query builder. See [PR](https://github.com/tgriesser/knex/pull/2553), [changelog](https://github.com/tgriesser/knex/blob/master/CHANGELOG.md#0145---8-apr-2018), or [documentation](https://knexjs.org/#Builder-clearOrder) of the addition.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/tgriesser/knex/pull/2553
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
