### PR TITLE
N3: Made term properties readonly

### DIFF
--- a/types/n3/index.d.ts
+++ b/types/n3/index.d.ts
@@ -21,10 +21,10 @@ export type Term = NamedNode | BlankNode | Literal | Variable | DefaultGraph;
 export type PrefixedToIri = (suffix: string) => RDF.NamedNode;
 
 export class NamedNode implements RDF.NamedNode {
-    termType: "NamedNode";
-    value: string;
+    readonly termType: "NamedNode";
+    readonly value: string;
     constructor(iri: string);
-    id: string;
+    readonly id: string;
     toJSON(): {};
     equals(other: RDF.Term): boolean;
     static subclass(type: any): void;
@@ -32,20 +32,20 @@ export class NamedNode implements RDF.NamedNode {
 
 export class BlankNode implements RDF.BlankNode {
     static nextId: number;
-    termType: "BlankNode";
-    value: string;
+    readonly termType: "BlankNode";
+    readonly value: string;
     constructor(name: string);
-    id: string;
+    readonly id: string;
     toJSON(): {};
     equals(other: RDF.Term): boolean;
     static subclass(type: any): void;
 }
 
 export class Variable  implements RDF.Variable {
-    termType: "Variable";
-    value: string;
+    readonly termType: "Variable";
+    readonly value: string;
     constructor(name: string);
-    id: string;
+    readonly id: string;
     toJSON(): {};
     equals(other: RDF.Term): boolean;
     static subclass(type: any): void;
@@ -53,23 +53,23 @@ export class Variable  implements RDF.Variable {
 
 export class Literal implements RDF.Literal {
     static readonly langStringDatatype: NamedNode;
-    termType: "Literal";
-    value: string;
-    id: string;
+    readonly termType: "Literal";
+    readonly value: string;
+    readonly id: string;
     toJSON(): {};
     equals(other: RDF.Term): boolean;
     static subclass(type: any): void;
-    language: string;
-    datatype: NamedNode;
-    datatypeString: string;
+    readonly language: string;
+    readonly datatype: NamedNode;
+    readonly datatypeString: string;
     constructor(id: string);
 }
 
 export class DefaultGraph implements RDF.DefaultGraph {
-    termType: "DefaultGraph";
-    value: "";
+    readonly termType: "DefaultGraph";
+    readonly value: "";
     constructor();
-    id: string;
+    readonly id: string;
     toJSON(): {};
     equals(other: RDF.Term): boolean;
     static subclass(type: any): void;


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/rdfjs/N3.js/blob/master/lib/N3DataFactory.js#L120

Considering N3 terms are considered immutable, should only be created via the factory, and considering N3 only provides getters, not setters, I've updated the typescript definitions to be more accurate.
Only applied this to the term interfaces