### PR TITLE
[jest] add type inference

### DIFF
--- a/types/jest/jest-tests.ts
+++ b/types/jest/jest-tests.ts
@@ -253,12 +253,25 @@ jest
 
 /* Mocks and spies */
 
-const mock1: jest.Mock = jest.fn();
-const mock2: jest.Mock<undefined> = jest.fn<undefined>(() => undefined);
-const mock3: jest.Mock<string> = jest.fn(() => "abc");
-const mock4: jest.Mock<"abc"> = jest.fn((): "abc" => "abc");
-const mock5: jest.Mock<string> = jest.fn((...args: string[]) => args.join(""));
-const mock6: jest.Mock = jest.fn((arg: {}) => arg);
+// $ExpectType Mock<{}, any[]>
+const mock1 = jest.fn();
+// $ExpectType Mock<undefined, []>
+const mock2 = jest.fn(() => undefined);
+// $ExpectType Mock<string, []>
+const mock3 = jest.fn(() => "abc");
+// $ExpectType Mock<"abc", []>
+const mock4 = jest.fn((): "abc" => "abc");
+// $ExpectType Mock<string, string[]>
+const mock5 = jest.fn((...args: string[]) => args.join(""));
+// $ExpectType Mock<{}, [{}]>
+const mock6 = jest.fn((arg: {}) => arg);
+// $ExpectType Mock<number, [number]>
+const mock7 = jest.fn((arg: number) => arg);
+
+// $ExpectError
+mock7('abc');
+// $ExpectError
+mock7.mockImplementation((arg: string) => 1);
 
 const genMockModule1: {} = jest.genMockFromModule("moduleName");
 const genMockModule2: { a: "b" } = jest.genMockFromModule<{ a: "b" }>("moduleName");
@@ -272,8 +285,8 @@ if (jest.isMockFunction(maybeMock)) {
 }
 
 const mockName: string = jest.fn().getMockName();
-const mockContextVoid: jest.MockContext<void> = jest.fn<void>().mock;
-const mockContextString: jest.MockContext<string> = jest.fn(() => "").mock;
+const mockContextVoid = jest.fn().mock;
+const mockContextString = jest.fn(() => "").mock;
 
 jest.fn().mockClear();
 
@@ -288,9 +301,20 @@ const spiedTarget = {
     }
 };
 
+class SpiedTargetClass {
+    private _value = 3;
+    get value() {
+        return this._value;
+    }
+    set value(value) {
+        this._value = value;
+    }
+}
+const spiedTarget2 = new SpiedTargetClass();
+
 const spy1 = jest.spyOn(spiedTarget, "returnsVoid");
 const spy2 = jest.spyOn(spiedTarget, "returnsVoid", "get");
-const spy3 = jest.spyOn(spiedTarget, "returnsString", "set");
+const spy3 = jest.spyOn(spiedTarget, "returnsString");
 const spy1Name: string = spy1.getMockName();
 
 const spy2Calls: any[][] = spy2.mock.calls;
@@ -298,9 +322,10 @@ const spy2Calls: any[][] = spy2.mock.calls;
 spy2.mockClear();
 spy2.mockReset();
 
-const spy3Mock: jest.Mock<() => string> = spy3
+const spy3Mock = spy3
     .mockImplementation(() => "")
     .mockImplementation()
+    // $ExpectError
     .mockImplementation((arg: {}) => arg)
     .mockImplementation((...args: string[]) => args.join(""))
     .mockImplementationOnce(() => "")
@@ -313,10 +338,17 @@ const spy3Mock: jest.Mock<() => string> = spy3
     .mockRejectedValue("value")
     .mockRejectedValueOnce("value");
 
-let spy4: jest.SpyInstance;
-
+let spy4;
 spy4 = jest.spyOn(spiedTarget, "returnsString");
 spy4.mockRestore();
+
+// $ExpectType SpyInstance<number, []>
+const spy5 = jest.spyOn(spiedTarget2, "value", "get");
+// $ExpectError
+spy5.mockReturnValue('5');
+
+// $ExpectType SpyInstance<void, [number]>
+const spy6 = jest.spyOn(spiedTarget2, "value", "set");
 
 /* Snapshot serialization */
 

--- a/types/jest/tsconfig.json
+++ b/types/jest/tsconfig.json
@@ -13,10 +13,12 @@
         "typeRoots": [
             "../"
         ],
+        "target": "es5",
         "types": [],
         "noEmit": true,
         "forceConsistentCasingInFileNames": true
     },
+
     "files": [
         "index.d.ts",
         "jest-tests.ts"


### PR DESCRIPTION
Jest typings should use latest typescript features to infer mock types. 

Tests in general should be using typed mocks instead of 'any' values.
With that in mind, I removed default values (e.g. T = {}) to force people to use the real types.

It may be a breaking change when explicitly declaring types.

before:
```
let spy4: jest.SpyInstance;
spy4 = jest.spyOn(spiedTarget, "returnsString");
```
after:
```
let spy4; // let spy4: jest.SpyInstance<string, []>; 
spy4 = jest.spyOn(spiedTarget, "returnsString");
```
----

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: private project
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
