### PR TITLE
[@babel/core]: Fixed typo in method name.

### DIFF
--- a/types/babel__core/babel__core-tests.ts
+++ b/types/babel__core/babel__core-tests.ts
@@ -29,3 +29,7 @@ babel.transformFromAst(parsedAst!, sourceCode, options, (err, result) => {
 
 const transformFromAstSyncResult = babel.transformFromAstSync(parsedAst!, sourceCode, options);
 const { code, map, ast } = transformFromAstSyncResult!;
+
+babel.transformFromAstAsync(parsedAst!, sourceCode, options).then(transformFromAstAsyncResult => {
+    const { code, map, ast } = transformFromAstAsyncResult!;
+});

--- a/types/babel__core/index.d.ts
+++ b/types/babel__core/index.d.ts
@@ -349,7 +349,7 @@ export function transformFromAstSync(ast: Node, code?: string, opts?: TransformO
 /**
  * Given an AST, transform it.
  */
-export function transformFromAstSync(ast: Node, code?: string, opts?: TransformOptions): Promise<BabelFileResult | null>;
+export function transformFromAstAsync(ast: Node, code?: string, opts?: TransformOptions): Promise<BabelFileResult | null>;
 
 // A babel plugin is a simple function which must return an object matching
 // the following interface. Babel will throw if it finds unknown properties.


### PR DESCRIPTION
Renamed one overload of `transformFromAstSync` to `transformFromAstAsync`. See https://github.com/babel/babel/blob/61f2aed5b0d3ef869dca2f8e2673e46079df7d09/packages/babel-core/src/transform-ast.js#L75 and https://github.com/babel/babel/blob/61f2aed5b0d3ef869dca2f8e2673e46079df7d09/packages/babel-core/src/index.js#L29

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: URLs above.
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.