### PR TITLE
Add type definitation for debounce-promise

### DIFF
--- a/types/debounce-promise/debounce-promise-tests.ts
+++ b/types/debounce-promise/debounce-promise-tests.ts
@@ -1,0 +1,25 @@
+import debounce = require("debounce-promise");
+import { DebounceOptions } from "debounce-promise";
+
+const options: DebounceOptions = {};
+const optionsA: DebounceOptions = { leading: true };
+const f = async () => 2;
+const f2 = (a: string) => 2;
+debounce(f, 100);
+debounce(f, 0, options);
+debounce(f, 100, optionsA);
+debounce(f, 10, { accumulate: true });
+const foo = debounce(async () => f2, 10, {
+    leading: true,
+    accumulate: true
+});
+foo().then(f => f("2"));
+const bar = debounce(async () => [1, 2, 3], 100);
+bar().then(ar => ar.concat());
+
+// Converts the return value from the producer function to a promise
+const two = debounce((a: string, b: number, c: { d: boolean }) => [4], 10, {
+    leading: true,
+    accumulate: true
+});
+two("1", 2, { d: false }).then(ar => ar.pop(), () => 2);

--- a/types/debounce-promise/index.d.ts
+++ b/types/debounce-promise/index.d.ts
@@ -1,0 +1,26 @@
+// Type definitions for debounce-promise 3.1
+// Project: https://github.com/bjoerge/debounce-promise
+// Definitions by: Wu Haotian <https://github.com/whtsky>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.0
+
+declare namespace debounce {
+    interface DebounceOptions {
+        leading?: boolean;
+        accumulate?: boolean;
+    }
+}
+
+type ArgumentsType<T> = T extends (...args: infer A) => any ? A : never;
+
+declare function debounce<T extends (...args: any[]) => any>(
+    func: T,
+    wait?: number,
+    options?: debounce.DebounceOptions
+): (
+    ...args: ArgumentsType<T>
+) => ReturnType<T> extends Promise<any>
+    ? ReturnType<T>
+    : Promise<ReturnType<T>>;
+
+export = debounce;

--- a/types/debounce-promise/index.d.ts
+++ b/types/debounce-promise/index.d.ts
@@ -11,14 +11,12 @@ declare namespace debounce {
     }
 }
 
-type ArgumentsType<T> = T extends (...args: infer A) => any ? A : never;
-
 declare function debounce<T extends (...args: any[]) => any>(
     func: T,
     wait?: number,
     options?: debounce.DebounceOptions
 ): (
-    ...args: ArgumentsType<T>
+    ...args: Parameters<T>
 ) => ReturnType<T> extends Promise<any>
     ? ReturnType<T>
     : Promise<ReturnType<T>>;

--- a/types/debounce-promise/tsconfig.json
+++ b/types/debounce-promise/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": ["index.d.ts", "debounce-promise-tests.ts"]
+}

--- a/types/debounce-promise/tslint.json
+++ b/types/debounce-promise/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
