### PR TITLE
react: Refactor Suspense to be augmentable

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -322,11 +322,8 @@ declare namespace React {
     const Children: ReactChildren;
     const Fragment: ExoticComponent<{ children?: ReactNode }>;
     const StrictMode: ExoticComponent<{ children?: ReactNode }>;
-    /**
-     * This feature is not yet available for server-side rendering.
-     * Suspense support will be added in a later release.
-     */
-    const Suspense: ExoticComponent<{
+
+    interface SuspenseProps {
         children?: ReactNode
 
         /** A fallback react tree to show when a Suspense child (like React.lazy) suspends */
@@ -338,7 +335,12 @@ declare namespace React {
          * Not implemented yet, requires unstable_ConcurrentMode
          */
         // maxDuration?: number
-    }>;
+    }
+    /**
+     * This feature is not yet available for server-side rendering.
+     * Suspense support will be added in a later release.
+     */
+    const Suspense: ExoticComponent<SuspenseProps>;
     const version: string;
 
     //

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -324,17 +324,17 @@ declare namespace React {
     const StrictMode: ExoticComponent<{ children?: ReactNode }>;
 
     interface SuspenseProps {
-        children?: ReactNode
+        children?: ReactNode;
 
         /** A fallback react tree to show when a Suspense child (like React.lazy) suspends */
-        fallback: NonNullable<ReactNode>|null
+        fallback: NonNullable<ReactNode>|null;
 
         // I tried looking at the code but I have no idea what it does.
         // https://github.com/facebook/react/issues/13206#issuecomment-432489986
         /**
          * Not implemented yet, requires unstable_ConcurrentMode
          */
-        // maxDuration?: number
+        // maxDuration?: number;
     }
     /**
      * This feature is not yet available for server-side rendering.


### PR DESCRIPTION
This is just so I can experiment with maxDuration locally by using a type augmentation.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Bonus: the module augmentation I'm trying to use:

```ts
import {} from 'react'
import {} from 'react-dom'

declare module 'react' {
  // This has an unstable_ prefix but only in 16.6; it's not unstable_ in 16.7
  export const ConcurrentMode: ExoticComponent<{ children?: React.ReactNode }>

  interface SuspenseProps {
    maxDuration?: number
  }
}

declare module 'react-dom' {
  interface ReactWork {
    // this is _almost_ a PromiseLike, but ReactWork does not allow chaining,
    // nor does it receive a second argument!
    then(callback: () => void): void
  }

  interface ReactRoot {
    /**
     * All ReactRoot renders are automatically in ConcurrentMode
     */
    render(children: React.ReactChild | React.ReactNodeArray, callback?: () => void): ReactWork
    unmount(callback?: () => void): ReactWork
    legacy_renderSubtreeIntoContainer(
      parent: React.Component<any, any> | null,
      children: React.ReactChild | React.ReactNodeArray,
      callback?: () => void
    ): ReactWork
    createBatch(): ReactBatch
  }

  interface ReactBatch extends ReactWork {
    render(children: React.ReactChild | React.ReactNodeArray): ReactWork
    commit(): void
  }

  interface RootOptions {
    hydrate?: boolean
  }

  // This has an unstable_ prefix but only in 16.6; it's not unstable_ in 16.7
  export function createRoot(el: ParentNode, options?: RootOptions): ReactRoot
}
```

---

PS: should I just submit them with the `unstable_` prefix as definitions? Or better wait until they're no longer `unstable_`? The `unstable_` being there is the only reason why I haven't done it yet.