### PR TITLE
[puppeteer] fix v1.10.0 definition of waitForTarget

### DIFF
--- a/types/puppeteer/index.d.ts
+++ b/types/puppeteer/index.d.ts
@@ -1715,7 +1715,7 @@ export interface Page extends EventEmitter, FrameBase {
 }
 
 export interface TargetAwaiter {
-    waitForTarget(predicate: (target: Target) => boolean, options: Timeoutable): Promise<void>;
+    waitForTarget(predicate: (target: Target) => boolean, options?: Timeoutable): Promise<Target>;
 }
 
 /** A Browser is created when Puppeteer connects to a Chromium instance, either through puppeteer.launch or puppeteer.connect. */


### PR DESCRIPTION
hello! i'm using the [fancy new waitForTarget](https://github.com/GoogleChrome/puppeteer/blob/v1.10.0/docs/api.md#browserwaitfortargetpredicate-options) and the definition appears to be slightly off. `options` is optional and the return is a `Target` Promise, not `void`. looking at the `BrowserContext` version, it's the same problem due to the new `Timeoutable` changes made in this recent version. i changed the one definition locally and the world did not seem to explode. thanks!

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/GoogleChrome/puppeteer/blob/v1.10.0/docs/api.md#browserwaitfortargetpredicate-options
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.