### PR TITLE
[react-native] Add option to insert Animated.Value instead of number to opacity style

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -1749,7 +1749,10 @@ export interface ViewStyle extends FlexStyle, ShadowStyleIOS, TransformsStyle {
     borderTopStartRadius?: number;
     borderTopWidth?: number;
     borderWidth?: number;
-    opacity?: number;
+    /**
+      * Allow to insert number or Animated.Value, because Animated.Value is not number
+      */
+    opacity?: number | Animated.Value;
     testID?: string;
     /**
       * Sets the elevation of a view, using Android's underlying


### PR DESCRIPTION
Adding second type for `opacity` in ViewStyle, because number is not enough. When user animate, the type is Animated.Value.


_Please fill in this template._

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/facebook/react-native/blob/master/Libraries/StyleSheet/StyleSheetTypes.js#L570
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
