### PR TITLE
[node] Add `spawn()` overload which takes `options` but no `args`

### DIFF
--- a/types/ansi/ansi-tests.ts
+++ b/types/ansi/ansi-tests.ts
@@ -22,7 +22,7 @@ Object.keys({
 }).forEach((color) => {
     const cname = color.replace(/([a-z])([A-Z])/g, (_: string, l: string, u: string): string => `${l} ${u.toLowerCase()}`);
 
-    ((<(...anything: any[]) => ansi.Cursor> cursor[color])()
+    ((cursor[color] as (...anything: any[]) => ansi.Cursor)()
         .bold()
         .bg)[color === 'blue' || color === 'brightBlue' ? 'black' : 'blue']()
         .write(

--- a/types/async/test/index.ts
+++ b/types/async/test/index.ts
@@ -390,22 +390,22 @@ async.auto({
     get_data: function (callback: AsyncResultCallback<any>) { },
     make_folder: function (callback: AsyncResultCallback<any>) { },
     //arrays with different types are not accepted by TypeScript.
-    write_file: ['get_data', 'make_folder', <any>function (callback: AsyncResultCallback<any>) {
+    write_file: ['get_data', 'make_folder', function (callback: AsyncResultCallback<any>) {
         callback(null, filename);
-    }],
+    } as any],
     //arrays with different types are not accepted by TypeScript.
-    email_link: ['write_file', <any>function (callback: AsyncResultCallback<any>, results: any) { }]
+    email_link: ['write_file', function (callback: AsyncResultCallback<any>, results: any) { } as any]
 });
 
 async.auto({
     get_data: function (callback: AsyncResultCallback<any>) { },
     make_folder: function (callback: AsyncResultCallback<any>) { },
     //arrays with different types are not accepted by TypeScript.
-    write_file: ['get_data', 'make_folder', <any>function (callback: AsyncResultCallback<any>) {
+    write_file: ['get_data', 'make_folder', function (callback: AsyncResultCallback<any>) {
         callback(null, filename);
-    }],
+    } as any],
     //arrays with different types are not accepted by TypeScript.
-    email_link: ['write_file', <any>function (callback: AsyncResultCallback<any>, results: any) { }]
+    email_link: ['write_file', function (callback: AsyncResultCallback<any>, results: any) { } as any]
 }, function (err, results) {
     console.log('finished auto');
 });
@@ -421,11 +421,11 @@ async.auto<A>({
     get_data: function (callback: AsyncResultCallback<any>) { },
     make_folder: function (callback: AsyncResultCallback<any>) { },
     //arrays with different types are not accepted by TypeScript.
-    write_file: ['get_data', 'make_folder', <any>function (callback: AsyncResultCallback<any>) {
+    write_file: ['get_data', 'make_folder', function (callback: AsyncResultCallback<any>) {
         callback(null, filename);
-    }],
+    } as any],
     //arrays with different types are not accepted by TypeScript.
-    email_link: ['write_file', <any>function (callback: AsyncResultCallback<any>, results: any) { }]
+    email_link: ['write_file', function (callback: AsyncResultCallback<any>, results: any) { } as any]
 }, 1, function (err, results) {
     console.log('finished auto');
 });

--- a/types/atom/atom-tests.ts
+++ b/types/atom/atom-tests.ts
@@ -557,8 +557,8 @@ function testDesializerManager() {
     }
 
     function isStorableClass(o: object): o is StorableClass {
-        if (typeof o === "object" && (<StorableClass> o).name &&
-            (<StorableClass> o).name === "test") {
+        if (typeof o === "object" && (o as StorableClass).name &&
+            (o as StorableClass).name === "test") {
             return true;
         } else {
             return false;

--- a/types/baconjs/baconjs-tests.ts
+++ b/types/baconjs/baconjs-tests.ts
@@ -120,7 +120,7 @@ function CommonMethodsInEventStreamsAndProperties() {
     Bacon.fromArray([1, 2, 3]).withStateMachine(0, (sum, event) => {
         if (event.hasValue()) {
             // had to cast to `number` because event:Bacon.Next<number>|Bacon.Error<{}>
-            return [sum + <number>event.value(), []];
+            return [sum + (event.value() as number), []];
         }
         else if (event.isEnd()) {
             return [undefined, [new Bacon.Next(sum), event]];
@@ -140,8 +140,8 @@ function CommonMethodsInEventStreamsAndProperties() {
 
     {
         // This is handy for keeping track whether we are currently awaiting an AJAX response:
-        var ajaxRequest = <Bacon.Observable<Error, JQueryXHR>>{},
-            ajaxResponse = <Bacon.Observable<Error, JQueryXHR>>{},
+        var ajaxRequest = {} as Bacon.Observable<Error, JQueryXHR>,
+            ajaxResponse = {} as Bacon.Observable<Error, JQueryXHR>,
             showAjaxIndicator = ajaxRequest.awaiting(ajaxResponse);
     }
 

--- a/types/bell/bell-tests.ts
+++ b/types/bell/bell-tests.ts
@@ -16,7 +16,7 @@ async function run() {
         clientSecret: '',
         scope(request) {
             const scopes = ['public_profile', 'email'];
-            if ((<RequestQuery> request.query).wantsSharePermission) {
+            if ((request.query as RequestQuery).wantsSharePermission) {
               scopes.push('publish_actions');
             }
             return scopes;

--- a/types/d3kit/d3kit-tests.ts
+++ b/types/d3kit/d3kit-tests.ts
@@ -304,7 +304,7 @@ function test_svg_chart() {
      * Test plate functions
      */
     plate = new d3kit.SvgPlate();
-    plate = <d3kit.SvgPlate> chart.addPlate('a-plate', plate, true); // with doNotAppend
+    plate = chart.addPlate('a-plate', plate, true) as d3kit.SvgPlate; // with doNotAppend
     chart = chart.addPlate('a-plate', plate);       // without doNotAppend
     chart = chart.removePlate('a-plate');
 
@@ -381,7 +381,7 @@ function test_hybrid_chart() {
      * Test plate functions
      */
     plate = new d3kit.SvgPlate();
-    plate = <d3kit.SvgPlate> chart.addPlate('a-plate', plate, true); // with doNotAppend
+    plate = chart.addPlate('a-plate', plate, true) as d3kit.SvgPlate; // with doNotAppend
     chart = chart.addPlate('a-plate', plate);       // without doNotAppend
     chart = chart.removePlate('a-plate');
 

--- a/types/d3kit/v1/d3kit-tests.ts
+++ b/types/d3kit/v1/d3kit-tests.ts
@@ -380,8 +380,8 @@ describe('Skeleton', function(){
           b: 2
         });
         expect(skeleton).to.include.keys(['a', 'b']);
-        expect((<any>skeleton).a).to.equal(1);
-        expect((<any>skeleton).b).to.equal(2);
+        expect((skeleton as any).a).to.equal(1);
+        expect((skeleton as any).b).to.equal(2);
       });
       it('should overwrite existing fields', function(){
         skeleton.mixin({
@@ -391,7 +391,7 @@ describe('Skeleton', function(){
           b: 3
         });
         expect(skeleton).to.include.keys(['b']);
-        expect((<any>skeleton).b).to.equal(3);
+        expect((skeleton as any).b).to.equal(3);
       });
       it('should keep original fields if not overwritten', function(){
         skeleton.mixin({
@@ -403,9 +403,9 @@ describe('Skeleton', function(){
           b: 3
         });
         expect(skeleton).to.include.keys(['a', 'b', 'c']);
-        expect((<any>skeleton).a).to.equal(1);
-        expect((<any>skeleton).b).to.equal(3);
-        expect((<any>skeleton).c).to.equal(20);
+        expect((skeleton as any).a).to.equal(1);
+        expect((skeleton as any).b).to.equal(3);
+        expect((skeleton as any).c).to.equal(20);
       });
     });
 
@@ -720,7 +720,7 @@ describe('Chartlet', function(){
   beforeEach(function(done){
     ChildChartlet = function() {
       var chartlet = new d3kit.Chartlet(callback, callback, callback);
-      (<any>chartlet).runTest = function (testFunction: any) {
+      (chartlet as any).runTest = function (testFunction: any) {
         testFunction(chartlet);
       };
       return chartlet;
@@ -730,7 +730,7 @@ describe('Chartlet', function(){
       var chartlet = new d3kit.Chartlet(callback, callback, callback);
       var child = ChildChartlet();
       configureFunction(chartlet, child);
-      (<any>chartlet).runTest = (<any>child).runTest;
+      (chartlet as any).runTest = (child as any).runTest;
       return chartlet;
     };
 
@@ -850,7 +850,7 @@ describe('Chartlet', function(){
         })
         .property('foo', function(d:number) {return 2 * d;});
 
-      (<any>parent).runTest(function(child: d3kit.Chartlet) {
+      (parent as any).runTest(function(child: d3kit.Chartlet) {
         expect(child.getPropertyValue('bar', 4, 0)).to.be.equal(8);
       });
     });
@@ -862,7 +862,7 @@ describe('Chartlet', function(){
         })
         .property('foo', function(d:number) {return 2 * d;});
 
-      (<any>parent).runTest(function(child: d3kit.Chartlet) {
+      (parent as any).runTest(function(child: d3kit.Chartlet) {
         expect(child.getPropertyValue('foo', 4, 0)).to.be.equal(8);
       });
     });
@@ -878,7 +878,7 @@ describe('Chartlet', function(){
         .property('bar', function(d:number) {return 3 * d;})
         .property('baz', function(d:number) {return 4 * d;});
 
-      (<any>parent).runTest(function(child: d3kit.Chartlet) {
+      (parent as any).runTest(function(child: d3kit.Chartlet) {
         expect(child.getPropertyValue('foo-x', 1, 0)).to.be.equal(2);
         expect(child.getPropertyValue('bar-x', 1, 0)).to.be.equal(3);
         expect(child.getPropertyValue('baz-x', 1, 0)).to.be.equal(4);
@@ -894,7 +894,7 @@ describe('Chartlet', function(){
         .property('bar', function(d:number) {return 3 * d;})
         .property('baz', function(d:number) {return 4 * d;});
 
-      (<any>parent).runTest(function(child: d3kit.Chartlet) {
+      (parent as any).runTest(function(child: d3kit.Chartlet) {
         expect(child.getPropertyValue('foo', 1, 0)).to.be.equal(2);
         expect(child.getPropertyValue('bar', 1, 0)).to.be.equal(3);
         expect(child.getPropertyValue('baz', 1, 0)).to.be.equal(4);
@@ -914,7 +914,7 @@ describe('Chartlet', function(){
       var child = new d3kit.Chartlet(callback, callback, callback, ['foo'])
         .publishEventsTo(parent.getDispatcher());
 
-      (<any>child.getDispatcher()).foo(99);
+      (child.getDispatcher() as any).foo(99);
     });
   });
 });

--- a/types/db-migrate-base/db-migrate-base-tests.ts
+++ b/types/db-migrate-base/db-migrate-base-tests.ts
@@ -3,7 +3,7 @@
 import * as DbMigrateBase from "db-migrate-base";
 
 // Throw together a dummy driver
-let db = <DbMigrateBase.Base>{};
+let db = {} as DbMigrateBase.Base;
 
 let callback = (err: any, response: any) => {
   // Do nothing.

--- a/types/db-migrate-pg/db-migrate-pg-tests.ts
+++ b/types/db-migrate-pg/db-migrate-pg-tests.ts
@@ -3,7 +3,7 @@
 import * as DbMigratePg from "db-migrate-pg";
 
 // Throw together a dummy driver
-let db = <DbMigratePg.PgDriver>{};
+let db = {} as DbMigratePg.PgDriver;
 
 let callback = (err: any, response: any) => {
   // Do nothing.

--- a/types/dot-prop/dot-prop-tests.ts
+++ b/types/dot-prop/dot-prop-tests.ts
@@ -18,6 +18,6 @@ dotProp.has({foo: {bar: 'unicorn'}}, 'foo.bar');
 
 dotProp.delete(obj, 'foo.bar');
 console.log(obj);
-(<any> obj).foo.bar = {x: 'y', y: 'x'};
+(obj as any).foo.bar = {x: 'y', y: 'x'};
 dotProp.delete(obj, 'foo.bar.x');
 console.log(obj);

--- a/types/duplexer3/duplexer3-tests.ts
+++ b/types/duplexer3/duplexer3-tests.ts
@@ -8,7 +8,7 @@ writable._write = (input, encoding, done) => {
     if (readable.push(input)) {
         done();
     } else {
-        readable.once('drain', <(...args: any[]) => void> done);
+        readable.once('drain', done as (...args: any[]) => void);
     }
 };
 

--- a/types/easy-api-request/easy-api-request-tests.ts
+++ b/types/easy-api-request/easy-api-request-tests.ts
@@ -17,7 +17,7 @@ APIRequest.create({
 var app = express();
 
 app.get('/', function (req:any, res:express.Response) {
-    var rMaker = <APIRequest.RequestMaker>req.testAPI;
+    var rMaker = req.testAPI as APIRequest.RequestMaker;
     var r = rMaker();
     r.get('/', function (err, resp) {
         if(err) {
@@ -28,7 +28,7 @@ app.get('/', function (req:any, res:express.Response) {
 });
 
 app.get('/', function (req:any, res:express.Response) {
-    var rMaker = <APIRequest.RequestMaker>req.testAPI;
+    var rMaker = req.testAPI as APIRequest.RequestMaker;
     var r = rMaker();
     r.get('/')
         .then(function (resp) {

--- a/types/express-fileupload/express-fileupload-tests.ts
+++ b/types/express-fileupload/express-fileupload-tests.ts
@@ -9,7 +9,7 @@ const app: express.Express = express();
 app.use(fileUpload({debug: true}));
 
 function isUploadedFile(file: UploadedFile | UploadedFile[]): file is UploadedFile {
-    return typeof file === 'object' && (<UploadedFile> file).name !== undefined;
+    return typeof file === 'object' && (file as UploadedFile).name !== undefined;
 }
 
 const uploadHandler: RequestHandler = (req: Request, res: Response, next: NextFunction) => {

--- a/types/hapi/v12/hapi-tests.ts
+++ b/types/hapi/v12/hapi-tests.ts
@@ -6,7 +6,7 @@ import * as Hapi from 'hapi';
 
 // Create a server with a host and port
 var server = new Hapi.Server();
-server.connection(<Hapi.IServerConnectionOptions>{
+server.connection({
     host: "localhost",
     port: 8000
 });

--- a/types/hapi/v16/test/continuation/errors.ts
+++ b/types/hapi/v16/test/continuation/errors.ts
@@ -26,7 +26,7 @@ const handleError: Hapi.ContinuationValueFunction = (err?: Boom.BoomError | null
 handleError(Boom.badData());
 
 // Accepts an error with custom data
-const errorWithData = Boom.badImplementation('', { custom1: 'test', customType: <'Custom1'>'Custom1', isCustom: <true>true });
+const errorWithData = Boom.badImplementation('', { custom1: 'test', customType: 'Custom1' as 'Custom1', isCustom: true as true });
 handleError(errorWithData);
 
 // Accepts an error with a more explicit type

--- a/types/hapi/v16/test/route/additional-options.ts
+++ b/types/hapi/v16/test/route/additional-options.ts
@@ -10,28 +10,28 @@ var authConfig: Hapi.RouteAdditionalConfigurationOptions = {
 var extConfigSingle: Hapi.RouteAdditionalConfigurationOptions = {
     ext: {
         type: 'onPreAuth',
-        method: <Hapi.ServerExtRequestHandler> function (request, reply) {
+        method: function (request, reply) {
             reply('ok');
-        }
+        } as Hapi.ServerExtRequestHandler
     }
 }
 
 var extConfigMulti: Hapi.RouteAdditionalConfigurationOptions = {
     ext: [{
         type: 'onPreAuth',
-        method: <Hapi.ServerExtRequestHandler> function (request, reply) {
+        method: function (request, reply) {
             reply('ok');
-        }
+        } as Hapi.ServerExtRequestHandler
     }, {
         type: 'onPostAuth',
-        method: <Hapi.ServerExtRequestHandler> function (request, reply) {
+        method: function (request, reply) {
             reply('ok');
-        }
+        } as Hapi.ServerExtRequestHandler
     }, {
         type: 'onPostStart',
-        method: <Hapi.ServerExtFunction> function (server, next) {
+        method: function (server, next) {
             next();
-        }
+        } as Hapi.ServerExtFunction
   }]
 }
 

--- a/types/hapi/v16/test/route/public-interface.ts
+++ b/types/hapi/v16/test/route/public-interface.ts
@@ -2,7 +2,7 @@
 
 import * as Hapi from '../../';
 
-var route = <Hapi.RoutePublicInterface> {};
+var route = {} as Hapi.RoutePublicInterface;
 
 var a: string = route.method;
 var a: string = route.path;
@@ -14,4 +14,4 @@ if (typeof(route.vhost) == 'string') {
 var c: Hapi.ServerRealm = route.realm;
 var d: Hapi.RouteAdditionalConfigurationOptions = route.settings;
 var a: string = route.fingerprint;
-var e: boolean = route.auth.access(<Hapi.Request> {});
+var e: boolean = route.auth.access({} as Hapi.Request);

--- a/types/hapi/v16/test/route/validate.ts
+++ b/types/hapi/v16/test/route/validate.ts
@@ -55,10 +55,10 @@ const responseValidationFunction: Hapi.ValidationFunctionForRouteResponse<Custom
 
 config = {
     validate: validateWithFunctions,
-    response: <Hapi.RouteResponseConfigurationObject<CustomValidationOptions>>{
+    response: {
         schema: responseValidationFunction,
         options: {
             myOption: 18
         }
-    }
+    } as Hapi.RouteResponseConfigurationObject<CustomValidationOptions>
 };

--- a/types/hapi/v16/test/server/listener.ts
+++ b/types/hapi/v16/test/server/listener.ts
@@ -15,5 +15,5 @@ io.sockets.on('connection', (socket) => {
     // a wrapper around socket.io.  Much less likely is either
     // a type error in the TypeScript definitions of socket.io or
     // an error in the Hapi docs.
-    socket.emit(<any> { msg: 'welcome' });
+    socket.emit({ msg: 'welcome' } as any);
 });

--- a/types/html-webpack-plugin/html-webpack-plugin-tests.ts
+++ b/types/html-webpack-plugin/html-webpack-plugin-tests.ts
@@ -103,7 +103,7 @@ const plugins: HtmlWebpackPlugin[] = optionsArray.map(options => new HtmlWebpack
 // Webpack plugin `apply` function
 function apply(compiler: Compiler) {
 	compiler.hooks.compilation.tap('SomeWebpackPlugin', (compilation: compilation.Compilation) => {
-		(<HtmlWebpackPlugin.Hooks> compilation.hooks).htmlWebpackPluginAfterHtmlProcessing.tap(
+		(compilation.hooks as HtmlWebpackPlugin.Hooks).htmlWebpackPluginAfterHtmlProcessing.tap(
 			'MyPlugin',
 			(data) => {
 				data.html += 'The Magic Footer';

--- a/types/http-assert/http-assert-tests.ts
+++ b/types/http-assert/http-assert-tests.ts
@@ -5,7 +5,7 @@ try {
     httpAssert.equal('hello', 'hello');
     httpAssert(false, 401, 'authentication failed');
 } catch (err) {
-    console.log((<HttpError> err).status);
-    console.log((<HttpError> err).message);
-    console.log((<HttpError> err).expose);
+    console.log((err as HttpError).status);
+    console.log((err as HttpError).message);
+    console.log((err as HttpError).expose);
 }

--- a/types/irc/irc-tests.ts
+++ b/types/irc/irc-tests.ts
@@ -13,15 +13,15 @@ function test_bot() {
         console.log("Connected");
     });
 
-    bot.addListener('error', <irc.handlers.IError> ((message: irc.IMessage) => {
+    bot.addListener('error', ((message: irc.IMessage) => {
     console.error('ERROR: %s: %s', message.command, message.args.join(' '));
-    }));
+    }) as irc.handlers.IError);
 
-    bot.addListener('message#blah', <irc.handlers.IMessageChannel> ((from: string, message: string) => {
+    bot.addListener('message#blah', ((from: string, message: string) => {
     console.log('<%s> %s', from, message);
-    }));
+    }) as irc.handlers.IMessageChannel);
 
-    bot.addListener('message', <irc.handlers.IRecievedMessage> ((from: string, to: string, message: string) => {
+    bot.addListener('message', ((from: string, to: string, message: string) => {
     console.log('%s => %s: %s', from, to, message);
 
     if (to.match(/^[#&]/)) {
@@ -40,23 +40,23 @@ function test_bot() {
         // private message
         console.log('private message');
     }
-    }));
+    }) as irc.handlers.IRecievedMessage);
 
-    bot.addListener('pm', <irc.handlers.IPm> ((nick: string, message: string) => {
+    bot.addListener('pm', ((nick: string, message: string) => {
     console.log('Got private message from %s: %s', nick, message);
-    }));
+    }) as irc.handlers.IPm);
 
-    bot.addListener('join', <irc.handlers.IJoin> ((channel: string, who: string) => {
+    bot.addListener('join', ((channel: string, who: string) => {
     console.log('%s has joined %s', who, channel);
-    }));
+    }) as irc.handlers.IJoin);
 
-    bot.addListener('part', <irc.handlers.IPart> ((channel: string, who: string, reason: string) => {
+    bot.addListener('part', ((channel: string, who: string, reason: string) => {
     console.log('%s has left %s: %s', who, channel, reason);
-    }));
+    }) as irc.handlers.IPart);
 
-    bot.addListener('kick', <irc.handlers.IKick> ((channel: string, who: string, by: string, reason: string) => {
+    bot.addListener('kick', ((channel: string, who: string, by: string, reason: string) => {
     console.log('%s was kicked from %s by %s: %s', who, channel, by, reason);
-    }));
+    }) as irc.handlers.IKick);
 }
 
 function test_secure() {

--- a/types/jsdom/jsdom-tests.ts
+++ b/types/jsdom/jsdom-tests.ts
@@ -120,7 +120,7 @@ function test_runVMScript() {
     dom.runVMScript(s);
     dom.runVMScript(s);
 
-    (<any> dom.window).ran === 3;
+    (dom.window as any).ran === 3;
 }
 
 function test_reconfigure() {

--- a/types/maker.js/maker.js-tests.ts
+++ b/types/maker.js/maker.js-tests.ts
@@ -100,9 +100,9 @@ function test() {
 	function testKit() {
 		makerjs.kit.construct(null, null);
 		makerjs.kit.getParameterValues(null);
-		(<MakerJs.IMetaParameter>{}).max;
-		(<MakerJs.IKit>{}).metaParameters;
-		(<MakerJs.IKit>{}).notes;
+		({} as MakerJs.IMetaParameter).max;
+		({} as MakerJs.IKit).metaParameters;
+		({} as MakerJs.IKit).notes;
 	}
 
 	function testMeasure() {

--- a/types/meteor/test/globals/meteor-tests.ts
+++ b/types/meteor/test/globals/meteor-tests.ts
@@ -697,7 +697,7 @@ Accounts.onPageLoadLogin(function () {
 });
 
 // Covers this PR:  https://github.com/DefinitelyTyped/DefinitelyTyped/pull/8065
-var loginOpts = <Meteor.LoginWithExternalServiceOptions>{
+var loginOpts = {
     requestPermissions: ["a", "b"],
     requestOfflineToken: true,
     loginUrlParameters: { asdf: 1, qwer: "1234" },
@@ -705,7 +705,7 @@ var loginOpts = <Meteor.LoginWithExternalServiceOptions>{
     loginStyle: "Bold and powerful",
     redirectUrl: "popup",
     profile: "asdfasdf"
-};
+} as Meteor.LoginWithExternalServiceOptions;
 Meteor.loginWithMeteorDeveloperAccount(loginOpts, function (error: Meteor.Error) { });
 
 Accounts.emailTemplates.siteName = "AwesomeSite";
@@ -748,7 +748,7 @@ const deeperPrivateSetting = Meteor.settings['somePrivateSettings']['deeperSetti
 
 
 // Covers https://github.com/meteor-typings/meteor/issues/9
-const username = (<HTMLInputElement>Template.instance().find('#username')).value;
+const username = (Template.instance().find('#username') as HTMLInputElement).value;
 
 
 // Covers https://github.com/meteor-typings/meteor/issues/3

--- a/types/meteor/test/meteor-tests.ts
+++ b/types/meteor/test/meteor-tests.ts
@@ -709,7 +709,7 @@ Accounts.onPageLoadLogin(function () {
 });
 
 // Covers this PR:  https://github.com/DefinitelyTyped/DefinitelyTyped/pull/8065
-var loginOpts = <Meteor.LoginWithExternalServiceOptions>{
+var loginOpts = {
     requestPermissions: ["a", "b"],
     requestOfflineToken: true,
     loginUrlParameters: { asdf: 1, qwer: "1234" },
@@ -717,7 +717,7 @@ var loginOpts = <Meteor.LoginWithExternalServiceOptions>{
     loginStyle: "Bold and powerful",
     redirectUrl: "popup",
     profile: "asdfasdf"
-};
+} as Meteor.LoginWithExternalServiceOptions;
 Meteor.loginWithMeteorDeveloperAccount(loginOpts, function (error: Meteor.Error) { });
 
 Accounts.emailTemplates.siteName = "AwesomeSite";
@@ -760,7 +760,7 @@ const deeperPrivateSetting = Meteor.settings['somePrivateSettings']['deeperSetti
 
 
 // Covers https://github.com/meteor-typings/meteor/issues/9
-const username = (<HTMLInputElement>Template.instance().find('#username')).value;
+const username = (Template.instance().find('#username') as HTMLInputElement).value;
 
 
 // Covers https://github.com/meteor-typings/meteor/issues/3

--- a/types/mongoose-paginate/mongoose-paginate-tests.ts
+++ b/types/mongoose-paginate/mongoose-paginate-tests.ts
@@ -40,7 +40,7 @@ let router: Router = Router();
 
 router.get('/users.json', function(req: Request, res: Response) {
     let descending: boolean = true;
-    let options: PaginateOptions = <PaginateOptions>{};
+    let options: PaginateOptions = {} as PaginateOptions;
     options.select = 'email username';
     options.sort = { 'username': (descending ? -1 : 1) };
     options.populate = '';

--- a/types/mz/mz-tests.ts
+++ b/types/mz/mz-tests.ts
@@ -136,7 +136,7 @@ describe('readline', function () {
     var input = new stream.PassThrough()
     var output = new stream.PassThrough()
     var bufferedOutput = ''
-    var rl = readline.createInterface( input, output, <readline.Completer>completer, true )
+    var rl = readline.createInterface( input, output, completer as readline.Completer, true )
 
     rl.question('a').then(function (answer: string) {
       assert.equal(answer, 'bTESTSTRING')
@@ -174,12 +174,12 @@ describe('readline', function () {
     it('completer support sync', function (done) {
       function completer (line: string) {
         assert.equal(line, 'b')
-        return <[string[], string]>[['bTESTSTRING'], line]
+        return [['bTESTSTRING'], line] as [string[], string]
       }
 
       var input = new stream.PassThrough()
       var output = new stream.PassThrough()
-      var rl = readline.createInterface(input, output, <readline.Completer>completer, true)
+      var rl = readline.createInterface(input, output, completer as readline.Completer, true)
 
       rl.question('a').then(function (answer) {
         assert.ok(output.read().toString().match(/TESTSTRING/))
@@ -197,7 +197,7 @@ describe('readline', function () {
 
       var input = new stream.PassThrough()
       var output = new stream.PassThrough()
-      var rl = readline.createInterface(input, output, <readline.Completer>completer, true )
+      var rl = readline.createInterface(input, output, completer as readline.Completer, true )
 
       rl.question('a').then(function (answer) {
         assert.ok(output.read().toString().match(/TESTSTRING/))

--- a/types/nightmare/nightmare-tests.ts
+++ b/types/nightmare/nightmare-tests.ts
@@ -17,7 +17,7 @@ new Nightmare()
   .click('.searchsubmit')
   .wait('.url.breadcrumb')
   .evaluate(() => {
-    return (<HTMLElement>document.querySelector('.url.breadcrumb')).innerText;
+    return (document.querySelector('.url.breadcrumb') as HTMLElement).innerText;
   }, (breadcrumb: string) => {
     // expect(breadcrumb).to.equal('github.com');
   })
@@ -165,7 +165,7 @@ new Nightmare()
   .goto('http://validator.w3.org/#validate_by_upload')
   .upload('#uploaded_file', 'test/files/jquery-2.1.1.min.js')
   .evaluate(function () {
-    return (<HTMLInputElement>document.getElementById('uploaded_file')).value;
+    return (document.getElementById('uploaded_file') as HTMLInputElement).value;
   }, function (value) {
   })
   .run(done);
@@ -214,7 +214,7 @@ new Nightmare()
 
 var seconds = function () {
   var gifs = document.querySelectorAll('img');
-  var split = (<HTMLImageElement>gifs[gifs.length - 2]).src.split('.gif')[0];
+  var split = (gifs[gifs.length - 2] as HTMLImageElement).src.split('.gif')[0];
   var seconds = split.split('.com/c')[1];
   return parseInt(seconds, 10);
 };
@@ -319,7 +319,7 @@ new Nightmare()
   .headers(headers)
   .goto('http://httpbin.org/headers')
   .evaluate(function () {
-    return (<HTMLElement>document.body.children[0]).innerHTML;
+    return (document.body.children[0] as HTMLElement).innerHTML;
   }, function (data: string) {
   })
   .run(done);

--- a/types/node-ral/node-ral-tests.ts
+++ b/types/node-ral/node-ral-tests.ts
@@ -17,7 +17,7 @@ class HashringBalance extends nodeRal.Balance {
         return 'hashring';
     }
     fetchServer(balanceContext: nodeRal.Balance.BalanceContextClass, conf: {}, prevBackend: nodeRal.Server) {
-        return <nodeRal.Server> {};
+        return {} as nodeRal.Server;
     }
 }
 

--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -2655,6 +2655,7 @@ declare module "child_process" {
         windowsHide?: boolean;
     }
 
+    function spawn(command: string, options?: SpawnOptions): ChildProcess;
     function spawn(command: string, args?: ReadonlyArray<string>, options?: SpawnOptions): ChildProcess;
 
     interface ExecOptions {

--- a/types/node/node-tests.ts
+++ b/types/node/node-tests.ts
@@ -2636,6 +2636,8 @@ async function asyncStreamPipelineFinished() {
     {
         childProcess.exec("echo test");
         childProcess.exec("echo test", { windowsHide: true });
+        childProcess.spawn("echo");
+        childProcess.spawn("echo", { windowsHide: true });
         childProcess.spawn("echo", ["test"], { windowsHide: true });
         childProcess.spawn("echo", ["test"], { windowsHide: true, argv0: "echo-test" });
         childProcess.spawn("echo", ["test"], { stdio: [0xdeadbeef, "inherit", undefined, "pipe"] });

--- a/types/nw.js/nw.js-tests.ts
+++ b/types/nw.js/nw.js-tests.ts
@@ -164,7 +164,7 @@ nw.Screen.chooseDesktopMedia( ["window", "screen"],
                 maxWidth: 1920,
                 maxHeight: 1080
             },
-            optional: <any[]>[]
+            optional: [] as any[]
         };
         //navigator.webkitGetUserMedia( { audio: false, video: constraint }, success_func, fallback_func );
     }

--- a/types/pouchdb-core/pouchdb-core-tests.ts
+++ b/types/pouchdb-core/pouchdb-core-tests.ts
@@ -50,7 +50,7 @@ function testBulkDocs() {
     const isError = (
         result: PouchDB.Core.Response | PouchDB.Core.Error
     ): result is PouchDB.Core.Error => {
-        return !!(<PouchDB.Core.Error> result).error;
+        return !!(result as PouchDB.Core.Error).error;
     };
 
     db.bulkDocs([model, model2]).then((result) => {

--- a/types/pouchdb-upsert/pouchdb-upsert-tests.ts
+++ b/types/pouchdb-upsert/pouchdb-upsert-tests.ts
@@ -15,7 +15,7 @@ function testUpsert_WithPromise_AndReturnDoc() {
     // `doc` may be empty if the document didn't already exist, so we have to
     // cast it to the type containing the required fields.  If the document type
     // had all optional fields, the cast would not be necessary.
-    return <UpsertDocModel> doc;
+    return doc as UpsertDocModel;
   }).then((res: PouchDB.UpsertResponse) => {
   });
 }
@@ -25,7 +25,7 @@ function testUpsert_WithPromise_AndReturnFalsey() {
     if (doc.readonly)
       return false;
     // Make some updates....
-    return <UpsertDocModel> doc;
+    return doc as UpsertDocModel;
   }).then((res: PouchDB.UpsertResponse) => {
   });
 }
@@ -41,7 +41,7 @@ function testUpsert_WithPromise_AndReturnNewObject() {
 function testUpsert_WithCallback_AndReturnDoc() {
   db.upsert(docToUpsert._id, (doc) => {
     // Make some updates....
-    return <UpsertDocModel> doc;
+    return doc as UpsertDocModel;
   }, (error: PouchDB.Core.Error, res: PouchDB.UpsertResponse) => {});
 }
 
@@ -51,7 +51,7 @@ function testUpsert_WithCallback_AndReturnFalsey() {
     if (doc.readonly)
       return false;
     // Make some updates....
-    return <UpsertDocModel> doc;
+    return doc as UpsertDocModel;
   }, (error: PouchDB.Core.Error, res: PouchDB.UpsertResponse) => {});
 }
 

--- a/types/project-oxford/project-oxford-tests.ts
+++ b/types/project-oxford/project-oxford-tests.ts
@@ -12,7 +12,7 @@ const {describe, it, before, after, beforeEach, afterEach} = null as any as {
 var client = new oxford.Client(process.env.OXFORD_KEY);
 
 // Store variables, no point in calling the api too often
-var billFaces = <string[]>[];
+var billFaces = [] as string[];
 var personGroupId = "uuid.v4()";
 var personGroupId2 = "uuid.v4()";
 var billPersonId: string;
@@ -113,7 +113,7 @@ describe('Project Oxford Face API Test', function () {
 
     describe('#grouping()', function () {
         it('detects groups faces', function (done) {
-            var faceIds = <string[]>[];
+            var faceIds = [] as string[];
 
             this.timeout(10000);
 

--- a/types/react/test/index.ts
+++ b/types/react/test/index.ts
@@ -121,7 +121,7 @@ class ModernComponent extends React.Component<Props, State, Snapshot>
         hello: PropTypes.string.isRequired,
         world: PropTypes.string,
         foo: PropTypes.number.isRequired,
-        key: <PropTypes.Validator<string | number | undefined>> PropTypes.oneOfType([PropTypes.number, PropTypes.string])
+        key: PropTypes.oneOfType([PropTypes.number, PropTypes.string]) as PropTypes.Validator<string | number | undefined>
     };
 
     static contextTypes: React.ValidationMap<Context> = {

--- a/types/restify/restify-tests.ts
+++ b/types/restify/restify-tests.ts
@@ -175,7 +175,7 @@ server.on('after', (req: restify.Request, res: restify.Response, route: restify.
     restify.plugins.auditLogger({ event: 'after', log: logger })(req, res, route, err);
 });
 
-(<any> restify).defaultResponseHeaders = function(this: restify.Request, data: any) {
+(restify as any).defaultResponseHeaders = function(this: restify.Request, data: any) {
     this.header('Server', 'helloworld');
 };
 

--- a/types/restify/v4/restify-tests.ts
+++ b/types/restify/v4/restify-tests.ts
@@ -285,11 +285,11 @@ server.on('after', (req: restify.Request, res: restify.Response, route: restify.
     restify.auditLogger({ log: () => { } })(req, res, route, err);
 });
 
-(<any> restify).defaultResponseHeaders = function(this: restify.Request, data: any) {
+(restify as any).defaultResponseHeaders = function(this: restify.Request, data: any) {
     this.header('Server', 'helloworld');
 };
 
-(<any> restify).defaultResponseHeaders = false;
+(restify as any).defaultResponseHeaders = false;
 
 // RESTIFY Client Tests
 

--- a/types/restify/v5/restify-tests.ts
+++ b/types/restify/v5/restify-tests.ts
@@ -170,7 +170,7 @@ server.on('after', (req: restify.Request, res: restify.Response, route: restify.
     restify.plugins.auditLogger({ event: 'after', log: logger })(req, res, route, err);
 });
 
-(<any> restify).defaultResponseHeaders = function(this: restify.Request, data: any) {
+(restify as any).defaultResponseHeaders = function(this: restify.Request, data: any) {
     this.header('Server', 'helloworld');
 };
 

--- a/types/rx.wamp/rx.wamp-tests.ts
+++ b/types/rx.wamp/rx.wamp-tests.ts
@@ -137,11 +137,11 @@ function weather_station_monitor(session: autobahn.Session) {
 
     //Home control settings
     var desiredTemperature = Rx.Observable.subscribeAsObservable(session, "temperature.indoors.desired")
-        .map(x => <number>x.args[0]);
+        .map(x => x.args[0] as number);
 
     var dailyForecast =
         sensorReadings
-            .map(rawValue => <IWeather>rawValue.kwargs)
+            .map(rawValue => rawValue.kwargs as IWeather)
             .throttle(1000) // At most once every second
             .bufferWithTime(1000 * 60 * 60 * 24) //Milliseconds in a day
             .tap(readings => {

--- a/types/set-cookie-parser/set-cookie-parser-tests.ts
+++ b/types/set-cookie-parser/set-cookie-parser-tests.ts
@@ -39,7 +39,7 @@ assert.equal(cookies[1].name, "foo");
 assert.equal(cookies[1].value, "bar");
 
 // HTTP response message test
-var message = <http.IncomingMessage>{};
+var message = {} as http.IncomingMessage;
 message.headers = { "set-cookie": ["bam=baz", "foo=bar"] };
 cookies = setCookie(message);
 assert.equal(cookies.length, 2);

--- a/types/shelljs/shelljs-tests.ts
+++ b/types/shelljs/shelljs-tests.ts
@@ -82,10 +82,10 @@ import child = require("child_process");
 
 const version = shell.exec("node --version").stdout;
 
-const version2 = <shell.ExecOutputReturnValue> shell.exec("node --version", { async: false });
+const version2 = shell.exec("node --version", { async: false }) as shell.ExecOutputReturnValue;
 const output = version2.stdout;
 
-const asyncVersion3 = <child.ChildProcess> shell.exec("node --version", { async: true });
+const asyncVersion3 = shell.exec("node --version", { async: true }) as child.ChildProcess;
 let pid = asyncVersion3.pid;
 
 shell.exec("node --version", { silent: true }, (code, stdout, stderr) => {

--- a/types/socketio-jwt/socketio-jwt-tests.ts
+++ b/types/socketio-jwt/socketio-jwt-tests.ts
@@ -27,7 +27,7 @@ io.on('connection', authorize({
 
 io.on('authenticated', (socket: SocketIo.Socket) => {
 	console.log('authenticated!!');
-	console.log(JSON.stringify((<any> socket).anyNameYouWant));
+	console.log(JSON.stringify((socket as any).anyNameYouWant));
 });
 
 const secrets: any = {

--- a/types/spdy/spdy-tests.ts
+++ b/types/spdy/spdy-tests.ts
@@ -58,7 +58,7 @@ describe('SPDY Client', () => {
         server.listen(fixtures.port, () => {
           agent = spdy.createAgent({
                                      rejectUnauthorized: false,
-                                     port: <number> fixtures.port,
+                                     port: fixtures.port as number,
                                      spdy: {
                                        plain,
                                        protocol: plain ? npn : null,

--- a/types/swaggerize-express/swaggerize-express-tests.ts
+++ b/types/swaggerize-express/swaggerize-express-tests.ts
@@ -15,13 +15,13 @@ const api = {
 };
 
 var app = express();
-app.use(swaggerize(<swaggerize.Options>{
+app.use(swaggerize({
     api,
     docspath: '/api-docs',
     handlers: './handlers'
-}));
+} as swaggerize.Options));
 
-app.use(swaggerize(<swaggerize.Options>{
+app.use(swaggerize({
     api,
     docspath: '/api-docs',
     handlers: {
@@ -33,9 +33,9 @@ app.use(swaggerize(<swaggerize.Options>{
             }
         }
     }
-}));
+} as swaggerize.Options));
 
-app.use(swaggerize(<swaggerize.Options>{
+app.use(swaggerize({
     api,
     docspath: '/api-docs',
     handlers: {
@@ -48,9 +48,9 @@ app.use(swaggerize(<swaggerize.Options>{
             }
         }
     }
-}));
+} as swaggerize.Options));
 
 var server = app.listen(18888, 'localhost', function () {
     const addr = server.address() as AddressInfo;
-    (<swaggerize.SwaggerizedExpress>app).swagger.api.host = addr.address + ':' + addr.port;
+    (app as swaggerize.SwaggerizedExpress).swagger.api.host = addr.address + ':' + addr.port;
 });

--- a/types/terminal-menu/terminal-menu-tests.ts
+++ b/types/terminal-menu/terminal-menu-tests.ts
@@ -1,6 +1,6 @@
 import * as tty from "tty"; // For typing
 
-let stdin = (<tty.ReadStream> process.stdin);
+let stdin = (process.stdin as tty.ReadStream);
 
 if(!stdin.isTTY) {
     console.log("Terminal not supported");

--- a/types/twilio/twilio-tests.ts
+++ b/types/twilio/twilio-tests.ts
@@ -240,5 +240,5 @@ twilio.webhook("MYAUTHTOKEN", { validate: false });
 
 
 function getMockExpressRequest(): Express.Request {
-    return <Express.Request>JSON.parse("{}");
+    return JSON.parse("{}") as Express.Request;
 }

--- a/types/vinyl-fs/vinyl-fs-tests.ts
+++ b/types/vinyl-fs/vinyl-fs-tests.ts
@@ -383,9 +383,9 @@ describe('dest stream', () => {
          cwd: __dirname,
          path: inputPath,
          contents: expectedContents,
-         stat: <fs.Stats> {
+         stat: {
             mode: expectedMode
-         }
+         } as fs.Stats
       });
 
       const onEnd = () => {
@@ -424,9 +424,9 @@ describe('dest stream', () => {
          cwd: __dirname,
          path: inputPath,
          contents: contentStream,
-         stat: <fs.Stats> {
+         stat: {
             mode: expectedMode
-         }
+         } as fs.Stats
       });
 
       const onEnd = () => {
@@ -467,10 +467,10 @@ describe('dest stream', () => {
          cwd: __dirname,
          path: inputPath,
          contents: null,
-         stat: <fs.Stats> {
+         stat: {
             isDirectory: () => true,
             mode: expectedMode
-         }
+         } as fs.Stats
       });
 
       const onEnd = () => {
@@ -711,9 +711,9 @@ describe('symlink stream', () => {
          cwd: __dirname,
          path: inputPath,
          contents: expectedContents,
-         stat: <fs.Stats> {
+         stat: {
             mode: expectedMode
-         }
+         } as fs.Stats
       });
 
       const onEnd = () => {
@@ -752,9 +752,9 @@ describe('symlink stream', () => {
          cwd: __dirname,
          path: inputPath,
          contents: contentStream,
-         stat: <fs.Stats> {
+         stat: {
             mode: expectedMode
-         }
+         } as fs.Stats
       });
 
       const onEnd = () => {
@@ -795,10 +795,10 @@ describe('symlink stream', () => {
          cwd: __dirname,
          path: inputPath,
          contents: null,
-         stat: <fs.Stats> {
+         stat: {
             isDirectory: () => true,
             mode: expectedMode
-         }
+         } as fs.Stats
       });
 
       const onEnd = () => {
@@ -870,9 +870,9 @@ describe('symlink stream', () => {
          cwd: __dirname,
          path: inputPath,
          contents: expectedContents,
-         stat: <fs.Stats> {
+         stat: {
             mode: expectedMode
-         }
+         } as fs.Stats
       });
 
       fs.mkdirSync(expectedBase);

--- a/types/vinyl/v0/vinyl-tests.ts
+++ b/types/vinyl/v0/vinyl-tests.ts
@@ -167,11 +167,11 @@ describe('File', () => {
 	});
 
 	describe('isDirectory()', () => {
-		var fakeStat = <fs.Stats>{
+		var fakeStat = {
 			isDirectory() {
 				return true;
 			}
-		};
+		} as fs.Stats;
 
 		it('should return false when the contents are a Buffer', done => {
 			var val = new Buffer("test");
@@ -216,10 +216,10 @@ describe('File', () => {
 
 			let fileUtf8Contents = fileContents instanceof Buffer ?
 				fileContents.toString('utf8') :
-				(<NodeJS.ReadableStream>fileContents).toString();
+				(fileContents as NodeJS.ReadableStream).toString();
 			let file2Utf8Contents = file2Contents instanceof Buffer ?
 				file2Contents.toString('utf8') :
-				(<NodeJS.ReadableStream>file2Contents).toString();
+				(file2Contents as NodeJS.ReadableStream).toString();
 
 			file2Utf8Contents.should.equal(fileUtf8Contents);
 			done();

--- a/types/whatwg-streams/whatwg-streams-tests.ts
+++ b/types/whatwg-streams/whatwg-streams-tests.ts
@@ -149,7 +149,7 @@ function makeReadableFileStream(filename: string) {
         pull(controller) {
             const buffer = new ArrayBuffer(CHUNK_SIZE);
 
-            return fs.read(fd, <any>buffer, 0, CHUNK_SIZE, position).then(bytesRead => {
+            return fs.read(fd, buffer as any, 0, CHUNK_SIZE, position).then(bytesRead => {
                 if (bytesRead === 0) {
                     return fs.close(fd).then(() => controller.close());
                 } else {
@@ -189,7 +189,7 @@ function makeReadableByteFileStream(filename: string) {
             // feature allocates a buffer and passes it to us via byobRequest.
             const v = controller.byobRequest!.view;
 
-            return fs.read(fd, <any>v.buffer, v.byteOffset, v.byteLength, position).then(bytesRead => {
+            return fs.read(fd, v.buffer as any, v.byteOffset, v.byteLength, position).then(bytesRead => {
                 if (bytesRead === 0) {
                     return fs.close(fd).then(() => controller.close());
                 } else {

--- a/types/yog-log/yog-log-tests.ts
+++ b/types/yog-log/yog-log-tests.ts
@@ -16,7 +16,7 @@ const cookie_value = log.getCookie('test');
 const getLogFile = log.getLogFile(0);
 const log_format = log.getLogFormat('ACCESS');
 
-const logid = log.getLogID(<express.Request> {}, 'test');
+const logid = log.getLogID({} as express.Request, 'test');
 const intlevel = log.getLogLevelInt('ACCESS');
 const prfix = log.getLogPrefix();
 const log_str = log.getLogString('test');

--- a/types/yog2-kernel/yog2-kernel-tests.ts
+++ b/types/yog2-kernel/yog2-kernel-tests.ts
@@ -17,8 +17,8 @@ const handler = async function(req: yog2Kernel.Request, resp: yog2Kernel.Respons
     resp.render("test", {});
 };
 
-const router = <yog2Kernel.Router> {};
-(<yog2Kernel.ActionObject> router.action("test")).get;
+const router = {} as yog2Kernel.Router;
+(router.action("test") as yog2Kernel.ActionObject).get;
 
 const handler1 = router.wrapAsync(function() { });
 const handler21 = router.wrapAsync(function(req: yog2Kernel.Request) { });


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
* [Node docs](https://nodejs.org/api/child_process.html#child_process_child_process_spawnsync_command_args_options)

* If you want to test the overload at home:

`void require("child_process").spawn('ping', { stdio: 'inherit' }).on('exit', console.log.bind(console, 'exit code:'))`

- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
