### PR TITLE
Add types for decode-uri-component

### DIFF
--- a/types/decode-uri-component/decode-uri-component-tests.ts
+++ b/types/decode-uri-component/decode-uri-component-tests.ts
@@ -1,0 +1,12 @@
+import decodeUriComponent = require('decode-uri-component');
+
+// $ExpectType string
+decodeUriComponent('%25');
+decodeUriComponent('%');
+decodeUriComponent('st%C3%A5le');
+decodeUriComponent('%st%C3%A5le%');
+decodeUriComponent('%%7Bst%C3%A5le%7D%');
+decodeUriComponent('%7B%ab%%7C%de%%7D');
+decodeUriComponent('%FE%FF');
+decodeUriComponent('%C2');
+decodeUriComponent('%C2%B5');

--- a/types/decode-uri-component/index.d.ts
+++ b/types/decode-uri-component/index.d.ts
@@ -1,0 +1,8 @@
+// Type definitions for decode-uri-component 0.2
+// Project: https://github.com/samverschueren/decode-uri-component#readme
+// Definitions by: BendingBender <https://github.com/BendingBender>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export = decodeUriComponent;
+
+declare function decodeUriComponent(encodedURI: string): string;

--- a/types/decode-uri-component/tsconfig.json
+++ b/types/decode-uri-component/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "decode-uri-component-tests.ts"
+    ]
+}

--- a/types/decode-uri-component/tslint.json
+++ b/types/decode-uri-component/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.