### PR TITLE
[prop-types] Don't require null in optional props

### DIFF
--- a/types/prop-types/index.d.ts
+++ b/types/prop-types/index.d.ts
@@ -41,7 +41,7 @@ export interface Requireable<T> extends Validator<T | undefined | null> {
     isRequired: Validator<NonNullable<T>>;
 }
 
-export type ValidationMap<T> = { [K in keyof T]-?: Validator<T[K]> };
+export type ValidationMap<T> = { [K in keyof T]-?: Validator<T[K] | null> };
 
 export type InferType<V> = V extends Validator<infer T> ? T : any;
 export type InferProps<V> =

--- a/types/prop-types/prop-types-tests.ts
+++ b/types/prop-types/prop-types-tests.ts
@@ -32,7 +32,8 @@ interface Props {
         bar?: boolean;
         baz?: any
     };
-    optionalNumber?: number | null;
+    optionalNumber?: number;
+    optionalNullableNumber?: number | null;
     customProp?: typeof uniqueType;
 }
 
@@ -74,6 +75,7 @@ const propTypes: PropTypesMap = {
     objectOf: PropTypes.objectOf(PropTypes.number.isRequired).isRequired,
     shape: PropTypes.shape(innerProps).isRequired,
     optionalNumber: PropTypes.number,
+    optionalNullableNumber: PropTypes.number,
     customProp: (() => null) as PropTypes.Validator<typeof uniqueType | undefined>
 };
 
@@ -100,6 +102,7 @@ const propTypesWithoutAnnotation = {
     objectOf: PropTypes.objectOf(PropTypes.number.isRequired).isRequired,
     shape: PropTypes.shape(innerProps).isRequired,
     optionalNumber: PropTypes.number,
+    optionalNullableNumber: PropTypes.number,
     customProp: (() => null) as PropTypes.Validator<typeof uniqueType | undefined>
 };
 


### PR DESCRIPTION
After https://github.com/DefinitelyTyped/DefinitelyTyped/pull/27378, it seems like every optional prop needs to be nullable in order to assign propTypes.

For example, the following will not compile unless className is nullable (`string | null`):

```tsx
import React, { FC } from "react";
import PropTypes from "prop-types";

type Props = { className?: string };
const Container: FC<Props> = props => <div className={props.className!} />;

Container.defaultProps = {
  className: ""
};

// Type 'null' is not assignable to type `string | undefined`
Container.propTypes = {
  className: PropTypes.string
};

export default Container;
```

Let's remove the null union so it is not required.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
