### PR TITLE
d3-hierarchy: Improve packSibling and packEnclose typing

### DIFF
--- a/types/d3-hierarchy/d3-hierarchy-tests.ts
+++ b/types/d3-hierarchy/d3-hierarchy-tests.ts
@@ -12,6 +12,7 @@ import * as d3Hierarchy from 'd3-hierarchy';
 // Preparatory Steps
 // -----------------------------------------------------------------------
 
+let str: string;
 let num: number;
 let numOrUndefined: number | undefined;
 let size: [number, number];
@@ -825,22 +826,34 @@ copiedPackNode = packRootNode.copy();
 // Pack Siblings and Enclosure
 // -----------------------------------------------------------------------
 
-interface CircleData extends d3Hierarchy.PackCircle {
-    v: string;
-}
-
-let circles: CircleData[] = [
+const radius = [
     { r: 10, v: 'a' },
-    { r: 1, v: 'b' },
+    { r: 30, v: 'b' },
     { r: 20, v: 'c' }
 ];
 
 // packSiblings
 
-circles = d3Hierarchy.packSiblings(circles);
+const circles = d3Hierarchy.packSiblings(radius);
+str = circles[0].v;
+num = circles[0].r;
+num = circles[0].x;
+num = circles[0].y;
 
 // packEnclose
 
-let enclosure: { r: number, x: number, y: number };
+const moreCircles = [
+    { r: 10, v: 'a', x: 0, y: 10 },
+    { r: 30, v: 'b', x: 5, y: 15 },
+    { r: 20, v: 'c', x: 7, y: 30 }
+];
 
-enclosure = d3Hierarchy.packEnclose(circles);
+const circle = d3Hierarchy.packEnclose(moreCircles);
+num = circle.r;
+num = circle.x;
+num = circle.y;
+// $ExpectError
+str = circle.v; // fails, property 'v' does not exist
+
+// $ExpectError
+d3Hierarchy.packEnclose(radius);

--- a/types/d3-hierarchy/index.d.ts
+++ b/types/d3-hierarchy/index.d.ts
@@ -802,7 +802,7 @@ export function pack<Datum>(): PackLayout<Datum>;
 // Pack Siblings and Enclosure
 // -----------------------------------------------------------------------
 
-export interface PackCircle {
+export interface PackRadius {
     /**
      * The radius of the circle.
      */
@@ -819,10 +819,25 @@ export interface PackCircle {
     y?: number;
 }
 
+export interface PackCircle {
+    /**
+     * The radius of the circle.
+     */
+    r: number;
+
+    /**
+     * The x-coordinate of the circle’s center.
+     */
+    x: number;
+
+    /**
+     * The y-coordinate of the circle’s center.
+     */
+    y: number;
+}
+
 // TODO: Since packSiblings manipulates the circles array in place, technically the x and y properties
 // are optional on invocation, but will be created after execution for each entry.
-// For invocation of packEnclose the x and y coordinates are mandatory. It seems easier to just comment
-// on the mandatory nature, then to create separate interfaces and having to deal with recasting.
 
 /**
  * Packs the specified array of circles, each of which must have a `circle.r` property specifying the circle’s radius.
@@ -830,7 +845,7 @@ export interface PackCircle {
  *
  * @param circles The specified array of circles to pack.
  */
-export function packSiblings<Datum extends PackCircle>(circles: Datum[]): Datum[];
+export function packSiblings<Datum extends PackRadius>(circles: Datum[]): Array<Datum & PackCircle>;
 
 /**
  * Computes the smallest circle that encloses the specified array of circles, each of which must have
@@ -839,4 +854,4 @@ export function packSiblings<Datum extends PackCircle>(circles: Datum[]): Datum[
  *
  * @param circles The specified array of circles to pack.
  */
-export function packEnclose<Datum extends PackCircle>(circles: Datum[]): { r: number, x: number, y: number };
+export function packEnclose<Datum extends PackCircle>(circles: Datum[]): PackCircle;


### PR DESCRIPTION
The `packSibling` datum `x` and `y` properties are optional and ignored.
But the output always has a `x` and `y` properties.

The `packEnclose` datum must have a `x` and `y` properties.
