### PR TITLE
[puppeteer] Remove Promise in Request.frame function

### DIFF
--- a/types/puppeteer/index.d.ts
+++ b/types/puppeteer/index.d.ts
@@ -968,7 +968,7 @@ export interface Request {
   /**
    * @returns The `Frame` object that initiated the request, or `null` if navigating to error pages
    */
-  frame(): Promise<Frame | null>;
+  frame(): Frame | null;
 
   /**
    * An object with HTTP headers associated with the request.


### PR DESCRIPTION
The type definition of the Request class declares the return type of the `frame()`
function as `Promise<Frame | null>`, but it should be `Frame | null` only.

Puppeteer defines [the function in NetworkManager.js](https://github.com/GoogleChrome/puppeteer/blob/45c4477e9fc80a159d8cbfe13cbe1aa5544a53c1/lib/NetworkManager.js#L361-L366). The return type is documented as:
```javascript
/**
 * @return {?Puppeteer.Frame}
 */
frame() {
  return this._frame;
}
```
This also matches the Response class, whose type definition is [without a Promise in this repository.](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/c34029e6e0361bf10a286e18aa8c9a3522d0230c/types/puppeteer/index.d.ts#L1045) Since the [Response class just forwards the Request frame() return value under the hood](https://github.com/GoogleChrome/puppeteer/blob/45c4477e9fc80a159d8cbfe13cbe1aa5544a53c1/lib/NetworkManager.js#L637-L642), one of the definitions in this repository has to be wrong.

The following JavaScript code should confirm that the return value is not a Promise:
```javascript
const puppeteer = require("puppeteer");

(async () => {
  const browser = await puppeteer.launch();
  const page = await browser.newPage();

  page.on("request", request => {
    let frame = request.frame();
    if (frame) {
      console.log(frame.constructor.name);
    }
  });

  await page.goto("https://www.example.com/");
  await browser.close();
})();
```
It prints `Frame`, not `Promise`.
