### PR TITLE
[jest] add type inference

### DIFF
--- a/types/expect-puppeteer/index.d.ts
+++ b/types/expect-puppeteer/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Josh Goldberg <https://github.com/JoshuaKGoldberg>
 //                 Tanguy Krotoff <https://github.com/tkrotoff>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.8
+// TypeScript Version: 3.0
 
 /// <reference types="jest" />
 

--- a/types/jest-axe/index.d.ts
+++ b/types/jest-axe/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/nickcolley/jest-axe
 // Definitions by: Josh Goldberg <https://github.com/JoshuaKGoldberg>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.4
+// TypeScript Version: 3.0
 
 /// <reference types="jest" />
 

--- a/types/jest-image-snapshot/index.d.ts
+++ b/types/jest-image-snapshot/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/americanexpress/jest-image-snapshot#readme
 // Definitions by: Janeene Beeforth <https://github.com/dawnmist>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 3.0
 
 /// <reference types="jest" />
 

--- a/types/jest-in-case/index.d.ts
+++ b/types/jest-in-case/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/thinkmill/jest-in-case#readme
 // Definitions by: Geovani de Souza <https://github.com/geovanisouza92>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 3.0
 
 /// <reference types="jest" />
 /// <reference types="node" />

--- a/types/jest-in-case/jest-in-case-tests.ts
+++ b/types/jest-in-case/jest-in-case-tests.ts
@@ -11,8 +11,8 @@ function subtract(minuend: number, subtrahend: number) {
 }
 
 beforeEach(() => {
-    jest.spyOn(global, 'describe').mockImplementation((title, fn) => fn());
-    jest.spyOn(global, 'test').mockImplementation((name, fn) => fn());
+    jest.spyOn(global, 'describe').mockImplementation((title, fn) => jest.fn());
+    jest.spyOn(global, 'test').mockImplementation((name, fn) => jest.fn());
     global.test.skip = jest.fn((name, fn) => fn());
     global.test.only = jest.fn((name, fn) => fn());
 });
