### PR TITLE
[socket.io] add overload for origins method

### DIFF
--- a/types/socket.io/index.d.ts
+++ b/types/socket.io/index.d.ts
@@ -143,6 +143,17 @@ declare namespace SocketIO {
 		origins( v: string|string[] ): Server;
 
 		/**
+		 * Provides a function taking two arguments origin:String
+         * and callback(error, success), where success is a boolean
+         * value indicating whether origin is allowed or not. If
+         * success is set to false, error must be provided as a string
+         * value that will be appended to the server response, e.g. “Origin not allowed”.
+		 * @param fn The function that will be called to check the origin
+		 * return This Server
+		 */
+		origins( fn: ( origin: string, callback: ( error: string | null, success: boolean ) => void ) => void ): Server;
+
+        /**
 		 * Attaches socket.io to a server
 		 * @param srv The http.Server that we want to attach to
 		 * @param opts An optional parameters object

--- a/types/socket.io/index.d.ts
+++ b/types/socket.io/index.d.ts
@@ -144,10 +144,10 @@ declare namespace SocketIO {
 
 		/**
 		 * Provides a function taking two arguments origin:String
-         * and callback(error, success), where success is a boolean
-         * value indicating whether origin is allowed or not. If
-         * success is set to false, error must be provided as a string
-         * value that will be appended to the server response, e.g. “Origin not allowed”.
+		 * and callback(error, success), where success is a boolean
+		 * value indicating whether origin is allowed or not. If
+		 * success is set to false, error must be provided as a string
+		 * value that will be appended to the server response, e.g. “Origin not allowed”.
 		 * @param fn The function that will be called to check the origin
 		 * return This Server
 		 */

--- a/types/socket.io/index.d.ts
+++ b/types/socket.io/index.d.ts
@@ -153,7 +153,7 @@ declare namespace SocketIO {
 		 */
 		origins( fn: ( origin: string, callback: ( error: string | null, success: boolean ) => void ) => void ): Server;
 
-        /**
+    /**
 		 * Attaches socket.io to a server
 		 * @param srv The http.Server that we want to attach to
 		 * @param opts An optional parameters object

--- a/types/socket.io/index.d.ts
+++ b/types/socket.io/index.d.ts
@@ -153,7 +153,7 @@ declare namespace SocketIO {
 		 */
 		origins( fn: ( origin: string, callback: ( error: string | null, success: boolean ) => void ) => void ): Server;
 
-    /**
+		/**
 		 * Attaches socket.io to a server
 		 * @param srv The http.Server that we want to attach to
 		 * @param opts An optional parameters object


### PR DESCRIPTION
As seen in https://socket.io/docs/server-api/#server-origins-fn

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:  https://socket.io/docs/server-api/#server-origins-fn
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
