### PR TITLE
Add type definition for the <LinkTo> component to @types/storybook__addons-links

### DIFF
--- a/types/storybook__addon-links/react.d.ts
+++ b/types/storybook__addon-links/react.d.ts
@@ -1,0 +1,6 @@
+import * as React from 'react';
+
+export default class LinkTo extends React.PureComponent<
+  React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement> &
+  { story: string, kind?: string }
+> {}

--- a/types/storybook__addon-links/storybook__addon-links-tests.tsx
+++ b/types/storybook__addon-links/storybook__addon-links-tests.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { storiesOf } from '@storybook/react';
 import { hrefTo, linkTo } from '@storybook/addon-links';
+import LinkTo from '@storybook/addon-links/react';
 
 storiesOf('Button', module)
   .add('First', () => (
@@ -11,6 +12,9 @@ storiesOf('Button', module)
   ))
   .add('With function', () => (
     <button onClick={linkTo((arg1, arg2) => 'Button', () => 'First')}>Go to "First"</button>
+  ))
+  .add('With <LinkTo> component', () => (
+    <LinkTo story="First" kind="Button"><button>Go to "First"</button></LinkTo>
   ));
 
 hrefTo('Button', 'First').then(link => link);

--- a/types/storybook__addon-links/tsconfig.json
+++ b/types/storybook__addon-links/tsconfig.json
@@ -17,6 +17,9 @@
             "@storybook/addon-links": [
                 "storybook__addon-links"
             ],
+            "@storybook/addon-links/react": [
+                "storybook__addon-links/react"
+            ],
             "@storybook/react": [
                 "storybook__react"
             ]
@@ -27,6 +30,7 @@
     },
     "files": [
         "index.d.ts",
+        "react.d.ts",
         "storybook__addon-links-tests.tsx"
     ]
 }


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.npmjs.com/package/@storybook/addon-links#linkto-component-react-only
- [ ] ~~Increase the version number in the header if appropriate.~~ See below.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

Notes: I'm not sure if the version number should be increased, since the source project does not include a changelog and I don't know when this was introduced (the commit is from a year ago).