### PR TITLE
@types/paper: Added Item.locked to the definition

### DIFF
--- a/types/paper/index.d.ts
+++ b/types/paper/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Paper.js v0.11.6
+// Type definitions for Paper.js v0.11.8
 // Project: http://paperjs.org/
 // Definitions by:  Clark Stevenson <https://github.com/clark-stevenson>,
 //                  Jon Lucas <https://github.com/Xakaloz>,

--- a/types/paper/index.d.ts
+++ b/types/paper/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Paper.js v0.11.5
+// Type definitions for Paper.js v0.11.6
 // Project: http://paperjs.org/
 // Definitions by:  Clark Stevenson <https://github.com/clark-stevenson>,
 //                  Jon Lucas <https://github.com/Xakaloz>,
@@ -1332,7 +1332,12 @@ declare module paper {
          * The path style of the item.
          */
         style: Style;
-
+        
+        /**
+         * Specifies whether the item is locked. When set to true, item interactions with the mouse are disabled.
+         */
+        locked: boolean;
+        
         /**
          * Specifies whether the item is visible. When set to false, the item won't be drawn.
          */


### PR DESCRIPTION
If changing an existing definition:
- [ x ] Provide a URL to documentation or source code which provides context for the suggested changes: http://paperjs.org/reference/layer/#locked
- [ x ] Increase the version number in the header if appropriate.