@@ -54,8 +54,8 @@ test('array', () => {
 });
 
 test('object', () => {
-    jest.spyOn(global, 'describe').mockImplementation((title, fn) => fn());
-    jest.spyOn(global, 'test').mockImplementation((name, fn) => fn());
+    jest.spyOn(global, 'describe').mockImplementation((title, fn) => jest.fn());
+    jest.spyOn(global, 'test').mockImplementation((name, fn) => jest.fn());
 
     const title = 'add(augend, addend)';
 

--- a/types/jest-json-schema/index.d.ts
+++ b/types/jest-json-schema/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/americanexpress/jest-json-schema#readme
 // Definitions by: Igor Korolev <https://github.com/deadNightTiger>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 3.0
 
 /// <reference types="jest" />
 import * as ajv from "ajv";

--- a/types/jest-matchers/index.d.ts
+++ b/types/jest-matchers/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/facebook/jest#readme
 // Definitions by: Joscha Feth <https://github.com/joscha>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 3.0
 
 /// <reference types="jest" />
 export = expect;

--- a/types/jest-plugin-context/index.d.ts
+++ b/types/jest-plugin-context/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/negativetwelve/jest-plugins/tree/master/packages/jest-plugin-context
 // Definitions by: Jonas Heinrich <https://github.com/jonasheinrich>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 3.0
 
 /// <reference types="jest" />
 

--- a/types/jest-specific-snapshot/index.d.ts
+++ b/types/jest-specific-snapshot/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/igor-dv/jest-specific-snapshot#readme
 // Definitions by: Janeene Beeforth <https://github.com/dawnmist>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.8
+// TypeScript Version: 3.0
 
 /// <reference types="jest" />
 

--- a/types/jest-when/index.d.ts
+++ b/types/jest-when/index.d.ts
@@ -9,7 +9,7 @@
 export type PartialMockInstance<T, Y extends any[]> = Pick<jest.MockInstance<T, Y>, 'mockReturnValue' | 'mockReturnValueOnce' | 'mockResolvedValue'
   | 'mockResolvedValueOnce' | 'mockRejectedValue' | 'mockRejectedValueOnce'>;
 
-export interface When<T = {}, Y extends any[] = any[]> {
+export interface When<T = {}, Y extends any[] = any> {
   (fn: jest.Mock<T, Y>): When<T, Y>;
   calledWith(...matchers: Y): PartialMockInstance<T, Y>;
   expectCalledWith(...matchers: Y): PartialMockInstance<T, Y>;

--- a/types/jest-when/index.d.ts
+++ b/types/jest-when/index.d.ts
@@ -2,21 +2,17 @@
 // Project: https://github.com/timkindberg/jest-when#readme
 // Definitions by: Alden Taylor <https://github.com/aldentaylor>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 3.0
 
 /// <reference types="jest" />
 
-export interface PartialMockInstance<T> {
-  mockReturnValue: jest.MockInstance<T>['mockReturnValue'];
-}
+export type PartialMockInstance<T, Y extends any[]> = Pick<jest.MockInstance<T, Y>, 'mockReturnValue' | 'mockReturnValueOnce' | 'mockResolvedValue'
+  | 'mockResolvedValueOnce' | 'mockRejectedValue' | 'mockRejectedValueOnce'>;
 
-export interface When {
-  <T>(fn: jest.Mocked<T> | jest.Mock<T>): When;
-  // due to no-unnecessary-generics lint rule, the generics have been replaced with 'any'
-  // calledWith<T>(...matchers: any[]): PartialMockInstance<T>;
-  // expectCalledWith<T>(...matchers: any[]): PartialMockInstance<T>;
-  calledWith(...matchers: any[]): PartialMockInstance<any>;
-  expectCalledWith(...matchers: any[]): PartialMockInstance<any>;
+export interface When<T = {}, Y extends any[] = any[]> {
+  (fn: jest.Mock<T, Y>): When<T, Y>;
+  calledWith(...matchers: Y): PartialMockInstance<T, Y>;
+  expectCalledWith(...matchers: Y): PartialMockInstance<T, Y>;
 }
 
 export const when: When;

--- a/types/jest-when/jest-when-tests.ts
+++ b/types/jest-when/jest-when-tests.ts
@@ -31,16 +31,20 @@ describe('mock-when test', () => {
 
   it('Supports compound declarations:', () => {
     const fn = jest.fn();
-    when(fn).calledWith(1).mockReturnValue('no');
+    when(fn).calledWith(1).mockReturnValueOnce('no').mockReturnValue('yes');
     when(fn).calledWith(2).mockReturnValue('way?');
-    when(fn).calledWith(3).mockReturnValue('yes');
-    when(fn).calledWith(4).mockReturnValue('way!');
+    when(fn).calledWith(3).mockResolvedValueOnce('no');
+    when(fn).calledWith(3).mockResolvedValue('yes');
+    when(fn).calledWith(4).mockRejectedValueOnce('no');
+    when(fn).calledWith(4).mockRejectedValue('yes');
 
     expect(fn(1)).toEqual('no');
+    expect(fn(1)).toEqual('yes');
     expect(fn(2)).toEqual('way?');
-    expect(fn(3)).toEqual('yes');
-    expect(fn(4)).toEqual('way!');
-    expect(fn(5)).toEqual(undefined);
+    expect(fn(3)).resolves.toEqual('no');
+    expect(fn(3)).resolves.toEqual('yes');
+    expect(fn(4)).rejects.toEqual('no');
+    expect(fn(4)).rejects.toEqual('yes');
   });
 
   it('Assert the args:', () => {

--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -763,12 +763,12 @@ declare namespace jest {
         new (...args: any[]): any;
     }
 
-    interface Mock<T = {}, Y extends any[] = any> extends Function, MockInstance<T, Y> {
+    interface Mock<T = any, Y extends any[] = any> extends Function, MockInstance<T, Y> {
         new (...args: Y): T;
         (...args: Y): T;
     }
 
-    interface SpyInstance<T = {}, Y extends any[] = any> extends MockInstance<T, Y> {}
+    interface SpyInstance<T = any, Y extends any[] = any> extends MockInstance<T, Y> {}
 
     /**
      * Wrap module with mock definitions

--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -947,9 +947,13 @@ declare namespace jest {
      * Represents the result of a single call to a mock function.
      */
     interface MockResult {
-        type: 'return' | 'throw' | 'incomplete';
         /**
-         * The value that was either thrown or returned by the function, or undefined if type = 'incomplete'
+         * True if the function threw.
+         * False if the function returned.
+         */
+        isThrow: boolean;
+        /**
+         * The value that was either thrown or returned by the function.
          */
         value: any;
     }

--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -121,7 +121,7 @@ declare namespace jest {
     /**
      * Returns whether the given function is a mock function.
      */
-    function isMockFunction(fn: any): fn is Mock<any, any[]>;
+    function isMockFunction(fn: any): fn is Mock;
     /**
      * Mocks a module with an auto-mocked version when it is being required.
      */
@@ -763,12 +763,12 @@ declare namespace jest {
         new (...args: any[]): any;
     }
 
-    interface Mock<T, Y extends any[]> extends Function, MockInstance<T, Y> {
+    interface Mock<T = {}, Y extends any[] = any> extends Function, MockInstance<T, Y> {
         new (...args: Y): T;
         (...args: Y): T;
     }
 
-    interface SpyInstance<T, Y extends any[]> extends MockInstance<T, Y> {}
+    interface SpyInstance<T = {}, Y extends any[] = any> extends MockInstance<T, Y> {}
 
     /**
      * Wrap module with mock definitions

--- a/types/jest/jest-tests.ts
+++ b/types/jest/jest-tests.ts
@@ -253,12 +253,25 @@ jest
 
 /* Mocks and spies */
 
-const mock1: jest.Mock = jest.fn();
-const mock2: jest.Mock<undefined> = jest.fn<undefined>(() => undefined);
-const mock3: jest.Mock<string> = jest.fn(() => "abc");
-const mock4: jest.Mock<"abc"> = jest.fn((): "abc" => "abc");
-const mock5: jest.Mock<string> = jest.fn((...args: string[]) => args.join(""));
-const mock6: jest.Mock = jest.fn((arg: {}) => arg);
+// $ExpectType Mock<{}, any[]>
+const mock1 = jest.fn();
+// $ExpectType Mock<undefined, []>
+const mock2 = jest.fn(() => undefined);
+// $ExpectType Mock<string, []>
+const mock3 = jest.fn(() => "abc");
+// $ExpectType Mock<"abc", []>
+const mock4 = jest.fn((): "abc" => "abc");
+// $ExpectType Mock<string, string[]>
+const mock5 = jest.fn((...args: string[]) => args.join(""));
+// $ExpectType Mock<{}, [{}]>
+const mock6 = jest.fn((arg: {}) => arg);
+// $ExpectType Mock<number, [number]>
+const mock7 = jest.fn((arg: number) => arg);
+
+// $ExpectError
+mock7('abc');
+// $ExpectError
+mock7.mockImplementation((arg: string) => 1);
 
 const genMockModule1: {} = jest.genMockFromModule("moduleName");
 const genMockModule2: { a: "b" } = jest.genMockFromModule<{ a: "b" }>("moduleName");
@@ -272,8 +285,8 @@ if (jest.isMockFunction(maybeMock)) {
 }
 
 const mockName: string = jest.fn().getMockName();
-const mockContextVoid: jest.MockContext<void> = jest.fn<void>().mock;
-const mockContextString: jest.MockContext<string> = jest.fn(() => "").mock;
+const mockContextVoid = jest.fn().mock;
+const mockContextString = jest.fn(() => "").mock;
 
 jest.fn().mockClear();
 
@@ -288,9 +301,20 @@ const spiedTarget = {
     }
 };
 
+class SpiedTargetClass {
+    private _value = 3;
+    get value() {
+        return this._value;
+    }
+    set value(value) {
+        this._value = value;
+    }
+}
+const spiedTarget2 = new SpiedTargetClass();
+
 const spy1 = jest.spyOn(spiedTarget, "returnsVoid");
 const spy2 = jest.spyOn(spiedTarget, "returnsVoid", "get");
-const spy3 = jest.spyOn(spiedTarget, "returnsString", "set");
+const spy3 = jest.spyOn(spiedTarget, "returnsString");
 const spy1Name: string = spy1.getMockName();
 
 const spy2Calls: any[][] = spy2.mock.calls;
@@ -298,9 +322,10 @@ const spy2Calls: any[][] = spy2.mock.calls;
 spy2.mockClear();
 spy2.mockReset();
 
-const spy3Mock: jest.Mock<() => string> = spy3
+const spy3Mock = spy3
     .mockImplementation(() => "")
     .mockImplementation()
+    // $ExpectError
     .mockImplementation((arg: {}) => arg)
     .mockImplementation((...args: string[]) => args.join(""))
     .mockImplementationOnce(() => "")
@@ -313,10 +338,17 @@ const spy3Mock: jest.Mock<() => string> = spy3
     .mockRejectedValue("value")
     .mockRejectedValueOnce("value");
 
-let spy4: jest.SpyInstance;
-
+let spy4;
 spy4 = jest.spyOn(spiedTarget, "returnsString");
 spy4.mockRestore();
+
+// $ExpectType SpyInstance<number, []>
+const spy5 = jest.spyOn(spiedTarget2, "value", "get");
+// $ExpectError
+spy5.mockReturnValue('5');
+
+// $ExpectType SpyInstance<void, [number]>
+const spy6 = jest.spyOn(spiedTarget2, "value", "set");
 
 /* Snapshot serialization */
 

--- a/types/jest/jest-tests.ts
+++ b/types/jest/jest-tests.ts
@@ -273,6 +273,10 @@ mock7('abc');
 // $ExpectError
 mock7.mockImplementation((arg: string) => 1);
 
+const mock8 = jest.fn((a: number, _b: string, _c: {}, _iReallyDontCare: [], _makeItStop: boolean) => Promise.resolve(_makeItStop));
+// mockImplementation not required to declare all arguments
+mock8.mockImplementation((a: number) => Promise.resolve(a === 0));
+
 const genMockModule1: {} = jest.genMockFromModule("moduleName");
 const genMockModule2: { a: "b" } = jest.genMockFromModule<{ a: "b" }>("moduleName");
 

--- a/types/jest/jest-tests.ts
+++ b/types/jest/jest-tests.ts
@@ -267,15 +267,20 @@ const mock5 = jest.fn((...args: string[]) => args.join(""));
 const mock6 = jest.fn((arg: {}) => arg);
 // $ExpectType Mock<number, [number]>
 const mock7 = jest.fn((arg: number) => arg);
+// $ExpectType Mock<number, [number]>
+const mock8: jest.Mock = jest.fn((arg: number) => arg);
 
 // $ExpectError
 mock7('abc');
 // $ExpectError
 mock7.mockImplementation((arg: string) => 1);
+// compiles because mock8 is declared as jest.Mock<{}, any>
+mock8('abc');
+mock8.mockImplementation((arg: string) => 1);
 
-const mock8 = jest.fn((a: number, _b: string, _c: {}, _iReallyDontCare: [], _makeItStop: boolean) => Promise.resolve(_makeItStop));
+const mock9 = jest.fn((a: number, _b: string, _c: {}, _iReallyDontCare: [], _makeItStop: boolean) => Promise.resolve(_makeItStop));
 // mockImplementation not required to declare all arguments
-mock8.mockImplementation((a: number) => Promise.resolve(a === 0));
+mock9.mockImplementation((a: number) => Promise.resolve(a === 0));
 
 const genMockModule1: {} = jest.genMockFromModule("moduleName");
 const genMockModule2: { a: "b" } = jest.genMockFromModule<{ a: "b" }>("moduleName");
@@ -342,8 +347,10 @@ const spy3Mock = spy3
     .mockRejectedValue("value")
     .mockRejectedValueOnce("value");
 
-let spy4;
+let spy4: jest.SpyInstance;
 spy4 = jest.spyOn(spiedTarget, "returnsString");
+// compiles because spy4 is declared as jest.SpyInstance<{}, any>
+spy4.mockImplementation(() => 1);
 spy4.mockRestore();
 
 // $ExpectType SpyInstance<number, []>

--- a/types/jest/jest-tests.ts
+++ b/types/jest/jest-tests.ts
@@ -305,6 +305,9 @@ jest.fn().mockRestore();
 
 const spiedTarget = {
     returnsVoid(): void { },
+    setValue(value: string): void {
+        this.value = value;
+    },
     returnsString(): string {
         return "";
     }
@@ -360,6 +363,9 @@ spy5.mockReturnValue('5');
 
 // $ExpectType SpyInstance<void, [number]>
 const spy6 = jest.spyOn(spiedTarget2, "value", "set");
+
+let spy7: jest.SpyInstance;
+spy7 = jest.spyOn(spiedTarget, "setValue");
 
 /* Snapshot serialization */
 

--- a/types/jest/tsconfig.json
+++ b/types/jest/tsconfig.json
@@ -13,6 +13,7 @@
         "typeRoots": [
             "../"
         ],
+        "target": "es5",
         "types": [],
         "noEmit": true,
         "forceConsistentCasingInFileNames": true

--- a/types/storybook__addon-storyshots/index.d.ts
+++ b/types/storybook__addon-storyshots/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/storybooks/storybook/tree/master/addons/storyshots
 // Definitions by: Bradley Ayers <https://github.com/bradleyayers>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.8
+// TypeScript Version: 3.0
 
 import * as React from 'react';
 import { StoryObject } from '@storybook/react';


### PR DESCRIPTION
Updated jest typings to use latest typescript features to infer mock types. 

### Breaking Change

With types inferred, mockImplementation(), mockReturnValue(), mock...() will not compile if they are not used with the right types.

----

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: **private project**
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
