### PR TITLE
fix(prettier): add missing options

### DIFF
--- a/types/prettier/index.d.ts
+++ b/types/prettier/index.d.ts
@@ -52,6 +52,10 @@ export interface RequiredOptions extends doc.printer.Options {
      */
     singleQuote: boolean;
     /**
+     * Use single quotes in JSX.
+     */
+    jsxSingleQuote: boolean;
+    /**
      * Print trailing commas wherever possible.
      */
     trailingComma: 'none' | 'es5' | 'all';
@@ -108,6 +112,14 @@ export interface RequiredOptions extends doc.printer.Options {
      * The plugin API is in a beta state.
      */
     plugins: Array<string | Plugin>;
+    /**
+     * How to handle whitespaces in HTML.
+     */
+    htmlWhitespaceSensitivity: 'css' | 'strict' | 'ignore';
+    /**
+     * Which end of line characters to apply.
+     */
+    endOfLine: 'auto' | 'lf' | 'crlf' | 'cr';
 }
 
 export interface ParserOptions extends RequiredOptions {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - [htmlWhitespaceSensitivity](https://prettier.io/blog/2018/11/07/1.15.0.html#whitespace-sensitive-formatting)
  - [jsxSingleQuote](https://prettier.io/blog/2018/11/07/1.15.0.html#option-to-use-single-quotes-in-jsx-4798-by-smirea)
  - [endOfLine](https://prettier.io/blog/2018/11/07/1.15.0.html#add-an-option-to-enforce-line-endings-5327-by-kachkaev)
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.