### PR TITLE
fix(remarkable): define types for Block Rules and Inline Rules

### DIFF
--- a/types/remarkable/index.d.ts
+++ b/types/remarkable/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for remarkable 1.7
 // Project: https://github.com/jonschlinkert/remarkable
 // Definitions by: makepost <https://github.com/makepost>
+//                 Richard Lea <https://github.com/chigix>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 import Remarkable = require("./lib");

--- a/types/remarkable/lib/index.d.ts
+++ b/types/remarkable/lib/index.d.ts
@@ -10,11 +10,11 @@ declare class Remarkable {
      */
     static utils: typeof Utils;
 
-    inline: { ruler: Ruler };
+    inline: { ruler: Ruler<Remarkable.InlineParsingRule> };
 
-    block: { ruler: Ruler };
+    block: { ruler: Ruler<Remarkable.BlockParsingRule> };
 
-    core: { ruler: Ruler };
+    core: { ruler: Ruler<Remarkable.CoreParsingRule> };
 
     renderer: Renderer;
 
@@ -134,36 +134,116 @@ declare namespace Remarkable {
         options: Options;
     }
 
-    interface ParsingState {
-        src: string;
-        env: Env;
-        options: Options;
-        tokens: [ContentToken];
-        inlineMode: boolean;
+    interface StateBlock {
+      src: string;
+      /** Shortcuts to simplify nested calls */
+      parser: ParserBlock;
+      options: Options;
+      env: Env;
+      tokens: [ContentToken];
+      bMarks: number[];
+      eMarks: number[];
+      tShift: number[];
+      /** required block content indent */
+      blkIndent: number;
+      /** line index in src */
+      line: number;
+      /** lines count */
+      lineMax: number;
+      /** loose/tight mode for lists */
+      tight: boolean;
+      /** If `list`, block parser stops on two newlines */
+      parentType: 'root' | 'list';
+      /** Indent of the current dd block, -1 if there isn't any */
+      ddIndent: number;
+      level: number;
+      result: string;
+      isEmpty: (line: number) => boolean;
+      skipEmptyLines: (from: number) => number;
+      skipSpaces: (pos: number) => number;
+      skipChars: (pos: number, code: number) => number;
+      getLines: (begin: number, end: number, indent: number, keepLastLF: boolean) => string;
+    }
+    interface StateInline {
+      src: string;
+      env: Env;
+      parser: ParserInline;
+      tokens: [ContentToken];
+      pos: number;
+      posMax: number;
+      level: number;
+      pending: string;
+      pendingLevel: number;
+      /** Set true when seek link label */
+      isInLabel: boolean;
+      /**
+       * Increment for each nesting link.
+       * Used to prevent nesting in definitions.
+       */
+      linkLevel: number;
+      /**
+       * Temporary storage for link url.
+       */
+      linkContent: string;
 
-        pos: number;
-        posMax: number;
-        pending: string;
-        level: number;
-
-        inline: ParserInline;
-        block: ParserBlock;
-        renderer: Renderer;
-        typographer: boolean;
-
-        push: (token: ContentToken) => void;
+      /**
+       * Track unpaired `[` for link labels.
+       */
+      labelUnmatchedScopes: number;
+      push: (token: ContentToken) => void;
+      pushPending: () => void;
     }
 
     /**
      * Return `true` if the parsing function has recognized the current position
      * in the input as one if its tokens.
      */
-    type ParsingRule = (
+    type CoreParsingRule = (
+      /**
+       * Representation of the current input stream, and the results of
+       * parsing it so far.
+       */
+      state: StateInline,
+  ) => boolean;
+
+    /**
+     * Return `true` if the parsing function has recognized the current position
+     * in the input as one if its tokens.
+     */
+    type InlineParsingRule = (
         /**
          * Representation of the current input stream, and the results of
          * parsing it so far.
          */
-        state: ParsingState,
+        state: StateInline,
+
+        /**
+         * If `true` we just do the recognition part, and don't bother to push a
+         * token.
+         */
+        silent: boolean
+    ) => boolean;
+
+    /**
+     * Return `true` if the parsing function has recognized the current position
+     * in the input as one if its tokens.
+     */
+    type BlockParsingRule = (
+        /**
+         * Representation of the current input stream, and the results of
+         * parsing it so far.
+         */
+        state: StateBlock,
+
+        /**
+         * The index of the current line.
+         */
+        startLine: number,
+
+        /**
+         * The index of the last available line.
+         */
+        endLine: number,
 
         /**
          * If `true` we just do the recognition part, and don't bother to push a
@@ -383,13 +463,13 @@ declare namespace Remarkable {
 }
 
 declare class ParserBlock {
-    tokenize(state: Remarkable.ParsingState, startLine: number, endLine: number): void;
+    tokenize(state: Remarkable.StateBlock, startLine: number, endLine: number): void;
     parse(str: string, options: Remarkable.Options, env: Remarkable.Env, tokens: [Remarkable.Token]): void;
 }
 
 declare class ParserInline {
-    skipToken(state: Remarkable.ParsingState): void;
-    tokenize(state: Remarkable.ParsingState): void;
+    skipToken(state: Remarkable.StateInline): void;
+    tokenize(state: Remarkable.StateInline): void;
     parse(str: string, options: Remarkable.Options, env: Remarkable.Env, tokens: [Remarkable.Token]): void;
     validateLink(url: string): boolean;
 }

--- a/types/remarkable/lib/ruler.d.ts
+++ b/types/remarkable/lib/ruler.d.ts
@@ -9,26 +9,26 @@ export = Ruler;
  *   - easy stack rules chains
  *   - getting main chain and named chains content (as arrays of functions)
  */
-declare class Ruler {
+declare class Ruler<RULE> {
   /**
    * Replace the rule `ruleName` with a new rule.
    */
-  at(ruleName: string, fn: Remarkable.ParsingRule, options: Remarkable.Options): void;
+  at(ruleName: string, fn: RULE, options: Remarkable.Options): void;
 
   /**
    * Add a rule to the chain before given the `ruleName`.
    */
-  before(beforeName: string, ruleName: string, fn: Remarkable.ParsingRule, options: Remarkable.Options): void;
+  before(beforeName: string, ruleName: string, fn: RULE, options: Remarkable.Options): void;
 
   /**
    * Add a rule to the chain after the given `ruleName`.
    */
-  after(afterName: string, ruleName: string, fn: Remarkable.ParsingRule, options: Remarkable.Options): void;
+  after(afterName: string, ruleName: string, fn: RULE, options: Remarkable.Options): void;
 
   /**
    * Add a rule to the end of chain.
    */
-  push(ruleName: string, fn: Remarkable.ParsingRule, options: Remarkable.Options): void;
+  push(ruleName: string, fn: RULE, options: Remarkable.Options): void;
 
   /**
    * Enable a rule or list of rules.


### PR DESCRIPTION
Signed-off-by: Richard Lea <chigix@zoho.com>

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.