### PR TITLE
[linkifyjs] Add types for linkifyjs/html 2.1

### DIFF
--- a/types/linkifyjs/.prettierrc.yml
+++ b/types/linkifyjs/.prettierrc.yml
@@ -1,0 +1,8 @@
+tabWidth: 4
+overrides:
+  - files: ".prettierrc.yml"
+    options:
+      tabWidth: 2
+  - files: "tsconfig.json"
+    options:
+      printWidth: 1

--- a/types/linkifyjs/.prettierrc.yml
+++ b/types/linkifyjs/.prettierrc.yml
@@ -1,8 +1,0 @@
-tabWidth: 4
-overrides:
-  - files: ".prettierrc.yml"
-    options:
-      tabWidth: 2
-  - files: "tsconfig.json"
-    options:
-      printWidth: 1

--- a/types/linkifyjs/html.d.ts
+++ b/types/linkifyjs/html.d.ts
@@ -1,0 +1,4 @@
+import { LinkifyOptions } from "./index";
+
+export let linkifyHtml: (input: string, options?: LinkifyOptions) => string;
+export default linkifyHtml;

--- a/types/linkifyjs/html.d.ts
+++ b/types/linkifyjs/html.d.ts
@@ -1,4 +1,4 @@
 import { LinkifyOptions } from "./index";
 
-export let linkifyHtml: (input: string, options?: LinkifyOptions) => string;
+export function linkifyHtml(input: string, options?: LinkifyOptions): string;
 export default linkifyHtml;

