### PR TITLE
WIP: [got] provide 'catch-all'-overload for inferring arguments

### DIFF
--- a/types/got/got-tests.ts
+++ b/types/got/got-tests.ts
@@ -12,6 +12,8 @@ import tough = require('tough-cookie');
 let str: string;
 let buf: Buffer;
 
+type Args<F> = F extends (...args: infer T) => any ? T : never;
+
 got('todomvc.com')
     .then(response => {
         str = response.body;
@@ -72,6 +74,16 @@ got('todomvc.com', {
     timeout: {connect: 20, request: 20, socket: 20}
 }).then(response => str = response.body);
 // following must lead to type checking error: got('todomvc.com', {form: true, body: ''}).then(response => str = response.body);
+
+// the following checks argument inference for GotFn overloads
+type ArgsGotFn = Args<got.GotFn>;
+const gotFnArgs01: ArgsGotFn = ['todomvc.com'];
+const gotFnArgs02: ArgsGotFn = ['todomvc.com', {json: true}];
+const gotFnArgs03: ArgsGotFn = ['todomvc.com', {json: true, body: {}}];
+const gotFnArgs04: ArgsGotFn = ['todomvc.com', {json: true, body: {}, encoding: null}];
+const gotFnArgs05: ArgsGotFn = ['todomvc.com', {json: true, body: {}, encoding: 'utf8'}];
+const gotFnArgs06: ArgsGotFn = ['todomvc.com', {form: true, body: [{}], encoding: null}];
+const gotFnArgs07: ArgsGotFn = ['todomvc.com', {form: true, body: [{}], encoding: 'utf8'}];
 
 got('todomvc.com', {encoding: null, hostname: 'todomvc'}).then(response => buf = response.body);
 got('todomvc.com', {encoding: 'utf8', hostname: 'todomvc'}).then(response => str = response.body);

--- a/types/got/index.d.ts
+++ b/types/got/index.d.ts
@@ -4,8 +4,9 @@
 //                 Linus Unnebäck <https://github.com/LinusU>
 //                 Konstantin Ikonnikov <https://github.com/ikokostya>
 //                 Stijn Van Nieuwenhuyse <https://github.com/stijnvn>
+//                 Jan Riemer <https://github.com/janriemer>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 3.0
 
 /// <reference types="node"/>
 
@@ -96,6 +97,8 @@ declare namespace got {
         (url: GotUrl, options: GotFormOptions<null>): GotPromise<Buffer>;
         (url: GotUrl, options: GotBodyOptions<string>): GotPromise<string>;
         (url: GotUrl, options: GotBodyOptions<null>): GotPromise<Buffer>;
+        (url: GotUrl, options?: GotJSONOptions | GotFormOptions<string> | GotFormOptions<null> | GotBodyOptions<string> | GotBodyOptions<null>):
+            GotPromise<any> | GotPromise<string> | GotPromise<Buffer>;
     }
 
     type GotStreamFn = (url: GotUrl, options?: GotOptions<string | null>) => GotEmitter & nodeStream.Duplex;


### PR DESCRIPTION
This is a work-in-progress. Do not merge yet!
## Problem
It is currently not possible to stub the overloaded function [got](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/2bc9203ec0121f4b0375979bb50e5dc6042ded8b/types/got/index.d.ts#L92) with [sinon](https://sinonjs.org/):
```typescript
import * as got from 'got';
import sinon from 'sinon';

describe(`Testing stuff`, () => {
    it('should compile', () => {
        const stubGot01 = sinon.stub({got}, 'got').withArgs('www.example.com'); // error
        // or
        const stubGot02 = sinon.stub({got}, 'got').withArgs('www.example.com', {form: true}); // error
        // ... the list can go on with all overloaded functions of `got`, except for the last one:
       const stubGot03 = sinon.stub({got}, 'got').withArgs('www.example.com', {encoding: null}); // OK
    });
});
```
## Reason
When trying to infer arguments of [GotFn](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/2bc9203ec0121f4b0375979bb50e5dc6042ded8b/types/got/index.d.ts#L92) in the package [got](https://github.com/sindresorhus/got), with the current implementation TypeScript will always infer the following type:
```typescript
type Args<F> = F extends (...args: infer T) => any ? T : never;
const args: Args<got.GotFn>;
// => (url: GotUrl, options: GotBodyOptions<null>)
```
This is due to TypeScript's [current limitation of only inferring the signature of the **last overload**](https://github.com/Microsoft/TypeScript/issues/26136).
This PR solves this by providing a "catch-all"-overload as the last overload.

## Why is this WIP?
When running `npm test`, the tests currently fail with the following output:
```
Error: p-any depends on got but has a lower required TypeScript version.
```
This is due to the fact that we have to increase version of ts from 2.3 to 3.0, so that we are able to infer arguments **in our tests**. The increase in version is actually **not required**, when only looking at index.d.ts and therefore the consumer of these types is not required to update ts version.
What can we do about this problem?

## Some further thoughts on this
I can imagine that this "catch-all"-overload is missing in many type definitions (I haven't checked it, though). Maybe, we should add it to [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/2bc9203ec0121f4b0375979bb50e5dc6042ded8b#common-mistakes) (although, it is more like a _best practice_ than a _common mistake_, but you hopefully get the idea)?

------------------------
Please fill in this template.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.) _tests currently fail (see above)!_
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/Microsoft/TypeScript/issues/26136 and https://github.com/sindresorhus/got
- [ ] Increase the version number in the header if appropriate. `N/A`
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. `N/A`
