### PR TITLE
[Marked] Add inlineLexer function to definitions

### DIFF
--- a/types/marked/index.d.ts
+++ b/types/marked/index.d.ts
@@ -1,8 +1,9 @@
-// Type definitions for Marked 0.4
+// Type definitions for Marked 0.5
 // Project: https://github.com/markedjs/marked
 // Definitions by: William Orr <https://github.com/worr>
 //                 BendingBender <https://github.com/BendingBender>
 //                 CrossR <https://github.com/CrossR>
+//                 Mike Wickett <https://github.com/mwickett>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 export as namespace marked;
@@ -33,6 +34,15 @@ declare namespace marked {
      * @param options Hash of options
      */
     function lexer(src: string, options?: MarkedOptions): TokensList;
+
+    /**
+     * @param src String of markdown source to be compiled
+     * @param links Array of links
+     * @param options Hash of options
+     * @return String of compiled HTML
+     */
+
+    function inlineLexer(src: string, links: string[], options?: MarkedOptions): string;
 
     /**
      * Compiles markdown to HTML.


### PR DESCRIPTION
Please fill in this template.

- [x ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

We use the `inlineLexer` method and I noticed it wasn't included in the definitions, so this adds it. I think it's fairly straightforward, but please let me know if I'm missing anything.

Unfortunately the `marked` docs aren't comprehensive and so this method isn't documented anywhere.
