### PR TITLE
@types/jsdom Reference lib "dom"

### DIFF
--- a/types/jsdom/index.d.ts
+++ b/types/jsdom/index.d.ts
@@ -5,6 +5,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
+/// <reference lib="dom" />
 /// <reference types="node" />
 
 import { EventEmitter } from 'events';

--- a/types/jsdom/package.json
+++ b/types/jsdom/package.json
@@ -2,5 +2,13 @@
     "private": true,
     "dependencies": {
         "parse5": "^4.0.0"
+    },
+    "types": "index",
+    "typesVersions": {
+        ">=3.1.0-0": {
+            "*": [
+                "ts3.1/*"
+            ]
+        }
     }
 }

--- a/types/jsdom/ts3.1/index.d.ts
+++ b/types/jsdom/ts3.1/index.d.ts
@@ -1,16 +1,10 @@
-// Type definitions for jsdom 12.2
-// Project: https://github.com/tmpvar/jsdom#readme
-// Definitions by: Leonard Thieu <https://github.com/leonard-thieu>
-//                 Johan Palmfjord <https://github.com/palmfjord>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
-
+/// <reference lib="dom" />
 /// <reference types="node" />
 
-import { EventEmitter } from 'events';
-import { MarkupData } from 'parse5';
-import * as tough from 'tough-cookie';
-import { Script } from 'vm';
+import { EventEmitter } from "events";
+import { MarkupData } from "parse5";
+import * as tough from "tough-cookie";
+import { Script } from "vm";
 
 export class JSDOM {
     static fromURL(url: string, options?: FromUrlOptions): Promise<JSDOM>;
@@ -19,7 +13,10 @@ export class JSDOM {
 
     static fragment(html: string): DocumentFragment;
 
-    constructor(html?: string | Buffer | BinaryData, options?: ConstructorOptions);
+    constructor(
+        html?: string | Buffer | BinaryData,
+        options?: ConstructorOptions
+    );
 
     readonly window: DOMWindow;
     readonly virtualConsole: VirtualConsole;
@@ -64,8 +61,8 @@ export interface Options {
      * and cannot be used with an XML content type since our XML parser does not support location info.
      */
     includeNodeLocations?: boolean;
-    runScripts?: 'dangerously' | 'outside-only';
-    resources?: 'usable' | ResourceLoader;
+    runScripts?: "dangerously" | "outside-only";
+    resources?: "usable" | ResourceLoader;
     virtualConsole?: VirtualConsole;
     cookieJar?: CookieJar;
     beforeParse?(window: DOMWindow): void;
@@ -109,13 +106,13 @@ export type ConstructorOptions = Options & {
      * When the pretendToBeVisual option is set to true, jsdom will pretend that it is rendering and displaying
      * content.
      */
-    pretendToBeVisual?: boolean
+    pretendToBeVisual?: boolean;
     /**
      * The maximum size in code units for the separate storage areas used by localStorage and sessionStorage.
      * Attempts to store data larger than this limit will cause a DOMException to be thrown. By default, it is set
      * to 5,000,000 code units per origin, as inspired by the HTML specification.
      */
-    storageQuota?: number
+    storageQuota?: number;
 };
 
 export interface DOMWindow extends Window {
@@ -266,11 +263,22 @@ export interface DOMWindow extends Window {
     NodeFilter: typeof NodeFilter;
 }
 
-export type BinaryData = ArrayBuffer | DataView | Int8Array | Uint8Array | Uint8ClampedArray | Int16Array | Uint16Array | Int32Array | Uint32Array | Float32Array | Float64Array;
+export type BinaryData =
+    | ArrayBuffer
+    | DataView
+    | Int8Array
+    | Uint8Array
+    | Uint8ClampedArray
+    | Int16Array
+    | Uint16Array
+    | Int32Array
+    | Uint32Array
+    | Float32Array
+    | Float64Array;
 
 export class VirtualConsole extends EventEmitter {
     on<K extends keyof Console>(method: K, callback: Console[K]): this;
-    on(event: 'jsdomError', callback: (e: Error) => void): this;
+    on(event: "jsdomError", callback: (e: Error) => void): this;
 
     sendTo(console: Console, options?: VirtualConsoleSendToOptions): this;
 }
@@ -279,7 +287,7 @@ export interface VirtualConsoleSendToOptions {
     omitJSDOMErrors: boolean;
 }
 
-export class CookieJar extends tough.CookieJar { }
+export class CookieJar extends tough.CookieJar {}
 
 export const toughCookie: typeof tough;
 
@@ -292,7 +300,11 @@ export interface FetchOptions {
     cookieJar?: CookieJar;
     referrer?: string;
     accept?: string;
-    element?: HTMLScriptElement | HTMLLinkElement | HTMLIFrameElement | HTMLImageElement;
+    element?:
+        | HTMLScriptElement
+        | HTMLLinkElement
+        | HTMLIFrameElement
+        | HTMLImageElement;
 }
 
 export interface ResourceLoaderConstructorOptions {

--- a/types/jsdom/ts3.1/jsdom-tests.ts
+++ b/types/jsdom/ts3.1/jsdom-tests.ts
@@ -1,0 +1,184 @@
+import { JSDOM, VirtualConsole, CookieJar, FromUrlOptions, FromFileOptions, DOMWindow, ResourceLoader, FetchOptions } from 'jsdom';
+import { CookieJar as ToughCookieJar, MemoryCookieStore } from 'tough-cookie';
+import { Script } from 'vm';
+
+function test_basic_usage() {
+    const dom = new JSDOM(`<!DOCTYPE html><p>Hello world</p>`);
+    console.log(dom.window.document.querySelector('p')!.textContent); // "Hello world"
+
+    const { window } = new JSDOM(`...`);
+    // or even
+    const { document } = (new JSDOM(`...`)).window;
+}
+
+function test_executing_scripts1() {
+    const dom = new JSDOM(`<body>
+  <script>document.body.appendChild(document.createElement("hr"));</script>
+</body>`);
+
+    // The script will not be executed, by default:
+    dom.window.document.body.children.length === 1;
+}
+
+function test_executing_scripts2() {
+    const dom = new JSDOM(`<body>
+  <script>document.body.appendChild(document.createElement("hr"));</script>
+</body>`, { runScripts: 'dangerously' });
+
+    // The script will be executed and modify the DOM:
+    dom.window.document.body.children.length === 2;
+}
+
+function test_executing_scripts3() {
+    const window = (new JSDOM(``, { runScripts: 'outside-only' })).window;
+
+    window.eval(`document.body.innerHTML = "<p>Hello, world!</p>";`);
+    window.document.body.children.length === 1;
+}
+
+function test_virtualConsole() {
+    const virtualConsole = new VirtualConsole();
+    const dom = new JSDOM(``, { virtualConsole });
+
+    virtualConsole.on('error', () => { });
+    virtualConsole.on('warn', () => { });
+    virtualConsole.on('info', () => { });
+    virtualConsole.on('dir', () => { });
+    // ... etc. See https://console.spec.whatwg.org/#logging
+
+    virtualConsole.sendTo(console);
+
+    const c = console;
+    virtualConsole.sendTo(c, { omitJSDOMErrors: true });
+}
+
+function test_cookieJar() {
+    const store = {} as MemoryCookieStore;
+    const options = {} as ToughCookieJar.Options;
+
+    const cookieJar = new CookieJar(store, options);
+    const dom = new JSDOM(``, { cookieJar });
+}
+
+function test_beforeParse() {
+    const dom = new JSDOM(`<p>Hello</p>`, {
+        beforeParse(window) {
+            window.document.childNodes.length === 0;
+        }
+    });
+}
+
+function test_storageQuota() {
+    new JSDOM('', { storageQuota: 1337 });
+}
+
+function test_pretendToBeVisual() {
+    new JSDOM('', { pretendToBeVisual: true });
+}
+
+function test_serialize() {
+    const dom = new JSDOM(`<!DOCTYPE html>hello`);
+
+    dom.serialize() === '<!DOCTYPE html><html><head></head><body>hello</body></html>';
+
+    // Contrast with:
+    // tslint:disable-next-line no-unnecessary-type-assertion
+    dom.window.document.documentElement!.outerHTML === '<html><head></head><body>hello</body></html>';
+}
+
+function test_nodeLocation() {
+    const dom = new JSDOM(
+        `<p>Hello
+    <img src="foo.jpg">
+  </p>`,
+        { includeNodeLocations: true }
+    );
+
+    const document = dom.window.document;
+    const bodyEl = document.body; // implicitly created
+    const pEl = document.querySelector('p')!;
+    const textNode = pEl.firstChild!;
+    const imgEl = document.querySelector('img')!;
+
+    console.log(dom.nodeLocation(bodyEl));   // null; it's not in the source
+    console.log(dom.nodeLocation(pEl));      // { startOffset: 0, endOffset: 39, startTag: ..., endTag: ... }
+    console.log(dom.nodeLocation(textNode)); // { startOffset: 3, endOffset: 13 }
+    console.log(dom.nodeLocation(imgEl));    // { startOffset: 13, endOffset: 32 }
+}
+
+function test_runVMScript() {
+    const dom = new JSDOM(``, { runScripts: 'outside-only' });
+    const s = new Script(`
+  if (!this.ran) {
+    this.ran = 0;
+  }
+
+  ++this.ran;
+`);
+
+    dom.runVMScript(s);
+    dom.runVMScript(s);
+    dom.runVMScript(s);
+
+    (<any> dom.window).ran === 3;
+}
+
+function test_reconfigure() {
+    const myFakeTopForTesting = {} as DOMWindow;
+
+    const dom = new JSDOM();
+
+    dom.window.top === dom.window;
+    dom.window.location.href === 'about:blank';
+
+    dom.reconfigure({ windowTop: myFakeTopForTesting, url: 'https://example.com/' });
+
+    dom.window.top === myFakeTopForTesting;
+    dom.window.location.href === 'https://example.com/';
+}
+
+function test_fromURL() {
+    const options = {} as FromUrlOptions;
+
+    JSDOM.fromURL('https://example.com/', options).then(dom => {
+        console.log(dom.serialize());
+    });
+}
+
+function test_fromFile() {
+    const options = {} as FromFileOptions;
+
+    JSDOM.fromFile('stuff.html', options).then(dom => {
+        console.log(dom.serialize());
+    });
+}
+
+function test_fragment() {
+    const frag = JSDOM.fragment(`<p>Hello</p><p><strong>Hi!</strong>`);
+
+    frag.childNodes.length === 2;
+    frag.querySelector('strong')!.textContent = 'Why hello there!';
+    // etc.
+}
+
+function test_fragment_serialization() {
+    const frag = JSDOM.fragment(`<p>Hello</p>`);
+    if (frag instanceof Element) {
+        if (frag.firstChild instanceof Element) {
+            console.log(frag.firstChild.outerHTML); // logs "<p>Hello</p>"
+        }
+    }
+}
+
+function test_custom_resource_loader() {
+    class CustomResourceLoader extends ResourceLoader {
+        fetch(url: string, options: FetchOptions) {
+          if (options.element) {
+            console.log(`Element ${options.element.localName} is requesting the url ${url}`);
+          }
+
+          return super.fetch(url, options);
+        }
+    }
+    new JSDOM('', { resources: new CustomResourceLoader() });
+}

--- a/types/jsdom/ts3.1/tsconfig.json
+++ b/types/jsdom/ts3.1/tsconfig.json
@@ -1,0 +1,19 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6", "dom"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../../",
+        "typeRoots": ["../../"],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "paths": {
+            "parse5": ["parse5/v4"]
+        }
+    },
+    "files": ["index.d.ts", "jsdom-tests.ts"]
+}

--- a/types/jsdom/ts3.1/tslint.json
+++ b/types/jsdom/ts3.1/tslint.json
@@ -1,0 +1,8 @@
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        // TODOs
+        "no-empty-interface": false,
+        "no-object-literal-type-assertion": false
+    }
+}


### PR DESCRIPTION
Currently lib "dom" is required for compilation.

However, including "dom" in lib can cause some opaque bugs on a server.

For example, the TS compiler won't complain when using `fetch` without something like `import fetch from "node-fetch"` or using `URL` without `import { URL } from "url"`.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
