### PR TITLE
ssh2-streams: Fix casing in HostKey properties

### DIFF
--- a/types/ssh2-streams/index.d.ts
+++ b/types/ssh2-streams/index.d.ts
@@ -659,8 +659,8 @@ export interface HostKeys {
 }
 
 export interface HostKey {
-    privatekey: ParsedKey;
-    publickey: ParsedKey;
+    privateKey: ParsedKey;
+    publicKey: ParsedKey;
 }
 
 /**

--- a/types/ssh2-streams/ssh2-streams-tests.ts
+++ b/types/ssh2-streams/ssh2-streams-tests.ts
@@ -2,16 +2,17 @@ import * as stream from "stream";
 import * as ssh2 from "ssh2-streams";
 
 declare const SERVER_KEY: string;
-declare const HOST_KEYS: { 'ssh-rsa': ssh2.HostKey };
+declare const HOST_KEY: { publicKey: ssh2.ParsedKey; privateKey: ssh2.ParsedKey };
 declare const clientBufStream: stream.Transform & { buffer: string; };
 declare const serverBufStream: stream.Transform & { buffer: string; };
 declare const parsedKey: ssh2.ParsedKey;
 declare const prompts: ssh2.Prompt[];
 declare const buffer: Buffer;
 
+const hostKeys = { 'ssh-rsa': HOST_KEY };
 const algos = ['ssh-dss', 'ssh-rsa', 'ecdsa-sha2-nistp521'];
 const client = new ssh2.SSH2Stream({ algorithms: { serverHostKey: algos } });
-const server = new ssh2.SSH2Stream({ server: true, hostKeys: HOST_KEYS });
+const server = new ssh2.SSH2Stream({ server: true, hostKeys: hostKeys });
 
 client
     .pipe(server)


### PR DESCRIPTION
Provided HostKey interface has `privatekey` and `publickey` properties (lowercase), but it should be written in camel case: `privateKey` and `publicKey`.

Test has been also enhanced to catch this issue.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/mscdex/ssh2-streams/blob/master/lib/ssh.js
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
