### PR TITLE
adding discriminator in PaginateModel

### DIFF
--- a/types/mongoose-paginate/index.d.ts
+++ b/types/mongoose-paginate/index.d.ts
@@ -29,6 +29,8 @@ declare module 'mongoose' {
 
   interface PaginateModel<T extends Document> extends Model<T> {
     paginate(query?: Object, options?: PaginateOptions, callback?: (err: any, result: PaginateResult<T>) => void): Promise<PaginateResult<T>>;
+    discriminator<U extends Document>(name: string, schema: Schema): PaginateModel<U>;
+    discriminator<U extends Document, V extends PaginateModel<U>>(name: string, schema: Schema): V;
   }
 
   export function model<T extends Document>(


### PR DESCRIPTION
Current type definition does not allow to use paginate static method on a discriminator model ([https://mongoosejs.com/docs/discriminators.html](https://mongoosejs.com/docs/discriminators.html))

Adding discriminator in PaginateModel allows us to build a proper model extending PaginateModel with discriminator.

```ts
const Author: IPagedModel<AuthorModel> = Person.discriminator('author', authorSchema)
```

this gives a TS error:

```
[ts]
Type 'Model<AuthorModel>' is not assignable to type 'IPagedModel<AuthorModel>'.
  Property 'paginate' is missing in type 'Model<AuthorModel>'. [2322]

```

With the modification proposed no error showed and paginate static function is inherited from Person.