### PR TITLE
[CKEditor] Add optional 'movingOut' parameter in DOM walker's guard property

### DIFF
--- a/types/ckeditor/ckeditor-tests.ts
+++ b/types/ckeditor/ckeditor-tests.ts
@@ -369,6 +369,7 @@ function test_dom_walker() {
     node = walker.lastForward();
     node = walker.next();
     node = walker.previous();
+    isSomething = walker.guard(node, true);
     walker.reset();
 
     isSomething = CKEDITOR.dom.walker.blockBoundary({ div: 1 })(node);

--- a/types/ckeditor/ckeditor-tests.ts
+++ b/types/ckeditor/ckeditor-tests.ts
@@ -486,7 +486,7 @@ function test_dialog() {
                 {
                     id: 'tab-basic',
                     label: 'Basic Settings',
-                    elements: <any[]> []
+                    elements: [] as any []
                 },
                 {
                     id: 'tab-adv',

--- a/types/ckeditor/index.d.ts
+++ b/types/ckeditor/index.d.ts
@@ -498,7 +498,7 @@ declare namespace CKEDITOR {
 
         class walker {
             evaluator: (node: node) => boolean;
-            guard: (node: node) => boolean;
+            guard: (node: node, movingOut?: boolean) => boolean;
 
             static validEmptyBlockContainers: { [key: string]: any };
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 

https://github.com/ckeditor/ckeditor-dev/blob/major/core/dom/walker.js#L47

- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
