### PR TITLE
react: Bump version of csstype used

### DIFF
--- a/types/react/package.json
+++ b/types/react/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
   "dependencies": {
-    "csstype": "^2.2.0"
+    "csstype": "^2.5.7"
   }
 }


### PR DESCRIPTION
The old version of csstype appears to be the cause of this error for us: 
```
 Type ‘“inline”’ is not assignable to type ‘ResizeProperty’.
```

From MDN, we can see that `"inline"` is in fact a valid property for `resize`, and I've verified that the latest version of `csstype` includes `"inline"` in the union type `ResizeProperty`.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)

It's failing when ran locally with the following error:

```
Error in react-native
Error: /Users/lewis/Develop/public/DefinitelyTyped/types/react-native/test/index.tsx:821:17
ERROR: 821:17  expect  TypeScript@next compile error:
JSX element type 'NativeBridgedComponent' does not have any construct or call signatures.

    at /Users/lewis/Develop/public/DefinitelyTyped/node_modules/dtslint/bin/index.js:158:19
    at Generator.next (<anonymous>)
    at fulfilled (/Users/lewis/Develop/public/DefinitelyTyped/node_modules/dtslint/bin/index.js:5:58)
Error: The following packages had errors: react-native
    at doRunTests (/Users/lewis/Develop/public/DefinitelyTyped/node_modules/types-publisher/src/tester/test-runner.ts:131:11)
    at process.internalTickCallback (internal/process/next_tick.js:77:7)
npm ERR! Test failed.  See above for more details.
```

But it seems to be unrelated.

- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/frenic/csstype/blob/master/index.d.ts (search for the definition of `ResizeProperties` in the raw file. It now includes a `"inline"` in the union.)
- [ ] Increase the version number in the header if appropriate. (Not sure which version to bump.)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

