### PR TITLE
styled-system: Remove all type exports, and pull in values from csstype

### DIFF
--- a/types/styled-system/dist/space.d.ts
+++ b/types/styled-system/dist/space.d.ts
@@ -1,6 +1,6 @@
+import * as CSS from 'csstype';
+export type TLengthStyledSystem = string | 0 | number;
 export type ResponsiveValue<T> = T | Array<T | null>;
-
-export type SpaceValue = number | string;
 
 /**
  * Converts shorthand margin and padding props to margin and padding CSS declarations
@@ -11,37 +11,36 @@ export type SpaceValue = number | string;
  * - String values are passed as raw CSS values.
  * - Array values are converted into responsive values.
  */
-export type ResponsiveSpaceValue = ResponsiveValue<SpaceValue>;
 
-export interface SpaceProps {
+export interface SpaceProps<TLength = TLengthStyledSystem> {
     /** Margin on top, left, bottom and right */
-    m?: ResponsiveSpaceValue;
+    m?: ResponsiveValue<CSS.MarginProperty<TLength>>;
     /** Margin for the top */
-    mt?: ResponsiveSpaceValue;
+    mt?: ResponsiveValue<CSS.MarginTopProperty<TLength>>;
     /** Margin for the right */
-    mr?: ResponsiveSpaceValue;
+    mr?: ResponsiveValue<CSS.MarginRightProperty<TLength>>;
     /** Margin for the bottom */
-    mb?: ResponsiveSpaceValue;
+    mb?: ResponsiveValue<CSS.MarginBottomProperty<TLength>>;
     /** Margin for the left */
-    ml?: ResponsiveSpaceValue;
+    ml?: ResponsiveValue<CSS.MarginLeftProperty<TLength>>;
     /** Margin for the left and right */
-    mx?: ResponsiveSpaceValue;
+    mx?: ResponsiveValue<CSS.PaddingProperty<TLength>>;
     /** Margin for the top and bottom */
-    my?: ResponsiveSpaceValue;
+    my?: ResponsiveValue<CSS.PaddingProperty<TLength>>;
     /** Padding on top, left, bottom and right */
-    p?: ResponsiveSpaceValue;
+    p?: ResponsiveValue<CSS.PaddingProperty<TLength>>;
     /** Padding for the top */
-    pt?: ResponsiveSpaceValue;
+    pt?: ResponsiveValue<CSS.PaddingTopProperty<TLength>>;
     /** Padding for the right */
-    pr?: ResponsiveSpaceValue;
+    pr?: ResponsiveValue<CSS.PaddingRightProperty<TLength>>;
     /** Padding for the bottom */
-    pb?: ResponsiveSpaceValue;
+    pb?: ResponsiveValue<CSS.PaddingBottomProperty<TLength>>;
     /** Padding for the left */
-    pl?: ResponsiveSpaceValue;
+    pl?: ResponsiveValue<CSS.PaddingLeftProperty<TLength>>;
     /** Padding for the left and right */
-    px?: ResponsiveSpaceValue;
+    px?: ResponsiveValue<CSS.PaddingProperty<TLength>>;
     /** Padding for the top and bottom */
-    py?: ResponsiveSpaceValue;
+    py?: ResponsiveValue<CSS.PaddingProperty<TLength>>;
 }
 
 export function space(...args: any[]): any;

--- a/types/styled-system/dist/styles.d.ts
+++ b/types/styled-system/dist/styles.d.ts
@@ -1,8 +1,7 @@
-import { ResponsiveValue, ResponsiveSpaceValue, SpaceValue } from './space';
+import * as CSS from 'csstype';
+import { ResponsiveValue, TLengthStyledSystem } from './space';
 
 export * from './space';
-
-export type GlobalStyleValues = "inherit" | "initial" | "unset";
 
 export interface BaseTheme {
     breakpoints?: number[];
@@ -17,10 +16,7 @@ export interface BaseTheme {
  * Font Size
  */
 
-export type FontSizeValue = number | string;
-export type ResponsiveFontSizeValue = ResponsiveValue<FontSizeValue>;
-
-export interface FontSizeProps {
+export interface FontSizeProps<TLength = TLengthStyledSystem> {
     /**
      * The fontSize utility parses a component's `fontSize` prop and converts it into a CSS font-size declaration.
      *
@@ -30,7 +26,7 @@ export interface FontSizeProps {
      * - And array values are converted into responsive values.
      *
      */
-    fontSize?: ResponsiveFontSizeValue;
+    fontSize?: ResponsiveValue<CSS.FontSizeProperty<TLength>>;
 }
 
 export function fontSize(...args: any[]): any;
@@ -38,8 +34,6 @@ export function fontSize(...args: any[]): any;
 /**
  * Color
  */
-export type ColorValue = string;
-export type ResponsiveColorValue = ResponsiveValue<ColorValue>;
 
 export interface TextColorProps {
     /**
@@ -51,12 +45,12 @@ export interface TextColorProps {
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/color)
      */
-    color?: ResponsiveColorValue;
+    color?: ResponsiveValue<CSS.ColorProperty>;
 }
 
 export function textColor(...args: any[]): any;
 
-export interface BgColorProps {
+export interface BgColorProps<TLength = TLengthStyledSystem> {
     /**
      * The color utility parses a component's `color` and `bg` props and converts them into CSS declarations.
      * By default the raw value of the prop is returned.
@@ -66,7 +60,7 @@ export interface BgColorProps {
      *
      * [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/CSS/background-color)
      */
-    bg?: ResponsiveColorValue;
+    bg?: ResponsiveValue<CSS.BackgroundProperty<TLength>>;
 }
 
 export function bgColor(...args: any[]): any;
@@ -78,24 +72,10 @@ export function color(...args: any[]): any;
 /**
  * Typography
  */
-export type TypographyValue = string;
-export type ResponsiveTypographyValue = ResponsiveValue<TypographyValue>;
-
 export interface FontFamilyProps {
-    fontFamily?: ResponsiveTypographyValue;
+    fontFamily?: ResponsiveValue<CSS.FontFamilyProperty>;
 }
 export function fontFamily(...args: any[]): any;
-
-export type TextAlignValue =
-    | "left"
-    | "right"
-    | "center"
-    | "justify"
-    | "justify-all"
-    | "start"
-    | "end"
-    | "match-parent";
-export type ResponsiveTextAlignValue = ResponsiveValue<TextAlignValue>;
 
 export interface TextAlignProps {
     /**
@@ -103,14 +83,12 @@ export interface TextAlignProps {
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/text-align)
      */
-    textAlign?: ResponsiveTextAlignValue;
+    textAlign?: ResponsiveValue<CSS.TextAlignProperty>;
 }
 
 export function textAlign(...args: any[]): any;
 
-export type LineHeightValue = number | string;
-export type ResponsiveLineHeightValue = ResponsiveValue<LineHeightValue>;
-export interface LineHeightProps {
+export interface LineHeightProps<TLength = TLengthStyledSystem> {
     /**
      * The line-height CSS property sets the amount of space used for lines, such as in text. On block-level elements,
      * it specifies the minimum height of line boxes within the element.
@@ -119,18 +97,9 @@ export interface LineHeightProps {
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/line-height)
      */
-    lineHeight?: ResponsiveLineHeightValue;
+    lineHeight?: ResponsiveValue<CSS.LineHeightProperty<TLength>>;
 }
 export function lineHeight(...args: any[]): any;
-
-export type FontWeightValue =
-    | GlobalStyleValues
-    | "normal"
-    | "bold"
-    | "lighter"
-    | "bolder"
-    | number;
-export type ResponsiveFontWeightValue = ResponsiveValue<FontWeightValue>;
 
 export interface FontWeightProps {
     /**
@@ -140,13 +109,11 @@ export interface FontWeightProps {
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight)
      */
-    fontWeight?: ResponsiveFontWeightValue;
+    fontWeight?: ResponsiveValue<CSS.FontWeightProperty>;
 }
 
 export function fontWeight(...args: any[]): any;
 
-export type FontStyleValue = string;
-export type ResponsiveFontStyleValue = ResponsiveValue<FontStyleValue>;
 export interface FontStyleProps {
     /**
      * The font-style CSS property specifies whether a font should be styled with a normal, italic,
@@ -154,19 +121,17 @@ export interface FontStyleProps {
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/font-style)
      */
-    fontStyle?: ResponsiveFontStyleValue;
+    fontStyle?: ResponsiveValue<CSS.FontStyleProperty>;
 }
 export function fontStyle(...args: any[]): any;
 
-export type LetterSpacingValue = number | string;
-export type ResponsiveLetterSpacingValue = ResponsiveValue<LetterSpacingValue>;
-export interface LetterSpacingProps {
+export interface LetterSpacingProps<TLength = TLengthStyledSystem> {
     /**
      * The letter-spacing CSS property sets the spacing behavior between text characters.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/letter-spacing)
      */
-    letterSpacing?: ResponsiveLetterSpacingValue;
+    letterSpacing?: ResponsiveValue<CSS.LetterSpacingProperty<TLength>>;
 }
 export function letterSpacing(...args: any[]): any;
 
@@ -174,15 +139,6 @@ export function letterSpacing(...args: any[]): any;
  * Layout
  */
 
-export type DisplayValue =
-    | "none"
-    | "inline"
-    | "block"
-    | "contents"
-    | "flex"
-    | "grid"
-    | "inline-block";
-export type ResponsiveDisplayValue = ResponsiveValue<DisplayValue>;
 export interface DisplayProps {
     /**
      * The display CSS property defines the display type of an element, which consists of the two basic qualities
@@ -191,36 +147,36 @@ export interface DisplayProps {
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/display)
      */
-    display?: ResponsiveDisplayValue;
+    display?: ResponsiveValue<CSS.DisplayProperty>;
 }
 
 export function display(...args: any[]): any;
 
-export interface MaxWidthProps {
+export interface MaxWidthProps<TLength = TLengthStyledSystem> {
     /**
      * The max-width CSS property sets the maximum width of an element.
      * It prevents the used value of the width property from becoming larger than the value specified by max-width.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/max-width)
      */
-    maxWidth?: ResponsiveSpaceValue;
+    maxWidth?: ResponsiveValue<CSS.MaxWidthProperty<TLength>>;
 }
 
 export function maxWidth(...args: any[]): any;
 
-export interface MinWidthProps {
+export interface MinWidthProps<TLength = TLengthStyledSystem> {
     /**
      * The min-width CSS property sets the minimum width of an element.
      * It prevents the used value of the width property from becoming smaller than the value specified for min-width.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/min-width)
      */
-    minWidth?: ResponsiveSpaceValue;
+    minWidth?: ResponsiveValue<CSS.MinWidthProperty<TLength>>;
 }
 
 export function minWidth(...args: any[]): any;
 
-export interface WidthProps {
+export interface WidthProps<TLength = TLengthStyledSystem> {
     /**
      *   The width utility parses a component's `width` prop and converts it into a CSS width declaration.
      *
@@ -229,57 +185,57 @@ export interface WidthProps {
      *   - String values are passed as raw CSS values.
      *   - And arrays are converted to responsive width styles.
      */
-    width?: ResponsiveSpaceValue;
+    width?: ResponsiveValue<CSS.WidthProperty<TLength>>;
 }
 
 export function width(...args: any[]): any;
 
-export interface MaxHeightProps {
+export interface MaxHeightProps<TLength = TLengthStyledSystem> {
     /**
      * The max-height CSS property sets the maximum height of an element. It prevents the used value of the height
      * property from becoming larger than the value specified for max-height.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/max-height)
      */
-    maxHeight?: ResponsiveSpaceValue;
+    maxHeight?: ResponsiveValue<CSS.MaxHeightProperty<TLength>>;
 }
 
 export function maxHeight(...args: any[]): any;
 
-export interface MinHeightProps {
+export interface MinHeightProps<TLength = TLengthStyledSystem> {
     /**
      * The min-height CSS property sets the minimum height of an element. It prevents the used value of the height
      * property from becoming smaller than the value specified for min-height.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/display)
      */
-    minHeight?: ResponsiveSpaceValue;
+    minHeight?: ResponsiveValue<CSS.MinHeightProperty<TLength>>;
 }
 
 export function minHeight(...args: any[]): any;
 
-export interface HeightProps {
+export interface HeightProps<TLength = TLengthStyledSystem> {
     /**
      * The height CSS property specifies the height of an element. By default, the property defines the height of the
      * content area. If box-sizing is set to border-box, however, it instead determines the height of the border area.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/height)
      */
-    height?: ResponsiveSpaceValue;
+    height?: ResponsiveValue<CSS.HeightProperty<TLength>>;
 }
 
 export function height(...args: any[]): any;
 
 // TODO: Document, I couldn't find any info on these two properties...
 
-export interface SizeWidthProps {
-    size?: ResponsiveSpaceValue;
+export interface SizeWidthProps<TLength = TLengthStyledSystem> {
+    size?: ResponsiveValue<CSS.WidthProperty<TLength>>;
 }
 
 export function sizeWidth(...args: any[]): any;
 
-export interface SizeHeightProps {
-    size?: ResponsiveSpaceValue;
+export interface SizeHeightProps<TLength = TLengthStyledSystem> {
+    size?: ResponsiveValue<CSS.HeightProperty<TLength>>;
 }
 
 export function sizeHeight(...args: any[]): any;
@@ -288,38 +244,22 @@ export interface SizeProps extends SizeHeightProps, SizeWidthProps {}
 
 export function size(...args: any[]): any;
 
-export type RatioValue = SpaceValue;
-export type ResponsiveRatioValue = ResponsiveValue<RatioValue>;
-
 export interface RatioProps {
     /**
      * The ration is height: 0 & paddingBottom
      */
-    ratio?: ResponsiveRatioValue;
+    ratio?: ResponsiveValue<number>;
 }
 
 export function ratio(...args: any[]): any;
 
-export type VerticalAlignValue =
-    | "baseline"
-    | "sub"
-    | "super"
-    | "text-top"
-    | "text-bottom"
-    | "middle"
-    | "top"
-    | "bottom"
-    | string
-    | number;
-export type ResponsiveVerticalAlignValue = ResponsiveValue<VerticalAlignValue>;
-
-export interface VerticalAlignProps {
+export interface VerticalAlignProps<TLength = TLengthStyledSystem> {
     /**
      * The vertical-align CSS property specifies sets vertical alignment of an inline or table-cell box.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/vertical-align)
      */
-    verticalAlign?: ResponsiveVerticalAlignValue;
+    verticalAlign?: ResponsiveValue<CSS.VerticalAlignProperty<TLength>>;
 }
 
 export function verticalAlign(...args: any[]): any;
@@ -327,25 +267,6 @@ export function verticalAlign(...args: any[]): any;
 /**
  * Flexbox
  */
-
-export type AlignItemsValue =
-    | "normal"
-    | "stretch"
-    | "center"
-    | "start"
-    | "end"
-    | "flex-start"
-    | "flex-end"
-    | "self-start"
-    | "self-end"
-    | "left"
-    | "right"
-    | "baseline"
-    | "first baseline"
-    | "last baseline"
-    | "safe center"
-    | "unsafe center";
-export type ResponsiveAlignItemsValue = ResponsiveValue<AlignItemsValue>;
 
 export interface AlignItemsProps {
     /**
@@ -357,29 +278,10 @@ export interface AlignItemsProps {
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/align-items)
      */
-    alignItems?: ResponsiveAlignItemsValue;
+    alignItems?: ResponsiveValue<CSS.AlignItemsProperty>;
 }
 
 export function alignItems(...args: any[]): any;
-
-export type AlignContentValue =
-    | GlobalStyleValues
-    | "center"
-    | "start"
-    | "end"
-    | "flex-start"
-    | "flex-end"
-    | "normal"
-    | "baseline"
-    | "first baseline"
-    | "last baseline"
-    | "space-between"
-    | "space-around"
-    | "space-evenly"
-    | "stretch"
-    | "safe center"
-    | "unsafe center";
-export type ResponsiveAlignContentValue = ResponsiveValue<AlignContentValue>;
 
 export interface AlignContentProps {
     /**
@@ -388,13 +290,10 @@ export interface AlignContentProps {
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/align-content)
      */
-    alignContent?: ResponsiveAlignContentValue;
+    alignContent?: ResponsiveValue<CSS.AlignContentProperty>;
 }
 
 export function alignContent(...args: any[]): any;
-
-export type JustifyItemsValue = string;
-export type ResponsiveJustifyItemsValue = ResponsiveValue<JustifyItemsValue>;
 
 export interface JustifyItemsProps {
     /**
@@ -403,29 +302,8 @@ export interface JustifyItemsProps {
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/justify-items)
      */
-    justifyItems?: ResponsiveJustifyItemsValue;
+    justifyItems?: ResponsiveValue<CSS.JustifyItemsProperty>;
 }
-
-export type JustifyContentValue =
-    | "center"
-    | "start"
-    | "end"
-    | "flex-start"
-    | "flex-end"
-    | "left"
-    | "right"
-    | "baseline"
-    | "first baseline"
-    | "last baseline"
-    | "space-between"
-    | "space-around"
-    | "space-evenly"
-    | "stretch"
-    | "safe center"
-    | "unsafe center";
-export type ResponsiveJustifyContentValue = ResponsiveValue<
-    JustifyContentValue
->;
 
 export interface JustifyContentProps {
     /**
@@ -434,13 +312,10 @@ export interface JustifyContentProps {
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/justify-content)
      */
-    justifyContent?: ResponsiveJustifyContentValue;
+    justifyContent?: ResponsiveValue<CSS.JustifyContentProperty>;
 }
 
 export function justifyContent(...args: any[]): any;
-
-export type FlexWrapValue = "nowrap" | "wrap" | "wrap-reverse";
-export type ResponsiveFlexWrapValue = ResponsiveValue<FlexWrapValue>;
 
 export interface FlexWrapProps {
     /**
@@ -449,39 +324,20 @@ export interface FlexWrapProps {
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/flex-wrap)
      */
-    flexWrap?: ResponsiveFlexWrapValue;
+    flexWrap?: ResponsiveValue<CSS.FlexWrapProperty>;
 }
 
 export function flexWrap(...args: any[]): any;
 
-export type FlexBasisValue =
-    | GlobalStyleValues
-    | "auto"
-    | "fill"
-    | "max-content"
-    | "min-content"
-    | "fit-content"
-    | "content";
-export type ResponsiveFlexBasisValue = ResponsiveValue<FlexBasisValue>;
-
-export interface FlexBasisProps {
+export interface FlexBasisProps<TLength = TLengthStyledSystem> {
     // TODO: The FlexBasisValue currently really only exists for documentation
     //       purposes, because flex-basis also accepts `Nem` and `Npx` strings.
     //       Not sure there’s a way to still have the union values show up as
     //       auto-completion results.
-    flexBasis?: ResponsiveFlexBasisValue | string;
+    flexBasis?: ResponsiveValue<CSS.FlexBasisProperty<TLength>>;
 }
 
 export function flexBasis(...args: any[]): any;
-
-export type FlexDirectionValue =
-    | GlobalStyleValues
-    | "row"
-    | "row-reverse"
-    | "column"
-    | "column-reverse";
-
-export type ResponsiveFlexDirectionValue = ResponsiveValue<FlexDirectionValue>;
 
 export interface FlexDirectionProps {
     /**
@@ -490,47 +346,22 @@ export interface FlexDirectionProps {
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/flex-direction)
      */
-    flexDirection?: ResponsiveFlexDirectionValue;
+    flexDirection?: ResponsiveValue<CSS.FlexDirectionProperty>;
 }
 
 export function flexDirection(...args: any[]): any;
 
-export type FlexValue = number | string;
-export type ResponsiveFlexValue = ResponsiveValue<FlexValue>;
-
-export interface FlexProps {
+export interface FlexProps<TLength = TLengthStyledSystem> {
     /**
      * The flex CSS property specifies how a flex item will grow or shrink so as to fit the space available in
      * its flex container. This is a shorthand property that sets flex-grow, flex-shrink, and flex-basis.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/flex)
      */
-    flex?: ResponsiveFlexValue;
+    flex?: ResponsiveValue<CSS.FlexProperty<TLength>>;
 }
 
 export function flex(...args: any[]): any;
-
-export type JustifySelfValue =
-    | GlobalStyleValues
-    | "auto"
-    | "normal"
-    | "stretch"
-    | "center"
-    | "start"
-    | "end"
-    | "flex-start"
-    | "flex-end"
-    | "self-start"
-    | "self-end"
-    | "left"
-    | "right"
-    | "baseline"
-    | "first baseline"
-    | "last baseline"
-    | "safe center"
-    | "unsafe center";
-
-export type ResponsiveJustifySelfValue = ResponsiveValue<JustifySelfValue>;
 
 export interface JustifySelfProps {
     /**
@@ -539,30 +370,10 @@ export interface JustifySelfProps {
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/justify-self)
      */
-    justifySelf?: ResponsiveJustifySelfValue;
+    justifySelf?: ResponsiveValue<CSS.JustifySelfProperty>;
 }
 
 export function justifySelf(...args: any[]): any;
-
-export type AlignSelfValue =
-    | "auto"
-    | "normal"
-    | "center"
-    | "start"
-    | "end"
-    | "self-start"
-    | "self-end"
-    | "flex-start"
-    | "flex-end"
-    | "left"
-    | "right"
-    | "baseline"
-    | "first baseline"
-    | "last baseline"
-    | "stretch"
-    | "safe center"
-    | "unsafe center";
-export type ResponsiveAlignSelfValue = ResponsiveValue<AlignSelfValue>;
 
 export interface AlignSelfProps {
     /**
@@ -573,13 +384,10 @@ export interface AlignSelfProps {
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/align-self)
      */
-    alignSelf?: ResponsiveAlignSelfValue;
+    alignSelf?: ResponsiveValue<CSS.AlignSelfProperty>;
 }
 
 export function alignSelf(...args: any[]): any;
-
-export type OrderValue = GlobalStyleValues | number;
-export type ResponsiveOrderValue = ResponsiveValue<OrderValue>;
 
 export interface OrderProps {
     /**
@@ -588,7 +396,7 @@ export interface OrderProps {
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/order)
      */
-    order?: ResponsiveOrderValue;
+    order?: ResponsiveValue<CSS.GlobalsNumber>;
 }
 
 export function order(...args: any[]): any;
@@ -597,10 +405,7 @@ export function order(...args: any[]): any;
  * Grid Layout
  */
 
-export type GridGapValue = number | string;
-export type ResponsiveGridGapValue = ResponsiveValue<GridGapValue>;
-
-export interface GridGapProps {
+export interface GridGapProps<TLength = TLengthStyledSystem> {
     /**
      * The gap CSS property sets the gaps (gutters) between rows and columns. It is a shorthand for row-gap
      * and column-gap.
@@ -609,12 +414,12 @@ export interface GridGapProps {
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/gap)
      */
-    gridGap?: ResponsiveGridGapValue;
+    gridGap?: ResponsiveValue<CSS.GridGapProperty<TLength>>;
 }
 
 export function gridGap(...args: any[]): any;
 
-export interface GridColumnGapProps {
+export interface GridColumnGapProps<TLength = TLengthStyledSystem> {
     /**
      * The column-gap CSS property sets the size of the gap (gutter) between an element's columns.
      *
@@ -622,12 +427,12 @@ export interface GridColumnGapProps {
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/column-gap)
      */
-    gridColumnGap?: ResponsiveGridGapValue;
+    gridColumnGap?: ResponsiveValue<CSS.GridColumnGapProperty<TLength>>;
 }
 
 export function gridColumnGap(...args: any[]): any;
 
-export interface GridRowGapProps {
+export interface GridRowGapProps<TLength = TLengthStyledSystem> {
     /**
      * The row-gap CSS property sets the size of the gap (gutter) between an element's rows.
      *
@@ -635,13 +440,10 @@ export interface GridRowGapProps {
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/row-gap)
      */
-    gridRowGap?: ResponsiveGridGapValue;
+    gridRowGap?: ResponsiveValue<CSS.GridRowGapProperty<TLength>>;
 }
 
 export function gridRowGap(...args: any[]): any;
-
-export type GridCellValue = string;
-export type ResponsiveGridCellValue = ResponsiveValue<GridCellValue>;
 
 export interface GridColumnProps {
     /**
@@ -651,7 +453,7 @@ export interface GridColumnProps {
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/grid-column)
      */
-    gridColumn?: ResponsiveGridCellValue;
+    gridColumn?: ResponsiveValue<CSS.GridColumnProperty>;
 }
 
 export function gridColumn(...args: any[]): any;
@@ -664,13 +466,10 @@ export interface GridRowProps {
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/grid-row)
      */
-    gridRow?: ResponsiveGridCellValue;
+    gridRow?: ResponsiveValue<CSS.GridRowProperty>;
 }
 
 export function gridRow(...args: any[]): any;
-
-export type GridAutoValue = string;
-export type ResponsiveGridAutoValue = ResponsiveValue<GridAutoValue>;
 
 export interface GridAutoFlowProps {
     /**
@@ -679,54 +478,51 @@ export interface GridAutoFlowProps {
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/grid-auto-flow)
      */
-    gridAutoFlow?: ResponsiveGridAutoValue;
+    gridAutoFlow?: ResponsiveValue<CSS.GridAutoFlowProperty>;
 }
 
 export function gridAutoFlow(...args: any[]): any;
 
-export interface GridAutoColumnsProps {
+export interface GridAutoColumnsProps<TLength = TLengthStyledSystem> {
     /**
      * The grid-auto-columns CSS property specifies the size of an implicitly-created grid column track.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/grid-auto-columns)
      */
-    gridAutoColumns?: ResponsiveGridAutoValue;
+    gridAutoColumns?: ResponsiveValue<CSS.GridAutoColumnsProperty<TLength>>;
 }
 
 export function gridAutoColumns(...args: any[]): any;
 
-export interface GridAutoRowsProps {
+export interface GridAutoRowsProps<TLength = TLengthStyledSystem> {
     /**
      * The grid-auto-rows CSS property specifies the size of an implicitly-created grid row track.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/grid-auto-rows)
      */
-    gridAutoRows?: ResponsiveGridAutoValue;
+    gridAutoRows?: ResponsiveValue<CSS.GridAutoRowsProperty<TLength>>;
 }
 
 export function gridAutoRows(...args: any[]): any;
 
-export type GridTemplateValue = string;
-export type ResponsiveGridTemplateValue = ResponsiveValue<GridTemplateValue>;
-
-export interface GridTemplatesColumnsProps {
+export interface GridTemplatesColumnsProps<TLength = TLengthStyledSystem> {
     /**
      * The grid-template-columns CSS property defines the line names and track sizing functions of the grid columns.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/grid-template-columns)
      */
-    gridTemplateColumns?: ResponsiveGridTemplateValue;
+    gridTemplateColumns?: ResponsiveValue<CSS.GridTemplateColumnsProperty<TLength>>;
 }
 
 export function gridTemplateColumns(...args: any[]): any;
 
-export interface GridTemplatesRowsProps {
+export interface GridTemplatesRowsProps<TLength = TLengthStyledSystem> {
     /**
      * The grid-template-rows CSS property defines the line names and track sizing functions of the grid rows.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/row-template-rows)
      */
-    gridTemplateRows?: ResponsiveGridTemplateValue;
+    gridTemplateRows?: ResponsiveValue<CSS.GridTemplateRowsProperty<TLength>>;
 }
 
 export function gridTemplateRows(...args: any[]): any;
@@ -737,7 +533,7 @@ export interface GridTemplatesAreasProps {
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/grid-template-areas)
      */
-    gridTemplateAreas?: ResponsiveGridTemplateValue;
+    gridTemplateAreas?: ResponsiveValue<CSS.GridTemplateAreasProperty>;
 }
 
 export function gridTemplateAreas(...args: any[]): any;
@@ -750,7 +546,7 @@ export interface GridAreaProps {
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/grid-area)
      */
-    gridArea?: ResponsiveGridTemplateValue;
+    gridArea?: ResponsiveValue<CSS.GridAreaProperty>;
 }
 
 export function gridArea(...args: any[]): any;
@@ -759,65 +555,62 @@ export function gridArea(...args: any[]): any;
  * Borders
  */
 
-export type BorderValue = string | number;
-export type ResponsiveBorderValue = ResponsiveValue<BorderValue>;
-
-export interface BorderProps {
+export interface BorderProps<TLength = TLengthStyledSystem> {
     /**
      * The border CSS property sets an element's border. It's a shorthand for border-width, border-style,
      * and border-color.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/border)
      */
-    border?: ResponsiveBorderValue;
+    border?: ResponsiveValue<CSS.BorderProperty<TLength>>;
 }
 
 export function border(...args: any[]): any;
 
-export interface BorderTopProps {
+export interface BorderTopProps<TLength = TLengthStyledSystem> {
     /**
      * The border-top CSS property is a shorthand that sets the values of border-top-width, border-top-style,
      * and border-top-color. These properties describe an element's top border.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/border-top)
      */
-    borderTop?: ResponsiveBorderValue;
+    borderTop?: ResponsiveValue<CSS.BorderTopProperty<TLength>>;
 }
 
 export function borderTop(...args: any[]): any;
 
-export interface BorderRightProps {
+export interface BorderRightProps<TLength = TLengthStyledSystem> {
     /**
      * The border-right CSS property is a shorthand that sets border-right-width, border-right-style,
      * and border-right-color. These properties set an element's right border.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/border-right)
      */
-    borderRight?: ResponsiveBorderValue;
+    borderRight?: ResponsiveValue<CSS.BorderRightProperty<TLength>>;
 }
 
 export function borderRight(...args: any[]): any;
 
-export interface BorderBottomProps {
+export interface BorderBottomProps<TLength = TLengthStyledSystem> {
     /**
      * The border-bottom CSS property sets an element's bottom border. It's a shorthand for
      * border-bottom-width, border-bottom-style and border-bottom-color.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/border-bottom)
      */
-    borderBottom?: ResponsiveBorderValue;
+    borderBottom?: ResponsiveValue<CSS.BorderBottomProperty<TLength>>;
 }
 
 export function borderBottom(...args: any[]): any;
 
-export interface BorderLeftProps {
+export interface BorderLeftProps<TLength = TLengthStyledSystem> {
     /**
      * The border-left CSS property is a shorthand that sets the values of border-left-width,
      * border-left-style, and border-left-color. These properties describe an element's left border.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/border-left)
      */
-    borderLeft?: ResponsiveBorderValue;
+    borderLeft?: ResponsiveValue<CSS.BorderLeftProperty<TLength>>;
 }
 
 export function borderLeft(...args: any[]): any;
@@ -826,37 +619,28 @@ export interface BordersProps extends BorderTopProps, BorderRightProps, BorderBo
 
 export function borders(...args: any[]): any;
 
-export type BorderColorValue = string;
-export type ResponsiveBorderColorValue = ResponsiveValue<BorderColorValue>;
-
 export interface BorderColorProps {
     /**
      * The border-color shorthand CSS property sets the color of all sides of an element's border.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/border-color)
      */
-    borderColor?: ResponsiveBorderColorValue;
+    borderColor?: ResponsiveValue<CSS.BorderColorProperty>;
 }
 
 export function borderColor(...args: any[]): any;
 
-export type BorderRadiusValue = string | number;
-export type ResponsiveBorderRadiusValue = ResponsiveValue<BorderRadiusValue>;
-
-export interface BorderRadiusProps {
+export interface BorderRadiusProps<TLength = TLengthStyledSystem> {
     /**
      * The border-radius CSS property rounds the corners of an element's outer border edge. You can set a single
      * radius to make circular corners, or two radii to make elliptical corners.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/border-radius)
      */
-    borderRadius?: ResponsiveBorderRadiusValue;
+    borderRadius?: ResponsiveValue<CSS.BorderRadiusProperty<TLength>>;
 }
 
 export function borderRadius(...args: any[]): any;
-
-export type BoxShadowValue = string | number;
-export type ResponsiveBoxShadowValue = ResponsiveValue<BoxShadowValue>;
 
 export interface BoxShadowProps {
     /**
@@ -866,13 +650,10 @@ export interface BoxShadowProps {
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/box-shadow)
      */
-    boxShadow?: ResponsiveBoxShadowValue;
+    boxShadow?: ResponsiveValue<CSS.BoxShadowProperty | number>;
 }
 
 export function boxShadow(...arg: any[]): any;
-
-export type OpacityValue = string | number;
-export type ResponsiveOpacityValue = ResponsiveValue<OpacityValue>;
 
 export interface OpacityProps {
     /**
@@ -881,13 +662,10 @@ export interface OpacityProps {
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/opacity)
      */
-    opacity?: ResponsiveOpacityValue;
+    opacity?: ResponsiveValue<CSS.GlobalsNumber>;
 }
 
 export function opacity(...arg: any[]): any;
-
-export type OverflowValue = string | number;
-export type ResponsiveOverflowValue = ResponsiveValue<OverflowValue>;
 
 export interface OverflowProps {
     /**
@@ -896,7 +674,7 @@ export interface OverflowProps {
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow)
      */
-    overflow?: ResponsiveOverflowValue;
+    overflow?: ResponsiveValue<CSS.OverflowProperty>;
 }
 
 export function overflow(...arg: any[]): any;
@@ -904,23 +682,17 @@ export function overflow(...arg: any[]): any;
  * Background
  */
 
-export type BackgroundValue = string;
-export type ResponsiveBackgroundValue = ResponsiveValue<BackgroundValue>;
-
-export interface BackgroundProps {
+export interface BackgroundProps<TLength = TLengthStyledSystem> {
     /**
      * The background shorthand CSS property sets all background style properties at once,
      * such as color, image, origin and size, repeat method, and others.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/background)
      */
-    background?: ResponsiveBackgroundValue;
+    background?: ResponsiveValue<CSS.BackgroundProperty<TLength>>;
 }
 
 export function background(...args: any[]): any;
-
-export type BackgroundImageValue = string;
-export type ResponsiveBackgroundImageValue = ResponsiveValue<BackgroundImageValue>;
 
 export interface BackgroundImageProps {
     /**
@@ -928,43 +700,34 @@ export interface BackgroundImageProps {
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/background-image)
      */
-    backgroundImage?: ResponsiveBackgroundImageValue;
+    backgroundImage?: ResponsiveValue<CSS.BackgroundImageProperty>;
 }
 
 export function backgroundImage(...args: any[]): any;
 
-export type BackgroundSizeValue = string;
-export type ResponsiveBackgroundSizeValue = ResponsiveValue<BackgroundSizeValue>;
-
-export interface BackgroundSizeProps {
+export interface BackgroundSizeProps<TLength = TLengthStyledSystem> {
     /**
      * The background-size CSS property sets the size of the element's background image. The
      * image can be left to its natural size, stretched, or constrained to fit the available space.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/background-size)
      */
-    backgroundSize?: ResponsiveBackgroundSizeValue;
+    backgroundSize?: ResponsiveValue<CSS.BackgroundSizeProperty<TLength>>;
 }
 
 export function backgroundSize(...args: any[]): any;
 
-export type BackgroundPositionValue = string;
-export type ResponsiveBackgroundPositionValue = ResponsiveValue<BackgroundPositionValue>;
-
-export interface BackgroundPositionProps {
+export interface BackgroundPositionProps<TLength = TLengthStyledSystem> {
     /**
      * The background-position CSS property sets the initial position for each background image. The
      * position is relative to the position layer set by background-origin.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/background-position)
      */
-    backgroundPosition?: ResponsiveBackgroundPositionValue;
+    backgroundPosition?: ResponsiveValue<CSS.BackgroundPositionProperty<TLength>>;
 }
 
 export function backgroundPosition(...args: any[]): any;
-
-export type BackgroundRepeatValue = string;
-export type ResponsiveBackgroundRepeatValue = ResponsiveValue<BackgroundRepeatValue>;
 
 export interface BackgroundRepeatProps {
     /**
@@ -973,7 +736,7 @@ export interface BackgroundRepeatProps {
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/background-repeat)
      */
-    backgroundRepeat?: ResponsiveBackgroundRepeatValue;
+    backgroundRepeat?: ResponsiveValue<CSS.BackgroundRepeatProperty>;
 }
 
 export function backgroundRepeat(...args: any[]): any;
@@ -982,14 +745,6 @@ export function backgroundRepeat(...args: any[]): any;
  * Position
  */
 
-export type PositionValue =
-    | "static"
-    | "relative"
-    | "absolute"
-    | "sticky"
-    | "fixed";
-export type ResponsivePositionValue = ResponsiveValue<PositionValue>;
-
 export interface PositionProps {
     /**
      * The position CSS property specifies how an element is positioned in a document.
@@ -997,13 +752,10 @@ export interface PositionProps {
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/position)
      */
-    position?: ResponsivePositionValue;
+    position?: ResponsiveValue<CSS.PositionProperty>;
 }
 
 export function position(...args: any[]): any;
-
-export type ZIndexValue = GlobalStyleValues | "auto" | number;
-export type ResponsiveZIndexValue = ResponsiveValue<ZIndexValue>;
 
 export interface ZIndexProps {
     /**
@@ -1012,88 +764,73 @@ export interface ZIndexProps {
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/z-index)
      */
-    zIndex?: ZIndexValue;
+    zIndex?: ResponsiveValue<CSS.ZIndexProperty>;
 }
 
 export function zIndex(...args: any[]): any;
 
-export type TopValue = string | number;
-export type ResponsiveTopValue = ResponsiveValue<TopValue>;
-
-export interface TopProps {
+export interface TopProps<TLength = TLengthStyledSystem> {
     /**
      * The top CSS property participates in specifying the vertical position of a
      * positioned element. It has no effect on non-positioned elements.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/top)
      */
-    top?: ResponsiveTopValue;
+    top?: ResponsiveValue<CSS.TopProperty<TLength>>;
 }
 
 export function top(...args: any[]): any;
 
-export type RightValue = string | number;
-export type ResponsiveRightValue = ResponsiveValue<RightValue>;
-
-export interface RightProps {
+export interface RightProps<TLength = TLengthStyledSystem> {
     /**
      * The right CSS property participates in specifying the horizontal position of a
      * positioned element. It has no effect on non-positioned elements.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/right)
      */
-    right?: ResponsiveRightValue;
+    right?: ResponsiveValue<CSS.RightProperty<TLength>>;
 }
 
 export function right(...args: any[]): any;
 
-export type BottomValue = string | number;
-export type ResponsiveBottomValue = ResponsiveValue<BottomValue>;
-
-export interface BottomProps {
+export interface BottomProps<TLength = TLengthStyledSystem> {
     /**
      * The bottom CSS property participates in specifying the vertical position of a
      * positioned element. It has no effect on non-positioned elements.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/top)
      */
-    bottom?: ResponsiveBottomValue;
+    bottom?: ResponsiveValue<CSS.BottomProperty<TLength>>;
 }
 
 export function bottom(...args: any[]): any;
 
-export type LeftValue = string | number;
-export type ResponsiveLeftValue = ResponsiveValue<LeftValue>;
-
-export interface LeftProps {
+export interface LeftProps<TLength = TLengthStyledSystem> {
     /**
      * The left CSS property participates in specifying the horizontal position
      * of a positioned element. It has no effect on non-positioned elements.
      *
      * [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/left)
      */
-    left?: ResponsiveLeftValue;
+    left?: ResponsiveValue<CSS.LeftProperty<TLength>>;
 }
 
 export function left(...args: any[]): any;
 
-export type Variant = string;
-export type ResponsiveVariant = ResponsiveValue<Variant>;
-
 export interface TextStyleProps {
-    textStyle?: ResponsiveVariant;
+    textStyle?: ResponsiveValue<string>;
 }
 
 export function textStyle(...args: any[]): any;
 
 export interface ColorStyleProps {
-    colors?: ResponsiveVariant;
+    colors?: ResponsiveValue<string>;
 }
 
 export function colorStyle(...args: any[]): any;
 
 export interface ButtonStyleProps {
-    variant?: ResponsiveVariant;
+    variant?: ResponsiveValue<string>;
 }
 
 export function buttonStyle(...args: any[]): any;

--- a/types/styled-system/package.json
+++ b/types/styled-system/package.json
@@ -1,0 +1,6 @@
+{
+  "private": true,
+  "dependencies": {
+    "csstype": "^2.2.0"
+  }
+}


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

<hr />

Alrighty, I believe I've hooked up everything to `[csstype](https://github.com/frenic/csstype)`. Let me know if you see anything of note.

Also, I'm removing most of the `export type` because IMO they're a relic, and most use cases for myself would have you extend the interface instead of adding a property yourself and the same behaviour can be achieved by importing the interface and referencing the property `ColorProps['color']`.