### PR TITLE
Remove react node dependencies

### DIFF
--- a/types/meteor/test/globals/meteor-tests.ts
+++ b/types/meteor/test/globals/meteor-tests.ts
@@ -371,19 +371,19 @@ Comments.find({ viewNumber: { $gt: 100 } });
 Comments.find({ viewNumber: { $not: { $lt: 100, $gt: 1000 } } });
 Comments.find({ tags: { $in: [ "tag-1", "tag-2", "tag-3" ] } });
 Comments.find({ $or: [ { text: "hello" }, { text: "world" } ] });
-Comments.find({ $or: [ 
-    { text: "hello" }, 
-    { text: "world", viewNumber: { $gt: 0 } } 
+Comments.find({ $or: [
+    { text: "hello" },
+    { text: "world", viewNumber: { $gt: 0 } }
 ], authorId: "test-author-id" });
-Comments.find({ $and: [ 
-    { $or: [{ authorId: "author-id-1" }, { authorId: "author-id-2" }] }, 
+Comments.find({ $and: [
+    { $or: [{ authorId: "author-id-1" }, { authorId: "author-id-2" }] },
     { $or: [{ tags: "tag-1" }, { tags: "tag-2" }] }
 ]});
 
 Comments.find({ $query: {inlineLinks: { $exists: true, $type: "array" } } });
-Comments.find({ inlineLinks: { $elemMatch: { 
-    objectType: InlineObjectType.Image, 
-    objectUrl: { $regex: "https://(www\.?)youtube\.com" } 
+Comments.find({ inlineLinks: { $elemMatch: {
+    objectType: InlineObjectType.Image,
+    objectUrl: { $regex: "https://(www\.?)youtube\.com" }
 } } });
 Comments.find({ "inlineLinks.objectType": InlineObjectType.Person });
 Comments.find({ tags: "tag-1" });

--- a/types/meteor/test/meteor-tests.ts
+++ b/types/meteor/test/meteor-tests.ts
@@ -383,19 +383,19 @@ Comments.find({ viewNumber: { $gt: 100 } });
 Comments.find({ viewNumber: { $not: { $lt: 100, $gt: 1000 } } });
 Comments.find({ tags: { $in: [ "tag-1", "tag-2", "tag-3" ] } });
 Comments.find({ $or: [ { text: "hello" }, { text: "world" } ] });
-Comments.find({ $or: [ 
-    { text: "hello" }, 
-    { text: "world", viewNumber: { $gt: 0 } } 
+Comments.find({ $or: [
+    { text: "hello" },
+    { text: "world", viewNumber: { $gt: 0 } }
 ], authorId: "test-author-id" });
-Comments.find({ $and: [ 
-    { $or: [{ authorId: "author-id-1" }, { authorId: "author-id-2" }] }, 
+Comments.find({ $and: [
+    { $or: [{ authorId: "author-id-1" }, { authorId: "author-id-2" }] },
     { $or: [{ tags: "tag-1" }, { tags: "tag-2" }] }
 ]});
 
 Comments.find({ $query: { inlineLinks: { $exists: true, $type: "array" } } });
-Comments.find({ inlineLinks: { $elemMatch: { 
-    objectType: InlineObjectType.Image, 
-    objectUrl: { $regex: "https://(www\.?)youtube\.com" } 
+Comments.find({ inlineLinks: { $elemMatch: {
+    objectType: InlineObjectType.Image,
+    objectUrl: { $regex: "https://(www\.?)youtube\.com" }
 } } });
 Comments.find({ "inlineLinks.objectType": InlineObjectType.Person });
 Comments.find({ tags: "tag-1" });

--- a/types/react-dom/server/index.d.ts
+++ b/types/react-dom/server/index.d.ts
@@ -1,4 +1,10 @@
-/// <reference types="node" />
+// forward declarations
+declare global {
+    namespace NodeJS {
+        // tslint:disable-next-line:no-empty-interface
+        interface ReadableStream {}
+    }
+}
 
 import { ReactElement } from 'react';
 

--- a/types/react/test/index.ts
+++ b/types/react/test/index.ts
@@ -14,6 +14,14 @@ import update = require("react-addons-update");
 import createReactClass = require("create-react-class");
 import * as DOM from "react-dom-factories";
 
+// NOTE: forward declarations for tests
+declare function setInterval(...args: any[]): any;
+declare function clearInterval(...args: any[]): any;
+declare var console: Console;
+interface Console {
+    log(...args: any[]): void;
+}
+
 interface Props extends React.Attributes {
     hello: string;
     world?: string | null;
@@ -86,7 +94,7 @@ declare const container: Element;
         render() { return null; }
         componentDidMount() {
             // $ExpectError -> this will be true in next BC release where state is gonna be `null | Readonly<S>`
-            this.state.inputValue;
+            console.log(this.state.inputValue);
         }
         mutateState() {
             // $ExpectError
@@ -167,7 +175,7 @@ class ModernComponent extends React.Component<Props, State, Snapshot>
                 value: this.state.inputValue ? this.state.inputValue : undefined
             }),
             DOM.input({
-                onChange: event => event.target
+                onChange: event => console.log(event.target)
             }));
     }
 
@@ -501,20 +509,17 @@ class Timer extends React.Component<{}, TimerState> {
     state = {
         secondsElapsed: 0
     };
-    // NOTE: creates unnecessary dependency on 'node'. leaving for reference purposes
-    // private _interval: NodeJS.Timer;
+    private _interval: number;
     tick() {
         this.setState((prevState, props) => ({
             secondsElapsed: prevState.secondsElapsed + 1
         }));
     }
     componentDidMount() {
-        // NOTE: creates unnecessary dependency on 'node'. leaving for reference purposes
-        // this._interval = setInterval(() => this.tick(), 1000);
+        this._interval = setInterval(() => this.tick(), 1000);
     }
     componentWillUnmount() {
-        // NOTE: creates unnecessary dependency on 'node'. leaving for reference purposes
-        // clearInterval(this._interval);
+        clearInterval(this._interval);
     }
     render() {
         return DOM.div(
@@ -601,14 +606,14 @@ Perf.printExclusive();
 Perf.printWasted();
 Perf.printOperations();
 
-Perf.getExclusive();
-Perf.getInclusive();
-Perf.getWasted();
-Perf.getOperations();
-Perf.getExclusive(measurements);
-Perf.getInclusive(measurements);
-Perf.getWasted(measurements);
-Perf.getOperations(measurements);
+console.log(Perf.getExclusive());
+console.log(Perf.getInclusive());
+console.log(Perf.getWasted());
+console.log(Perf.getOperations());
+console.log(Perf.getExclusive(measurements));
+console.log(Perf.getInclusive(measurements));
+console.log(Perf.getWasted(measurements));
+console.log(Perf.getOperations(measurements));
 
 // Renamed to printOperations().  Please use it instead.
 Perf.printDOM(measurements);

--- a/types/react/test/index.ts
+++ b/types/react/test/index.ts
@@ -14,23 +14,6 @@ import update = require("react-addons-update");
 import createReactClass = require("create-react-class");
 import * as DOM from "react-dom-factories";
 
-// forward declarations (avoids an unnecessary dependency on NodeJS)
-declare global {
-    interface Console {
-        log(message?: any, ...optionalParams: any[]): void;
-    }
-    var console: Console;
-
-    function setInterval(callback: (...args: any[]) => void, ms: number, ...args: any[]): NodeJS.Timeout;
-    function clearInterval(intervalId: NodeJS.Timeout): void;
-
-    namespace NodeJS {
-        // tslint:disable-next-line:no-empty-interface
-        interface Timer {}
-        interface Timeout extends Timer {}
-    }
-}
-
 interface Props extends React.Attributes {
     hello: string;
     world?: string | null;
@@ -103,7 +86,7 @@ declare const container: Element;
         render() { return null; }
         componentDidMount() {
             // $ExpectError -> this will be true in next BC release where state is gonna be `null | Readonly<S>`
-            console.log(this.state.inputValue);
+            this.state.inputValue;
         }
         mutateState() {
             // $ExpectError
@@ -184,7 +167,7 @@ class ModernComponent extends React.Component<Props, State, Snapshot>
                 value: this.state.inputValue ? this.state.inputValue : undefined
             }),
             DOM.input({
-                onChange: event => console.log(event.target)
+                onChange: event => event.target
             }));
     }
 
@@ -518,17 +501,20 @@ class Timer extends React.Component<{}, TimerState> {
     state = {
         secondsElapsed: 0
     };
-    private _interval: NodeJS.Timer;
+    // NOTE: creates unnecessary dependency on 'node'. leaving for reference purposes
+    // private _interval: NodeJS.Timer;
     tick() {
         this.setState((prevState, props) => ({
             secondsElapsed: prevState.secondsElapsed + 1
         }));
     }
     componentDidMount() {
-        this._interval = setInterval(() => this.tick(), 1000);
+        // NOTE: creates unnecessary dependency on 'node'. leaving for reference purposes
+        // this._interval = setInterval(() => this.tick(), 1000);
     }
     componentWillUnmount() {
-        clearInterval(this._interval);
+        // NOTE: creates unnecessary dependency on 'node'. leaving for reference purposes
+        // clearInterval(this._interval);
     }
     render() {
         return DOM.div(
@@ -615,14 +601,14 @@ Perf.printExclusive();
 Perf.printWasted();
 Perf.printOperations();
 
-console.log(Perf.getExclusive());
-console.log(Perf.getInclusive());
-console.log(Perf.getWasted());
-console.log(Perf.getOperations());
-console.log(Perf.getExclusive(measurements));
-console.log(Perf.getInclusive(measurements));
-console.log(Perf.getWasted(measurements));
-console.log(Perf.getOperations(measurements));
+Perf.getExclusive();
+Perf.getInclusive();
+Perf.getWasted();
+Perf.getOperations();
+Perf.getExclusive(measurements);
+Perf.getInclusive(measurements);
+Perf.getWasted(measurements);
+Perf.getOperations(measurements);
 
 // Renamed to printOperations().  Please use it instead.
 Perf.printDOM(measurements);

--- a/types/react/test/index.ts
+++ b/types/react/test/index.ts
@@ -14,6 +14,23 @@ import update = require("react-addons-update");
 import createReactClass = require("create-react-class");
 import * as DOM from "react-dom-factories";
 
+// forward declarations (avoids an unnecessary dependency on NodeJS)
+declare global {
+    interface Console {
+        log(message?: any, ...optionalParams: any[]): void;
+    }
+    var console: Console;
+
+    function setInterval(callback: (...args: any[]) => void, ms: number, ...args: any[]): NodeJS.Timeout;
+    function clearInterval(intervalId: NodeJS.Timeout): void;
+
+    namespace NodeJS {
+        // tslint:disable-next-line:no-empty-interface
+        interface Timer {}
+        interface Timeout extends Timer {}
+    }
+}
+
 interface Props extends React.Attributes {
     hello: string;
     world?: string | null;

--- a/types/react/v15/test/index.ts
+++ b/types/react/v15/test/index.ts
@@ -11,6 +11,14 @@ import * as TestUtils from "react-addons-test-utils";
 import TransitionGroup = require("react-addons-transition-group");
 import update = require("react-addons-update");
 
+// NOTE: forward declarations for tests
+declare function setInterval(...args: any[]): any;
+declare function clearInterval(...args: any[]): any;
+declare var console: Console;
+interface Console {
+    log(...args: any[]): void;
+}
+
 interface Props extends React.Attributes {
     hello: string;
     world?: string;
@@ -120,7 +128,7 @@ class ModernComponent extends React.Component<Props, State>
                 value: this.state.inputValue
             }),
             React.DOM.input({
-                onChange: event => event.target
+                onChange: event => console.log(event.target)
             }));
     }
 
@@ -342,7 +350,7 @@ const htmlAttr: React.HTMLProps<HTMLElement> = {
         event.stopPropagation();
     },
     onAnimationStart: event => {
-        event.currentTarget.className;
+        console.log(event.currentTarget.className);
     },
     dangerouslySetInnerHTML: {
         __html: "<strong>STRONG</strong>"
@@ -505,20 +513,17 @@ class Timer extends React.Component<{}, TimerState> {
     state = {
         secondsElapsed: 0
     };
-    // NOTE: creates unnecessary dependency on 'node'. leaving for reference purposes
-    // private _interval: NodeJS.Timer;
+    private _interval: number;
     tick() {
         this.setState((prevState, props) => ({
             secondsElapsed: prevState.secondsElapsed + 1
         }));
     }
     componentDidMount() {
-        // NOTE: creates unnecessary dependency on 'node'. leaving for reference purposes
-        // this._interval = setInterval(() => this.tick(), 1000);
+        this._interval = setInterval(() => this.tick(), 1000);
     }
     componentWillUnmount() {
-        // NOTE: creates unnecessary dependency on 'node'. leaving for reference purposes
-        // clearInterval(this._interval);
+        clearInterval(this._interval);
     }
     render() {
         return React.DOM.div(
@@ -605,14 +610,14 @@ Perf.printExclusive();
 Perf.printWasted();
 Perf.printOperations();
 
-Perf.getExclusive();
-Perf.getInclusive();
-Perf.getWasted();
-Perf.getOperations();
-Perf.getExclusive(measurements);
-Perf.getInclusive(measurements);
-Perf.getWasted(measurements);
-Perf.getOperations(measurements);
+console.log(Perf.getExclusive());
+console.log(Perf.getInclusive());
+console.log(Perf.getWasted());
+console.log(Perf.getOperations());
+console.log(Perf.getExclusive(measurements));
+console.log(Perf.getInclusive(measurements));
+console.log(Perf.getWasted(measurements));
+console.log(Perf.getOperations(measurements));
 
 // Renamed to printOperations().  Please use it instead.
 Perf.printDOM(measurements);

--- a/types/react/v15/test/index.ts
+++ b/types/react/v15/test/index.ts
@@ -120,7 +120,7 @@ class ModernComponent extends React.Component<Props, State>
                 value: this.state.inputValue
             }),
             React.DOM.input({
-                onChange: event => console.log(event.target)
+                onChange: event => event.target
             }));
     }
 
@@ -342,7 +342,7 @@ const htmlAttr: React.HTMLProps<HTMLElement> = {
         event.stopPropagation();
     },
     onAnimationStart: event => {
-        console.log(event.currentTarget.className);
+        event.currentTarget.className;
     },
     dangerouslySetInnerHTML: {
         __html: "<strong>STRONG</strong>"
@@ -505,17 +505,20 @@ class Timer extends React.Component<{}, TimerState> {
     state = {
         secondsElapsed: 0
     };
-    private _interval: NodeJS.Timer;
+    // NOTE: creates unnecessary dependency on 'node'. leaving for reference purposes
+    // private _interval: NodeJS.Timer;
     tick() {
         this.setState((prevState, props) => ({
             secondsElapsed: prevState.secondsElapsed + 1
         }));
     }
     componentDidMount() {
-        this._interval = setInterval(() => this.tick(), 1000);
+        // NOTE: creates unnecessary dependency on 'node'. leaving for reference purposes
+        // this._interval = setInterval(() => this.tick(), 1000);
     }
     componentWillUnmount() {
-        clearInterval(this._interval);
+        // NOTE: creates unnecessary dependency on 'node'. leaving for reference purposes
+        // clearInterval(this._interval);
     }
     render() {
         return React.DOM.div(
@@ -602,14 +605,14 @@ Perf.printExclusive();
 Perf.printWasted();
 Perf.printOperations();
 
-console.log(Perf.getExclusive());
-console.log(Perf.getInclusive());
-console.log(Perf.getWasted());
-console.log(Perf.getOperations());
-console.log(Perf.getExclusive(measurements));
-console.log(Perf.getInclusive(measurements));
-console.log(Perf.getWasted(measurements));
-console.log(Perf.getOperations(measurements));
+Perf.getExclusive();
+Perf.getInclusive();
+Perf.getWasted();
+Perf.getOperations();
+Perf.getExclusive(measurements);
+Perf.getInclusive(measurements);
+Perf.getWasted(measurements);
+Perf.getOperations(measurements);
 
 // Renamed to printOperations().  Please use it instead.
 Perf.printDOM(measurements);


### PR DESCRIPTION
This removes a mostly-unnecessary dependency on `node` from `react-dom` (and conversely `react`), replacing it with a forward-declaration for `NodeJS.ReadableStream`. This reduces the number of transitive dependencies for `node` and should hopefully reduce the amount of time it takes to test definition changes for `node` on DefinitelyTyped.