### PR TITLE
react: Add types for components that don't include a default defaultProps

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -53,7 +53,8 @@ declare namespace React {
         {
             [K in keyof JSX.IntrinsicElements]: P extends JSX.IntrinsicElements[K] ? K : never
         }[keyof JSX.IntrinsicElements] |
-        ComponentType<P>;
+        BareComponentType<P>;
+    type BareComponentType<P = {}> = BareComponentClass<P> | BareFunctionComponent<P>;
     type ComponentType<P = {}> = ComponentClass<P> | FunctionComponent<P>;
 
     type Key = string | number;
@@ -457,24 +458,33 @@ declare namespace React {
 
     type FC<P = {}> = FunctionComponent<P>;
 
-    interface FunctionComponent<P = {}> {
+    interface BareFunctionComponent<P = {}> {
         (props: P & { children?: ReactNode }, context?: any): ReactElement<any> | null;
+    }
+
+    interface FunctionComponent<P = {}> extends BareFunctionComponent<P> {
         propTypes?: ValidationMap<P>;
         contextTypes?: ValidationMap<any>;
         defaultProps?: Partial<P>;
         displayName?: string;
     }
 
-    interface RefForwardingComponent<T, P = {}> {
+    interface BareRefForwardingComponent<T, P = {}> {
         (props: P & { children?: ReactNode }, ref: Ref<T> | null): ReactElement<any> | null;
+    }
+
+    interface RefForwardingComponent<T, P = {}> extends BareRefForwardingComponent<T, P> {
         propTypes?: ValidationMap<P>;
         contextTypes?: ValidationMap<any>;
         defaultProps?: Partial<P>;
         displayName?: string;
     }
 
-    interface ComponentClass<P = {}, S = ComponentState> extends StaticLifecycle<P, S> {
+    interface BareComponentClass<P = {}, S = ComponentState> extends StaticLifecycle<P, S> {
         new (props: P, context?: any): Component<P, S>;
+    }
+
+    interface ComponentClass<P = {}, S = ComponentState> extends BareComponentClass<P, S> {
         propTypes?: ValidationMap<P>;
         contextType?: Context<any>;
         contextTypes?: ValidationMap<any>;
@@ -717,13 +727,13 @@ declare namespace React {
      * or ComponentPropsWithoutRef when refs are not supported.
      */
     type ComponentProps<T extends ReactType> =
-        T extends ComponentType<infer P>
+        T extends BareComponentType<infer P>
             ? P
             : T extends keyof JSX.IntrinsicElements
                 ? JSX.IntrinsicElements[T]
                 : {};
     type ComponentPropsWithRef<T extends ReactType> =
-        T extends ComponentClass<infer P>
+        T extends BareComponentClass<infer P>
             ? PropsWithoutRef<P> & RefAttributes<InstanceType<T>>
             : PropsWithRef<ComponentProps<T>>;
     type ComponentPropsWithoutRef<T extends ReactType> =

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -460,28 +460,29 @@ declare namespace React {
 
     interface BareFunctionComponent<P = {}> {
         (props: P & { children?: ReactNode }, context?: any): ReactElement<any> | null;
+        displayName?: string;
     }
 
     interface FunctionComponent<P = {}> extends BareFunctionComponent<P> {
         propTypes?: ValidationMap<P>;
         contextTypes?: ValidationMap<any>;
         defaultProps?: Partial<P>;
-        displayName?: string;
     }
 
     interface BareRefForwardingComponent<T, P = {}> {
         (props: P & { children?: ReactNode }, ref: Ref<T> | null): ReactElement<any> | null;
+        displayName?: string;
     }
 
     interface RefForwardingComponent<T, P = {}> extends BareRefForwardingComponent<T, P> {
         propTypes?: ValidationMap<P>;
         contextTypes?: ValidationMap<any>;
         defaultProps?: Partial<P>;
-        displayName?: string;
     }
 
     interface BareComponentClass<P = {}, S = ComponentState> extends StaticLifecycle<P, S> {
         new (props: P, context?: any): Component<P, S>;
+        displayName?: string;
     }
 
     interface ComponentClass<P = {}, S = ComponentState> extends BareComponentClass<P, S> {
@@ -490,7 +491,6 @@ declare namespace React {
         contextTypes?: ValidationMap<any>;
         childContextTypes?: ValidationMap<any>;
         defaultProps?: Partial<P>;
-        displayName?: string;
     }
 
     interface ClassicComponentClass<P = {}> extends ComponentClass<P> {

--- a/types/styled-components/index.d.ts
+++ b/types/styled-components/index.d.ts
@@ -34,7 +34,7 @@ export type StyledProps<P> = ThemedStyledProps<P, AnyIfEmpty<DefaultTheme>>;
 
 export type StyledComponentProps<
     // The Component from whose props are derived
-    C extends keyof JSX.IntrinsicElements | React.ComponentType<any>,
+    C extends React.ReactType,
     // The Theme from the current context
     T extends object,
     // The other props added by the template
@@ -48,7 +48,7 @@ export type StyledComponentProps<
 >;
 
 type StyledComponentPropsWithAs<
-    C extends keyof JSX.IntrinsicElements | React.ComponentType<any>,
+    C extends React.ReactType,
     T extends object,
     O extends object,
     A extends keyof any
@@ -115,7 +115,7 @@ export type AnyStyledComponent =
     | StyledComponent<any, any, any>;
 
 export type StyledComponent<
-    C extends keyof JSX.IntrinsicElements | React.ComponentType<any>,
+    C extends React.ReactType,
     T extends object,
     O extends object = {},
     A extends keyof any = never
@@ -124,7 +124,7 @@ export type StyledComponent<
     string & StyledComponentBase<C, T, O, A>;
 
 export interface StyledComponentBase<
-    C extends keyof JSX.IntrinsicElements | React.ComponentType<any>,
+    C extends React.ReactType,
     T extends object,
     O extends object = {},
     A extends keyof any = never
@@ -137,7 +137,7 @@ export interface StyledComponentBase<
     // (
     //     props: StyledComponentProps<C, T, O, A> & { as?: never }
     //   ): React.ReactElement<StyledComponentProps<C, T, O, A>>
-    // <AsC extends keyof JSX.IntrinsicElements | React.ComponentType<any> = C>(
+    // <AsC extends React.ReactType = C>(
     //   props: StyledComponentPropsWithAs<AsC, T, O, A>
     // ): React.ReactElement<StyledComponentPropsWithAs<AsC, T, O, A>>
 
@@ -149,7 +149,7 @@ export interface StyledComponentBase<
              *
              * String types need to be cast to themselves to become literal types (as={'a' as 'a'}).
              */
-            as?: keyof JSX.IntrinsicElements | React.ComponentType<any>;
+            as?: React.ReactType;
         }
     ): React.ReactElement<StyledComponentProps<C, T, O, A>>;
     withComponent<WithC extends AnyStyledComponent>(
@@ -161,14 +161,16 @@ export interface StyledComponentBase<
         A | StyledComponentInnerAttrs<WithC>
     >;
     withComponent<
-        WithC extends keyof JSX.IntrinsicElements | React.ComponentType<any>
+        WithC extends React.ReactType
     >(
         component: WithC
     ): StyledComponent<WithC, T, O, A>;
+
+    readonly defaultProps: C extends { defaultProps: infer DP } ? Readonly<DP> : undefined
 }
 
 export interface ThemedStyledFunctionBase<
-    C extends keyof JSX.IntrinsicElements | React.ComponentType<any>,
+    C extends React.ReactType,
     T extends object,
     O extends object = {},
     A extends keyof any = never
@@ -208,7 +210,7 @@ export interface ThemedStyledFunctionBase<
 }
 
 export interface ThemedStyledFunction<
-    C extends keyof JSX.IntrinsicElements | React.ComponentType<any>,
+    C extends React.ReactType,
     T extends object,
     O extends object = {},
     A extends keyof any = never
@@ -238,7 +240,7 @@ export interface ThemedStyledFunction<
 }
 
 export type StyledFunction<
-    C extends keyof JSX.IntrinsicElements | React.ComponentType<any>
+    C extends React.ReactType
 > = ThemedStyledFunction<C, any>;
 
 type ThemedStyledComponentFactories<T extends object> = {
@@ -253,7 +255,7 @@ type StyledComponentInnerComponent<
     ? I
     : C;
 type StyledComponentPropsWithRef<
-    C extends keyof JSX.IntrinsicElements | React.ComponentType<any>
+    C extends React.ReactType
 > = C extends AnyStyledComponent
     ? React.ComponentPropsWithRef<StyledComponentInnerComponent<C>>
     : React.ComponentPropsWithRef<C>;
@@ -274,7 +276,7 @@ export interface ThemedBaseStyledInterface<T extends object>
         StyledComponentInnerOtherProps<C>,
         StyledComponentInnerAttrs<C>
     >;
-    <C extends keyof JSX.IntrinsicElements | React.ComponentType<any>>(
+    <C extends React.ReactType>(
         // unfortunately using a conditional type to validate that it can receive a `theme?: Theme`
         // causes tests to fail in TS 3.1
         component: C

--- a/types/styled-components/test/index.tsx
+++ b/types/styled-components/test/index.tsx
@@ -101,13 +101,13 @@ const fadeIn = keyframes`
 `;
 
 const showAnimation = css`
-  opacity: 1;
-  transform: scale(1) translateY(0);
+    opacity: 1;
+    transform: scale(1) translateY(0);
 `;
 
 const hideAnimation = css`
-  opacity: 0;
-  transform: scale(0.95, 0.8) translateY(20px);
+    opacity: 0;
+    transform: scale(0.95, 0.8) translateY(20px);
 `;
 
 const entryAnimation = keyframes`
@@ -867,3 +867,26 @@ function cssProp() {
         </>
     );
 }
+
+// This is a TS 3.2 test written using syntax that would work on TS 2.8
+
+// The TS 3.2 equivalent would be:
+// function HasDefaultProps(props: { x: boolean }) { return <div/>; }
+// HasDefaultProps.defaultProps = { x: true };
+// <HasDefaultProps/>;
+// const StyledHasDefaultProps = styled(HasDefaultProps)``;
+// <StyledHasDefaultProps/>;
+
+declare const HasDefaultProps: {
+    (props: { x: boolean }): JSX.Element;
+    defaultProps: { x: boolean };
+};
+const requiredProps: JSX.LibraryManagedAttributes<
+    typeof HasDefaultProps,
+    React.ComponentProps<typeof HasDefaultProps>
+> = {};
+const StyledHasDefaultProps = styled(HasDefaultProps)``;
+const styledRequiredProps: JSX.LibraryManagedAttributes<
+    typeof StyledHasDefaultProps,
+    React.ComponentProps<typeof StyledHasDefaultProps>
+> = {};


### PR DESCRIPTION
Try using them in styled-components to forward the library managed attributes and check that this works.

There might be a better way to do this but I don't see how to do it without making it a breaking change. This is arguably already breaking but it's not like the `.defaultProps` is useful without this change anyway.

This will need iteration, and the type defs to be able to do it will not be easy...

See https://github.com/DefinitelyTyped/DefinitelyTyped/issues/30791.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
