### PR TITLE
[react-table] Remove unnecessary import from tests

### DIFF
--- a/types/react-table/react-table-tests.tsx
+++ b/types/react-table/react-table-tests.tsx
@@ -3,7 +3,6 @@ import * as ReactDOM from 'react-dom';
 
 // Import React Table
 import ReactTable, { Column, FinalState, Instance } from "react-table";
-import "react-table/react-table.css";
 
 interface Data {
   firstName: string;


### PR DESCRIPTION
The import of a ".css" file was resulting in test failures in other PRs.