### PR TITLE
[url-assembler]: making 'strict: boolean' parameter optional

### DIFF
--- a/types/url-assembler/index.d.ts
+++ b/types/url-assembler/index.d.ts
@@ -7,8 +7,8 @@ interface UrlAssembler {
 	template(template: string): UrlAssembler;
 	prefix(subPath: string): UrlAssembler;
 	segment(subPathTemplate: string): UrlAssembler;
-	param(key: string, value: string, strict: boolean): UrlAssembler;
-	param(params: {[s: string]: any}, strict: boolean): UrlAssembler;
+	param(key: string, value: string, strict?: boolean): UrlAssembler;
+	param(params: {[s: string]: any}, strict?: boolean): UrlAssembler;
 	query(key: string, value: any): UrlAssembler;
 	query(params: {[s: string]: any}): UrlAssembler;
 	toString(): string;

--- a/types/url-assembler/index.d.ts
+++ b/types/url-assembler/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for url-assembler 1.2
+// Type definitions for url-assembler 1.2.10
 // Project: https://github.com/Floby/node-url-assembler
 // Definitions by: Wolfgang Faust <https://github.com/wolfgang42>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/url-assembler/index.d.ts
+++ b/types/url-assembler/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for url-assembler 1.2.10
+// Type definitions for url-assembler 1.2
 // Project: https://github.com/Floby/node-url-assembler
 // Definitions by: Wolfgang Faust <https://github.com/wolfgang42>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped


### PR DESCRIPTION
as per api-definition of 1.2.10

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.npmjs.com/package/url-assembler
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.