### PR TITLE
Fix typo in chooseEntry(…) for multiple files

### DIFF
--- a/types/chrome-apps/index.d.ts
+++ b/types/chrome-apps/index.d.ts
@@ -3369,7 +3369,7 @@ declare namespace chrome {
         function chooseEntry(options: ChooseEntryOptionsBase, callback: FileEntryCallback<ChooseEntryOptionsBase>): void;
         function chooseEntry(options: ChooseFileEntryOptions, callback: FileEntryCallback<ChooseFileEntryOptions>): void;
         function chooseEntry(options: ChooseSaveFileEntryOptions, callback: FileEntryCallback<ChooseSaveFileEntryOptions>): void;
-        function chooseEntry(options: ChooseMultipleFilesEntryOptions, callback: FileEntryCallback<ChooseFileEntryOptions>): void;
+        function chooseEntry(options: ChooseMultipleFilesEntryOptions, callback: FileEntryCallback<ChooseMultipleFilesEntryOptions>): void;
         function chooseEntry(options: ChooseDirectoryEntryOptions, callback: FileEntryCallback<ChooseDirectoryEntryOptions>): void;
         /** Returns the file entry with the given id if it can be restored. This call will fail with a runtime error otherwise. */
         function restoreEntry(id: string, callback: (entry: FileEntry) => void): void;


### PR DESCRIPTION
This simply aligns the type of the callback with the options when calling chooseEntry for selecting multiple files.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.chrome.com/apps/fileSystem#method-chooseEntry (search for 'acceptsMultiple')
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.