### PR TITLE
Added missing blendStroke property to PieProps

### DIFF
--- a/types/recharts/index.d.ts
+++ b/types/recharts/index.d.ts
@@ -447,6 +447,7 @@ export interface PieProps extends EventAttributes, Partial<PresentationAttribute
     } | React.ReactElement<any> | ContentRenderer<any> | boolean;
     activeShape?: object | ContentRenderer<any> | React.ReactElement<any>;
     activeIndex?: number | number[];
+    blendStroke?: boolean;
 }
 
 export class Pie extends React.Component<PieProps> { }


### PR DESCRIPTION
blendStroke property exists in the pie component, yet is not recognized by the ts definition

blendStroke property:
https://github.com/recharts/recharts/pull/1436/files