### PR TITLE
[just-pick] Add typings for just-pick

### DIFF
--- a/types/just-pick/index.d.ts
+++ b/types/just-pick/index.d.ts
@@ -1,0 +1,11 @@
+// Type definitions for just-pick 2.1
+// Project: https://github.com/angus-c/just#readme
+// Definitions by: Peter Safranek <https://github.com/pe8ter>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.1
+
+declare function pick<T, U extends keyof T>(obj: T, select: U[]): Pick<T, U>;
+
+declare function pick<T, U extends keyof T>(obj: T, select1: U, ...selectn: U[]): Pick<T, U>;
+
+export = pick;

--- a/types/just-pick/just-pick-tests.ts
+++ b/types/just-pick/just-pick-tests.ts
@@ -1,0 +1,26 @@
+import pick = require("just-pick");
+
+const a = "a";
+const b = "b";
+const c = "c";
+const obj = { a, b };
+
+pick(obj, []); // $ExpectType Pick<{ a: string; b: string; }, never>
+pick(obj, [a]); // $ExpectType Pick<{ a: string; b: string; }, "a">
+pick(obj, [a, a]); // $ExpectType Pick<{ a: string; b: string; }, "a">
+pick(obj, [a, b]); // $ExpectType Pick<{ a: string; b: string; }, "a" | "b">
+pick(obj, [a, b, c]); // $ExpectError
+
+pick(obj, a); // $ExpectType Pick<{ a: string; b: string; }, "a">
+pick(obj, a, a); // $ExpectType Pick<{ a: string; b: string; }, "a">
+pick(obj, a, b); // $ExpectType Pick<{ a: string; b: string; }, "a" | "b">
+pick(obj, a, b, c); // $ExpectError
+
+pick(); // $ExpectError
+pick(obj); // $ExpectError
+pick(obj, 0); // $ExpectError
+pick(obj, false); // $ExpectError
+pick(obj, null); // $ExpectError
+pick(obj, undefined); // $ExpectError
+pick(obj, {}); // $ExpectError
+pick(obj, () => {}); // $ExpectError

--- a/types/just-pick/tsconfig.json
+++ b/types/just-pick/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "just-pick-tests.ts"
+    ]
+}

--- a/types/just-pick/tslint.json
+++ b/types/just-pick/tslint.json
@@ -1,0 +1,6 @@
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "file-name-casing": false
+    }
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

For review, note that the [comments above the source code](https://github.com/angus-c/just/blob/master/packages/object-pick/index.js) claim that keys not present in an object can be picked even though these typings do not allow it. The code actually has a check to prevent this, and I have a pull request https://github.com/angus-c/just/pull/117 to fix the comments.