### PR TITLE
[@babel/traverse]: Fixed types of Visitor

### DIFF
--- a/types/babel__traverse/babel__traverse-tests.ts
+++ b/types/babel__traverse/babel__traverse-tests.ts
@@ -112,3 +112,40 @@ const BindingKindTest: Visitor = {
         // kind === 'anythingElse';
     },
 };
+
+interface SomeVisitorState { someState: string; }
+
+const VisitorStateTest: Visitor<SomeVisitorState> = {
+    enter(path, state) {
+        // $ExpectType SomeVisitorState
+        state;
+        // $ExpectType SomeVisitorState
+        this;
+    },
+    exit(path, state) {
+        // $ExpectType SomeVisitorState
+        state;
+        // $ExpectType SomeVisitorState
+        this;
+    },
+    Identifier(path, state) {
+        // $ExpectType SomeVisitorState
+        state;
+        // $ExpectType SomeVisitorState
+        this;
+    },
+    FunctionDeclaration: {
+        enter(path, state) {
+            // $ExpectType SomeVisitorState
+            state;
+            // $ExpectType SomeVisitorState
+            this;
+        },
+        exit(path, state) {
+            // $ExpectType SomeVisitorState
+            state;
+            // $ExpectType SomeVisitorState
+            this;
+        }
+    }
+};

--- a/types/babel__traverse/babel__traverse-tests.ts
+++ b/types/babel__traverse/babel__traverse-tests.ts
@@ -4,10 +4,14 @@ import * as t from "@babel/types";
 // Examples from: https://github.com/thejameskyle/babel-handbook/blob/master/translations/en/plugin-handbook.md
 const MyVisitor: Visitor = {
     Identifier: {
-        enter() {
+        enter(path) {
+            // $ExpectType NodePath<Identifier>
+            path;
             console.log("Entered!");
         },
-        exit() {
+        exit(path) {
+            // $ExpectType NodePath<Identifier>
+            path;
             console.log("Exited!");
         }
     }

--- a/types/babel__traverse/index.d.ts
+++ b/types/babel__traverse/index.d.ts
@@ -142,7 +142,7 @@ export type Visitor<S = Node> = VisitNodeObject<Node> & {
     [P in Node["type"]]?: VisitNode<S, Extract<Node, { type: P; }>>;
 };
 
-export type VisitNode<T, P> = VisitNodeFunction<T, P> | VisitNodeObject<T>;
+export type VisitNode<T, P> = VisitNodeFunction<T, P> | VisitNodeObject<P>;
 
 export type VisitNodeFunction<T, P> = (this: T, path: NodePath<P>, state: any) => void;
 

--- a/types/babel__traverse/index.d.ts
+++ b/types/babel__traverse/index.d.ts
@@ -138,17 +138,17 @@ export class Binding {
     constantViolations: NodePath[];
 }
 
-export type Visitor<S = Node> = VisitNodeObject<Node> & {
-    [P in Node["type"]]?: VisitNode<S, Extract<Node, { type: P; }>>;
+export type Visitor<S = {}> = VisitNodeObject<S, Node> & {
+    [Type in Node["type"]]?: VisitNode<S, Extract<Node, { type: Type; }>>;
 };
 
-export type VisitNode<T, P> = VisitNodeFunction<T, P> | VisitNodeObject<P>;
+export type VisitNode<S, P> = VisitNodeFunction<S, P> | VisitNodeObject<S, P>;
 
-export type VisitNodeFunction<T, P> = (this: T, path: NodePath<P>, state: any) => void;
+export type VisitNodeFunction<S, P> = (this: S, path: NodePath<P>, state: S) => void;
 
-export interface VisitNodeObject<T> {
-    enter?(path: NodePath<T>, state: any): void;
-    exit?(path: NodePath<T>, state: any): void;
+export interface VisitNodeObject<S, P> {
+    enter?: VisitNodeFunction<S, P>;
+    exit?: VisitNodeFunction<S, P>;
 }
 
 export class NodePath<T = Node> {


### PR DESCRIPTION
* Made path argument be correctly typed when using the `VisitNodeObject` form of a visitor.
* Fixed types of `this` and `state` argument in a visitor.
* Made the state argument of `Visitor` not default to `Node`, since it being of type `Node` doesn't make sense - I believe this was a mistake by the original author. Instead, it now defaults to `{}` which is a sensible default if your visitor is stateless.
* Made names of type parameters in the vicinity consistent - `S` for state and `P` for nodes.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: N/a.
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.