### PR TITLE
storybook__addon-options: Add types for withOptions decorator, replacing deprecated setOptions

### DIFF
--- a/types/storybook__addon-options/index.d.ts
+++ b/types/storybook__addon-options/index.d.ts
@@ -1,10 +1,13 @@
-// Type definitions for @storybook/addon-options 3.2
+// Type definitions for @storybook/addon-options 4.0
 // Project: https://github.com/storybooks/storybook
 // Definitions by: Joscha Feth <https://github.com/joscha>
 //                 Simon Helle Nielsen <https://github.com/simonhn>
 //                 A.MacLeay <https://github.com/amacleay>
+//                 Gaetan Maisse <https://github.com/gaetanmaisse>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
+
+import { StoryDecorator } from '@storybook/react';
 
 export interface Options {
     name?: string;
@@ -20,7 +23,12 @@ export interface Options {
     sortStoriesByKind?: boolean;
     hierarchySeparator?: RegExp | string;
     hierarchyRootSeparator?: RegExp | string;
+    sidebarAnimations?: boolean;
     selectedAddonPanel?: string;
+    enableShortcuts?: boolean;
 }
 
+// Deprecated
 export function setOptions(options: Options): void;
+
+export function withOptions(options: Options): StoryDecorator;

--- a/types/storybook__addon-options/storybook__addon-options-tests.ts
+++ b/types/storybook__addon-options/storybook__addon-options-tests.ts
@@ -1,4 +1,23 @@
-import { setOptions } from '@storybook/addon-options';
+import { addDecorator } from '@storybook/react';
+import { setOptions, withOptions } from '@storybook/addon-options';
+
+addDecorator(
+  withOptions({
+    name: 'My Storybook',
+    url: 'https://example.com',
+    goFullScreen: false,
+    showStoriesPanel: false,
+    showAddonPanel: false,
+    showSearchBox: false,
+    addonPanelInRight: false,
+    sortStoriesByKind: false,
+    hierarchySeparator: /\//,
+    hierarchyRootSeparator: /\|/,
+    sidebarAnimations: false,
+    selectedAddonPanel: 'storybook/actions/action-panel',
+    enableShortcuts: false
+  })
+);
 
 setOptions({
   name: 'My Storybook',
@@ -11,7 +30,9 @@ setOptions({
   sortStoriesByKind: false,
   hierarchySeparator: /\//,
   hierarchyRootSeparator: /\|/,
+  sidebarAnimations: false,
   selectedAddonPanel: 'storybook/actions/action-panel',
+  enableShortcuts: false
 });
 
 setOptions({

--- a/types/storybook__addon-options/tsconfig.json
+++ b/types/storybook__addon-options/tsconfig.json
@@ -15,6 +15,9 @@
         "paths": {
             "@storybook/addon-options": [
                 "storybook__addon-options"
+            ],
+            "@storybook/react": [
+                "storybook__react"
             ]
         },
         "types": [],


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/storybooks/storybook/commit/d309b918cc487a55bb29c21806fb38a00b05409e
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. -> It was already there 
