### PR TITLE
Fix compilation errors for three CodeMirror addons

### DIFF
--- a/types/codemirror/codemirror-comment.d.ts
+++ b/types/codemirror/codemirror-comment.d.ts
@@ -41,7 +41,3 @@ declare module "codemirror" {
         fullLines?: boolean;
     }
 }
-
-declare module "codemirror/addon/comment/comment" {
-    export = CodeMirror;
-}

--- a/types/codemirror/codemirror-panel.d.ts
+++ b/types/codemirror/codemirror-panel.d.ts
@@ -45,7 +45,3 @@ declare module "codemirror" {
 
     }
 }
-
-declare module "codemirror/addon/display/panel" {
-    export = CodeMirror;
-}

--- a/types/codemirror/codemirror-showhint.d.ts
+++ b/types/codemirror/codemirror-showhint.d.ts
@@ -76,7 +76,3 @@ declare module "codemirror" {
         hintOptions?: ShowHintOptions;
     }
 }
-
-declare module "codemirror/addon/hint/show-hint" {
-    export = CodeMirror;
-}


### PR DESCRIPTION
I was seeing typescript throw this error when importing the `panel` `showhint` and `comment` addons:

`Invalid module name in augmentation. Module 'codemirror/addon/display/panel' resolves to an untyped module at '/absolute/path/to/node_modules/codemirror/addon/display/panel.js', which cannot be augmented.`

It seems like the cause of this issue is that you are not allowed to declare a **new** module in the same file as you are **augmenting** another module. One option was to move all the module declarations into a separate file, and then augment those in similar to what the [Ace editor project did](https://github.com/ajaxorg/ace/pull/3696). This approach doesn't work for codemirror because the addons are not full modules, so I have chosen the alternate approach of removing the module creation. It also doesn't work for codemirror because of the syntax that was chosen of `export = CodeMirror`, which the typescript compiler rejects as well. The addons still work, as the tests show.



Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://stackoverflow.com/questions/42388217/having-error-module-name-resolves-to-an-untyped-module-at-when-writing-cu
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

