### PR TITLE
Remove global Express.Request.user declaration

### DIFF
--- a/types/express-jwt/index.d.ts
+++ b/types/express-jwt/index.d.ts
@@ -58,10 +58,3 @@ declare namespace jwt {
         constructor(code: ErrorCode, error: { message: string });
     }
 }
-declare global {
-    namespace Express {
-        export interface Request {
-            user?: any
-        }
-    }
-}


### PR DESCRIPTION
This should be defined by the consumer based on what they know the type might be, 
rather than by the type definitions
