### PR TITLE
Add type definitions for neat-csv

### DIFF
--- a/types/neat-csv/index.d.ts
+++ b/types/neat-csv/index.d.ts
@@ -1,0 +1,36 @@
+// Type definitions for neat-csv 4.0
+// Project: https://github.com/sindresorhus/neat-csv
+// Definitions by: Alex Ruble <https://github.com/calamitizer>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types="node" />
+import { Readable } from 'stream';
+
+declare function neatCsv(input: neatCsv.Input, options?: neatCsv.Options): Promise<neatCsv.Row[]>;
+
+declare namespace neatCsv {
+    /** The CSV data to parse. */
+    type Input = string | Buffer | Readable;
+
+    /** A configuration object to be passed to csv-parser. */
+    interface Options {
+        escape?: string;
+        headers?: ReadonlyArray<string> | boolean;
+        mapHeaders?: (args: { header: string; index: number }) => string | null;
+        mapValues?: (args: { header: string; index: number; value: any }) => any;
+        newline?: string;
+        quote?: string;
+        raw?: boolean;
+        separator?: string;
+        skipLines?: number;
+        maxRowBytes?: number;
+        strict?: boolean;
+    }
+
+    /** A representation of one row of the input CSV. */
+    interface Row {
+        [header: string]: string;
+    }
+}
+
+export = neatCsv;

--- a/types/neat-csv/neat-csv-tests.ts
+++ b/types/neat-csv/neat-csv-tests.ts
@@ -1,0 +1,10 @@
+import * as neatCsv from 'neat-csv';
+
+const data: neatCsv.Input = 'type,part\nunicorn,horn\nrainbow,pink';
+const options: neatCsv.Options = { separator: ',' };
+
+neatCsv(data); // $ExpectType Promise<Row[]>
+const rowsPromise = neatCsv(data, options); // $ExpectType Promise<Row[]>
+
+rowsPromise.then(rows =>
+    rows.map(({ type, part }: neatCsv.Row) => `type: ${type}, part: ${part}`));

--- a/types/neat-csv/tsconfig.json
+++ b/types/neat-csv/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "neat-csv-tests.ts"
+    ]
+}

--- a/types/neat-csv/tslint.json
+++ b/types/neat-csv/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

[Here](https://github.com/sindresorhus/neat-csv) is the module in question, `neat-csv`. This is my first contribution, so let me know if anything looks off. Cheers!