### PR TITLE
Refine types for npm package "ini"

### DIFF
--- a/types/ini/index.d.ts
+++ b/types/ini/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for ini v1.3.3
 // Project: https://github.com/isaacs/ini
 // Definitions by: Marcin Porębski <https://github.com/marcinporebski>
+//                 Chris Arnesen <https://github.com/carnesen>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 interface EncodeOptions {
@@ -8,9 +9,13 @@ interface EncodeOptions {
     whitespace: boolean
 }
 
-export function decode(inistring: string): any;
-export function parse(initstring: string): any;
-export function encode(object: any, options?: EncodeOptions): string;
-export function stringify(object: any, options?: EncodeOptions): string;
+export function decode(str: string): {
+  [key: string]: any;
+};
+export function parse(str: string): {
+  [key: string]: any;
+};
+export function encode(object: any, options?: EncodeOptions | string): string;
+export function stringify(object: any, options?: EncodeOptions | string): string;
 export function safe(val: string): string;
 export function unsafe(val: string): string;


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
https://github.com/npm/ini/blob/738eca59d77d8cfdddf5c477c17a0d8f8fbfe0fd/ini.js#L15 shows that the second argument of `encode` can be a string. As for the return type of `decode` (alias `parse`), the "out" variable is initialized as an empty object and never reassigned. String-keyed properties are subsequently added based on the contents of the blob being parsed. https://github.com/npm/ini/blob/738eca59d77d8cfdddf5c477c17a0d8f8fbfe0fd/ini.js#L70
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
