### PR TITLE
Extend node-forge defs for pki.CAStore handling

### DIFF
--- a/types/node-forge/index.d.ts
+++ b/types/node-forge/index.d.ts
@@ -247,7 +247,7 @@ declare module "node-forge" {
         }
 
         interface CAStore {
-            addCertificate(cert: Certificate | string): any;
+            addCertificate(cert: Certificate | string): void;
             hasCertificate(cert: Certificate | string): boolean;
             removeCertificate(cert: Certificate | string): Certificate | null;
             listAllCertificates(): pki.Certificate[];

--- a/types/node-forge/index.d.ts
+++ b/types/node-forge/index.d.ts
@@ -67,6 +67,8 @@ declare module "node-forge" {
         function privateKeyFromPem(pem: PEM): PrivateKey;
         function certificateToPem(cert: Certificate, maxline?: number): PEM;
         function certificateFromPem(pem: PEM, computeHash?: boolean, strict?: boolean): Certificate;
+        function createCaStore(): CAStore;
+        function verifyCertificateChain(caStore: CAStore, chain: Certificate[], customVerifyCallback?: (verified: boolean | string, depth: number, chain: Certificate[]) => boolean): boolean;
 
         interface oids {
             [key: string]: string;
@@ -202,7 +204,7 @@ declare module "node-forge" {
              */
             setSubject(attrs: CertificateField[], uniqueId?: string): void;
             /**
-              * Sets the subject of this certificate.
+              * Sets the issuer of this certificate.
               *
               * @param attrs the array of subject attributes to use.
               * @param uniqueId an optional a unique ID to use.
@@ -242,6 +244,15 @@ declare module "node-forge" {
              */
             verify(child: Certificate): boolean;
 
+        }
+
+        interface CAStore {
+            addCertificate(cert: Certificate | string): any;
+            hasCertificate(cert: Certificate | string): boolean;
+            removeCertificate(cert: Certificate | string): Certificate | null;
+            listAllCertificates(): pki.Certificate[];
+            getIssuer(subject: Certificate): Certificate | null;
+            getBySubject(subject: string): Certificate | null;
         }
 
         function certificateFromAsn1(obj: asn1.Asn1, computeHash?: boolean): Certificate;

--- a/types/node-forge/node-forge-tests.ts
+++ b/types/node-forge/node-forge-tests.ts
@@ -203,3 +203,22 @@ if (forge.util.fillString('1', 5) !== '11111') throw Error('forge.util.fillStrin
         throw Error("rsa signature verification fail");
     }
 }
+
+{
+    const emptyStore = forge.pki.createCaStore();
+
+    const certificate = forge.pki.createCertificate();
+    const pem = forge.pki.certificateToPem(certificate);
+
+    const caStore = forge.pki.createCaStore();
+    caStore.addCertificate(certificate);
+    caStore.removeCertificate(certificate);
+
+    caStore.listAllCertificates();
+
+    caStore.removeCertificate(certificate);
+
+    forge.pki.verifyCertificateChain(caStore, [certificate], (verified, depth, chain) => {
+        return true;
+    });
+}


### PR DESCRIPTION
Namely:
- `pki.createCaStore()`
- `pki.verifyCertificateChain()`
- interface `CAStore`

... and fix a copy&paste error in the APIDoc of `pki.Certificate.setIssuer()`.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/digitalbazaar/forge/blob/8e54eca094b47a1b7ab62de45f8c3748a8bf9b15/lib/x509.js#L2708
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.