### PR TITLE
[@types/mongo-sanitize] Let input not extend object

### DIFF
--- a/types/mongo-sanitize/index.d.ts
+++ b/types/mongo-sanitize/index.d.ts
@@ -4,6 +4,6 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
-export function sanitize<T extends object>(v: T): T;
+export function sanitize<T>(v: T): T;
 
 export as namespace mongoSanitize;


### PR DESCRIPTION
`mongo-sanitize` takes any value as input, but only processes objects, returning the value unchanged if it's not an object. Relevant code below:

```javascript
module.exports = function(v) {
  if (v instanceof Object) {
    for (var key in v) {
      if (/^\$/.test(key)) {
        delete v[key];
      }
    }
  }
  return v;
};
```

See also from https://github.com/vkarpov15/mongo-sanitize/blob/master/index.js#L2

