### PR TITLE
Add redact to pino options

### DIFF
--- a/types/pino/index.d.ts
+++ b/types/pino/index.d.ts
@@ -173,6 +173,20 @@ declare namespace P {
          * Warning: this option may not be supported by downstream transports.
          */
         useOnlyCustomLevels?: boolean;
+
+        /**
+         * As an array, the redact option specifies paths that should have their values redacted from any log output.
+         *
+         * Each path must be a string using a syntax which corresponds to JavaScript dot and bracket notation.
+         *
+         * If an object is supplied, three options can be specified:
+         *
+         *      paths (String[]): Required. An array of paths
+         *      censor (String): Optional. A value to overwrite key which are to be redacted. Default: '[Redacted]'
+         *      remove (Boolean): Optional. Instead of censoring the value, remove both the key and the value. Default: false
+         */
+        redact?: string[] | redactOptions;
+
         /**
          * When defining a custom log level via level, set to an integer value to define the new level. Default: `undefined`.
          */
@@ -419,5 +433,11 @@ declare namespace P {
     interface LogFn {
         (msg: string, ...args: any[]): void;
         (obj: object, msg?: string, ...args: any[]): void;
+    }
+
+    interface redactOptions {
+        paths: string[];
+        censor?: string;
+        remove?: boolean;
     }
 }

--- a/types/pino/pino-tests.ts
+++ b/types/pino/pino-tests.ts
@@ -102,3 +102,24 @@ const handler = pino.final(logExtreme, (err: Error, finalLogger: pino.BaseLogger
 });
 
 handler(new Error('error'));
+
+const redacted = pino({
+    redact: ['path']
+});
+
+redacted.info({
+    msg: 'logged with redacted properties',
+    path: 'Not shown'
+});
+
+const anotherRedacted = pino({
+    redact: {
+        paths: ['anotherPath'],
+        censor: 'Not the log you\re looking for'
+    }
+});
+
+anotherRedacted.info({
+    msg: 'another logged with redacted properties',
+    anotherPath: 'Not shown'
+});


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://getpino.io/#/docs/api?id=redact-array-object
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

This PR adds a missing property in pino options, as per issue #30631