### PR TITLE
[node] second argument to process.emit() is optional when emitting signals

### DIFF
--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -711,7 +711,7 @@ declare namespace NodeJS {
     type UnhandledRejectionListener = (reason: any, promise: Promise<any>) => void;
     type WarningListener = (warning: Error) => void;
     type MessageListener = (message: any, sendHandle: any) => void;
-    type SignalsListener = (signal: Signals) => void;
+    type SignalsListener = (signal?: Signals) => void;
     type NewListenerListener = (type: string | symbol, listener: (...args: any[]) => void) => void;
     type RemoveListenerListener = (type: string | symbol, listener: (...args: any[]) => void) => void;
     type MultipleResolveListener = (type: MultipleResolveType, promise: Promise<any>, value: any) => void;
@@ -868,7 +868,7 @@ declare namespace NodeJS {
         emit(event: "unhandledRejection", reason: any, promise: Promise<any>): boolean;
         emit(event: "warning", warning: Error): boolean;
         emit(event: "message", message: any, sendHandle: any): this;
-        emit(event: Signals, signal: Signals): boolean;
+        emit(event: Signals, signal?: Signals): boolean;
         emit(event: "newListener", eventName: string | symbol, listener: (...args: any[]) => void): this;
         emit(event: "removeListener", eventName: string, listener: (...args: any[]) => void): this;
         emit(event: "multipleResolves", listener: MultipleResolveListener): this;

--- a/types/node/node-tests.ts
+++ b/types/node/node-tests.ts
@@ -3270,6 +3270,9 @@ import * as p from "process";
         process.once("removeListener", (event: string | symbol, listener: Function) => { });
         process.on("multipleResolves", (type: NodeJS.MultipleResolveType, prom: Promise<any>, value: any) => {});
 
+        process.emit("SIGTERM");
+        process.emit("SIGTERM", "SIGTERM");
+
         const listeners = process.listeners('uncaughtException');
         const oldHandler = listeners[listeners.length - 1];
         process.addListener('uncaughtException', oldHandler);


### PR DESCRIPTION
The types for `process.emit(<signal>)` were changed in #28352 to match the signature of the listener passed to `process.on(<signal>)` to make both non-optional. However, at runtime both are optional. This PR updates the types to reflect that.

```bash
$ cat emit-test.js
process.on('SIGTERM', (...args) => console.log(args.length, args));
process.emit('SIGTERM');
process.emit('SIGTERM', 'SIGTERM');

$ node emit-test.js
0 []
1 [ 'SIGTERM' ]
```

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/28352/commits/d860b0497aa40e04a33553e43f1485c8ccfd0943
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.