### PR TITLE
[puppeteer] 1.11.0 update type definitions

### DIFF
--- a/types/puppeteer/index.d.ts
+++ b/types/puppeteer/index.d.ts
@@ -2061,10 +2061,10 @@ export interface ConnectOptions {
 }
 
 export interface ConnectionTransport {
-  send: (message: string) => void;
-  close: () => void;
-  onmessage?: (message: string) => void;
-  onclose?: () => void;
+  send(message: string): void;
+  close(): void;
+  onmessage?(message: string): void;
+  onclose?(): void;
 }
 
 export interface CDPSession extends EventEmitter {

--- a/types/puppeteer/index.d.ts
+++ b/types/puppeteer/index.d.ts
@@ -513,6 +513,9 @@ export interface DirectNavigationOptions extends NavigationOptions {
   referer?: string;
 }
 
+/** Accepts values labeled with units. If number, treat as pixels. */
+export type LayoutDimension = string | number;
+
 export type PDFFormat =
   | "Letter"
   | "Legal"
@@ -580,22 +583,21 @@ export interface PDFOptions {
    * @default 'Letter'
    */
   format?: PDFFormat;
-  /** Paper width, accepts values labeled with units. Treat numbers as pixel values */
-  width?: string | number;
-  /** Paper height, accepts values labeled with units. Treat numbers as pixel values */
-  height?: string | number;
-  /** Paper margins, defaults to none.  */
+  /** Paper width. */
+  width?: LayoutDimension;
+  /** Paper height. */
+  height?: LayoutDimension;
+  /** Paper margins, defaults to none. */
   margin?: {
-    /** Top margin, accepts values labeled with units. Treat numbers as pixel values */
-    top?: string | number;
-    /** Right margin, accepts values labeled with units. Treat numbers as pixel values */
-    right?: string | number;
-    /** Bottom margin, accepts values labeled with units. Treat numbers as pixel values */
-    bottom?: string | number;
-    /** Left margin, accepts values labeled with units. Treat numbers as pixel values */
-    left?: string | number;
+    /** Top margin. */
+    top?: LayoutDimension;
+    /** Right margin. */
+    right?: LayoutDimension;
+    /** Bottom margin. */
+    bottom?: LayoutDimension;
+    /** Left margin. */
+    left?: LayoutDimension;
   };
-
   /**
    * Give any CSS @page size declared in the page priority over what is declared in width and
    * height or format options.

--- a/types/puppeteer/index.d.ts
+++ b/types/puppeteer/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for puppeteer 1.10
+// Type definitions for puppeteer 1.11
 // Project: https://github.com/GoogleChrome/puppeteer#readme
 // Definitions by: Marvin Hagemeister <https://github.com/marvinhagemeister>
 //                 Christopher Deutsch <https://github.com/cdeutsch>
@@ -398,6 +398,8 @@ export interface Cookie {
   path: string;
   /** The cookie Unix expiration time in seconds. */
   expires: number;
+  /** The cookie size */
+  size: number;
   /** The cookie http only flag. */
   httpOnly: boolean;
   /** The session cookie flag. */
@@ -414,7 +416,6 @@ export interface DeleteCookie {
   url?: string;
   domain?: string;
   path?: string;
-  secure?: boolean;
 }
 
 export interface SetCookie {
@@ -579,20 +580,20 @@ export interface PDFOptions {
    * @default 'Letter'
    */
   format?: PDFFormat;
-  /** Paper width, accepts values labeled with units. */
-  width?: string;
-  /** Paper height, accepts values labeled with units. */
-  height?: string;
+  /** Paper width, accepts values labeled with units. Treat numbers as pixel values */
+  width?: string | number;
+  /** Paper height, accepts values labeled with units. Treat numbers as pixel values */
+  height?: string | number;
   /** Paper margins, defaults to none.  */
   margin?: {
-    /** Top margin, accepts values labeled with units. */
-    top?: string;
-    /** Right margin, accepts values labeled with units. */
-    right?: string;
-    /** Bottom margin, accepts values labeled with units. */
-    bottom?: string;
-    /** Left margin, accepts values labeled with units. */
-    left?: string;
+    /** Top margin, accepts values labeled with units. Treat numbers as pixel values */
+    top?: string | number;
+    /** Right margin, accepts values labeled with units. Treat numbers as pixel values */
+    right?: string | number;
+    /** Bottom margin, accepts values labeled with units. Treat numbers as pixel values */
+    bottom?: string | number;
+    /** Left margin, accepts values labeled with units. Treat numbers as pixel values */
+    left?: string | number;
   };
 
   /**
@@ -1177,8 +1178,9 @@ export interface FrameBase extends Evalable {
   /**
    * Sets the page content.
    * @param html HTML markup to assign to the page.
+   * @param options The navigation parameters.
    */
-  setContent(html: string): Promise<void>;
+  setContent(html: string, options?: NavigationOptions): Promise<void>;
 
   /**
    * This method fetches an element with `selector`, scrolls it into view if needed,
@@ -1395,11 +1397,11 @@ export interface AXNode {
   /**
    * Whether the checkbox is checked, or "mixed".
    */
-  checked: boolean | string;
+  checked: boolean | "mixed";
   /**
    * Whether the toggle button is checked, or "mixed".
    */
-  pressed: boolean | string;
+  pressed: boolean | "mixed";
   /**
    * The level of a heading.
    */
@@ -1620,9 +1622,9 @@ export interface Page extends EventEmitter, FrameBase {
 
   /**
    * Determines whether cache is enabled on the page.
-   * @param enabled Whether or not to enable cache on the page.
+   * @param enabled Whether or not to enable cache on the page. Defaults to true.
    */
-  setCacheEnabled(enabled: boolean): Promise<void>;
+  setCacheEnabled(enabled?: boolean): Promise<void>;
 
   /**
    * Sets the cookies on the page.
@@ -1935,36 +1937,79 @@ export interface Target {
 
 export interface LaunchOptions extends Timeoutable {
   /**
-   * Whether to open chrome in appMode.
-   * @default false
-   */
-  appMode?: boolean;
-  /**
-   * Whether to ignore HTTPS errors during navigation.
-   * @default false
-   */
-  ignoreHTTPSErrors?: boolean;
-  /**
-   * Do not use `puppeteer.defaultArgs()` for launching Chromium.
-   * @default false
-   */
-  ignoreDefaultArgs?: boolean | string[];
-  /**
-   * Whether to run Chromium in headless mode.
-   * @default true
-   */
-  headless?: boolean;
-  /**
    * Path to a Chromium executable to run instead of bundled Chromium. If
    * executablePath is a relative path, then it is resolved relative to current
    * working directory.
    */
   executablePath?: string;
   /**
-   * Slows down Puppeteer operations by the specified amount of milliseconds.
-   * Useful so that you can see what is going on.
+   * Do not use `puppeteer.defaultArgs()` for launching Chromium.
+   * @default false
    */
-  slowMo?: number;
+  ignoreDefaultArgs?: boolean | string[];
+  /**
+   * Close chrome process on Ctrl-C.
+   * @default true
+   */
+  handleSIGINT?: boolean;
+  /**
+   * Close chrome process on SIGTERM.
+   * @default true
+   */
+  handleSIGTERM?: boolean;
+  /**
+   * Close chrome process on SIGHUP.
+   * @default true
+   */
+  handleSIGHUP?: boolean;
+  /**
+   * Whether to pipe browser process stdout and stderr into process.stdout and
+   * process.stderr.
+   * @default false
+   */
+  dumpio?: boolean;
+  /**
+   * Specify environment variables that will be visible to Chromium.
+   * @default `process.env`.
+   */
+  env?: {
+    [key: string]: string | boolean | number;
+  };
+  /**
+   * Connects to the browser over a pipe instead of a WebSocket.
+   * @default false
+   */
+  pipe?: boolean;
+}
+
+export interface ChromeArgOptions {
+    /**
+     * Whether to run browser in headless mode.
+     * @default true unless the devtools option is true.
+     */
+    headless?: boolean;
+    /**
+     * Additional arguments to pass to the browser instance.
+     * The list of Chromium flags can be found here.
+     */
+    args?: string[];
+    /**
+     * Path to a User Data Directory.
+     */
+    userDataDir?: string;
+    /**
+     * Whether to auto-open a DevTools panel for each tab.
+     * If this option is true, the headless option will be set false.
+     */
+    devtools?: boolean;
+}
+
+export interface BrowserOptions {
+  /**
+   * Whether to ignore HTTPS errors during navigation.
+   * @default false
+   */
+  ignoreHTTPSErrors?: boolean;
   /**
    * Sets a consistent viewport for each page. Defaults to an 800x600 viewport. null disables the default viewport.
    */
@@ -2000,81 +2045,26 @@ export interface LaunchOptions extends Timeoutable {
     isLandscape?: boolean;
   };
   /**
-   * Additional arguments to pass to the Chromium instance. List of Chromium
-   * flags can be found here.
+   * Slows down Puppeteer operations by the specified amount of milliseconds.
+   * Useful so that you can see what is going on.
    */
-  args?: string[];
-  /**
-   * Close chrome process on Ctrl-C.
-   * @default true
-   */
-  handleSIGINT?: boolean;
-  /**
-   * Close chrome process on SIGTERM.
-   * @default true
-   */
-  handleSIGTERM?: boolean;
-  /**
-   * Close chrome process on SIGHUP.
-   * @default true
-   */
-  handleSIGHUP?: boolean;
-  /**
-   * Whether to pipe browser process stdout and stderr into process.stdout and
-   * process.stderr.
-   * @default false
-   */
-  dumpio?: boolean;
-  /** Path to a User Data Directory. */
-  userDataDir?: string;
-  /**
-   * Specify environment variables that will be visible to Chromium.
-   * @default `process.env`.
-   */
-  env?: {
-    [key: string]: string | boolean | number;
-  };
-  /**
-   * Whether to auto-open DevTools panel for each tab. If this option is true, the headless option will be set false.
-   */
-  devtools?: boolean;
-  /**
-   * Connects to the browser over a pipe instead of a WebSocket.
-   * @default false
-   */
-  pipe?: boolean;
-}
-
-export interface DefaultArgsOptions {
-    /**
-     * Whether to run browser in headless mode.
-     * @default true unless the devtools option is true.
-     */
-    headless?: boolean;
-    /**
-     * Additional arguments to pass to the browser instance.
-     * The list of Chromium flags can be found here.
-     */
-    args?: string[];
-    /**
-     * Path to a User Data Directory.
-     */
-    userDataDir?: string;
-    /**
-     * Whether to auto-open a DevTools panel for each tab.
-     * If this option is true, the headless option will be set false.
-     */
-    devtools?: boolean;
+  slowMo?: number;
 }
 
 export interface ConnectOptions {
   /** A browser websocket endpoint to connect to. */
   browserWSEndpoint?: string;
   /**
-   * Whether to ignore HTTPS errors during navigation.
-   * @default false
+   * **Experimental** Specify a custom transport object for Puppeteer to use.
    */
-  ignoreHTTPSErrors?: boolean;
+  transport?: ConnectionTransport;
+}
+
+export interface ConnectionTransport {
+  send: (message: string) => void;
+  close: () => void;
+  onmessage?: (message: string) => void;
+  onclose?: () => void;
 }
 
 export interface CDPSession extends EventEmitter {
@@ -2117,10 +2107,10 @@ export interface CoverageEntry {
 }
 
 /** Attaches Puppeteer to an existing Chromium instance */
-export function connect(options?: ConnectOptions): Promise<Browser>;
+export function connect(options?: ConnectOptions & BrowserOptions): Promise<Browser>;
 /** The default flags that Chromium will be launched with */
-export function defaultArgs(options?: DefaultArgsOptions): string[];
+export function defaultArgs(options?: ChromeArgOptions): string[];
 /** Path where Puppeteer expects to find bundled Chromium */
 export function executablePath(): string;
 /** The method launches a browser instance with given arguments. The browser will be closed when the parent node.js process is closed. */
-export function launch(options?: LaunchOptions): Promise<Browser>;
+export function launch(options?: LaunchOptions & ChromeArgOptions & BrowserOptions): Promise<Browser>;

--- a/types/puppeteer/index.d.ts
+++ b/types/puppeteer/index.d.ts
@@ -2033,7 +2033,6 @@ export interface BrowserOptions {
      */
     isMobile?: boolean;
     /**
-     *
      * Specifies if viewport supports touch events.
      * @default false
      */

--- a/types/puppeteer/index.d.ts
+++ b/types/puppeteer/index.d.ts
@@ -1624,7 +1624,7 @@ export interface Page extends EventEmitter, FrameBase {
 
   /**
    * Determines whether cache is enabled on the page.
-   * @param enabled Whether or not to enable cache on the page. Defaults to true.
+   * @param [enabled=true] Whether or not to enable cache on the page.
    */
   setCacheEnabled(enabled?: boolean): Promise<void>;
 

--- a/types/puppeteer/index.d.ts
+++ b/types/puppeteer/index.d.ts
@@ -1937,7 +1937,7 @@ export interface Target {
   url(): string;
 }
 
-export interface LaunchOptions extends Timeoutable {
+export interface LaunchOptions extends ChromeArgOptions, BrowserOptions, Timeoutable {
   /**
    * Path to a Chromium executable to run instead of bundled Chromium. If
    * executablePath is a relative path, then it is resolved relative to current
@@ -2052,7 +2052,7 @@ export interface BrowserOptions {
   slowMo?: number;
 }
 
-export interface ConnectOptions {
+export interface ConnectOptions extends BrowserOptions {
   /** A browser websocket endpoint to connect to. */
   browserWSEndpoint?: string;
   /**
@@ -2108,10 +2108,10 @@ export interface CoverageEntry {
 }
 
 /** Attaches Puppeteer to an existing Chromium instance */
-export function connect(options?: ConnectOptions & BrowserOptions): Promise<Browser>;
+export function connect(options?: ConnectOptions): Promise<Browser>;
 /** The default flags that Chromium will be launched with */
 export function defaultArgs(options?: ChromeArgOptions): string[];
 /** Path where Puppeteer expects to find bundled Chromium */
 export function executablePath(): string;
 /** The method launches a browser instance with given arguments. The browser will be closed when the parent node.js process is closed. */
-export function launch(options?: LaunchOptions & ChromeArgOptions & BrowserOptions): Promise<Browser>;
+export function launch(options?: LaunchOptions): Promise<Browser>;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
  - https://github.com/GoogleChrome/puppeteer/blob/v1.11.0/docs/api.md
  - https://github.com/GoogleChrome/puppeteer/blob/v1.11.0/lib/Launcher.js#L377
- [x] Increase the version number in the header if appropriate.

Please find below **the details of the changes**:
- Add `size` property to `Cookie` interface for [v1.11.0](https://github.com/GoogleChrome/puppeteer/blob/v1.11.0/docs/api.md#pagecookiesurls) compared to [v1.10.0](https://github.com/GoogleChrome/puppeteer/blob/v1.10.0/docs/api.md#pagecookiesurls)
- Update `DeleteCookie` interface as it [no longer has a `secure` property in v1.11.0](https://github.com/GoogleChrome/puppeteer/blob/v1.11.0/docs/api.md#pagedeletecookiecookies) compared to [v1.10.0](https://github.com/GoogleChrome/puppeteer/blob/v1.10.0/docs/api.md#pagedeletecookiecookies)
- Update `PDFOptions` "layout dimensions" properties (`width`, `height`, `margins`) which also allow numbers in [v1.11.0](https://github.com/GoogleChrome/puppeteer/blob/v1.11.0/docs/api.md#pagepdfoptions) compared to [v.1.10.0](https://github.com/GoogleChrome/puppeteer/blob/v1.10.0/docs/api.md#pagepdfoptions)
- Update `page.setContent` signature due to the new feature to [support `waitUntil` option](https://github.com/GoogleChrome/puppeteer/commit/927d0f443b832609c91ecd7bdbf1945a5d219c60)
- Change `enabled` parameter of `page.setCacheEnabled` to optional for [v1.11.0](https://github.com/GoogleChrome/puppeteer/blob/v1.11.0/docs/api.md#pagesetcacheenabledenabled) compared to [v1.10.0](https://github.com/GoogleChrome/puppeteer/blob/v1.10.0/docs/api.md#pagesetcacheenabledenabled)
- Fix `ConnectOptions` interface where `defaultViewport` and `slowMo` properties were missing + add experimental `transport` property introduced in [v1.11.0](https://github.com/GoogleChrome/puppeteer/blob/v1.11.0/docs/api.md#puppeteerconnectoptions)
- Rename the `DefaultArgsOptions` interface to `ChromeArgOptions` to align with [terminology used in source code](https://github.com/GoogleChrome/puppeteer/blob/v1.11.0/lib/Launcher.js#L377)
-  `ConnectOptions` now extends `BrowserOptions` interface and `LaunchOptions` extends `BrowserOptions` and `ChromeArgOptions` (based on [launch](https://github.com/GoogleChrome/puppeteer/blob/v1.11.0/lib/Puppeteer.js#L32) & [connect](https://github.com/GoogleChrome/puppeteer/blob/v1.11.0/lib/Puppeteer.js#L40) methods JSDoc and [api.md](https://github.com/GoogleChrome/puppeteer/blob/v1.11.0/docs/api.md#puppeteerconnectoptions))