### PR TITLE
local should be optional as per the Alt doc.

### DIFF
--- a/types/alt/index.d.ts
+++ b/types/alt/index.d.ts
@@ -54,7 +54,7 @@ declare namespace AltJS {
   export type Source = {[name:string]: () => SourceModel<any>};
 
   export interface SourceModel<S> {
-    local(state:any, ...args: any[]):any;
+    local?(state:any, ...args: any[]):any;
     remote(state:any, ...args: any[]):Promise<S>;
     shouldFetch?(fetchFn:(...args:Array<any>) => boolean):void;
     loading?:(args:any) => void;


### PR DESCRIPTION
As per the http://alt.js.org/docs/async/ document, the local function in the SourceModel Interface should be optional.