### PR TITLE
Improve types for csso

### DIFF
--- a/types/csso/csso-tests.ts
+++ b/types/csso/csso-tests.ts
@@ -15,7 +15,7 @@ csso.minify('.test { color: #ff0000; }', {
     logger: () => {}
 });
 
-csso.minifyBlock('color: rgba(255, 0, 0, 1); color: #ff0000').css;
+csso.minifyBlock('color: rgba(255, 0, 0, 1); color: #ff0000').css; // $ExpectType string
 csso.minifyBlock('color: rgba(255, 0, 0, 1); color: #ff0000').map;
 csso.minifyBlock('color: rgba(255, 0, 0, 1); color: #ff0000', {
     sourceMap: true,
@@ -27,14 +27,30 @@ csso.minifyBlock('color: rgba(255, 0, 0, 1); color: #ff0000', {
     forceMediaMerge: true,
     clone: false,
     comments: '',
-    logger: () => {}
+    logger: () => {},
+    usage: {
+        tags: ['ul', 'li'],
+        ids: ['x'],
+        classes: ['a', 'b'],
+        blacklist: {
+            tags: ['body'],
+            ids: ['y'],
+            classes: ['c'],
+        },
+        scopes: [
+            ['a', 'b', 'c'],
+            ['d', 'e']
+        ],
+    },
 });
 
-csso.compress({}).ast;
-csso.compress({}, {
+csso.compress({ type: 'CDC' }).ast; // $ExpectType CssNode
+csso.compress({ type: 'CDC' }, {
     restructure: false,
     forceMediaMerge: true,
     clone: false,
     comments: '',
     logger: () => {}
-}).ast;
+}).ast; // $ExpectType CssNode
+
+csso.syntax.parse('.b {font-weight: bold}'); // $ExpectType CssNode

--- a/types/csso/index.d.ts
+++ b/types/csso/index.d.ts
@@ -1,8 +1,11 @@
 // Type definitions for csso 3.5
 // Project: https://github.com/css/csso
 // Definitions by: Christian Rackerseder <https://github.com/screendriver>
+//                 Erik Källén <https://github.com/erik-kallen>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.7
+
+import * as csstree from 'css-tree';
 
 declare namespace csso {
     interface Result {
@@ -14,6 +17,18 @@ declare namespace csso {
          * Instance of SourceMapGenerator or null.
          */
         map: object | null;
+    }
+
+    interface Usage {
+        tags?: string[];
+        ids?: string[];
+        classes?: string[];
+        scopes?: string[][];
+        blacklist?: {
+            tags?: string[];
+            ids?: string[];
+            classes?: string[];
+        };
     }
 
     interface CompressOptions {
@@ -44,7 +59,7 @@ declare namespace csso {
         /**
          * Usage data for advanced optimisations.
          */
-        usage?: object;
+        usage?: Usage;
         /**
          * Function to track every step of transformation.
          */
@@ -100,7 +115,9 @@ interface Csso {
     /**
      * Does the main task – compress an AST.
      */
-    compress(ast: object, options?: csso.CompressOptions): { ast: object };
+    compress(ast: csstree.CssNode, options?: csso.CompressOptions): { ast: csstree.CssNode };
+
+    syntax: typeof csstree;
 }
 
 declare const csso: Csso;


### PR DESCRIPTION
Now that we have types for the `css-tree` module, we can improve types for `csso`, which depends on it. I needed to up to typescript 2.7 since the css-tree package requires that version

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/css/csso
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
