### PR TITLE
@types/parse Remove const enum

### DIFF
--- a/types/parse/index.d.ts
+++ b/types/parse/index.d.ts
@@ -833,7 +833,7 @@ subscription.on('close', () => {});
     /*
      * We need to inline the codes in order to make compilation work without this type definition as dependency.
      */
-    const enum ErrorCode {
+    enum ErrorCode {
 
         OTHER_CAUSE = -1,
         INTERNAL_SERVER_ERROR = 1,


### PR DESCRIPTION
Was throwing error:

Type error: Ambient const enums are not allowed when the '--isolatedModules' flag is provided.