### PR TITLE
[aws-lambda] Added method attribute to APIGatewayProxyEvent

### DIFF
--- a/types/aws-lambda/index.d.ts
+++ b/types/aws-lambda/index.d.ts
@@ -24,6 +24,7 @@
 //                 Oliver Hookins <https://github.com/ohookins>
 //                 Trevor Leach <https://github.com/trevor-leach>
 //                 James Gregory <https://github.com/jagregory>
+//                 Terence Nero <https://github.com/terencenero007>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -62,6 +63,7 @@ export interface APIGatewayProxyEvent {
     headers: { [name: string]: string };
     multiValueHeaders: { [name: string]: string[] };
     httpMethod: string;
+    method: string;
     isBase64Encoded: boolean;
     path: string;
     pathParameters: { [name: string]: string } | null;

--- a/types/aws-lambda/index.d.ts
+++ b/types/aws-lambda/index.d.ts
@@ -63,7 +63,7 @@ export interface APIGatewayProxyEvent {
     headers: { [name: string]: string };
     multiValueHeaders: { [name: string]: string[] };
     httpMethod: string;
-    method: string;
+    method?: string;
     isBase64Encoded: boolean;
     path: string;
     pathParameters: { [name: string]: string } | null;


### PR DESCRIPTION
Added `method` attribute to APIGatewayProxyEvent in order to support APIGateway  integration mode `LAMBDA`

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/apollographql/apollo-server/issues/1964
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.