### PR TITLE
Add MSSQL PreparedStatement constructor using Transaction

### DIFF
--- a/types/mssql/index.d.ts
+++ b/types/mssql/index.d.ts
@@ -316,6 +316,7 @@ export declare class PreparedStatement extends events.EventEmitter {
     public parameters: IRequestParameters;
     public stream: any;
     public constructor(connection?: ConnectionPool);
+    public constructor(transaction: Transaction);
     public input(name: string, type: (() => ISqlType) | ISqlType): PreparedStatement;
     public output(name: string, type: (() => ISqlType) | ISqlType): PreparedStatement;
     public prepare(statement?: string): Promise<void>;

--- a/types/mssql/mssql-tests.ts
+++ b/types/mssql/mssql-tests.ts
@@ -189,6 +189,16 @@ function test_request_constructor() {
     var request4 = new sql.Request();
 }
 
+function test_prepared_statement_constructor() {
+    // Request can be constructed with a connection, preparedStatment, transaction or no arguments
+    var connection: sql.ConnectionPool = new sql.ConnectionPool(config);
+    var preparedStatment = new sql.PreparedStatement(connection);
+    var transaction = new sql.Transaction(connection);
+
+    var preparedSatement1 = new sql.PreparedStatement(connection);
+    var preparedSatement2 = new sql.PreparedStatement(transaction);
+}
+
 function test_classes_extend_eventemitter() {
     var connection: sql.ConnectionPool = new sql.ConnectionPool(config);
     var transaction = new sql.Transaction();


### PR DESCRIPTION
MSSQL npm package PreparedStatement object allows constructor with Transaction. Current type definition only defined one constructor for PreparedStatement using ConnectionPool. This PR just adds that other constructor and a unit test to double check the new constructor doesn't throw errors.
