### PR TITLE
Add definition for shpjs

### DIFF
--- a/types/shpjs/index.d.ts
+++ b/types/shpjs/index.d.ts
@@ -1,0 +1,29 @@
+// Type definitions for shpjs 3.4
+// Project: https://github.com/calvinmetcalf/shapefile-js#readme
+// Definitions by: Hsiao-Ting Yu <https://github.com/littlebtc>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
+
+/// <reference types="node" />
+/// <reference types="geojson" />
+
+declare namespace shpjs {
+    // All toBuffer() compatible buffers.
+    type ShpJSBuffer = Buffer | ArrayBuffer | { buffer: ArrayBuffer };
+
+    interface FeatureCollectionWithFilename extends GeoJSON.FeatureCollection {
+        fileName: string;
+    }
+
+    interface ShpJS {
+        (base: string | ShpJSBuffer, whiteList?: ReadonlyArray<string>): Promise<FeatureCollectionWithFilename | FeatureCollectionWithFilename[]>;
+        parseZip(buffer: ShpJSBuffer, whiteList?: ReadonlyArray<string>): Promise<FeatureCollectionWithFilename | FeatureCollectionWithFilename[]>;
+        getShapeFile(base: string | ShpJSBuffer, whiteList?: ReadonlyArray<string>): Promise<FeatureCollectionWithFilename | FeatureCollectionWithFilename[]>;
+        combine(arr: [ReadonlyArray<GeoJSON.Geometry>, ReadonlyArray<GeoJSON.GeoJsonProperties>]): GeoJSON.FeatureCollection;
+        parseShp(shp: ShpJSBuffer, prj: string | Buffer): GeoJSON.Geometry[];
+        parseDbf(dbf: ShpJSBuffer, cpg: ShpJSBuffer): GeoJSON.GeoJsonProperties[];
+    }
+}
+
+declare var shpjs: shpjs.ShpJS;
+export = shpjs;

--- a/types/shpjs/index.d.ts
+++ b/types/shpjs/index.d.ts
@@ -12,7 +12,7 @@ declare namespace shpjs {
     type ShpJSBuffer = Buffer | ArrayBuffer | { buffer: ArrayBuffer };
 
     interface FeatureCollectionWithFilename extends GeoJSON.FeatureCollection {
-        fileName: string;
+        fileName?: string;
     }
 
     interface ShpJS {

--- a/types/shpjs/shpjs-tests.ts
+++ b/types/shpjs/shpjs-tests.ts
@@ -1,0 +1,41 @@
+import shp = require('shpjs');
+
+shp('https://this.is.a.url', ['white', 'list']).then((geojson) => {});
+shp(new Buffer('')).then((geojson) => {});
+shp(new ArrayBuffer(50)).then((geojson) => {});
+shp(new Int32Array(50)).then((geojson) => {});
+
+shp.parseZip(new Buffer('')).then((geojson) => {});
+shp.parseZip(new Buffer(''), ['white', 'list']).then((geojson) => {});
+shp.parseZip(new ArrayBuffer(50)).then((geojson) => {});
+shp.parseZip(new Int32Array(50)).then((geojson) => {});
+
+shp.getShapeFile('xxx.zip').then((geojson) => {});
+shp.getShapeFile('xxx.zip', ['white', 'list']).then((geojson) => {});
+shp.getShapeFile(new Buffer('')).then((geojson) => {});
+shp.getShapeFile(new ArrayBuffer(50)).then((geojson) => {});
+shp.getShapeFile(new Int32Array(50)).then((geojson) => {});
+
+const combinedGeojson = shp.combine([
+    [{
+        type: 'Point',
+        coordinates: []
+    }],
+    [{
+        test: 'test'
+    }]
+]);
+
+let parsedShp: GeoJSON.Geometry[];
+let parsedDbf: GeoJSON.GeoJsonProperties[];
+
+parsedShp = shp.parseShp(new Buffer(''), 'proj');
+parsedShp = shp.parseShp(new Buffer(''), new Buffer('proj'));
+parsedShp = shp.parseShp(new ArrayBuffer(50), 'proj');
+parsedShp = shp.parseShp(new Int32Array(50), 'proj');
+
+parsedDbf = shp.parseDbf(new Buffer(''), new Buffer(''));
+parsedDbf = shp.parseDbf(new ArrayBuffer(50), new Buffer(''));
+parsedDbf = shp.parseDbf(new Int32Array(50), new Buffer(''));
+
+shp.combine([shp.parseShp(new Buffer(''), 'proj'), shp.parseDbf(new Buffer(''), new Buffer(''))]);

--- a/types/shpjs/tsconfig.json
+++ b/types/shpjs/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "shpjs-tests.ts"
+    ]
+}

--- a/types/shpjs/tslint.json
+++ b/types/shpjs/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
I had done my best to understand what is under the package.

Example of using this with this definition:

```typescript
import * as shp from 'shpjs';
shp('https://this.is.a.url', ['white', 'list']).then((geojson) => {
  console.log(geojson as shp.FeatureCollectionWithFilename); });
```

A casting is needed since it could return a list of GeoJSON or just a GeoJSON depending on how many shpfiles in the zip (see `parseZip` in code).

---------------

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.