### PR TITLE
swagger-schema-official: fixing types for exclusiveMinimum and exclusiveMaximum in BaseSchema

### DIFF
--- a/types/swagger-schema-official/index.d.ts
+++ b/types/swagger-schema-official/index.d.ts
@@ -127,9 +127,9 @@ export interface BaseSchema {
   default?: string|boolean|number|{};
   multipleOf?: number;
   maximum?: number;
-  exclusiveMaximum?: number;
+  exclusiveMaximum?: boolean;
   minimum?: number;
-  exclusiveMinimum?: number;
+  exclusiveMinimum?: boolean;
   maxLength?: number;
   minLength?: number;
   pattern?: string;

--- a/types/swagger-schema-official/swagger-schema-official-tests.ts
+++ b/types/swagger-schema-official/swagger-schema-official-tests.ts
@@ -1243,7 +1243,11 @@ const uber: swagger.Spec = {
         },
         "surge_multiplier": {
           "type": "number",
-          "description": "Expected surge multiplier. Surge is active if surge_multiplier is greater than 1. Price estimate already factors in the surge multiplier."
+          "description": "Expected surge multiplier. Surge is active if surge_multiplier is greater than 1. Price estimate already factors in the surge multiplier.",
+          "minimum": 0,
+          "exclusiveMinimum": true,
+          "maximum": 10,
+          "exclusiveMaximum": true
         }
       }
     },


### PR DESCRIPTION
Happy to chat about how to release this one, I can understand this might break people if they were relying on the wrong types for `exclusiveMinimum` and `exclusiveMaximum`.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
-- https://swagger.io/specification/v2/#parameterObject
-- https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.1.2
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.