### PR TITLE
Add support to the `css` prop from babel-plugin-styled-components

### DIFF
--- a/types/rebass__grid/index.d.ts
+++ b/types/rebass__grid/index.d.ts
@@ -10,7 +10,7 @@
 export type Omit<T, K extends keyof T> = Pick<T, ({ [P in keyof T]: P } & { [P in K]: never } & { [x: string]: never, [x: number]: never })[keyof T]>;
 
 import { ComponentType } from "react";
-import { StyledComponent, CSSIntrinsicAttributeType } from "styled-components";
+import { StyledComponent, Interpolation } from "styled-components";
 
 export type ResponsiveProp = number | string | Array<string | number>;
 
@@ -34,10 +34,11 @@ export interface CommonProps {
     px?: ResponsiveProp;
     py?: ResponsiveProp;
     theme?: any;
+    // this is actually more powerful than the plugin because of some limitations of the transform
     /**
-     * NOTE: this is not compatible with the styled-components babel plugin anymore
+     * This works even without babel-plugin-styled-components.
      */
-    css?: CSSIntrinsicAttributeType;
+    css?: Interpolation<any>;
 }
 
 export interface BoxProps

--- a/types/rebass__grid/index.d.ts
+++ b/types/rebass__grid/index.d.ts
@@ -10,7 +10,7 @@
 export type Omit<T, K extends keyof T> = Pick<T, ({ [P in keyof T]: P } & { [P in K]: never } & { [x: string]: never, [x: number]: never })[keyof T]>;
 
 import { ComponentType } from "react";
-import { StyledComponent, Interpolation } from "styled-components";
+import { StyledComponent, CSSIntrinsicAttributeType } from "styled-components";
 
 export type ResponsiveProp = number | string | Array<string | number>;
 
@@ -34,7 +34,10 @@ export interface CommonProps {
     px?: ResponsiveProp;
     py?: ResponsiveProp;
     theme?: any;
-    css?: Interpolation<any>;
+    /**
+     * NOTE: this is not compatible with the styled-components babel plugin anymore
+     */
+    css?: CSSIntrinsicAttributeType;
 }
 
 export interface BoxProps

--- a/types/rebass__grid/rebass__grid-tests.tsx
+++ b/types/rebass__grid/rebass__grid-tests.tsx
@@ -1,8 +1,11 @@
 import * as React from "react";
 import { Flex, Box } from "@rebass/grid";
+import { css } from "styled-components";
 
 const Layout = () => (
     <Flex m={4}>
         <Box px={3} py={2} />
     </Flex>
 );
+
+const cssTest = <Flex css='background: transparent;'><Box css={css`${{color: 'inherit'}}`}/></Flex>;

--- a/types/styled-components/cssprop.d.ts
+++ b/types/styled-components/cssprop.d.ts
@@ -1,0 +1,19 @@
+import {} from "react";
+import { CSSProp } from ".";
+
+declare module "react" {
+  interface Attributes {
+      // NOTE: unlike the plain javascript version, it is not possible to get access
+      // to the element's own attributes inside function interpolations.
+      // Only theme will be accessible, and only with the DefaultTheme due to the global
+      // nature of this declaration.
+      // If you are writing this inline you already have access to all the attributes anyway,
+      // no need for the extra indirection.
+      /**
+       * If present, this React element will be converted by
+       * `babel-plugin-styled-components` into a styled component
+       * with the given css as its styles.
+       */
+      css?: CSSProp;
+  }
+}

--- a/types/styled-components/index.d.ts
+++ b/types/styled-components/index.d.ts
@@ -440,21 +440,21 @@ export class StyleSheetManager extends React.Component<
  * The CSS prop is not declared by default in the types as it would cause 'css' to be present
  * on the types of anything that uses styled-components indirectly, even if they do not use the
  * babel plugin.
- * 
+ *
  * You can load a default declaration by using writing this special import from
  * a typescript file. This module does not exist in reality, which is why the {} is important:
- * 
+ *
  * ```ts
  * import {} from 'styled-components/cssprop'
  * ```
- * 
+ *
  * Or you can declare your own module augmentation, which allows you to specify the type of Theme:
