### PR TITLE
Add type definitions for css-tree 1.0

### DIFF
--- a/types/css-tree/css-tree-tests.ts
+++ b/types/css-tree/css-tree-tests.ts
@@ -1,0 +1,612 @@
+import * as csstree from "css-tree";
+
+const ast = csstree.parse('.a { color: red; }');
+ast; // $ExpectType CssNode
+
+csstree.parse('.a { color: red; }', {}); // $ExpectType CssNode
+csstree.parse('.a { color: red; }', {context: 'selector', positions: true}); // $ExpectType CssNode
+
+csstree.walk(ast, (node, item, list) => {
+    node; // $ExpectType CssNode
+    item; // $ExpectType ListItem<CssNode>
+    list; // $ExpectType List<CssNode>
+});
+
+csstree.walk(ast, {});
+
+csstree.walk(ast, {
+    enter(node, item, list) {
+        this.stylesheet; // $ExpectType StyleSheet
+        node; // $ExpectType CssNode
+        item; // $ExpectType ListItem<CssNode>
+        list; // $ExpectType List<CssNode>
+    },
+    leave(node, item, list) {
+        this.stylesheet; // $ExpectType StyleSheet
+        node; // $ExpectType CssNode
+        item; // $ExpectType ListItem<CssNode>
+        list; // $ExpectType List<CssNode>
+    },
+    visit: 'ClassSelector',
+    reverse: false,
+});
+
+csstree.generate(ast); // $ExpectType string
+
+csstree.generate(ast, {}); // $ExpectType string
+
+csstree.generate(ast, {
+    sourceMap: true,
+    decorator: handlers => ({
+        children(node, delimiter) {
+            node; // $ExpectType CssNode
+            delimiter; // $ExpectType ((node: CssNode) => void) | undefined
+            handlers.children.call(handlers, node, delimiter);
+        },
+        node(node) {
+            node; // $ExpectType CssNode
+            handlers.node.call(node);
+        },
+        chunk(chunk) {
+            chunk; // $ExpectType string
+            handlers.chunk.call(chunk);
+        },
+        result() {
+            return handlers.result.call(handlers);
+        }
+    }),
+});
+
+const property = csstree.property('*-vendor-property');
+property.name = 'test'; // $ExpectError
+
+const keyword = csstree.keyword('-vendor-keyword');
+keyword.name = 'test'; // $ExpectError
+
+csstree.clone(ast); // $ExpectType CssNode
+
+const fromPlain = csstree.fromPlainObject({
+    type: 'SelectorList',
+    children: []
+});
+fromPlain; // $ExpectType CssNode
+
+const toPlain = csstree.toPlainObject({
+    type: 'SelectorList',
+    children: new csstree.List<csstree.CssNode>(),
+});
+toPlain; // $ExpectType CssNodePlain
+
+interface Test {
+    a: string;
+}
+
+const list = new csstree.List<Test>();
+
+const anItem = list.createItem({a: 'c'});
+anItem; // $ExpectType ListItem<Test>
+
+list.fromArray([{a: 'b'}]);
+list.toArray(); // $ExpectType Test[]
+list.getSize(); // $ExpectType number
+list.isEmpty(); // $ExpectType boolean
+list.first(); // $ExpectType Test | null
+list.last(); // $ExpectType Test | null
+list.each(function(item, node, list) {
+    this.b; // $ExpectType string
+    item; // $ExpectType Test
+    node; // $ExpectType ListItem<Test>
+    list; // $ExpectType List<Test>
+}, {b: 'c'});
+list.each(function(item, node, list) {
+    this; // $ExpectType List<Test>
+    item; // $ExpectType Test
+    node; // $ExpectType ListItem<Test>
+    list; // $ExpectType List<Test>
+});
+list.forEach(function(item, node, list) {
+    this.b; // $ExpectType string
+    item; // $ExpectType Test
+    node; // $ExpectType ListItem<Test>
+    list; // $ExpectType List<Test>
+}, {b: 'c'});
+list.forEach(function(item, node, list) {
+    this; // $ExpectType List<Test>
+    item; // $ExpectType Test
+    node; // $ExpectType ListItem<Test>
+    list; // $ExpectType List<Test>
+});
+list.eachRight(function(item, node, list) {
+    this.b; // $ExpectType string
+    item; // $ExpectType Test
+    node; // $ExpectType ListItem<Test>
+    list; // $ExpectType List<Test>
+}, {b: 'c'});
+list.eachRight(function(item, node, list) {
+    this; // $ExpectType List<Test>
+    item; // $ExpectType Test
+    node; // $ExpectType ListItem<Test>
+    list; // $ExpectType List<Test>
+});
+list.forEachRight(function(item, node, list) {
+    this.b; // $ExpectType string
+    item; // $ExpectType Test
+    node; // $ExpectType ListItem<Test>
+    list; // $ExpectType List<Test>
+}, {b: 'c'});
+list.forEachRight(function(item, node, list) {
+    this; // $ExpectType List<Test>
+    item; // $ExpectType Test
+    node; // $ExpectType ListItem<Test>
+    list; // $ExpectType List<Test>
+});
+list.nextUntil(anItem, function(item, node, list) {
+    this.b; // $ExpectType string
+    item; // $ExpectType Test
+    node; // $ExpectType ListItem<Test>
+    list; // $ExpectType List<Test>
+    return true;
+}, {b: 'c'});
+list.nextUntil(anItem, function(item, node, list) {
+    this; // $ExpectType List<Test>
+    item; // $ExpectType Test
+    node; // $ExpectType ListItem<Test>
+    list; // $ExpectType List<Test>
+    return true;
+});
+list.prevUntil(anItem, function(item, node, list) {
+    this.b; // $ExpectType string
+    item; // $ExpectType Test
+    node; // $ExpectType ListItem<Test>
+    list; // $ExpectType List<Test>
+    return true;
+}, {b: 'c'});
+list.prevUntil(anItem, function(item, node, list) {
+    this; // $ExpectType List<Test>
+    item; // $ExpectType Test
+    node; // $ExpectType ListItem<Test>
+    list; // $ExpectType List<Test>
+    return true;
+});
+list.some(function(item, node, list) {
+    this.b; // $ExpectType string
+    item; // $ExpectType Test
+    node; // $ExpectType ListItem<Test>
+    list; // $ExpectType List<Test>
+    return true;
+}, {b: 'c'});
+list.some(function(item, node, list) {
+    this; // $ExpectType List<Test>
+    item; // $ExpectType Test
+    node; // $ExpectType ListItem<Test>
+    list; // $ExpectType List<Test>
+    return true;
+});
+const map1 = list.map(function(item, node, list) {
+    this.b; // $ExpectType string
+    item; // $ExpectType Test
+    node; // $ExpectType ListItem<Test>
+    list; // $ExpectType List<Test>
+    return { c: 'd' };
+}, {b: 'c'});
+map1; // $ExpectType List<{ c: string; }>
+const map2 = list.map(function(item, node, list) {
+    this; // $ExpectType List<Test>
+    item; // $ExpectType Test
+    node; // $ExpectType ListItem<Test>
+    list; // $ExpectType List<Test>
+    return { c: 'd' };
+});
+map2; // $ExpectType List<{ c: string; }>
+
+const list2 = new csstree.List<Test | null>();
+
+const filter1 = list2.filter(function(item, node, list): item is Test {
+    this.b; // $ExpectType string
+    item; // $ExpectType Test | null
+    node; // $ExpectType ListItem<Test | null>
+    list; // $ExpectType List<Test | null>
+    return !!item;
+}, {b: 'c'});
+filter1; // $ExpectType List<Test>
+const filter2 = list2.filter(function(item, node, list): item is Test {
+    this; // $ExpectType List<Test | null>
+    item; // $ExpectType Test | null
+    node; // $ExpectType ListItem<Test | null>
+    list; // $ExpectType List<Test | null>
+    return !!item;
+});
+filter2; // $ExpectType List<Test>
+const filter3 = list2.filter(function(item, node, list) {
+    this.b; // $ExpectType string
+    item; // $ExpectType Test | null
+    node; // $ExpectType ListItem<Test | null>
+    list; // $ExpectType List<Test | null>
+    return true;
+}, {b: 'c'});
+filter3; // $ExpectType List<Test | null>
+const filter4 = list2.filter(function(item, node, list) {
+    this; // $ExpectType List<Test | null>
+    item; // $ExpectType Test | null
+    node; // $ExpectType ListItem<Test | null>
+    list; // $ExpectType List<Test | null>
+    return true;
+});
+filter4; // $ExpectType List<Test | null>
+
+list.clear();
+list.copy(); // $ExpectType List<Test>
+list.prepend(anItem); // $ExpectType List<Test>
+list.prependData({a: 'b'}); // $ExpectType List<Test>
+list.append(anItem); // $ExpectType List<Test>
+list.appendData({a: 'b'}); // $ExpectType List<Test>
+list.insert(anItem, anItem); // $ExpectType List<Test>
+list.insertData({a: 'b'}, anItem); // $ExpectType List<Test>
+list.remove(anItem); // $ExpectType ListItem<Test>
+list.push({a: 'b'}); // $ExpectType void
+list.pop(); // $ExpectType ListItem<Test> | undefined
+list.unshift({a: 'b'}); // $ExpectType void
+list.shift(); // $ExpectType ListItem<Test> | undefined
+list.prependList(list); // $ExpectType List<Test>
+list.appendList(list); // $ExpectType List<Test>
+list.insertList(list, anItem); // $ExpectType List<Test>
+list.replace(anItem, list); // $ExpectType List<Test>
+list.replace(anItem, anItem); // $ExpectType List<Test>
+
+switch (ast.type) {
+    case 'AnPlusB':
+        ast.a; // $ExpectType string | null
+        ast.b; // $ExpectType string | null
+        break;
+
+    case 'Atrule':
+        ast.name; // $ExpectType string
+        ast.prelude; // $ExpectType AtrulePrelude | Raw | null
+        ast.block; // $ExpectType Block | null
+        break;
+
+    case 'AtrulePrelude':
+        ast.children; // $ExpectType List<CssNode>
+        break;
+
+    case 'AttributeSelector':
+        ast.name; // $ExpectType Identifier
+        ast.matcher; // $ExpectType string | null
+        ast.value; // $ExpectType Identifier | StringNode | null
+        ast.flags; // $ExpectType string | null
+        break;
+
+    case 'Block':
+        ast.children; // $ExpectType List<CssNode>
+        break;
+
+    case 'Brackets':
+        ast.children; // $ExpectType List<CssNode>
+        break;
+
+    case 'CDC':
+        break;
+
+    case 'CDO':
+        break;
+
+    case 'ClassSelector':
+        ast.name; // $ExpectType string
+        break;
+
+    case 'Combinator':
+        ast.name; // $ExpectType string
+        break;
+
+    case 'Comment':
+        ast.value; // $ExpectType string
+        break;
+
+    case 'Declaration':
+        ast.important; // $ExpectType string | boolean
+        ast.property; // $ExpectType string
+        ast.value; // $ExpectType Raw | Value
+        break;
+
+    case 'DeclarationList':
+        ast.children; // $ExpectType List<CssNode>
+        break;
+
+    case 'Dimension':
+        ast.value; // $ExpectType string
+        ast.unit; // $ExpectType string
+        break;
+
+    case 'Function':
+        ast.name; // $ExpectType string
+        ast.children; // $ExpectType List<CssNode>
+        break;
+
+    case 'HexColor':
+        ast.value; // $ExpectType string
+        break;
+
+    case 'IdSelector':
+        ast.name; // $ExpectType string
+        break;
+
+    case 'Identifier':
+        ast.name; // $ExpectType string
+        break;
+
+    case 'MediaFeature':
+        ast.name; // $ExpectType string
+        ast.value; // $ExpectType Dimension | Identifier | NumberNode | Ratio | null
+        break;
+
+    case 'MediaQuery':
+        ast.children; // $ExpectType List<CssNode>
+        break;
+
+    case 'MediaQueryList':
+        ast.children; // $ExpectType List<CssNode>
+        break;
+
+    case 'Nth':
+        ast.nth; // $ExpectType AnPlusB | Identifier
+        ast.selector; // $ExpectType SelectorList | null
+        break;
+
+    case 'Number':
+        ast.value; // $ExpectType string
+        break;
+
+    case 'Operator':
+        ast.value; // $ExpectType string
+        break;
+
+    case 'Parentheses':
+        ast.children; // $ExpectType List<CssNode>
+        break;
+
+    case 'Percentage':
+        ast.value; // $ExpectType string
+        break;
+
+    case 'PseudoClassSelector':
+        ast.name; // $ExpectType string
+        ast.children; // $ExpectType List<CssNode> | null
+        break;
+
+    case 'PseudoElementSelector':
+        ast.name; // $ExpectType string
+        ast.children; // $ExpectType List<CssNode> | null
+        break;
+
+    case 'Ratio':
+        ast.left; // $ExpectType string
+        ast.right; // $ExpectType string
+        break;
+
+    case 'Raw':
+        ast.value; // $ExpectType string
+        break;
+
+    case 'Rule':
+        ast.prelude; // $ExpectType Raw | SelectorList
+        ast.block; // $ExpectType Block
+        break;
+
+    case 'Selector':
+        ast.children; // $ExpectType List<CssNode>
+        break;
+
+    case 'SelectorList':
+        ast.children; // $ExpectType List<CssNode>
+        break;
+
+    case 'String':
+        ast.value; // $ExpectType string
+        break;
+
+    case 'StyleSheet':
+        ast.children; // $ExpectType List<CssNode>
+        break;
+
+    case 'TypeSelector':
+        ast.name; // $ExpectType string
+        break;
+
+    case 'UnicodeRange':
+        ast.value; // $ExpectType string
+        break;
+
+    case 'Url':
+        ast.value; // $ExpectType Raw | StringNode
+        break;
+
+    case 'Value':
+        ast.children; // $ExpectType List<CssNode>
+        break;
+
+    case 'WhiteSpace':
+        ast.value; // $ExpectType string
+        break;
+
+    default:
+        ast; // $ExpectType never
+}
+
+switch (toPlain.type) {
+    case 'AnPlusB':
+        toPlain.a; // $ExpectType string | null
+        toPlain.b; // $ExpectType string | null
+        break;
+
+    case 'Atrule':
+        toPlain.name; // $ExpectType string
+        toPlain.prelude; // $ExpectType Raw | AtrulePreludePlain | null
+        toPlain.block; // $ExpectType BlockPlain | null
+        break;
+
+    case 'AtrulePrelude':
+        toPlain.children; // $ExpectType CssNodePlain[]
+        break;
+
+    case 'AttributeSelector':
+        toPlain.name; // $ExpectType Identifier
+        toPlain.matcher; // $ExpectType string | null
+        toPlain.value; // $ExpectType Identifier | StringNode | null
+        toPlain.flags; // $ExpectType string | null
+        break;
+
+    case 'Block':
+        toPlain.children; // $ExpectType CssNodePlain[]
+        break;
+
+    case 'Brackets':
+        toPlain.children; // $ExpectType CssNodePlain[]
+        break;
+
+    case 'CDC':
+        break;
+
+    case 'CDO':
+        break;
+
+    case 'ClassSelector':
+        toPlain.name; // $ExpectType string
+        break;
+
+    case 'Combinator':
+        toPlain.name; // $ExpectType string
+        break;
+
+    case 'Comment':
+        toPlain.value; // $ExpectType string
+        break;
+
+    case 'Declaration':
+        toPlain.important; // $ExpectType string | boolean
+        toPlain.property; // $ExpectType string
+        toPlain.value; // $ExpectType Raw | ValuePlain
+        break;
+
+    case 'DeclarationList':
+        toPlain.children; // $ExpectType CssNodePlain[]
+        break;
+
+    case 'Dimension':
+        toPlain.value; // $ExpectType string
+        toPlain.unit; // $ExpectType string
+        break;
+
+    case 'Function':
+        toPlain.name; // $ExpectType string
+        toPlain.children; // $ExpectType CssNodePlain[]
+        break;
+
+    case 'HexColor':
+        toPlain.value; // $ExpectType string
+        break;
+
+    case 'IdSelector':
+        toPlain.name; // $ExpectType string
+        break;
+
+    case 'Identifier':
+        toPlain.name; // $ExpectType string
+        break;
+
+    case 'MediaFeature':
+        toPlain.name; // $ExpectType string
+        toPlain.value; // $ExpectType Dimension | Identifier | NumberNode | Ratio | null
+        break;
+
+    case 'MediaQuery':
+        toPlain.children; // $ExpectType CssNodePlain[]
+        break;
+
+    case 'MediaQueryList':
+        toPlain.children; // $ExpectType CssNodePlain[]
+        break;
+
+    case 'Nth':
+        toPlain.nth; // $ExpectType AnPlusB | Identifier
+        toPlain.selector; // $ExpectType SelectorListPlain | null
+        break;
+
+    case 'Number':
+        toPlain.value; // $ExpectType string
+        break;
+
+    case 'Operator':
+        toPlain.value; // $ExpectType string
+        break;
+
+    case 'Parentheses':
+        toPlain.children; // $ExpectType CssNodePlain[]
+        break;
+
+    case 'Percentage':
+        toPlain.value; // $ExpectType string
+        break;
+
+    case 'PseudoClassSelector':
+        toPlain.name; // $ExpectType string
+        toPlain.children; // $ExpectType CssNodePlain[] | null
+        break;
+
+    case 'PseudoElementSelector':
+        toPlain.name; // $ExpectType string
+        toPlain.children; // $ExpectType CssNodePlain[] | null
+        break;
+
+    case 'Ratio':
+        toPlain.left; // $ExpectType string
+        toPlain.right; // $ExpectType string
+        break;
+
+    case 'Raw':
+        toPlain.value; // $ExpectType string
+        break;
+
+    case 'Rule':
+        toPlain.prelude; // $ExpectType Raw | SelectorListPlain
+        toPlain.block; // $ExpectType BlockPlain
+        break;
+
+    case 'Selector':
+        toPlain.children; // $ExpectType CssNodePlain[]
+        break;
+
+    case 'SelectorList':
+        toPlain.children; // $ExpectType CssNodePlain[]
+        break;
+
+    case 'String':
+        toPlain.value; // $ExpectType string
+        break;
+
+    case 'StyleSheet':
+        toPlain.children; // $ExpectType CssNodePlain[]
+        break;
+
+    case 'TypeSelector':
+        toPlain.name; // $ExpectType string
+        break;
+
+    case 'UnicodeRange':
+        toPlain.value; // $ExpectType string
+        break;
+
+    case 'Url':
+        toPlain.value; // $ExpectType Raw | StringNode
+        break;
+
+    case 'Value':
+        toPlain.children; // $ExpectType CssNodePlain[]
+        break;
+
+    case 'WhiteSpace':
+        toPlain.value; // $ExpectType string
+        break;
+
+    default:
+        toPlain; // $ExpectType never
+}

