### PR TITLE
fix format arg for jsPDF() constructor

### DIFF
--- a/types/jspdf/index.d.ts
+++ b/types/jspdf/index.d.ts
@@ -7,7 +7,7 @@ declare module 'jspdf' {
     class jsPDF {
         constructor(orientation?:any,
                     unit?:string,
-                    format?:string,
+                    format?:string | number[],
                     compressPdf?:number);
 
         CapJoinStyles:any;

--- a/types/prosemirror-model/index.d.ts
+++ b/types/prosemirror-model/index.d.ts
@@ -832,7 +832,7 @@ export class ResolvedPos {
    * its parent node or its parent node isn't a textblock (in which
    * case no marks should be preserved).
    */
-  marksAcross(): Mark[] | null | void;
+  marksAcross($end: ResolvedPos): Mark[] | null | void;
   /**
    * The depth up to which this position and the given (non-resolved)
    * position share the same parent nodes.

--- a/types/prosemirror-view/index.d.ts
+++ b/types/prosemirror-view/index.d.ts
@@ -180,6 +180,8 @@ export class EditorView {
    * Focus the editor.
    */
   focus(): void;
+
+  focused: boolean;
   /**
    * Get the document root in which the editor exists. This will
    * usually be the top-level `document`, but might be a [shadow


### PR DESCRIPTION
Please fill in this template.

- [ ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
