### PR TITLE
[pouchdb-replication] Add missing checkpoint attribute to ReplicateOptions

### DIFF
--- a/types/pouchdb-replication/index.d.ts
+++ b/types/pouchdb-replication/index.d.ts
@@ -84,9 +84,9 @@ declare namespace PouchDB {
             back_off_function?(delay: number): number;
             
             /**
-             * Can be used if you want to disable checkpoints on the source, target, or both. 
-             * Setting this option to false will prevent writing checkpoints on both source and target. 
-             * Setting it to source will only write checkpoints on the source. 
+             * Can be used if you want to disable checkpoints on the source, target, or both.
+             * Setting this option to false will prevent writing checkpoints on both source and target.
+             * Setting it to source will only write checkpoints on the source.
              * Setting it to target will only write checkpoints on the target.
              */
             checkpoint?: boolean | 'target' | 'source';

--- a/types/pouchdb-replication/index.d.ts
+++ b/types/pouchdb-replication/index.d.ts
@@ -82,6 +82,14 @@ declare namespace PouchDB {
              * The default delay will never exceed 10 minutes.
              */
             back_off_function?(delay: number): number;
+            
+            /**
+             * Can be used if you want to disable checkpoints on the source, target, or both. 
+             * Setting this option to false will prevent writing checkpoints on both source and target. 
+             * Setting it to source will only write checkpoints on the source. 
+             * Setting it to target will only write checkpoints on the target.
+             */
+            checkpoint?: boolean | 'target' | 'source';
         }
 
         interface ReplicationEventEmitter<Content extends {}, C, F> extends EventEmitter {

--- a/types/pouchdb-replication/index.d.ts
+++ b/types/pouchdb-replication/index.d.ts
@@ -82,7 +82,7 @@ declare namespace PouchDB {
              * The default delay will never exceed 10 minutes.
              */
             back_off_function?(delay: number): number;
-            
+
             /**
              * Can be used if you want to disable checkpoints on the source, target, or both.
              * Setting this option to false will prevent writing checkpoints on both source and target.


### PR DESCRIPTION
According to the docs (https://pouchdb.com/api.html#sync) and the source code, there's a missing 'checkpoint' attribute in ReplicateOptions.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
