### PR TITLE
Add dom-mediacapture-record type definitions

### DIFF
--- a/types/dom-mediacapture-record/dom-mediacapture-record-tests.ts
+++ b/types/dom-mediacapture-record/dom-mediacapture-record-tests.ts
@@ -40,8 +40,8 @@ recorder.requestData();
 const state: RecordingState = recorder.state;
 const isRecording = state === 'recording';
 
-recorder.addEventListener('dataavailable', onDataAvailable);
-recorder.removeEventListener('dataavailable', onDataAvailable);
+recorder.addEventListener('start', onEvent);
+recorder.removeEventListener('start', onEvent);
 recorder.dispatchEvent(blobEvent);
 
 recorder.ondataavailable = onDataAvailable;

--- a/types/dom-mediacapture-record/dom-mediacapture-record-tests.ts
+++ b/types/dom-mediacapture-record/dom-mediacapture-record-tests.ts
@@ -1,0 +1,53 @@
+const isWebmSupported: boolean = window.MediaRecorder.isTypeSupported(
+    'video/webm'
+);
+
+const mediaStream = new MediaStream();
+
+const mediaRecorderOptions: MediaRecorderOptions = {
+    mimeType: 'video/webm',
+    audioBitsPerSecond: 1000000,
+    videoBitsPerSecond: 4000000
+};
+
+const blobEvent = new BlobEvent('dataavailable', {
+    data: new Blob(),
+    bubbles: false
+});
+const errorEvent = new MediaRecorderErrorEvent('error', {
+    error: new DOMException(),
+    bubbles: false
+});
+
+const onDataAvailable = (event: BlobEvent) => {
+    const blobType = event.data.type;
+};
+
+const onError = (event: MediaRecorderErrorEvent) => {
+    const errorMessage = event.error.message;
+};
+
+const onEvent = (event: Event) => {};
+
+let recorder = new window.MediaRecorder(mediaStream);
+recorder = new MediaRecorder(mediaStream, mediaRecorderOptions);
+
+recorder.start();
+recorder.stop();
+recorder.start(1000);
+recorder.pause();
+recorder.requestData();
+const state: RecordingState = recorder.state;
+const isRecording = state === 'recording';
+
+recorder.addEventListener('dataavailable', onDataAvailable);
+recorder.removeEventListener('dataavailable', onDataAvailable);
+recorder.dispatchEvent(blobEvent);
+
+recorder.ondataavailable = onDataAvailable;
+recorder.ondataavailable = onEvent;
+recorder.onerror = onError;
+recorder.onpause = onEvent;
+recorder.onresume = onEvent;
+recorder.onstart = onEvent;
+recorder.onstop = onEvent;

--- a/types/dom-mediacapture-record/index.d.ts
+++ b/types/dom-mediacapture-record/index.d.ts
@@ -41,10 +41,10 @@ declare class MediaRecorder extends EventTarget {
 
     ondataavailable: (event: BlobEvent) => void;
     onerror: (event: MediaRecorderErrorEvent) => void;
-    onpause: (event: Event) => void;
-    onresume: (event: Event) => void;
-    onstart: (event: Event) => void;
-    onstop: (event: Event) => void;
+    onpause: EventListener;
+    onresume: EventListener;
+    onstart: EventListener;
+    onstop: EventListener;
 
     constructor(stream: MediaStream, options?: MediaRecorderOptions);
 

--- a/types/dom-mediacapture-record/index.d.ts
+++ b/types/dom-mediacapture-record/index.d.ts
@@ -1,0 +1,64 @@
+// Type definitions for w3c MediaStream Recording (Editor’s Draft, 7 November 2018)
+// Project: https://w3c.github.io/mediacapture-record
+// Definitions by: Elias Meire <https://github.com/eliasmeire>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare interface MediaRecorderErrorEventInit extends EventInit {
+    error: DOMException;
+}
+
+declare class MediaRecorderErrorEvent extends Event {
+    constructor(type: string, eventInitDict: MediaRecorderErrorEventInit);
+    readonly error: DOMException;
+}
+
+declare interface BlobEventInit extends EventInit {
+    data: Blob;
+    timecode?: DOMHighResTimeStamp;
+}
+
+declare class BlobEvent extends Event {
+    constructor(type: string, eventInitDict: BlobEventInit);
+    readonly data: Blob;
+    readonly timecode: DOMHighResTimeStamp;
+}
+
+declare interface MediaRecorderOptions {
+    mimeType?: string;
+    audioBitsPerSecond?: number;
+    videoBitsPerSecond?: number;
+    bitsPerSecond?: number;
+}
+
+declare type RecordingState = 'inactive' | 'recording' | 'paused';
+
+declare class MediaRecorder extends EventTarget {
+    readonly stream: MediaStream;
+    readonly mimeType: string;
+    readonly state: RecordingState;
+    readonly videoBitsPerSecond: number;
+    readonly audioBitsPerSecond: number;
+
+    ondataavailable: (event: BlobEvent) => void;
+    onerror: (event: MediaRecorderErrorEvent) => void;
+    onpause: (event: Event) => void;
+    onresume: (event: Event) => void;
+    onstart: (event: Event) => void;
+    onstop: (event: Event) => void;
+
+    constructor(stream: MediaStream, options?: MediaRecorderOptions);
+
+    start(timeslice?: number): void;
+    stop(): void;
+    resume(): void;
+    pause(): void;
+    requestData(): void;
+
+    static isTypeSupported(type: string): boolean;
+}
+
+interface Window {
+    MediaRecorder: typeof MediaRecorder;
+    BlobEvent: typeof BlobEvent;
+    MediaRecorderErrorEvent: typeof MediaRecorderErrorEvent;
+}

