### PR TITLE
@types/react-intl: Add timezone prop to IntlProvider

### DIFF
--- a/types/react-intl/index.d.ts
+++ b/types/react-intl/index.d.ts
@@ -190,6 +190,7 @@ declare namespace ReactIntl {
     namespace IntlProvider {
         interface Props {
             locale?: string;
+            timeZone?: string;
             formats?: any;
             messages?: any;
             defaultLocale?: string;

--- a/types/react-intl/react-intl-tests.tsx
+++ b/types/react-intl/react-intl-tests.tsx
@@ -401,7 +401,7 @@ class TestApp extends React.Component {
             hello: "Hello, {name}!"
         };
         return (
-            <IntlProvider locale="en" formats={{}} messages={messages} defaultLocale="en" defaultFormats={messages}>
+            <IntlProvider locale="en" formats={{}} messages={messages} defaultLocale="en" defaultFormats={messages} timeZone="UTC">
                 <SomeComponentWithIntl className="just-for-test" />
                 <SomeFunctionalComponentWithIntl className="another-one" />
             </IntlProvider>


### PR DESCRIPTION
It is possible to define the time zone on the intl provider but the types do not reflect this.
Source: https://github.com/yahoo/react-intl/blob/00c622c67f7a96fd20cf7dd0051da2df65176bdf/examples/explicit-timezone/src/index.js
