### PR TITLE
[react-table] allow using refs after applying HOCs

### DIFF
--- a/types/react-table/lib/hoc/selectTable.d.ts
+++ b/types/react-table/lib/hoc/selectTable.d.ts
@@ -1,4 +1,4 @@
-import { ComponentType } from 'react';
+import { ComponentType, ComponentClass } from 'react';
 
 import { TableProps } from '../../index';
 
@@ -49,8 +49,8 @@ export interface SelectTableHOCOptions {
 }
 
 declare function selectTableHOC<Props extends Partial<TableProps>>(
-    Component: ComponentType<Props>,
+    WrappedComponent: ComponentType<Props>,
     options?: SelectTableHOCOptions
-): ComponentType<Props & SelectTableAdditionalProps>;
+): ComponentClass<Props & SelectTableAdditionalProps>;
 
 export default selectTableHOC;

--- a/types/react-table/lib/hoc/treeTable.d.ts
+++ b/types/react-table/lib/hoc/treeTable.d.ts
@@ -1,9 +1,9 @@
-import { ComponentType } from 'react';
+import { ComponentType, ComponentClass } from 'react';
 
 import { TableProps } from '../../index';
 
 declare function treeTableHOC<Props extends Partial<TableProps>>(
-    Component: ComponentType<Props>
-): ComponentType<Props>;
+    WrappedComponent: ComponentType<Props>
+): ComponentClass<Props>;
 
 export default treeTableHOC;

--- a/types/react-table/test/select-table-tests.tsx
+++ b/types/react-table/test/select-table-tests.tsx
@@ -52,6 +52,7 @@ ReactDOM.render(
         {...selectTableAdditionalProps}
         data={data}
         columns={columns}
+        ref={React.createRef()}
     />,
     document.getElementById('root')
 );

--- a/types/react-table/test/tree-table-tests.tsx
+++ b/types/react-table/test/tree-table-tests.tsx
@@ -4,7 +4,7 @@ import * as ReactDOM from 'react-dom';
 import ReactTable, { Column } from 'react-table';
 import treeTableHOC from 'react-table/lib/hoc/treeTable';
 
-const SelectTable = treeTableHOC(ReactTable);
+const TreeTable = treeTableHOC(ReactTable);
 
 const data = [{ id: 1, name: 'Foo' }, { id: 2, name: 'Bar' }];
 
@@ -14,6 +14,6 @@ const columns: Column[] = [
 ];
 
 ReactDOM.render(
-    <SelectTable data={data} columns={columns} />,
+    <TreeTable data={data} columns={columns} ref={React.createRef()} />,
     document.getElementById('root')
 );


### PR DESCRIPTION
This PR fixes #31261.

The return type of HOCs did not match the reality.
The return type was `ComponentType` which allowed StatelessComponent
(which does not allow refs by default) to be returned,
whereas in reality it was always the class component
(`ComponentClass`) that was returned from a HOC.

Here are the definitions of components returned from the HOCs:
* `selectTableHOC` https://github.com/react-tools/react-table/blob/master/src/hoc/selectTable/index.js#L21
* `treeTableHOC` https://github.com/react-tools/react-table/blob/master/src/hoc/treeTable/index.js#L6

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).



If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: (the URLs are provided at the beginning of the description)
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

