### PR TITLE
make jest ProvidesCallback optional

### DIFF
--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -251,7 +251,7 @@ declare namespace jest {
          * @param fn The function for your test
          * @param timeout The timeout for an async function test
          */
-        (name: string, fn: ProvidesCallback, timeout?: number): void;
+        (name: string, fn?: ProvidesCallback, timeout?: number): void;
         /**
          * Only runs this test in the current file.
          */


### PR DESCRIPTION
https://github.com/DefinitelyTyped/DefinitelyTyped/issues/30766

`ProvidesCallback` of `interface It` should be optional. See official flow typing definition from facebook jest https://github.com/facebook/jest/blob/master/flow-typed/npm/jest_v23.x.x.js#L933 

![image](https://user-images.githubusercontent.com/5873198/49001349-c0478d00-f15c-11e8-9ba5-9307d00421a4.png)
