### PR TITLE
[WebAssembly] Align bufferSource value type to WebAssembly JS API Specification

### DIFF
--- a/types/webassembly-js-api/index.d.ts
+++ b/types/webassembly-js-api/index.d.ts
@@ -3,7 +3,9 @@
 // Definitions by: 01alchemist <https://twitter.com/01alchemist>
 //                 Wink Saville <wink@saville.com>
 //                 Periklis Tsirakidis <https://github.com/periklis>
+//                 Sergey Rubanov <https://github.com/chicoxyzzy>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.2
 
 /**
  * The WebAssembly namespace, see [WebAssembly](https://github.com/webassembly)
@@ -22,11 +24,13 @@ declare namespace WebAssembly {
         kind: string;
     }>;
 
+    type BufferSource = ArrayBufferView | ArrayBuffer;
+
     /**
      * WebAssembly.Module
      */
     class Module {
-        constructor(bufferSource: ArrayBuffer | Uint8Array);
+        constructor(bufferSource: BufferSource);
         static customSections(module: Module, sectionName: string): ArrayBuffer[];
         static exports(module: Module): Imports;
         static imports(module: Module): Exports;
@@ -99,15 +103,15 @@ declare namespace WebAssembly {
         toString(): string;
     }
 
-    function compile(bufferSource: ArrayBuffer | Uint8Array): Promise<Module>;
+    function compile(bufferSource: BufferSource): Promise<Module>;
 
     interface ResultObject {
         module: Module;
         instance: Instance;
     }
 
-    function instantiate(bufferSource: ArrayBuffer | Uint8Array, importObject?: any): Promise<ResultObject>;
-    function instantiate(module: Module, importObject?: any): Promise<Instance>;
+    function instantiate(bufferSource: BufferSource, importObject?: object): Promise<ResultObject>;
+    function instantiate(module: Module, importObject?: object): Promise<Instance>;
 
-    function validate(bufferSource: ArrayBuffer | Uint8Array): boolean;
+    function validate(bufferSource: BufferSource): boolean;
 }

--- a/types/webassembly-web-api/index.d.ts
+++ b/types/webassembly-web-api/index.d.ts
@@ -13,5 +13,5 @@
  */
 declare namespace WebAssembly {
     function compileStreaming(source: Response | Promise<Response>): Promise<Module>;
-    function instantiateStreaming(source: Response | Promise<Response>, importObject?: any): Promise<ResultObject>;
+    function instantiateStreaming(source: Response | Promise<Response>, importObject?: object): Promise<ResultObject>;
 }


### PR DESCRIPTION
According to [WebAssembly JS API specification](https://webassembly.github.io/spec/js-api/#webassembly-namespace) `bufferSource` is of type `BufferSource` which is union of [these types](https://heycam.github.io/webidl/#BufferSource)