### PR TITLE
[jquery] Fix issue with unbinding event handlers for specific event types.

### DIFF
--- a/types/jquery/JQuery.d.ts
+++ b/types/jquery/JQuery.d.ts
@@ -7304,10 +7304,12 @@ $( "body" ).on( "click", "p", foo );
 $( "body" ).off( "click", "p", foo );
 ```
      */
-    off(events: string,
+    off<TType extends string>(
+        events: TType,
         selector: JQuery.Selector,
-        handler: JQuery.TypeEventHandler<TElement, any, any, any, string> |
-                 false): this;
+        handler: JQuery.TypeEventHandler<TElement, any, any, any, TType> |
+                 false
+    ): this;
     /**
      * Remove an event handler.
      * @param events One or more space-separated event types and optional namespaces, or just namespaces, such as
@@ -7337,10 +7339,12 @@ $( "form" ).on( "keypress.validator", "input[type='text']", validate );
 $( "form" ).off( ".validator" );
 ```
      */
-    off(events: string,
+    off<TType extends string>(
+        events: TType,
         selector_handler?: JQuery.Selector |
-                           JQuery.TypeEventHandler<TElement, any, any, any, string> |
-                           false): this;
+                           JQuery.TypeEventHandler<TElement, any, any, any, TType> |
+                           false
+    ): this;
     /**
      * Remove an event handler.
      * @param events An object where the string keys represent one or more space-separated event types and optional
@@ -11968,9 +11972,10 @@ $( "p" ).bind( "click", foo ); // ... Now foo will be called when paragraphs are
 $( "p" ).unbind( "click", foo ); // ... foo will no longer be called.
 ```
      */
-    unbind(event: string,
-           handler: JQuery.TypeEventHandler<TElement, any, TElement, TElement, string> |
-                    false
+    unbind<TType extends string>(
+        event: TType,
+        handler: JQuery.TypeEventHandler<TElement, any, TElement, TElement, TType> |
+                 false
     ): this;
     /**
      * Remove a previously-attached event handler from the elements.
@@ -12062,10 +12067,11 @@ $( "body" ).delegate( "p", "click", foo );
 $( "body" ).undelegate( "p", "click", foo );
 ```
      */
-    undelegate(selector: JQuery.Selector,
-               eventType: string,
-               handler: JQuery.TypeEventHandler<TElement, any, any, any, string> |
-                        false
+    undelegate<TType extends string>(
+        selector: JQuery.Selector,
+        eventType: TType,
+        handler: JQuery.TypeEventHandler<TElement, any, any, any, TType> |
+                 false
     ): this;
     /**
      * Remove a handler from the event for all elements which match the current selector, based upon a specific set of root elements.

--- a/types/jquery/jquery-tests.ts
+++ b/types/jquery/jquery-tests.ts
@@ -3969,11 +3969,16 @@ function JQuery() {
 
             function customData(this: HTMLElement, event: JQuery.TriggeredEvent<HTMLElement, string>) { }
 
+            function specificEventType(this: HTMLElement, event: JQuery.MouseDownEvent<HTMLElement>) { }
+
             // $ExpectType JQuery<HTMLElement>
             $('table').off('myEvent', 'td', defaultData);
 
             // $ExpectType JQuery<HTMLElement>
             $('table').off('myEvent', 'td', customData);
+
+            // $ExpectType JQuery<HTMLElement>
+            $('table').off('mousedown', 'td', specificEventType);
 
             // $ExpectType JQuery<HTMLElement>
             $('table').off('myEvent', 'td', false);
@@ -3986,6 +3991,9 @@ function JQuery() {
 
             // $ExpectType JQuery<HTMLElement>
             $('table').off('myEvent', customData);
+
+            // $ExpectType JQuery<HTMLElement>
+            $('table').off('mousedown', specificEventType);
 
             // $ExpectType JQuery<HTMLElement>
             $('table').off('myEvent', false);
@@ -4473,11 +4481,16 @@ function JQuery() {
 
             function customData(this: HTMLElement, event: JQuery.TriggeredEvent<HTMLElement, string>) { }
 
+            function specificEventType(this: HTMLElement, event: JQuery.MouseDownEvent<HTMLElement>) { }
+
             // $ExpectType JQuery<HTMLElement>
             $('p').unbind('myEvent', defaultData);
 
             // $ExpectType JQuery<HTMLElement>
             $('p').unbind('myEvent', customData);
+
+            // $ExpectType JQuery<HTMLElement>
+            $('p').unbind('mousedown', specificEventType);
 
             // $ExpectType JQuery<HTMLElement>
             $('p').unbind('myEvent', false);
@@ -4498,11 +4511,16 @@ function JQuery() {
 
             function customData(this: HTMLElement, event: JQuery.TriggeredEvent<HTMLElement, string>) { }
 
+            function specificEventType(this: HTMLElement, event: JQuery.MouseDownEvent<HTMLElement>) { }
+
             // $ExpectType JQuery<HTMLElement>
             $('table').undelegate('td', 'click', defaultData);
 
             // $ExpectType JQuery<HTMLElement>
             $('table').undelegate('td', 'click', customData);
+
+            // $ExpectType JQuery<HTMLElement>
+            $('table').undelegate('td', 'mousedown', specificEventType);
 
             // $ExpectType JQuery<HTMLElement>
             $('table').undelegate('td', 'click', false);


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
https://api.jquery.com/off/
https://api.jquery.com/unbind/
https://api.jquery.com/undelegate/
- ~~Increase the version number in the header if appropriate.~~
- ~~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.~~

---

Signatures that unbind event handlers were not accepting event handlers with a more specific type declared for the `event` parameter with `strictFunctionTypes` enabled. The signatures have been changed so that the same function passed to a binding API is accepted by an unbinding API.

Fixes #31117