### PR TITLE
[react-native] accessibilityStates prop should be an array

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -1859,13 +1859,15 @@ export interface AccessibilityProps extends AccessibilityPropsAndroid, Accessibi
     /**
      * Accessibility State tells a person using either VoiceOver on iOS or TalkBack on Android the state of the element currently focused on.
      */
-    accessibilityStates?: "selected" | "disabled";
+    accessibilityStates?: AccessibilityState[];
 
     /**
      * An accessibility hint helps users understand what will happen when they perform an action on the accessibility element when that result is not obvious from the accessibility label.
      */
     accessibilityHint?: string;
 }
+
+export type AccessibilityState = "selected" | "disabled";
 
 export type AccessibilityRole =
     | "none"

--- a/types/react-native/test/index.tsx
+++ b/types/react-native/test/index.tsx
@@ -756,7 +756,7 @@ class AccessibilityTest extends React.Component {
                 accessibilityTraits={'none'}
                 onAccessibilityTap={() => {}}
                 accessibilityRole="header"
-                accessibilityStates="selected"
+                accessibilityStates={["selected"]}
                 accessibilityHint="Very importent header"
             >
                 <Text


### PR DESCRIPTION
The react-native docs state that the new `accessibilityStates` prop takes an array of either `selected` or `disabled` or both. Not just the string itself:

> Accessibility State tells a person using either VoiceOver on iOS or TalkBack on Android the state of the element currently focused on. The state of the element can be set either to selected or disabled or both:
> - **selected** Used when the element is in a selected state. For example, a button is selected.
> - **disabled** Used when the element is disabled and cannot be interacted with.
>
> To use, set the accessibilityStates to an array containing either selected, disabled, or both.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://facebook.github.io/react-native/docs/accessibility.html#accessibility-properties
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
