### PR TITLE
types/react-map-gl: Change onViewStateChange to an optional property 

### DIFF
--- a/types/react-map-gl/index.d.ts
+++ b/types/react-map-gl/index.d.ts
@@ -301,7 +301,7 @@ export class Popup extends BaseControl<PopupProps> {}
 export interface NavigationControlProps extends BaseControlProps {
     className?: string;
     onViewStateChange?: (info: ViewStateChangeInfo) => void;
-    onViewportChange: (viewport: ViewState) => void;
+    onViewportChange?: (viewport: ViewState) => void;
     showCompass?: boolean;
     showZoom?: boolean;
 }

--- a/types/react-map-gl/index.d.ts
+++ b/types/react-map-gl/index.d.ts
@@ -300,7 +300,7 @@ export class Popup extends BaseControl<PopupProps> {}
 
 export interface NavigationControlProps extends BaseControlProps {
     className?: string;
-    onViewStateChange: (info: ViewStateChangeInfo) => void;
+    onViewStateChange?: (info: ViewStateChangeInfo) => void;
     onViewportChange: (viewport: ViewState) => void;
     showCompass?: boolean;
     showZoom?: boolean;


### PR DESCRIPTION
Package: types/react-map-gl
Description: The `onViewStateChange` is an optional property, please see [react-map-gl's what's new doc](https://github.com/uber/react-map-gl/blob/fe1aa482a6fffe52125ad70d1bbecb223ae9bed6/docs/whats-new.md)
This PR just adds a question mark to change it to an optional property and prevent TS errors when it is omitted.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.) ***RETURNS AN ERROR***
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present). ***RETURNS AN ERROR***

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate. WHRE IS THIS? SHOULD I CHANGE IT?
- [ ] ~~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.~~

