### PR TITLE
Made react-map-gl width/height correct types

### DIFF
--- a/types/react-map-gl/index.d.ts
+++ b/types/react-map-gl/index.d.ts
@@ -40,8 +40,8 @@ export interface MapboxProps extends Partial<Viewport> {
 
     mapStyle?: string | {};
 
-    width: number;
-    height: number;
+    width: number|string;
+    height: number|string;
 
     viewState?: Viewport;
 
@@ -217,8 +217,8 @@ export interface NavigationControlProps extends BaseControlProps {
 export class NavigationControl extends BaseControl<NavigationControlProps> {}
 
 export interface HTMLRedrawOptions {
-    width: number;
-    height: number;
+    width: number|string;
+    height: number|string;
     project: (lnglat: number[]) => number[];
     unproject: (xy: number[]) => number[];
 }
@@ -270,8 +270,8 @@ export namespace experimental {
     }
 
     class MapState implements Viewport {
-        width: number;
-        height: number;
+        width: number|string;
+        height: number|string;
         latitude: number;
         longitude: number;
         zoom: number;


### PR DESCRIPTION
Super basic, react-map-gl can take in a string such as `100%` for the width property

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://uber.github.io/react-map-gl/#/Documentation/api-reference/static-map?section=initialization