### PR TITLE
Remove wrapper namespace from karma module and related fixes/cleanup

### DIFF
--- a/types/karma-coverage/index.d.ts
+++ b/types/karma-coverage/index.d.ts
@@ -1,27 +1,22 @@
-// Type definitions for karma-coverage v0.5.3
+// Type definitions for karma-coverage 1.1
 // Project: https://github.com/karma-runner/karma-coverage
 // Definitions by: Tanguy Krotoff <https://github.com/tkrotoff>
+//                 Yaroslav Admin <https://github.com/devoto13>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
-import * as karma from 'karma';
+import 'karma';
 import * as istanbul from 'istanbul';
 
-declare namespace karmaCoverage {
-    interface Karma extends karma.Karma { }
-
-    interface Config extends karma.Config {
-        set: (config: ConfigOptions) => void;
-    }
-
-    interface ConfigOptions extends karma.ConfigOptions {
+declare module 'karma' {
+    interface ConfigOptions {
         /**
          * See https://github.com/karma-runner/karma-coverage/blob/master/docs/configuration.md
          */
-        coverageReporter?: (Reporter | Reporter[]);
+        coverageReporter?: KarmaCoverageReporter & { reporters?: KarmaCoverageReporter[] };
     }
 
-    interface Reporter {
+    interface KarmaCoverageReporter {
         type?: string;
         dir?: string;
         subdir?: string | ((browser: string) => string);
@@ -33,7 +28,3 @@ declare namespace karmaCoverage {
         [moreSettings: string]: any;
     }
 }
-
-declare var karmaCoverage: karmaCoverage.Karma;
-
-export = karmaCoverage;

--- a/types/karma-coverage/karma-coverage-tests.ts
+++ b/types/karma-coverage/karma-coverage-tests.ts
@@ -1,6 +1,6 @@
-import * as karma from 'karma-coverage';
+import * as karma from 'karma';
 
-// See https://github.com/karma-runner/karma-coverage/blob/v0.5.3/README.md#basic
+// See https://github.com/karma-runner/karma-coverage/blob/v1.1.2/README.md#basic
 module.exports = function(config: karma.Config) {
   config.set({
     files: [
@@ -20,13 +20,13 @@ module.exports = function(config: karma.Config) {
 
     // optionally, configure the reporter
     coverageReporter: {
-      type : 'html',
-      dir : 'coverage/'
+      type: 'html',
+      dir: 'coverage/'
     }
   });
 };
 
-// See https://github.com/karma-runner/karma-coverage/blob/v0.5.3/README.md#advanced-multiple-reporters
+// See https://github.com/karma-runner/karma-coverage/blob/v1.1.2/README.md#advanced-multiple-reporters
 module.exports = function(config: karma.Config) {
   config.set({
     files: [
@@ -56,7 +56,7 @@ module.exports = function(config: karma.Config) {
   });
 };
 
-// See https://github.com/karma-runner/karma-coverage/blob/v0.5.3/README.md#dont-minify-instrumenter-output
+// See https://github.com/karma-runner/karma-coverage/blob/v1.1.2/README.md#dont-minify-instrumenter-output
 module.exports = function(config: karma.Config) {
   config.set({
     coverageReporter: {
@@ -67,7 +67,7 @@ module.exports = function(config: karma.Config) {
   });
 };
 
-// See https://github.com/karma-runner/karma-coverage/blob/v0.5.3/docs/configuration.md#subdir
+// See https://github.com/karma-runner/karma-coverage/blob/v1.1.2/docs/configuration.md#subdir
 module.exports = function(config: karma.Config) {
   config.set({
     coverageReporter: {
@@ -93,7 +93,7 @@ module.exports = function(config: karma.Config) {
     coverageReporter: {
       dir: 'coverage',
       subdir: function(browser) {
-        // normalization process to keep a consistent browser name accross different
+        // normalization process to keep a consistent browser name across different
         // OS
         return browser.toLowerCase().split(/[ /-]/)[0];
       }
@@ -102,18 +102,18 @@ module.exports = function(config: karma.Config) {
   });
 };
 
-// See https://github.com/karma-runner/karma-coverage/blob/v0.5.3/docs/configuration.md#file
+// See https://github.com/karma-runner/karma-coverage/blob/v1.1.2/docs/configuration.md#file
 module.exports = function(config: karma.Config) {
   config.set({
     coverageReporter: {
-      type : 'text',
-      dir : 'coverage/',
-      file : 'coverage.txt'
+      type: 'text',
+      dir: 'coverage/',
+      file: 'coverage.txt'
     }
   });
 };
 
-// See https://github.com/karma-runner/karma-coverage/blob/v0.5.3/docs/configuration.md#check
+// See https://github.com/karma-runner/karma-coverage/blob/v1.1.2/docs/configuration.md#check
 module.exports = function(config: karma.Config) {
   config.set({
     coverageReporter: {
@@ -146,7 +146,7 @@ module.exports = function(config: karma.Config) {
   });
 };
 
-// See https://github.com/karma-runner/karma-coverage/blob/v0.5.3/docs/configuration.md#watermarks
+// See https://github.com/karma-runner/karma-coverage/blob/v1.1.2/docs/configuration.md#watermarks
 module.exports = function(config: karma.Config) {
   config.set({
     coverageReporter: {
@@ -160,24 +160,36 @@ module.exports = function(config: karma.Config) {
   });
 };
 
-// See https://github.com/karma-runner/karma-coverage/blob/v0.5.3/docs/configuration.md#sourcestore
-module.exports = function(config: karma.Config) {
+// See https://github.com/karma-runner/karma-coverage/blob/v1.1.2/docs/configuration.md#includeallsources
+module.exports = function (config: karma.Config) {
   config.set({
     coverageReporter: {
-      type : 'text',
-      dir : 'coverage/',
-      file : 'coverage.txt',
-      sourceStore : require('istanbul').Store.create('fslookup')
+      type: 'text',
+      dir: 'coverage/',
+      file: 'coverage.txt',
+      includeAllSources: true
     }
   });
 };
 
-// See https://github.com/karma-runner/karma-coverage/blob/v0.5.3/docs/configuration.md#reporters
+// See https://github.com/karma-runner/karma-coverage/blob/v1.1.2/docs/configuration.md#sourcestore
 module.exports = function(config: karma.Config) {
   config.set({
     coverageReporter: {
-      reporters:[
-        {type: 'html', dir:'coverage/'},
+      type: 'text',
+      dir: 'coverage/',
+      file: 'coverage.txt',
+      sourceStore: require('istanbul').Store.create('fslookup')
+    }
+  });
+};
+
+// See https://github.com/karma-runner/karma-coverage/blob/v1.1.2/docs/configuration.md#reporters
+module.exports = function(config: karma.Config) {
+  config.set({
+    coverageReporter: {
+      reporters: [
+        {type: 'html', dir: 'coverage/'},
         {type: 'teamcity'},
         {type: 'text-summary'}
       ],
@@ -185,7 +197,7 @@ module.exports = function(config: karma.Config) {
   });
 };
 
-// See https://github.com/karma-runner/karma-coverage/blob/v0.5.3/docs/configuration.md#instrumenter
+// See https://github.com/karma-runner/karma-coverage/blob/v1.1.2/docs/configuration.md#instrumenter
 module.exports = function(config: karma.Config) {
   config.set({
     coverageReporter: {

--- a/types/karma/index.d.ts
+++ b/types/karma/index.d.ts
@@ -13,464 +13,460 @@ import Promise = require('bluebird');
 import https = require('https');
 import { Appender } from 'log4js';
 
-declare namespace karma {
-    /**
-     * `start` method is deprecated since 0.13. It will be removed in 0.14.
-     * Please use
-     * <code>
-     *     server = new Server(config, [done])
-     *     server.start()
-     * </code>
-     * instead.
-     *
-     * @deprecated
-     */
-    const server: DeprecatedServer;
+/**
+ * `start` method is deprecated since 0.13. It will be removed in 0.14.
+ * Please use
+ * <code>
+ *     server = new Server(config, [done])
+ *     server.start()
+ * </code>
+ * instead.
+ *
+ * @deprecated
+ */
+export const server: DeprecatedServer;
 
-    const runner: Runner;
-    const stopper: Stopper;
+export const runner: Runner;
+export const stopper: Stopper;
 
-    const VERSION: string;
-    const constants: Constants;
+export const VERSION: string;
+export const constants: Constants;
 
-    interface Constants {
-        VERSION: string;
-        DEFAULT_PORT: number;
-        DEFAULT_HOSTNAME: string;
-        DEFAULT_LISTEN_ADDR: string;
-        LOG_DISABLE: string;
-        LOG_ERROR: string;
-        LOG_WARN: string;
-        LOG_INFO: string;
-        LOG_DEBUG: string;
-        LOG_LOG: string;
-        LOG_PRIORITIES: string[];
-        COLOR_PATTERN: string;
-        NO_COLOR_PATTERN: string;
-        CONSOLE_APPENDER: {
+export interface Constants {
+    VERSION: string;
+    DEFAULT_PORT: number;
+    DEFAULT_HOSTNAME: string;
+    DEFAULT_LISTEN_ADDR: string;
+    LOG_DISABLE: string;
+    LOG_ERROR: string;
+    LOG_WARN: string;
+    LOG_INFO: string;
+    LOG_DEBUG: string;
+    LOG_LOG: string;
+    LOG_PRIORITIES: string[];
+    COLOR_PATTERN: string;
+    NO_COLOR_PATTERN: string;
+    CONSOLE_APPENDER: {
+        type: string;
+        layout: {
             type: string;
-            layout: {
-                type: string;
-                pattern: string;
-            };
+            pattern: string;
         };
-        EXIT_CODE: string;
-    }
+    };
+    EXIT_CODE: string;
+}
 
-    namespace launcher {
-        class Launcher {
-            static generateId(): string;
+export namespace launcher {
+    class Launcher {
+        static generateId(): string;
 
-            constructor(emitter: NodeJS.EventEmitter, injector: any);
+        constructor(emitter: NodeJS.EventEmitter, injector: any);
 
-            // TODO: Can this return value ever be typified?
-            launch(names: string[], protocol: string, hostname: string, port: number, urlRoot: string): any[];
-            kill(id: string, callback: () => void): boolean;
-            restart(id: string): boolean;
-            killAll(callback: () => void): void;
-            areAllCaptured(): boolean;
-            markCaptured(id: string): void;
-        }
-    }
-
-    /** @deprecated */
-    interface DeprecatedServer {
-        /** @deprecated */
-        start(options?: any, callback?: ServerCallback): void;
-    }
-
-    interface Runner {
-        run(options?: ConfigOptions | ConfigFile, callback?: ServerCallback): void;
-    }
-
-    interface Stopper {
-        /**
-         * This function will signal a running server to stop. The equivalent of karma stop.
-         */
-        stop(options?: ConfigOptions, callback?: ServerCallback): void;
-    }
-
-    interface TestResults {
-        disconnected: boolean;
-        error: boolean;
-        exitCode: number;
-        failed: number;
-        success: number;
-    }
-
-    class Server extends NodeJS.EventEmitter {
-        constructor(options?: ConfigOptions | ConfigFile, callback?: ServerCallback);
-        /**
-         * Start the server
-         */
-        start(): void;
-        /**
-         * Get properties from the injector
-         * @param token
-         */
-        get(token: string): any;
-        /**
-         * Force a refresh of the file list
-         */
-        refreshFiles(): Promise<any>;
-
-        on(event: string, listener: (...args: any[]) => void): this;
-
-        /**
-         * Listen to the 'run_complete' event.
-         */
-        on(event: 'run_complete', listener: (browsers: any, results: TestResults) => void): this;
-
-        /**
-         * Backward-compatibility with karma-intellij bundled with WebStorm.
-         * Deprecated since version 0.13, to be removed in 0.14
-         */
-        // static start(): void;
-    }
-
-    type ServerCallback = (exitCode: number) => void;
-
-    interface Config {
-        set: (config: ConfigOptions) => void;
-        LOG_DISABLE: string;
-        LOG_ERROR: string;
-        LOG_WARN: string;
-        LOG_INFO: string;
-        LOG_DEBUG: string;
-    }
-
-    interface ConfigFile {
-        configFile: string;
-    }
-
-    interface ConfigOptions {
-        /**
-         * @description Enable or disable watching files and executing the tests whenever one of these files changes.
-         * @default true
-         */
-        autoWatch?: boolean;
-        /**
-         * @description When Karma is watching the files for changes, it tries to batch multiple changes into a single run
-         * so that the test runner doesn't try to start and restart running tests more than it should.
-         * The configuration setting tells Karma how long to wait (in milliseconds) after any changes have occurred
-         * before starting the test process again.
-         * @default 250
-         */
-        autoWatchBatchDelay?: number;
-        /**
-         * @default ''
-         * @description The root path location that will be used to resolve all relative paths defined in <code>files</code> and <code>exclude</code>.
-         * If the basePath configuration is a relative path then it will be resolved to
-         * the <code>__dirname</code> of the configuration file.
-         */
-        basePath?: string;
-        /**
-         * @default 2000
-         * @description How long does Karma wait for a browser to reconnect (in ms).
-         * <p>
-         * With a flaky connection it is pretty common that the browser disconnects,
-         * but the actual test execution is still running without any problems. Karma does not treat a disconnection
-         * as immediate failure and will wait <code>browserDisconnectTimeout</code> (ms).
-         * If the browser reconnects during that time, everything is fine.
-         * </p>
-         */
-        browserDisconnectTimeout?: number;
-        /**
-         * @default 0
-         * @description The number of disconnections tolerated.
-         * <p>
-         * The <code>disconnectTolerance</code> value represents the maximum number of tries a browser will attempt
-         * in the case of a disconnection. Usually any disconnection is considered a failure,
-         * but this option allows you to define a tolerance level when there is a flaky network link between
-         * the Karma server and the browsers.
-         * </p>
-         */
-        browserDisconnectTolerance?: number;
-        /**
-         * @default 10000
-         * @description How long will Karma wait for a message from a browser before disconnecting from it (in ms).
-         * <p>
-         * If, during test execution, Karma does not receive any message from a browser within
-         * <code>browserNoActivityTimeout</code> (ms), it will disconnect from the browser
-         * </p>
-         */
-        browserNoActivityTimeout?: number;
-        /**
-         * @default []
-         * Possible Values:
-         * <ul>
-         *     <li>Chrome (launcher comes installed with Karma)</li>
-         *     <li>ChromeCanary (launcher comes installed with Karma)</li>
-         *     <li>PhantomJS (launcher comes installed with Karma)</li>
-         *     <li>Firefox (launcher requires karma-firefox-launcher plugin)</li>
-         *     <li>Opera (launcher requires karma-opera-launcher plugin)</li>
-         *     <li>Internet Explorer (launcher requires karma-ie-launcher plugin)</li>
-         *     <li>Safari (launcher requires karma-safari-launcher plugin)</li>
-         * </ul>
-         * @description A list of browsers to launch and capture. When Karma starts up, it will also start up each browser
-         * which is placed within this setting. Once Karma is shut down, it will shut down these browsers as well.
-         * You can capture any browser manually by opening the browser and visiting the URL where
-         * the Karma web server is listening (by default it is <code>http://localhost:9876/</code>).
-         */
-        browsers?: string[];
-        /**
-         * @default 60000
-         * @description Timeout for capturing a browser (in ms).
-         * <p>
-         * The <code>captureTimeout</code> value represents the maximum boot-up time allowed for a
-         * browser to start and connect to Karma. If any browser does not get captured within the timeout, Karma
-         * will kill it and try to launch it again and, after three attempts to capture it, Karma will give up.
-         * </p>
-         */
-        captureTimeout?: number;
-        client?: ClientOptions;
-        /**
-         * @default true
-         * @description Enable or disable colors in the output (reporters and logs).
-         */
-        colors?: boolean;
-        /**
-         * @default 'Infinity'
-         * @description How many browsers Karma launches in parallel.
-         * Especially on services like SauceLabs and Browserstack, it makes sense only to launch a limited
-         * amount of browsers at once, and only start more when those have finished. Using this configuration,
-         * you can specify how many browsers should be running at once at any given point in time.
-         */
-        concurrency?: number;
-        customLaunchers?: { [key: string]: CustomLauncher };
-        /**
-         * @default []
-         * @description List of files/patterns to exclude from loaded files.
-         */
-        exclude?: string[];
-        /**
-         * @default []
-         * @description List of files/patterns to load in the browser.
-         */
-        files?: Array<FilePattern | string>;
-        /**
-         * @default []
-         * @description List of test frameworks you want to use. Typically, you will set this to ['jasmine'], ['mocha'] or ['qunit']...
-         * Please note just about all frameworks in Karma require an additional plugin/framework library to be installed (via NPM).
-         */
-        frameworks?: string[];
-        /**
-         * @default 'localhost'
-         * @description Hostname to be used when capturing browsers.
-         */
-        hostname?: string;
-        /**
-         * @default {}
-         * @description Options object to be used by Node's https class.
-         * Object description can be found in the
-         * [NodeJS.org API docs](https://nodejs.org/api/tls.html#tls_tls_createserver_options_secureconnectionlistener)
-         */
-        httpsServerOptions?: https.ServerOptions;
-        /**
-         * @default config.LOG_INFO
-         * Possible values:
-         * <ul>
-         *   <li>config.LOG_DISABLE</li>
-         *   <li>config.LOG_ERROR</li>
-         *   <li>config.LOG_WARN</li>
-         *   <li>config.LOG_INFO</li>
-         *   <li>config.LOG_DEBUG</li>
-         * </ul>
-         * @description Level of logging.
-         */
-        logLevel?: string;
-        /**
-         * @default [{type: 'console'}]
-         * @description A list of log appenders to be used. See the documentation for [log4js] for more information.
-         */
-        loggers?: { [name: string]: Appender } | Appender[];
-        /**
-         * @default []
-         * @description List of names of additional middleware you want the
-         * Karma server to use. Middleware will be used in the order listed.
-         * You must have installed the middleware via a plugin/framework
-         * (either inline or via NPM). Additional information can be found in
-         * [plugins](http://karma-runner.github.io/2.0/config/plugins.html).
-         * The plugin must provide an express/connect middleware function
-         * (details about this can be found in the
-         * [Express](http://expressjs.com/guide/using-middleware.html) docs).
-         */
-        middleware?: string[];
-        /**
-         * @default {}
-         * @description Redefine default mapping from file extensions to MIME-type.
-         * Set property name to required MIME, provide Array of extensions (without dots) as it's value.
-         */
-        mime?: {[type: string]: string[]};
-        /**
-         * @default ['karma-*']
-         * @description List of plugins to load. A plugin can be a string (in which case it will be required
-         * by Karma) or an inlined plugin - Object.
-         * By default, Karma loads all sibling NPM modules which have a name starting with karma-*.
-         * Note: Just about all plugins in Karma require an additional library to be installed (via NPM).
-         */
-        plugins?: any[];
-        /**
-         * @default 9876
-         * @description The port where the web server will be listening.
-         */
-        port?: number;
-        /**
-         * @default {'**\/*.coffee': 'coffee'}
-         * @description A map of preprocessors to use.
-         *
-         * Preprocessors can be loaded through [plugins].
-         *
-         * Note: Just about all preprocessors in Karma (other than CoffeeScript and some other defaults)
-         * require an additional library to be installed (via NPM).
-         *
-         * Be aware that preprocessors may be transforming the files and file types that are available at run time. For instance,
-         * if you are using the "coverage" preprocessor on your source files, if you then attempt to interactively debug
-         * your tests, you'll discover that your expected source code is completely changed from what you expected.  Because
-         * of that, you'll want to engineer this so that your automated builds use the coverage entry in the "reporters" list,
-         * but your interactive debugging does not.
-         *
-         */
-        preprocessors?: { [name: string]: string | string[] };
-        /**
-         * @default 'http:'
-         * Possible Values:
-         * <ul>
-         *   <li>http:</li>
-         *   <li>https:</li>
-         * </ul>
-         * @description Protocol used for running the Karma webserver.
-         * Determines the use of the Node http or https class.
-         * Note: Using <code>'https:'</code> requires you to specify <code>httpsServerOptions</code>.
-         */
-        protocol?: string;
-        /**
-         * @default {}
-         * @description A map of path-proxy pairs.
-         */
-        proxies?: { [path: string]: string };
-        /**
-         * @default true
-         * @description Whether or not Karma or any browsers should raise an error when an inavlid SSL certificate is found.
-         */
-        proxyValidateSSL?: boolean;
-        /**
-         * @default 0
-         * @description Karma will report all the tests that are slower than given time limit (in ms).
-         * This is disabled by default (since the default value is 0).
-         */
-        reportSlowerThan?: number;
-        /**
-         * @default ['progress']
-         * Possible Values:
-         * <ul>
-         *   <li>dots</li>
-         *   <li>progress</li>
-         * </ul>
-         * @description A list of reporters to use.
-         * Additional reporters, such as growl, junit, teamcity or coverage can be loaded through plugins.
-         * Note: Just about all additional reporters in Karma (other than progress) require an additional library to be installed (via NPM).
-         */
-        reporters?: string[];
-        /**
-         * @default false
-         * @description Continuous Integration mode.
-         * If true, Karma will start and capture all configured browsers, run tests and then exit with an exit code of 0 or 1 depending
-         * on whether all tests passed or any tests failed.
-         */
-        singleRun?: boolean;
-        /**
-         * @default ['polling', 'websocket']
-         * @description An array of allowed transport methods between the browser and testing server. This configuration setting
-         * is handed off to [socket.io](http://socket.io/) (which manages the communication
-         * between browsers and the testing server).
-         */
-        transports?: string[];
-        /**
-         * @default '/'
-         * @description The base url, where Karma runs.
-         * All of Karma's urls get prefixed with the urlRoot. This is helpful when using proxies, as
-         * sometimes you might want to proxy a url that is already taken by Karma.
-         */
-        urlRoot?: string;
-    }
-
-    interface ClientOptions {
-        /**
-         * @default undefined
-         * @description When karma run is passed additional arguments on the command-line, they
-         * are passed through to the test adapter as karma.config.args (an array of strings).
-         * The client.args option allows you to set this value for actions other than run.
-         * How this value is used is up to your test adapter - you should check your adapter's
-         * documentation to see how (and if) it uses this value.
-         */
-        args?: string[];
-        /**
-         * @default true
-         * @description Run the tests inside an iFrame or a new window
-         * If true, Karma runs the tests inside an iFrame. If false, Karma runs the tests in a new window. Some tests may not run in an
-         * iFrame and may need a new window to run.
-         */
-        useIframe?: boolean;
-        /**
-         * @default true
-         * @description Capture all console output and pipe it to the terminal.
-         */
-        captureConsole?: boolean;
-        /**
-         * @default false
-         * @description Run the tests on the same window as the client, without using iframe or a new window
-         */
-        runInParent?: boolean;
-        /**
-         * @default true
-         * @description Clear the context window
-         * If true, Karma clears the context window upon the completion of running the tests.
-         * If false, Karma does not clear the context window upon the completion of running the tests.
-         * Setting this to false is useful when embedding a Jasmine Spec Runner Template.
-         */
-        clearContext?: boolean;
-    }
-
-    interface FilePattern {
-        /**
-         * The pattern to use for matching. This property is mandatory.
-         */
-        pattern: string;
-        /**
-         * @default true
-         * @description If <code>autoWatch</code> is true all files that have set watched to true will be watched
-         * for changes.
-         */
-        watched?: boolean;
-        /**
-         * @default true
-         * @description Should the files be included in the browser using <script> tag? Use false if you want to
-         * load them manually, eg. using Require.js.
-         */
-        included?: boolean;
-        /**
-         * @default true
-         * @description Should the files be served by Karma's webserver?
-         */
-        served?: boolean;
-        /**
-         * @default false
-         * @description Should the files be served from disk on each request by Karma's webserver?
-         */
-        nocache?: boolean;
-    }
-
-    interface CustomLauncher {
-        base: string;
-        browserName?: string;
-        flags?: string[];
-        platform?: string;
-    }
-
-    namespace config {
-        function parseConfig(configFilePath: string, cliOptions: ConfigOptions): Config;
+        // TODO: Can this return value ever be typified?
+        launch(names: string[], protocol: string, hostname: string, port: number, urlRoot: string): any[];
+        kill(id: string, callback: () => void): boolean;
+        restart(id: string): boolean;
+        killAll(callback: () => void): void;
+        areAllCaptured(): boolean;
+        markCaptured(id: string): void;
     }
 }
 
-export = karma;
+/** @deprecated */
+export interface DeprecatedServer {
+    /** @deprecated */
+    start(options?: any, callback?: ServerCallback): void;
+}
+
+export interface Runner {
+    run(options?: ConfigOptions | ConfigFile, callback?: ServerCallback): void;
+}
+
+export interface Stopper {
+    /**
+     * This function will signal a running server to stop. The equivalent of karma stop.
+     */
+    stop(options?: ConfigOptions, callback?: ServerCallback): void;
+}
+
+export interface TestResults {
+    disconnected: boolean;
+    error: boolean;
+    exitCode: number;
+    failed: number;
+    success: number;
+}
+
+export class Server extends NodeJS.EventEmitter {
+    constructor(options?: ConfigOptions | ConfigFile, callback?: ServerCallback);
+    /**
+     * Start the server
+     */
+    start(): void;
+    /**
+     * Get properties from the injector
+     * @param token
+     */
+    get(token: string): any;
+    /**
+     * Force a refresh of the file list
+     */
+    refreshFiles(): Promise<any>;
+
+    on(event: string, listener: (...args: any[]) => void): this;
+
+    /**
+     * Listen to the 'run_complete' event.
+     */
+    on(event: 'run_complete', listener: (browsers: any, results: TestResults) => void): this;
+
+    /**
+     * Backward-compatibility with karma-intellij bundled with WebStorm.
+     * Deprecated since version 0.13, to be removed in 0.14
+     */
+    // static start(): void;
+}
+
+export type ServerCallback = (exitCode: number) => void;
+
+export interface Config {
+    set: (config: ConfigOptions) => void;
+    LOG_DISABLE: string;
+    LOG_ERROR: string;
+    LOG_WARN: string;
+    LOG_INFO: string;
+    LOG_DEBUG: string;
+}
+
+export interface ConfigFile {
+    configFile: string;
+}
+
+export interface ConfigOptions {
+    /**
+     * @description Enable or disable watching files and executing the tests whenever one of these files changes.
+     * @default true
+     */
+    autoWatch?: boolean;
+    /**
+     * @description When Karma is watching the files for changes, it tries to batch multiple changes into a single run
+     * so that the test runner doesn't try to start and restart running tests more than it should.
+     * The configuration setting tells Karma how long to wait (in milliseconds) after any changes have occurred
+     * before starting the test process again.
+     * @default 250
+     */
+    autoWatchBatchDelay?: number;
+    /**
+     * @default ''
+     * @description The root path location that will be used to resolve all relative paths defined in <code>files</code> and <code>exclude</code>.
+     * If the basePath configuration is a relative path then it will be resolved to
+     * the <code>__dirname</code> of the configuration file.
+     */
+    basePath?: string;
+    /**
+     * @default 2000
+     * @description How long does Karma wait for a browser to reconnect (in ms).
+     * <p>
+     * With a flaky connection it is pretty common that the browser disconnects,
+     * but the actual test execution is still running without any problems. Karma does not treat a disconnection
+     * as immediate failure and will wait <code>browserDisconnectTimeout</code> (ms).
+     * If the browser reconnects during that time, everything is fine.
+     * </p>
+     */
+    browserDisconnectTimeout?: number;
+    /**
+     * @default 0
+     * @description The number of disconnections tolerated.
+     * <p>
+     * The <code>disconnectTolerance</code> value represents the maximum number of tries a browser will attempt
+     * in the case of a disconnection. Usually any disconnection is considered a failure,
+     * but this option allows you to define a tolerance level when there is a flaky network link between
+     * the Karma server and the browsers.
+     * </p>
+     */
+    browserDisconnectTolerance?: number;
+    /**
+     * @default 10000
+     * @description How long will Karma wait for a message from a browser before disconnecting from it (in ms).
+     * <p>
+     * If, during test execution, Karma does not receive any message from a browser within
+     * <code>browserNoActivityTimeout</code> (ms), it will disconnect from the browser
+     * </p>
+     */
+    browserNoActivityTimeout?: number;
+    /**
+     * @default []
+     * Possible Values:
+     * <ul>
+     *     <li>Chrome (launcher comes installed with Karma)</li>
+     *     <li>ChromeCanary (launcher comes installed with Karma)</li>
+     *     <li>PhantomJS (launcher comes installed with Karma)</li>
+     *     <li>Firefox (launcher requires karma-firefox-launcher plugin)</li>
+     *     <li>Opera (launcher requires karma-opera-launcher plugin)</li>
+     *     <li>Internet Explorer (launcher requires karma-ie-launcher plugin)</li>
+     *     <li>Safari (launcher requires karma-safari-launcher plugin)</li>
+     * </ul>
+     * @description A list of browsers to launch and capture. When Karma starts up, it will also start up each browser
+     * which is placed within this setting. Once Karma is shut down, it will shut down these browsers as well.
+     * You can capture any browser manually by opening the browser and visiting the URL where
+     * the Karma web server is listening (by default it is <code>http://localhost:9876/</code>).
+     */
+    browsers?: string[];
+    /**
+     * @default 60000
+     * @description Timeout for capturing a browser (in ms).
+     * <p>
+     * The <code>captureTimeout</code> value represents the maximum boot-up time allowed for a
+     * browser to start and connect to Karma. If any browser does not get captured within the timeout, Karma
+     * will kill it and try to launch it again and, after three attempts to capture it, Karma will give up.
+     * </p>
+     */
+    captureTimeout?: number;
+    client?: ClientOptions;
+    /**
+     * @default true
+     * @description Enable or disable colors in the output (reporters and logs).
+     */
+    colors?: boolean;
+    /**
+     * @default 'Infinity'
+     * @description How many browsers Karma launches in parallel.
+     * Especially on services like SauceLabs and Browserstack, it makes sense only to launch a limited
+     * amount of browsers at once, and only start more when those have finished. Using this configuration,
+     * you can specify how many browsers should be running at once at any given point in time.
+     */
+    concurrency?: number;
+    customLaunchers?: { [key: string]: CustomLauncher };
+    /**
+     * @default []
+     * @description List of files/patterns to exclude from loaded files.
+     */
+    exclude?: string[];
+    /**
+     * @default []
+     * @description List of files/patterns to load in the browser.
+     */
+    files?: Array<FilePattern | string>;
+    /**
+     * @default []
+     * @description List of test frameworks you want to use. Typically, you will set this to ['jasmine'], ['mocha'] or ['qunit']...
+     * Please note just about all frameworks in Karma require an additional plugin/framework library to be installed (via NPM).
+     */
+    frameworks?: string[];
+    /**
+     * @default 'localhost'
+     * @description Hostname to be used when capturing browsers.
+     */
+    hostname?: string;
+    /**
+     * @default {}
+     * @description Options object to be used by Node's https class.
+     * Object description can be found in the
+     * [NodeJS.org API docs](https://nodejs.org/api/tls.html#tls_tls_createserver_options_secureconnectionlistener)
+     */
+    httpsServerOptions?: https.ServerOptions;
+    /**
+     * @default config.LOG_INFO
+     * Possible values:
+     * <ul>
+     *   <li>config.LOG_DISABLE</li>
+     *   <li>config.LOG_ERROR</li>
+     *   <li>config.LOG_WARN</li>
+     *   <li>config.LOG_INFO</li>
+     *   <li>config.LOG_DEBUG</li>
+     * </ul>
+     * @description Level of logging.
+     */
+    logLevel?: string;
+    /**
+     * @default [{type: 'console'}]
+     * @description A list of log appenders to be used. See the documentation for [log4js] for more information.
+     */
+    loggers?: { [name: string]: Appender } | Appender[];
+    /**
+     * @default []
+     * @description List of names of additional middleware you want the
+     * Karma server to use. Middleware will be used in the order listed.
+     * You must have installed the middleware via a plugin/framework
+     * (either inline or via NPM). Additional information can be found in
+     * [plugins](http://karma-runner.github.io/2.0/config/plugins.html).
+     * The plugin must provide an express/connect middleware function
+     * (details about this can be found in the
+     * [Express](http://expressjs.com/guide/using-middleware.html) docs).
+     */
+    middleware?: string[];
+    /**
+     * @default {}
+     * @description Redefine default mapping from file extensions to MIME-type.
+     * Set property name to required MIME, provide Array of extensions (without dots) as it's value.
+     */
+    mime?: {[type: string]: string[]};
+    /**
+     * @default ['karma-*']
+     * @description List of plugins to load. A plugin can be a string (in which case it will be required
+     * by Karma) or an inlined plugin - Object.
+     * By default, Karma loads all sibling NPM modules which have a name starting with karma-*.
+     * Note: Just about all plugins in Karma require an additional library to be installed (via NPM).
+     */
+    plugins?: any[];
+    /**
+     * @default 9876
+     * @description The port where the web server will be listening.
+     */
+    port?: number;
+    /**
+     * @default {'**\/*.coffee': 'coffee'}
+     * @description A map of preprocessors to use.
+     *
+     * Preprocessors can be loaded through [plugins].
+     *
+     * Note: Just about all preprocessors in Karma (other than CoffeeScript and some other defaults)
+     * require an additional library to be installed (via NPM).
+     *
+     * Be aware that preprocessors may be transforming the files and file types that are available at run time. For instance,
+     * if you are using the "coverage" preprocessor on your source files, if you then attempt to interactively debug
+     * your tests, you'll discover that your expected source code is completely changed from what you expected.  Because
+     * of that, you'll want to engineer this so that your automated builds use the coverage entry in the "reporters" list,
+     * but your interactive debugging does not.
+     *
+     */
+    preprocessors?: { [name: string]: string | string[] };
+    /**
+     * @default 'http:'
+     * Possible Values:
+     * <ul>
+     *   <li>http:</li>
+     *   <li>https:</li>
+     * </ul>
+     * @description Protocol used for running the Karma webserver.
+     * Determines the use of the Node http or https class.
+     * Note: Using <code>'https:'</code> requires you to specify <code>httpsServerOptions</code>.
+     */
+    protocol?: string;
+    /**
+     * @default {}
+     * @description A map of path-proxy pairs.
+     */
+    proxies?: { [path: string]: string };
+    /**
+     * @default true
+     * @description Whether or not Karma or any browsers should raise an error when an inavlid SSL certificate is found.
+     */
+    proxyValidateSSL?: boolean;
+    /**
+     * @default 0
+     * @description Karma will report all the tests that are slower than given time limit (in ms).
+     * This is disabled by default (since the default value is 0).
+     */
+    reportSlowerThan?: number;
+    /**
+     * @default ['progress']
+     * Possible Values:
+     * <ul>
+     *   <li>dots</li>
+     *   <li>progress</li>
+     * </ul>
+     * @description A list of reporters to use.
+     * Additional reporters, such as growl, junit, teamcity or coverage can be loaded through plugins.
+     * Note: Just about all additional reporters in Karma (other than progress) require an additional library to be installed (via NPM).
+     */
+    reporters?: string[];
+    /**
+     * @default false
+     * @description Continuous Integration mode.
+     * If true, Karma will start and capture all configured browsers, run tests and then exit with an exit code of 0 or 1 depending
+     * on whether all tests passed or any tests failed.
+     */
+    singleRun?: boolean;
+    /**
+     * @default ['polling', 'websocket']
+     * @description An array of allowed transport methods between the browser and testing server. This configuration setting
+     * is handed off to [socket.io](http://socket.io/) (which manages the communication
+     * between browsers and the testing server).
+     */
+    transports?: string[];
+    /**
+     * @default '/'
+     * @description The base url, where Karma runs.
+     * All of Karma's urls get prefixed with the urlRoot. This is helpful when using proxies, as
+     * sometimes you might want to proxy a url that is already taken by Karma.
+     */
+    urlRoot?: string;
+}
+
+export interface ClientOptions {
+    /**
+     * @default undefined
+     * @description When karma run is passed additional arguments on the command-line, they
+     * are passed through to the test adapter as karma.config.args (an array of strings).
+     * The client.args option allows you to set this value for actions other than run.
+     * How this value is used is up to your test adapter - you should check your adapter's
+     * documentation to see how (and if) it uses this value.
+     */
+    args?: string[];
+    /**
+     * @default true
+     * @description Run the tests inside an iFrame or a new window
+     * If true, Karma runs the tests inside an iFrame. If false, Karma runs the tests in a new window. Some tests may not run in an
+     * iFrame and may need a new window to run.
+     */
+    useIframe?: boolean;
+    /**
+     * @default true
+     * @description Capture all console output and pipe it to the terminal.
+     */
+    captureConsole?: boolean;
+    /**
+     * @default false
+     * @description Run the tests on the same window as the client, without using iframe or a new window
+     */
+    runInParent?: boolean;
+    /**
+     * @default true
+     * @description Clear the context window
+     * If true, Karma clears the context window upon the completion of running the tests.
+     * If false, Karma does not clear the context window upon the completion of running the tests.
+     * Setting this to false is useful when embedding a Jasmine Spec Runner Template.
+     */
+    clearContext?: boolean;
+}
+
+export interface FilePattern {
+    /**
+     * The pattern to use for matching. This property is mandatory.
+     */
+    pattern: string;
+    /**
+     * @default true
+     * @description If <code>autoWatch</code> is true all files that have set watched to true will be watched
+     * for changes.
+     */
+    watched?: boolean;
+    /**
+     * @default true
+     * @description Should the files be included in the browser using <script> tag? Use false if you want to
+     * load them manually, eg. using Require.js.
+     */
+    included?: boolean;
+    /**
+     * @default true
+     * @description Should the files be served by Karma's webserver?
+     */
+    served?: boolean;
+    /**
+     * @default false
+     * @description Should the files be served from disk on each request by Karma's webserver?
+     */
+    nocache?: boolean;
+}
+
+export interface CustomLauncher {
+    base: string;
+    browserName?: string;
+    flags?: string[];
+    platform?: string;
+}
+
+export namespace config {
+    function parseConfig(configFilePath: string, cliOptions: ConfigOptions): Config;
+}

--- a/types/karma/index.d.ts
+++ b/types/karma/index.d.ts
@@ -14,24 +14,24 @@ import https = require('https');
 import { Appender } from 'log4js';
 
 declare namespace karma {
-    interface Karma {
-        /**
-         * `start` method is deprecated since 0.13. It will be removed in 0.14.
-         * Please use
-         * <code>
-         *     server = new Server(config, [done])
-         *     server.start()
-         * </code>
-         * instead.
-         */
-        server: DeprecatedServer;
-        Server: Server;
-        runner: Runner;
-        stopper: Stopper;
-        launcher: Launcher;
-        VERSION: string;
-        constants: Constants;
-    }
+    /**
+     * `start` method is deprecated since 0.13. It will be removed in 0.14.
+     * Please use
+     * <code>
+     *     server = new Server(config, [done])
+     *     server.start()
+     * </code>
+     * instead.
+     *
+     * @deprecated
+     */
+    const server: DeprecatedServer;
+
+    const runner: Runner;
+    const stopper: Stopper;
+
+    const VERSION: string;
+    const constants: Constants;
 
     interface Constants {
         VERSION: string;
@@ -57,24 +57,25 @@ declare namespace karma {
         EXIT_CODE: string;
     }
 
-    interface LauncherStatic {
-        generateId(): string;
-        // TODO: injector should be of type `di.Injector`
-        new (emitter: NodeJS.EventEmitter, injector: any): Launcher;
+    namespace launcher {
+        class Launcher {
+            static generateId(): string;
+
+            constructor(emitter: NodeJS.EventEmitter, injector: any);
+
+            // TODO: Can this return value ever be typified?
+            launch(names: string[], protocol: string, hostname: string, port: number, urlRoot: string): any[];
+            kill(id: string, callback: () => void): boolean;
+            restart(id: string): boolean;
+            killAll(callback: () => void): void;
+            areAllCaptured(): boolean;
+            markCaptured(id: string): void;
+        }
     }
 
-    interface Launcher {
-        Launcher: LauncherStatic;
-        // TODO: Can this return value ever be typified?
-        launch(names: string[], protocol: string, hostname: string, port: number, urlRoot: string): any[];
-        kill(id: string, callback: () => void): boolean;
-        restart(id: string): boolean;
-        killAll(callback: () => void): void;
-        areAllCaptured(): boolean;
-        markCaptured(id: string): void;
-    }
-
+    /** @deprecated */
     interface DeprecatedServer {
+        /** @deprecated */
         start(options?: any, callback?: ServerCallback): void;
     }
 
@@ -97,10 +98,8 @@ declare namespace karma {
         success: number;
     }
 
-    interface Server extends NodeJS.EventEmitter {
-        // TODO: Figure out how to convert Server to class and remove suppression
-        // tslint:disable-next-line:no-misused-new
-        new (options?: ConfigOptions | ConfigFile, callback?: ServerCallback): Server;
+    class Server extends NodeJS.EventEmitter {
+        constructor(options?: ConfigOptions | ConfigFile, callback?: ServerCallback);
         /**
          * Start the server
          */
@@ -468,8 +467,10 @@ declare namespace karma {
         flags?: string[];
         platform?: string;
     }
-}
 
-declare var karma: karma.Karma;
+    namespace config {
+        function parseConfig(configFilePath: string, cliOptions: ConfigOptions): Config;
+    }
+}
 
 export = karma;

--- a/types/karma/karma-tests.ts
+++ b/types/karma/karma-tests.ts
@@ -1,16 +1,6 @@
-import gulp = require('gulp');
 import karma = require('karma');
 
-function runKarma(singleRun: boolean): void {
-    // MEMO: `start` method is deprecated since 0.13. It will be removed in 0.14.
-    karma.server.start({
-        configFile: __dirname + '/karma.conf.js',
-        singleRun
-    });
-}
-
-gulp.task('test:unit:karma', gulp.parallel('build:test:unit', () => runKarma(true)));
-
+// karma.server is deprecated and will eventually be removed
 karma.server.start({port: 9876}, (exitCode: number) => {
   console.log('Karma has exited with ' + exitCode);
   process.exit(exitCode);
@@ -54,7 +44,8 @@ karma.runner.run({port: 9876}, (exitCode: number) => {
     process.exit(exitCode);
 });
 
-const captured: boolean = karma.launcher.areAllCaptured();
+const launcher: karma.launcher.Launcher = null;
+const captured: boolean = launcher.areAllCaptured();
 
 // Example of configuration file karma.conf.ts, see http://karma-runner.github.io/latest/config/configuration-file.html
 module.exports = (config: karma.Config) => {
@@ -123,3 +114,10 @@ const foo = (config: karma.Config) => {
     }
   });
 };
+
+console.log(karma.constants.DEFAULT_HOSTNAME);
+console.log(karma.VERSION);
+
+karma.config.parseConfig('karma.conf.js', {
+    singleRun: true
+});


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: the change is mostly refactoring, applicable URLs are provided where needed
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

This should be easier to review commit by commit:

1a. Eliminate `karma.Karma` interface and move its properties into the namespace as constants, convert two relevant interfaces into proper classes. This fixes last linter complaint about defining constructors in the interface as I [finally figured out the solution](
https://github.com/DefinitelyTyped/DefinitelyTyped/pull/29386#discussion_r222771313).

1b. Add missing type definition for `karma.config.parseConfig()` ([relevant docs](http://karma-runner.github.io/3.0/dev/public-api.html)).

1c. Add `Launcher` class into `launcher` namespace (the existing declaration without a wrapper was incorrect and does not exist at runtime). In fact, it does not make sense to expose it this way at all, but this is a story for another day :smile: 

2. Linter hinted that there is [no reason to export just a namespace](https://github.com/Microsoft/dtslint/blob/master/docs/export-just-namespace.md), so namespace is no more. There are no other changes besides adding `export` to all symbols, but GitHub does not produce a nice diff because of indentation change...

3a. Adjusted the `karma-coverage` type definitions to use same approach as `karma-webpack` (i.e. module augmentation). Although technically this is not augmenting module from the end-user perspective the expected behavior is to type-check plugin-specific configurations and this seems to be the best way to achieve it.

3b. Fixed incorrect type for `coverageReporter` property as it does not accept list of reporters, but rather it can have a `reporters` property ([docs](https://github.com/karma-runner/karma-coverage/blob/master/docs/configuration.md#reporters)) with a list of reporters.

---

The main risk with this change is a removal of `karma.Karma` interface. However shape of the module is rather an implementation detail and it is probably better to ask users to migrate as it is much cleaner without a wrapping namespace and `export =` syntax.