### PR TITLE
[node] Add additional REPLServer members

### DIFF
--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -1992,8 +1992,9 @@ declare module "punycode" {
 }
 
 declare module "repl" {
-    import { ReadLine, Completer, AsyncCompleter } from "readline";
+    import { Interface, Completer, AsyncCompleter } from "readline";
     import { Context } from "vm";
+    import { InspectOptions } from "util";
 
     interface ReplOptions {
         /**
@@ -2014,7 +2015,8 @@ declare module "repl" {
         /**
          * If `true`, specifies that the output should be treated as a TTY terminal, and have
          * ANSI/VT100 escape codes written to it.
-         * Default: checking the value of the `isTTY` property on the output stream upon instantiation.
+         * Default: checking the value of the `isTTY` property on the output stream upon
+         * instantiation.
          */
         terminal?: boolean;
         /**
@@ -2022,8 +2024,11 @@ declare module "repl" {
          * Default: an async wrapper for the JavaScript `eval()` function. An `eval` function can
          * error with `repl.Recoverable` to indicate the input was incomplete and prompt for
          * additional lines.
+         *
+         * @see https://nodejs.org/dist/latest-v10.x/docs/api/repl.html#repl_default_evaluation
+         * @see https://nodejs.org/dist/latest-v10.x/docs/api/repl.html#repl_custom_evaluation_functions
          */
-        eval?: (evalCmd: string, context: Context, file: string, cb: (err: Error | null, result: any) => void) => void;
+        eval?: REPLEval;
         /**
          * If `true`, specifies that the default `writer` function should include ANSI color
          * styling to REPL output. If a custom `writer` function is provided then this has no
@@ -2046,16 +2051,26 @@ declare module "repl" {
         ignoreUndefined?: boolean;
         /**
          * The function to invoke to format the output of each command before writing to `output`.
-         * Default: `util.inspect()`.
+         * Default: a wrapper for `util.inspect`.
+         *
+         * @see https://nodejs.org/dist/latest-v10.x/docs/api/repl.html#repl_customizing_repl_output
          */
-        writer?: (obj: any) => string;
+        writer?: REPLWriter;
         /**
-         * An optional function used for custom Tab auto completion. See
-         * [`readline.InterfaceCompleter`](https://nodejs.org/dist/latest-v11.x/docs/api/readline.html#readline_use_of_the_completer_function)
-         * for an example.
+         * An optional function used for custom Tab auto completion.
+         *
+         * @see https://nodejs.org/dist/latest-v11.x/docs/api/readline.html#readline_use_of_the_completer_function
          */
         completer?: Completer | AsyncCompleter;
-        replMode?: any;
+        /**
+         * A flag that specifies whether the default evaluator executes all JavaScript commands in
+         * strict mode or default (sloppy) mode.
+         * Accepted values are:
+         * - `repl.REPL_MODE_SLOPPY` - evaluates expressions in sloppy mode.
+         * - `repl.REPL_MODE_STRICT` - evaluates expressions in strict mode. This is equivalent to
+         *   prefacing every repl statement with `'use strict'`.
+         */
+        replMode?: typeof REPL_MODE_SLOPPY | typeof REPL_MODE_STRICT;
         /**
          * Stop evaluating the current piece of code when `SIGINT` is received, i.e. `Ctrl+C` is
          * pressed. This cannot be used together with a custom `eval` function.
@@ -2063,6 +2078,17 @@ declare module "repl" {
          */
         breakEvalOnSigint?: boolean;
     }
+
+    type REPLEval = (this: REPLServer, evalCmd: string, context: Context, file: string, cb: (err: Error | null, result: any) => void) => void;
+    type REPLWriter = (this: REPLServer, obj: any) => string;
+
+    /**
+     * This is the default "writer" value, if none is passed in the REPL options,
+     * and it can be overridden by custom print functions.
+     */
+    const writer: REPLWriter & { options: InspectOptions };
+
+    type REPLCommandAction = (this: REPLServer, text: string) => void;
 
     interface REPLCommand {
         /**
@@ -2072,21 +2098,139 @@ declare module "repl" {
         /**
          * The function to execute, optionally accepting a single string argument.
          */
-        action: (this: REPLServer, text: string) => void;
+        action: REPLCommandAction;
     }
 
-    interface REPLServer extends ReadLine {
-        context: Context;
-        inputStream: NodeJS.ReadableStream;
-        outputStream: NodeJS.WritableStream;
+    /**
+     * Provides a customizable Read-Eval-Print-Loop (REPL).
+     *
+     * Instances of `repl.REPLServer` will accept individual lines of user input, evaluate those
+     * according to a user-defined evaluation function, then output the result. Input and output
+     * may be from `stdin` and `stdout`, respectively, or may be connected to any Node.js `stream`.
+     *
+     * Instances of `repl.REPLServer` support automatic completion of inputs, simplistic Emacs-style
+     * line editing, multi-line inputs, ANSI-styled output, saving and restoring current REPL session
+     * state, error recovery, and customizable evaluation functions.
+     *
+     * Instances of `repl.REPLServer` are created using the `repl.start()` method and _should not_
+     * be created directly using the JavaScript `new` keyword.
+     *
+     * @see https://nodejs.org/dist/latest-v10.x/docs/api/repl.html#repl_repl
+     */
+    class REPLServer extends Interface {
+        /**
+         * The `vm.Context` provided to the `eval` function to be used for JavaScript
+         * evaluation.
+         */
+        readonly context: Context;
+        /**
+         * The `Readable` stream from which REPL input will be read.
+         */
+        readonly inputStream: NodeJS.ReadableStream;
+        /**
+         * The `Writable` stream to which REPL output will be written.
+         */
+        readonly outputStream: NodeJS.WritableStream;
+        /**
+         * The commands registered via `replServer.defineCommand()`.
+         */
+        readonly commands: { readonly [name: string]: REPLCommand | undefined };
+        /**
+         * A value indicating whether the REPL is currently in "editor mode".
+         *
+         * @see https://nodejs.org/dist/latest-v10.x/docs/api/repl.html#repl_commands_and_special_keys
+         */
+        readonly editorMode: boolean;
+        /**
+         * A value indicating whether the `_` variable has been assigned.
+         *
+         * @see https://nodejs.org/dist/latest-v10.x/docs/api/repl.html#repl_assignment_of_the_underscore_variable
+         */
+        readonly underscoreAssigned: boolean;
+        /**
+         * The last evaluation result from the REPL (assigned to the `_` variable inside of the REPL).
+         *
+         * @see https://nodejs.org/dist/latest-v10.x/docs/api/repl.html#repl_assignment_of_the_underscore_variable
+         */
+        readonly last: any;
+        /**
+         * A value indicating whether the `_error` variable has been assigned.
+         *
+         * @since v9.8.0
+         * @see https://nodejs.org/dist/latest-v10.x/docs/api/repl.html#repl_assignment_of_the_underscore_variable
+         */
+        readonly underscoreErrAssigned: boolean;
+        /**
+         * The last error raised inside the REPL (assigned to the `_error` variable inside of the REPL).
+         *
+         * @since v9.8.0
+         * @see https://nodejs.org/dist/latest-v10.x/docs/api/repl.html#repl_assignment_of_the_underscore_variable
+         */
+        readonly lastError: any;
+        /**
+         * Specified in the REPL options, this is the function to be used when evaluating each
+         * given line of input. If not specified in the REPL options, this is an async wrapper
+         * for the JavaScript `eval()` function.
+         */
+        readonly eval: REPLEval;
+        /**
+         * Specified in the REPL options, this is a value indicating whether the default
+         * `writer` function should include ANSI color styling to REPL output.
+         */
+        readonly useColors: boolean;
+        /**
+         * Specified in the REPL options, this is a value indicating whether the default `eval`
+         * function will use the JavaScript `global` as the context as opposed to creating a new
+         * separate context for the REPL instance.
+         */
+        readonly useGlobal: boolean;
+        /**
+         * Specified in the REPL options, this is a value indicating whether the default `writer`
+         * function should output the result of a command if it evaluates to `undefined`.
+         */
+        readonly ignoreUndefined: boolean;
+        /**
+         * Specified in the REPL options, this is the function to invoke to format the output of
+         * each command before writing to `outputStream`. If not specified in the REPL options,
+         * this will be a wrapper for `util.inspect`.
+         */
+        readonly writer: REPLWriter;
+        /**
+         * Specified in the REPL options, this is the function to use for custom Tab auto-completion.
+         */
+        readonly completer: Completer | AsyncCompleter;
+        /**
+         * Specified in the REPL options, this is a flag that specifies whether the default `eval`
+         * function should execute all JavaScript commands in strict mode or default (sloppy) mode.
+         * Possible values are:
+         * - `repl.REPL_MODE_SLOPPY` - evaluates expressions in sloppy mode.
+         * - `repl.REPL_MODE_STRICT` - evaluates expressions in strict mode. This is equivalent to
+         *    prefacing every repl statement with `'use strict'`.
+         */
+        readonly replMode: typeof REPL_MODE_SLOPPY | typeof REPL_MODE_STRICT;
+
+        /**
+         * NOTE: According to the documentation:
+         *
+         * > Instances of `repl.REPLServer` are created using the `repl.start()` method and
+         * > _should not_ be created directly using the JavaScript `new` keyword.
+         *
+         * `REPLServer` cannot be subclassed due to implementation specifics in NodeJS.
+         *
+         * @see https://nodejs.org/dist/latest-v10.x/docs/api/repl.html#repl_class_replserver
+         */
+        private constructor();
 
         /**
          * Used to add new `.`-prefixed commands to the REPL instance. Such commands are invoked
          * by typing a `.` followed by the `keyword`.
+         *
          * @param keyword The command keyword (_without_ a leading `.` character).
          * @param cmd The function to invoke when the command is processed.
+         *
+         * @see https://nodejs.org/dist/latest-v10.x/docs/api/repl.html#repl_replserver_definecommand_keyword_cmd
          */
-        defineCommand(keyword: string, cmd: ((this: REPLServer, text: string) => void) | REPLCommand): void;
+        defineCommand(keyword: string, cmd: REPLCommandAction | REPLCommand): void;
         /**
          * Readies the REPL instance for input from the user, printing the configured `prompt` to a
          * new line in the `output` and resuming the `input` to accept new input.
@@ -2111,37 +2255,108 @@ declare module "repl" {
 
         /**
          * events.EventEmitter
-         * 1. exit
-         * 2. reset
+         * 1. close - inherited from `readline.Interface`
+         * 2. line - inherited from `readline.Interface`
+         * 3. pause - inherited from `readline.Interface`
+         * 4. resume - inherited from `readline.Interface`
+         * 5. SIGCONT - inherited from `readline.Interface`
+         * 6. SIGINT - inherited from `readline.Interface`
+         * 7. SIGTSTP - inherited from `readline.Interface`
+         * 8. exit
+         * 9. reset
          */
 
         addListener(event: string, listener: (...args: any[]) => void): this;
+        addListener(event: "close", listener: () => void): this;
+        addListener(event: "line", listener: (input: string) => void): this;
+        addListener(event: "pause", listener: () => void): this;
+        addListener(event: "resume", listener: () => void): this;
+        addListener(event: "SIGCONT", listener: () => void): this;
+        addListener(event: "SIGINT", listener: () => void): this;
+        addListener(event: "SIGTSTP", listener: () => void): this;
         addListener(event: "exit", listener: () => void): this;
         addListener(event: "reset", listener: (context: Context) => void): this;
 
         emit(event: string | symbol, ...args: any[]): boolean;
+        emit(event: "close"): boolean;
+        emit(event: "line", input: string): boolean;
+        emit(event: "pause"): boolean;
+        emit(event: "resume"): boolean;
+        emit(event: "SIGCONT"): boolean;
+        emit(event: "SIGINT"): boolean;
+        emit(event: "SIGTSTP"): boolean;
         emit(event: "exit"): boolean;
         emit(event: "reset", context: Context): boolean;
 
         on(event: string, listener: (...args: any[]) => void): this;
+        on(event: "close", listener: () => void): this;
+        on(event: "line", listener: (input: string) => void): this;
+        on(event: "pause", listener: () => void): this;
+        on(event: "resume", listener: () => void): this;
+        on(event: "SIGCONT", listener: () => void): this;
+        on(event: "SIGINT", listener: () => void): this;
+        on(event: "SIGTSTP", listener: () => void): this;
         on(event: "exit", listener: () => void): this;
         on(event: "reset", listener: (context: Context) => void): this;
 
         once(event: string, listener: (...args: any[]) => void): this;
+        once(event: "close", listener: () => void): this;
+        once(event: "line", listener: (input: string) => void): this;
+        once(event: "pause", listener: () => void): this;
+        once(event: "resume", listener: () => void): this;
+        once(event: "SIGCONT", listener: () => void): this;
+        once(event: "SIGINT", listener: () => void): this;
+        once(event: "SIGTSTP", listener: () => void): this;
         once(event: "exit", listener: () => void): this;
         once(event: "reset", listener: (context: Context) => void): this;
 
         prependListener(event: string, listener: (...args: any[]) => void): this;
+        prependListener(event: "close", listener: () => void): this;
+        prependListener(event: "line", listener: (input: string) => void): this;
+        prependListener(event: "pause", listener: () => void): this;
+        prependListener(event: "resume", listener: () => void): this;
+        prependListener(event: "SIGCONT", listener: () => void): this;
+        prependListener(event: "SIGINT", listener: () => void): this;
+        prependListener(event: "SIGTSTP", listener: () => void): this;
         prependListener(event: "exit", listener: () => void): this;
         prependListener(event: "reset", listener: (context: Context) => void): this;
 
         prependOnceListener(event: string, listener: (...args: any[]) => void): this;
+        prependOnceListener(event: "close", listener: () => void): this;
+        prependOnceListener(event: "line", listener: (input: string) => void): this;
+        prependOnceListener(event: "pause", listener: () => void): this;
+        prependOnceListener(event: "resume", listener: () => void): this;
+        prependOnceListener(event: "SIGCONT", listener: () => void): this;
+        prependOnceListener(event: "SIGINT", listener: () => void): this;
+        prependOnceListener(event: "SIGTSTP", listener: () => void): this;
         prependOnceListener(event: "exit", listener: () => void): this;
         prependOnceListener(event: "reset", listener: (context: Context) => void): this;
     }
 
+    /**
+     * A flag passed in the REPL options. Evaluates expressions in sloppy mode.
+     */
+    export const REPL_MODE_SLOPPY: symbol; // TODO: unique symbol
+
+    /**
+     * A flag passed in the REPL options. Evaluates expressions in strict mode.
+     * This is equivalent to prefacing every repl statement with `'use strict'`.
+     */
+    export const REPL_MODE_STRICT: symbol; // TODO: unique symbol
+
+    /**
+     * Creates and starts a `repl.REPLServer` instance.
+     *
+     * @param options The options for the `REPLServer`. If `options` is a string, then it specifies
+     * the input prompt.
+     */
     function start(options?: string | ReplOptions): REPLServer;
 
+    /**
+     * Indicates a recoverable error that a `REPLServer` can use to support multi-line input.
+     *
+     * @see https://nodejs.org/dist/latest-v10.x/docs/api/repl.html#repl_recoverable_errors
+     */
     class Recoverable extends SyntaxError {
         err: Error;
 
@@ -2161,12 +2376,33 @@ declare module "readline" {
         shift?: boolean;
     }
 
-    interface ReadLine extends events.EventEmitter {
+    class Interface extends events.EventEmitter {
+        readonly terminal: boolean;
+
+        /**
+         * NOTE: According to the documentation:
+         *
+         * > Instances of the `readline.Interface` class are constructed using the
+         * > `readline.createInterface()` method.
+         *
+         * @see https://nodejs.org/dist/latest-v10.x/docs/api/readline.html#readline_class_interface
+         */
+        protected constructor(input: NodeJS.ReadableStream, output?: NodeJS.WritableStream, completer?: Completer | AsyncCompleter, terminal?: boolean);
+        /**
+         * NOTE: According to the documentation:
+         *
+         * > Instances of the `readline.Interface` class are constructed using the
+         * > `readline.createInterface()` method.
+         *
+         * @see https://nodejs.org/dist/latest-v10.x/docs/api/readline.html#readline_class_interface
+         */
+        protected constructor(options: ReadLineOptions);
+
         setPrompt(prompt: string): void;
         prompt(preserveCursor?: boolean): void;
         question(query: string, callback: (answer: string) => void): void;
-        pause(): ReadLine;
-        resume(): ReadLine;
+        pause(): this;
+        resume(): this;
         close(): void;
         write(data: string | Buffer, key?: Key): void;
 
@@ -2183,7 +2419,7 @@ declare module "readline" {
 
         addListener(event: string, listener: (...args: any[]) => void): this;
         addListener(event: "close", listener: () => void): this;
-        addListener(event: "line", listener: (input: any) => void): this;
+        addListener(event: "line", listener: (input: string) => void): this;
         addListener(event: "pause", listener: () => void): this;
         addListener(event: "resume", listener: () => void): this;
         addListener(event: "SIGCONT", listener: () => void): this;
@@ -2192,7 +2428,7 @@ declare module "readline" {
 
         emit(event: string | symbol, ...args: any[]): boolean;
         emit(event: "close"): boolean;
-        emit(event: "line", input: any): boolean;
+        emit(event: "line", input: string): boolean;
         emit(event: "pause"): boolean;
         emit(event: "resume"): boolean;
         emit(event: "SIGCONT"): boolean;
@@ -2201,7 +2437,7 @@ declare module "readline" {
 
         on(event: string, listener: (...args: any[]) => void): this;
         on(event: "close", listener: () => void): this;
-        on(event: "line", listener: (input: any) => void): this;
+        on(event: "line", listener: (input: string) => void): this;
         on(event: "pause", listener: () => void): this;
         on(event: "resume", listener: () => void): this;
         on(event: "SIGCONT", listener: () => void): this;
@@ -2210,7 +2446,7 @@ declare module "readline" {
 
         once(event: string, listener: (...args: any[]) => void): this;
         once(event: "close", listener: () => void): this;
-        once(event: "line", listener: (input: any) => void): this;
+        once(event: "line", listener: (input: string) => void): this;
         once(event: "pause", listener: () => void): this;
         once(event: "resume", listener: () => void): this;
         once(event: "SIGCONT", listener: () => void): this;
@@ -2219,7 +2455,7 @@ declare module "readline" {
 
         prependListener(event: string, listener: (...args: any[]) => void): this;
         prependListener(event: "close", listener: () => void): this;
-        prependListener(event: "line", listener: (input: any) => void): this;
+        prependListener(event: "line", listener: (input: string) => void): this;
         prependListener(event: "pause", listener: () => void): this;
         prependListener(event: "resume", listener: () => void): this;
         prependListener(event: "SIGCONT", listener: () => void): this;
@@ -2228,13 +2464,15 @@ declare module "readline" {
 
         prependOnceListener(event: string, listener: (...args: any[]) => void): this;
         prependOnceListener(event: "close", listener: () => void): this;
-        prependOnceListener(event: "line", listener: (input: any) => void): this;
+        prependOnceListener(event: "line", listener: (input: string) => void): this;
         prependOnceListener(event: "pause", listener: () => void): this;
         prependOnceListener(event: "resume", listener: () => void): this;
         prependOnceListener(event: "SIGCONT", listener: () => void): this;
         prependOnceListener(event: "SIGINT", listener: () => void): this;
         prependOnceListener(event: "SIGTSTP", listener: () => void): this;
     }
+
+    type ReadLine = Interface; // type forwarded for backwards compatiblity
 
     type Completer = (line: string) => CompleterResult;
     type AsyncCompleter = (line: string, callback: (err: any, result: CompleterResult) => void) => any;
@@ -2252,11 +2490,11 @@ declare module "readline" {
         removeHistoryDuplicates?: boolean;
     }
 
-    function createInterface(input: NodeJS.ReadableStream, output?: NodeJS.WritableStream, completer?: Completer | AsyncCompleter, terminal?: boolean): ReadLine;
-    function createInterface(options: ReadLineOptions): ReadLine;
+    function createInterface(input: NodeJS.ReadableStream, output?: NodeJS.WritableStream, completer?: Completer | AsyncCompleter, terminal?: boolean): Interface;
+    function createInterface(options: ReadLineOptions): Interface;
 
     function cursorTo(stream: NodeJS.WritableStream, x: number, y?: number): void;
-    function emitKeypressEvents(stream: NodeJS.ReadableStream, interface?: ReadLine): void;
+    function emitKeypressEvents(stream: NodeJS.ReadableStream, interface?: Interface): void;
     function moveCursor(stream: NodeJS.WritableStream, dx: number | string, dy: number | string): void;
     function clearLine(stream: NodeJS.WritableStream, dir: number): void;
     function clearScreenDown(stream: NodeJS.WritableStream): void;

--- a/types/node/node-tests.ts
+++ b/types/node/node-tests.ts
@@ -3644,15 +3644,31 @@ import * as p from "process";
         _server.clearBufferedCommand();
         _server.displayPrompt();
         _server.displayPrompt(true);
-        _server.defineCommand("cmd", text => {
+        _server.defineCommand("cmd", function(text) {
             // $ExpectType string
             text;
+            // $ExpectType REPLServer
+            this;
         });
         _server.defineCommand("cmd", {
             help: "",
-            action: text => {
+            action(text) {
                 // $ExpectType string
                 text;
+                // $ExpectType REPLServer
+                this;
+            }
+        });
+
+        repl.start({
+            eval() {
+                // $ExpectType REPLServer
+                this;
+            },
+            writer() {
+                // $ExpectType REPLServer
+                this;
+                return "";
             }
         });
 

--- a/types/node/v9/index.d.ts
+++ b/types/node/v9/index.d.ts
@@ -1881,8 +1881,9 @@ declare module "punycode" {
 }
 
 declare module "repl" {
-    import { ReadLine, Completer, AsyncCompleter } from "readline";
+    import { Interface, Completer, AsyncCompleter } from "readline";
     import { Context } from "vm";
+    import { InspectOptions } from "util";
 
     interface ReplOptions {
         /**
@@ -1903,7 +1904,8 @@ declare module "repl" {
         /**
          * If `true`, specifies that the output should be treated as a TTY terminal, and have
          * ANSI/VT100 escape codes written to it.
-         * Default: checking the value of the `isTTY` property on the output stream upon instantiation.
+         * Default: checking the value of the `isTTY` property on the output stream upon
+         * instantiation.
          */
         terminal?: boolean;
         /**
@@ -1911,8 +1913,11 @@ declare module "repl" {
          * Default: an async wrapper for the JavaScript `eval()` function. An `eval` function can
          * error with `repl.Recoverable` to indicate the input was incomplete and prompt for
          * additional lines.
+         *
+         * @see https://nodejs.org/dist/latest-v10.x/docs/api/repl.html#repl_default_evaluation
+         * @see https://nodejs.org/dist/latest-v10.x/docs/api/repl.html#repl_custom_evaluation_functions
          */
-        eval?: (evalCmd: string, context: Context, file: string, cb: (err: Error | null, result: any) => void) => void;
+        eval?: REPLEval;
         /**
          * If `true`, specifies that the default `writer` function should include ANSI color
          * styling to REPL output. If a custom `writer` function is provided then this has no
@@ -1935,16 +1940,26 @@ declare module "repl" {
         ignoreUndefined?: boolean;
         /**
          * The function to invoke to format the output of each command before writing to `output`.
-         * Default: `util.inspect()`.
+         * Default: a wrapper for `util.inspect`.
+         *
+         * @see https://nodejs.org/dist/latest-v10.x/docs/api/repl.html#repl_customizing_repl_output
          */
-        writer?: (obj: any) => string;
+        writer?: REPLWriter;
         /**
-         * An optional function used for custom Tab auto completion. See
-         * [`readline.InterfaceCompleter`](https://nodejs.org/dist/latest-v11.x/docs/api/readline.html#readline_use_of_the_completer_function)
-         * for an example.
+         * An optional function used for custom Tab auto completion.
+         *
+         * @see https://nodejs.org/dist/latest-v11.x/docs/api/readline.html#readline_use_of_the_completer_function
          */
         completer?: Completer | AsyncCompleter;
-        replMode?: any;
+        /**
+         * A flag that specifies whether the default evaluator executes all JavaScript commands in
+         * strict mode or default (sloppy) mode.
+         * Accepted values are:
+         * - `repl.REPL_MODE_SLOPPY` - evaluates expressions in sloppy mode.
+         * - `repl.REPL_MODE_STRICT` - evaluates expressions in strict mode. This is equivalent to
+         *   prefacing every repl statement with `'use strict'`.
+         */
+        replMode?: typeof REPL_MODE_SLOPPY | typeof REPL_MODE_STRICT;
         /**
          * Stop evaluating the current piece of code when `SIGINT` is received, i.e. `Ctrl+C` is
          * pressed. This cannot be used together with a custom `eval` function.
@@ -1952,6 +1967,17 @@ declare module "repl" {
          */
         breakEvalOnSigint?: boolean;
     }
+
+    type REPLEval = (this: REPLServer, evalCmd: string, context: Context, file: string, cb: (err: Error | null, result: any) => void) => void;
+    type REPLWriter = (this: REPLServer, obj: any) => string;
+
+    /**
+     * This is the default "writer" value, if none is passed in the REPL options,
+     * and it can be overridden by custom print functions.
+     */
+    const writer: REPLWriter & { options: InspectOptions };
+
+    type REPLCommandAction = (this: REPLServer, text: string) => void;
 
     interface REPLCommand {
         /**
@@ -1961,21 +1987,139 @@ declare module "repl" {
         /**
          * The function to execute, optionally accepting a single string argument.
          */
-        action: (this: REPLServer, text: string) => void;
+        action: REPLCommandAction;
     }
 
-    interface REPLServer extends ReadLine {
-        context: Context;
-        inputStream: NodeJS.ReadableStream;
-        outputStream: NodeJS.WritableStream;
+    /**
+     * Provides a customizable Read-Eval-Print-Loop (REPL).
+     *
+     * Instances of `repl.REPLServer` will accept individual lines of user input, evaluate those
+     * according to a user-defined evaluation function, then output the result. Input and output
+     * may be from `stdin` and `stdout`, respectively, or may be connected to any Node.js `stream`.
+     *
+     * Instances of `repl.REPLServer` support automatic completion of inputs, simplistic Emacs-style
+     * line editing, multi-line inputs, ANSI-styled output, saving and restoring current REPL session
+     * state, error recovery, and customizable evaluation functions.
+     *
+     * Instances of `repl.REPLServer` are created using the `repl.start()` method and _should not_
+     * be created directly using the JavaScript `new` keyword.
+     *
+     * @see https://nodejs.org/dist/latest-v10.x/docs/api/repl.html#repl_repl
+     */
+    class REPLServer extends Interface {
+        /**
+         * The `vm.Context` provided to the `eval` function to be used for JavaScript
+         * evaluation.
+         */
+        readonly context: Context;
+        /**
+         * The `Readable` stream from which REPL input will be read.
+         */
+        readonly inputStream: NodeJS.ReadableStream;
+        /**
+         * The `Writable` stream to which REPL output will be written.
+         */
+        readonly outputStream: NodeJS.WritableStream;
+        /**
+         * The commands registered via `replServer.defineCommand()`.
+         */
+        readonly commands: { readonly [name: string]: REPLCommand | undefined };
+        /**
+         * A value indicating whether the REPL is currently in "editor mode".
+         *
+         * @see https://nodejs.org/dist/latest-v10.x/docs/api/repl.html#repl_commands_and_special_keys
+         */
+        readonly editorMode: boolean;
+        /**
+         * A value indicating whether the `_` variable has been assigned.
+         *
+         * @see https://nodejs.org/dist/latest-v10.x/docs/api/repl.html#repl_assignment_of_the_underscore_variable
+         */
+        readonly underscoreAssigned: boolean;
+        /**
+         * The last evaluation result from the REPL (assigned to the `_` variable inside of the REPL).
+         *
+         * @see https://nodejs.org/dist/latest-v10.x/docs/api/repl.html#repl_assignment_of_the_underscore_variable
+         */
+        readonly last: any;
+        /**
+         * A value indicating whether the `_error` variable has been assigned.
+         *
+         * @since v9.8.0
+         * @see https://nodejs.org/dist/latest-v10.x/docs/api/repl.html#repl_assignment_of_the_underscore_variable
+         */
+        readonly underscoreErrAssigned: boolean;
+        /**
+         * The last error raised inside the REPL (assigned to the `_error` variable inside of the REPL).
+         *
+         * @since v9.8.0
+         * @see https://nodejs.org/dist/latest-v10.x/docs/api/repl.html#repl_assignment_of_the_underscore_variable
+         */
+        readonly lastError: any;
+        /**
+         * Specified in the REPL options, this is the function to be used when evaluating each
+         * given line of input. If not specified in the REPL options, this is an async wrapper
+         * for the JavaScript `eval()` function.
+         */
+        readonly eval: REPLEval;
+        /**
+         * Specified in the REPL options, this is a value indicating whether the default
+         * `writer` function should include ANSI color styling to REPL output.
+         */
+        readonly useColors: boolean;
+        /**
+         * Specified in the REPL options, this is a value indicating whether the default `eval`
+         * function will use the JavaScript `global` as the context as opposed to creating a new
+         * separate context for the REPL instance.
+         */
+        readonly useGlobal: boolean;
+        /**
+         * Specified in the REPL options, this is a value indicating whether the default `writer`
+         * function should output the result of a command if it evaluates to `undefined`.
+         */
+        readonly ignoreUndefined: boolean;
+        /**
+         * Specified in the REPL options, this is the function to invoke to format the output of
+         * each command before writing to `outputStream`. If not specified in the REPL options,
+         * this will be a wrapper for `util.inspect`.
+         */
+        readonly writer: REPLWriter;
+        /**
+         * Specified in the REPL options, this is the function to use for custom Tab auto-completion.
+         */
+        readonly completer: Completer | AsyncCompleter;
+        /**
+         * Specified in the REPL options, this is a flag that specifies whether the default `eval`
+         * function should execute all JavaScript commands in strict mode or default (sloppy) mode.
+         * Possible values are:
+         * - `repl.REPL_MODE_SLOPPY` - evaluates expressions in sloppy mode.
+         * - `repl.REPL_MODE_STRICT` - evaluates expressions in strict mode. This is equivalent to
+         *    prefacing every repl statement with `'use strict'`.
+         */
+        readonly replMode: typeof REPL_MODE_SLOPPY | typeof REPL_MODE_STRICT;
+
+        /**
+         * NOTE: According to the documentation:
+         *
+         * > Instances of `repl.REPLServer` are created using the `repl.start()` method and
+         * > _should not_ be created directly using the JavaScript `new` keyword.
+         *
+         * `REPLServer` cannot be subclassed due to implementation specifics in NodeJS.
+         *
+         * @see https://nodejs.org/dist/latest-v10.x/docs/api/repl.html#repl_class_replserver
+         */
+        private constructor();
 
         /**
          * Used to add new `.`-prefixed commands to the REPL instance. Such commands are invoked
          * by typing a `.` followed by the `keyword`.
+         *
          * @param keyword The command keyword (_without_ a leading `.` character).
          * @param cmd The function to invoke when the command is processed.
+         *
+         * @see https://nodejs.org/dist/latest-v10.x/docs/api/repl.html#repl_replserver_definecommand_keyword_cmd
          */
-        defineCommand(keyword: string, cmd: ((this: REPLServer, text: string) => void) | REPLCommand): void;
+        defineCommand(keyword: string, cmd: REPLCommandAction | REPLCommand): void;
         /**
          * Readies the REPL instance for input from the user, printing the configured `prompt` to a
          * new line in the `output` and resuming the `input` to accept new input.
@@ -2000,37 +2144,108 @@ declare module "repl" {
 
         /**
          * events.EventEmitter
-         * 1. exit
-         * 2. reset
+         * 1. close - inherited from `readline.Interface`
+         * 2. line - inherited from `readline.Interface`
+         * 3. pause - inherited from `readline.Interface`
+         * 4. resume - inherited from `readline.Interface`
+         * 5. SIGCONT - inherited from `readline.Interface`
+         * 6. SIGINT - inherited from `readline.Interface`
+         * 7. SIGTSTP - inherited from `readline.Interface`
+         * 8. exit
+         * 9. reset
          */
 
         addListener(event: string, listener: (...args: any[]) => void): this;
+        addListener(event: "close", listener: () => void): this;
+        addListener(event: "line", listener: (input: string) => void): this;
+        addListener(event: "pause", listener: () => void): this;
+        addListener(event: "resume", listener: () => void): this;
+        addListener(event: "SIGCONT", listener: () => void): this;
+        addListener(event: "SIGINT", listener: () => void): this;
+        addListener(event: "SIGTSTP", listener: () => void): this;
         addListener(event: "exit", listener: () => void): this;
         addListener(event: "reset", listener: (context: Context) => void): this;
 
         emit(event: string | symbol, ...args: any[]): boolean;
+        emit(event: "close"): boolean;
+        emit(event: "line", input: string): boolean;
+        emit(event: "pause"): boolean;
+        emit(event: "resume"): boolean;
+        emit(event: "SIGCONT"): boolean;
+        emit(event: "SIGINT"): boolean;
+        emit(event: "SIGTSTP"): boolean;
         emit(event: "exit"): boolean;
         emit(event: "reset", context: Context): boolean;
 
         on(event: string, listener: (...args: any[]) => void): this;
+        on(event: "close", listener: () => void): this;
+        on(event: "line", listener: (input: string) => void): this;
+        on(event: "pause", listener: () => void): this;
+        on(event: "resume", listener: () => void): this;
+        on(event: "SIGCONT", listener: () => void): this;
+        on(event: "SIGINT", listener: () => void): this;
+        on(event: "SIGTSTP", listener: () => void): this;
         on(event: "exit", listener: () => void): this;
         on(event: "reset", listener: (context: Context) => void): this;
 
         once(event: string, listener: (...args: any[]) => void): this;
+        once(event: "close", listener: () => void): this;
+        once(event: "line", listener: (input: string) => void): this;
+        once(event: "pause", listener: () => void): this;
+        once(event: "resume", listener: () => void): this;
+        once(event: "SIGCONT", listener: () => void): this;
+        once(event: "SIGINT", listener: () => void): this;
+        once(event: "SIGTSTP", listener: () => void): this;
         once(event: "exit", listener: () => void): this;
         once(event: "reset", listener: (context: Context) => void): this;
 
         prependListener(event: string, listener: (...args: any[]) => void): this;
+        prependListener(event: "close", listener: () => void): this;
+        prependListener(event: "line", listener: (input: string) => void): this;
+        prependListener(event: "pause", listener: () => void): this;
+        prependListener(event: "resume", listener: () => void): this;
+        prependListener(event: "SIGCONT", listener: () => void): this;
+        prependListener(event: "SIGINT", listener: () => void): this;
+        prependListener(event: "SIGTSTP", listener: () => void): this;
         prependListener(event: "exit", listener: () => void): this;
         prependListener(event: "reset", listener: (context: Context) => void): this;
 
         prependOnceListener(event: string, listener: (...args: any[]) => void): this;
+        prependOnceListener(event: "close", listener: () => void): this;
+        prependOnceListener(event: "line", listener: (input: string) => void): this;
+        prependOnceListener(event: "pause", listener: () => void): this;
+        prependOnceListener(event: "resume", listener: () => void): this;
+        prependOnceListener(event: "SIGCONT", listener: () => void): this;
+        prependOnceListener(event: "SIGINT", listener: () => void): this;
+        prependOnceListener(event: "SIGTSTP", listener: () => void): this;
         prependOnceListener(event: "exit", listener: () => void): this;
         prependOnceListener(event: "reset", listener: (context: Context) => void): this;
     }
 
+    /**
+     * A flag passed in the REPL options. Evaluates expressions in sloppy mode.
+     */
+    export const REPL_MODE_SLOPPY: symbol; // TODO: unique symbol
+
+    /**
+     * A flag passed in the REPL options. Evaluates expressions in strict mode.
+     * This is equivalent to prefacing every repl statement with `'use strict'`.
+     */
+    export const REPL_MODE_STRICT: symbol; // TODO: unique symbol
+
+    /**
+     * Creates and starts a `repl.REPLServer` instance.
+     *
+     * @param options The options for the `REPLServer`. If `options` is a string, then it specifies
+     * the input prompt.
+     */
     function start(options?: string | ReplOptions): REPLServer;
 
+    /**
+     * Indicates a recoverable error that a `REPLServer` can use to support multi-line input.
+     *
+     * @see https://nodejs.org/dist/latest-v10.x/docs/api/repl.html#repl_recoverable_errors
+     */
     class Recoverable extends SyntaxError {
         err: Error;
 
@@ -2042,7 +2257,7 @@ declare module "readline" {
     import * as events from "events";
     import * as stream from "stream";
 
-    export interface Key {
+    interface Key {
         sequence?: string;
         name?: string;
         ctrl?: boolean;
@@ -2050,12 +2265,33 @@ declare module "readline" {
         shift?: boolean;
     }
 
-    export interface ReadLine extends events.EventEmitter {
+    class Interface extends events.EventEmitter {
+        readonly terminal: boolean;
+
+        /**
+         * NOTE: According to the documentation:
+         *
+         * > Instances of the `readline.Interface` class are constructed using the
+         * > `readline.createInterface()` method.
+         *
+         * @see https://nodejs.org/dist/latest-v10.x/docs/api/readline.html#readline_class_interface
+         */
+        protected constructor(input: NodeJS.ReadableStream, output?: NodeJS.WritableStream, completer?: Completer | AsyncCompleter, terminal?: boolean);
+        /**
+         * NOTE: According to the documentation:
+         *
+         * > Instances of the `readline.Interface` class are constructed using the
+         * > `readline.createInterface()` method.
+         *
+         * @see https://nodejs.org/dist/latest-v10.x/docs/api/readline.html#readline_class_interface
+         */
+        protected constructor(options: ReadLineOptions);
+
         setPrompt(prompt: string): void;
         prompt(preserveCursor?: boolean): void;
         question(query: string, callback: (answer: string) => void): void;
-        pause(): ReadLine;
-        resume(): ReadLine;
+        pause(): this;
+        resume(): this;
         close(): void;
         write(data: string | Buffer, key?: Key): void;
 
@@ -2125,12 +2361,14 @@ declare module "readline" {
         prependOnceListener(event: "SIGTSTP", listener: () => void): this;
     }
 
+    type ReadLine = Interface; // type forwarded for backwards compatiblity
+
     type Completer = (line: string) => CompleterResult;
     type AsyncCompleter = (line: string, callback: (err: any, result: CompleterResult) => void) => any;
 
-    export type CompleterResult = [string[], string];
+    type CompleterResult = [string[], string];
 
-    export interface ReadLineOptions {
+    interface ReadLineOptions {
         input: NodeJS.ReadableStream;
         output?: NodeJS.WritableStream;
         completer?: Completer | AsyncCompleter;
@@ -2141,14 +2379,14 @@ declare module "readline" {
         removeHistoryDuplicates?: boolean;
     }
 
-    export function createInterface(input: NodeJS.ReadableStream, output?: NodeJS.WritableStream, completer?: Completer | AsyncCompleter, terminal?: boolean): ReadLine;
-    export function createInterface(options: ReadLineOptions): ReadLine;
+    function createInterface(input: NodeJS.ReadableStream, output?: NodeJS.WritableStream, completer?: Completer | AsyncCompleter, terminal?: boolean): Interface;
+    function createInterface(options: ReadLineOptions): Interface;
 
-    export function cursorTo(stream: NodeJS.WritableStream, x: number, y?: number): void;
-    export function emitKeypressEvents(stream: NodeJS.ReadableStream, interface?: ReadLine): void;
-    export function moveCursor(stream: NodeJS.WritableStream, dx: number | string, dy: number | string): void;
-    export function clearLine(stream: NodeJS.WritableStream, dir: number): void;
-    export function clearScreenDown(stream: NodeJS.WritableStream): void;
+    function cursorTo(stream: NodeJS.WritableStream, x: number, y?: number): void;
+    function emitKeypressEvents(stream: NodeJS.ReadableStream, interface?: Interface): void;
+    function moveCursor(stream: NodeJS.WritableStream, dx: number | string, dy: number | string): void;
+    function clearLine(stream: NodeJS.WritableStream, dir: number): void;
+    function clearScreenDown(stream: NodeJS.WritableStream): void;
 }
 
 declare module "vm" {

--- a/types/node/v9/node-tests.ts
+++ b/types/node/v9/node-tests.ts
@@ -3064,15 +3064,31 @@ namespace repl_tests {
         _server.clearBufferedCommand();
         _server.displayPrompt();
         _server.displayPrompt(true);
-        _server.defineCommand("cmd", text => {
+        _server.defineCommand("cmd", function(text) {
             // $ExpectType string
             text;
+            // $ExpectType REPLServer
+            this;
         });
         _server.defineCommand("cmd", {
             help: "",
-            action: text => {
+            action(text) {
                 // $ExpectType string
                 text;
+                // $ExpectType REPLServer
+                this;
+            }
+        });
+
+        repl.start({
+            eval() {
+                // $ExpectType REPLServer
+                this;
+            },
+            writer() {
+                // $ExpectType REPLServer
+                this;
+                return "";
             }
         });
 


### PR DESCRIPTION
This PR includes the following changes:
- **Adds additional members to `repl.REPLServer` instances.** These are properties that the underlying implementation copies from the `repl.ReplOptions` object and are useful for REPL implementers.
- **Changes `repl.REPLServer` to a `class` with a private constructor.** This better represents the underlying implementation, allows for `value instanceof repl.REPLServer` checks, and allows possible `repl.REPLServer.prototype` patching if necessary.
- **Adds missing events to `repl.REPLServer`.** The previous definition was missing events inherited from `readline.Interface`.
- **Adds the `REPL_MODE_SLOPPY` and `REPL_MODE_STRICT` exports.** These are the possible values for `repl.ReplOptions.replMode`. Ideally they would be typed as `unique symbol`, however that is not compatible with TypeScript 2.0. This will be resolved once #30477 has been merged.
- **Renames `readline.ReadLine` to `readline.Interface` and changes it to be a `class`.** This better represents the underlying implementation, allows for `value instanceof readline.Interface` checks, and allows possible `readline.Interface.prototype` patching if necessary.
- **Adds `readline.ReadLine` as a type alias to `readline.Interface`.** This type forwarding provides backwards compatibility for existing implementers.
- **Adds additional members to `readline.Interface` instances.** These are properties that the underlying implementation copies from the `readline.ReadLineOptions` object and are useful for REPL implementers.
- **Adds additional documentation.**

Please fill in this template:
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/dist/latest-v10.x/docs/api/repl.html
- [ ] ~Increase the version number in the header if appropriate.~
- [ ] ~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.~

