### PR TITLE
Add types for clean-regexp

### DIFF
--- a/types/clean-regexp/clean-regexp-tests.ts
+++ b/types/clean-regexp/clean-regexp-tests.ts
@@ -1,0 +1,12 @@
+import cleanRegexp = require('clean-regexp');
+
+// $ExpectType string
+cleanRegexp('[0-9]');
+cleanRegexp('[^0-9]');
+cleanRegexp('[a-zA-Z0-9_]');
+cleanRegexp('[a-z0-9_]', 'i');
+cleanRegexp('[^a-zA-Z0-9_]');
+cleanRegexp('[^a-z0-9_]', 'i');
+cleanRegexp('[a-zA-Z\\d_]');
+cleanRegexp('[^a-zA-Z\\d_]');
+cleanRegexp('[0-9]+\\.[a-zA-Z0-9_]?');

--- a/types/clean-regexp/index.d.ts
+++ b/types/clean-regexp/index.d.ts
@@ -1,0 +1,8 @@
+// Type definitions for clean-regexp 1.0
+// Project: https://github.com/samverschueren/clean-regexp#readme
+// Definitions by: BendingBender <https://github.com/BendingBender>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export = cleanRegexp;
+
+declare function cleanRegexp(regexp: string, flags?: string): string;

--- a/types/clean-regexp/tsconfig.json
+++ b/types/clean-regexp/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "clean-regexp-tests.ts"
+    ]
+}

--- a/types/clean-regexp/tslint.json
+++ b/types/clean-regexp/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.