--- a/types/linkifyjs/index.d.ts
+++ b/types/linkifyjs/index.d.ts
@@ -1,0 +1,185 @@
+// Type definitions for linkifyjs 2.1
+// Project: https://github.com/SoapBox/linkifyjs#readme
+// Definitions by: Sean Zhu <https://github.com/szhu>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.1
+
+export type PossiblyFuncOfHrefAndType<T> =
+    | T
+    | ((href: string, type: string) => T);
+
+// There's always a possibility that values at a string key can always be
+// undefined; i.e., if the key does not exist.
+export type PossiblyByType<T> = T | { [type: string]: T | undefined };
+
+export type EventHandler = (e: HTMLElement) => void;
+
+export interface LinkifyOptions {
+    /**
+     * attributes
+     * - Type: Object | Function (String href, String type)
+     * - Default: null
+     *
+     * Object of attributes to add to each new link. Note: the class and target
+     * attributes have dedicated options.
+     *
+     * Also accepts a function that takes the unformatted href, the link type
+     * (e.g., 'url', 'email', etc.) and returns the object.
+     */
+    attributes?: PossiblyFuncOfHrefAndType<{
+        [attrName: string]: string;
+    }> | null;
+
+    /**
+     * className
+     * - Type: String | Function (String href, String type) | Object
+     * - Default: 'linkified' (may be removed in future releases)
+     *
+     * class attribute to use for newly created links.
+     *
+     * Accepts a function that takes the unformatted href value and link type
+     * (e.g., 'url', 'email', etc.) and returns the string.
+     *
+     * Accepts an object where each key is the link type and each value is the
+     * string or function to use for that type.
+     */
+    className?: PossiblyByType<PossiblyFuncOfHrefAndType<string | undefined>>;
+
+    /**
+     * defaultProtocol
+     * - Type: String
+     * - Default: 'http'
+     * - Values: 'http', 'https', 'ftp', 'ftps', etc.
+     *
+     * Protocol that should be used in href attributes for URLs without a
+     * protocol (e.g., github.com).
+     */
+    defaultProtocol?: string;
+
+    /**
+     * events
+     * - *element, jquery interfaces only*
+     * - Type: Object | Function (String href, String type) | Object
+     * - Default: null
+     *
+     * Add event listeners to newly created link elements. Takes a hash where
+     * each key is an standard event name and the value is an event handler.
+     *
+     * Also accepts a function that takes the unformatted href and the link type
+     * (e.g., 'url', 'email', etc.) and returns the hash.
+     *
+     * For React, specify events in the attributes option as standard React
+     * events.
+     *
+     * See the React Event docs and the linkify-react event docs
+     */
+    events?: PossiblyFuncOfHrefAndType<{
+        [eventName: string]: EventHandler;
+    }> | null;
+
+    /**
+     * format
+     * - Type: Function (String value, String type) | Object
+     * - Default: null
+     *
+     * Format the text displayed by a linkified entity. e.g., truncate a long
+     * URL.
+     *
+     * Accepts an object where each key is the link type (e.g., 'url', 'email',
+     * etc.) and each value is the formatting function to use for that type.
+     *
+     * NOTE: According to the linkifyjs implementation, `format` can be just a
+     * string, but this is not mentioned in the docs, so we exclude it.
+     */
+    format?: PossiblyByType<(value: string, type: string) => string>;
+    //
+
+    /**
+     * formatHref
+     * - Type: Function (String href, String type) | Object
+     * - Default: null
+     *
+     * Similar to format, except the result of this function will be used as the
+     * href attribute of the new link.
+     *
+     * This is useful when finding hashtags, where you don’t necessarily want
+     * the default to be a link to a named anchor.
+     *
+     * Accepts an object where each key is the link type (e.g., 'url', 'email',
+     * etc.) and each value is the formatting function to use for that type.
+     *
+     * NOTE: According to the linkifyjs implementation, `formatHref` can be just
+     * a string, but this is not mentioned in the docs, so we exclude it.
+     */
+    formatHref?: PossiblyByType<(href: string, type: string) => string>;
+
+    /**
+     * ignoreTags
+     * - *element, html, and jquery interfaces only*
+     * - Type: Array
+     * - Default: []
+     *
+     * Prevent linkify from trying to parse links in the specified tags. This is
+     * useful when running linkify on arbitrary HTML.
+     */
+    ignoreTags?: string[];
+
+    /**
+     * nl2br
+     * - Type: Boolean
+     * - Default: false
+     *
+     * If true, \n line breaks will automatically be converted to <br> tags.
+     *
+     */
+    nl2br?: boolean;
+
+    /**
+     * tagName
+     * - Type: String | Function (String href, String type) | Object
+     * - Default: a
+     *
+     * The tag name to use for each link. For cases where you can’t use anchor
+     * tags.
+     *
+     * Accepts a function that takes the unformatted href, the link type (e.g.,
+     * 'url', 'email', etc.) and returns the tag name.
+     *
+     * Accepts an object where each key is the link type and each value is the
+     * tag name to use for that type.
+     */
+    tagName?: PossiblyByType<PossiblyFuncOfHrefAndType<string>>;
+
+    /**
+     * target
+     * - Type: String | Function (String href, String type) | Object
+     * - Default: '_blank' for URLs, null for everything else
+     *
+     * target attribute for generated link.
+     *
+     * Accepts a function that takes the unformatted href, the link type (e.g.,
+     * 'url', 'email', etc.) and returns the target
+     *
+     * Accepts an object where each key is the link type and each value is the
+     * target to use for that type.
+     */
+    target?: PossiblyByType<
+        PossiblyFuncOfHrefAndType<string | null | undefined>
+    >;
+
+    /**
+     * validate
+     * - Type: Boolean | Function (String value, String type) | Object
+     * - Default: null
+     *
+     * If option resolves to false, the given value will not show up as a link.
+     *
+     * Accepts a function that takes a discovered link and the link type (e.g.,
+     * 'url', 'email', etc.) and returns true if the link should be converted
+     * into an anchor tag, and false otherwise.
+     *
+     * Accepts an object where each key is the link type and each value is the
+     * the validation option to use for that type
+     */
+    validate?: PossiblyByType<PossiblyFuncOfHrefAndType<boolean>>;
+}