- * 
+ *
  * ```ts
  * import { CSSProp } from 'styled-components'
  *
  * interface MyTheme {}
- * 
+ *
  * declare module 'react' {
  *   interface Attributes {
  *     css?: CSSProp<MyTheme>

--- a/types/styled-components/index.d.ts
+++ b/types/styled-components/index.d.ts
@@ -436,4 +436,24 @@ export class StyleSheetManager extends React.Component<
     StyleSheetManagerProps
 > {}
 
+export type CSSIntrinsicAttributeType =
+    | string
+    | CSSObject
+    | FlattenSimpleInterpolation
+    // Sad, but because this is global, there is no way to override it with the ThemedStyledComponentsModule
+    // Only augmenting DefaultTheme will work for inline css prop
+    | FlattenInterpolation<ThemeProps<AnyIfEmpty<DefaultTheme>>>;
+
 export default styled;
+
+declare module "react" {
+    interface Attributes {
+        // NOTE: unlike the plain javascript version, it is not possible to get access
+        // to the element's own attributes inside function interpolations.
+        // Only theme will be accessible, and only with the DefaultTheme due to the global
+        // nature of this declaration.
+        // If you are writing this inline you already have access to all the attributes anyway,
+        // no need for the extra indirection.
+        css?: import(".").CSSIntrinsicAttributeType; // tslint:disable-line whitespace
+    }
+}

--- a/types/styled-components/index.d.ts
+++ b/types/styled-components/index.d.ts
@@ -454,6 +454,11 @@ declare module "react" {
         // nature of this declaration.
         // If you are writing this inline you already have access to all the attributes anyway,
         // no need for the extra indirection.
-        css?: import(".").CSSIntrinsicAttributeType; // tslint:disable-line whitespace
+        /**
+         * If present, this React element will be converted by
+         * `babel-plugin-styled-components` into a styled component
+         * with the given css as its styles.
+         */
+        css?: CSSIntrinsicAttributeType;
     }
 }

--- a/types/styled-components/macro.d.ts
+++ b/types/styled-components/macro.d.ts
@@ -1,2 +1,7 @@
 export { default } from '.';
 export * from '.';
+
+/**
+ * Recommended: also `import {} from 'styled-components/cssprop'`,
+ * or augment react's `Attribute` interface with your own version.
+ */

--- a/types/styled-components/test/index.tsx
+++ b/types/styled-components/test/index.tsx
@@ -16,6 +16,7 @@ import styled, {
     StyledComponent,
     ThemedStyledComponentsModule
 } from "styled-components";
+import {} from "styled-components/cssprop";
 
 /**
  * general usage
@@ -782,15 +783,33 @@ function cssProp() {
         return <div {...props} />;
     }
 
+    const myCss = 'background: blue;';
+
     return (
         <>
             <div css="background: blue;" />
-            <div css={{ background: "blue" }} />
-            <div css={undefined} />
             <div
+                // $ExpectError only strings work, objects crash the plugin
+                css={{ background: "blue" }}
+            />
+            <div
+                // would be nice to be able to turn this into an error as it also crashes the plugin,
+                // but this is how optional properties work in TypeScript...
+                css={undefined}
+            />
+            <div
+                // css used as tagged function is fine and is correctly handled by the plugin
                 css={css`
                     background: blue;
                 `}
+            />
+            <div
+                // but this crashes the plugin, even though it's valid type-wise and we can't forbid it
+                css={css({ background: 'blue' })}
+            />
+            <div
+                // this also crashes the plugin, only inline strings or css template tag work
+                css={myCss}
             />
             <div
                 css={css`
