### PR TITLE
bull: Fix error type in backoffStrategies interface

### DIFF
--- a/types/bull/index.d.ts
+++ b/types/bull/index.d.ts
@@ -92,7 +92,7 @@ declare namespace Bull {
      * Define a custom backoff strategy
      */
     backoffStrategies?: {
-      [key: string]: (attemptsMade: number, err: typeof Error) => number;
+      [key: string]: (attemptsMade: number, err: Error) => number;
     };
 
     /**


### PR DESCRIPTION
change `typeof Error` (resolves to `ErrorConstructor`) to just `Error`.

This allows accessing actual error instance properties (message, etc.)

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
https://github.com/OptimalBits/bull/blob/master/PATTERNS.md#custom-backoff-strategy
