### PR TITLE
recharts: added tooltip.payload.payload

### DIFF
--- a/types/recharts/index.d.ts
+++ b/types/recharts/index.d.ts
@@ -796,6 +796,7 @@ export interface TooltipPayload {
     fill?: string;
     dataKey?: DataKey;
     formatter?: TooltipFormatter;
+    payload?: any;
 }
 
 export interface TooltipProps extends Animatable {


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/recharts/recharts/blob/9c6b0102af9b2dfa9a9dd4eed85d3ce254e849d6/src/chart/generateCategoricalChart.js#L569
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

---

As referenced in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/23057, recharts `Tooltip` contains several undocumented properties, widely used in examples and codebases.

One property not present in the typedef is `payload` ([defined here](https://github.com/recharts/recharts/blob/9c6b0102af9b2dfa9a9dd4eed85d3ce254e849d6/src/chart/generateCategoricalChart.js#L569)), which is a data object that contains data relating to the current tooltip data point.

The property cannot easily be typed as it changes per chart, but it should at least be declared as `any` to note that it exists. This follows the same format as other data payloads in the typings, for example [ScatterPoint](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/28be0fcccbe2b847929d78d159573bf8e0f7c9ab/types/recharts/index.d.ts#L718)

Also relates to https://github.com/recharts/recharts.org/issues/48