### PR TITLE
puppeteer: allow disabling default viewport using null

### DIFF
--- a/types/puppeteer/index.d.ts
+++ b/types/puppeteer/index.d.ts
@@ -2044,7 +2044,7 @@ export interface BrowserOptions {
      * @default false
      */
     isLandscape?: boolean;
-  };
+  } | null;
   /**
    * Slows down Puppeteer operations by the specified amount of milliseconds.
    * Useful so that you can see what is going on.

--- a/types/puppeteer/puppeteer-tests.ts
+++ b/types/puppeteer/puppeteer-tests.ts
@@ -200,6 +200,13 @@ puppeteer.launch().then(async browser => {
   browser.close();
 })();
 
+// Launching with default viewport disabled
+(async () => {
+  await puppeteer.launch({
+    defaultViewport: null
+  });
+})();
+
 // Test v0.12 features
 (async () => {
   const browser = await puppeteer.launch({


### PR DESCRIPTION
`null` disables the default viewport (verified locally). comment already mentions that, but it wasn't accepted in the type.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/GoogleChrome/puppeteer/blob/v1.11.0/test/puppeteer.spec.js#L283
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.