### PR TITLE
Added a use for expect 'checker' with a callback

### DIFF
--- a/types/supertest/index.d.ts
+++ b/types/supertest/index.d.ts
@@ -24,7 +24,7 @@ declare namespace supertest {
       serverAddress(app: any, path: string): string;
       expect(status: number, callback?: CallbackHandler): this;
       expect(status: number, body: any, callback?: CallbackHandler): this;
-      expect(checker: (res: Response) => any): this;
+      expect(checker: (res: Response) => any, callback?: CallbackHandler): this;
       expect(body: string, callback?: CallbackHandler): this;
       expect(body: RegExp, callback?: CallbackHandler): this;
       expect(body: Object, callback?: CallbackHandler): this;


### PR DESCRIPTION
I often use expect(Object, CallbackHandler) because expect((Response) => any, CallbackHandler) doesn't exist. On the other hand, making callback nullable will allow those using it without callback to keep doing it.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://gist.github.com/alex-dev/c8ba1e640ff519db9d5faccc179536fa
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
