### PR TITLE
Add defaultSort property to reactable.Table

### DIFF
--- a/types/reactable/index.d.ts
+++ b/types/reactable/index.d.ts
@@ -13,12 +13,15 @@ export interface KeyLabelObject {
 
 export type ColumnsType = string | KeyLabelObject;
 
+export type SortDirection = 'asc' | 'desc';
+
 export type FilterMethodType = (text: string) => void;
 
 export interface TableComponentProperties<T> {
     data?: T[];
     className?: string;
     columns?: ColumnsType[];
+    defaultSort?: { column: string, direction: SortDirection };
     id?: string;
     sortable?: string[];
     filterable?: string[];

--- a/types/reactable/reactable-tests.tsx
+++ b/types/reactable/reactable-tests.tsx
@@ -65,7 +65,7 @@ export class FullblownReactableTestComponent extends React.Component {
             );
         }
         return (
-            <PersonTable>
+            <PersonTable defaultSort={{ column: "name", direction: 'asc' }}>
                 <PersonTableHeader>
                     {columns}
                 </PersonTableHeader>


### PR DESCRIPTION
Looking at the commit log I see that ther `defaultSort` property has been present at least since 0.13.2, thus I'm not increasing the version number in the header. `tslint.json` is already present, thus I'm not adding it.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/abdulrahman-khankan/reactable#sorting
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.