### PR TITLE
[react-intl] Add onError prop to IntlProvider

### DIFF
--- a/types/react-intl/index.d.ts
+++ b/types/react-intl/index.d.ts
@@ -11,7 +11,7 @@
 //                 Kanitkorn Sujautra <https://github.com/lukyth>
 //                 obedm503 <https://github.com/obedm503>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.8
+// TypeScript Version: 2.9
 
 declare namespace ReactIntl {
     type DateSource = Date | string | number;

--- a/types/react-intl/index.d.ts
+++ b/types/react-intl/index.d.ts
@@ -47,7 +47,7 @@ declare namespace ReactIntl {
         messages: React.Requireable<any>;
         defaultLocale: React.Requireable<any>;
         defaultFormats: React.Requireable<any>;
-        onError?: (error: string) => void
+        onError: React.Requireable<any>;
     }
 
     interface IntlFormat {
@@ -80,7 +80,7 @@ declare namespace ReactIntl {
         defaultLocale: string;
         defaultFormats: any;
         now(): number;
-        onError: (error: string) => void;
+        onError(error: string): void;
     }
 
     interface InjectedIntlProps {
@@ -200,6 +200,7 @@ declare namespace ReactIntl {
             defaultFormats?: any;
             textComponent?: any;
             initialNow?: any;
+            onError?: (error: string) => void;
         }
     }
 

--- a/types/react-intl/index.d.ts
+++ b/types/react-intl/index.d.ts
@@ -9,6 +9,7 @@
 //                 Krister Kari <https://github.com/kristerkari>
 //                 Martin Raedlinger <https://github.com/formatlos>
 //                 Kanitkorn Sujautra <https://github.com/lukyth>
+//                 obedm503 <https://github.com/obedm503>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -46,6 +47,7 @@ declare namespace ReactIntl {
         messages: React.Requireable<any>;
         defaultLocale: React.Requireable<any>;
         defaultFormats: React.Requireable<any>;
+        onError?: (error: string) => void
     }
 
     interface IntlFormat {
@@ -78,6 +80,7 @@ declare namespace ReactIntl {
         defaultLocale: string;
         defaultFormats: any;
         now(): number;
+        onError: (error: string) => void;
     }
 
     interface InjectedIntlProps {

--- a/types/react-intl/index.d.ts
+++ b/types/react-intl/index.d.ts
@@ -11,7 +11,7 @@
 //                 Kanitkorn Sujautra <https://github.com/lukyth>
 //                 obedm503 <https://github.com/obedm503>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.9
+// TypeScript Version: 2.8
 
 declare namespace ReactIntl {
     type DateSource = Date | string | number;

--- a/types/react-intl/react-intl-tests.tsx
+++ b/types/react-intl/react-intl-tests.tsx
@@ -401,7 +401,15 @@ class TestApp extends React.Component {
             hello: "Hello, {name}!"
         };
         return (
-            <IntlProvider locale="en" formats={{}} messages={messages} defaultLocale="en" defaultFormats={messages} timeZone="UTC">
+            <IntlProvider 
+                locale="en" 
+                formats={{}} 
+                messages={messages} 
+                defaultLocale="en" 
+                defaultFormats={messages} 
+                timeZone="UTC" 
+                onError={(error: string) => console.error(error)}
+            >
                 <SomeComponentWithIntl className="just-for-test" />
                 <SomeFunctionalComponentWithIntl className="another-one" />
             </IntlProvider>

--- a/types/react-intl/react-intl-tests.tsx
+++ b/types/react-intl/react-intl-tests.tsx
@@ -401,13 +401,13 @@ class TestApp extends React.Component {
             hello: "Hello, {name}!"
         };
         return (
-            <IntlProvider 
-                locale="en" 
-                formats={{}} 
-                messages={messages} 
-                defaultLocale="en" 
-                defaultFormats={messages} 
-                timeZone="UTC" 
+            <IntlProvider
+                locale="en"
+                formats={{}}
+                messages={messages}
+                defaultLocale="en"
+                defaultFormats={messages}
+                timeZone="UTC"
                 onError={(error: string) => console.error(error)}
             >
                 <SomeComponentWithIntl className="just-for-test" />


### PR DESCRIPTION
Optional `onError` prop was added to `IntlProvider` back in v2.7.0.

feature addition: https://github.com/yahoo/react-intl/pull/880
release: https://github.com/yahoo/react-intl/pull/1185

After running the tests and linting there is a consistent error with `react` and `csstype`, but this was already there before any of my changes.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/yahoo/react-intl/pull/1185
- [x] Increase the version number in the header if appropriate.