### PR TITLE
Mongoose posthook overload

### DIFF
--- a/types/mongoose/index.d.ts
+++ b/types/mongoose/index.d.ts
@@ -811,11 +811,11 @@ declare module "mongoose" {
      * @param fn callback
      */
     post<T extends Document>(method: string, fn: (
-      error: mongodb.MongoError, doc: T, next: (err?: NativeError) => void
-    ) => void): this;
+        doc: T, next: (err?: NativeError) => void
+      ) => void): this;
 
     post<T extends Document>(method: string, fn: (
-      doc: T, next: (err?: NativeError) => void
+      error: mongodb.MongoError, doc: T, next: (err?: NativeError) => void
     ) => void): this;
 
     /**

--- a/types/mongoose/index.d.ts
+++ b/types/mongoose/index.d.ts
@@ -811,8 +811,8 @@ declare module "mongoose" {
      * @param fn callback
      */
     post<T extends Document>(method: string, fn: (
-        doc: T, next: (err?: NativeError) => void
-      ) => void): this;
+      doc: T, next: (err?: NativeError) => void
+    ) => void): this;
 
     post<T extends Document>(method: string, fn: (
       error: mongodb.MongoError, doc: T, next: (err?: NativeError) => void

--- a/types/mongoose/mongoose-tests.ts
+++ b/types/mongoose/mongoose-tests.ts
@@ -491,12 +491,12 @@ preHookTestSchemaArr.push(
 );
 
 schema
-.post('save', function (error, doc, next) {
+.post('save', function (error: mongoose.Error, doc: mongoose.Document, next: (err?: mongoose.NativeError) => void) {
   error.stack;
   doc.model;
   next.apply;
 })
-.post('save', function (doc: mongoose.Document, next: Function) {
+.post('save', function (doc: mongoose.Document, next: (err?: mongoose.NativeError) => void) {
   doc.model;
   next(new Error());
 })


### PR DESCRIPTION
Fixes incorrect selection of function overload in Mongoose post hooks.

Using the two-argument overload of the function **should** select an arity with the `mongoose.Document` first, and a `next()` handler after:

```ts
ExampleSchema.post('save', (doc: mongoose.Document, next: (err) => void) => { ... });
```

Currently, the order of the overloads causes the two-argument function to be interpreted as the three-argument overload, which places the arguments as error, document and next handler, respectively, and causes the following incorrect typing:

```ts
ExampleSchema.post('save', (doc: MongoError, next: mongoose.Document /*, (err) => void */) => { ... });
```

Switched order of function overloads and added types to test script for that function.

I wasn't able to find an open issue for this, but did locate another person who reported this same problem [on StackOverflow](https://stackoverflow.com/questions/41155815/typescript-doesnt-select-the-correct-overload).
