### PR TITLE
react: Improve type checking of component static properties.

### DIFF
--- a/types/react-foundation/components/responsive.d.ts
+++ b/types/react-foundation/components/responsive.d.ts
@@ -24,36 +24,6 @@ export declare class ResponsiveNavigation extends Component<ResponsiveNavigation
      */
     toggle(): void;
     render(): JSX.Element;
-    static propTypes: {
-        breakpoint: PropTypes.Validator<any>;
-        alignX: PropTypes.Requireable<any>;
-        alignY: PropTypes.Requireable<any>;
-        selfAlignX: PropTypes.Requireable<any>;
-        selfAlignY: PropTypes.Requireable<any>;
-        centerAlign: PropTypes.Requireable<any>;
-        flexContainer: PropTypes.Requireable<any>;
-        flexDirRow: PropTypes.Requireable<any>;
-        flexDirRowRev: PropTypes.Requireable<any>;
-        flexDirCol: PropTypes.Requireable<any>;
-        flexDirColRev: PropTypes.Requireable<any>;
-        flexChild: PropTypes.Requireable<any>;
-        flexOrder: PropTypes.Requireable<any>;
-        flexOrderSmall: PropTypes.Requireable<any>;
-        flexOrderMedium: PropTypes.Requireable<any>;
-        flexOrderLarge: PropTypes.Requireable<any>;
-        showFor: PropTypes.Requireable<any>;
-        showOnlyFor: PropTypes.Requireable<any>;
-        hideFor: PropTypes.Requireable<any>;
-        hideOnlyFor: PropTypes.Requireable<any>;
-        isHidden: PropTypes.Requireable<any>;
-        isInvisible: PropTypes.Requireable<any>;
-        showForLandscape: PropTypes.Requireable<any>;
-        showForPortrait: PropTypes.Requireable<any>;
-        showForSr: PropTypes.Requireable<any>;
-        showOnFocus: PropTypes.Requireable<any>;
-        isClearfix: PropTypes.Requireable<any>;
-        float: PropTypes.Requireable<any>;
-    };
     static defaultProps: {
         breakpoint: number;
     };

