### PR TITLE
Add types for pid-from-port

### DIFF
--- a/types/pid-from-port/index.d.ts
+++ b/types/pid-from-port/index.d.ts
@@ -1,0 +1,26 @@
+// Type definitions for pid-from-port 1.1
+// Project: https://github.com/kevva/pid-from-port#readme
+// Definitions by: BendingBender <https://github.com/BendingBender>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export = pidFromPort;
+
+/**
+ * Get PID from a port
+ * @param port Port to lookup.
+ */
+declare function pidFromPort(port: number): Promise<number>;
+
+declare namespace pidFromPort {
+    /**
+     * Get PIDs for a list of ports.
+     * @param ports Ports to lookup.
+     * @returns A `Promise<Map>` with the port as key and the PID as value.
+     */
+    function all(ports: number[]): Promise<Map<number, number>>;
+    /**
+     * Get all PIDs from ports.
+     * @returns A `Promise<Map>` with the port as key and the PID as value.
+     */
+    function list(): Promise<Map<number, number>>;
+}

--- a/types/pid-from-port/pid-from-port-tests.ts
+++ b/types/pid-from-port/pid-from-port-tests.ts
@@ -1,0 +1,10 @@
+import pidFromPort = require('pid-from-port');
+
+// $ExpectType Promise<number>
+pidFromPort(8080);
+
+// $ExpectType Promise<Map<number, number>>
+pidFromPort.all([8080, 22]);
+
+// $ExpectType Promise<Map<number, number>>
+pidFromPort.list();

--- a/types/pid-from-port/tsconfig.json
+++ b/types/pid-from-port/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "pid-from-port-tests.ts"
+    ]
+}

--- a/types/pid-from-port/tslint.json
+++ b/types/pid-from-port/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.