### PR TITLE
Use as assert instead of angle bracket assert

### DIFF
--- a/types/ember/test/transition.ts
+++ b/types/ember/test/transition.ts
@@ -11,7 +11,7 @@ Ember.Route.extend({
 });
 
 Ember.Controller.extend({
-    previousTransition: <Transition | null> null,
+    previousTransition: null as Transition | null,
 
     actions: {
         login() {


### PR DESCRIPTION
Fix lint error caused by angle bracket type assertion in tests.