### PR TITLE
fix(gapi.people): replace deprecated RequestMask with PersonFields

### DIFF
--- a/types/gapi.auth2/gapi.auth2-tests.ts
+++ b/types/gapi.auth2/gapi.auth2-tests.ts
@@ -144,7 +144,8 @@ function handleSignoutClick(event: MouseEvent) {
 // Load the API and make an API call.  Display the results on the screen.
 function makeApiCall() {
   gapi.client.people.people.get({
-    resourceName: 'people/me'
+    resourceName: 'people/me',
+    personFields: 'names'
   }).then((resp) => {
     const p = document.createElement('p');
     const name = resp.result.names[0].givenName;

--- a/types/gapi.people/gapi.people-tests.ts
+++ b/types/gapi.people/gapi.people-tests.ts
@@ -64,6 +64,7 @@
     var request = gapi.client.people.people.connections.list({
         'resourceName': 'people/me',
         'pageSize': 10,
+        'personFields': 'names'
       });
 
       request.execute(function(resp) {

--- a/types/gapi.people/index.d.ts
+++ b/types/gapi.people/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for Google People API 1.0
 // Project: https://developers.google.com/people/
 // Definitions by: Tanguy Krotoff <https://github.com/tkrotoff>
+//                 Joshua O'Brien <https://github.com/joshuaobrien>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -13,7 +14,7 @@ declare namespace gapi.client.people {
       resourceName: string;
 
       // Query parameters
-      requestMask?: RequestMask;
+      personFields: string;
     }
 
     function get(parameters: GetParameters): HttpRequest<Person>;
@@ -21,7 +22,7 @@ declare namespace gapi.client.people {
     interface GetBatchGetParameters {
       // Query parameters
       resourcesName?: string;
-      requestMask?: RequestMask;
+      personFields: string;
     }
 
     function getBatchGet(parameters: GetBatchGetParameters): HttpRequest<BatchGetResponse>;
@@ -49,7 +50,7 @@ declare namespace gapi.client.people {
         pageSize?: number;
         sortOrder?: SortOrder;
         syncToken?: string;
-        requestMask?: RequestMask;
+        personFields: string;
       }
 
       interface Response {
@@ -58,10 +59,6 @@ declare namespace gapi.client.people {
         nextSyncToken: string;
       }
     }
-  }
-
-  interface RequestMask {
-    includeField: string;
   }
 
   type SourceType = 'SOURCE_TYPE_UNSPECIFIED' | 'ACCOUNT' | 'PROFILE' | 'DOMAIN_PROFILE' | 'CONTACT';

--- a/types/gapi/gapi-tests.ts
+++ b/types/gapi/gapi-tests.ts
@@ -20,7 +20,8 @@ https://developers.google.com/api-client-library/javascript/reference/referenced
     }).then(function() {
       // 3. Initialize and make the API request.
       return gapi.client.people.people.get({
-        resourceName: 'people/me'
+        resourceName: 'people/me',
+        personFields: 'name'
       });
     }).then(function(response) {
       console.log(response.result);


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.


The RequestMask field has been deprecated (see https://developers.google.com/people/api/rest/v1/RequestMask). It is replaced with a required string.