### PR TITLE
react: Remove useMutationEffect

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -835,17 +835,6 @@ declare namespace React {
     // TODO (TypeScript 3.0): <T extends unknown>
     function useRef<T>(initialValue: T|null): RefObject<T>;
     /**
-     * The signature is identical to `useEffect`, but it fires synchronously during the same phase that
-     * React performs its DOM mutations, before sibling components have been updated. Use this to perform
-     * custom DOM mutations.
-     *
-     * Prefer the standard `useEffect` when possible to avoid blocking visual updates.
-     *
-     * @version experimental
-     * @see https://reactjs.org/docs/hooks-reference.html#usemutationeffect
-     */
-    function useMutationEffect(effect: EffectCallback, inputs?: InputIdentityList): void;
-    /**
      * The signature is identical to `useEffect`, but it fires synchronously after all DOM mutations.
      * Use this to read layout from the DOM and synchronously re-render. Updates scheduled inside
      * `useLayoutEffect` will be flushed synchronously, before the browser has a chance to paint.

--- a/types/react/test/hooks.tsx
+++ b/types/react/test/hooks.tsx
@@ -95,11 +95,9 @@ function useEveryHook(ref: React.Ref<{ id: number }>|undefined): () => boolean {
     // $ExpectError
     React.useImperativeMethods(ref, () => ({}), [id]);
 
-    React.useMutationEffect(() => {
+    React.useLayoutEffect(() => {
         setState(1);
         setState(prevState => prevState - 1);
-    }, []);
-    React.useLayoutEffect(() => {
         didLayout.current = true;
     }, []);
     React.useEffect(() => {


### PR DESCRIPTION
It was deleted in https://github.com/facebook/react/pull/14336. Any of the current use cases are provided by `useLayoutEffect`, it wasn't useful for any potential new use cases because refs are not yet attached when it's called. It might be brought back if they find a way to make it useful.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
