### PR TITLE
@types/code: Fix `equal` when comparing arrays

### DIFF
--- a/types/code/code-tests.ts
+++ b/types/code/code-tests.ts
@@ -103,6 +103,7 @@ expect("abcd").to.have.length(4);
 
 expect(5).to.equal(5);
 expect({ a: 1 }).to.equal({ a: 1 });
+expect([1, 2, 3]).to.equal([1, 2, 3]);
 
 expect(Object.create(null)).to.equal({}, { prototype: false });
 

--- a/types/code/index.d.ts
+++ b/types/code/index.d.ts
@@ -125,9 +125,9 @@ export interface Values<T> {
     /** Asserts that the reference value has a length property matching the provided size or an object with the specified number of keys. */
     length(size: number): AssertionChain<T>;
     /** Asserts that the reference value equals the provided value. */
-    equal(value: T, options?: any): AssertionChain<T>;
+    equal(value: T | T[], options?: any): AssertionChain<T>;
     /** Asserts that the reference value equals the provided value. */
-    equals(value: T, options?: any): AssertionChain<T>;
+    equals(value: T | T[], options?: any): AssertionChain<T>;
     /** Asserts that the reference value is greater than (>) the provided value. */
     above(value: T): AssertionChain<T>;
     /** Asserts that the reference value is greater than (>) the provided value. */


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/hapijs/code/blob/HEAD/API.md#equalvalue-options
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.