### PR TITLE
Add types for is-obj and is-regexp

### DIFF
--- a/types/is-obj/index.d.ts
+++ b/types/is-obj/index.d.ts
@@ -1,0 +1,9 @@
+// Type definitions for is-obj 1.0
+// Project: https://github.com/sindresorhus/is-obj#readme
+// Definitions by: Emily Marigold Klassen <https://github.com/forivall>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.2
+
+export = isObj;
+
+declare function isObj(x: any): x is object;

--- a/types/is-obj/is-obj-tests.ts
+++ b/types/is-obj/is-obj-tests.ts
@@ -1,0 +1,10 @@
+import isObj = require('is-obj');
+
+isObj({foo: 'bar'});
+// => true
+
+isObj([1, 2, 3]);
+// => true
+
+isObj('foo');
+// => false

--- a/types/is-obj/tsconfig.json
+++ b/types/is-obj/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "is-obj-tests.ts"
+    ]
+}

--- a/types/is-obj/tslint.json
+++ b/types/is-obj/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/is-regexp/index.d.ts
+++ b/types/is-regexp/index.d.ts
@@ -1,0 +1,9 @@
+// Type definitions for is-regexp 2.0
+// Project: https://github.com/sindresorhus/is-regexp#readme
+// Definitions by: Emily Marigold Klassen <https://github.com/forivall>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.2
+
+export = isRegexp;
+
+declare function isRegexp(input: any): input is RegExp;

--- a/types/is-regexp/is-regexp-tests.ts
+++ b/types/is-regexp/is-regexp-tests.ts
@@ -1,0 +1,10 @@
+import isRegexp = require('is-regexp');
+
+isRegexp('unicorn');
+// => false
+
+isRegexp(/unicorn/);
+// => true
+
+isRegexp(new RegExp('unicorn'));
+// => true

--- a/types/is-regexp/tsconfig.json
+++ b/types/is-regexp/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "is-regexp-tests.ts"
+    ]
+}

--- a/types/is-regexp/tslint.json
+++ b/types/is-regexp/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
My apologies if this should have been two separate PRs. They're very similar modules.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
