### PR TITLE
[@types/mongoose] add autoIndex at top level of connection options

### DIFF
--- a/types/mongoose/index.d.ts
+++ b/types/mongoose/index.d.ts
@@ -424,6 +424,7 @@ declare module "mongoose" {
        */
       autoIndex?: boolean;
     };
+    autoIndex?: boolean;
   }
 
   /** See the node-mongodb-native driver instance for options that it understands. */

--- a/types/mongoose/mongoose-tests.ts
+++ b/types/mongoose/mongoose-tests.ts
@@ -27,7 +27,8 @@ const connection2: Promise<mongoose.Mongoose> = mongoose.connect(connectUri, {
   bufferCommands: false,
   useNewUrlParser: true,
   useFindAndModify: true,
-  useCreateIndex: true
+  useCreateIndex: true,
+  autoIndex: true
 });
 const connection3: null = mongoose.connect(connectUri, function (error) {
   error.stack;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://mongoosejs.com/docs/api.html#mongoose_Mongoose-connect>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

According to mongoose api doc of 5.3.15, `autoIndex` is set at the top level of connection options object. 

API links:
https://mongoosejs.com/docs/api.html#mongoose_Mongoose-connect

Code links:
https://github.com/Automattic/mongoose/blob/master/lib/connection.js#L440

I'm not sure if the `config` option in `ConnectionOpenOptions` should still be kept in type definitions. There is no doc supports this config in mongoose 5.

If this config option should be removed, please comment below~