### PR TITLE
[simple-oauth2] Fix typing of authorizeURL params (dynamic name)

### DIFF
--- a/types/simple-oauth2/index.d.ts
+++ b/types/simple-oauth2/index.d.ts
@@ -3,13 +3,14 @@
 // Definitions by: Michael Müller <https://github.com/mad-mike>,
 //                 Troy Lamerton <https://github.com/troy-lamerton>
 //                 Martín Rodriguez <https://github.com/netux>
+//                 Linus Unnebäck <https://github.com/LinusU>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.9
 
 /** Creates a new simple-oauth2 client with the passed configuration */
-export function create(options: ModuleOptions): OAuthClient;
+export function create<ClientIdName extends string = 'client_id'>(options: ModuleOptions<ClientIdName>): OAuthClient<ClientIdName>;
 
-export interface ModuleOptions {
+export interface ModuleOptions<ClientIdName extends string = 'client_id'> {
     client: {
         /** Service registered client id. Required. */
         id: string,
@@ -18,7 +19,7 @@ export interface ModuleOptions {
         /** Parameter name used to send the client secret. Default to client_secret. */
         secretParamName?: string,
         /** Parameter name used to send the client id. Default to client_id. */
-        idParamName?: string
+        idParamName?: ClientIdName
     };
     auth: {
         /** String used to set the host to request the tokens to. Required. */
@@ -91,7 +92,7 @@ export interface ClientCredentialTokenConfig {
     scope?: string | string[];
 }
 
-export interface OAuthClient {
+export interface OAuthClient<ClientIdName extends string = 'client_id'> {
     authorizationCode: {
         /**
          * Redirect the user to the autorization page
@@ -99,8 +100,8 @@ export interface OAuthClient {
          */
         authorizeURL(
             params?: {
-                /** A key-value pair where key is ModuleOptions#client.idParamName and the value represents the Client-ID */
-                [ idParamName: string ]: string | undefined
+                /** A string that represents the Client-ID */
+                [key in ClientIdName]?: string
             } & {
                 /** A string that represents the registered application URI where the user is redirected after authentication */
                 redirect_uri?: string,

--- a/types/simple-oauth2/simple-oauth2-tests.ts
+++ b/types/simple-oauth2/simple-oauth2-tests.ts
@@ -17,12 +17,24 @@ const credentials: oauth2lib.ModuleOptions = {
 
 const oauth2 = oauth2lib.create(credentials);
 
+// Test custom `idParamName`
+{
+    const oauth2 = oauth2lib.create({ client: { id: 'x', secret: 'x', idParamName: 'foobar' }, auth: { tokenHost: 'x' } });
+    oauth2.authorizationCode.authorizeURL({ foobar: 'x' });
+}
+
 // #Authorization Code flow
 (async () => {
     // Authorization oauth2 URI
     const authorizationUri = oauth2.authorizationCode.authorizeURL({
         redirect_uri: 'http://localhost:3000/callback',
         scope: '<scope>',
+        state: '<state>'
+    });
+
+    oauth2.authorizationCode.authorizeURL({
+        redirect_uri: 'http://localhost:3000/callback',
+        scope: ['<scope1>', '<scope2>'],
         state: '<state>'
     });
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

This is an alternative approach to #30725 (and #30613) that preserves the actual key name and uses that.

I personally think that it becomes a bit ugly, and I don't know if anyone is using this feature (that is, is using a different name **and are passing it to `authorizeURL`**), but I guess it's the most correct one.