### PR TITLE
added various events and variables around that were missing

### DIFF
--- a/types/sip.js/index.d.ts
+++ b/types/sip.js/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for sip.js 0.8
+// Type definitions for sip.js 0.9
 // Project: http://sipjs.com
 // Definitions by: Kir Dergachev <https://github.com/decyrus>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -75,6 +75,8 @@ export namespace C {
 export type DescriptionModifier = (description: RTCSessionDescription) => Promise<RTCSessionDescription>;
 
 export interface SessionDescriptionHandler {
+    peerConnection: any;
+
     getDescription(options: SessionDescriptionHandlerParameters, modifiers: DescriptionModifier[]): Promise<any>;
     setDescription(sessionDescription: string, options: SessionDescriptionHandlerParameters, modifiers: DescriptionModifier[]): Promise<any>;
     hasDescription: (contentType: string) => boolean;
@@ -128,11 +130,17 @@ export interface Session {
     on(name: 'accepted', callback: (data: { code: number, response: IncomingResponse }) => void): void;
     on(name: 'failed' | 'rejected', callback: (response: IncomingResponse, cause: string) => void): void;
     on(name: 'terminated', callback: (message: IncomingResponse, cause: string) => void): void;
-    on(name: 'cancel' | string, callback: () => void): void;
-    on(name: 'replaced', callback: (newSession: Session) => void): void;
+    on(name: 'cancel' | 'directionChanged' | 'trackAdded' | 'SessionDescriptionHandler-created' | string, callback: () => void): void;
+    on(name: 'replaced' | 'reinvite', callback: (newSession: Session) => void): void;
     on(name: 'dtmf', callback: (request: IncomingRequest, dtmf: Session.DTMF) => void): void;
     on(name: 'muted' | 'unmuted', callback: (data: Session.Muted) => void): void;
     on(name: 'refer' | 'bye', callback: (request: IncomingRequest) => void): void;
+    on(name: 'referRequested', callback: (request: ClientContext | ServerContext) => void): void;
+
+    /*    these come from the ClientContext that is on the session somehow */
+    on(name: 'referAccepted' | 'referRejected' | 'referRequestAccepted' | 'referRequestRejected' | 'referProgress',
+        callback: (ClientContext: ClientContext) => void): void;
+    on(name: 'notify', callback: (request: IncomingRequest) => void): void;
 }
 
 export namespace Session {
@@ -164,7 +172,10 @@ export namespace Session {
         };
     }
 
-    interface DTMF extends Object { }
+    interface DTMF extends Object {
+        direction: string | 'incoming';
+        tone: any;
+    }
 
     interface Muted {
         audio?: boolean;
@@ -364,27 +375,40 @@ export interface Subscription extends ClientContext {
 }
 
 /* Context */
-export interface Context {
+export class Context {
     ua: UA;
     method: string;
     request: OutgoingRequest;
     localIdentity: NameAddrHeader;
     remoteIdentity: NameAddrHeader;
     data: {};
+}
+
+export class ClientContext extends Context {
+    cancel(options?: { status_code?: number, reason_phrase?: string }): ClientContext;
+
+    //This exists on all Context, but I cant make it work right
     on(name: 'progress' | 'accepted' | 'rejected' | 'failed', callback: (response: IncomingMessage, cause: string) => void): void;
     on(name: 'notify', callback: (request: IncomingRequest) => void): void;
     on(name: string, callback: () => void): void;
+
+    on(name: 'referAccepted' | 'referRejected' | 'referRequestAccepted' | 'referRequestRejected' | 'referProgress',
+        callback: (ClientContext: ClientContext) => void): void;
 }
 
-export interface ClientContext extends Context {
-    cancel(options?: { status_code?: number, reason_phrase?: string }): ClientContext;
-}
-
-export interface ServerContext extends Context {
+export class ServerContext extends Context {
     progress(options?: Session.ProgressOptions): void;
     accept(options?: Session.AcceptOptions): void;
     reject(options?: Session.CommonOptions): void;
     reply(options?: Session.CommonOptions): void;
+
+    //This exists on all Context, but I cant make it work right
+    on(name: 'progress' | 'accepted' | 'rejected' | 'failed', callback: (response: IncomingMessage, cause: string) => void): void;
+    on(name: 'notify', callback: (request: IncomingRequest) => void): void;
+    on(name: string, callback: () => void): void;
+
+    on(name: 'referRequestAccepted' | 'referRequestRejected' | 'referInviteSent' | 'referProgress' | 'referAccepted' | 'referRejected',
+        callback: (ServerContext: ServerContext) => void): void;
 }
 
 /* Request */
@@ -398,6 +422,7 @@ export interface OutgoingRequest extends Request {
 }
 
 export interface IncomingResponse extends Request {
+    reason_phrase: string | 'Ringing';
 }
 
 export interface IncomingMessage extends Request {

--- a/types/sip.js/index.d.ts
+++ b/types/sip.js/index.d.ts
@@ -134,13 +134,12 @@ export interface Session {
     on(name: 'replaced' | 'reinvite', callback: (newSession: Session) => void): void;
     on(name: 'dtmf', callback: (request: IncomingRequest, dtmf: Session.DTMF) => void): void;
     on(name: 'muted' | 'unmuted', callback: (data: Session.Muted) => void): void;
-    on(name: 'refer' | 'bye', callback: (request: IncomingRequest) => void): void;
+    on(name: 'refer' | 'bye' | 'notify', callback: (request: IncomingRequest) => void): void;
     on(name: 'referRequested', callback: (request: ClientContext | ServerContext) => void): void;
 
     /*    these come from the ClientContext that is on the session somehow */
     on(name: 'referAccepted' | 'referRejected' | 'referRequestAccepted' | 'referRequestRejected' | 'referProgress',
         callback: (ClientContext: ClientContext) => void): void;
-    on(name: 'notify', callback: (request: IncomingRequest) => void): void;
 }
 
 export namespace Session {
@@ -387,7 +386,7 @@ export class Context {
 export class ClientContext extends Context {
     cancel(options?: { status_code?: number, reason_phrase?: string }): ClientContext;
 
-    //This exists on all Context, but I cant make it work right
+    // This exists on all Context, but I cant make it work right
     on(name: 'progress' | 'accepted' | 'rejected' | 'failed', callback: (response: IncomingMessage, cause: string) => void): void;
     on(name: 'notify', callback: (request: IncomingRequest) => void): void;
     on(name: string, callback: () => void): void;
@@ -402,7 +401,7 @@ export class ServerContext extends Context {
     reject(options?: Session.CommonOptions): void;
     reply(options?: Session.CommonOptions): void;
 
-    //This exists on all Context, but I cant make it work right
+    // This exists on all Context, but I cant make it work right
     on(name: 'progress' | 'accepted' | 'rejected' | 'failed', callback: (response: IncomingMessage, cause: string) => void): void;
     on(name: 'notify', callback: (request: IncomingRequest) => void): void;
     on(name: string, callback: () => void): void;


### PR DESCRIPTION
This is not in any way complete, but I know for sure these things are in here because I use the following in my code and there is documentation:
https://sipjs.com/api/0.11.0/context/server/
https://sipjs.com/api/0.11.0/context/client/


- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
