### PR TITLE
[web3] Make the parameters in the provider class' send function optional

### DIFF
--- a/types/web3/providers.d.ts
+++ b/types/web3/providers.d.ts
@@ -12,11 +12,13 @@ interface JsonRPCResponse {
     error?: string;
 }
 
+interface Callback<ResultType> {
+  (error: Error): void;
+  (error: null, val: ResultType): void;
+}
+
 export class Provider {
-    send(
-        payload: JsonRPCRequest,
-        callback: (e: Error, val: JsonRPCResponse) => void
-    ): any;
+  send(payload: JsonRPCRequest, callback: Callback<JsonRPCResponse>): any;
 }
 
 export class WebsocketProvider extends Provider {

--- a/types/web3/web3-tests.ts
+++ b/types/web3/web3-tests.ts
@@ -2,6 +2,7 @@ import Web3 = require("web3");
 import BigNumber = require("bn.js");
 import { TransactionReceipt } from "web3/types";
 import PromiEvent from "web3/promiEvent";
+import { Provider, JsonRPCResponse } from "web3/providers";
 
 const contractAddress = "0xde0B295669a9FD93d5F28D9Ec85E40f4cb697BAe";
 
@@ -10,6 +11,25 @@ const contractAddress = "0xde0B295669a9FD93d5F28D9Ec85E40f4cb697BAe";
 // --------------------------------------------------------------------------
 const web3 = new Web3();
 const myProvider = new web3.providers.HttpProvider("http://localhost:5454");
+
+const createFailingHttpProvider = (): Provider => ({
+  send(payload, callback) {
+    callback(new Error("Illegal!"));
+  }
+});
+
+const createSuccesfulHttpProvider = (): Provider => ({
+  send(payload, callback) {
+    const response = {};
+    callback(null, response as JsonRPCResponse);
+  }
+});
+
+const fakeProvider: Provider = createFailingHttpProvider();
+const otherFakeProvider: Provider = createSuccesfulHttpProvider();
+
+web3.setProvider(fakeProvider);
+web3.setProvider(otherFakeProvider);
 web3.setProvider(myProvider);
 web3.eth.setProvider(myProvider);
 


### PR DESCRIPTION
Hi all,

It looks like in the provider class the `send` function has two required parameters. The `err` parameter should definitely not be required and the way the following code is written, neither should `result`.

```javascript
this.provider[this.provider.sendAsync ? 'sendAsync' : 'send'](payload, function (err, result) {
        if(result && result.id && payload.id !== result.id) return callback(new Error('Wrong response id "'+ result.id +'" (expected: "'+ payload.id +'") in '+ JSON.stringify(payload)));

        if (err) {
            return callback(err);
        }

        if (result && result.error) {
            return callback(errors.ErrorResponse(result));
        }

        if (!Jsonrpc.isValidResponse(result)) {
            return callback(errors.InvalidResponse(result));
        }

        callback(null, result.result);
    });
```
See the context [here](https://github.com/ethereum/web3.js/blob/1.0/packages/web3-core-requestmanager/src/index.js#L132-L148
).

For that reason, I have proposed making both parameters optional.
