### PR TITLE
[element-resize-detector] Updated type definition

### DIFF
--- a/types/element-resize-detector/element-resize-detector-tests.ts
+++ b/types/element-resize-detector/element-resize-detector-tests.ts
@@ -1,19 +1,19 @@
-import * as elementResizeDetectorMaker from 'element-resize-detector';
+import elementResizeDetectorMaker from 'element-resize-detector';
 
 const erd = elementResizeDetectorMaker({
     strategy: "scroll"
-  });
+});
 
 const testElement: HTMLElement = null;
 
-  erd.listenTo(testElement, (element) => {
+erd.listenTo(testElement, (element) => {
     const width = element.offsetWidth;
     const height = element.offsetHeight;
     console.log(`Size: " + ${width} + "x" + ${height}`);
-  });
+});
 
-  erd.removeListener(testElement, (testElement) => {});
+erd.removeListener(testElement, (testElement) => {});
 
-  erd.removeAllListeners(testElement);
+erd.removeAllListeners(testElement);
 
-  erd.uninstall(testElement);
+erd.uninstall(testElement);

--- a/types/element-resize-detector/element-resize-detector-tests.ts
+++ b/types/element-resize-detector/element-resize-detector-tests.ts
@@ -1,7 +1,9 @@
-import elementResizeDetectorMaker from 'element-resize-detector';
+import * as elementResizeDetectorMaker from 'element-resize-detector';
 
 const erd = elementResizeDetectorMaker({
-    strategy: "scroll"
+    strategy: "scroll",
+    debug: true,
+    callOnAdd: false
 });
 
 const testElement: HTMLElement | null = null;

--- a/types/element-resize-detector/element-resize-detector-tests.ts
+++ b/types/element-resize-detector/element-resize-detector-tests.ts
@@ -4,16 +4,16 @@ const erd = elementResizeDetectorMaker({
     strategy: "scroll"
 });
 
-const testElement: HTMLElement = null;
+const testElement: HTMLElement | null = null;
 
