### PR TITLE
@reach/router | LocationProvider defaultProps fix

### DIFF
--- a/types/reach__router/index.d.ts
+++ b/types/reach__router/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for @reach/router 1.2
+// Type definitions for @reach/router 1.2.1
 // Project: https://github.com/reach/router
 // Definitions by: Kingdaro <https://github.com/kingdaro>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -123,7 +123,9 @@ export interface LocationContext {
     navigate: NavigateFn;
 }
 
-export class LocationProvider extends React.Component<LocationProviderProps> { }
+export class LocationProvider extends React.Component<LocationProviderProps> {
+    public static defaultProps: LocationProviderProps;
+}
 
 export interface ServerLocationProps {
     url: string;


### PR DESCRIPTION
FIX:
TS2339: Propery 'defaultProps' does not exist on type 'typeof LocationProvider'
