### PR TITLE
Update validators.d.ts

### DIFF
--- a/types/vuelidate/index.d.ts
+++ b/types/vuelidate/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for vuelidate 0.7
 // Project: https://github.com/janesser/vuelidate.ts
 // Definitions by: Jan Esser <https://github.com/janesser>
+//                 Jubair Saidi <https://github.com/jubairsaidi>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.4
 

--- a/types/vuelidate/lib/validators.d.ts
+++ b/types/vuelidate/lib/validators.d.ts
@@ -18,10 +18,10 @@ export interface ValidationRule {
     $pending(): boolean
 }
 
-export type CustomRule = (value: any, parentVm?: Vue) => boolean
+export type CustomRule = (value: any, parentVm?: any) => boolean
 
 export interface Helpers {
-    withParams(params: Params, rule: CustomRule): ValidationRule
+    withParams(params: Params, rule: CustomRule | ValidationRule): ValidationRule
     req(value: any): ValidationRule
     ref(reference: string | ((vm: any, parentVm?: Vue) => any), vm: any, parentVm?: Vue): any
     len(value: any): number
@@ -42,10 +42,13 @@ export function between(min: number, max: number): ValidationRule
 export function alpha(): ValidationRule
 export function alphaNum(): ValidationRule
 export function numeric(): ValidationRule
+export function integer(): ValidationRule
+export function decimal(): ValidationRule
 export function email(): ValidationRule
 export function ipAddress(): ValidationRule
 export function macAddress(): ValidationRule
 export function sameAs(field: string | ((vm: any, parentVm?: Vue) => any)): ValidationRule
 export function url(): ValidationRule
-export function or(...validators: ValidationRule[]): ValidationRule
-export function and(...validators: ValidationRule[]): ValidationRule
+export function not(validator: ValidationRule | CustomRule): ValidationRule
+export function or(...validators: Array<ValidationRule | CustomRule>): ValidationRule
+export function and(...validators: Array<ValidationRule | CustomRule>): ValidationRule

--- a/types/vuelidate/vuelidate-tests.ts
+++ b/types/vuelidate/vuelidate-tests.ts
@@ -1,5 +1,5 @@
 import { Validation } from 'vuelidate'
-import { required, minLength, sameAs, helpers } from 'vuelidate/lib/validators'
+import { required, integer, decimal,  minLength, sameAs, helpers } from 'vuelidate/lib/validators'
 
 import Vue, { ComponentOptions } from 'vue'
 
@@ -54,14 +54,25 @@ const mustHaveLength = (minLen: number) => helpers.withParams(
             },
             nestedB: {
                 required
+            },
+            nestedOfLength: {
+                mustHaveLength: mustHaveLength(6)
             }
+        },
+        age: {
+            required,
+            integer
+        },
+        coolFactor: {
+            required,
+            decimal
         },
         flatA: { required },
         flatB: { required },
         forGroup: {
             nested: { required }
         },
-        validationGroup: ['flatA', 'flatB', 'forGroup.nested'],
+        validationGroup: ['age', 'coolFactor', 'flatA', 'flatB', 'forGroup.nested'],
         people: {
             required,
             minLength: minLength(3),
@@ -90,7 +101,7 @@ const mustHaveLength = (minLen: number) => helpers.withParams(
             required,
             mustBeCool,
             mustBeCool2,
-            containsA: contains("a"),
+            containsA: contains('a'),
             mustBeCool3
         }
     }
@@ -101,8 +112,12 @@ export class ValidComponent extends Vue {
 
     form = {
         nestedA: 'A',
-        nestedB: 'B'
+        nestedB: 'B',
+        nestedOfLength: ''
     }
+
+    age = 50
+    coolFactor = 0.25
 
     flatA = ''
     flatB = ''
@@ -132,6 +147,8 @@ export class ValidComponent extends Vue {
             console.log(this.$v.form.$params)
             console.log(this.$v.form.$params.nestedA)
             console.log(this.$v.form.nestedA)
+            console.log(this.$v.form.$params.nestedOfLength)
+            console.log(this.$v.form.nestedOfLength)
         }
         console.log(this.$v.validationGroup.$params)
     }


### PR DESCRIPTION
Fixes `withParam` helper, and `or`, and `and` rules to allow for either ValidationRule or CustomRule since in practice they are interchangeable.

Fixes CustomRule `parentVm` param to be of type any.  the parentVm for nested elements are often still nested, I,e. not the Vue Component.

Added missing rules: `integer`, `decimal`, and `not`.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <[Adds missing rules](https://github.com/monterail/vuelidate/tree/master/src/validators), [Fixes signature of some rules](https://github.com/monterail/vuelidate/blob/master/src/validators/or.js) , [Fixes withParam to correctly accept CustomRule or ValidationRule](https://github.com/monterail/vuelidate/blob/master/src/validators/common.js)>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.