### PR TITLE
[@types/classnames] Fix classnames/bind when using esModuleInterop

### DIFF
--- a/types/classnames/bind.d.ts
+++ b/types/classnames/bind.d.ts
@@ -1,3 +1,3 @@
-import * as cn from "./index";
+import cn = require("./index");
 
 export function bind(styles: Record<string, string>): typeof cn;

--- a/types/classnames/classnames-tests.ts
+++ b/types/classnames/classnames-tests.ts
@@ -1,8 +1,5 @@
 import classNames = require('classnames');
-import { default as classNames2 } from 'classnames';
-import { default as cn } from 'classnames/bind';
-
-classNames2('foo', 'bar'); // => 'foo bar'
+import cn = require('classnames/bind');
 
 classNames('foo', 'bar'); // => 'foo bar'
 classNames('foo', { bar: true }); // => 'foo bar'

--- a/types/classnames/classnames-tests.ts
+++ b/types/classnames/classnames-tests.ts
@@ -1,6 +1,6 @@
 import classNames = require('classnames');
-import * as classNames2 from 'classnames';
-import * as cn from 'classnames/bind';
+import { default as classNames2 } from 'classnames';
+import { default as cn } from 'classnames/bind';
 
 classNames2('foo', 'bar'); // => 'foo bar'
 

--- a/types/classnames/tsconfig.json
+++ b/types/classnames/tsconfig.json
@@ -6,7 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
-        "strictNullChecks": false,
+        "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/classnames/tsconfig.json
+++ b/types/classnames/tsconfig.json
@@ -8,6 +8,7 @@
         "noImplicitThis": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
+        "esModuleInterop": true,
         "baseUrl": "../",
         "typeRoots": [
             "../"


### PR DESCRIPTION
I was having an issue using `classnames/bind` with `esModuleInterop` in my `tsconfig.json`. The compiler would expect `classNames.bind(styles)` to return a `{ default: ClassNamesExport }` instead of just a `ClassNamesExport`.

```ts
import * as classNames from 'classnames/bind';
import styles from './styles.module.css';

const cx = classNames.bind(styles);

const className = cx('app'); // (at compile-time) => [ts] Cannot invoke an expression whose type lacks a call signature. Type '{ default: ClassNamesFn; }' has no compatible call signatures. [2349]

const className2 = cx.default('app'); // (at runtime) => TypeError: cx.default is not a function
```

I was able to fix the issue by using a require import instead of a star import in `bind.d.ts`.

Tests passed with the change before adding the `esModuleInterop` option in the `tsconfig.json` here, but I had to update the imports after adding the option to test.

Additionally, I enabled `strictNullChecks` in `tsconfig.json` as [recommended in the readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/7e1ba4933f518f884bf5f8c372ed27c099423fd1/README.md#some-packages-have-no-tslintjson-and-some-tsconfigjson-are-missing-noimplicitany-true-noimplicitthis-true-or-strictnullchecks-true).

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: (see example above)
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

