### PR TITLE
d3: Fix no-angle-bracket-type-assertion

### DIFF
--- a/types/d3-brush/d3-brush-tests.ts
+++ b/types/d3-brush/d3-brush-tests.ts
@@ -48,7 +48,7 @@ brush = brush.extent(function(d, i, group) {
 // chainable
 brush = brush.filter(function(d, i, group) {
     // Cast d3 event to D3ZoomEvent to be used in filter logic
-    const e = <d3Brush.D3BrushEvent<BrushDatum>> event;
+    const e = event as d3Brush.D3BrushEvent<BrushDatum>;
 
     console.log('Owner SVG Element of svg group: ', this.ownerSVGElement); // this is of type SVGGElement
     return e.sourceEvent.type !== 'zoom' || !d.filterZoomEvent; // datum type is BrushDatum (as propagated to SVGGElement with brush event attached)

--- a/types/d3-drag/d3-drag-tests.ts
+++ b/types/d3-drag/d3-drag-tests.ts
@@ -134,7 +134,7 @@ touchableFn = circleDrag.touchable();
 
 circleCustomDrag.subject(function(d, i, g) {
     // Cast event type for completeness, otherwise event is of type any.
-    const e = <d3Drag.D3DragEvent<SVGCircleElement, CircleDatum, CustomSubject | d3Drag.SubjectPosition>> event;
+    const e = event as d3Drag.D3DragEvent<SVGCircleElement, CircleDatum, CustomSubject | d3Drag.SubjectPosition>;
     const that: SVGCircleElement = this;
     const datum: CircleDatum = d;
     const index: number = i;
@@ -163,14 +163,14 @@ subjectAccessor = circleCustomDrag.subject();
 
 function dragstarted(this: SVGCircleElement, d: CircleDatum) {
     // cast d3 event to drag event. Otherwise, d3 event is currently defined as type 'any'
-    const e = <d3Drag.D3DragEvent<SVGCircleElement, CircleDatum, CircleDatum | d3Drag.SubjectPosition>> event;
+    const e = event as d3Drag.D3DragEvent<SVGCircleElement, CircleDatum, CircleDatum | d3Drag.SubjectPosition>;
     e.sourceEvent.stopPropagation();
     select(this).classed('dragging', true);
 }
 
 function dragged(this: SVGCircleElement, d: CircleDatum) {
     // cast d3 event to drag event. Otherwise, d3 event is currently defined as type 'any'
-    const e = <d3Drag.D3DragEvent<SVGCircleElement, CircleDatum, CircleDatum | d3Drag.SubjectPosition>> event;
+    const e = event as d3Drag.D3DragEvent<SVGCircleElement, CircleDatum, CircleDatum | d3Drag.SubjectPosition>;
     select(this).attr('cx', d.x = e.x).attr('cy', d.y = e.y);
 }
 

--- a/types/d3-selection/d3-selection-tests.ts
+++ b/types/d3-selection/d3-selection-tests.ts
@@ -1060,7 +1060,7 @@ interface SuccessEvent {
 const successEvent = { type: 'wonEuro2016', team: 'Island' };
 
 function customListener(this: HTMLBodyElement | null, finalOpponent: string): string {
-    const e = <SuccessEvent> d3Selection.event;
+    const e = d3Selection.event as SuccessEvent;
 
     return `${e.team} defeated ${finalOpponent} in the EURO 2016 Cup. Who would have thought!!!`;
 }

--- a/types/d3-selection/tslint.json
+++ b/types/d3-selection/tslint.json
@@ -2,7 +2,6 @@
     "extends": "dtslint/dt.json",
     "rules": {
         // TODO
-        "no-angle-bracket-type-assertion": false,
         "no-this-assignment": false,
         "unified-signatures": false,
         "no-unnecessary-generics": false

--- a/types/d3-zoom/d3-zoom-tests.ts
+++ b/types/d3-zoom/d3-zoom-tests.ts
@@ -91,7 +91,7 @@ interface GroupDatum {
 
 function zoomedCanvas(this: HTMLCanvasElement, d: CanvasDatum) {
     // Cast d3 event to D3ZoomEvent to be used in zoom event handler
-    const e = <d3Zoom.D3ZoomEvent<HTMLCanvasElement, any>> event;
+    const e = event as d3Zoom.D3ZoomEvent<HTMLCanvasElement, any>;
     if (context) {
         context.save();
         context.clearRect(0, 0, this.width, this.height); // this element
@@ -112,7 +112,7 @@ canvasZoom = d3Zoom.zoom<HTMLCanvasElement, CanvasDatum>()
 
 function zoomedSVGOverlay(this: SVGRectElement) {
     // Cast d3 event to D3ZoomEvent to be used in zoom event handler
-    const e = <d3Zoom.D3ZoomEvent<HTMLCanvasElement, any>> event;
+    const e = event as d3Zoom.D3ZoomEvent<HTMLCanvasElement, any>;
 
     g.attr('transform', e.transform.toString());
 }
@@ -146,7 +146,7 @@ constraintFn = svgZoom.constrain();
 // chainable
 svgZoom = svgZoom.filter(function(d, i, group) {
     // Cast d3 event to D3ZoomEvent to be used in filter logic
-    const e = <d3Zoom.D3ZoomEvent<SVGRectElement, SVGDatum>> event;
+    const e = event as d3Zoom.D3ZoomEvent<SVGRectElement, SVGDatum>;
 
     console.log('Overlay Rectangle width: ', this.width.baseVal.value); // this typing is SVGRectElement
     return e.sourceEvent.type !== 'brush' || !d.filterBrushEvent; // datum type is SVGDatum (as propagated to SVGRectElement with zoom event attached)
@@ -178,7 +178,7 @@ touchableFn = svgZoom.touchable();
 // chainable
 svgZoom = svgZoom.wheelDelta(function(d, i, group) {
     // Cast d3 event to D3ZoomEvent to be used in filter logic
-    const e = <WheelEvent> event;
+    const e = event as WheelEvent;
     const that: SVGRectElement = this;
     const datum: SVGDatum = d;
     const index: number = i;

--- a/types/d3-zoom/tslint.json
+++ b/types/d3-zoom/tslint.json
@@ -2,7 +2,6 @@
     "extends": "dtslint/dt.json",
     "rules": {
         // TODO
-        "no-angle-bracket-type-assertion": false,
         "no-this-assignment": false,
         "unified-signatures": false,
         "no-unnecessary-generics": false

--- a/types/d3kit/d3kit-tests.ts
+++ b/types/d3kit/d3kit-tests.ts
@@ -304,7 +304,7 @@ function test_svg_chart() {
      * Test plate functions
      */
     plate = new d3kit.SvgPlate();
-    plate = <d3kit.SvgPlate> chart.addPlate('a-plate', plate, true); // with doNotAppend
+    plate = chart.addPlate('a-plate', plate, true) as d3kit.SvgPlate; // with doNotAppend
     chart = chart.addPlate('a-plate', plate);       // without doNotAppend
     chart = chart.removePlate('a-plate');
 
@@ -381,7 +381,7 @@ function test_hybrid_chart() {
      * Test plate functions
      */
     plate = new d3kit.SvgPlate();
-    plate = <d3kit.SvgPlate> chart.addPlate('a-plate', plate, true); // with doNotAppend
+    plate = chart.addPlate('a-plate', plate, true) as d3kit.SvgPlate; // with doNotAppend
     chart = chart.addPlate('a-plate', plate);       // without doNotAppend
     chart = chart.removePlate('a-plate');
 


### PR DESCRIPTION
Remove _no-angle-bracket-type-assertion_ in tslint from d3 libraries.

Related: #30592

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
