### PR TITLE
[yeoman-assert] Add types for yeoman-assert

### DIFF
--- a/types/yeoman-assert/index.d.ts
+++ b/types/yeoman-assert/index.d.ts
@@ -1,0 +1,156 @@
+// Type definitions for yeoman-assert 3.1
+// Project: https://github.com/yeoman/yeoman-assert
+// Definitions by: Toilal <https://github.com/Toilal>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.4
+
+import assert = require('assert');
+
+declare module 'assert' {
+    /**
+     * Assert that a file exists or that each files in the array exists
+     * @param path path to a file or an array of paths to files
+     * @example
+     * assert.file('templates/user.hbs');
+     * assert.noFile(['templates/user.hbs', 'templates/user/edit.hbs']);
+     */
+    function file(path: string | string[]): void;
+
+    /**
+     * Assert that a file doesn't exist
+     * @param file path to a file
+     * @example
+     * assert.noFile('templates/user.hbs');
+     * assert.noFile(['templates/user.hbs', 'templates/user/edit.hbs']);
+     */
+    function noFile(file: string | string[]): void;
+
+    /**
+     * Assert that a file's content matches a regex or string
+     * @param file path to a file
+     * @param reg regex / string that will be used to search the file
+     * @example
+     * assert.fileContent('models/user.js', /App\.User = DS\.Model\.extend/);
+     * assert.fileContent('models/user.js', 'App.User = DS.Model.extend');
+     */
+    function fileContent(file: string | string[], reg: string | RegExp): void;
+
+    /**
+     * Assert that each file in an array of file-regex pairs matches its corresponding regex
+     * @param pairs an array of arrays, where each subarray is a [String, RegExp] pair
+     * @example
+     * var arg = [
+     *   [ 'models/user.js', /App\.User = DS\.Model\.extend/ ],
+     *   [ 'controllers/user.js', /App\.UserController = Ember\.ObjectController\.extend/ ]
+     * ]
+     * assert.fileContent(arg);
+     */
+    function fileContent(pairs: Array<[string, RegExp]>): void;
+
+    /**
+     * Assert that a file's content is the same as the given string
+     * @param file path to a file
+     * @param expectedContent the expected content of the file
+     * @example
+     * assert.equalsFileContent(
+     *   'data.js',
+     *   'const greeting = "Hello";\nexport default { greeting }'
+     * );
+     */
+    function equalsFileContent(file: string, expectedContent: string): void;
+
+    /**
+     * Assert that each file in an array of file-string pairs equals its corresponding string
+     * @param pairs an array of arrays, where each subarray is a [String, String] pair
+     * @example
+     * assert.equalsFileContent([
+     *   ['data.js', 'const greeting = "Hello";\nexport default { greeting }'],
+     *   ['user.js', 'export default {\n  name: 'Coleman',\n  age: 0\n}']
+     * ]);
+     */
+    function equalsFileContent(pairs: Array<[string, string]>): void;
+
+    /**
+     * Assert that a file's content does not match a regex / string
+     * @param file path to a file
+     * @param reg regex / string that will be used to search the file
+     * @example
+     * assert.noFileContent('models/user.js', /App\.User = DS\.Model\.extend/);
+     * assert.noFileContent('models/user.js', 'App.User = DS.Model.extend');
+     */
+    function noFileContent(file: string | string[], reg: RegExp | string): void;
+
+    /**
+     * Assert that each file in an array of file-regex pairs does not match its corresponding regex
+     * @param pairs an array of arrays, where each subarray is a [String, RegExp] pair
+     * var arg = [
+     *   [ 'models/user.js', /App\.User \ DS\.Model\.extend/ ],
+     *   [ 'controllers/user.js', /App\.UserController = Ember\.ObjectController\.extend/ ]
+     * ]
+     * assert.noFileContent(arg);
+     */
+    function noFileContent(pairs: Array<[string, RegExp]>): void;
+
+    /**
+     * Assert that two strings are equal after standardization of newlines
+     * @param value a string
+     * @param expected the expected value of the string
+     * @example
+     * assert.textEqual('I have a yellow cat', 'I have a yellow cat');
+     */
+    function textEqual(value: string, expected: string): void;
+
+    /**
+     * Assert an Object implements an interface
+     * @param subject subject implementing the façade
+     * @param methods a façace, hash or array of keys to be implemented
+     */
+    function implement(subject: object, methods: object | string[]): void;
+
+    /**
+     * Assert an Object doesn't implements any method of an interface
+     * @param subject subject not implementing the methods
+     * @param methods hash or array of method names to be implemented
+     */
+    function notImplement(subject: object, methods: object | string[]): void;
+
+    /**
+     * Assert an object contains the provided keys
+     * @param obj Object that should match the given pattern
+     * @param content An object of key/values the object should contains
+     */
+    function objectContent(obj: object, content: object): void;
+
+    /**
+     * Assert an object does not contain the provided keys
+     * @param obj Object that should not match the given pattern
+     * @param content An object of key/values the object should not contain
+     */
+    function noObjectContent(obj: object, content: object): void;
+
+    /**
+     * Assert a JSON file contains the provided keys
+     * @param filename
+     * @param content An object of key/values the file should contains
+     */
+    function JSONFileContent(filename: string, content: object): void;
+
+    /**
+     * @see JSONFileContent
+     */
+    function jsonFileContent(filename: string, content: object): void;
+
+    /**
+     * Assert a JSON file does not contain the provided keys
+     * @param filename
+     * @param content An object of key/values the file should not contain
+     */
+    function noJSONFileContent(filename: string, content: object): void;
+
+    /**
+     * @see noJSONFileContent
+     */
+    function noJsonFileContent(filename: string, content: object): void;
+}
+
+export = assert;

--- a/types/yeoman-assert/tsconfig.json
+++ b/types/yeoman-assert/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "yeoman-assert-tests.ts"
+    ]
+}

--- a/types/yeoman-assert/tslint.json
+++ b/types/yeoman-assert/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "dtslint/dt.json"
+}

--- a/types/yeoman-assert/yeoman-assert-tests.ts
+++ b/types/yeoman-assert/yeoman-assert-tests.ts
@@ -1,0 +1,34 @@
+import * as assert from 'yeoman-assert';
+
+assert.file('path');
+assert.file(['path', 'path2']);
+
+assert.noFile('path');
+assert.noFile(['path', 'path2']);
+
+assert.fileContent('file', /abc/g);
+assert.fileContent(['file', 'file2'], 'abc');
+
+assert.equalsFileContent('file', 'expectedContent');
+assert.equalsFileContent([['file', 'expectedContent'], ['file2', 'expectedContent2']]);
+
+assert.noFileContent('file', /abc/g);
+assert.noFileContent(['file', 'file2'], 'abc');
+
+assert.textEqual('value', 'expected');
+assert.implement({value: 'test'}, {other: 'test2'});
+assert.implement({value: 'test'}, ['test2', 'test3']);
+
+assert.notImplement({value: 'test'}, {other: 'test2'});
+assert.notImplement({value: 'test'}, ['test2', 'test3']);
+
+assert.objectContent({value: 'test'}, {value: 'test2'});
+assert.noObjectContent({value: 'test'}, {value: 'test2'});
+
+assert.JSONFileContent('filename', {root: 'content'});
+assert.jsonFileContent('filename', {root: 'content'});
+
+assert.noJSONFileContent('filename', {root: 'content'});
+assert.noJsonFileContent('filename', {root: 'content'});
+
+assert.equal('test', 'expected');


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
