### PR TITLE
Update types for Electron Packager (electron-packager) to 13.0

### DIFF
--- a/types/electron-packager/electron-packager-tests.ts
+++ b/types/electron-packager/electron-packager-tests.ts
@@ -13,25 +13,6 @@ function ignoreFunction(path: string) {
 	return true;
 }
 
-// this is the obsolete API and will be removed in a future version
-
-packager({
-	dir: ".",
-	name: "myapplication",
-	platform: "win32",
-	arch: "all",
-	electronVersion: "0.34.0",
-	win32metadata: {
-		CompanyName: "Acme CO",
-		FileDescription: "My application",
-		OriginalFilename: "myapp.exe",
-		ProductName: "Application",
-		InternalName: "roadrunner",
-		"requested-execution-level": "highestAvailable",
-		"application-manifest": "manifest.xml"
-	}
-}, callback);
-
 function onCompleted(appPaths: string | string[]) {
 }
 
@@ -102,7 +83,7 @@ packager({
 	afterExtract: [
 		completeFunction
 	],
-	afterPrune:  [
+	afterPrune: [
 		completeFunction
 	],
 	appCopyright: "Copyright",
@@ -122,7 +103,6 @@ packager({
 	ignore: /ab+c/,
 	out: "out",
 	overwrite: true,
-	packageManager: false,
 	prune: true,
 	quiet: true,
 	tmpdir: "/tmp",
@@ -157,7 +137,6 @@ packager({
 		new RegExp('abc')
 	],
 	overwrite: false,
-	packageManager: "npm",
 	platform: "darwin",
 	prune: false,
 	quiet: false,
@@ -184,7 +163,14 @@ packager({
 		strictSSL: false
 	},
 	ignore: ignoreFunction,
-	packageManager: "cnpm",
+	platform: "linux"
+}).then(onCompleted).catch(onError);
+
+packager({
+	dir: ".",
+	arch: "mips64el",
+	electronVersion: "1.8.8",
+	prebuiltAsar: "prebuilt.asar",
 	platform: "linux"
 }).then(onCompleted).catch(onError);
 
@@ -200,10 +186,13 @@ packager({
 		quiet: true,
 		strictSSL: false
 	},
-	packageManager: "yarn",
 	platform: "mas",
 	extendInfo: {
 		foo: "bar"
+	},
+	osxNotarize: {
+		appleId: "My ID",
+		appleIdPassword: "Bad Password"
 	},
 	osxSign: {
 		identity: "myidentity",

--- a/types/electron-packager/index.d.ts
+++ b/types/electron-packager/index.d.ts
@@ -1,9 +1,10 @@
-// Type definitions for electron-packager 12.0
+// Type definitions for electron-packager 13.0
 // Project: https://github.com/electron-userland/electron-packager
 // Definitions by: Maxime LUCE <https://github.com/SomaticIT>
 //                 Juan Jimenez-Anca <https://github.com/cortopy>
 //                 John Kleinschmidt <https://github.com/jkleinsc>
 //                 Brendan Forster <https://github.com/shiftkey>
+//                 Mark Lee <https://github.com/malept>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />
@@ -23,20 +24,6 @@ export = electronPackager;
  */
 declare function electronPackager(opts: electronPackager.Options): Promise<string|string[]>;
 
-/**
- * This will:
- * - Find or download the correct release of Electron
- * - Use that version of electron to create a app in <out>/<appname>-<platform>-<arch>
- *
- * You should be able to launch the app on the platform you built for. If not, check your settings and try again.
- *
- * @param opts - Options to configure packaging.
- * @param callback - Callback which is called when packaging is done or an error occured.
- *
- * @deprecated since version 12.0
- */
-declare function electronPackager(opts: electronPackager.Options, callback: electronPackager.finalCallback): void;
-
 declare namespace electronPackager {
     /**
      * Callback which is called when electron-packager is done.
@@ -48,8 +35,7 @@ declare namespace electronPackager {
 
     type ignoreFunction = (path: string) => boolean;
     type onCompleteFn = (buildPath: string, electronVersion: string, platform: string, arch: string, callbackFn: () => void) => void;
-    type arch = "ia32" | "x64" | "armv7l" | "arm64" |"all";
-    type packageManager = "npm" | "cnpm" | "yarn" | false;
+    type arch = "ia32" | "x64" | "armv7l" | "arm64" | "mips64el" | "all";
     type platform = "linux" | "win32" | "darwin" | "mas" | "all";
 
     interface AsarOptions {
@@ -63,6 +49,11 @@ declare namespace electronPackager {
         mirror?: string;
         quiet?: boolean;
         strictSSL?: boolean;
+    }
+
+    interface ElectronNotarizeOptions {
+        appleId: string;
+        appleIdPassword: string;
     }
 
     interface ElectronOsXSignOptions {
@@ -117,6 +108,10 @@ declare namespace electronPackager {
          */
         asar?: boolean | AsarOptions;
         /**
+         * The path to a prebuilt ASAR file.
+         */
+        prebuiltAsar?: string;
+        /**
          * The build version of the application. Defaults to the value of appVersion.
          * Maps to the FileVersion metadata property on Windows, and CFBundleVersion on OS X.
          */
@@ -161,10 +156,6 @@ declare namespace electronPackager {
          */
         overwrite?: boolean;
         /**
-         * The package manager used to prune devDependencies modules from the outputted Electron app
-         */
-        packageManager?: packageManager;
-        /**
          * The target platform(s) to build for. Not required if the all option is set.
          */
         platform?: platform;
@@ -202,6 +193,14 @@ declare namespace electronPackager {
          * The bundle identifier to use in the application helper's plist.
          */
         helperBundleId?: string;
+        /**
+         * Forces support for Mojave (macOS 10.14) dark mode in the packaged app.
+         */
+        darwinDarkModeSupport?: boolean;
+        /**
+         * If present, notarizes OS X target apps when the host platform is OS X and XCode is installed.
+         */
+        osxNotarize?: ElectronNotarizeOptions;
         /**
          * If present, signs OS X target apps when the host platform is OS X and XCode is installed.
          */


### PR DESCRIPTION
Electron Packager was upgraded to 13.0 today. (I'm the maintainer :wave:)

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/electron-userland/electron-packager/releases/tag/v13.0.0>
- [x] Increase the version number in the header if appropriate.
- ~~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.~~