--- a/types/react-select/lib/components/Menu.d.ts
+++ b/types/react-select/lib/components/Menu.d.ts
@@ -67,9 +67,6 @@ export type MenuProps<OptionType> = CommonProps<OptionType> & {
 export function menuCSS(state: MenuState): React.CSSProperties;
 
 export class Menu<OptionType> extends Component<MenuProps<OptionType>, MenuState> {
-  static contextTypes: {
-    getPortalPlacement: (state: MenuState) => void,
-  };
   getPlacement: (ref: ElementRef<any>) => void;
   getState: () => MenuProps<OptionType> & MenuState;
 }
@@ -146,9 +143,6 @@ interface PortalStyleArgs {
 export function menuPortalCSS(args: PortalStyleArgs): React.CSSProperties;
 
 export class MenuPortal<OptionType> extends Component<MenuPortalProps<OptionType>, MenuPortalState> {
-  static childContextTypes: {
-    getPortalPlacement: (state: MenuState) => void,
-  };
   getChildContext(): {
     getPortalPlacement: (state: MenuState) => void;
   };

--- a/types/react-select/test/examples/CustomNoOptionsMessage.tsx
+++ b/types/react-select/test/examples/CustomNoOptionsMessage.tsx
@@ -18,7 +18,12 @@ const NoOptionsMessage = (props: any) => {
 export default class CustomNoOptionsMessage extends React.Component {
   render() {
     return (
-      <Select
+      // Without the type argument, `OptionType` is inferred as `never` from the
+      // `options` attribute of type `never[]`, and `Select.defaultProps` (of
+      // type `Props<any>`) fails to be assignable to the instantiated props
+      // type, `Props<never>`.  This issue shouldn't come up in real code where
+      // the `options` attribute isn't a literal empty array.
+      <Select<{ label: string; value: string }>
         isClearable
         components={{ NoOptionsMessage }}
         styles={{ noOptionsMessage: (base: any) => ({ ...base, ...msgStyles }) }}

--- a/types/react-virtualized/dist/es/List.d.ts
+++ b/types/react-virtualized/dist/es/List.d.ts
@@ -30,7 +30,7 @@ export type ListProps = GridCoreProps & {
     /** Height constraint for list (determines how many actual rows are rendered) */
     height: number;
     /** Optional renderer to be used in place of rows when rowCount is 0 */
-    noRowsRenderer?: () => JSX.Element;
+    noRowsRenderer?: () => JSX.Element | null;
     /**
      * Callback invoked with information about the slice of rows that were just rendered.
      * ({ startIndex, stopIndex }): void

--- a/types/react-virtualized/dist/es/Table.d.ts
+++ b/types/react-virtualized/dist/es/Table.d.ts
@@ -152,26 +152,6 @@ export type ColumnProps = {
     width: number;
 };
 export class Column extends Component<ColumnProps> {
-    static propTypes: {
-        "aria-label": Requireable<string>;
-        cellDataGetter: Requireable<TableCellDataGetter>;
-        cellRenderer: Requireable<TableCellRenderer>;
-        className: Requireable<string>;
-        columnData: Requireable<object>;
-        dataKey: Validator<string>;
-        disableSort: Requireable<boolean>;
-        flexGrow: Requireable<number>;
-        flexShrink: Requireable<number>;
-        headerClassName: Requireable<string>;
-        headerRenderer: Validator<TableHeaderRowRenderer>;
-        label: Requireable<string>;
-        maxWidth: Requireable<number>;
-        minWidth: Requireable<number>;
-        style: Requireable<React.CSSProperties>;
-        width: Validator<number>;
-        id: Requireable<string>;
-    };
-
     static defaultProps: {
         cellDataGetter: TableCellDataGetter;
         cellRenderer: TableCellRenderer;
@@ -378,63 +358,6 @@ export const SortIndicator: React.StatelessComponent<{
  * This component expects explicit width, height, and padding parameters.
  */
 export class Table extends PureComponent<TableProps> {
-    static propTypes: {
-        "aria-label": Requireable<string>;
-        autoHeight: Requireable<boolean>;
-        children: Validator<Column>;
-        className: Requireable<string>;
-        disableHeader: Requireable<boolean>;
-        estimatedRowSize: Validator<number>;
-        gridClassName: Requireable<string>;
-        gridStyle: Requireable<React.CSSProperties>;
-        headerClassName: Requireable<string>;
-        headerHeight: Validator<number>;
-        headerRowRenderer: Requireable<TableHeaderRowRenderer>;
-        headerStyle: Requireable<React.CSSProperties>;
-        height: Validator<number>;
-        id: Requireable<string>;
-        noRowsRenderer: Requireable<() => JSX.Element>;
-        onHeaderClick: Requireable<
-            (params: HeaderMouseEventHandlerParams) => void
-        >;
-        onRowClick: Requireable<(params: RowMouseEventHandlerParams) => void>;
-        onRowDoubleClick: Requireable<
-            (params: RowMouseEventHandlerParams) => void
-        >;
-        onRowMouseOut: Requireable<
-            (params: RowMouseEventHandlerParams) => void
-        >;
-        onRowMouseOver: Requireable<
-            (params: RowMouseEventHandlerParams) => void
-        >;
-        onRowsRendered: Requireable<
-            (params: RowMouseEventHandlerParams) => void
-        >;
-        onScroll: Requireable<(params: ScrollEventData) => void>;
-        overscanRowCount: Validator<number>;
-        rowClassName: Requireable<string | ((params: Index) => string)>;
-        rowGetter: Validator<(params: Index) => any>;
-        rowHeight: Validator<number | ((params: Index) => number)>;
-        rowCount: Validator<number>;
-        rowRenderer: Requireable<(props: TableRowProps) => React.ReactNode>;
-        rowStyle: Validator<
-            React.CSSProperties | ((params: Index) => React.CSSProperties)
-        >;
-        scrollToAlignment: Validator<Alignment>;
-        scrollToIndex: Validator<number>;
-        scrollTop: Requireable<number>;
-        sort: Requireable<
-            (
-                params: { sortBy: string; sortDirection: SortDirectionType }
-            ) => void
-        >;
-        sortBy: Requireable<string>;
-        sortDirection: Validator<SortDirectionType>;
-        style: Requireable<React.CSSProperties>;
-        tabIndex: Requireable<number>;
-        width: Validator<number>;
-    };
-
     static defaultProps: {
         disableHeader: false;
         estimatedRowSize: 30;
@@ -445,7 +368,7 @@ export class Table extends PureComponent<TableProps> {
         onScroll: () => null;
         overscanRowCount: 10;
         rowRenderer: TableRowRenderer;
-        headerRowRenderer: TableHeaderRenderer;
+        headerRowRenderer: TableHeaderRowRenderer;
         rowStyle: {};
         scrollToAlignment: "auto";
         scrollToIndex: -1;

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -418,6 +418,34 @@ declare namespace React {
         refs: {
             [key: string]: ReactInstance
         };
+
+        // Static properties copied from ComponentClass interface.
+        /**
+         * The validity of the type of `propTypes` cannot be checked
+         * automatically at the definition of a component class because the
+         * required type depends on `P`.  We recommend checking it using
+         * `asPropTypes` from the `react-typescript-helpers` package.  If you
+         * don't do that, then the type will still be checked by
+         * JSX.LibraryManagedAttributes every time the component is used,
+         * assuming you use TypeScript 3.0 or newer.
+         */
+        // Note: `propTypes` and `defaultProps` need to be `any` so that a
+        // component class that does not redeclare them is assignable to
+        // `ComponentClass<P>`.
+        static propTypes?: any;
+        static contextTypes?: ValidationMap<any>;
+        static childContextTypes?: ValidationMap<any>;
+        /**
+         * The validity of the type of `defaultProps` cannot be checked
+         * automatically at the definition of a component class because the
+         * required type depends on `P`.  We recommend checking it using
+         * `asDefaultProps` from the `react-typescript-helpers` package.  If you
+         * don't do that, then the type will still be checked by
+         * JSX.LibraryManagedAttributes every time the component is used,
+         * assuming you use TypeScript 3.0 or newer.
+         */
+        static defaultProps?: any;
+        static displayName?: string;
     }
 
     class PureComponent<P = {}, S = {}, SS = any> extends Component<P, S, SS> { }
@@ -2633,30 +2661,76 @@ declare namespace React {
          */
         componentStack: string;
     }
+
+    const Invalid_propTypes: unique symbol;
+    /**
+     * Dummy interface that is intersected into the props type of a component on
+     * use to generate an error if the component's `propTypes` static property
+     * is invalid.  In most cases, you can get more information about the
+     * problem with the `propTypes` by trying to assign the component to a
+     * variable of type `React.ComponentType<P>` where `P` is the appropriate
+     * props type.  You can bypass the type checking of `propTypes` by defining
+     * a static property named `bypassPropTypesTypecheck`.
+     */
+    interface Invalid_propTypes<P, T> {
+        [Invalid_propTypes]: never;
+    }
+
+    const Invalid_defaultProps: unique symbol;
+    /**
+     * Dummy interface that is intersected into the props type of a component on
+     * use to generate an error if the component's `defaultProps` static
+     * property is invalid.  In most cases, you can get more information about
+     * the problem with the `defaultProps` by trying to assign the component to
+     * a variable of type `React.ComponentType<P>` where `P` is the appropriate
+     * props type.  You can bypass the type checking of `defaultProps` by
+     * defining a static property named `bypassDefaultPropsTypecheck`.
+     */
+    interface Invalid_defaultProps<P, D> {
+        [Invalid_defaultProps]: never;
+    }
+
+    // For a component class, the P passed to JSX.LibraryManagedAttributes is
+    // based on the `props` property and includes `children` regardless of
+    // whether the original props type (the `P` type argument to
+    // React.Component) does.  However, it's common for component classes not
+    // to list `children` in the `propTypes` if the original props type did not
+    // include `children`.  We accommodate that here by making the validator for
+    // `children` optional.
+    type ValidationMapWithOptionalChildren<P> =
+        ValidationMap<Pick<P, Exclude<keyof P, "children">>> &
+        Partial<ValidationMap<Pick<P, Extract<keyof P, "children">>>>;
+
+    // Explicitly check for excess properties in CheckPropTypes and
+    // CheckDefaultProps because by the time we get to
+    // JSX.LibraryManagedAttributes, we have lost the opportunity to do an
+    // excess properties check on the original object literal.
+
+    type CheckPropTypes<P, T> =
+        // This condition attempts to single out `T = any`, which needs to bypass the rest of the check
+        // because `keyof T` would come out as not extending `keyof P`.
+        T extends typeof Invalid_propTypes ? {} :
+        [keyof T, T] extends [keyof P, ValidationMapWithOptionalChildren<P>] ? {} : Invalid_propTypes<P, T>;
+
+    type CheckDefaultProps<P, D> =
+        D extends typeof Invalid_defaultProps ? {} :
+        [keyof D, D] extends [keyof P, Partial<P>] ? {} : Invalid_defaultProps<P, D>;
+
+    // Any prop that has a default prop becomes optional, but its type is unchanged
+    // If declared props have indexed properties, ignore default props entirely as keyof gets widened
+    // Wrap in an outer-level conditional type to allow distribution over props that are unions
+    type Defaultize<P, D> = P extends any
+        ? string extends keyof P ? P :
+            & Pick<P, Exclude<keyof P, keyof D>>
+            & Partial<Pick<P, Extract<keyof P, keyof D>>>
+        : never;
+
+    type ReactManagedAttributes<C, P> =
+        (C extends { propTypes: infer T; }
+            ? (C extends { bypassPropTypesTypecheck: {}; } ? {} : CheckPropTypes<P, T>) : {}) &
+        (C extends { defaultProps: infer D; }
+            ? (C extends { bypassDefaultPropsTypecheck: {}; } ? {} : CheckDefaultProps<P, D>) & Defaultize<P, D> : P);
 }
-
-// Declared props take priority over inferred props
-// If declared props have indexed properties, ignore inferred props entirely as keyof gets widened
-type MergePropTypes<P, T> = P & Pick<T, Exclude<keyof T, keyof P>>;
-
-// Any prop that has a default prop becomes optional, but its type is unchanged
-// Undeclared default props are augmented into the resulting allowable attributes
-// If declared props have indexed properties, ignore default props entirely as keyof gets widened
-// Wrap in an outer-level conditional type to allow distribution over props that are unions
-type Defaultize<P, D> = P extends any
-    ? string extends keyof P ? P :
-        & Pick<P, Exclude<keyof P, keyof D>>
-        & Partial<Pick<P, Extract<keyof P, keyof D>>>
-        & Partial<Pick<D, Exclude<keyof D, keyof P>>>
-    : never;
-
-type ReactManagedAttributes<C, P> = C extends { propTypes: infer T; defaultProps: infer D; }
-    ? Defaultize<MergePropTypes<P, PropTypes.InferProps<T>>, D>
-    : C extends { propTypes: infer T; }
-        ? MergePropTypes<P, PropTypes.InferProps<T>>
-        : C extends { defaultProps: infer D; }
-            ? Defaultize<P, D>
-            : P;
 
 declare global {
     namespace JSX {
@@ -2672,9 +2746,9 @@ declare global {
         // let's assume it's reasonable to do a single React.lazy() around a single React.memo() / vice-versa
         type LibraryManagedAttributes<C, P> = C extends React.MemoExoticComponent<infer T> | React.LazyExoticComponent<infer T>
             ? T extends React.MemoExoticComponent<infer U> | React.LazyExoticComponent<infer U>
-                ? ReactManagedAttributes<U, P>
-                : ReactManagedAttributes<T, P>
-            : ReactManagedAttributes<C, P>;
+                ? React.ReactManagedAttributes<U, P>
+                : React.ReactManagedAttributes<T, P>
+            : React.ReactManagedAttributes<C, P>;
 
         // tslint:disable-next-line:no-empty-interface
         interface IntrinsicAttributes extends React.Attributes { }

--- a/types/react/test/managedAttributes.tsx
+++ b/types/react/test/managedAttributes.tsx
@@ -1,14 +1,18 @@
 interface LeaveMeAloneDtslint { foo: string; }
-// // Re-enable when we move @types/react to TS 3.0
+// Re-enable when we move @types/react to TS 3.0 (except for the tests marked as
+// requiring TS >= 3.2)
+//
+// In the meantime, these tests can be run manually by uncommenting the code
+// below and running `dtslint --onlyTestTsNext`.
 
 // import * as React from 'react';
 // import * as PropTypes from 'prop-types';
 
 // interface Props {
-//     bool?: boolean;
+//     bool?: boolean | null;
 //     fnc: () => any;
 //     node?: React.ReactNode;
-//     num?: number;
+//     num?: number | null;
 //     reqNode: NonNullable<React.ReactNode>;
 //     str: string;
 // }
@@ -18,14 +22,12 @@ interface LeaveMeAloneDtslint { foo: string; }
 //     fnc: PropTypes.func.isRequired,
 //     node: PropTypes.node,
 //     num: PropTypes.number,
+//     reqNode: PropTypes.node.isRequired,
 //     str: PropTypes.string.isRequired,
-//     extraStr: PropTypes.string.isRequired,
-//     extraNum: PropTypes.number
 // };
 
 // const defaultProps = {
 //     fnc: (() => 'abc') as () => any,
-//     extraBool: false,
 //     reqNode: 'text_node' as NonNullable<React.ReactNode>
 // };
 
@@ -36,39 +38,12 @@ interface LeaveMeAloneDtslint { foo: string; }
 
 // const annotatedPropTypesAndDefaultPropsTests = [
 //     // $ExpectError
-//     <AnnotatedPropTypesAndDefaultProps />, // str and extraStr are required
-//     <AnnotatedPropTypesAndDefaultProps extraStr='abc' str='abc' />,
+//     <AnnotatedPropTypesAndDefaultProps />, // str is required
+//     <AnnotatedPropTypesAndDefaultProps str='abc' />,
 //     // $ExpectError
 //     <AnnotatedPropTypesAndDefaultProps num='abc' />, // num type mismatch
 //     <AnnotatedPropTypesAndDefaultProps
 //         bool={true}
-//         extraBool={true}
-//         extraNum={0}
-//         extraStr='abc'
-//         fnc={console.log}
-//         node={<span />}
-//         num={0}
-//         reqNode={<span />}
-//         str='abc'
-//     />
-// ];
-
-// class UnannotatedPropTypesAndDefaultProps extends React.Component {
-//     static propTypes = propTypes;
-//     static defaultProps = defaultProps;
-// }
-
-// const unannotatedPropTypesAndDefaultPropsTests = [
-//     // $ExpectError
-//     <UnannotatedPropTypesAndDefaultProps />, // stra and extraStr are required
-//     <UnannotatedPropTypesAndDefaultProps extraStr='abc' str='abc' />,
-//     // $ExpectError
-//     <UnannotatedPropTypesAndDefaultProps extraBool={0} />, // extraBool type mismatch
-//     <UnannotatedPropTypesAndDefaultProps
-//         bool={true}
-//         extraBool={true}
-//         extraNum={0}
-//         extraStr='abc'
 //         fnc={console.log}
 //         node={<span />}
 //         num={0}
@@ -83,43 +58,18 @@ interface LeaveMeAloneDtslint { foo: string; }
 
 // const annotatedPropTypesTests = [
 //     // $ExpectError
-//     <AnnotatedPropTypes />, // str, extraStr, reqNode and fnc are required
-//     <AnnotatedPropTypes fnc={console.log} extraStr='abc' str='abc' reqNode={<span />} />,
+//     <AnnotatedPropTypes />, // str, reqNode and fnc are required
+//     <AnnotatedPropTypes fnc={console.log} str='abc' reqNode={<span />} />,
 //     // $ExpectError
-//     <AnnotatedPropTypes fnc={console.log} extraStr='abc' str='abc' reqNode={<span />} extraBool={false} />, // extraBool doesn't exist
+//     <AnnotatedPropTypes fnc={console.log} str='abc' reqNode={<span />} extraBool={false} />, // extraBool doesn't exist
 //     // $ExpectError
-//     <AnnotatedPropTypes fnc={console.log} extraStr='abc' str='abc' reqNode={<span />} num='abc' />, // num type mismatch
+//     <AnnotatedPropTypes fnc={console.log} str='abc' reqNode={<span />} num='abc' />, // num type mismatch
 //     <AnnotatedPropTypes
 //         bool={false}
-//         extraNum={0}
-//         extraStr='abc'
 //         fnc={console.log}
 //         node={<React.Fragment />}
 //         num={0}
 //         reqNode={<React.Fragment />}
-//         str='abc'
-//     />
-// ];
-
-// class UnannotatedPropTypes extends React.Component {
-//     static propTypes = propTypes;
-// }
-
-// const unannotatedPropTypesTests = [
-//     // $ExpectError
-//     <UnannotatedPropTypes />, // str, extraStr and fnc are required
-//     <UnannotatedPropTypes fnc={console.log} extraStr='abc' str='abc' />,
-//     // $ExpectError
-//     <UnannotatedPropTypes fnc={console.log} extraStr='abc' str='abc' reqNode={<span />} />, // reqNode doesn't exist
-//     // $ExpectError
-//     <UnannotatedPropTypes fnc={console.log} extraStr='abc' str='abc' reqNode={<span />} num='abc' />, // num type mismatch
-//     <UnannotatedPropTypes
-//         bool={false}
-//         extraNum={0}
-//         extraStr='abc'
-//         fnc={console.log}
-//         node={<React.Fragment />}
-//         num={0}
 //         str='abc'
 //     />
 // ];
@@ -137,7 +87,6 @@ interface LeaveMeAloneDtslint { foo: string; }
 //     <AnnotatedDefaultProps str={() => { }} />, // str type mismatch
 //     <AnnotatedDefaultProps
 //         bool={true}
-//         extraBool={false}
 //         fnc={console.log}
 //         node={null}
 //         num={0}
@@ -146,31 +95,15 @@ interface LeaveMeAloneDtslint { foo: string; }
 //     />
 // ];
 
-// class UnannotatedDefaultProps extends React.Component {
-//     static defaultProps = defaultProps;
-// }
-
-// const unannotatedDefaultPropsTests = [
-//     <UnannotatedDefaultProps />,
-//     <UnannotatedDefaultProps
-//         extraBool={true}
-//         fnc={console.log}
-//         reqNode={<span />}
-//     />
-// ];
-
 // class ComponentWithNoDefaultProps extends React.Component<Props> {}
 
-// function FunctionalComponent(props: Props) { return <>{props.reqNode}</> }
+// function FunctionalComponent(props: Props) { return <>{props.reqNode}</>; }
 // FunctionalComponent.defaultProps = defaultProps;
 
 // const functionalComponentTests = [
 //     // $ExpectError
 //     <FunctionalComponent />,
-//     // This is possibly a bug/limitation of TS
-//     // Even if JSX.LibraryManagedAttributes returns the correct type, it doesn't seem to work with non-classes
-//     // This also doesn't work with things typed React.SFC<P> because defaultProps will always be Partial<P>
-//     // $ExpectError
+//     // NOTE: This test requires TypeScript >= 3.2, which honors JSX.LibraryManagedAttributes for function components.
 //     <FunctionalComponent str='' />
 // ];
 
@@ -182,27 +115,28 @@ interface LeaveMeAloneDtslint { foo: string; }
 // const memoTests = [
 //     // $ExpectError
 //     <MemoFunctionalComponent />,
-//     // $ExpectError won't work as long as FunctionalComponent doesn't work either
+//     // Requires TypeScript >= 3.2; see comment re FunctionalComponent above
 //     <MemoFunctionalComponent str='abc' />,
 //     // $ExpectError
 //     <MemoAnnotatedDefaultProps />,
 //     <AnnotatedDefaultProps str='abc' />,
-//     // $ExpectError this doesn't work despite JSX.LibraryManagedAttributes returning the correct type
+//     // Requires TypeScript >= 3.2; see comment re FunctionalComponent above
 //     <MemoAnnotatedDefaultProps str='abc' />,
-//     // $ExpectError won't work as long as FunctionalComponent doesn't work either
+//     // Requires TypeScript >= 3.2; see comment re FunctionalComponent above
 //     <LazyMemoFunctionalComponent str='abc' />,
 //     // $ExpectError
 //     <LazyMemoAnnotatedDefaultProps />,
-//     // $ExpectError this doesn't work despite JSX.LibraryManagedAttributes returning the correct type
+//     // Requires TypeScript >= 3.2; see comment re FunctionalComponent above
 //     <LazyMemoAnnotatedDefaultProps str='abc' />
 // ];
 
+// // $ExpectType Pick<Props, "bool" | "node" | "num" | "str"> & Partial<Pick<Props, "fnc" | "reqNode">>
 // type AnnotatedDefaultPropsLibraryManagedAttributes = JSX.LibraryManagedAttributes<typeof AnnotatedDefaultProps, Props>;
-// // $ExpectType AnnotatedDefaultPropsLibraryManagedAttributes
+// // $ExpectType Pick<Props, "bool" | "node" | "num" | "str"> & Partial<Pick<Props, "fnc" | "reqNode">>
 // type FunctionalComponentLibraryManagedAttributes = JSX.LibraryManagedAttributes<typeof FunctionalComponent, Props>;
-// // $ExpectType FunctionalComponentLibraryManagedAttributes
+// // $ExpectType Pick<Props, "bool" | "node" | "num" | "str"> & Partial<Pick<Props, "fnc" | "reqNode">>
 // type MemoFunctionalComponentLibraryManagedAttributes = JSX.LibraryManagedAttributes<typeof MemoFunctionalComponent, Props>;
-// // $ExpectType FunctionalComponentLibraryManagedAttributes
+// // $ExpectType Pick<Props, "bool" | "node" | "num" | "str"> & Partial<Pick<Props, "fnc" | "reqNode">>
 // type LazyMemoFunctionalComponentLibraryManagedAttributes = JSX.LibraryManagedAttributes<typeof LazyMemoFunctionalComponent, Props>;
 
 // const ForwardRef = React.forwardRef((props: Props, ref: React.Ref<ComponentWithNoDefaultProps>) => (
@@ -218,7 +152,97 @@ interface LeaveMeAloneDtslint { foo: string; }
 //         reqNode={<span />}
 //         str=''
 //     />,
-//     // same bug as MemoFunctionalComponent and React.SFC-typed things
-//     // $ExpectError the type of ForwardRef.defaultProps stays Partial<P> anyway even if assigned
+//     // the type of ForwardRef.defaultProps stays Partial<P> anyway even if assigned
+//     // $ExpectError
 //     <ForwardRef str='abc' />
+// ];
+
+// const wrongDefaultProps = {
+//     fnc: 42
+// };
+// class WrongDefaultPropsComponent extends React.Component<Props> {
+//     static defaultProps = wrongDefaultProps;
+// }
+// const wrongDefaultPropsComponentTests = [
+//     // $ExpectError
+//     <WrongDefaultPropsComponent fnc={() => undefined} reqNode="text" str="str" />
+// ];
+// // $ExpectError
+// const investigateWrongDefaultPropsComponent: React.ComponentType<Props> = WrongDefaultPropsComponent;
+
+// const excessDefaultProps = {
+//     another: 43
+// };
+// class ExcessDefaultPropsComponent extends React.Component<Props> {
+//     static defaultProps = excessDefaultProps;
+// }
+// const excessDefaultPropsComponentTests = [
+//     // $ExpectError
+//     <ExcessDefaultPropsComponent fnc={() => undefined} reqNode="text" str="str" />
+// ];
+// // $ExpectError
+// const investigateExcessDefaultPropsComponent: React.ComponentType<Props> = ExcessDefaultPropsComponent;
+
+// const wrongPropTypes = {
+//     bool: PropTypes.bool,
+//     fnc: PropTypes.number.isRequired,
+//     node: PropTypes.node,
+//     num: PropTypes.number,
+//     reqNode: PropTypes.node.isRequired,
+//     str: PropTypes.string.isRequired,
+// };
+// class WrongPropTypesComponent extends React.Component<Props> {
+//     static propTypes = wrongPropTypes;
+// }
+// const wrongPropTypesComponentTests = [
+//     // $ExpectError
+//     <WrongPropTypesComponent fnc={() => undefined} reqNode="text" str="str" />
+// ];
+
+// const incompletePropTypes = {
+//     bool: PropTypes.bool,
+//     node: PropTypes.node,
+//     num: PropTypes.number,
+//     reqNode: PropTypes.node.isRequired,
+//     str: PropTypes.string.isRequired,
+// };
+// class IncompletePropTypesComponent extends React.Component<Props> {
+//     static propTypes = incompletePropTypes;
+// }
+// const incompletePropTypesComponentTests = [
+//     // $ExpectError
+//     <IncompletePropTypesComponent fnc={() => undefined} reqNode="text" str="str" />
+// ];
+
+// const excessPropTypes = {
+//     another: PropTypes.number.isRequired,
+//     bool: PropTypes.bool,
+//     fnc: PropTypes.func.isRequired,
+//     node: PropTypes.node,
+//     num: PropTypes.number,
+//     reqNode: PropTypes.node.isRequired,
+//     str: PropTypes.string.isRequired,
+// };
+// class ExcessPropTypesComponent extends React.Component<Props> {
+//     static propTypes = excessPropTypes;
+// }
+// const ExcessPropTypesComponentTests = [
+//     // $ExpectError
+//     <ExcessPropTypesComponent fnc={() => undefined} reqNode="text" str="str" />
+// ];
+
+// class WrongDefaultPropsSuppressedComponent extends React.Component<Props> {
+//     static defaultProps = wrongDefaultProps;
+//     static bypassDefaultPropsTypecheck = true;
+// }
+// const wrongDefaultPropsSuppressedComponentTests = [
+//     <WrongDefaultPropsSuppressedComponent fnc={() => undefined} reqNode="text" str="str" />
+// ];
+
+// class WrongPropTypesSuppressedComponent extends React.Component<Props> {
+//     static propTypes = wrongPropTypes;
+//     static bypassPropTypesTypecheck = true;
+// }
+// const wrongPropTypesSuppressedComponentTests = [
+//     <WrongPropTypesSuppressedComponent fnc={() => undefined} reqNode="text" str="str" />
 // ];

--- a/types/theming/index.d.ts
+++ b/types/theming/index.d.ts
@@ -40,7 +40,7 @@ export interface ThemeListener<C extends string> {
     callback: (theme: Theme) => void
   ): SubscriptionId;
   unsubscribe(context: ContextWithTheme<C>, id: SubscriptionId): void;
-  contextTypes: React.ValidationMap<C>;
+  contextTypes: React.ValidationMap<ContextWithTheme<C>>;
 }
 /**
  * ThemeListener for the default channel


### PR DESCRIPTION
- Copy properties from ComponentClass to the Component class.

- Recommend the react-typescript-helpers package for checking the
  defaultProps and propTypes at a component definition.

- As a fallback, have JSX.LibraryManagedAttributes check the
  defaultProps and propTypes every time a component is used.

- Fix test failures in dependent packages.

Fixes #28515.
Fixes #16967.

Please review the fixes to the dependent packages!  I took my best guess at how to fix them because if I waited for the owners to answer a question, I suspect I would be waiting forever.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: N/A, improving type checking for already known runtime features
- [X] Increase the version number in the header if appropriate. (Not necessary)
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. (Already there)
