### PR TITLE
Type definitions for passport-saml/multiSamlStrategy

### DIFF
--- a/types/passport-saml/index.d.ts
+++ b/types/passport-saml/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/bergie/passport-saml
 // Definitions by: Chris Barth <https://github.com/cjbarth>
 //                 Damian Assennato <https://github.com/dassennato>
+//                 Karol Samborski <https://github.com/ksamborski>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 

--- a/types/passport-saml/multiSamlStrategy.d.ts
+++ b/types/passport-saml/multiSamlStrategy.d.ts
@@ -1,0 +1,10 @@
+import express = require('express');
+import { Strategy, SamlConfig, VerifyWithRequest, VerifyWithoutRequest } from './index';
+
+export interface MultiSamlConfig extends SamlConfig {
+    getSamlOptions(req: express.Request, callback: (err: Error | null, samlOptions: SamlConfig) => void): void;
+}
+
+export class MultiSamlStrategy extends Strategy {
+    constructor(config: MultiSamlConfig, verify: VerifyWithRequest | VerifyWithoutRequest);
+}

--- a/types/passport-saml/passport-saml-tests.ts
+++ b/types/passport-saml/passport-saml-tests.ts
@@ -1,6 +1,7 @@
 import express = require('express');
 import passport = require('passport');
 import SamlStrategy = require('passport-saml');
+import MultiSamlStrategy = require('passport-saml/multiSamlStrategy');
 import fs = require('fs');
 
 const samlStrategy = new SamlStrategy.Strategy(
@@ -33,3 +34,27 @@ passport.use(samlStrategy);
 passport.authenticate('samlCustomName', {failureRedirect: '/', failureFlash: true});
 
 const metadata = samlStrategy.generateServiceProviderMetadata("decryptionCert");
+
+const multiSamlStrategy = new MultiSamlStrategy.MultiSamlStrategy(
+	{
+		name: 'samlCustomName',
+		path: '/login/callback',
+		entryPoint: 'https://openidp.feide.no/simplesaml/saml2/idp/SSOService.php',
+		issuer: 'passport-saml',
+        getSamlOptions(req: express.Request, callback: (err: Error | null, samlOptions: SamlStrategy.SamlConfig) => void) {
+            callback(null, {
+                name: 'samlCustomName',
+                path: '/login/callback2',
+                entryPoint: 'https://openidp.feide.no/simplesaml/saml2/idp/SSOService.php',
+                issuer: 'passport-saml',
+            });
+        }
+	},
+	(profile: {}, done: (err: Error | null, user: {}, info?: {}) => void) => {
+		const user = {};
+		done(null, user);
+	}
+);
+
+passport.use(multiSamlStrategy);
+passport.authenticate('samlCustomName', {failureRedirect: '/', failureFlash: true});

--- a/types/passport-saml/tsconfig.json
+++ b/types/passport-saml/tsconfig.json
@@ -18,6 +18,7 @@
     },
     "files": [
         "index.d.ts",
+        "multiSamlStrategy.d.ts",
         "passport-saml-tests.ts"
     ]
 }


### PR DESCRIPTION
I've prepared missing type definitions for [passport-saml/multiSamlStrategy.js](https://github.com/bergie/passport-saml/blob/master/multiSamlStrategy.js). It resolves issue #30771 

@cjbarth Please review it.