### PR TITLE
Downloadjs: Fix downloadjs function return type

### DIFF
--- a/types/downloadjs/index.d.ts
+++ b/types/downloadjs/index.d.ts
@@ -1,10 +1,11 @@
 // Type definitions for downloadjs 1.4
 // Project: http://danml.com/download.html
 // Definitions by: cwmoo740 <https://github.com/cwmoo740>
+//                 josuedevmark <https://github.com/josuedevmark>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
 declare namespace download {
 }
-declare function download(data: string | File | Blob, filename?: string, mimeType?: string): void;
+declare function download(data: string | File | Blob, filename?: string, mimeType?: string): XMLHttpRequest | boolean;
 export = download;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 

1.  XMLHttpRequest return [see](https://github.com/rndme/download/blob/master/download.js#L58)

2.  boolean return [return_01](https://github.com/rndme/download/blob/master/download.js#L70) [return_02](https://github.com/rndme/download/blob/master/download.js#L148) [return_03](https://github.com/rndme/download/blob/master/download.js#L170)

- [x] Increase the version number in the header if appropriate.
<del>- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.</del>