### PR TITLE
Add definition for removeAllListeners to noble

### DIFF
--- a/types/noble/index.d.ts
+++ b/types/noble/index.d.ts
@@ -30,6 +30,8 @@ export declare function removeListener(event: "scanStop", listener: () => void):
 export declare function removeListener(event: "discover", listener: (peripheral: Peripheral) => void): events.EventEmitter;
 export declare function removeListener(event: string, listener: Function): events.EventEmitter;
 
+export declare function removeAllListeners(event?: string): events.EventEmitter;
+
 export declare var state:string;
 
 export declare class Peripheral extends events.EventEmitter {

--- a/types/noble/noble-tests.ts
+++ b/types/noble/noble-tests.ts
@@ -35,6 +35,12 @@ noble.removeListener("discover", (peripheral: noble.Peripheral): void => {
     peripheral.disconnect((): void => {});
 });
 
+noble.removeAllListeners("stateChange");
+noble.removeAllListeners("scanStart");
+noble.removeAllListeners("scanStop");
+noble.removeAllListeners("discover");
+noble.removeAllListeners();
+
 var peripheral: noble.Peripheral = new noble.Peripheral();
 peripheral.uuid = "12ad4e81";
 peripheral.advertisement = {


### PR DESCRIPTION
noble inherits from EventEmitter, but does not expose a `removeAllListeners` method.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/api/events.html#events_emitter_removealllisteners_eventname
- [ ] Increase the version number in the header if appropriate. **There is none**
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. **I did not**