### PR TITLE
StripeJS adjustments based off Stripe Element Examples on GitHub

### DIFF
--- a/types/stripejs/element.d.ts
+++ b/types/stripejs/element.d.ts
@@ -163,7 +163,7 @@ export interface StripeElement {
  * The type of element that can be created by the ElementCreator
  * @see ElementCreator
  */
-export type ElementType = 'card' | 'cardNumber' | 'cardExpiry' | 'cardCvc' | 'postalCode';
+export type ElementType = 'card' | 'cardNumber' | 'cardExpiry' | 'cardCvc' | 'postalCode' | 'paymentRequestButton';
 
 // --- ELEMENT EVENTS --- //
 export interface OnChange {
@@ -295,6 +295,7 @@ export interface PaymentButtonOptions {
         complete?: PaymentRequestButtonStyle;
         empty?: PaymentRequestButtonStyle;
         invalid?: PaymentRequestButtonStyle;
+        paymentRequestButton?: PaymentRequestButtonStyle;
     };
 }
 

--- a/types/stripejs/index.d.ts
+++ b/types/stripejs/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for stripe.js 3.0
 // Project: https://stripe.com/
 // Definitions by: Robin van Tienhoven <https://github.com/RobinvanTienhoven>
+//                 Matt Ferderer <https://github.com/mattferderer>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.1
 

--- a/types/stripejs/token.d.ts
+++ b/types/stripejs/token.d.ts
@@ -57,10 +57,15 @@ export interface TokenData {
     name: string;
 
     /**
+     * The amount paid, not a decimal. In USD this is in cents.
+     */
+    amount: number;
+
+    /**
      * Fields for billing address information.
      */
     address_line1: string;
-    address_line2: string;
+    address_line2?: string;
     address_city: string;
     address_state: string;
     address_zip: string;
@@ -69,7 +74,7 @@ export interface TokenData {
      * A two character country code identifying the country
      * @example 'US'
      */
-    address_country: string;
+    address_country?: string;
 
     /**
      * Used to add a card to an account

--- a/types/stripejs/token.d.ts
+++ b/types/stripejs/token.d.ts
@@ -59,7 +59,7 @@ export interface TokenData {
     /**
      * The amount paid, not a decimal. In USD this is in cents.
      */
-    amount: number;
+    amount?: number;
 
     /**
      * Fields for billing address information.


### PR DESCRIPTION
Adjusted based off use on Stripe Element examples by Stripe on GitHub. 

Select one of these and delete the others:
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/stripe/elements-examples/blob/master/js/example5.js
https://github.com/stripe/elements-examples/blob/master/js/index.js
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
