### PR TITLE
Add 'null' to the type of React.Ref, fixes React.forwardRef

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -59,7 +59,7 @@ declare namespace React {
         readonly current: T | null;
     }
 
-    type Ref<T> = { bivarianceHack(instance: T | null): void }["bivarianceHack"] | RefObject<T>;
+    type Ref<T> = { bivarianceHack(instance: T | null): void }["bivarianceHack"] | RefObject<T> | null;
     type LegacyRef<T> = string | Ref<T>;
 
     type ComponentState = any;

--- a/types/react/test/tsx.tsx
+++ b/types/react/test/tsx.tsx
@@ -320,7 +320,7 @@ type ImgProps = React.ComponentProps<'img'>;
 // $ExpectType "async" | "auto" | "sync" | undefined
 type ImgPropsDecoding = ImgProps['decoding'];
 type ImgPropsWithRef = React.ComponentPropsWithRef<'img'>;
-// $ExpectType ((instance: HTMLImageElement | null) => void) | RefObject<HTMLImageElement> | undefined
+// $ExpectType ((instance: HTMLImageElement | null) => void) | RefObject<HTMLImageElement> | null | undefined
 type ImgPropsWithRefRef = ImgPropsWithRef['ref'];
 type ImgPropsWithoutRef = React.ComponentPropsWithoutRef<'img'>;
 // $ExpectType false


### PR DESCRIPTION
I don't know why tests didn't fail on yesterday's PR, there _are_ tests for this. This most obviously broke `React.forwardRef`, but the point is, `ref` in React elements default to `null` when not specified.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
