### PR TITLE
[assert] Fix passing RegEx to .throws

### DIFF
--- a/types/assert/assert-tests.ts
+++ b/types/assert/assert-tests.ts
@@ -5,6 +5,7 @@ assert(true, "it's working");
 assert.ok(true, "inner functions work as well");
 
 assert.throws(() => {});
+assert.throws(() => {}, /Regex test/);
 assert.throws(() => {}, () => {}, "works wonderfully");
 
 assert['fail'](true, true, "works like a charm");

--- a/types/assert/index.d.ts
+++ b/types/assert/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for commonjs-assert 1.4
 // Project: https://github.com/browserify/commonjs-assert
 // Definitions by: Nico Gallinal <https://github.com/nicoabie>
+//                 Linus Unnebäck <https://github.com/LinusU>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare function assert(value: any, message?: string): void;
@@ -23,10 +24,10 @@ declare namespace assert {
     function notStrictEqual(actual: any, expected: any, message?: string): void;
 
     function throws(block: () => void, message?: string): void;
-    function throws(block: () => void, error: () => void | ((err: any) => boolean) | RegExp, message?: string): void;
+    function throws(block: () => void, error: (() => void) | ((err: any) => boolean) | RegExp, message?: string): void;
 
     function doesNotThrow(block: () => void, message?: string): void;
-    function doesNotThrow(block: () => void, error: () => void | ((err: any) => boolean) | RegExp, message?: string): void;
+    function doesNotThrow(block: () => void, error: (() => void) | ((err: any) => boolean) | RegExp, message?: string): void;
 
     function ifError(value: any): void;
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/browserify/commonjs-assert#assertthrowsblock-error-message
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
