### PR TITLE
fix: extend @types/elasticsearch IndicesUpdateAliasesParamsAction parameters

### DIFF
--- a/types/elasticsearch/elasticsearch-tests.ts
+++ b/types/elasticsearch/elasticsearch-tests.ts
@@ -209,7 +209,7 @@ client.get({
   id: '1',
   routing: '1'
 }, (error, response) => {
-    const routing = response._routing;
+  const routing = response._routing;
 });
 
 client.mget({
@@ -338,22 +338,43 @@ client.indices.updateAliases({
   // ...
 });
 
-client.reindex({
-    body: {
-        source: {
-          index: "twitter"
-        },
-        dest: {
-          index: "new_twitter"
+client.indices.updateAliases({
+  body: {
+    actions: [
+      {
+        add: {
+          index: 'logstash-2018.11', alias: 'logstash-filtered', filter: {
+            query: {
+              exists: { field: 'id' }
+            }
+          },
+          routing: 'id'
         }
       }
+    ]
+  }
+}).then((response) => {
+  // ...
+}, (error) => {
+  // ...
+});
+
+client.reindex({
+  body: {
+    source: {
+      index: "twitter"
+    },
+    dest: {
+      index: "new_twitter"
+    }
+  }
 })
-.then(response => {
+  .then(response => {
     const { took, timed_out } = response;
     // ...
-});
+  });
 
 // Errors
 function testErrors() {
-    throw new elasticsearch.errors.AuthenticationException();
+  throw new elasticsearch.errors.AuthenticationException();
 }

--- a/types/elasticsearch/index.d.ts
+++ b/types/elasticsearch/index.d.ts
@@ -1400,11 +1400,15 @@ export interface IndicesUpdateAliasesParamsAction {
         index?: string;
         indices?: string[];
         alias: string;
+        routing?: string;
+        filter?: object;
     };
     remove?: {
         index?: string;
         indices?: string[];
         alias: string;
+        routing?: string;
+        filter?: object;
     };
     remove_index?: {
         index: string;

--- a/types/elasticsearch/index.d.ts
+++ b/types/elasticsearch/index.d.ts
@@ -1407,8 +1407,6 @@ export interface IndicesUpdateAliasesParamsAction {
         index?: string;
         indices?: string[];
         alias: string;
-        routing?: string;
-        filter?: object;
     };
     remove_index?: {
         index: string;


### PR DESCRIPTION
As shown in elasticsearch documentation (https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-aliases.html#filtered), an alias can have a routing value and a filter specified.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-aliases.html#filtered>>
