### PR TITLE
fix(react-router): match can be null

### DIFF
--- a/types/react-router-dom/react-router-dom-tests.tsx
+++ b/types/react-router-dom/react-router-dom-tests.tsx
@@ -27,6 +27,10 @@ type OtherProps = RouteComponentProps<{
 }>;
 
 const Component: React.SFC<OtherProps> = props => {
+  if (!props.match) {
+    return null;
+  }
+
   const { id } = props.match.params;
   return (
     <div>{id}</div>

--- a/types/react-router/index.d.ts
+++ b/types/react-router/index.d.ts
@@ -68,7 +68,7 @@ export interface StaticContext {
 export interface RouteComponentProps<Params extends { [K in keyof Params]?: string } = {}, C extends StaticContext = StaticContext, S = H.LocationState> {
   history: H.History;
   location: H.Location<S>;
-  match: match<Params>;
+  match: match<Params> | null;
   staticContext?: C;
 }
 

--- a/types/react-router/test/examples-from-react-router-website/Ambiguous.tsx
+++ b/types/react-router/test/examples-from-react-router-website/Ambiguous.tsx
@@ -41,7 +41,7 @@ const AmbiguousExample = () => (
 
 const About = () => <h2>About</h2>;
 const Company = () => <h2>Company</h2>;
-const User: React.SFC<RouteComponentProps<{user: string}>> = ({ match }) => (
+const User: React.SFC<RouteComponentProps<{user: string}>> = ({ match }) => match && (
   <div>
     <h2>User: {match.params.user}</h2>
   </div>

--- a/types/react-router/test/examples-from-react-router-website/Animation.tsx
+++ b/types/react-router/test/examples-from-react-router-website/Animation.tsx
@@ -72,12 +72,12 @@ interface HSLParams {
   l: string;
 }
 
-const HSL: React.SFC<RouteComponentProps<HSLParams>> = ({ match: { params } }) => (
+const HSL: React.SFC<RouteComponentProps<HSLParams>> = ({ match }) => match && (
   <div style={{
     ...styles.fill,
     ...styles.hsl,
-    background: `hsl(${params.h}, ${params.s}%, ${params.l}%)`
-  }}>hsl({params.h}, {params.s}%, {params.l}%)</div>
+    background: `hsl(${match.params.h}, ${match.params.s}%, ${match.params.l}%)`
+  }}>hsl({match.params.h}, {match.params.s}%, {match.params.l}%)</div>
 );
 
 const styles: any = {};

--- a/types/react-router/test/examples-from-react-router-website/Basic.tsx
+++ b/types/react-router/test/examples-from-react-router-website/Basic.tsx
@@ -36,7 +36,7 @@ const About = () => (
   </div>
 );
 
-const Topics: React.SFC<RouteComponentProps> = ({ match }) => (
+const Topics: React.SFC<RouteComponentProps> = ({ match }) => match === null ? null : (
   <div>
     <h2>Topics</h2>
     <ul>
@@ -64,7 +64,7 @@ const Topics: React.SFC<RouteComponentProps> = ({ match }) => (
   </div>
 );
 
-const Topic: React.SFC<RouteComponentProps<{topicId: string}>> = ({ match }) => (
+const Topic: React.SFC<RouteComponentProps<{topicId: string}>> = ({ match }) => match && (
   <div>
     <h3>{match.params.topicId}</h3>
   </div>

--- a/types/react-router/test/examples-from-react-router-website/ModalGallery.tsx
+++ b/types/react-router/test/examples-from-react-router-website/ModalGallery.tsx
@@ -114,6 +114,10 @@ const Gallery = () => (
 );
 
 const ImageView: React.SFC<RouteComponentProps<{ id: string }>> = ({ match }) => {
+  if (!match) {
+    return null;
+  }
+
   const image = IMAGES[parseInt(match.params.id, 10)];
   if (!image) {
     return <div>Image not found</div>;
@@ -128,6 +132,10 @@ const ImageView: React.SFC<RouteComponentProps<{ id: string }>> = ({ match }) =>
 };
 
 const Modal: React.SFC<RouteComponentProps<{ id: string }>> = ({ match, history }) => {
+  if (!match) {
+    return null;
+  }
+
   const image = IMAGES[parseInt(match.params.id, 10)];
   if (!image) {
     return null;

--- a/types/react-router/test/examples-from-react-router-website/Params.tsx
+++ b/types/react-router/test/examples-from-react-router-website/Params.tsx
@@ -22,7 +22,7 @@ const ParamsExample = () => (
   </Router>
 );
 
-const Child: React.SFC<RouteComponentProps<{id: string}>> = ({ match }) => (
+const Child: React.SFC<RouteComponentProps<{id: string}>> = ({ match }) => match && (
   <div>
     <h3>ID: {match.params.id}</h3>
   </div>

--- a/types/react-router/test/examples-from-react-router-website/Recursive.tsx
+++ b/types/react-router/test/examples-from-react-router-website/Recursive.tsx
@@ -39,6 +39,10 @@ interface InitialPersonProps {
 type PersonProps = RouteComponentProps<{ id: string }>;
 
 const Person: React.SFC<InitialPersonProps | PersonProps> = ({ match }) => {
+  if (!match) {
+    return null;
+  }
+
   const person = find(match.params.id);
 
   return (


### PR DESCRIPTION
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://reacttraining.com/react-router/web/api/match/null-matches
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.