### PR TITLE
update definitions of @types/unist to match what library author wrote

### DIFF
--- a/types/mdast/index.d.ts
+++ b/types/mdast/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/syntax-tree/mdast
 // Definitions by: Jun Lu <https://github.com/lujun2>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.4
+// TypeScript Version: 3.0
 
 import { Parent as UnistParent, Literal as UnistLiteral, Node } from 'unist';
 

--- a/types/unist/index.d.ts
+++ b/types/unist/index.d.ts
@@ -1,40 +1,63 @@
 // Type definitions for Unist 2.0
-// Project: https://github.com/syntax-tree/unist
+// Project: https://github.com/syntax-tree/unist-ts
 // Definitions by: bizen241 <https://github.com/bizen241>
 //                 Jun Lu <https://github.com/lujun2>
+//                 Hernan Rajchert <https://github.com/hrajchert>
+//                 Titus Wormer <https://github.com/wooorm>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.4
+// TypeScript Version: 3.1
 
+export as namespace Unist
+
+// Syntactic units in unist syntax trees are called nodes.
 export interface Node {
+    // The variant of a node.
     type: string;
+
+    // Information from the ecosystem.
     data?: Data;
+
+    // Location of a node in a source document.
+    // Must not be present if a node is generated.
     position?: Position;
 }
 
 export interface Data {
-    [key: string]: any;
+    [key: string]: unknown;
 }
 
+// Location of a node in a source file.
 export interface Position {
+    // Place of the first character of the parsed source region.
     start: Point;
+
+    // Place of the first character after the parsed source region.
     end: Point;
-    /** >= 1 */
-    indent?: number[];
+
+    // Start column at each index (plus start line) in the source region,
+    // for elements that span multiple lines.
+    indent: number[];
 }
 
+// One place in a source file.
 export interface Point {
-    /** >= 1 */
+    // Line in a source file (1-indexed integer).
     line: number;
-    /** >= 1 */
+
+    // Column in a source file (1-indexed integer).
     column: number;
-    /** >= 0 */
+
+    // Character in a source file (0-indexed integer).
     offset?: number;
 }
 
+// Nodes containing other nodes.
 export interface Parent extends Node {
+    // List representing the children of a node.
     children: Node[];
 }
 
+// Nodes containing a value.
 export interface Literal extends Node {
     value: any;
 }

--- a/types/unist/index.d.ts
+++ b/types/unist/index.d.ts
@@ -7,8 +7,6 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.0
 