-erd.listenTo(testElement, (element) => {
+erd.listenTo(testElement!, (element) => {
     const width = element.offsetWidth;
     const height = element.offsetHeight;
     console.log(`Size: " + ${width} + "x" + ${height}`);
 });
 
-erd.removeListener(testElement, (testElement) => {});
+erd.removeListener(testElement!, (testElement) => {});
 
-erd.removeAllListeners(testElement);
+erd.removeAllListeners(testElement!);
 
-erd.uninstall(testElement);
+erd.uninstall(testElement!);

--- a/types/element-resize-detector/index.d.ts
+++ b/types/element-resize-detector/index.d.ts
@@ -4,32 +4,34 @@
 //                 Frank Li <https://github.com/franklixuefei>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-export interface IdHandlerProps {
-    get(element: HTMLElement, readonly: boolean): string;
-    set(element: HTMLElement): string;
+declare function elementResizeDetectorMaker(options?: elementResizeDetectorMaker.ErdmOptions): elementResizeDetectorMaker.Erd;
+
+declare namespace elementResizeDetectorMaker {
+    interface ErdmOptions {
+    	strategy?: 'scroll' | 'object';
+    	reporter?: ReporterProps;
+	    callOnAdd?: boolean;
+	    idHandler?: IdHandlerProps;
+	    debug?: boolean;
+    }
+
+    interface IdHandlerProps {
+	    get(element: HTMLElement, readonly: boolean): string;
+	    set(element: HTMLElement): string;
+	}
+
+	interface ReporterProps {
+		log(): void;
+		warn(): void;
+		error(): void;
+	}
+
+    interface Erd {
+	    listenTo(element: HTMLElement, callback: (elem: HTMLElement) => void): void;
+	    removeListener(element: HTMLElement, callback: (elem: HTMLElement) => void): void;
+	    removeAllListeners(element: HTMLElement): void;
+	    uninstall(element: HTMLElement): void;
+    }
 }
 
-export interface ReporterProps {
-    log(): void;
-    warn(): void;
-    error(): void;
-}
-
-export interface ElementResizeDetectorProps {
-    strategy?: 'scroll' | 'object';
-    reporter?: ReporterProps;
-    callOnAdd?: boolean;
-    idHandler?: IdHandlerProps;
-    debug?: boolean;
-}
-
-export interface ElementResizeDetectorActions {
-    listenTo(element: HTMLElement, callback: (elem: HTMLElement) => void): void;
-    removeListener(element: HTMLElement, callback: (elem: HTMLElement) => void): void;
-    removeAllListeners(element: HTMLElement): void;
-    uninstall(element: HTMLElement): void;
-}
-
-export default function elementResizeDetectorMaker(
-    options?: ElementResizeDetectorProps
-): ElementResizeDetectorActions;
+export = elementResizeDetectorMaker;

--- a/types/element-resize-detector/index.d.ts
+++ b/types/element-resize-detector/index.d.ts
@@ -3,18 +3,17 @@
 // Definitions by: Saransh Kataria <https://github.com/saranshkataria>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare function elementResizeDetectorMaker(options?: elementResizeDetectorMaker.ErdmOptions): elementResizeDetectorMaker.Erd;
-
-declare namespace elementResizeDetectorMaker {
-    interface ErdmOptions {
+export interface ElementResizeDetectorProps {
     strategy?: 'scroll' | 'object';
-    }
+}
 
-    interface Erd {
+export interface ElementResizeDetectorActions {
     listenTo(element: HTMLElement, callback: (elem: HTMLElement) => void): void;
     removeListener(element: HTMLElement, callback: (elem: HTMLElement) => void): void;
     removeAllListeners(element: HTMLElement): void;
     uninstall(element: HTMLElement): void;
-    }
 }
-export = elementResizeDetectorMaker;
+
+export default function elementResizeDetectorMaker(
+    options?: ElementResizeDetectorProps
+): ElementResizeDetectorActions;

--- a/types/element-resize-detector/index.d.ts
+++ b/types/element-resize-detector/index.d.ts
@@ -8,29 +8,29 @@ declare function elementResizeDetectorMaker(options?: elementResizeDetectorMaker
 
 declare namespace elementResizeDetectorMaker {
     interface ErdmOptions {
-    	strategy?: 'scroll' | 'object';
-    	reporter?: ReporterProps;
-	    callOnAdd?: boolean;
-	    idHandler?: IdHandlerProps;
-	    debug?: boolean;
+        strategy?: 'scroll' | 'object';
+        reporter?: ReporterProps;
+        callOnAdd?: boolean;
+        idHandler?: IdHandlerProps;
+        debug?: boolean;
     }
 
     interface IdHandlerProps {
-	    get(element: HTMLElement, readonly: boolean): string;
-	    set(element: HTMLElement): string;
-	}
+        get(element: HTMLElement, readonly: boolean): string;
+        set(element: HTMLElement): string;
+    }
 
-	interface ReporterProps {
-		log(): void;
-		warn(): void;
-		error(): void;
-	}
+    interface ReporterProps {
+        log(): void;
+        warn(): void;
+        error(): void;
+    }
 
     interface Erd {
-	    listenTo(element: HTMLElement, callback: (elem: HTMLElement) => void): void;
-	    removeListener(element: HTMLElement, callback: (elem: HTMLElement) => void): void;
-	    removeAllListeners(element: HTMLElement): void;
-	    uninstall(element: HTMLElement): void;
+        listenTo(element: HTMLElement, callback: (elem: HTMLElement) => void): void;
+        removeListener(element: HTMLElement, callback: (elem: HTMLElement) => void): void;
+        removeAllListeners(element: HTMLElement): void;
+        uninstall(element: HTMLElement): void;
     }
 }
 

--- a/types/element-resize-detector/index.d.ts
+++ b/types/element-resize-detector/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for element-resize-detector 1.2
+// Type definitions for element-resize-detector 1.1.14
 // Project: https://github.com/wnr/element-resize-detector
 // Definitions by: Saransh Kataria <https://github.com/saranshkataria>
 //                 Frank Li <https://github.com/franklixuefei>

--- a/types/element-resize-detector/index.d.ts
+++ b/types/element-resize-detector/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for element-resize-detector 1.2
+// Type definitions for element-resize-detector 1.1
 // Project: https://github.com/wnr/element-resize-detector
 // Definitions by: Saransh Kataria <https://github.com/saranshkataria>
 //                 Frank Li <https://github.com/franklixuefei>

--- a/types/element-resize-detector/index.d.ts
+++ b/types/element-resize-detector/index.d.ts
@@ -1,6 +1,7 @@
-// Type definitions for element-resize-detector 1.1
+// Type definitions for element-resize-detector 1.2
 // Project: https://github.com/wnr/element-resize-detector
 // Definitions by: Saransh Kataria <https://github.com/saranshkataria>
+//                 Frank Li <https://github.com/franklixuefei>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 export interface ElementResizeDetectorProps {

--- a/types/element-resize-detector/index.d.ts
+++ b/types/element-resize-detector/index.d.ts
@@ -4,8 +4,23 @@
 //                 Frank Li <https://github.com/franklixuefei>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
+export interface IdHandlerProps {
+    get(element: HTMLElement, readonly: boolean): string;
+    set(element: HTMLElement): string;
+}
+
+export interface ReporterProps {
+    log(): void;
+    warn(): void;
+    error(): void;
+}
+
 export interface ElementResizeDetectorProps {
     strategy?: 'scroll' | 'object';
+    reporter?: ReporterProps;
+    callOnAdd?: boolean;
+    idHandler?: IdHandlerProps;
+    debug?: boolean;
 }
 
 export interface ElementResizeDetectorActions {

--- a/types/element-resize-detector/index.d.ts
+++ b/types/element-resize-detector/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for element-resize-detector 1.1.14
+// Type definitions for element-resize-detector 1.2
 // Project: https://github.com/wnr/element-resize-detector
 // Definitions by: Saransh Kataria <https://github.com/saranshkataria>
 //                 Frank Li <https://github.com/franklixuefei>

--- a/types/element-resize-detector/tsconfig.json
+++ b/types/element-resize-detector/tsconfig.json
@@ -7,7 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
-        "strictNullChecks": false,
+        "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",
         "typeRoots": [


### PR DESCRIPTION
Removed namespace of the type definition for `element-resize-detector` and updated the test.
From now on, people do not have to do 

```jsx
import * as elementResizeDetectorMaker from 'element-resize-detector'
```

in typescript. Just simply use

```jsx
import elementResizeDetectorMaker from 'element-resize-detector'
```

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] Increase the version number in the header if appropriate.
