### PR TITLE
[node] add node inspector protocol extensions

### DIFF
--- a/types/node/node-tests.ts
+++ b/types/node/node-tests.ts
@@ -4673,6 +4673,10 @@ import * as constants from 'constants';
             const pauseReason: string = message.params.reason;
         });
         session.on('Debugger.resumed', () => {});
+        // Node Inspector events
+        session.on('NodeTracing.dataCollected', (message: inspector.InspectorNotification<inspector.NodeTracing.DataCollectedEventDataType>) => {
+          const value: Array<{}> = message.params.value;
+        });
     }
 }
 

--- a/types/node/scripts/generate-inspector/event-emitter.ts
+++ b/types/node/scripts/generate-inspector/event-emitter.ts
@@ -66,10 +66,11 @@ export const createListeners = (events: Event[]): string[] => {
         "",
         ...createListenerBlockFn("prependOnceListener")(events),
     ].reduce((acc, next, index, arr) => {
-        // removes trailing and consecutive empty lines
+        // removes leading, trailing and consecutive empty lines
+        const isFirst = index === 0;
         const isLast = index === arr.length - 1;
         const followsEmptyLine = acc.length > 0 && acc[acc.length - 1] === "";
-        if ((isLast || followsEmptyLine) && next === "") {
+        if ((isFirst || isLast || followsEmptyLine) && next === "") {
             return acc;
         } else {
             acc.push(next);

--- a/types/node/scripts/generate-inspector/index.ts
+++ b/types/node/scripts/generate-inspector/index.ts
@@ -2,25 +2,55 @@
 // [tag] corresponds to a tag name in the node-core repository.
 
 import { execSync } from "child_process";
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
+import { existsSync, readFileSync, writeFileSync } from "fs";
 import * as https from "https";
 import * as schema from "./devtools-protocol-schema";
 import { generateSubstituteArgs } from "./generate-substitute-args";
-import { flattenArgs, substitute, trimRight } from "./utils";
+import { substitute, trimRight } from "./utils";
+import { string } from "parsimmon";
+
+const httpsGet = (url: string) => new Promise<string>((resolve, reject) => {
+    https.get(url, res => {
+        const frames: Buffer[] = [];
+        res.on("data", (data: Buffer) => {
+            frames.push(data);
+        });
+        res.on("end", () => {
+            resolve(Buffer.concat(frames).toString("utf8"));
+        });
+        res.on("error", (err: Error) => {
+            reject(err);
+        });
+    });
+});
 
 // Input arguments
 const tag = process.argv[2] || process.version;
 
-const PROTOCOL_URL = `https://raw.githubusercontent.com/nodejs/node/${tag}/deps/v8/src/inspector/js_protocol.json`;
+const V8_PROTOCOL_URL = `https://raw.githubusercontent.com/nodejs/node/${tag}/deps/v8/src/inspector/js_protocol.json`;
+const NODE_PROTOCOL_URL = `https://raw.githubusercontent.com/nodejs/node/${tag}/src/inspector/node_protocol.pdl`;
+const INSPECTOR_PROTOCOL_REMOTE = `https://chromium.googlesource.com/deps/inspector_protocol`;
+const INSPECTOR_PROTOCOL_LOCAL_DIR = "/tmp/inspector_protocol";
 
-const devToolsPath = `${__dirname}/../../node_modules/devtools-protocol`;
-
-function writeProtocolToFile(json: string) {
-    const protocol: schema.Schema = JSON.parse(json);
-
+/**
+ * Given a list of Inspector protocol definitions, write an inspector.d.ts
+ * containing all of those definitions merged together.
+ * @param jsonProtocols A list of Inspector protocol definitions.
+ */
+function writeProtocolsToFile(jsonProtocols: string[]) {
+    const combinedProtocol: schema.Schema = {
+        version: { major: '', minor: '' }, // doesn't matter
+        domains: []
+    };
+    for (const json of jsonProtocols) {
+        if (json) {
+            const protocol: schema.Schema = JSON.parse(json);
+            combinedProtocol.domains.push(...protocol.domains);
+        }
+    }
+    const substituteArgs = generateSubstituteArgs(combinedProtocol);
     const template = readFileSync(`${__dirname}/inspector.d.ts.template`, "utf8");
-
-    const substituteArgs = generateSubstituteArgs(protocol);
+    
     const inspectorDts = substitute(template, substituteArgs).split("\n")
         .map(line => trimRight(line))
         .join("\n");
@@ -28,12 +58,24 @@ function writeProtocolToFile(json: string) {
     writeFileSync("./inspector.d.ts", inspectorDts, "utf8");
 }
 
-https.get(PROTOCOL_URL, res => {
-    const frames: Buffer[] = [];
-    res.on("data", (data: Buffer) => {
-        frames.push(data);
-    });
-    res.on("end", () => {
-        writeProtocolToFile(Buffer.concat(frames).toString("utf8"));
-    });
-});
+/**
+ * Given a PDL-formatted string, return a JSON-formatted string.
+ * Note that this function run blocking shell commands, as it depends on an
+ * external script to do the conversion.
+ * @param pdl A PDL-formatted string.
+ */
+function convertPdlToJson(pdl: string): string {
+    if (!existsSync(INSPECTOR_PROTOCOL_LOCAL_DIR)) {
+        execSync(`git clone ${INSPECTOR_PROTOCOL_REMOTE} ${INSPECTOR_PROTOCOL_LOCAL_DIR}`);
+    }
+    writeFileSync("/tmp/inspector_protocol.pdl", pdl);
+    execSync(`${INSPECTOR_PROTOCOL_LOCAL_DIR}/convert_protocol_to_json.py /tmp/inspector_protocol.pdl /tmp/inspector_protocol.json`);
+    return readFileSync("/tmp/inspector_protocol.json", 'utf8');
+}
+
+// "Main" -- get the V8 built-in inspector protocol definition, as well as the
+// Node extensions, and then write this to inspector.d.ts.
+Promise.all([
+    httpsGet(V8_PROTOCOL_URL),
+    httpsGet(NODE_PROTOCOL_URL).then(convertPdlToJson).catch(() => '')
+]).then(writeProtocolsToFile).catch(console.error);


### PR DESCRIPTION
In Node 10+, `NodeTracing` and `NodeWorkers` are introduced as Node-specific Inspector domains. This PR adds them and updates the generation script to include the new Node-specific protocol definitions.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/nodejs/node/blob/master/src/inspector/node_protocol.pdl
- [X] Increase the version number in the header if appropriate.