### PR TITLE
[react-native] Added Image width and height props

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -3629,7 +3629,7 @@ interface ImagePropsAndroid {
      * Duration of fade in animation.
      */
     fadeDuration?: number;
-    
+
     /**
      * Required sizes if using native image resources on Android
      */

--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -3631,9 +3631,15 @@ interface ImagePropsAndroid {
     fadeDuration?: number;
 
     /**
-     * Required sizes if using native image resources on Android
+     * Required if loading images via 'uri' from drawable folder on Android.
+     * Explanation: https://medium.com/@adamjacobb/react-native-performance-images-adf5843e120
      */
     width?: number;
+
+    /**
+     * Required if loading images via 'uri' from drawable folder on Android
+     * Explanation: https://medium.com/@adamjacobb/react-native-performance-images-adf5843e120
+     */
     height?: number;
 }
 

--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -3629,6 +3629,12 @@ interface ImagePropsAndroid {
      * Duration of fade in animation.
      */
     fadeDuration?: number;
+    
+    /**
+     * Required sizes if using native image resources on Android
+     */
+    width?: number;
+    height?: number;
 }
 
 /**


### PR DESCRIPTION
When using native image resources in RN (drawable in Android, xcassets in iOS), Android requires `width` and `height` props to be set in order to render the image. This functionality is not documented in official RN docs, however it's necessary procedure for many releases now.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://medium.com/@adamjacobb/react-native-performance-images-adf5843e120