### PR TITLE
Add types for move-file

### DIFF
--- a/types/move-file/index.d.ts
+++ b/types/move-file/index.d.ts
@@ -1,0 +1,20 @@
+// Type definitions for move-file 1.0
+// Project: https://github.com/sindresorhus/move-file#readme
+// Definitions by: BendingBender <https://github.com/BendingBender>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export = moveFile;
+
+declare function moveFile(
+    source: string,
+    destination: string,
+    options?: moveFile.Options
+): Promise<void>;
+
+declare namespace moveFile {
+    function sync(source: string, destination: string, options?: Options): void;
+
+    interface Options {
+        overwrite?: boolean;
+    }
+}

--- a/types/move-file/move-file-tests.ts
+++ b/types/move-file/move-file-tests.ts
@@ -1,0 +1,10 @@
+import moveFile = require('move-file');
+
+// $ExpectType Promise<void>
+moveFile('source/unicorn.png', 'destination/unicorn.png');
+// $ExpectType Promise<void>
+moveFile('source/unicorn.png', 'destination/unicorn.png', { overwrite: false });
+// $ExpectType void
+moveFile.sync('source/unicorn.png', 'destination/unicorn.png');
+// $ExpectType void
+moveFile.sync('source/unicorn.png', 'destination/unicorn.png', { overwrite: false });

--- a/types/move-file/tsconfig.json
+++ b/types/move-file/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "move-file-tests.ts"
+    ]
+}

--- a/types/move-file/tslint.json
+++ b/types/move-file/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.