### PR TITLE
@types/graphql-relay: Proper type definition for Relay connection args

### DIFF
--- a/types/graphql-relay/graphql-relay-tests.ts
+++ b/types/graphql-relay/graphql-relay-tests.ts
@@ -11,6 +11,7 @@ import {
     GraphQLInputFieldConfigMap,
     GraphQLNonNull,
     GraphQLID,
+    GraphQLInt
 } from "graphql";
 import {
     // Connections
@@ -30,18 +31,19 @@ import {
     // Mutations
     mutationWithClientMutationId,
 } from "graphql-relay";
+
 // Connections
 // connectionArgs returns the arguments that fields should provide when they return a connection type that supports bidirectional pagination.
-connectionArgs.first = 10;
-connectionArgs.after = "a";
-connectionArgs.before = "b";
-connectionArgs.last = 10;
+connectionArgs.first = { type: GraphQLInt };
+connectionArgs.after = { type: GraphQLString };
+connectionArgs.before = { type: GraphQLString };
+connectionArgs.last = { type: GraphQLInt };
 // forwardConnectionArgs returns the arguments that fields should provide when they return a connection type that only supports forward pagination.
-forwardConnectionArgs.after = "a";
-forwardConnectionArgs.first = 10;
+forwardConnectionArgs.after = { type: GraphQLString };
+forwardConnectionArgs.first = { type: GraphQLInt };
 // backwardConnectionArgs returns the arguments that fields should provide when they return a connection type that only supports backward pagination.
-backwardConnectionArgs.before = "b";
-backwardConnectionArgs.last = 10;
+backwardConnectionArgs.before = { type: GraphQLString };
+backwardConnectionArgs.last = { type: GraphQLInt };
 // connectionDefinitions returns a connectionType and its associated edgeType, given a node type.
 const resolve: GraphQLFieldResolver<any, any> = (source, args, context, info) => {
     context.flag = "f";

--- a/types/graphql-relay/index.d.ts
+++ b/types/graphql-relay/index.d.ts
@@ -34,27 +34,20 @@ import {
  * whose return type is a connection type with forward pagination.
  */
 export interface ForwardConnectionArgs {
-    after?: ConnectionCursor | null;
-    first?: number | null;
+    after: { type: GraphQLScalarType };
+    first: { type: GraphQLScalarType };
 }
-export const forwardConnectionArgs: GraphQLFieldConfigArgumentMap & {
-    after?: ConnectionCursor | null;
-    first?: number | null;
-};
+export const forwardConnectionArgs: GraphQLFieldConfigArgumentMap & ForwardConnectionArgs;
 
 /**
  * Returns a GraphQLFieldConfigArgumentMap appropriate to include on a field
  * whose return type is a connection type with backward pagination.
  */
 export interface BackwardConnectionArgs {
-    before?: ConnectionCursor | null;
-    last?: number | null;
+    before: { type: GraphQLScalarType };
+    last: { type: GraphQLScalarType };
 }
-export const backwardConnectionArgs: GraphQLFieldConfigArgumentMap & {
-    before?: ConnectionCursor | null;
-    last?: number | null;
-};
-
+export const backwardConnectionArgs: GraphQLFieldConfigArgumentMap & BackwardConnectionArgs;
 /**
  * Returns a GraphQLFieldConfigArgumentMap appropriate to include on a field
  * whose return type is a connection type with bidirectional pagination.


### PR DESCRIPTION
In the [`graphql-relay` implementation](https://github.com/graphql/graphql-relay-js/blob/da2801ab9e64006b1e41bcdb28c889799ee5c170/src/connection/connection.js#L30-L59), `forwardConnectionArgs`, `backwardConnectionArgs` and `connectionArgs` refer to the argument's GraphQL schema definition instead of the argument structured when used in a GraphQL query. Fixing these definition to match the implementation.

Tagging previous contributors (@ravishivt, @roballsopp, @joonhocho, @sibelius) for review 🙏 