### PR TITLE
Add checkReturnValue annotations to Jasmine#expect

### DIFF
--- a/types/jasmine/index.d.ts
+++ b/types/jasmine/index.d.ts
@@ -80,18 +80,21 @@ declare function afterAll(action: (done: DoneFn) => void, timeout?: number): voi
 
 /**
  * Create an expectation for a spec.
+ * @checkReturnValue see https://tsetse.info/check-return-value
  * @param spy
  */
 declare function expect(spy: Function): jasmine.Matchers<any>;
 
 /**
  * Create an expectation for a spec.
+ * @checkReturnValue see https://tsetse.info/check-return-value
  * @param actual
  */
 declare function expect<T>(actual: ArrayLike<T>): jasmine.ArrayLikeMatchers<T>;
 
 /**
  * Create an expectation for a spec.
+ * @checkReturnValue see https://tsetse.info/check-return-value
  * @param actual Actual computed value to test expectations against.
  */
 declare function expect<T>(actual: T): jasmine.Matchers<T>;


### PR DESCRIPTION
Under Bazel, we install the Tsetse static checks to augment the type-checking done by the TypeScript compiler.
Calling expect() from Jasmine and throwing away the return value appears to be a test, but actually does nothing.
Tsetse makes this condition a type-check failure. We need to annotate the function with `@checkReturnValue` to enable this feature.
See https://tsetse.info/check-return-value
