### PR TITLE
[@types/mapbox-gl] Fix source type in source events + indentation fix

### DIFF
--- a/types/mapbox-gl/index.d.ts
+++ b/types/mapbox-gl/index.d.ts
@@ -1071,7 +1071,7 @@ declare namespace mapboxgl {
     export interface MapSourceDataEvent extends MapboxEvent {
         dataType: 'source';
         isSourceLoaded: boolean;
-        source: Style;
+        source: Source;
         sourceId: string;
         sourceDataType: 'metadata' | 'content';
         tile: any;

--- a/types/mapbox-gl/mapbox-gl-tests.ts
+++ b/types/mapbox-gl/mapbox-gl-tests.ts
@@ -465,10 +465,10 @@ expectType<mapboxgl.Point>(mapboxgl.Point.convert(pointlike));
 
 expectType<mapboxgl.TransformRequestFunction>((url: string) => ({ url }));
 expectType<mapboxgl.TransformRequestFunction>((url: string, resourceType: mapboxgl.ResourceType) => ({
-	 url,
-	 credentials: 'same-origin',
-	 headers: { 'Accept-Encoding': 'compress' },
-	 method: 'POST',
+	url,
+	credentials: 'same-origin',
+	headers: { 'Accept-Encoding': 'compress' },
+	method: 'POST',
 	collectResourceTiming: true,
  }));
 


### PR DESCRIPTION
The source in a `MapSourceDataEvent` is, as the name would imply, just a source, not the full style.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/mapbox/mapbox-gl-js/blob/v0.51.0/src/ui/events.js#L245
