### PR TITLE
Knockout - add readonly types for observables, observable arrays, and computeds

### DIFF
--- a/types/knockout/index.d.ts
+++ b/types/knockout/index.d.ts
@@ -158,7 +158,12 @@ interface KnockoutComputedStatic {
     <T>(def: KnockoutComputedDefine<T>, context?: any): KnockoutComputed<T>;
 }
 
-interface KnockoutComputed<T> extends KnockoutObservable<T>, KnockoutComputedFunctions<T> {
+interface KnockoutReadonlyComputed<T> extends KnockoutReadonlyObservable<T> {
+    isActive(): boolean;
+    getDependenciesCount(): number;
+}
+
+interface KnockoutComputed<T> extends KnockoutReadonlyComputed<T>, KnockoutObservable<T>, KnockoutComputedFunctions<T> {
     fn: KnockoutComputedFunctions<any>;
 
     // It's possible for a to be undefined, since the equalityComparer is run on the initial
@@ -166,8 +171,6 @@ interface KnockoutComputed<T> extends KnockoutObservable<T>, KnockoutComputedFun
     equalityComparer(a: T | undefined, b: T): boolean;
 
     dispose(): void;
-    isActive(): boolean;
-    getDependenciesCount(): number;
     extend(requestedExtenders: { [key: string]: any; }): KnockoutComputed<T>;
 }
 

--- a/types/knockout/index.d.ts
+++ b/types/knockout/index.d.ts
@@ -191,13 +191,22 @@ interface KnockoutObservableStatic {
     <T = any>(): KnockoutObservable<T | undefined>
 }
 
-interface KnockoutObservable<T> extends KnockoutSubscribable<T>, KnockoutObservableFunctions<T> {
+/**
+ * While all observable are writable at runtime, this type is analogous to the native ReadonlyArray type:
+ * casting an observable to this type expresses the intention that this observable shouldn't be mutated.
+ */
+interface KnockoutReadonlyObservable<T> extends KnockoutSubscribable<T>, KnockoutObservableFunctions<T> {
     (): T;
-    (value: T): void;
 
     peek(): T;
     valueHasMutated?: { (): void; };
     valueWillMutate?: { (): void; };
+}
+
+interface KnockoutObservable<T> extends KnockoutReadonlyObservable<T> {
+    (value: T): void;
+
+    // Since .extend does arbitrary thing to an observable, it's not safe to do on a readonly observable
     extend(requestedExtenders: { [key: string]: any; }): KnockoutObservable<T>;
 }
 

--- a/types/knockout/index.d.ts
+++ b/types/knockout/index.d.ts
@@ -21,8 +21,8 @@ interface KnockoutObservableFunctions<T> {
     equalityComparer(a: T, b: T): boolean;
 }
 
-interface KnockoutObservableArrayFunctions<T> {
-    // General Array functions
+// The functions of observable arrays that don't mutate the array
+interface KnockoutReadonlyObservableArrayFunctions<T> {
     /**
       * Returns the index of the first occurrence of a value in an array.
       * @param searchElement The value to locate in the array.
@@ -35,6 +35,9 @@ interface KnockoutObservableArrayFunctions<T> {
       * @param end The end of the specified portion of the array.
       */
     slice(start: number, end?: number): T[];
+}
+// The functions of observable arrays that mutate the array
+interface KnockoutObservableArrayFunctions<T> extends KnockoutReadonlyObservableArrayFunctions<T> {
     /**
      * Removes and returns all the remaining elements starting from a given index.
      * @param start The zero-based location in the array from which to start removing elements.
@@ -174,6 +177,23 @@ interface KnockoutObservableArrayStatic {
     <T>(value?: T[] | null): KnockoutObservableArray<T>;
 }
 
+/**
+ * While all observable arrays are writable at runtime, this type is analogous to the native ReadonlyArray type:
+ * casting an observable array to this type expresses the intention that it shouldn't be mutated.
+ */
+interface KnockoutReadonlyObservableArray<T> extends KnockoutReadonlyObservable<ReadonlyArray<T>>, KnockoutReadonlyObservableArrayFunctions<T> {
+    // NOTE: Keep in sync with KnockoutObservableArray<T>, see note on KnockoutObservableArray<T>
+    subscribe(callback: (newValue: KnockoutArrayChange<T>[]) => void, target: any, event: "arrayChange"): KnockoutSubscription;
+    subscribe(callback: (newValue: T[]) => void, target: any, event: "beforeChange"): KnockoutSubscription;
+    subscribe(callback: (newValue: T[]) => void, target?: any, event?: "change"): KnockoutSubscription;
+    subscribe<TEvent>(callback: (newValue: TEvent) => void, target: any, event: string): KnockoutSubscription;
+}
+
+/*
+    NOTE: In theory this should extend both Observable<T[]> and ReadonlyObservableArray<T>,
+        but can't since they both provide conflicting typings of .subscribe.
+    So it extends Observable<T[]> and duplicates the subscribe definitions, which should be kept in sync
+*/
 interface KnockoutObservableArray<T> extends KnockoutObservable<T[]>, KnockoutObservableArrayFunctions<T> {
     subscribe(callback: (newValue: KnockoutArrayChange<T>[]) => void, target: any, event: "arrayChange"): KnockoutSubscription;
     subscribe(callback: (newValue: T[]) => void, target: any, event: "beforeChange"): KnockoutSubscription;

--- a/types/knockout/index.d.ts
+++ b/types/knockout/index.d.ts
@@ -7,6 +7,7 @@
 //                 Benjamin Eckardt <https://github.com/BenjaminEckardt>,
 //                 Mathias Lorenzen <https://github.com/ffMathy>,
 //                 Leonardo Lombardi <https://github.com/ltlombardi>
+//                 Retsam <https://github.com/Retsam>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 

--- a/types/knockout/test/readonly.ts
+++ b/types/knockout/test/readonly.ts
@@ -11,3 +11,22 @@ function testReadonlyObservable() {
     const writeAgain = read as KnockoutObservable<string>
     writeAgain("bar");
 };
+
+
+function testReadonlyObservableArray() {
+    // Normal observable array behavior
+    const write = ko.observableArray(["foo"]);
+    write(["bar"]);
+    write.push("foo");
+
+    // Readonly observable array
+    const read = write as KnockoutReadonlyObservableArray<string>;
+    read(); //$ExpectType ReadonlyArray<string>
+    read.slice(0, 1); //$ExpectType string[]
+    read(["foo"]); // $ExpectError
+    read.push; // $ExpectError
+
+    // Can cast back to a writeable
+    const writeAgain = read as KnockoutObservableArray<string>
+    writeAgain(["foo"]);
+}

--- a/types/knockout/test/readonly.ts
+++ b/types/knockout/test/readonly.ts
@@ -30,3 +30,15 @@ function testReadonlyObservableArray() {
     const writeAgain = read as KnockoutObservableArray<string>
     writeAgain(["foo"]);
 }
+
+function testReadonlyComputed() {
+    const write = ko.computed({
+        read: () => {},
+        write: () => {},
+    });
+
+    // Can cast a computed as readonly
+    const read: KnockoutReadonlyComputed<any> = write;
+    read();
+    read("foo"); // $ExpectError
+}

--- a/types/knockout/test/readonly.ts
+++ b/types/knockout/test/readonly.ts
@@ -1,0 +1,13 @@
+function testReadonlyObservable() {
+    const write = ko.observable("foo");
+    write("bar");
+    const read = write as KnockoutReadonlyObservable<string>;
+
+    read(); // $ExpectType string
+    read.subscribe(() => {});  // Can still subscribe
+    // But can't write to it
+    read("foo"); // $ExpectError
+
+    const writeAgain = read as KnockoutObservable<string>
+    writeAgain("bar");
+};

--- a/types/knockout/tsconfig.json
+++ b/types/knockout/tsconfig.json
@@ -20,6 +20,7 @@
     "files": [
         "index.d.ts",
         "test/templatingBehaviors.ts",
-        "test/index.ts"
+        "test/index.ts",
+        "test/readonly.ts"
     ]
 }


### PR DESCRIPTION
- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://knockoutjs.com/documentation/computedObservables.html
- [X] Increase the version number in the header if appropriate.
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

---

Knockout's current typings don't have any consideration for the idea of readonly.  In particular, `computed`s can be readonly:

```ts
const observable = ko.observable(5);
// A read only computed
const readOnlyComputed = ko.computed(() => observable()); 

// A read-write computed
const writableComputed = ko.computed({
     read: () => observable(),
     write: val => observable(val),
});
```

Unfortunately the types don't distinguish between these and so `readOnlyComputed(10)` is valid, type-checked code, but fails with a runtime error.

This PR, unfortunately, does not fix that problem: I've written the changes that would fix it, but it created a prohibitive number of breaking changes in my codebase, and didn't want to break everyone's typings.

But it does at least introduce typings that can represent a readonly computed, so it is now possible to write:

```ts
const readOnlyComputed: KnockoutReadonlyComputed<number> = ko.computed(() => observable()); 
readOnlyComputed(10); // Type error!
```

---

Similarly, it introduces `KnockoutReadonlyObservable` and `KnockoutReadonlyObservableArray`.  Unlike `computed`, there isn't really such a concept as a read-only observable, in runtime; but just as it's useful to cast an actually-mutable-at-runtime array to Typescript's `ReadonlyArray` type, I find it useful to have readonly variants of `observable` and `observableArray` as well.  

For example, a function signature written as `function doSomething(observable: KnockoutReadonlyObservable<number>) {` conveys the intention that `doSomething` will not mutate the observable, only read from it or subscribe to it.  