### PR TITLE
react-datepicker: Bump library version to 1.8 to prepare for 2.00

### DIFF
--- a/types/react-datepicker/index.d.ts
+++ b/types/react-datepicker/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-datepicker 1.1
+// Type definitions for react-datepicker 1.8
 // Project: https://github.com/Hacker0x01/react-datepicker
 // Definitions by: Rajab Shakirov <https://github.com/radziksh>,
 //                 Andrey Balokha <https://github.com/andrewBalekha>,
@@ -7,6 +7,7 @@
 //                 Roy Xue <https://github.com/royxue>
 //                 Koala Human <https://github.com/KoalaHuman>
 //                 Sean Kelley <https://github.com/seansfkelley>
+//                 Justin Grant <https://github.com/justingrant>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 


### PR DESCRIPTION
react-datepicker recently released a 2.00 release with lots of breaking changes.  The current typings file is version 1.1. Before updating the typings version to 2.00, it makes sense to bring the current typings version up to 1.8 (the latest library version before 2.0) to make it easier for future pre-2.0 library users to find the correct typings version to use. 

To see why this is needed, imagine a future developer who is sticking with version 1.8 of the library because they want to defer rewriting their code from Moment to Date. If you're that developer, should you use version 1.1 or 2.0 of the typings?  If we bump the typings version to 1.8 before a future update to 2.0, then that choice is obvious.

This PR doesn't make any typings or tests changes-- it only bumps the library version in the first header line so that the version of the resulting @types/react-datepicker package will also be 1.8.

IMHO, the usual PR template steps don't apply because I'm not changing any typings or tests, only the library (and therefore the typings package) version number.