### PR TITLE
Add types for follow-redirects

### DIFF
--- a/types/follow-redirects/follow-redirects-tests.ts
+++ b/types/follow-redirects/follow-redirects-tests.ts
@@ -1,0 +1,32 @@
+import { http, https } from 'follow-redirects';
+
+http.request({
+    host: 'localhost',
+    path: '/a/b',
+    port: 8000,
+    maxRedirects: 12,
+}, (response) => {
+    console.log(response.responseUrl, response.redirects);
+    response.on('data', (chunk) => {
+        console.log(chunk);
+    });
+}).on('error', (err) => {
+    console.error(err);
+});
+
+http.get('http://bit.ly/900913', (response) => {
+    response.on('data', (chunk) => {
+        console.log(chunk);
+    });
+}).on('error', (err) => {
+    console.error(err);
+});
+
+https.get('http://bit.ly/900913', (response) => {
+    console.log(response.responseUrl, response.redirects);
+    response.on('data', (chunk) => {
+        console.log(chunk);
+    });
+}).on('error', (err: Error) => {
+    console.error(err);
+});

--- a/types/follow-redirects/http.d.ts
+++ b/types/follow-redirects/http.d.ts
@@ -1,0 +1,3 @@
+import { http } from '.';
+
+export = http;

--- a/types/follow-redirects/https.d.ts
+++ b/types/follow-redirects/https.d.ts
@@ -1,0 +1,3 @@
+import { https } from '.';
+
+export = https;

--- a/types/follow-redirects/index.d.ts
+++ b/types/follow-redirects/index.d.ts
@@ -1,0 +1,118 @@
+// Type definitions for follow-redirects 1.5
+// Project: https://github.com/olalonde/follow-redirects
+// Definitions by: Emily Klassen <https://github.com/forivall>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.8
+
+/// <reference types="node" />
+
+import * as coreHttp from 'http';
+import * as coreHttps from 'https';
+import { Writable } from 'stream';
+
+export interface WrappableRequest {
+    getHeader?(...args: any[]): any;
+    setHeader(...args: any[]): any;
+    removeHeader(...args: any[]): any;
+
+    abort?(...args: any[]): any;
+    flushHeaders?(...args: any[]): any;
+    setNoDelay?(...args: any[]): any;
+    setSocketKeepAlive?(...args: any[]): any;
+    setTimeout?(...args: any[]): any;
+}
+export interface WrappableResponse {
+    statusCode?: number;
+    headers: {
+        location?: string
+    };
+    destroy(): any;
+}
+
+export interface Scheme<Options, Request extends WrappableRequest, Response> {
+    request(options: Options, callback?: (res: Response) => any): Request;
+}
+
+export interface RedirectableRequest<Request extends WrappableRequest, Response> extends Writable {
+    setHeader: Request['setHeader'];
+    removeHeader: Request['removeHeader'];
+    abort: Request['abort'];
+    flushHeaders: Request['flushHeaders'];
+    getHeader: Request['getHeader'];
+    setNoDelay: Request['setNoDelay'];
+    setSocketKeepAlive: Request['setSocketKeepAlive'];
+    setTimeout: Request['setTimeout'];
+
+    addListener(event: string, listener: (...args: any[]) => void): this;
+    addListener(event: "response", listener: (response: Response) => void): this;
+    addListener(event: "error", listener: (err: Error) => void): this;
+
+    emit(event: string | symbol, ...args: any[]): boolean;
+    emit(event: "response", response: Response): boolean;
+    emit(event: "error", err: Error): boolean;
+
+    on(event: string, listener: (...args: any[]) => void): this;
+    on(event: "response", listener: (response: Response) => void): this;
+    on(event: "error", listener: (err: Error) => void): this;
+
+    once(event: string, listener: (...args: any[]) => void): this;
+    once(event: "response", listener: (response: Response) => void): this;
+    once(event: "error", listener: (err: Error) => void): this;
+
+    prependListener(event: string, listener: (...args: any[]) => void): this;
+    prependListener(event: "response", listener: (response: Response) => void): this;
+    prependListener(event: "error", listener: (err: Error) => void): this;
+
+    prependOnceListener(event: string, listener: (...args: any[]) => void): this;
+    prependOnceListener(event: "response", listener: (response: Response) => void): this;
+    prependOnceListener(event: "error", listener: (err: Error) => void): this;
+}
+
+export interface RedirectScheme<Options, Request extends WrappableRequest, Response> {
+    request(
+        options: string | Options & FollowOptions,
+        callback?: (res: Response & FollowResponse) => void
+    ): RedirectableRequest<Request, Response>;
+    get(
+        options: string | Options & FollowOptions,
+        callback?: (res: Response & FollowResponse) => void
+    ): RedirectableRequest<Request, Response>;
+}
+
+export type Override<T, U> = Pick<T, Exclude<keyof T, keyof U>> & U;
+export interface FollowOptions {
+    maxRedirects?: number;
+    maxBodyLength?: number;
+}
+
+export interface FollowResponse {
+    responseUrl: string;
+    redirects: Redirect[];
+}
+
+export interface Redirect {
+    url: string;
+    headers: coreHttp.IncomingHttpHeaders;
+    statusCode: number;
+}
+
+export const http: Override<typeof coreHttp, RedirectScheme<
+    coreHttp.RequestOptions,
+    coreHttp.ClientRequest,
+    coreHttp.IncomingMessage
+>>;
+export const https: Override<typeof coreHttps, RedirectScheme<
+    coreHttps.RequestOptions,
+    coreHttp.ClientRequest,
+    coreHttp.IncomingMessage
+>>;
+
+export type WrappedScheme<T extends Scheme<any, any, any>> = Override<T, RedirectScheme<
+    T extends Scheme<infer Options, any, any> ? Options : never,
+    T extends Scheme<any, infer Request, any> ? Request : never,
+    T extends Scheme<any, any, infer Response> ? Response : never
+>>;
+
+export function wrap<T extends {[key: string]: Scheme<any, any, any>}>(protocols: T): {
+    [K in keyof T]: WrappedScheme<T[K]>
+};

--- a/types/follow-redirects/tsconfig.json
+++ b/types/follow-redirects/tsconfig.json
@@ -1,0 +1,25 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "http.d.ts",
+        "https.d.ts",
+        "follow-redirects-tests.ts"
+    ]
+}

--- a/types/follow-redirects/tslint.json
+++ b/types/follow-redirects/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
