### PR TITLE
[react-native] Make requireNativeComponent work with an update to @types/react

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -9037,8 +9037,11 @@ export const PixelRatio: PixelRatioStatic;
  *
  *   const View = requireNativeComponent('RCTView');
  *
+ * The concrete return type of `requireNativeComponent` is a string, but the declared type is
+ * `any` because TypeScript assumes anonymous JSX intrinsics (`string` instead of `"div", for
+ * example) not to have any props.
  */
-export function requireNativeComponent(viewName: string): React.ReactType;
+export function requireNativeComponent(viewName: string): any;
 
 export function findNodeHandle(
     componentOrHandle: null | number | React.Component<any, any> | React.ComponentClass<any>


### PR DESCRIPTION
4dd9510a504875fb79a399d468e8f39e892af617 changed `React.ReactType` to look at entries in the `JSX.IntrinsicElements` map, which caused rendering `React.ReactType<any>` elements to fail. This commit fixes the RN type declarations by returning `any`. We don't care about the actual return type that much -- it's concretely a string but externally, as a user of react-native, you'd want to only use it as a JSX component type and not as a string.

And since it's a string that isn't registered with `JSX.IntrinsicElements`, there's no extra type information (ex: list of valid props) associated with it. Longer term, it might make sense for `@types/react-native` to add native component types like `RCTView` to `JSX.IntrinsicElements` and go back to using `React.ReactType<'RCTView'>` with `requireNativeComponent`, but this is a disruptive change.

Test plan: Ran tests, verified they pass again.

Fixes #30958.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: (see description above)
- [x] Increase the version number in the header if appropriate. (N/A)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. (N/A)