--- a/types/css-tree/index.d.ts
+++ b/types/css-tree/index.d.ts
@@ -1,0 +1,565 @@
+// Type definitions for css-tree 1.0
+// Project: https://github.com/csstree/csstree
+// Definitions by: Erik Källén <https://github.com/erik-kallen>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.7
+
+export interface CssLocation {
+    source: string;
+    start: {
+        offset: number;
+        line: number;
+        column: number
+    };
+    end: {
+        offset: number;
+        line: number;
+        column: number
+    };
+}
+
+export interface ListItem<TData> {
+    prev: ListItem<TData> | null;
+    next: ListItem<TData> | null;
+    data: TData;
+}
+
+export type IteratorFn<TData, TResult, TContext = List<TData>> = (this: TContext, item: TData, node: ListItem<TData>, list: List<TData>) => TResult;
+export type FilterFn<TData, TResult extends TData, TContext = List<TData>> = (this: TContext, item: TData, node: ListItem<TData>, list: List<TData>) => item is TResult;
+
+export class List<TData> {
+    constructor();
+    fromArray(array: TData[]): List<TData>;
+    createItem(data: TData): ListItem<TData>;
+    toArray(): TData[];
+    toJSON(): TData[];
+    getSize(): number;
+    isEmpty(): boolean;
+    first(): TData | null;
+    last(): TData | null;
+    each<TContext>(fn: IteratorFn<TData, void, TContext>, context: TContext): void;
+    each(fn: IteratorFn<TData, void>): void;
+    forEach<TContext>(fn: IteratorFn<TData, void, TContext>, context: TContext): void;
+    forEach(fn: IteratorFn<TData, void>): void;
+    eachRight<TContext>(fn: IteratorFn<TData, void, TContext>, context: TContext): void;
+    eachRight(fn: IteratorFn<TData, void>): void;
+    forEachRight<TContext>(fn: IteratorFn<TData, void, TContext>, context: TContext): void;
+    forEachRight(fn: IteratorFn<TData, void>): void;
+    nextUntil<TContext>(start: ListItem<TData>, fn: IteratorFn<TData, boolean, TContext>, context: TContext): void;
+    nextUntil(start: ListItem<TData>, fn: IteratorFn<TData, boolean>): void;
+    prevUntil<TContext>(start: ListItem<TData>, fn: IteratorFn<TData, boolean, TContext>, context: TContext): void;
+    prevUntil(start: ListItem<TData>, fn: IteratorFn<TData, boolean>): void;
+    some<TContext>(fn: IteratorFn<TData, boolean, TContext>, context: TContext): void;
+    some(fn: IteratorFn<TData, boolean>): void;
+    map<TContext, TResult>(fn: IteratorFn<TData, TResult, TContext>, context: TContext): List<TResult>;
+    map<TResult>(fn: IteratorFn<TData, TResult>): List<TResult>;
+    filter<TContext, TResult extends TData>(fn: FilterFn<TData, TResult, TContext>, context: TContext): List<TResult>;
+    filter<TResult extends TData>(fn: FilterFn<TData, TResult>): List<TResult>;
+    filter<TContext>(fn: IteratorFn<TData, boolean, TContext>, context: TContext): List<TData>;
+    filter(fn: IteratorFn<TData, boolean>): List<TData>;
+    clear(): void;
+    copy(): List<TData>;
+    prepend(item: ListItem<TData>): List<TData>;
+    prependData(data: TData): List<TData>;
+    append(item: ListItem<TData>): List<TData>;
+    appendData(data: TData): List<TData>;
+    insert(item: ListItem<TData>, before: ListItem<TData>): List<TData>;
+    insertData(data: TData, before: ListItem<TData>): List<TData>;
+    remove(item: ListItem<TData>): ListItem<TData>;
+    push(item: TData): void;
+    pop(): ListItem<TData> | undefined;
+    unshift(data: TData): void;
+    shift(): ListItem<TData> | undefined;
+    prependList(list: List<TData>): List<TData>;
+    appendList(list: List<TData>): List<TData>;
+    insertList(list: List<TData>, before: ListItem<TData>): List<TData>;
+    replace(oldItem: ListItem<TData>, newItemOrList: List<TData> | ListItem<TData>): List<TData>;
+}
+
+export interface CssNodeCommon {
+    type: string;
+    loc?: CssLocation;
+}
+
+export interface AnPlusB extends CssNodeCommon {
+    type: 'AnPlusB';
+    a: string | null;
+    b: string | null;
+}
+
+export interface Atrule extends CssNodeCommon {
+    type: 'Atrule';
+    name: string;
+    prelude: AtrulePrelude | Raw | null;
+    block: Block | null;
+}
+
+export interface AtrulePlain extends CssNodeCommon {
+    type: 'Atrule';
+    name: string;
+    prelude: AtrulePreludePlain | Raw | null;
+    block: BlockPlain | null;
+}
+
+export interface AtrulePrelude extends CssNodeCommon {
+    type: 'AtrulePrelude';
+    children: List<CssNode>;
+}
+
+export interface AtrulePreludePlain extends CssNodeCommon {
+    type: 'AtrulePrelude';
+    children: CssNodePlain[];
+}
+
+export interface AttributeSelector extends CssNodeCommon {
+    type: 'AttributeSelector';
+    name: Identifier;
+    matcher: string | null;
+    value: StringNode | Identifier | null;
+    flags: string | null;
+}
+
+export interface Block extends CssNodeCommon {
+    type: 'Block';
+    children: List<CssNode>;
+}
+
+export interface BlockPlain extends CssNodeCommon {
+    type: 'Block';
+    children: CssNodePlain[];
+}
+
+export interface Brackets extends CssNodeCommon {
+    type: 'Brackets';
+    children: List<CssNode>;
+}
+
+export interface BracketsPlain extends CssNodeCommon {
+    type: 'Brackets';
+    children: CssNodePlain[];
+}
+
+export interface CDC extends CssNodeCommon {
+    type: 'CDC';
+}
+
+export interface CDO extends CssNodeCommon {
+    type: 'CDO';
+}
+
+export interface ClassSelector extends CssNodeCommon {
+    type: 'ClassSelector';
+    name: string;
+}
+
+export interface Combinator extends CssNodeCommon {
+    type: 'Combinator';
+    name: string;
+}
+
+export interface Comment extends CssNodeCommon {
+    type: 'Comment';
+    value: string;
+}
+
+export interface Declaration extends CssNodeCommon {
+    type: 'Declaration';
+    important: boolean | string;
+    property: string;
+    value: Value | Raw;
+}
+
+export interface DeclarationPlain extends CssNodeCommon {
+    type: 'Declaration';
+    important: boolean | string;
+    property: string;
+    value: ValuePlain | Raw;
+}
+
+export interface DeclarationList extends CssNodeCommon {
+    type: 'DeclarationList';
+    children: List<CssNode>;
+}
+
+export interface DeclarationListPlain extends CssNodeCommon {
+    type: 'DeclarationList';
+    children: CssNodePlain[];
+}
+
+export interface Dimension extends CssNodeCommon {
+    type: 'Dimension';
+    value: string;
+    unit: string;
+}
+
+export interface FunctionNode extends CssNodeCommon {
+    type: 'Function';
+    name: string;
+    children: List<CssNode>;
+}
+
+export interface FunctionNodePlain extends CssNodeCommon {
+    type: 'Function';
+    name: string;
+    children: CssNodePlain[];
+}
+
+export interface HexColor extends CssNodeCommon {
+    type: 'HexColor';
+    value: string;
+}
+
+export interface IdSelector extends CssNodeCommon {
+    type: 'IdSelector';
+    name: string;
+}
+
+export interface Identifier extends CssNodeCommon {
+    type: 'Identifier';
+    name: string;
+}
+
+export interface MediaFeature extends CssNodeCommon {
+    type: 'MediaFeature';
+    name: string;
+    value: Identifier | NumberNode | Dimension | Ratio | null;
+}
+
+export interface MediaQuery extends CssNodeCommon {
+    type: 'MediaQuery';
+    children: List<CssNode>;
+}
+
+export interface MediaQueryPlain extends CssNodeCommon {
+    type: 'MediaQuery';
+    children: CssNodePlain[];
+}
+
+export interface MediaQueryList extends CssNodeCommon {
+    type: 'MediaQueryList';
+    children: List<CssNode>;
+}
+
+export interface MediaQueryListPlain extends CssNodeCommon {
+    type: 'MediaQueryList';
+    children: CssNodePlain[];
+}
+
+export interface Nth extends CssNodeCommon {
+    type: 'Nth';
+    nth: AnPlusB | Identifier;
+    selector: SelectorList | null;
+}
+
+export interface NthPlain extends CssNodeCommon {
+    type: 'Nth';
+    nth: AnPlusB | Identifier;
+    selector: SelectorListPlain | null;
+}
+
+export interface NumberNode extends CssNodeCommon {
+    type: 'Number';
+    value: string;
+}
+
+export interface Operator extends CssNodeCommon {
+    type: 'Operator';
+    value: string;
+}
+
+export interface Parentheses extends CssNodeCommon {
+    type: 'Parentheses';
+    children: List<CssNode>;
+}
+
+export interface ParenthesesPlain extends CssNodeCommon {
+    type: 'Parentheses';
+    children: CssNodePlain[];
+}
+
+export interface Percentage extends CssNodeCommon {
+    type: 'Percentage';
+    value: string;
+}
+
+export interface PseudoClassSelector extends CssNodeCommon {
+    type: 'PseudoClassSelector';
+    name: string;
+    children: List<CssNode> | null;
+}
+
+export interface PseudoClassSelectorPlain extends CssNodeCommon {
+    type: 'PseudoClassSelector';
+    name: string;
+    children: CssNodePlain[] | null;
+}
+
+export interface PseudoElementSelector extends CssNodeCommon {
+    type: 'PseudoElementSelector';
+    name: string;
+    children: List<CssNode> | null;
+}
+
+export interface PseudoElementSelectorPlain extends CssNodeCommon {
+    type: 'PseudoElementSelector';
+    name: string;
+    children: CssNodePlain[] | null;
+}
+
+export interface Ratio extends CssNodeCommon {
+    type: 'Ratio';
+    left: string;
+    right: string;
+}
+
+export interface Raw extends CssNodeCommon {
+    type: 'Raw';
+    value: string;
+}
+
+export interface Rule extends CssNodeCommon {
+    type: 'Rule';
+    prelude: SelectorList | Raw;
+    block: Block;
+}
+
+export interface RulePlain extends CssNodeCommon {
+    type: 'Rule';
+    prelude: SelectorListPlain | Raw;
+    block: BlockPlain;
+}
+
+export interface Selector extends CssNodeCommon {
+    type: 'Selector';
+    children: List<CssNode>;
+}
+
+export interface SelectorPlain extends CssNodeCommon {
+    type: 'Selector';
+    children: CssNodePlain[];
+}
+
+export interface SelectorList extends CssNodeCommon {
+    type: 'SelectorList';
+    children: List<CssNode>;
+}
+
+export interface SelectorListPlain extends CssNodeCommon {
+    type: 'SelectorList';
+    children: CssNodePlain[];
+}
+
+export interface StringNode extends CssNodeCommon {
+    type: 'String';
+    value: string;
+}
+
+export interface StyleSheet extends CssNodeCommon {
+    type: 'StyleSheet';
+    children: List<CssNode>;
+}
+
+export interface StyleSheetPlain extends CssNodeCommon {
+    type: 'StyleSheet';
+    children: CssNodePlain[];
+}
+
+export interface TypeSelector extends CssNodeCommon {
+    type: 'TypeSelector';
+    name: string;
+}
+
+export interface UnicodeRange extends CssNodeCommon {
+    type: 'UnicodeRange';
+    value: string;
+}
+
+export interface Url extends CssNodeCommon {
+    type: 'Url';
+    value: StringNode | Raw;
+}
+
+export interface Value extends CssNodeCommon {
+    type: 'Value';
+    children: List<CssNode>;
+}
+
+export interface ValuePlain extends CssNodeCommon {
+    type: 'Value';
+    children: CssNodePlain[];
+}
+
+export interface WhiteSpace extends CssNodeCommon {
+    type: 'WhiteSpace';
+    value: string;
+}
+
+export type CssNode =
+    AnPlusB
+    | Atrule
+    | AtrulePrelude
+    | AttributeSelector
+    | Block
+    | Brackets
+    | CDC
+    | CDO
+    | ClassSelector
+    | Combinator
+    | Comment
+    | Declaration
+    | DeclarationList
+    | Dimension
+    | FunctionNode
+    | HexColor
+    | IdSelector
+    | Identifier
+    | MediaFeature
+    | MediaQuery
+    | MediaQueryList
+    | Nth
+    | NumberNode
+    | Operator
+    | Parentheses
+    | Percentage
+    | PseudoClassSelector
+    | PseudoElementSelector
+    | Ratio
+    | Raw
+    | Rule
+    | Selector
+    | SelectorList
+    | StringNode
+    | StyleSheet
+    | TypeSelector
+    | UnicodeRange
+    | Url
+    | Value
+    | WhiteSpace;
+
+export type CssNodePlain =
+    AnPlusB
+    | AtrulePlain
+    | AtrulePreludePlain
+    | AttributeSelector
+    | BlockPlain
+    | BracketsPlain
+    | CDC
+    | CDO
+    | ClassSelector
+    | Combinator
+    | Comment
+    | DeclarationPlain
+    | DeclarationListPlain
+    | Dimension
+    | FunctionNodePlain
+    | HexColor
+    | IdSelector
+    | Identifier
+    | MediaFeature
+    | MediaQueryPlain
+    | MediaQueryListPlain
+    | NthPlain
+    | NumberNode
+    | Operator
+    | ParenthesesPlain
+    | Percentage
+    | PseudoClassSelectorPlain
+    | PseudoElementSelectorPlain
+    | Ratio
+    | Raw
+    | RulePlain
+    | SelectorPlain
+    | SelectorListPlain
+    | StringNode
+    | StyleSheetPlain
+    | TypeSelector
+    | UnicodeRange
+    | Url
+    | ValuePlain
+    | WhiteSpace;
+
+export interface SyntaxParseError extends SyntaxError {
+    input: string;
+    offset: number;
+    rawMessage: string;
+}
+
+export interface ParseOptions {
+    context?: string;
+    atrule?: string;
+    positions?: boolean;
+    onParseError?: (error: SyntaxParseError, fallbackNode: CssNode) => void;
+    filename?: string;
+    offset?: number;
+    line?: number;
+    column?: number;
+    parseAtrulePrelude?: boolean;
+    parseRulePrelude?: boolean;
+    parseValue?: boolean;
+    parseCustomProperty?: boolean;
+}
+
+export function parse(text: string, options?: ParseOptions): CssNode;
+
+export interface GenerateHandlers {
+    children: (node: CssNode, delimiter?: (node: CssNode) => void) => void;
+    node: (node: CssNode) => void;
+    chunk: (chunk: string) => void;
+    result: () => string;
+}
+
+export interface GenerateOptions {
+    sourceMap?: boolean;
+    decorator?: (handlers: GenerateHandlers) => GenerateHandlers;
+}
+
+export function generate(ast: CssNode, options?: GenerateOptions): string;
+
+export interface WalkContext {
+    root: CssNode;
+    stylesheet: StyleSheet;
+    atrule: Atrule;
+    atrulePrelude: AtrulePrelude;
+    rule: Rule;
+    selector: SelectorList;
+    block: Block;
+    declaration: Declaration;
+    function: FunctionNode | PseudoClassSelector | PseudoElementSelector;
+}
+
+export type EnterOrLeaveFn = (this: WalkContext, node: CssNode, item: ListItem<CssNode>, list: List<CssNode>) => void;
+
+export interface WalkOptions {
+    enter?: EnterOrLeaveFn;
+    leave?: EnterOrLeaveFn;
+    visit?: string;
+    reverse?: boolean;
+}
+
+export function walk(ast: CssNode, options: EnterOrLeaveFn | WalkOptions): void;
+
+export interface Property {
+    readonly basename: string;
+    readonly name: string;
+    readonly hack: string;
+    readonly vendor: string;
+    readonly prefix: string;
+    readonly custom: boolean;
+}
+
+export function property(value: string): Property;
+
+export interface Keyword {
+    readonly basename: string;
+    readonly name: string;
+    readonly vendor: string;
+    readonly prefix: string;
+    readonly custom: boolean;
+}
+
+export function keyword(value: string): Keyword;
+
+export function clone(node: CssNode): CssNode;
+
+export function fromPlainObject(node: CssNodePlain): CssNode;
+export function toPlainObject(node: CssNode): CssNodePlain;

--- a/types/css-tree/tsconfig.json
+++ b/types/css-tree/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "css-tree-tests.ts"
+    ]
+}

--- a/types/css-tree/tslint.json
+++ b/types/css-tree/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Add type definitions for css-tree (https://www.npmjs.com/package/css-tree / https://github.com/csstree/csstree).

Hopefully everything is OK, but `npm run lint css-tree` complains that the test file must be camel-cased, but the instructions say that it shouldn't be. Also, the `dts-gen` tool does not add the the `strictFunctionTypes to the tsconfig.json`.

One issue I encountered is that the `children` member might be either a `cssTree.List<T>`, or a plain `Array<T>`. I would have liked to do something like

```
interface Block<TCollection> {
    children: TCollection<CssNode>;
}
```
and then use `Block<csstree.List>` and `Block<Array>`, but this does not seem possible.


- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
