### PR TITLE
Add types for get-certain

### DIFF
--- a/types/get-certain/get-certain-tests.ts
+++ b/types/get-certain/get-certain-tests.ts
@@ -1,0 +1,9 @@
+import getCertain = require('get-certain');
+
+const map = new Map<string, number>();
+
+map.set('foo', 1);
+
+// $ExpectType number
+getCertain(map, 'foo');
+getCertain(map, 'bar', 'This map is barless.');

--- a/types/get-certain/index.d.ts
+++ b/types/get-certain/index.d.ts
@@ -1,0 +1,12 @@
+// Type definitions for get-certain 1.0
+// Project: https://github.com/wtgtybhertgeghgtwtg/get-certain#readme
+// Definitions by: BendingBender <https://github.com/BendingBender>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export = getCertain;
+
+declare function getCertain<TKey, TValue>(
+    map: Map<TKey, TValue>,
+    key: TKey,
+    message?: string
+): TValue;

--- a/types/get-certain/tsconfig.json
+++ b/types/get-certain/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "get-certain-tests.ts"
+    ]
+}

--- a/types/get-certain/tslint.json
+++ b/types/get-certain/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.