### PR TITLE
react-copy-to-clipboard: Remove 'export = CopyToClipboard'

### DIFF
--- a/types/react-copy-to-clipboard/index.d.ts
+++ b/types/react-copy-to-clipboard/index.d.ts
@@ -1,15 +1,14 @@
-// Type definitions for react-copy-to-clipboard 4.2
+// Type definitions for react-copy-to-clipboard 5.0
 // Project: https://github.com/nkbt/react-copy-to-clipboard
 // Definitions by: Meno Abels <https://github.com/mabels>
 //                 Bernabe <https://github.com/BernabeFelix>
+//                 Inje Yeo <https://github.com/inje>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
 import * as React from "react";
 
 export as namespace CopyToClipboard;
-
-export = CopyToClipboard;
 
 declare namespace CopyToClipboard {
   interface Options {


### PR DESCRIPTION
# Changelog
- Remove `line 12`
```
export = CopyToClipboard;
```
Fixes type error below:
```
Type error: Module '"/node_modules/@types/react-copy-to-clipboard/index"' has no exported member 'CopyToClipboard'.  TS2305
```
Importing `CopyToClipboard` gets imported from `node_modules/@types/react-copy-to-clipboard` instead of `node_modules/react-copy-to-clipboard` because of the `CopyToClipboard` export from the `@types/react-copy-to-clipboard`.

---------------------------------------------------------------------------------------------

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/DefinitelyTyped/DefinitelyTyped/pull/30876/files#diff-6cdb339d0cba0576cf206d6bac983f38L12>>
- [x] Increase the version number in the header if appropriate.
