### PR TITLE
Support validator isEmpty option.

### DIFF
--- a/types/validator/index.d.ts
+++ b/types/validator/index.d.ts
@@ -83,7 +83,7 @@ declare namespace ValidatorJS {
     isEmail(str: string, options?: IsEmailOptions): boolean;
 
     // check if the string has a length of zero.
-    isEmpty(str: string): boolean;
+    isEmpty(str: string, options?: IsEmptyOptions): boolean;
 
     // check if the string is a fully qualified domain name (e.g. domain.com).
     isFQDN(str: string, options?: IsFQDNOptions): boolean;
@@ -308,6 +308,11 @@ declare namespace ValidatorJS {
     require_display_name?: boolean;
     allow_utf8_local_part?: boolean;
     require_tld?: boolean;
+  }
+
+  // options for isEmpty
+  interface IsEmptyOptions {
+    ignore_whitespace?: boolean;
   }
 
   // options for isFQDN

--- a/types/validator/validator-tests.ts
+++ b/types/validator/validator-tests.ts
@@ -425,7 +425,9 @@ let any: any;
   result = validator.isEmail('sample');
   result = validator.isEmail('sample', isEmailOptions);
 
+  let isEmptyOptions: ValidatorJS.IsEmptyOptions = {};
   result = validator.isEmpty('sample');
+  result = validator.isEmpty('sample', isEmptyOptions);
 
   let isFQDNOptions: ValidatorJS.IsFQDNOptions = {};
   result = validator.isFQDN('sample');


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
https://github.com/chriso/validator.js/blob/10.9.0/README.md#validators (isEmpty)
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

This is for isEmpty method of vallidator(https://www.npmjs.com/package/validator), it is source of this definition below.
https://github.com/chriso/validator.js/blob/10.9.0/src/lib/isEmpty.js#L8
On validator version 10.9.0, compilation was errored and I fixed it locally and used. I'v made PR of it.