### PR TITLE
Add types for promise-memoize

### DIFF
--- a/types/promise-memoize/index.d.ts
+++ b/types/promise-memoize/index.d.ts
@@ -8,7 +8,9 @@ export = promiseMemoize;
 
 declare function promiseMemoize<T extends (...args: any[]) => PromiseLike<any>>(
     fn: T, options?: promiseMemoize.Options
-): T;
+): T & {
+    clear(): void;
+};
 
 declare namespace promiseMemoize {
     interface Options {
@@ -17,6 +19,4 @@ declare namespace promiseMemoize {
         resolve?: KeyResolver;
     }
     type KeyResolver = 'simple' | 'json' | ((args: any[]) => any) | ReadonlyArray<'json' | ((arg: any) => any)>;
-
-    function clear(): void;
 }

--- a/types/promise-memoize/index.d.ts
+++ b/types/promise-memoize/index.d.ts
@@ -1,0 +1,22 @@
+// Type definitions for promise-memoize 1.2
+// Project: https://github.com/nodeca/promise-memoize#readme
+// Definitions by: Emily Marigold Klassen <https://github.com/forivall>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.1
+
+export = promiseMemoize;
+
+declare function promiseMemoize<T extends (...args: any[]) => PromiseLike<any>>(
+    fn: T, options?: promiseMemoize.Options
+): T;
+
+declare namespace promiseMemoize {
+    interface Options {
+        maxAge?: number;
+        maxErrorAge?: number;
+        resolve?: KeyResolver;
+    }
+    type KeyResolver = 'simple' | 'json' | ((args: any[]) => any) | ReadonlyArray<'json' | ((arg: any) => any)>;
+
+    function clear(): void;
+}

--- a/types/promise-memoize/promise-memoize-tests.ts
+++ b/types/promise-memoize/promise-memoize-tests.ts
@@ -1,0 +1,12 @@
+import promiseMemoize = require('promise-memoize');
+
+async function lastPosts(n: number) {
+    return n + 1;
+}
+
+const cachedLastPosts = promiseMemoize(lastPosts, {maxAge: 60000});
+
+// Later...
+cachedLastPosts(10).then(posts => {
+    posts;
+});

--- a/types/promise-memoize/promise-memoize-tests.ts
+++ b/types/promise-memoize/promise-memoize-tests.ts
@@ -10,3 +10,5 @@ const cachedLastPosts = promiseMemoize(lastPosts, {maxAge: 60000});
 cachedLastPosts(10).then(posts => {
     posts;
 });
+
+cachedLastPosts.clear();

--- a/types/promise-memoize/tsconfig.json
+++ b/types/promise-memoize/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "promise-memoize-tests.ts"
+    ]
+}

--- a/types/promise-memoize/tslint.json
+++ b/types/promise-memoize/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
