### PR TITLE
restify (metrics plugin): Callback in metrics is called with arguments, not an object.

### DIFF
--- a/types/restify/restify-tests.ts
+++ b/types/restify/restify-tests.ts
@@ -175,7 +175,7 @@ server.on('after', (req: restify.Request, res: restify.Response, route: restify.
     restify.plugins.auditLogger({ event: 'after', log: logger })(req, res, route, err);
 });
 
-(<any> restify).defaultResponseHeaders = function(this: restify.Request, data: any) {
+(restify as any).defaultResponseHeaders = function(this: restify.Request, data: any) {
     this.header('Server', 'helloworld');
 };
 

--- a/types/restify/v5/index.d.ts
+++ b/types/restify/v5/index.d.ts
@@ -1198,23 +1198,6 @@ export namespace plugins {
         overrides?: any; // any
     }
 
-    interface MetricsCallback {
-        /**
-         *  An error if the request had an error
-         */
-        err: Error;
-
-        metrics: MetricsCallbackOptions;
-
-        req: Request;
-        res: Response;
-
-        /**
-         * The route obj that serviced the request
-         */
-        route: Route;
-    }
-
     type TMetricsCallback = 'close' | 'aborted' | undefined;
 
     interface MetricsCallbackOptions {
@@ -1257,7 +1240,7 @@ export namespace plugins {
      * }));
      * ```
      */
-    function metrics(opts: { server: Server }, callback: (options: MetricsCallback) => any): (...args: any[]) => void;
+    function metrics(opts: { server: Server }, callback: (err: Error, metrics: MetricsCallbackOptions, req: Request, res: Response, route: Route) => any): (...args: any[]) => void;
 
     /**
      * Parse the client's request for an OAUTH2 access tokensTable

--- a/types/restify/v5/restify-tests.ts
+++ b/types/restify/v5/restify-tests.ts
@@ -171,11 +171,11 @@ server.on('after', (req: restify.Request, res: restify.Response, route: restify.
 });
 
 server.on('after', restify.plugins.metrics(
-    {server: server},
+    {server},
     (err, metrics, req, res, route) => err || metrics
 ));
 
-(<any> restify).defaultResponseHeaders = function(this: restify.Request, data: any) {
+(restify as any).defaultResponseHeaders = function(this: restify.Request, data: any) {
     this.header('Server', 'helloworld');
 };
 

--- a/types/restify/v5/restify-tests.ts
+++ b/types/restify/v5/restify-tests.ts
@@ -170,6 +170,11 @@ server.on('after', (req: restify.Request, res: restify.Response, route: restify.
     restify.plugins.auditLogger({ event: 'after', log: logger })(req, res, route, err);
 });
 
+server.on('after', restify.plugins.metrics(
+    {server: server},
+    (err, metrics, req, res, route) => err || metrics
+));
+
 (<any> restify).defaultResponseHeaders = function(this: restify.Request, data: any) {
     this.header('Server', 'helloworld');
 };


### PR DESCRIPTION
Please fill in this template.

- [ X ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ X ] Test the change in your own code. (Compile and run.)
- [ X ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ X ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ X ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ X ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ X ] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/restify/node-restify/blob/master/lib/plugins/metrics.js#L92
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.