### PR TITLE
AutoCompleteEditor options props are not constraining id to number type

### DIFF
--- a/types/react-data-grid/index.d.ts
+++ b/types/react-data-grid/index.d.ts
@@ -583,7 +583,7 @@ declare namespace AdazzleReactDataGrid {
   declare namespace AdazzleReactDataGridPlugins {
     interface AutoCompleteEditorProps {
         onCommit?: () => void;
-        options?: Array<{ id: number; title: string }>;
+        options?: Array<{ id: any; title: string }>;
         label?: any;
         value?: any;
         height?: number;


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [ X] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/adazzle/react-data-grid/blob/master/packages/react-data-grid-addons/src/editors/AutoCompleteEditor.js>

