### PR TITLE
Fix overly permissible first argument on styled-components

### DIFF
--- a/types/styled-components/index.d.ts
+++ b/types/styled-components/index.d.ts
@@ -73,7 +73,7 @@ export type SimpleInterpolation =
     | InterpolationValue
     | FlattenSimpleInterpolation;
 // must be an interface to be self-referential
-interface FlattenSimpleInterpolation
+export interface FlattenSimpleInterpolation
     extends ReadonlyArray<SimpleInterpolation> {}
 
 export type InterpolationFunction<P> = (props: P) => Interpolation<P>;
@@ -176,10 +176,9 @@ export interface ThemedStyledFunctionBase<
     (
         first:
             | TemplateStringsArray
-            | NonNullable<
-                  Interpolation<
-                      ThemedStyledProps<StyledComponentPropsWithRef<C> & O, T>
-                  >
+            | CSSObject
+            | InterpolationFunction<
+                  ThemedStyledProps<StyledComponentPropsWithRef<C> & O, T>
               >,
         ...rest: Array<
             Interpolation<
@@ -187,17 +186,12 @@ export interface ThemedStyledFunctionBase<
             >
         >
     ): StyledComponent<C, T, O, A>;
-    // at least the first argument is required, whatever it is
     <U extends object>(
         first:
             | TemplateStringsArray
-            | NonNullable<
-                  Interpolation<
-                      ThemedStyledProps<
-                          StyledComponentPropsWithRef<C> & O & U,
-                          T
-                      >
-                  >
+            | CSSObject
+            | InterpolationFunction<
+                  ThemedStyledProps<StyledComponentPropsWithRef<C> & O & U, T>
               >,
         ...rest: Array<
             Interpolation<
@@ -288,19 +282,21 @@ export type StyledInterface = ThemedStyledInterface<DefaultTheme>;
 
 export interface BaseThemedCssFunction<T extends object> {
     (
-        first: TemplateStringsArray | NonNullable<SimpleInterpolation>,
+        first: TemplateStringsArray | CSSObject,
         ...interpolations: SimpleInterpolation[]
     ): FlattenSimpleInterpolation;
     (
         first:
             | TemplateStringsArray
-            | NonNullable<Interpolation<ThemedStyledProps<{}, T>>>,
+            | CSSObject
+            | InterpolationFunction<ThemedStyledProps<{}, T>>,
         ...interpolations: Array<Interpolation<ThemedStyledProps<{}, T>>>
     ): FlattenInterpolation<ThemedStyledProps<{}, T>>;
     <P extends object>(
         first:
             | TemplateStringsArray
-            | NonNullable<Interpolation<ThemedStyledProps<P, T>>>,
+            | CSSObject
+            | InterpolationFunction<ThemedStyledProps<P, T>>,
         ...interpolations: Array<Interpolation<ThemedStyledProps<P, T>>>
     ): FlattenInterpolation<ThemedStyledProps<P, T>>;
 }
@@ -333,7 +329,8 @@ export interface ThemedStyledComponentsModule<
     createGlobalStyle<P extends object = {}>(
         first:
             | TemplateStringsArray
-            | NonNullable<Interpolation<ThemedStyledProps<P, T>>>,
+            | CSSObject
+            | InterpolationFunction<ThemedStyledProps<P, T>>,
         ...interpolations: Array<Interpolation<ThemedStyledProps<P, T>>>
     ): GlobalStyleComponent<P, T>;
 
@@ -405,7 +402,8 @@ export function keyframes(
 export function createGlobalStyle<P extends object = {}>(
     first:
         | TemplateStringsArray
-        | NonNullable<Interpolation<ThemedStyledProps<P, DefaultTheme>>>,
+        | CSSObject
+        | InterpolationFunction<ThemedStyledProps<P, DefaultTheme>>,
     ...interpolations: Array<Interpolation<ThemedStyledProps<P, DefaultTheme>>>
 ): GlobalStyleComponent<P, DefaultTheme>;
 
@@ -468,7 +466,7 @@ export class StyleSheetManager extends React.Component<
  */
 // ONLY string literals and inline invocations of css`` are supported, anything else crashes the plugin
 export type CSSProp<T = AnyIfEmpty<DefaultTheme>> =
-      string |
-      FlattenInterpolation<ThemeProps<T>>;
+    | string
+    | FlattenInterpolation<ThemeProps<T>>;
 
 export default styled;


### PR DESCRIPTION
Both `styled()` and `createGlobalStyle` are built on top of the `css` helper, and it only _specifically_ has support for function or object first argument. If the first argument is an array... such as the result of `css` itself, `css` will think it is being invoked as a template and will only consume as many elements past the first as there are interpolations (the `...rest`), which will almost certainly result in broken output and invalid syntax.

I shipped this bug into production a few days ago because TypeScript didn't catch it and it's my fault 😭

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