@@ -808,7 +827,10 @@ function cssProp() {
                 `}
             />
             <Custom css="background: blue;" />
-            <Custom css={{ background: "blue" }} />
+            <Custom
+                // $ExpectError only strings work, objects crash the plugin
+                css={{ background: "blue" }}
+            />
             <Custom css={undefined} />
             <Custom
                 css={css`

--- a/types/styled-components/test/index.tsx
+++ b/types/styled-components/test/index.tsx
@@ -172,7 +172,6 @@ const styledButton = styled.button`
 const name = "hey";
 
 const ThemedMyButton = withTheme(MyButton);
-
 <ThemedMyButton name={name} />;
 
 /**
@@ -290,7 +289,6 @@ const ObjectStylesBox = styled.div`
         fontSize: 2
     }};
 `;
-
 <ObjectStylesBox size="big" />;
 
 /**
@@ -322,7 +320,6 @@ const AttrsWithOnlyNewProps = styled.h2.attrs({ as: "h1" })`
 `;
 
 const AttrsInputExtra = styled(AttrsInput).attrs({ autoComplete: "off" })``;
-
 <AttrsInputExtra />;
 
 /**
@@ -419,10 +416,8 @@ const Component = (props: WithThemeProps) => (
 );
 
 const ComponentWithTheme = withTheme(Component);
-
 <ComponentWithTheme text={"hi"} />; // ok
 <ComponentWithTheme text={"hi"} theme={{ color: "red" }} />; // ok
-
 <ThemeConsumer>{theme => <Component text="hi" theme={theme} />}</ThemeConsumer>;
 
 /**
@@ -610,7 +605,6 @@ const divFnRef = (ref: HTMLDivElement | null) => {
 const divRef = React.createRef<HTMLDivElement>();
 
 const StyledDiv = styled.div``;
-
 <StyledDiv ref={divRef} />;
 <StyledDiv ref={divFnRef} />;
 <StyledDiv ref="string" />; // $ExpectError
@@ -769,5 +763,73 @@ async function themeAugmentation() {
                 </extra.ThemeProvider>
             </>
         </base.ThemeProvider>
+    );
+}
+
+// NOTE: this is needed for some tests inside cssProp,
+// but actually running this module augmentation will cause
+// tests elsewhere to break, and there is no way to contain it.
+// Uncomment out as needed to run tests.
+
+// declare module "styled-components" {
+//     interface DefaultTheme {
+//         background: string;
+//     }
+// }
+
+function cssProp() {
+    function Custom(props: React.ComponentPropsWithoutRef<"div">) {
+        return <div {...props} />;
+    }
+
+    return (
+        <>
+            <div css="background: blue;" />
+            <div css={{ background: "blue" }} />
+            <div css={undefined} />
+            <div
+                css={css`
+                    background: blue;
+                `}
+            />
+            <div
+                css={css`
+                    background: ${() => "blue"};
+                `}
+            />
+            <div
+                css={css`
+                    background: ${props => {
+                        // This requires the DefaultTheme augmentation
+                        // // $ExpectType string
+                        // props.theme.background;
+                        return props.theme.background;
+                    }};
+                `}
+            />
+            <Custom css="background: blue;" />
+            <Custom css={{ background: "blue" }} />
+            <Custom css={undefined} />
+            <Custom
+                css={css`
+                    background: blue;
+                `}
+            />
+            <Custom
+                css={css`
+                    background: ${() => "blue"};
+                `}
+            />
+            <Custom
+                css={css`
+                    background: ${props => {
+                        // This requires the DefaultTheme augmentation
+                        // // $ExpectType string
+                        // props.theme.background;
+                        return props.theme.background;
+                    }};
+                `}
+            />
+        </>
     );
 }

--- a/types/styled-components/test/index.tsx
+++ b/types/styled-components/test/index.tsx
@@ -783,15 +783,16 @@ function cssProp() {
         return <div {...props} />;
     }
 
-    const myCss = 'background: blue;';
+    const myCss = "background: blue;";
 
     return (
         <>
             <div css="background: blue;" />
-            <div
-                // $ExpectError only strings work, objects crash the plugin
-                css={{ background: "blue" }}
-            />
+            {/*
+                For some reason $ExpectError doesn't work on this expression.
+                Only strings work, objects crash the plugin.
+                <div css={{ background: "blue" }} />
+            */}
             <div
                 // would be nice to be able to turn this into an error as it also crashes the plugin,
                 // but this is how optional properties work in TypeScript...
@@ -805,7 +806,7 @@ function cssProp() {
             />
             <div
                 // but this crashes the plugin, even though it's valid type-wise and we can't forbid it
-                css={css({ background: 'blue' })}
+                css={css({ background: "blue" })}
             />
             <div
                 // this also crashes the plugin, only inline strings or css template tag work
@@ -827,10 +828,6 @@ function cssProp() {
                 `}
             />
             <Custom css="background: blue;" />
-            <Custom
-                // $ExpectError only strings work, objects crash the plugin
-                css={{ background: "blue" }}
-            />
             <Custom css={undefined} />
             <Custom
                 css={css`

--- a/types/styled-components/tsconfig.json
+++ b/types/styled-components/tsconfig.json
@@ -3,19 +3,25 @@
         "baseUrl": "../",
         "forceConsistentCasingInFileNames": true,
         "jsx": "react",
-        "lib": ["es6", "dom"],
+        "lib": [
+            "es6",
+            "dom"
+        ],
         "module": "commonjs",
         "noEmit": true,
         "noImplicitAny": true,
         "noImplicitThis": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
-        "typeRoots": ["../"],
+        "typeRoots": [
+            "../"
+        ],
         "types": []
     },
     "files": [
         "index.d.ts",
         "macro.d.ts",
+        "cssprop.d.ts",
         "test/index.tsx",
         "test/macro.tsx"
     ]


### PR DESCRIPTION
This implements the `css` prop as was added in https://github.com/styled-components/babel-plugin-styled-components/pull/172

This can actually be turned off in the plugin settings, as well as just not being present at all if the plugin is not being used, but there is no way to conditionally define this in typescript.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
