### PR TITLE
[@babel/core] Explicitly depend on imported `@babel/template`.

### DIFF
--- a/types/babel__core/index.d.ts
+++ b/types/babel__core/index.d.ts
@@ -6,6 +6,8 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.9
 
+/// <reference types="@babel/template" />
+
 import { GeneratorOptions } from "@babel/generator";
 import traverse, { Visitor, NodePath } from "@babel/traverse";
 import template from "@babel/template";


### PR DESCRIPTION
Without this, some valid `node_modules` layouts–i.e. pnpm's–will not work.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://rushjs.io/pages/advanced/phantom_deps/
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

Running `npm run lint babel__core` seems to fail on `master`:

```
❯ npm run lint babel__core

> definitely-typed@0.0.3 lint /Users/donovan/src/public/DefinitelyTyped
> dtslint types "babel__core"

Error: Errors in typescript@next for external dependencies:
../babel__generator/index.d.ts(9,20): error TS2307: Cannot find module '@babel/types'.
../babel__template/index.d.ts(9,31): error TS2307: Cannot find module '@babel/parser'.
../babel__template/index.d.ts(10,54): error TS2307: Cannot find module '@babel/types'.
../babel__traverse/index.d.ts(10,20): error TS2307: Cannot find module '@babel/types'.
../babel__traverse/index.d.ts(18,5): error TS2411: Property 'scope' of type 'Scope | undefined' is not assignable to string index type 'VisitNodeFunction<S, any> | VisitNodeObject<S> | undefined'.
../babel__traverse/index.d.ts(19,5): error TS2411: Property 'noScope' of type 'boolean | undefined' is not assignable to string index type 'VisitNodeFunction<S, any> | VisitNodeObject<S> | undefined'.
```

So I'm not really sure whether I've broken anything if it fails similarly on this branch.