### PR TITLE
CodeMirror documentation differs from types for addLineWidget

### DIFF
--- a/types/codemirror/index.d.ts
+++ b/types/codemirror/index.d.ts
@@ -670,6 +670,11 @@ declare namespace CodeMirror {
         /** Returns an array containing all marked ranges in the document. */
         getAllMarks(): CodeMirror.TextMarker[];
 
+        /** Adds a line widget, an element shown below a line, spanning the whole of the editor's width, and moving the lines below it downwards.
+        line should be either an integer or a line handle, and node should be a DOM node, which will be displayed below the given line.
+        options, when given, should be an object that configures the behavior of the widget.
+        Note that the widget node will become a descendant of nodes with CodeMirror-specific CSS classes, and those classes might in some cases affect it. */
+        addLineWidget(line: any, node: HTMLElement, options?: CodeMirror.LineWidgetOptions): CodeMirror.LineWidget;
 
         /** Gets the mode object for the editor. Note that this is distinct from getOption("mode"), which gives you the mode specification,
         rather than the resolved, instantiated mode object. */

--- a/types/codemirror/test/index.ts
+++ b/types/codemirror/test/index.ts
@@ -91,3 +91,12 @@ CodeMirror.registerHelper("lint", "javascript", {});
 
 myCodeMirror.isReadOnly();
 myCodeMirror.execCommand('selectAll');
+
+let htmlElement1 = document.createElement('div');
+let htmlElement2 = document.createElement('div');
+let widget1 = myCodeMirror.addLineWidget(1, htmlElement1, {});
+let widget2 = doc.addLineWidget(1, htmlElement2, {});
+widget1.clear();
+widget2.clear();
+htmlElement1.remove();
+htmlElement2.remove();


### PR DESCRIPTION
The `addLineWidget` function can be called from two places, both `CodeMirror.addLineWidget` and `CodeMirror.Editor.addLineWidget`, but the existing type definitions are for the undocumented one of the two.

The [documentation](https://codemirror.net/doc/manual.html#addLineWidget) for `addLineWidget` only mentions that it works on a document, 
`doc.addLineWidget(line: integer|LineHandle, node: Element, ?options: object) → LineWidget`
so I've taken the existing documentation and copied it to the CodeMirror.Document interface.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://codemirror.net/doc/manual.html#addLineWidget
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

