### PR TITLE
[ejs] renderFile returns Promise without callback, fixes #28934

### DIFF
--- a/types/ejs/ejs-tests.ts
+++ b/types/ejs/ejs-tests.ts
@@ -29,6 +29,9 @@ result = ejs.render(template, data, options);
 result = ejs.renderFile(fileName, SimpleCallback);
 result = ejs.renderFile(fileName, data, SimpleCallback);
 result = ejs.renderFile(fileName, data, options, SimpleCallback);
+asyncResult = ejs.renderFile(fileName);
+asyncResult = ejs.renderFile(fileName, data);
+asyncResult = ejs.renderFile(fileName, data, options);
 
 ejsFunction = ejs.compile('');
 ejsFunction = ejs.compile(read(fileName, "utf8"));

--- a/types/ejs/index.d.ts
+++ b/types/ejs/index.d.ts
@@ -54,6 +54,8 @@ export type RenderFileCallback<T> = (err: Error, str?: string) => T;
 export function renderFile<T>(path: string, cb: RenderFileCallback<T>): T;
 export function renderFile<T>(path: string, data: Data, cb: RenderFileCallback<T>): T;
 export function renderFile<T>(path: string, data: Data, opts: Options, cb: RenderFileCallback<T>): T;
+// tslint:disable-next-line no-unnecessary-generics
+export function renderFile<T>(path: string, data?: Data, opts?: Options): Promise<T>;
 
 /**
  * Clear intermediate JavaScript cache. Calls {@link Cache#reset}.


### PR DESCRIPTION
EJS has support for returning promises from renderFile method.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/mde/ejs/blob/master/lib/ejs.js#L235
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