--- a/types/dom-mediacapture-record/index.d.ts
+++ b/types/dom-mediacapture-record/index.d.ts
@@ -1,9 +1,9 @@
-// Type definitions for w3c MediaStream Recording (Editor’s Draft, 7 November 2018)
+// Type definitions for w3c MediaStream Recording 1.0
 // Project: https://w3c.github.io/mediacapture-record
 // Definitions by: Elias Meire <https://github.com/eliasmeire>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare interface MediaRecorderErrorEventInit extends EventInit {
+interface MediaRecorderErrorEventInit extends EventInit {
     error: DOMException;
 }
 
@@ -12,25 +12,25 @@ declare class MediaRecorderErrorEvent extends Event {
     readonly error: DOMException;
 }
 
-declare interface BlobEventInit extends EventInit {
+interface BlobEventInit extends EventInit {
     data: Blob;
-    timecode?: DOMHighResTimeStamp;
+    timecode?: number;
 }
 
 declare class BlobEvent extends Event {
     constructor(type: string, eventInitDict: BlobEventInit);
     readonly data: Blob;
-    readonly timecode: DOMHighResTimeStamp;
+    readonly timecode: number;
 }
 
-declare interface MediaRecorderOptions {
+interface MediaRecorderOptions {
     mimeType?: string;
     audioBitsPerSecond?: number;
     videoBitsPerSecond?: number;
     bitsPerSecond?: number;
 }
 
-declare type RecordingState = 'inactive' | 'recording' | 'paused';
+type RecordingState = 'inactive' | 'recording' | 'paused';
 
 declare class MediaRecorder extends EventTarget {
     readonly stream: MediaStream;

--- a/types/dom-mediacapture-record/tsconfig.json
+++ b/types/dom-mediacapture-record/tsconfig.json
@@ -5,6 +5,7 @@
         "noImplicitAny": true,
         "noImplicitThis": true,
         "strictNullChecks": true,
+        "strictFunctionTypes": true,
         "baseUrl": "../",
         "typeRoots": ["../"],
         "types": [],

--- a/types/dom-mediacapture-record/tsconfig.json
+++ b/types/dom-mediacapture-record/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6", "dom"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": false,
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": ["index.d.ts", "dom-mediacapture-record-tests.ts"]
+}

--- a/types/dom-mediacapture-record/tsconfig.json
+++ b/types/dom-mediacapture-record/tsconfig.json
@@ -5,7 +5,7 @@
         "noImplicitAny": true,
         "noImplicitThis": true,
         "strictNullChecks": true,
-        "strictFunctionTypes": false,
+        "strictFunctionTypes": true,
         "baseUrl": "../",
         "typeRoots": ["../"],
         "types": [],

--- a/types/dom-mediacapture-record/tsconfig.json
+++ b/types/dom-mediacapture-record/tsconfig.json
@@ -5,7 +5,6 @@
         "noImplicitAny": true,
         "noImplicitThis": true,
         "strictNullChecks": true,
-        "strictFunctionTypes": false,
         "baseUrl": "../",
         "typeRoots": ["../"],
         "types": [],

--- a/types/dom-mediacapture-record/tsconfig.json
+++ b/types/dom-mediacapture-record/tsconfig.json
@@ -5,7 +5,7 @@
         "noImplicitAny": true,
         "noImplicitThis": true,
         "strictNullChecks": true,
-        "strictFunctionTypes": true,
+        "strictFunctionTypes": false,
         "baseUrl": "../",
         "typeRoots": ["../"],
         "types": [],

--- a/types/dom-mediacapture-record/tslint.json
+++ b/types/dom-mediacapture-record/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "dtslint/dt.json"
+}


### PR DESCRIPTION
This PR adds type definitions for the MediaStream Recording w3c draft: https://w3c.github.io/mediacapture-record/ 

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
