### PR TITLE
matchSelector should be matchesSelector in @types/sizzle

### DIFF
--- a/types/sizzle/index.d.ts
+++ b/types/sizzle/index.d.ts
@@ -15,7 +15,7 @@ interface SizzleStatic {
     (selector: string, context?: Element | Document | DocumentFragment): Element[];
     // tslint:disable-next-line:ban-types
     compile(selector: string): Function;
-    matchSelector(element: Element, selector: string): boolean;
+    matchesSelector(element: Element, selector: string): boolean;
     matches(selector: string, elements: Element[]): Element[];
 }
 


### PR DESCRIPTION
According to documentation (https://github.com/jquery/sizzle/wiki) the correct API is
Sizzle.matchesSelector( DOMElement element, String selector).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/jquery/sizzle/wiki