### PR TITLE
Fixed @feathersjs/feathers find service method return type

### DIFF
--- a/types/feathersjs__feathers/index.d.ts
+++ b/types/feathersjs__feathers/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for @feathersjs/feathers 3.0
+// Type definitions for @feathersjs/feathers 3.1
 // Project: http://feathersjs.com/
 // Definitions by:  Jan Lohage <https://github.com/j2L4e>
 //                  Abraao Alves <https://github.com/AbraaoAlves>
@@ -138,7 +138,7 @@ export interface HooksObject {
 
 // todo: figure out what to do: These methods don't actually need to be implemented, so they can be undefined at runtime. Yet making them optional gets cumbersome in strict mode.
 export interface ServiceMethods<T> {
-    find(params?: Params): Promise<T[] | Paginated<T>>;
+    find(params?: Params): Promise<T | T[] | Paginated<T>>;
 
     get(id: Id, params?: Params): Promise<T>;
 


### PR DESCRIPTION
**Description**
I noticed the type definition for the service method `find` in `feathersjs__feathers` was inaccurate, as it was not accepting `Promise<T>` as a valid return type, whereas the feathers docs specify that the return type can be an object, and not necessarily an array.

**Checklist**
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.) - tests currently don't work on master because of this error: `Error: Bad character in DefinitelyTyped/types/ace/test/selection.ts`
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/feathersjs/docs/blob/master/api/services.md#findparams
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

