### PR TITLE
@reach/router | LocationProvider defaultProps fix

### DIFF
--- a/types/reach__router/index.d.ts
+++ b/types/reach__router/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for @reach/router 1.2
+// Type definitions for @reach/router 1.3
 // Project: https://github.com/reach/router
 // Definitions by: Kingdaro <https://github.com/kingdaro>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -123,7 +123,9 @@ export interface LocationContext {
     navigate: NavigateFn;
 }
 
-export class LocationProvider extends React.Component<LocationProviderProps> { }
+export class LocationProvider extends React.Component<LocationProviderProps> {
+    static defaultProps: LocationProviderProps;
+}
 
 export interface ServerLocationProps {
     url: string;


### PR DESCRIPTION
**FIX:**
TS2339: Propery 'defaultProps' does not exist on type 'typeof LocationProvider'
![TS2339](https://user-images.githubusercontent.com/16494616/48431215-d6774580-e779-11e8-9bc3-d0f81d853804.png)

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
N/A (I just fix issue TS2339).
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.