### PR TITLE
Add import function to MathJS types

### DIFF
--- a/types/mathjs/index.d.ts
+++ b/types/mathjs/index.d.ts
@@ -3,11 +3,11 @@
 // Definitions by: Ilya Shestakov <https://github.com/siavol>,
 //                  Andy Patterson <https://github.com/andnp>,
 //                  Brad Besserman <https://github.com/bradbesserman>
+//                  Pawel Krol <https://github.com/pawkrol>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
 import { Decimal } from "decimal.js";
-import { ImportOptions } from "mathjs";
 
 declare const math: math.MathJsStatic;
 export as namespace math;

--- a/types/mathjs/index.d.ts
+++ b/types/mathjs/index.d.ts
@@ -2575,16 +2575,20 @@ declare namespace math {
 
         /**
          * Import functions from an object or a module
+         * To avoid errors when using one of the imported functions extend module like this:
+         *
+         * @example
+         * // imported_math_functions.ts
+         * declare module 'mathjs' {
+         *      interface MathJsStatic {
+         *          hello(a: number): number;
+         *      }
+         * }
+         *
          * @param object An object with functions to be imported.
          * @param options An object with import options.
          */
         import(object: ImportObject | ImportObject[], options: ImportOptions): void;
-        // TypeScript Version: 2.4
-
-        /**
-         * It may not exists - this is _only_ for import functionality.
-         */
-        [key: string]: any;
     }
 
     interface Matrix {

--- a/types/mathjs/index.d.ts
+++ b/types/mathjs/index.d.ts
@@ -2578,7 +2578,8 @@ declare namespace math {
          * @param object An object with functions to be imported.
          * @param options An object with import options.
          */
-        import(object: object | Array<object>, options: ImportOptions);
+        import(object: ImportObject | ImportObject[], options: ImportOptions): void;
+        // TypeScript Version: 2.4
 
         /**
          * It may not exists - this is _only_ for import functionality.
@@ -4560,5 +4561,9 @@ declare namespace math {
         override?: boolean;
         silent?: boolean;
         wrap?: boolean;
+    }
+
+    interface ImportObject {
+        [key: string]: any;
     }
 }

--- a/types/mathjs/index.d.ts
+++ b/types/mathjs/index.d.ts
@@ -7,6 +7,7 @@
 // TypeScript Version: 2.2
 
 import { Decimal } from "decimal.js";
+import { ImportOptions } from "mathjs";
 
 declare const math: math.MathJsStatic;
 export as namespace math;
@@ -2571,6 +2572,18 @@ declare namespace math {
          * ‘string’, ‘Array’, ‘Date’.
          */
         typeof(x: any): string;
+
+        /**
+         * Import functions from an object or a module
+         * @param object An object with functions to be imported.
+         * @param options An object with import options.
+         */
+        import(object: object | Array<object>, options: ImportOptions);
+
+        /**
+         * It may not exists - this is _only_ for import functionality.
+         */
+        [key: string]: any;
     }
 
     interface Matrix {
@@ -4541,5 +4554,11 @@ declare namespace math {
          * Determine the type of a variable.
          */
         typeof(): MathJsChain;
+    }
+
+    interface ImportOptions {
+        override?: boolean;
+        silent?: boolean;
+        wrap?: boolean;
     }
 }

--- a/types/mathjs/mathjs-tests.ts
+++ b/types/mathjs/mathjs-tests.ts
@@ -1,3 +1,6 @@
+// Import needed for mathjs.import functionality (declaring/extending module)
+import * as math from 'mathjs';
+
 /*
 Basic usage examples
 */
@@ -396,10 +399,16 @@ JSON serialization/deserialization
 /*
 Extend functionality with import
  */
+
+declare module 'mathjs' {
+    interface MathJsStatic {
+        testFun(): number;
+        value: number;
+    }
+}
+
 {
-    const testFun = function() {
-        return 5;
-    };
+    const testFun = () => 5;
 
     math.import({
         testFun,

--- a/types/mathjs/mathjs-tests.ts
+++ b/types/mathjs/mathjs-tests.ts
@@ -392,3 +392,21 @@ JSON serialization/deserialization
 	const parsed = JSON.parse(stringified, math.json.reviver);
 	parsed.bigNumber === math.bignumber('1.5'); // true
 }
+
+/*
+Extend functionality with import
+ */
+{
+    const testFun = function() {
+        return 5;
+    };
+
+    math.import({
+        testFun,
+        value: 10
+    }, {});
+
+    math.testFun();
+
+    const a = math.value * 2;
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://mathjs.org/docs/reference/functions/import.html
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

Although we needed this in our project, and use it with this implementation, I'm not quite sure about the line containing: `[key: string]: any;` in `MathJsStatic` interface. However not adding it, spawns errors for imported to MathJS functions or variables when being used.