### PR TITLE
[@ember/routing] Fix redirect hook

### DIFF
--- a/types/ember/v2/index.d.ts
+++ b/types/ember/v2/index.d.ts
@@ -1895,20 +1895,26 @@ declare module 'ember' {
             paramsFor(name: string): {};
 
             /**
-             * Refresh the model on this route and any child routes, firing the
-             * `beforeModel`, `model`, and `afterModel` hooks in a similar fashion
-             * to how routes are entered when transitioning in from other route.
-             * The current route params (e.g. `article_id`) will be passed in
-             * to the respective model hooks, and if a different model is returned,
-             * `setupController` and associated route hooks will re-fire as well.
-             * An example usage of this method is re-querying the server for the
-             * latest information using the same parameters as when the route
-             * was first entered.
-             * Note that this will cause `model` hooks to fire even on routes
-             * that were provided a model object when the route was initially
-             * entered.
+             * A hook you can implement to optionally redirect to another route.
+             *
+             * If you call `this.transitionTo` from inside of this hook, this route
+             * will not be entered in favor of the other hook.
+             *
+             * `redirect` and `afterModel` behave very similarly and are
+             * called almost at the same time, but they have an important
+             * distinction in the case that, from one of these hooks, a
+             * redirect into a child route of this route occurs: redirects
+             * from `afterModel` essentially invalidate the current attempt
+             * to enter this route, and will result in this route's `beforeModel`,
+             * `model`, and `afterModel` hooks being fired again within
+             * the new, redirecting transition. Redirects that occur within
+             * the `redirect` hook, on the other hand, will _not_ cause
+             * these hooks to be fired again the second time around; in
+             * other words, by the time the `redirect` hook has been called,
+             * both the resolved model and attempted entry into this route
+             * are considered to be fully validated.
              */
-            redirect(): Transition;
+            redirect(model: {}, transition: Transition): void;
 
             /**
              * Refresh the model on this route and any child routes, firing the

--- a/types/ember/v2/test/route.ts
+++ b/types/ember/v2/test/route.ts
@@ -86,6 +86,14 @@ Route.extend({
     },
 });
 
+class RedirectRoute extends Route {
+    redirect(model: {}, a: Ember.Transition) {
+        if (!model) {
+            this.transitionTo('there');
+        }
+    }
+}
+
 class RouteUsingClass extends Route.extend({
     randomProperty: 'the .extend + extends bit type-checks properly',
 }) {

--- a/types/ember__routing/route.d.ts
+++ b/types/ember__routing/route.d.ts
@@ -79,20 +79,26 @@ export default class Route extends EmberObject.extend(ActionHandler, Evented) {
     paramsFor(name: string): {};
 
     /**
-     * Refresh the model on this route and any child routes, firing the
-     * `beforeModel`, `model`, and `afterModel` hooks in a similar fashion
-     * to how routes are entered when transitioning in from other route.
-     * The current route params (e.g. `article_id`) will be passed in
-     * to the respective model hooks, and if a different model is returned,
-     * `setupController` and associated route hooks will re-fire as well.
-     * An example usage of this method is re-querying the server for the
-     * latest information using the same parameters as when the route
-     * was first entered.
-     * Note that this will cause `model` hooks to fire even on routes
-     * that were provided a model object when the route was initially
-     * entered.
+     * A hook you can implement to optionally redirect to another route.
+     *
+     * If you call `this.transitionTo` from inside of this hook, this route
+     * will not be entered in favor of the other hook.
+     *
+     * `redirect` and `afterModel` behave very similarly and are
+     * called almost at the same time, but they have an important
+     * distinction in the case that, from one of these hooks, a
+     * redirect into a child route of this route occurs: redirects
+     * from `afterModel` essentially invalidate the current attempt
+     * to enter this route, and will result in this route's `beforeModel`,
+     * `model`, and `afterModel` hooks being fired again within
+     * the new, redirecting transition. Redirects that occur within
+     * the `redirect` hook, on the other hand, will _not_ cause
+     * these hooks to be fired again the second time around; in
+     * other words, by the time the `redirect` hook has been called,
+     * both the resolved model and attempted entry into this route
+     * are considered to be fully validated.
      */
-    redirect(): Transition;
+    redirect(model: {}, transition: Transition): void;
 
     /**
      * Refresh the model on this route and any child routes, firing the

--- a/types/ember__routing/test/route.ts
+++ b/types/ember__routing/test/route.ts
@@ -80,6 +80,22 @@ Route.extend({
     },
 });
 
+class RedirectRoute extends Route {
+    redirect(model: {}, a: Transition) {
+        if (!model) {
+            this.transitionTo('there');
+        }
+    }
+}
+
+class InvalidRedirect extends Route {
+    redirect(model: {}, a: Transition, anOddArg: any) { // $ExpectError
+        if (!model) {
+            this.transitionTo('there');
+        }
+    }
+}
+
 class ApplicationController extends Controller {}
 declare module '@ember/controller' {
     interface Registry {


### PR DESCRIPTION
Prior to this commit `redirect()` hook was mistakenly typed and documented the same way as `refresh()`.

It's fixed for v2 and v3 here.

While v3 is provided with a positive and a negative test cases, v2 is only provided with a positive one. This is because v2 uses typescript of version 2.4 which is not able to catch the failing test case.

One more point to note: I've used a `class` syntax in tests cause seems like an old style `Route.extend` don't handle method signatures well. In other words I haven't figured out how to write a failing test with an old style `extend`.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <https://www.emberjs.com/api/ember/3.5/classes/Route/methods/redirect?anchor=redirect>