--- a/types/linkifyjs/linkifyjs-tests.ts
+++ b/types/linkifyjs/linkifyjs-tests.ts
@@ -1,0 +1,141 @@
+import linkifyHtml from "linkifyjs/html";
+
+// From the docs here: https://soapbox.github.io/linkifyjs/docs/options.html
+
+/* attributes */
+
+linkifyHtml("github.com", {
+    attributes: {
+        rel: "nofollow"
+    }
+});
+
+/* className */
+
+linkifyHtml("github.com", {
+    className: "new-link--url"
+});
+
+linkifyHtml("github.com", {
+    className(href, type) {
+        return "new-link--" + type;
+    }
+});
+
+linkifyHtml("github.com", {
+    className: {
+        url: "new-link--url",
+        email(href: string) {
+            return "new-link--email";
+        }
+    }
+});
+
+/* events */
+
+linkifyHtml("", {
+    events: {
+        click(e) {
+            alert("Link clicked!");
+        },
+        mouseover(e) {
+            alert("Link hovered!");
+        }
+    }
+});
+
+/* defaultProtocol */
+
+/* format */
+
+linkifyHtml("", {
+    format(value, type) {
+        if (type === "url" && value.length > 50) {
+            value = value.slice(0, 50) + "…";
+        }
+        return value;
+    }
+});
+
+linkifyHtml("", {
+    format: {
+        url(value) {
+            return value.length > 50 ? value.slice(0, 50) + "…" : value;
+        }
+    }
+});
+
+/* formatHref */
+
+linkifyHtml("This site is #rad", {
+    formatHref(href, type) {
+        if (type === "hashtag") {
+            href = "https://twitter.com/hashtag/" + href.substring(1);
+        }
+        return href;
+    }
+});
+
+linkifyHtml("Hey @dhh, check out issue #23", {
+    formatHref: {
+        mention(href) {
+            return "https://github.com" + href;
+        },
+        ticket(href) {
+            return (
+                "https://github.com/SoapBox/linkifyjs/issues/" +
+                href.substring(1)
+            );
+        }
+    }
+});
+
+/* ignoreTags */
+
+linkifyHtml(
+    // tslint:disable-next-line:prefer-template
+    'Please ignore <script>var a = {}; a.com = "Hi";</script> \n' +
+        "but do <span>b.ca</span>",
+    {
+        ignoreTags: ["script", "style"]
+    }
+);
+
+/* nl2br */
+
+/* tagName */
+
+linkifyHtml("github.com", {
+    tagName: "span"
+});
+
+linkifyHtml("#swag", {
+    tagName: {
+        hashtag: "span"
+    }
+});
+
+/* target */
+
+linkifyHtml("github.com", {
+    target: "_parent"
+});
+
+linkifyHtml("test-email@example.com", {
+    target: {
+        url: "_parent",
+        email: null
+    }
+});
+
+/* validate */
+
+// Don't linkify links that don't begin in a protocol
+// e.g., "http://google.com" will be linkified, but "google.com" will not.
+linkifyHtml("www.google.com", {
+    validate: {
+        url(value) {
+            return /^(http|ftp)s?:\/\//.test(value);
+        }
+    }
+});

--- a/types/linkifyjs/tsconfig.json
+++ b/types/linkifyjs/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "linkifyjs-tests.ts"
+    ]
+}

--- a/types/linkifyjs/tsconfig.json
+++ b/types/linkifyjs/tsconfig.json
@@ -19,6 +19,7 @@
     },
     "files": [
         "index.d.ts",
+        "html.d.ts",
         "linkifyjs-tests.ts"
     ]
 }

--- a/types/linkifyjs/tslint.json
+++ b/types/linkifyjs/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Note: I am only adding types for `linkifyjs/html`. The rest of `linkifyjs` is not added.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
   It errors, which directory am I supposed to run this from?
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
   How would I run `--declaration`?
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
