### PR TITLE
[ssh2|ssh2-streams] - Include missing type for the method readFile

### DIFF
--- a/types/ssh2-streams/index.d.ts
+++ b/types/ssh2-streams/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for ssh2-streams v0.1.9
 // Project: https://github.com/mscdex/ssh2-streams
 // Definitions by: Ron Buckton <https://github.com/rbuckton>
+// Definitions by: Ron Buckton <https://github.com/lucasmotta>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />
@@ -1046,6 +1047,24 @@ export class SFTPStream extends stream.Transform {
 
     /**
      * (Client-only)
+     * Reads a file in memory and returns its contents
+     */
+    readFile(remotePath: string, options: ReadFileOptions, callback: (err: any, handle: Buffer) => void): void;
+
+    /**
+     * (Client-only)
+     * Reads a file in memory and returns its contents
+     */
+    readFile(remotePath: string, encoding: string, callback: (err: any, handle: Buffer) => void): void;
+
+    /**
+     * (Client-only)
+     * Reads a file in memory and returns its contents
+     */
+    readFile(remotePath: string, callback: (err: any, handle: Buffer) => void): void;
+
+    /**
+     * (Client-only)
      * Returns a new readable stream for `path`.
      */
     createReadStream(path: string, options?: ReadStreamOptions): stream.Readable;
@@ -1610,6 +1629,11 @@ export interface TransferOptions {
      * Called every time a part of a file was transferred
      */
     step?: (total_transferred: number, chunk: number, total: number) => void;
+}
+
+export interface ReadFileOptions {
+    encoding?: string
+    flag?: string
 }
 
 export interface ReadStreamOptions {

--- a/types/ssh2-streams/index.d.ts
+++ b/types/ssh2-streams/index.d.ts
@@ -1,7 +1,6 @@
 // Type definitions for ssh2-streams v0.1.9
 // Project: https://github.com/mscdex/ssh2-streams
 // Definitions by: Ron Buckton <https://github.com/rbuckton>
-// Definitions by: Lucas Motta <https://github.com/lucasmotta>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />
@@ -1631,11 +1630,6 @@ export interface TransferOptions {
     step?: (total_transferred: number, chunk: number, total: number) => void;
 }
 
-export interface ReadFileOptions {
-    encoding?: string
-    flag?: string
-}
-
 export interface ReadStreamOptions {
     flags?: string;
     encoding?: string;
@@ -1704,4 +1698,9 @@ export interface ParsedKey {
     publicOrig: Buffer;
     ppk?: boolean;
     privateMAC?: string;
+}
+
+export interface ReadFileOptions {
+    encoding?: string;
+    flag?: string;
 }

--- a/types/ssh2-streams/index.d.ts
+++ b/types/ssh2-streams/index.d.ts
@@ -1,7 +1,7 @@
 // Type definitions for ssh2-streams v0.1.9
 // Project: https://github.com/mscdex/ssh2-streams
 // Definitions by: Ron Buckton <https://github.com/rbuckton>
-// Definitions by: Ron Buckton <https://github.com/lucasmotta>
+// Definitions by: Lucas Motta <https://github.com/lucasmotta>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />

--- a/types/ssh2/index.d.ts
+++ b/types/ssh2/index.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: Qubo <https://github.com/tkQubo>
 //                 Ron Buckton <https://github.com/rbuckton>
 //                 Will Boyce <https://github.com/wrboyce>
+//                 Lucas Motta <https://github.com/lucasmotta>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />
@@ -21,6 +22,7 @@ import {
     Attributes,
     Stats,
     TransferOptions,
+    ReadFileOptions,
     ReadStreamOptions,
     WriteStreamOptions,
     FileEntry
@@ -1272,6 +1274,24 @@ export interface SFTPWrapper extends events.EventEmitter {
      * Uploads a file from `localPath` to `remotePath` using parallel reads for faster throughput.
      */
     fastPut(localPath: string, remotePath: string, callback: (err: any) => void): void;
+
+    /**
+     * (Client-only)
+     * Reads a file in memory and returns its contents
+     */
+    readFile(remotePath: string, options: ReadFileOptions, callback: (err: any, handle: Buffer) => void): void;
+
+    /**
+     * (Client-only)
+     * Reads a file in memory and returns its contents
+     */
+    readFile(remotePath: string, encoding: string, callback: (err: any, handle: Buffer) => void): void;
+
+    /**
+     * (Client-only)
+     * Reads a file in memory and returns its contents
+     */
+    readFile(remotePath: string, callback: (err: any, handle: Buffer) => void): void;
 
     /**
      * (Client-only)


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/mscdex/ssh2-streams/blob/master/lib/sftp.js#L1188
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
--

The `readFile` method was always implemented, but it's missing documentation from the original ssh2-streams lib, which I will send another PR to include.
