### PR TITLE
[mailgun-js] add inline to SendData and allow multiple attachments

### DIFF
--- a/types/mailgun-js/index.d.ts
+++ b/types/mailgun-js/index.d.ts
@@ -49,6 +49,8 @@ declare namespace Mailgun {
         contentType?: string;
         getType(): string;
     }
+    
+    type AttachmentData = string | Buffer | NodeJS.ReadWriteStream | Attachment;
 
     interface MailgunExport {
         new (options: ConstructorParams): Mailgun;
@@ -64,7 +66,8 @@ declare namespace Mailgun {
             subject?: string;
             text?: string;
             html?: string;
-            attachment?: string | Buffer | NodeJS.ReadWriteStream | Attachment;
+            attachment?: AttachmentData | AttachmentData[];
+            inline?: AttachmentData | AttachmentData[];
         }
 
         interface BatchData extends SendData {

--- a/types/mailgun-js/index.d.ts
+++ b/types/mailgun-js/index.d.ts
@@ -49,7 +49,7 @@ declare namespace Mailgun {
         contentType?: string;
         getType(): string;
     }
-    
+
     type AttachmentData = string | Buffer | NodeJS.ReadWriteStream | Attachment;
 
     interface MailgunExport {

--- a/types/mailgun-js/index.d.ts
+++ b/types/mailgun-js/index.d.ts
@@ -66,8 +66,8 @@ declare namespace Mailgun {
             subject?: string;
             text?: string;
             html?: string;
-            attachment?: AttachmentData | AttachmentData[];
-            inline?: AttachmentData | AttachmentData[];
+            attachment?: AttachmentData | ReadonlyArray<AttachmentData>;
+            inline?: AttachmentData | ReadonlyArray<AttachmentData>;
         }
 
         interface BatchData extends SendData {

--- a/types/mailgun-js/mailgun-js-tests.ts
+++ b/types/mailgun-js/mailgun-js-tests.ts
@@ -25,7 +25,14 @@ const exampleSendData: mailgunFactory.messages.SendData = {
     attachment: new mailgun.Attachment({
         data: "filepath",
         filename: "my_custom_name.png"
-    })
+    }),
+    inline: [
+        new mailgun.Attachment({
+            data: "filepath",
+            filename: "my_custom_name_2.png"
+        }),
+        "my_custom_file_3.png"
+    ]
   };
 
 mailgun.messages().send(exampleSendData, (err, body) => {});

--- a/types/mailgun-js/mailgun-js-tests.ts
+++ b/types/mailgun-js/mailgun-js-tests.ts
@@ -31,7 +31,8 @@ const exampleSendData: mailgunFactory.messages.SendData = {
             data: "filepath",
             filename: "my_custom_name_2.png"
         }),
-        "my_custom_file_3.png"
+        "my_custom_file_3.png",
+        Buffer.from("plain text")
     ]
   };
 


### PR DESCRIPTION
1. Allow array of `attachment`s in SendData interface.
2. Add `inline` to SendData interface.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/bojand/mailgun-js/tree/v0.16.0#attachments>>
