### PR TITLE
@feathersjs/feathers: make default export type generic

### DIFF
--- a/types/feathersjs__feathers/feathersjs__feathers-tests.ts
+++ b/types/feathersjs__feathers/feathersjs__feathers-tests.ts
@@ -9,7 +9,7 @@ interface Services {
     users: User;
 }
 
-const app = feathers() as Application<Services>;
+const app = feathers<Services>();
 
 app.service('users').get(0).then(u => {
     const user: User = u;

--- a/types/feathersjs__feathers/index.d.ts
+++ b/types/feathersjs__feathers/index.d.ts
@@ -12,6 +12,7 @@
 import { EventEmitter } from 'events';
 import * as self from '@feathersjs/feathers';
 
+// tslint:disable-next-line no-unnecessary-generics
 declare const feathers: (<T = any>() => Application<T>) & typeof self;
 export default feathers;
 

--- a/types/feathersjs__feathers/index.d.ts
+++ b/types/feathersjs__feathers/index.d.ts
@@ -12,7 +12,7 @@
 import { EventEmitter } from 'events';
 import * as self from '@feathersjs/feathers';
 
-declare const feathers: (() => Application<object>) & typeof self;
+declare const feathers: (<T = any>() => Application<T>) & typeof self;
 export default feathers;
 
 export const version: string;


### PR DESCRIPTION
`Application<object>` was too restrictive. Using a generic was suggested in #29565 .
Fixes https://github.com/feathers-plus/generator-feathers-plus/pull/133