### PR TITLE
DrawerItemsProps should be using DrawerNavigationState

### DIFF
--- a/types/react-navigation/index.d.ts
+++ b/types/react-navigation/index.d.ts
@@ -899,7 +899,7 @@ export function createSwitchNavigator(
 export const DrawerItems: React.ComponentType<DrawerItemsProps>;
 
 export interface DrawerItemsProps {
-  navigation: NavigationScreenProp<NavigationState>;
+  navigation: NavigationScreenProp<DrawerNavigationState>;
   items: NavigationRoute[];
   activeItemKey?: string;
   activeTintColor?: string;


### PR DESCRIPTION
Hey, this is a pretty simple change. DrawerNavigationState already existed but wasn't being used. As far as I can tell, it should be used in DrawerItemsProps.

I added the url to show it's a standard prop inside a DrawerNavigator below.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/react-navigation/react-navigation-drawer/blob/bf4bdba7f6a4fbc12192f5d5ba2285f6280431b7/src/views/DrawerView.js#L48
- [x] Increase the version number in the header if appropriate (N/A).
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }` (N/A).
