### PR TITLE
[jquery] Fix ArrayLike handling for call signature.

### DIFF
--- a/types/jquery/JQueryStatic.d.ts
+++ b/types/jquery/JQueryStatic.d.ts
@@ -148,21 +148,26 @@ $( "div", xml.responseXML );
 $( document.body ).css( "background", "black" );
 ```
      */
-    // Using a unified signature is not possible due to a TypeScript 2.4 bug (DefinitelyTyped#27810)
-    <T extends Element>(element: T): JQuery<T>;
+    // NOTE: `HTMLSelectElement` is both an Element and an Array-Like Object but jQuery treats it as an Element.
+    (element: HTMLSelectElement): JQuery<HTMLSelectElement>;
     /**
      * Return a collection of matched elements either found in the DOM based on passed argument(s) or created by passing an HTML string.
-     * @param elementArray An array containing a set of DOM elements to wrap in a jQuery object.
+     * @param element_elementArray _&#x40;param_ `element_elementArray`
+     * <br>
+     * * `element` — A DOM element to wrap in a jQuery object. <br>
+     * * `elementArray` — An array containing a set of DOM elements to wrap in a jQuery object.
      * @see \`{@link https://api.jquery.com/jQuery/ }\`
      * @since 1.0
+     * @example ​ ````Set the background color of the page to black.
+```javascript
+$( document.body ).css( "background", "black" );
+```
      * @example ​ ````Hide all the input elements within a form.
 ```javascript
 $( myForm.elements ).hide();
 ```
      */
-    // Using a unified signature is not possible due to a TypeScript 2.4 bug (DefinitelyTyped#27810)
-    // tslint:disable-next-line:unified-signatures
-    <T extends Element>(elementArray: T[]): JQuery<T>;
+    <T extends Element>(element_elementArray: T | ArrayLike<T>): JQuery<T>;
     /**
      * Return a collection of matched elements either found in the DOM based on passed argument(s) or created by passing an HTML string.
      * @param selection An existing jQuery object to clone.

--- a/types/jquery/jquery-tests.ts
+++ b/types/jquery/jquery-tests.ts
@@ -160,6 +160,9 @@ function JQueryStatic() {
         // $ExpectType JQuery<HTMLSelectElement>
         $([new HTMLSelectElement()]);
 
+        // $ExpectType JQuery<HTMLParagraphElement>
+        $(document.querySelectorAll('p'));
+
         // https://github.com/DefinitelyTyped/DefinitelyTyped/issues/19597#issuecomment-378218432
         function issue_19597_378218432() {
             const myDiv = $(document.createElement('div'));


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
http://jsfiddle.net/leonard_thieu/9kha387s/4/
- ~~Increase the version number in the header if appropriate.~~
- ~~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.~~

---

Passing in a non-array array-like object to the call signature results in the object being treated as a plain object. This is not the correct behavior as demonstrated by the linked fiddle. `NodeList` is an array-like object and when passed to jQuery has its contained elements copied to the resulting jQuery object. This bug was introduced by #27810 which fixed behavior for `HTMLSelectElement`. `HTMLSelectElement` is both an `Element` and an array-like object but is treated as an `Element` by jQuery. The `ArrayLike` signature was removed at the time because it was determined that jQuery did not support `ArrayLike` objects for the call signature.

To remedy this, `HTMLSelectElement` is given its own higher priority signature to ensure that it is treated as an `Element`, The old `ArrayLike` signature is restored to fix the behavior for non-`HTMLSelectElement` array-like objects.

@denisname 