### PR TITLE
Fix mali dependents

### DIFF
--- a/types/ember/test/transition.ts
+++ b/types/ember/test/transition.ts
@@ -11,7 +11,7 @@ Ember.Route.extend({
 });
 
 Ember.Controller.extend({
-    previousTransition: <Transition | null> null,
+    previousTransition: null as Transition | null,
 
     actions: {
         login() {

--- a/types/ember/v2/test/transition.ts
+++ b/types/ember/v2/test/transition.ts
@@ -10,7 +10,7 @@ Ember.Route.extend({
 });
 
 Ember.Controller.extend({
-    previousTransition: <Ember.Transition | null> null,
+    previousTransition: null as Ember.Transition | null,
 
     actions: {
         login() {

--- a/types/mali-compose/index.d.ts
+++ b/types/mali-compose/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/malijs/mali-compose
 // Definitions by: Daniel Byrne <https://github.com/danwbyrne>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.1
+// TypeScript Version: 2.3
 
 import { Context } from "mali";
 

--- a/types/mali-compose/package.json
+++ b/types/mali-compose/package.json
@@ -1,0 +1,8 @@
+{
+    "private": true,
+    "dependencies": {
+        "grpc": "^1.16.1",
+        "mali": "^0.10.2",
+        "protobufjs": "^6.8.8"
+    }
+}

--- a/types/mali-onerror/index.d.ts
+++ b/types/mali-onerror/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/malijs/onerror
 // Definitions by: Daniel Byrne <https://github.com/danwbyrne>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.1
+// TypeScript Version: 2.3
 
 import { Context } from "mali";
 

--- a/types/mali-onerror/package.json
+++ b/types/mali-onerror/package.json
@@ -1,0 +1,8 @@
+{
+    "private": true,
+    "dependencies": {
+        "grpc": "^1.16.1",
+        "mali": "^0.10.2",
+        "protobufjs": "^6.8.8"
+    }
+}

--- a/types/ssh2/ssh2-tests.ts
+++ b/types/ssh2/ssh2-tests.ts
@@ -313,7 +313,7 @@ var buffersEqual = require('buffer-equal-constant-time'),
     //ssh2 = require('ssh2'),
     utils = ssh2.utils;
 
-var pubKey = utils.genPublicKey(<ssh2_streams.ParsedKey>utils.parseKey(fs.readFileSync('user.pub')));
+var pubKey = utils.genPublicKey(utils.parseKey(fs.readFileSync('user.pub')) as ssh2_streams.ParsedKey);
 
 new ssh2.Server({
     hostKeys: [fs.readFileSync('host.key')]


### PR DESCRIPTION
Mali dependents weren't updated when it was removed in #29985. This changes adds mali and its peer dependencies to package.json for mali-onerror and mali-compose.