### PR TITLE
nodegit: Add 'start' method to Commit history() return type

### DIFF
--- a/types/nodegit/commit.d.ts
+++ b/types/nodegit/commit.d.ts
@@ -9,6 +9,10 @@ import { Tree } from './tree';
 import { TreeEntry } from './tree-entry';
 import { Diff } from './diff';
 
+export interface HistoryEventEmitter extends EventEmitter {
+    start(): void;
+}
+
 export class Commit {
     static create(repo: Repository, updateRef: string, author: Signature, committer: Signature, messageEncoding: string, message: string, tree: Tree, parentCount: number, parents: any[]): Oid;
     static createV(id: Oid, repo: Repository, updateRef: string, author: Signature, committer: Signature, messageEncoding: string, message: string, tree: Tree, parentCount: number): number;
@@ -75,11 +79,11 @@ export class Commit {
     /**
      * Walk the history from this commit backwards.
      * An EventEmitter is returned that will emit a "commit" event for each commit in the history, and one "end"
-     * event when the walk is completed. Don't forget to call start() on the returned event.
+     * event when the walk is completed. Don't forget to call start() on the returned EventEmitter.
      *
      *
      */
-    history(): EventEmitter;
+    history(): HistoryEventEmitter;
     /**
      * Retrieve the commit's parents as commit objects.
      *


### PR DESCRIPTION
This small PR fixes https://github.com/DefinitelyTyped/DefinitelyTyped/issues/29969. I had this change locally so figured I may as well submit it. I'm new to OSS and TS, so please be gentle :)

Template below:

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  * [Existing DefinitelyTyped issue](https://github.com/DefinitelyTyped/DefinitelyTyped/issues/29969)
  * [nodegit source code](https://github.com/nodegit/nodegit/blob/master/lib/commit.js#L216)
  * [Existing issue filed for source code docs](https://github.com/nodegit/nodegit/issues/1571)
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.