### PR TITLE
Add type definitions for insert-css

### DIFF
--- a/types/insert-css/index.d.ts
+++ b/types/insert-css/index.d.ts
@@ -1,0 +1,18 @@
+// Type definitions for insert-css 2.0
+// Project: https://github.com/substack/insert-css
+// Definitions by: Heye Vöcking <https://github.com/hvoecking>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export interface InsertCssOptions {
+    container?: HTMLElement;
+    prepend?: boolean;
+}
+
+export interface InsertCssStyleElement extends HTMLStyleElement {
+    styleSheet?: CSSStyleSheet;
+}
+
+export function insertCss(
+    css: string,
+    options?: InsertCssOptions,
+): InsertCssStyleElement;

--- a/types/insert-css/insert-css-tests.ts
+++ b/types/insert-css/insert-css-tests.ts
@@ -5,23 +5,23 @@ insertCss('body{position:absolute}');
 insertCss('body{position:absolute}', {});
 
 insertCss('body{text-decoration:underline !important}', {
-  prepend: true,
+    prepend: true,
 });
 
 insertCss('body{text-decoration:underline !important}', {
-  prepend: false,
+    prepend: false,
 });
 
 insertCss('body{position:absolute}', {
-  container: document.createElement(''),
+    container: document.createElement(''),
 });
 
 insertCss('body{text-decoration:underline !important}', {
-  prepend: true,
-  container: document.createElement('div'),
+    prepend: true,
+    container: document.createElement('div'),
 });
 
 insertCss('body{text-decoration:underline !important}', {
-  prepend: false,
-  container: document.createElement('div'),
+    prepend: false,
+    container: document.createElement('div'),
 });

--- a/types/insert-css/insert-css-tests.ts
+++ b/types/insert-css/insert-css-tests.ts
@@ -1,4 +1,4 @@
-import { insertCss } from "insert-css";
+import { insertCss } from 'insert-css';
 
 insertCss('body{position:absolute}');
 

--- a/types/insert-css/insert-css-tests.ts
+++ b/types/insert-css/insert-css-tests.ts
@@ -18,10 +18,10 @@ insertCss('body{position:absolute}', {
 
 insertCss('body{text-decoration:underline !important}', {
     prepend: true,
-    container: document.createElement('div'),
+    container: document.createElement(''),
 });
 
 insertCss('body{text-decoration:underline !important}', {
     prepend: false,
-    container: document.createElement('div'),
+    container: document.createElement(''),
 });

--- a/types/insert-css/insert-css-tests.ts
+++ b/types/insert-css/insert-css-tests.ts
@@ -1,0 +1,27 @@
+import { insertCss } from "insert-css";
+
+insertCss('body{position:absolute}');
+
+insertCss('body{position:absolute}', {});
+
+insertCss('body{text-decoration:underline !important}', {
+  prepend: true,
+});
+
+insertCss('body{text-decoration:underline !important}', {
+  prepend: false,
+});
+
+insertCss('body{position:absolute}', {
+  container: document.createElement(''),
+});
+
+insertCss('body{text-decoration:underline !important}', {
+  prepend: true,
+  container: document.createElement('div'),
+});
+
+insertCss('body{text-decoration:underline !important}', {
+  prepend: false,
+  container: document.createElement('div'),
+});

--- a/types/insert-css/tsconfig.json
+++ b/types/insert-css/tsconfig.json
@@ -1,0 +1,26 @@
+{
+    "compilerOptions": {
+        "baseUrl": "../",
+        "forceConsistentCasingInFileNames": true,
+        "lib": [
+            "dom",
+            "es6"
+        ],
+        "module": "commonjs",
+        "noEmit": true,
+        "noImplicitAny": true,
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "strictNullChecks": true,
+        "typeRoots": ["../"],
+        "types": []
+    },
+    "files": [
+        "index.d.ts",
+        "insert-css-tests.ts"
+    ]
+}

--- a/types/insert-css/tslint.json
+++ b/types/insert-css/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.