### PR TITLE
Add types for abort-controller

### DIFF
--- a/types/abort-controller/abort-controller-tests.ts
+++ b/types/abort-controller/abort-controller-tests.ts
@@ -1,0 +1,10 @@
+import AbortController = require('abort-controller');
+
+const controller = new AbortController();
+const signal = controller.signal;
+
+signal.addEventListener('abort', () => {
+    console.log('aborted!');
+});
+
+controller.abort();

--- a/types/abort-controller/index.d.ts
+++ b/types/abort-controller/index.d.ts
@@ -1,0 +1,11 @@
+// Type definitions for abort-controller 1.0
+// Project: https://github.com/mysticatea/abort-controller#readme
+// Definitions by: BendingBender <https://github.com/BendingBender>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.7
+
+export as namespace AbortControllerShim;
+
+export = abortController;
+
+declare const abortController: typeof AbortController;

--- a/types/abort-controller/tsconfig.json
+++ b/types/abort-controller/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "abort-controller-tests.ts"
+    ]
+}

--- a/types/abort-controller/tslint.json
+++ b/types/abort-controller/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.