### PR TITLE
pouchdb-upsert: Enable strictFunctionTypes and make the type of the parameter to UpsertDiffCallback more useful.

### DIFF
--- a/types/pouchdb-upsert/index.d.ts
+++ b/types/pouchdb-upsert/index.d.ts
@@ -59,7 +59,10 @@ declare namespace PouchDB {
   }
 
   type CancelUpsert = '' | 0 | false | null | undefined; // falsey values
-  type UpsertDiffCallback<Content extends {}> = (doc: Core.Document<Content> | {}) => Content & Partial<Core.IdMeta> | CancelUpsert;
+  // `Partial<Core.Document<Content>>` seems more useful than
+  // `{} | Core.Document<Content>` since there isn't an easy way to narrow
+  // `{} | Core.Document<Content>` to `Core.Document<Content>`.
+  type UpsertDiffCallback<Content extends {}> = (doc: Partial<Core.Document<Content>>) => Content & Partial<Core.IdMeta> | CancelUpsert;
 
   interface UpsertResponse {
     id: Core.DocumentId;

--- a/types/pouchdb-upsert/pouchdb-upsert-tests.ts
+++ b/types/pouchdb-upsert/pouchdb-upsert-tests.ts
@@ -2,61 +2,64 @@ import * as pouchdbUpsert from 'pouchdb-upsert';
 PouchDB.plugin(pouchdbUpsert);
 
 interface UpsertDocModel {
-   name: string;
-   readonly?: boolean;
+  name: string;
+  readonly?: boolean;
 }
 
 declare const docToUpsert: PouchDB.Core.Document<UpsertDocModel>;
 const db = new PouchDB<UpsertDocModel>();
 
 function testUpsert_WithPromise_AndReturnDoc() {
-  db.upsert(docToUpsert._id, (doc: PouchDB.Core.Document<UpsertDocModel>) => {
+  db.upsert(docToUpsert._id, (doc) => {
     // Make some updates....
-    return doc;
+    // `doc` may be empty if the document didn't already exist, so we have to
+    // cast it to the type containing the required fields.  If the document type
+    // had all optional fields, the cast would not be necessary.
+    return <UpsertDocModel> doc;
   }).then((res: PouchDB.UpsertResponse) => {
   });
 }
 
 function testUpsert_WithPromise_AndReturnFalsey() {
-  db.upsert<UpsertDocModel>(docToUpsert._id, (doc: PouchDB.Core.Document<UpsertDocModel>) => {
+  db.upsert(docToUpsert._id, (doc) => {
     if (doc.readonly)
       return false;
     // Make some updates....
-    return doc;
+    return <UpsertDocModel> doc;
   }).then((res: PouchDB.UpsertResponse) => {
   });
 }
 
 function testUpsert_WithPromise_AndReturnNewObject() {
   // callback return boolean
-  db.upsert<UpsertDocModel>(docToUpsert._id, (doc: PouchDB.Core.Document<UpsertDocModel>) => {
+  db.upsert(docToUpsert._id, (doc) => {
     return {name: 'test', readonly: true};
   }).then((res: PouchDB.UpsertResponse) => {
   });
 }
 
 function testUpsert_WithCallback_AndReturnDoc() {
-  db.upsert<UpsertDocModel>(docToUpsert._id, (doc: PouchDB.Core.Document<UpsertDocModel>) => {
+  db.upsert(docToUpsert._id, (doc) => {
     // Make some updates....
-    return doc;
-  }, (res: PouchDB.UpsertResponse) => {});
+    return <UpsertDocModel> doc;
+  }, (error: PouchDB.Core.Error, res: PouchDB.UpsertResponse) => {});
 }
 
 function testUpsert_WithCallback_AndReturnFalsey() {
   // callback return boolean
-  db.upsert<UpsertDocModel>(docToUpsert._id, (doc: PouchDB.Core.Document<UpsertDocModel>) => {
+  db.upsert(docToUpsert._id, (doc) => {
     if (doc.readonly)
       return false;
     // Make some updates....
-    return doc;
-  }, (res: PouchDB.UpsertResponse) => {});
+    return <UpsertDocModel> doc;
+  }, (error: PouchDB.Core.Error, res: PouchDB.UpsertResponse) => {});
 }
 
 function testUpsert_WithCallback_AndReturnNewObject() {
   // callback return boolean
-  db.upsert<UpsertDocModel>(docToUpsert._id, (doc: PouchDB.Core.Document<UpsertDocModel>) => {
+  db.upsert(docToUpsert._id, (doc) => {
     return {name: 'test', readonly: true};
-  }, (res: PouchDB.UpsertResponse) => {});
+  }, (error: PouchDB.Core.Error, res: PouchDB.UpsertResponse) => {});
 }
 
 function testPutIfNotExists_WithPromise() {
@@ -64,5 +67,5 @@ function testPutIfNotExists_WithPromise() {
 }
 
 function testPutIfNotExists_WithCallback() {
-  db.putIfNotExists(docToUpsert, (res: PouchDB.UpsertResponse) => {});
+  db.putIfNotExists(docToUpsert, (error: PouchDB.Core.Error, res: PouchDB.UpsertResponse) => {});
 }

--- a/types/pouchdb-upsert/tsconfig.json
+++ b/types/pouchdb-upsert/tsconfig.json
@@ -8,7 +8,7 @@
         "noImplicitAny": true,
         "noImplicitThis": true,
         "strictNullChecks": false,
-        "strictFunctionTypes": false,
+        "strictFunctionTypes": true,
         "baseUrl": "../",
         "typeRoots": [
             "../"


### PR DESCRIPTION
Addresses https://stackoverflow.com/q/53275861 .

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)  (Compiled the example from [here](https://stackoverflow.com/q/53275861) but did not run.  The runtime behavior does not appear to be in doubt.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: N/A, improvement to type declarations for the behavior already described by the documentation in the type declaration file.
- [X] Increase the version number in the header if appropriate: N/A.
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`: Already there.
