### PR TITLE
@types/range-parser Remove const enum

### DIFF
--- a/types/range-parser/index.d.ts
+++ b/types/range-parser/index.d.ts
@@ -27,7 +27,7 @@ declare namespace RangeParser {
          */
         combine?: boolean;
     }
-    const enum Result {
+    enum Result {
         invaild = -2,
         unsatisifiable = -1,
     }


### PR DESCRIPTION
Was throwing error:
```
Type error: Ambient const enums are not allowed when the '--isolatedModules' flag is provided.  TS1209
```

RE: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/28744#issue-358403102