### PR TITLE
Add vfile message

### DIFF
--- a/types/vfile-message/index.d.ts
+++ b/types/vfile-message/index.d.ts
@@ -9,6 +9,10 @@
 import * as Unist from 'unist';
 
 declare namespace vfileMessage {
+    interface AnyNode extends Unist.Node{
+        [key: string]: unknown
+    }
+
     /**
      * Create a virtual message.
      */
@@ -21,7 +25,7 @@ declare namespace vfileMessage {
          * @param position Place at which the message occurred in a file (`Node`, `Position`, or `Point`, optional).
          * @param origin Place in code the message originates from (`string`, optional).
          */
-        (reason: string | Error, position?: Unist.Node | Unist.Position | Unist.Point, origin?: string): VFileMessage;
+        (reason: string | Error, position?: AnyNode | Unist.Position | Unist.Point, origin?: string): VFileMessage;
         /**
          * Category of message.
          */

--- a/types/vfile-message/index.d.ts
+++ b/types/vfile-message/index.d.ts
@@ -1,0 +1,74 @@
+// Type definitions for vfile-message 1.0
+// Project: https://github.com/vfile/vfile-message#readme
+// Definitions by: Junyoung Choi <https://github.com/rokt33r>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types='node' />
+
+import * as Unist from 'unist';
+
+declare namespace vfileMessage {
+    /**
+     * Create a virtual message.
+     */
+    interface VFileMessage extends Error {
+        /**
+         * Constructor of a message for `reason` at `position` from `origin`.
+         * When an error is passed in as `reason`, copies the `stack`.
+         *
+         * @param reason Reason for message (`string` or `Error`). Uses the stack and message of the error if given.
+         * @param position Place at which the message occurred in a file (`Node`, `Position`, or `Point`, optional).
+         * @param origin Place in code the message originates from (`string`, optional).
+         */
+        (reason: string | Error, position?: Unist.Node | Unist.Position | Unist.Point, origin?: string): VFileMessage
+        /**
+         * Category of message.
+         */
+        ruleId: string | null;
+        /**
+         * Reason for message.
+         */
+        reason: string;
+        /**
+         * Starting line of error.
+         */
+        line: number | null;
+        /**
+         * Starting column of error.
+         */
+        column: number | null;
+        /**
+         * Full range information, when available.
+         * Has start and end properties, both set to an object with line and column, set to number?.
+         */
+        location: Unist.Position;
+        /**
+         * Namespace of warning.
+         */
+        source: string | null;
+        /**
+         * If true, marks associated file as no longer processable.
+         */
+        fatal?: boolean | null;
+        /**
+         * You may add a file property with a path of a file (used throughout the VFile ecosystem).
+         */
+        file?: string;
+        /**
+         * You may add a note property with a long form description of the message (supported by vfile-reporter).
+         */
+        note?: string;
+        /**
+         * You may add a url property with a link to documentation for the message.
+         */
+        url?: string;
+        /**
+         * It’s OK to store custom data directly on the VMessage, some of those are handled by utilities.
+         */
+        [key: string]: unknown;
+    }
+}
+
+declare const vfileMessage: vfileMessage.VFileMessage;
+
+export = vfileMessage;

--- a/types/vfile-message/index.d.ts
+++ b/types/vfile-message/index.d.ts
@@ -9,8 +9,8 @@
 import * as Unist from 'unist';
 
 declare namespace vfileMessage {
-    interface AnyNode extends Unist.Node{
-        [key: string]: unknown
+    interface AnyNode extends Unist.Node {
+        [key: string]: unknown;
     }
 
     /**

--- a/types/vfile-message/index.d.ts
+++ b/types/vfile-message/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/vfile/vfile-message#readme
 // Definitions by: Junyoung Choi <https://github.com/rokt33r>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.0
 
 /// <reference types='node' />
 
@@ -20,7 +21,7 @@ declare namespace vfileMessage {
          * @param position Place at which the message occurred in a file (`Node`, `Position`, or `Point`, optional).
          * @param origin Place in code the message originates from (`string`, optional).
          */
-        (reason: string | Error, position?: Unist.Node | Unist.Position | Unist.Point, origin?: string): VFileMessage
+        (reason: string | Error, position?: Unist.Node | Unist.Position | Unist.Point, origin?: string): VFileMessage;
         /**
          * Category of message.
          */

--- a/types/vfile-message/tsconfig.json
+++ b/types/vfile-message/tsconfig.json
@@ -7,6 +7,7 @@
         "noImplicitAny": true,
         "noImplicitThis": true,
         "strictNullChecks": true,
+        "strictFunctionTypes": true,
         "baseUrl": "../",
         "typeRoots": [
             "../"

--- a/types/vfile-message/tsconfig.json
+++ b/types/vfile-message/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "vfile-message-tests.ts"
+    ]
+}

--- a/types/vfile-message/tslint.json
+++ b/types/vfile-message/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/vfile-message/vfile-message-tests.ts
+++ b/types/vfile-message/vfile-message-tests.ts
@@ -1,0 +1,32 @@
+import vfileMessage = require('vfile-message');
+
+const message = vfileMessage('Error!');
+vfileMessage(new Error());
+vfileMessage('Error!', {
+  type: 'random node'
+});
+vfileMessage('Error!', {
+  start: {
+    line: 1,
+    column: 1
+  },
+  end: {
+    line: 1,
+    column: 1
+  }
+});
+vfileMessage('Error!', {
+  line: 1,
+  column: 1
+});
+vfileMessage('Error!', undefined, 'test');
+
+message.file = '';
+message.name = '';
+message.reason = '';
+message.message = '';
+message.stack = '';
+message.fatal = null;
+message.fatal = true;
+message.column = 1;
+message.line = 1;

--- a/types/vfile/index.d.ts
+++ b/types/vfile/index.d.ts
@@ -13,11 +13,6 @@ import * as vfileMessage from 'vfile-message';
 declare namespace vfile {
     type VFileContents = string | Buffer;
 
-    interface NodeWithPosition extends Unist.Node {
-        position: Unist.Position;
-        [key: string]: any;
-    }
-
     interface VFileOptions {
         contents?: VFileContents;
         path?: string;
@@ -103,7 +98,7 @@ declare namespace vfile {
          * @param position Place at which the message occurred in `vfile`.
          * @param ruleId Category of message.
          */
-        message: (reason: string, position?: Unist.Point | Unist.Position | NodeWithPosition, ruleId?: string) => vfileMessage.VFileMessage;
+        message: (reason: string, position?: Unist.Point | Unist.Position | vfileMessage.AnyNode, ruleId?: string) => vfileMessage.VFileMessage;
         /**
          * Associates a fatal message with the file, then immediately throws it.
          * Note: fatal errors mean a file is no longer processable.
@@ -112,7 +107,7 @@ declare namespace vfile {
          * @param position Place at which the message occurred in `vfile`.
          * @param ruleId Category of message.
          */
-        fail: (reason: string, position?: Unist.Point | Unist.Position | NodeWithPosition, ruleId?: string) => never;
+        fail: (reason: string, position?: Unist.Point | Unist.Position | vfileMessage.AnyNode, ruleId?: string) => never;
         /**
          * Associates an informational message with the file, where `fatal` is set to `null`.
          * Calls `message()` internally.
@@ -120,7 +115,7 @@ declare namespace vfile {
          * @param position Place at which the message occurred in `vfile`.
          * @param ruleId Category of message.
          */
-        info: (reason: string, position?: Unist.Point | Unist.Position | NodeWithPosition, ruleId?: string) => vfileMessage.VFileMessage;
+        info: (reason: string, position?: Unist.Point | Unist.Position | vfileMessage.AnyNode, ruleId?: string) => vfileMessage.VFileMessage;
     }
 }
 

--- a/types/vfile/index.d.ts
+++ b/types/vfile/index.d.ts
@@ -30,47 +30,11 @@ declare namespace vfile {
         [key: string]: any;
     }
 
-    /**
-     * Associates a message with the file for `reason` at `position`.
-     * When an error is passed in as `reason`, copies the stack.
-     * Each message has a `fatal` property which by default is set to `false` (ie. `warning`).
-     * @param reason Reason for message. Uses the stack and message of the error if given.
-     * @param position Place at which the message occurred in `vfile`.
-     * @param ruleId Category of message.
-     */
-    type Message = (reason: string, position?: Unist.Point | Unist.Position | NodeWithPosition, ruleId?: string) => vfileMessage.VFileMessage;
-    /**
-     * Associates a fatal message with the file, then immediately throws it.
-     * Note: fatal errors mean a file is no longer processable.
-     * Calls `message()` internally.
-     * @param reason Reason for message. Uses the stack and message of the error if given.
-     * @param position Place at which the message occurred in `vfile`.
-     * @param ruleId Category of message.
-     */
-    type Fail = (reason: string, position?: Unist.Point | Unist.Position | NodeWithPosition, ruleId?: string) => never;
-    /**
-     * Associates an informational message with the file, where `fatal` is set to `null`.
-     * Calls `message()` internally.
-     * @param reason Reason for message. Uses the stack and message of the error if given.
-     * @param position Place at which the message occurred in `vfile`.
-     * @param ruleId Category of message.
-     */
-    type Info = (reason: string, position?: Unist.Point | Unist.Position | NodeWithPosition, ruleId?: string) => vfileMessage.VFileMessage;
-
-    /**
-     * Convert contents of `vfile` to string.
-     * @param encoding If `contents` is a buffer, `encoding` is used to stringify buffers (default: `'utf8'`).
-     */
-    type ToString = (encoding?: BufferEncoding) => string;
-
     interface VFile {
         /**
          * @param options If `options` is `string` or `Buffer`, treats it as `{contents: options}`. If `options` is a `VFile`, returns it. All other options are set on the newly created `vfile`.
          */
         <F extends VFile>(input?: VFileContents | F | VFileOptions): F;
-        message: Message;
-        fail: Fail;
-        info: Info;
         /**
          * List of file-paths the file moved between.
          */
@@ -119,7 +83,37 @@ declare namespace vfile {
          * Defaults to `process.cwd()`.
          */
         cwd: string;
-        toString: ToString;
+        /**
+         * Convert contents of `vfile` to string.
+         * @param encoding If `contents` is a buffer, `encoding` is used to stringify buffers (default: `'utf8'`).
+         */
+        toString: (encoding?: BufferEncoding) => string;
+        /**
+         * Associates a message with the file for `reason` at `position`.
+         * When an error is passed in as `reason`, copies the stack.
+         * Each message has a `fatal` property which by default is set to `false` (ie. `warning`).
+         * @param reason Reason for message. Uses the stack and message of the error if given.
+         * @param position Place at which the message occurred in `vfile`.
+         * @param ruleId Category of message.
+         */
+        message: (reason: string, position?: Unist.Point | Unist.Position | NodeWithPosition, ruleId?: string) => vfileMessage.VFileMessage;
+        /**
+         * Associates a fatal message with the file, then immediately throws it.
+         * Note: fatal errors mean a file is no longer processable.
+         * Calls `message()` internally.
+         * @param reason Reason for message. Uses the stack and message of the error if given.
+         * @param position Place at which the message occurred in `vfile`.
+         * @param ruleId Category of message.
+         */
+        fail: (reason: string, position?: Unist.Point | Unist.Position | NodeWithPosition, ruleId?: string) => never;
+        /**
+         * Associates an informational message with the file, where `fatal` is set to `null`.
+         * Calls `message()` internally.
+         * @param reason Reason for message. Uses the stack and message of the error if given.
+         * @param position Place at which the message occurred in `vfile`.
+         * @param ruleId Category of message.
+         */
+        info: (reason: string, position?: Unist.Point | Unist.Position | NodeWithPosition, ruleId?: string) => vfileMessage.VFileMessage;
     }
 }
 

--- a/types/vfile/index.d.ts
+++ b/types/vfile/index.d.ts
@@ -32,6 +32,13 @@ declare namespace vfile {
 
     interface VFile {
         /**
+         * Create a new virtual file. If `options` is `string` or `Buffer`, treats it as `{contents: options}`.
+         * If `options` is a `VFile`, returns it. All other options are set on the newly created `vfile`.
+         *
+         * Path related properties are set in the following order (least specific to most specific): `history`, `path`, `basename`, `stem`, `extname`, `dirname`.
+         *
+         * It’s not possible to set either `dirname` or `extname` without setting either `history`, `path`, `basename`, or `stem` as well.
+         *
          * @param options If `options` is `string` or `Buffer`, treats it as `{contents: options}`. If `options` is a `VFile`, returns it. All other options are set on the newly created `vfile`.
          */
         <F extends VFile>(input?: VFileContents | F | VFileOptions): F;
@@ -117,11 +124,6 @@ declare namespace vfile {
     }
 }
 
-/**
- * Create a new virtual file.
- * Path related properties are set in the following order (least specific to most specific): `history`, `path`, `basename`, `stem`, `extname`, `dirname`.
- * It’s not possible to set either `dirname` or `extname` without setting either `history`, `path`, `basename`, or `stem` as well.
- */
 declare const vfile: vfile.VFile;
 
 export = vfile;

--- a/types/vfile/index.d.ts
+++ b/types/vfile/index.d.ts
@@ -55,7 +55,7 @@ declare namespace vfile {
      * @param position Place at which the message occurred in `vfile`.
      * @param ruleId Category of message.
      */
-    type Info = (reason: string, position?: Unist.Point | Unist.Position | NodeWithPosition, ruleId?: string) => void;
+    type Info = (reason: string, position?: Unist.Point | Unist.Position | NodeWithPosition, ruleId?: string) => vfileMessage.VFileMessage;
 
     /**
      * Convert contents of `vfile` to string.

--- a/types/vfile/index.d.ts
+++ b/types/vfile/index.d.ts
@@ -8,6 +8,7 @@
 /// <reference types='node' />
 
 import * as Unist from 'unist';
+import * as vfileMessage from 'vfile-message';
 
 declare namespace vfile {
     type VFileContents = string | Buffer;
@@ -30,45 +31,6 @@ declare namespace vfile {
     }
 
     /**
-     * File-related message describing something at certain position.
-     */
-    interface VFileMessage {
-        /**
-         * File-path, when the message was triggered.
-         */
-        file: string;
-        /**
-         * Category of message.
-         */
-        ruleId: string | null;
-        /**
-         * Reason for message.
-         */
-        reason: string;
-        /**
-         * Starting line of error.
-         */
-        line: number | null;
-        /**
-         * Starting column of error.
-         */
-        column: number | null;
-        /**
-         * Full range information, when available.
-         * Has start and end properties, both set to an object with line and column, set to number?.
-         */
-        location: Unist.Position;
-        /**
-         * Namespace of warning.
-         */
-        source: string | null;
-        /**
-         * If true, marks associated file as no longer processable.
-         */
-        fatal?: boolean | null;
-    }
-
-    /**
      * Associates a message with the file for `reason` at `position`.
      * When an error is passed in as `reason`, copies the stack.
      * Each message has a `fatal` property which by default is set to `false` (ie. `warning`).
@@ -76,7 +38,7 @@ declare namespace vfile {
      * @param position Place at which the message occurred in `vfile`.
      * @param ruleId Category of message.
      */
-    type Message = (reason: string, position?: Unist.Point | Unist.Position | NodeWithPosition, ruleId?: string) => VFileMessage;
+    type Message = (reason: string, position?: Unist.Point | Unist.Position | NodeWithPosition, ruleId?: string) => vfileMessage.VFileMessage;
     /**
      * Associates a fatal message with the file, then immediately throws it.
      * Note: fatal errors mean a file is no longer processable.
@@ -121,7 +83,7 @@ declare namespace vfile {
         /**
          * List of messages associated with the file.
          */
-        messages: VFileMessage[];
+        messages: vfileMessage.VFileMessage[];
         /**
          * Raw value.
          */

--- a/types/vfile/vfile-tests.ts
+++ b/types/vfile/vfile-tests.ts
@@ -40,6 +40,10 @@ file.message('test', {
 
 file.message('test', { start: 'invalid point' }); // $ExpectError
 
+file.fail('test');
+
+const infoMessage: vfileMessage.VFileMessage = file.info('test');
+
 // Using `data` prop
 interface CustomData {
     message: string;

--- a/types/vfile/vfile-tests.ts
+++ b/types/vfile/vfile-tests.ts
@@ -1,5 +1,6 @@
 import vfile = require('vfile');
 import * as Unist from 'unist';
+import vfileMessage = require('vfile-message');
 
 // Instantiation
 const file: vfile.VFile = vfile();
@@ -15,24 +16,7 @@ file.dirname = '~';
 file.extname = '.md';
 file.basename = 'test.text';
 file.history = ['~/test.txt']; // => ['~/example.txt', '~/example.md', '~/index.text']
-file.messages = [{
-    file: '~/test.txt',
-    ruleId: '',
-    reason: '',
-    line: 1,
-    column: 1,
-    location: {
-        start: {
-            line: 1,
-            column: 1,
-        },
-        end: {
-            line: 1,
-            column: 1,
-        }
-    },
-    source: ''
-}];
+file.messages = [vfileMessage('random error')];
 
 const startPoint: Unist.Point = {
     line: 1,
@@ -46,7 +30,7 @@ const position: Unist.Position = {
     },
 };
 
-file.message('test', startPoint);
+const message: vfileMessage.VFileMessage = file.message('test', startPoint, 'test origin');
 file.message('test', position);
 file.message('test', {
     type: 'ramdom node',


### PR DESCRIPTION
I added type definitions for vfile-message and updated vfile too.

I did... :
- Move VFileMessage type definition in `vfile` to `vfile-message`.
- Fix return type of `VFile#info` method.
- Introduce `AnyNode` type to make `vfile-message` constructor can takes any nodes for `position`.

---
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/vfile/vfile#vfileinforeason-position-origin
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
