### PR TITLE
[@babel/traverse]: Added types to argument of Scope#push.

### DIFF
--- a/types/babel__traverse/babel__traverse-tests.ts
+++ b/types/babel__traverse/babel__traverse-tests.ts
@@ -89,7 +89,8 @@ const v1: Visitor = {
 
         const id = path.scope.generateUidIdentifierBasedOnNode(path.node.id!);
         path.remove();
-        path.scope.parent.push({ id, init: path.node });
+        path.scope.parent.push({ id });
+        path.scope.parent.push({ id, init: t.stringLiteral('foo'), kind: "const" });
 
         path.scope.rename("n", "x");
         path.scope.rename("n");

--- a/types/babel__traverse/babel__traverse-tests.ts
+++ b/types/babel__traverse/babel__traverse-tests.ts
@@ -105,7 +105,7 @@ const BindingKindTest: Visitor = {
         kind === 'const';
         kind === 'let';
         kind === 'var';
-        // The following should fail when uncommented
-        // kind === 'anythingElse';
+        // $ExpectError
+        kind === 'anythingElse';
     },
 };

--- a/types/babel__traverse/index.d.ts
+++ b/types/babel__traverse/index.d.ts
@@ -90,7 +90,13 @@ export class Scope {
 
     removeData(key: string): void;
 
-    push(opts: any): void;
+    push(opts: {
+        id: object,
+        init?: object,
+        unique?: boolean,
+        _blockHoist?: number,
+        kind?: "var" | "let",
+    }): void;
 
     getProgramParent(): Scope;
 

--- a/types/babel__traverse/index.d.ts
+++ b/types/babel__traverse/index.d.ts
@@ -91,11 +91,10 @@ export class Scope {
     removeData(key: string): void;
 
     push(opts: {
-        id: object,
-        init?: object,
+        id: t.LVal,
+        init?: t.Expression,
         unique?: boolean,
-        _blockHoist?: number,
-        kind?: "var" | "let",
+        kind?: "var" | "let" | "const",
     }): void;
 
     getProgramParent(): Scope;


### PR DESCRIPTION
Copied from the flow types (https://github.com/babel/babel/blob/61f2aed5b0d3ef869dca2f8e2673e46079df7d09/packages/babel-traverse/src/scope/index.js#L778) with one exception - kind was made optional, since this is assigned a default value (https://github.com/babel/babel/blob/61f2aed5b0d3ef869dca2f8e2673e46079df7d09/packages/babel-traverse/src/scope/index.js#L801) and is most likely a mistake in the flow types.

Existing tests give this change a bit of coverage - let me know if you'd like me to add more.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: URLs above.
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
