### PR TITLE
fix [SerialPort]: Change `data` -> `delimiter` in ready-parser options

### DIFF
--- a/types/serialport/index.d.ts
+++ b/types/serialport/index.d.ts
@@ -103,7 +103,7 @@ declare namespace SerialPort {
 			constructor(options: {delimiter: string | Buffer | number[], encoding?: 'ascii'|'utf8'|'utf16le'|'ucs2'|'base64'|'binary'|'hex'});
 		}
 		class Ready extends Stream.Transform {
-			constructor(options: {data: string | Buffer | number[]});
+			constructor(options: {delimiter: string | Buffer | number[]});
 		}
 		class Regex extends Stream.Transform {
 			constructor(options: {regex: RegExp});

--- a/types/serialport/serialport-tests.ts
+++ b/types/serialport/serialport-tests.ts
@@ -107,7 +107,7 @@ function test_parsers() {
     const CCTalkParser = new SerialPort.parsers.CCTalk();
     const DelimiterParser = new SerialPort.parsers.Delimiter({ delimiter: Buffer.from('EOL') });
     const ReadlineParser = new SerialPort.parsers.Readline({ delimiter: '\r\n' });
-    const ReadyParser = new SerialPort.parsers.Ready({ data: 'READY' });
+    const ReadyParser = new SerialPort.parsers.Ready({ delimiter: 'READY' });
     const RegexParser = new SerialPort.parsers.Regex({regex: /.*/});
 
     port.pipe(ByteLengthParser);


### PR DESCRIPTION
See [the implementation](https://github.com/node-serialport/node-serialport/blob/8825d264436e91ca727a0c9b4d04a756479c4b1f/packages/parser-ready/ready.js#L22-L24) of the ready parser

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
