### PR TITLE
[@type/paper] fillColor/strokeColor/shaderColor can be null

### DIFF
--- a/types/paper/index.d.ts
+++ b/types/paper/index.d.ts
@@ -1491,7 +1491,7 @@ declare module paper {
         /**
          * The color of the stroke.
          */
-        strokeColor: Color | string;
+        strokeColor: Color | string | null;
 
         /**
          * The width of the stroke.
@@ -1539,7 +1539,7 @@ declare module paper {
         /**
          * The fill color of the item.
          */
-        fillColor: Color | string;
+        fillColor: Color | string | null;
 
         /**
          * The fill-rule with which the shape gets filled. Please note that only modern browsers support fill-rules other than 'nonzero'.
@@ -1551,7 +1551,7 @@ declare module paper {
         /**
          * The shadow color.
          */
-        shadowColor: Color | string;
+        shadowColor: Color | string | null;
 
         /**
          * The shadow’s blur radius.


### PR DESCRIPTION
According the paper.js design, fillColor/strokeColor/shaderColor can be set to null to turn off the rendering.
