### PR TITLE
DefinitelyTyped/openlayers: added moveTolerance to mapOptions

### DIFF
--- a/types/ol/ol-tests.ts
+++ b/types/ol/ol-tests.ts
@@ -303,7 +303,7 @@ import VectorTile from 'ol/vectortile';
 import View from 'ol/view';
 
 // Map
-const map: ol.Map = new Map(<any> {});
+const map: ol.Map = new Map({} as any);
 declare const mapView: View;
 declare const layerBase: LayerBase;
 declare const control: ControlControl;
@@ -320,6 +320,6 @@ declare const size: ol.Size;
 declare const position: ol.Pixel;
 view = map.getView();
 view.getProjection();
-view.animate(<any> {});
-view.calculateExtent(<any> 'size');
+view.animate({} as any);
+view.calculateExtent('size' as any);
 view.centerOn(coordinate, size, position);

--- a/types/openlayers/index.d.ts
+++ b/types/openlayers/index.d.ts
@@ -12494,6 +12494,7 @@ export namespace olx {
         renderer?: (ol.RendererType | Array<(ol.RendererType | string)> | string);
         target?: (Element | string);
         view?: ol.View;
+        moveTolerance?: number;
     }
 
     /**

--- a/types/openlayers/openlayers-tests.ts
+++ b/types/openlayers/openlayers-tests.ts
@@ -175,7 +175,7 @@ loadingStrategy = ol.loadingstrategy.tile(tilegrid);
 // ol.geom.Circle
 //
 booleanValue = circle.intersectsExtent(extent);
-circle = <ol.geom.Circle> circle.transform(projectionLike, projectionLike);
+circle = circle.transform(projectionLike, projectionLike) as ol.geom.Circle;
 
 //
 //


### PR DESCRIPTION
added moveTolerance to mapOptions

Changing an existing definition:
Documentation:
http://openlayers.org/en/v4.6.5/apidoc/ol.Map.html
Issue:
https://github.com/DefinitelyTyped/DefinitelyTyped/issues/29999
