### PR TITLE
[react] Allow aria attributes to be added to SVG elements

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -2120,7 +2120,7 @@ declare namespace React {
     //   - "number | string"
     //   - "string"
     //   - union of string literals
-    interface SVGAttributes<T> extends DOMAttributes<T> {
+    interface SVGAttributes<T> extends DOMAttributes<T>, AriaAttributes {
         // Attributes which also defined in HTMLAttributes
         // See comment in SVGDOMPropertyConfig.js
         className?: string;

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -1419,7 +1419,9 @@ declare namespace React {
     }
 
     // All the WAI-ARIA 1.1 attributes from https://www.w3.org/TR/wai-aria-1.1/
-    interface HTMLAttributes<T> extends DOMAttributes<T> {
+    interface HTMLAttributes<T> extends DOMAttributes<T>, AriaAttributes { }
+
+    interface AriaAttributes {
         /** Identifies the currently active element when DOM focus is on a composite widget, textbox, group, or application. */
         'aria-activedescendant'?: string;
         /** Indicates whether assistive technologies will present all, or only parts of, the changed region based on the change notifications defined by the aria-relevant attribute. */

--- a/types/react/test/tsx.tsx
+++ b/types/react/test/tsx.tsx
@@ -53,6 +53,15 @@ FunctionComponent2.defaultProps = {
     <b>bar</b>
 </div>;
 
+<svg
+    aria-checked='true'
+    aria-hidden='true'
+    aria-labelledby='svg-aria-test'
+    role='checkbox'
+>
+    <title id='svg-aria-test'>Foo</title>
+</svg>;
+
 interface Props {
     hello: string;
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
   - https://www.w3.org/TR/wai-aria-practices-1.1/#no_aria_better_bad_aria
      > From the perspective of assistive technologies, ARIA gives authors the ability to dress up HTML *and SVG* elements with critical accessibility semantics that the assistive technologies would not otherwise be able to reliably derive.
      (emphasis mine)
   - https://www.w3.org/TR/svg-aam-1.0/
- [ ] ~Increase the version number in the header if appropriate.~ **N/A**
- [ ] ~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.~ **N/A**

