### PR TITLE
@types/yeoman-generator: Changing options object definition to key value pair

### DIFF
--- a/types/yeoman-generator/index.d.ts
+++ b/types/yeoman-generator/index.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: Kentaro Okuno <https://github.com/armorik83>
 //                 Jay Anslow <https://github.com/janslow>
 //                 Ika <https://github.com/ikatyang>
+//                 Joshua Cherry <https://github.com/tasadar2>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -91,7 +92,7 @@ declare class Generator extends EventEmitter {
     appname: string;
     config: Generator.Storage;
     fs: Generator.MemFsEditor;
-    options: {};
+    options: { [name: string]: any };
     log(message?: string, context?: any): void;
 
     argument(name: string, config: Generator.ArgumentConfig): this;

--- a/types/yeoman-generator/yeoman-generator-tests.ts
+++ b/types/yeoman-generator/yeoman-generator-tests.ts
@@ -108,6 +108,8 @@ generator.option('opt4', {
   default: 3.2,
 });
 
+const optionValue1 = generator.options.opt1;
+
 const optionsHelp: string = generator.optionsHelp();
 
 const answers: Promise<Answers> = generator.prompt([] as Questions);


### PR DESCRIPTION
Using a type of `{}` for `options` causes an error when transpiling based on the suggested usage of options([yeoman.io/authoring/user-interactions.html](yeoman.io/authoring/user-interactions.html)).

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [option setter](https://github.com/yeoman/generator/blob/1cd1031eb1cc2ed0288265dd15ddc6cfbcffabb7/lib/index.js#L342), [options setter](https://github.com/yeoman/generator/blob/1cd1031eb1cc2ed0288265dd15ddc6cfbcffabb7/lib/index.js#L346)
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
