### PR TITLE
Add types for command-exists

### DIFF
--- a/types/command-exists/command-exists-tests.ts
+++ b/types/command-exists/command-exists-tests.ts
@@ -1,0 +1,14 @@
+import commandExists = require('command-exists');
+
+commandExists('ls', (err, commandExists) => {
+    // $ExpectType boolean
+    commandExists;
+});
+
+commandExists('ls').then(command => {
+    // $ExpectType string
+    command;
+});
+
+// $ExpectType boolean
+commandExists.sync('ls');

--- a/types/command-exists/index.d.ts
+++ b/types/command-exists/index.d.ts
@@ -1,0 +1,16 @@
+// Type definitions for command-exists 1.2
+// Project: https://github.com/mathisonian/command-exists
+// Definitions by: BendingBender <https://github.com/BendingBender>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export = commandExists;
+
+declare function commandExists(commandName: string): Promise<string>;
+declare function commandExists(
+    commandName: string,
+    cb: (error: null, exists: boolean) => void
+): void;
+
+declare namespace commandExists {
+    function sync(commandName: string): boolean;
+}

--- a/types/command-exists/tsconfig.json
+++ b/types/command-exists/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "command-exists-tests.ts"
+    ]
+}

--- a/types/command-exists/tslint.json
+++ b/types/command-exists/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.