-export as namespace Unist
-
 // Syntactic units in unist syntax trees are called nodes.
 export interface Node {
     // The variant of a node.
@@ -59,5 +57,5 @@ export interface Parent extends Node {
 
 // Nodes containing a value.
 export interface Literal extends Node {
-    value: any;
+    value: unknown;
 }

--- a/types/unist/index.d.ts
+++ b/types/unist/index.d.ts
@@ -1,5 +1,5 @@
 // Type definitions for Unist 2.0
-// Project: https://github.com/syntax-tree/unist-ts
+// Project: https://github.com/syntax-tree/unist
 // Definitions by: bizen241 <https://github.com/bizen241>
 //                 Jun Lu <https://github.com/lujun2>
 //                 Hernan Rajchert <https://github.com/hrajchert>

--- a/types/unist/index.d.ts
+++ b/types/unist/index.d.ts
@@ -34,7 +34,7 @@ export interface Position {
 
     // Start column at each index (plus start line) in the source region,
     // for elements that span multiple lines.
-    indent: number[];
+    indent?: number[];
 }
 
 // One place in a source file.

--- a/types/unist/index.d.ts
+++ b/types/unist/index.d.ts
@@ -5,7 +5,7 @@
 //                 Hernan Rajchert <https://github.com/hrajchert>
 //                 Titus Wormer <https://github.com/wooorm>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.1
+// TypeScript Version: 3.0
 
 export as namespace Unist
 

--- a/types/unist/index.d.ts
+++ b/types/unist/index.d.ts
@@ -7,55 +7,89 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 3.0
 
-// Syntactic units in unist syntax trees are called nodes.
+/**
+ * Syntactic units in unist syntax trees are called nodes.
+ */
 export interface Node {
-    // The variant of a node.
+    /**
+     * The variant of a node.
+     */
     type: string;
 
-    // Information from the ecosystem.
+    /**
+     * Information from the ecosystem.
+     */
     data?: Data;
 
-    // Location of a node in a source document.
-    // Must not be present if a node is generated.
+    /**
+     * Location of a node in a source document.
+     * Must not be present if a node is generated.
+     */
     position?: Position;
 }
 
+/**
+ * Information associated by the ecosystem with the node.
+ * Space is guaranteed to never be specified by unist or specifications
+ * implementing unist.
+ */
 export interface Data {
     [key: string]: unknown;
 }
 
-// Location of a node in a source file.
+/**
+ * Location of a node in a source file.
+ */
 export interface Position {
-    // Place of the first character of the parsed source region.
+    /**
+     * Place of the first character of the parsed source region.
+     */
     start: Point;
 
-    // Place of the first character after the parsed source region.
+    /**
+     * Place of the first character after the parsed source region.
+     */
     end: Point;
 
-    // Start column at each index (plus start line) in the source region,
-    // for elements that span multiple lines.
+    /**
+     * Start column at each index (plus start line) in the source region,
+     * for elements that span multiple lines.
+     */
     indent?: number[];
 }
 
-// One place in a source file.
+/**
+ * One place in a source file.
+ */
 export interface Point {
-    // Line in a source file (1-indexed integer).
+    /**
+     * Line in a source file (1-indexed integer).
+     */
     line: number;
 
-    // Column in a source file (1-indexed integer).
+    /**
+     * Column in a source file (1-indexed integer).
+     */
     column: number;
-
-    // Character in a source file (0-indexed integer).
+    /**
+     * Character in a source file (0-indexed integer).
+     */
     offset?: number;
 }
 
-// Nodes containing other nodes.
+/**
+ * Nodes containing other nodes.
+ */
 export interface Parent extends Node {
-    // List representing the children of a node.
+    /**
+     * List representing the children of a node.
+     */
     children: Node[];
 }
 
-// Nodes containing a value.
+/**
+ * Nodes containing a value.
+ */
 export interface Literal extends Node {
     value: unknown;
 }

--- a/types/unist/unist-tests.ts
+++ b/types/unist/unist-tests.ts
@@ -1,4 +1,4 @@
-import {Data, Point, Position, Node, Literal, Parent} from './index';
+import { Data, Point, Position, Node, Literal, Parent } from 'unist';
 
 const data: Data = {
     string: 'string',

--- a/types/unist/unist-tests.ts
+++ b/types/unist/unist-tests.ts
@@ -1,4 +1,6 @@
-const data: Unist.Data = {
+import {Data, Point, Position, Node, Literal, Parent} from './index';
+
+const data: Data = {
     string: 'string',
     number: 1,
     object: {
@@ -9,32 +11,32 @@ const data: Unist.Data = {
     null: null
 };
 
-const point: Unist.Point = {
+const point: Point = {
     line: 1,
     column: 1,
     offset: 0
 };
 
-const position: Unist.Position = {
+const position: Position = {
     start: point,
     end: point,
     indent: [1]
 };
 
-const node: Unist.Node = {
+const node: Node = {
     type: 'node',
     data,
     position
 };
 
-const text: Unist.Literal = {
+const text: Literal = {
     type: 'text',
     data,
     position,
     value: 'value'
 };
 
-const parent: Unist.Parent = {
+const parent: Parent = {
     type: 'parent',
     data,
     position,

--- a/types/unist/unist-tests.ts
+++ b/types/unist/unist-tests.ts
@@ -1,5 +1,3 @@
-import * as Unist from 'unist';
-
 const data: Unist.Data = {
     string: 'string',
     number: 1,


### PR DESCRIPTION
Update definitions to match those defined by the library author

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/syntax-tree/unist-ts/issues/3
- [X] Increase the version number in the header if appropriate.
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

As stated in this issue https://github.com/syntax-tree/unist-ts/issues/3, I spoke with @wooorm, the library author, and he gave me permission to publish the latest version of the unist definition on his behalf.

Once this is accepted I can publish other definitions on the ecosystem that currently resides in this repository https://github.com/hrajchert/unified-typings-test
