### PR TITLE
[chroma-js] fix valid interpolation modes

### DIFF
--- a/types/chroma-js/index.d.ts
+++ b/types/chroma-js/index.d.ts
@@ -21,7 +21,7 @@ declare namespace chroma {
         gl: [number, number, number, number];
     }
 
-    type InterpolationMode = "rgb" | "hsl" | "hsv" | "hsi" | "lab" | "lch" | "hcl"
+    type InterpolationMode = "rgb" | "hsl" | "hsv" | "hsi" | "lab" | "lch" | "hcl";
 
     interface ChromaStatic {
         /**

--- a/types/chroma-js/index.d.ts
+++ b/types/chroma-js/index.d.ts
@@ -21,6 +21,8 @@ declare namespace chroma {
         gl: [number, number, number, number];
     }
 
+    type InterpolationMode = "rgb" | "hsl" | "hsv" | "hsi" | "lab" | "lch" | "hcl"
+
     interface ChromaStatic {
         /**
          * Creates a color from a string representation (as supported in CSS).
@@ -311,7 +313,7 @@ declare namespace chroma {
 
         domain(d?: number[], n?: number, mode?: string): this;
 
-        mode(mode: keyof ColorSpaces): this;
+        mode(mode: InterpolationMode): this;
 
         gamma(g: number): this;
 


### PR DESCRIPTION
Not all `ColorSpaces` are valid for interpolation, so i created the `InterpolationMode` type, which has valid modes for interpolating between. Modes such as `'rgba'` or `'cmyk'` will now throw errors at compile time rather than at runtime.

----

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/gka/chroma.js/blob/5a562f043f7b5ccfbc35db2f55ba0f1e497de63e/src/generator/mix.js#L12
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.