### PR TITLE
Update definitions to accommodate API changes

### DIFF
--- a/types/react-places-autocomplete/index.d.ts
+++ b/types/react-places-autocomplete/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-places-autocomplete 7
+// Type definitions for react-places-autocomplete 7.2
 // Project: https://github.com/kenny-hibino/react-places-autocomplete/
 // Definitions by: Guilherme Hübner <https://github.com/guilhermehubner>
 //                 Andrew Makarov <https://github.com/r3nya>

--- a/types/react-places-autocomplete/index.d.ts
+++ b/types/react-places-autocomplete/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-places-autocomplete 6.1
+// Type definitions for react-places-autocomplete 7
 // Project: https://github.com/kenny-hibino/react-places-autocomplete/
 // Definitions by: Guilherme Hübner <https://github.com/guilhermehubner>
 //                 Andrew Makarov <https://github.com/r3nya>

--- a/types/react-places-autocomplete/index.d.ts
+++ b/types/react-places-autocomplete/index.d.ts
@@ -15,9 +15,7 @@ export interface formattedSuggestionType {
 }
 
 export interface PropTypes {
-    inputProps: {
-        value: string;
-        onChange: (value: string) => void;
+    inputProps?: {
         type?: string;
         name?: string;
         placeholder?: string;
@@ -49,6 +47,9 @@ export interface PropTypes {
         radius?: number | string;
         types?: string[];
     };
+    value: string;
+    onChange?: (value: string) => void;
+    onBlur?: (event: React.FocusEvent<HTMLInputElement>) => void;
 
     debounce?: number;
     highlightFirstSuggestion?: boolean;

--- a/types/react-places-autocomplete/index.d.ts
+++ b/types/react-places-autocomplete/index.d.ts
@@ -19,7 +19,6 @@ export interface PropTypes {
         type?: string;
         name?: string;
         placeholder?: string;
-        onBlur?: (event: React.FocusEvent<HTMLInputElement>) => void;
         disabled?: boolean;
     };
     onError?: (status: string, clearSuggestion: () => void) => void;
@@ -47,7 +46,7 @@ export interface PropTypes {
         radius?: number | string;
         types?: string[];
     };
-    value: string;
+    value?: string;
     onChange?: (value: string) => void;
     onBlur?: (event: React.FocusEvent<HTMLInputElement>) => void;
 

--- a/types/react-places-autocomplete/react-places-autocomplete-tests.tsx
+++ b/types/react-places-autocomplete/react-places-autocomplete-tests.tsx
@@ -45,7 +45,7 @@ class Test extends React.Component {
 
         return (
             <form onSubmit={this.handleFormSubmit}>
-                <PlacesAutocomplete inputProps={inputProps} />
+                <PlacesAutocomplete value={this.state.address} onChange={this.onChange} />
             </form>
         );
     }


### PR DESCRIPTION
InputProps are now optional.
The Component now receives props via direct application.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/hibiken/react-places-autocomplete/compare/v6.1.3...master
