### PR TITLE
[simple-oauth2] Fix typing of authorizeURL params (fixed name)

### DIFF
--- a/types/simple-oauth2/index.d.ts
+++ b/types/simple-oauth2/index.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: Michael Müller <https://github.com/mad-mike>,
 //                 Troy Lamerton <https://github.com/troy-lamerton>
 //                 Martín Rodriguez <https://github.com/netux>
+//                 Linus Unnebäck <https://github.com/LinusU>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.9
 
@@ -99,9 +100,8 @@ export interface OAuthClient {
          */
         authorizeURL(
             params?: {
-                /** A key-value pair where key is ModuleOptions#client.idParamName and the value represents the Client-ID */
-                [ idParamName: string ]: string | undefined
-            } & {
+                /** A string that represents the Client-ID */
+                client_id?: string,
                 /** A string that represents the registered application URI where the user is redirected after authentication */
                 redirect_uri?: string,
                 /** A string or array of strings that represents the application privileges */

--- a/types/simple-oauth2/simple-oauth2-tests.ts
+++ b/types/simple-oauth2/simple-oauth2-tests.ts
@@ -26,6 +26,12 @@ const oauth2 = oauth2lib.create(credentials);
         state: '<state>'
     });
 
+    oauth2.authorizationCode.authorizeURL({
+        redirect_uri: 'http://localhost:3000/callback',
+        scope: ['<scope1>', '<scope2>'],
+        state: '<state>'
+    });
+
     // Redirect example using Express (see http://expressjs.com/api.html#res.redirect)
     // res.redirect(authorizationUri);
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).


This is an alternative proposal to #30613. Instead of allowing any key to be passed with `any` value, this hardcodes the key to `client_id`.

I think it's quite uncommon to change the key from `client_id`, and it's even more uncommon to pass the client id into the `authorizeURL` function at all. Therefore I think that this is a much better solution.

With the other approach, it wouldn't warn if you passed in e.g. `scopes: ['a', 'b']` instead of `scope: ['a', 'b']` (note the added `s`).