### PR TITLE
[redux-saga-tester] Added support for params when starting sagaTester.

### DIFF
--- a/types/redux-saga-tester/index.d.ts
+++ b/types/redux-saga-tester/index.d.ts
@@ -1,27 +1,19 @@
 // Type definitions for redux-saga-tester 1.0
 // Project: https://github.com/wix/redux-saga-tester#readme
-// Definitions by: Ben Lorantfy <https://github.com/BenLorantfy>
+// Definitions by: Ben Lorantfy <https://github.com/BenLorantfy>, Law Smith <https://github.com/lawsumisu>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.4
 
-export interface AnyAction {
-    type: string;
-    [key: string]: any;
-}
-export type Reducer = (state: object, action: AnyAction) => object;
-export interface ReducerMap {
-    [key: string]: Reducer;
-}
-export type ReduxMiddleware = (options: { dispatch: (action: AnyAction) => void, getState: () => object })
-    => (next: (action: AnyAction) => any)
-    => any;
+import {Task} from 'redux-saga';
+import {AnyAction, Middleware, Reducer, ReducersMapObject} from 'redux';
+
 export type SagaFunction = (...args: any[]) => any;
 
-export interface SagaTesterOptions<StateType extends object> {
+export interface SagaTesterOptions<StateType> {
     initialState?: StateType;
-    reducers?: ReducerMap|Reducer;
-    middlewares?: ReduxMiddleware[];
-    combineReducers?: (map: ReducerMap) => Reducer;
+    reducers?: ReducersMapObject | Reducer<StateType>;
+    middlewares?: Middleware[];
+    combineReducers?: (map: ReducersMapObject) => Reducer<StateType>;
     ignoreReduxActions?: boolean;
     options?: object;
 }
@@ -32,7 +24,7 @@ export default class SagaTester<StateType extends object> {
     /**
      * Starts execution of the provided saga.
      */
-    start(saga: SagaFunction): void;
+    start(saga: SagaFunction, ...args: any[]): Task;
 
     /**
      * Dispatches an action to the redux store.

--- a/types/redux-saga-tester/index.d.ts
+++ b/types/redux-saga-tester/index.d.ts
@@ -4,8 +4,8 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.4
 
-import {Task} from 'redux-saga';
-import {AnyAction, Middleware, Reducer, ReducersMapObject} from 'redux';
+import { Task } from 'redux-saga';
+import { AnyAction, Middleware, Reducer, ReducersMapObject } from 'redux';
 
 export type SagaFunction = (...args: any[]) => any;
 

--- a/types/redux-saga-tester/package.json
+++ b/types/redux-saga-tester/package.json
@@ -1,0 +1,7 @@
+{
+  "private": true,
+  "dependencies": {
+    "redux": "^3.7.2",
+    "redux-saga": "^0.15.3"
+  }
+}

--- a/types/redux-saga-tester/redux-saga-tester-tests.ts
+++ b/types/redux-saga-tester/redux-saga-tester-tests.ts
@@ -49,7 +49,7 @@ function* fakeSaga() {
 }
 
 function* fakeSagaWithParams(param1: string, param2: number) {
-    return param1.length > param2
+    return param1.length > param2;
 }
 
 sagaTester.start(fakeSaga);

--- a/types/redux-saga-tester/redux-saga-tester-tests.ts
+++ b/types/redux-saga-tester/redux-saga-tester-tests.ts
@@ -2,62 +2,79 @@ import SagaTester from 'redux-saga-tester';
 
 // constructor with all options
 new SagaTester({
-  initialState: {
-    orders: [],
-  },
-  reducers: {
-    orders: (state, action) => state,
-  },
-  middlewares: [
-    ({ dispatch, getState }) => (next) => (action: { type: string }) => {
-      dispatch({ type: 'BLA' });
-      getState();
-
-      return next(action);
+    initialState: {
+        orders: [],
     },
-  ],
-  ignoreReduxActions: false,
-  options: {
-    a: 23,
-  },
+    reducers: {
+        orders: (state, action) => state,
+    },
+    middlewares: [
+        ({dispatch, getState}) => (next) => (action) => {
+            dispatch({type: 'BLA'});
+            getState();
+
+            return next(action);
+        },
+    ],
+    ignoreReduxActions: false,
+    options: {
+        a: 23,
+    },
 });
 
 // constructor with function as reducers
 new SagaTester({
-  reducers: (state, action) => state,
+    reducers: (state = {}, action) => state,
+});
+
+// constructor with reducer map
+new SagaTester({
+    reducers: {
+        a: (state, action) => state,
+        b: (state, action) => state,
+        c: (state, action) => state,
+    }
 });
 
 // constructor with no options
 interface MockStateType {
-  orders: Array<{ name: string }>;
+    orders: Array<{ name: string }>;
 }
-const sagaTester = new SagaTester<MockStateType>({ initialState: { orders: [] }});
+
+const sagaTester = new SagaTester<MockStateType>({initialState: {orders: []}});
 
 // start
 function* fakeSaga() {
-  return 23;
+    return 23;
+}
+
+function* fakeSagaWithParams(param1: string, param2: number) {
+    return param1.length > param2
 }
 
 sagaTester.start(fakeSaga);
+sagaTester.start(fakeSagaWithParams, 'foo', 3);
 
 // dispatch
-sagaTester.dispatch({ type: 'LOAD_ORDERS', orders: [] });
+sagaTester.dispatch({type: 'LOAD_ORDERS', orders: []});
 
 // updateState
-sagaTester.updateState({ orders: [] });
+sagaTester.updateState({orders: []});
 
 // getState
 sagaTester.getState().orders;
 
 // waitFor
-sagaTester.waitFor('LOAD_ORDERS').then(() => {});
-sagaTester.waitFor('LOAD_ORDERS', true).then(() => {});
+sagaTester.waitFor('LOAD_ORDERS').then(() => {
+});
+sagaTester.waitFor('LOAD_ORDERS', true).then(() => {
+});
 
 // wasCalled
-sagaTester.wasCalled("LOAD_ORDERS");
+sagaTester.wasCalled('LOAD_ORDERS');
 
 // numCalled
-sagaTester.numCalled("LOAD_ORDERS") === 1;
+sagaTester.numCalled('LOAD_ORDERS') === 1;
 
 // getLatestCalledAction
 sagaTester.getLatestCalledAction().type;
@@ -68,3 +85,8 @@ sagaTester.getCalledActions()[0].type;
 // getCalledActions
 sagaTester.reset();
 sagaTester.reset(true);
+
+// getState
+const state = sagaTester.getState();
+state.orders.length;
+state.orders[0].name;


### PR DESCRIPTION
This PR functionally is for adding support for arguments when running `sagaTester.start()`. It also makes such of `redux-saga` and `redux` types rather than redeclaring them in this type definition.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/wix/redux-saga-tester/blob/master/src/SagaTester.js#L109
- [x] Increase the version number in the header if appropriate.
