### PR TITLE
Add non-singleton version of yargs, and other things used by lerna

### DIFF
--- a/types/yargs/v11/index.d.ts
+++ b/types/yargs/v11/index.d.ts
@@ -5,6 +5,7 @@
 //                 Jeffery Grajkowski <https://github.com/pushplay>
 //                 Jeff Kenney <https://github.com/jeffkenney>
 //                 Jimi (Dimitris) Charalampidis <https://github.com/JimiC>
+//                 Emily Marigold Klassen <https://github.com/forivall>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
@@ -31,6 +32,8 @@ declare namespace yargs {
         alias(aliases: { [shortName: string]: string | string[] }): Argv;
 
         argv: Arguments;
+
+        parsed: DetailedArguments | false;
 
         array(key: string | string[]): Argv;
 
@@ -105,6 +108,8 @@ declare namespace yargs {
         epilogue(msg: string): Argv;
 
         example(command: string, description: string): Argv;
+
+        exit(code: number, err: Error): void;
 
         exitProcess(enabled: boolean): Argv;
 
@@ -231,6 +236,28 @@ declare namespace yargs {
         $0: string;
         /** All remaining options */
         [argName: string]: any;
+    }
+
+    interface DetailedArguments {
+        argv: Arguments;
+        error: Error | null;
+        aliases: {[alias: string]: string[]};
+        newAliases: {[alias: string]: boolean};
+        configuration: Configuration;
+    }
+
+    interface Configuration {
+        'boolean-negation': boolean;
+        'camel-case-expansion': boolean;
+        'combine-arrays': boolean;
+        'dot-notation': boolean;
+        'duplicate-arguments-array': boolean;
+        'flatten-duplicate-arrays': boolean;
+        'negation-prefix': string;
+        'parse-numbers': boolean;
+        'populate--': boolean;
+        'set-placeholder-key': boolean;
+        'short-option-groups': boolean;
     }
 
     interface RequireDirectoryOptions {

--- a/types/yargs/v11/yargs.d.ts
+++ b/types/yargs/v11/yargs.d.ts
@@ -1,0 +1,9 @@
+import {Argv} from '.'
+
+export = Yargs
+
+declare function Yargs(
+    processArgs?: string[],
+    cwd?: string,
+    parentRequire?: NodeRequireFunction,
+): Argv


### PR DESCRIPTION
Let me know if these methods _must_ be documented in the yargs documentation, and I'll open a PR to the yargs docs. In particular, when investigating the lerna tool, I noticed that they use `Argv.parsed` and `Argv.exit()`. `require('argv/argv')` is at least documented in a comment.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/yargs/yargs/blob/331cb203ecc95348e2b547d51ecece6f2e7271d2/index.js#L4
https://github.com/lerna/lerna/blob/8c2843f00e4a95359e3badf5a88927947a45cf2d/core/cli/index.js#L33
https://github.com/lerna/lerna/blob/8c2843f00e4a95359e3badf5a88927947a45cf2d/core/cli/index.js#L40
- [ ] Increase the version number in the header if appropriate. (N/A)
