### PR TITLE
Add types for sort-object-keys

### DIFF
--- a/types/sort-object-keys/index.d.ts
+++ b/types/sort-object-keys/index.d.ts
@@ -1,0 +1,12 @@
+// Type definitions for sort-object-keys 1.1
+// Project: https://github.com/keithamus/sort-object-keys#readme
+// Definitions by: Emily Marigold Klassen <https://github.com/forivall>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.1
+
+export = sortObjectByKeyNameList;
+
+declare function sortObjectByKeyNameList<T>(
+    object: T,
+    sortWith?: ReadonlyArray<keyof T> | ((a: keyof T, b: keyof T) => number)
+): T;

--- a/types/sort-object-keys/sort-object-keys-tests.ts
+++ b/types/sort-object-keys/sort-object-keys-tests.ts
@@ -1,0 +1,44 @@
+import assert = require('assert');
+import sortObject = require('sort-object-keys');
+
+assert.equal(JSON.stringify({
+    c: 1,
+    b: 1,
+    d: 1,
+    a: 1,
+}), JSON.stringify({
+    a: 1,
+    b: 1,
+    c: 1,
+    d: 1,
+}));
+
+assert.equal(JSON.stringify(sortObject({
+    c: 1,
+    b: 1,
+    d: 1,
+    a: 1,
+}, ['b', 'a', 'd', 'c'])), JSON.stringify({
+    b: 1,
+    a: 1,
+    d: 1,
+    c: 1,
+}));
+
+function removeKeyAncCompareIndex(keyA: string, keyB: string) {
+    const a = parseInt(keyA.slice(4), 10);
+    const b = parseInt(keyB.slice(4), 10);
+    return a - b;
+}
+
+assert.equal(JSON.stringify(sortObject({
+    "key-1": 1,
+    "key-3": 1,
+    "key-10": 1,
+    "key-2": 1,
+}, removeKeyAncCompareIndex)), JSON.stringify({
+    "key-1": 1,
+    "key-2": 1,
+    "key-3": 1,
+    "key-10": 1,
+}));

--- a/types/sort-object-keys/tsconfig.json
+++ b/types/sort-object-keys/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "sort-object-keys-tests.ts"
+    ]
+}

--- a/types/sort-object-keys/tslint.json
+++ b/types/sort-object-keys/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
