### PR TITLE
Chore: Add callbacks to eureka-js-client methods

### DIFF
--- a/types/eureka-js-client/eureka-js-client-tests.ts
+++ b/types/eureka-js-client/eureka-js-client-tests.ts
@@ -43,3 +43,11 @@ const newerClient = new Eureka({
     port: 32768,
   }
 });
+
+// Test callbacks
+newerClient.start((err: Error) => {});
+newerClient.start(() => {});
+newerClient.start();
+newerClient.stop((err: Error) => {});
+newerClient.start(() => {});
+newerClient.stop();

--- a/types/eureka-js-client/eureka-js-client-tests.ts
+++ b/types/eureka-js-client/eureka-js-client-tests.ts
@@ -1,4 +1,4 @@
-import { Eureka } from 'eureka-js-client';
+import { Eureka, EurekaClient } from 'eureka-js-client';
 
 // example configuration
 const client = new Eureka({
@@ -44,6 +44,11 @@ const newerClient = new Eureka({
   }
 });
 
+const ymlInitClient = new Eureka({
+  cwd: `/opt/config`,
+  filename: 'eureka-config'
+});
+
 // Test callbacks
 newerClient.start((err: Error) => {});
 newerClient.start(() => {});
@@ -51,3 +56,37 @@ newerClient.start();
 newerClient.stop((err: Error) => {});
 newerClient.start(() => {});
 newerClient.stop();
+
+const fakeInstanceResponse: EurekaClient.EurekaInstanceConfig[] = [
+  {
+    instanceId: 'config-server:8888',
+    hostName: '10.10.10.10',
+    app: 'CONFIG-SERVER',
+    ipAddr: '10.10.10.10',
+    status: 'UP',
+    overriddenstatus: 'UNKNOWN',
+    port: {
+      $: 8888,
+      '@enabled': true
+    },
+    securePort: {
+      $: 443,
+      '@enabled': true
+    },
+    countryId: 1,
+    dataCenterInfo: {
+      '@class': 'com.netflix.appinfo.InstanceInfo$DefaultDataCenterInfo',
+      name: 'MyOwn'
+    },
+    metadata: { '@class': 'java.util.Collections$EmptyMap' },
+    homePageUrl: 'http://10.10.10.10:8888/',
+    statusPageUrl: 'http://10.10.10.10:8888/info',
+    healthCheckUrl: 'http://10.10.10.10:8888/v1/service-health',
+    vipAddress: 'config-server',
+    secureVipAddress: 'config-server',
+    isCoordinatingDiscoveryServer: false,
+    lastUpdatedTimestamp: 1544691255230,
+    lastDirtyTimestamp: 1544691254634,
+    actionType: 'ADDED'
+  }
+];

--- a/types/eureka-js-client/index.d.ts
+++ b/types/eureka-js-client/index.d.ts
@@ -6,11 +6,11 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 export class Eureka {
-    constructor(config: EurekaClient.EurekaConfig)
-    start(cb?: (err?: Error) => void): void;
-    stop(cb?: (err?: Error) => void): void;
-    getInstancesByAppId(appId: string): string[];
-    getInstancesByVipAddress(vidAddress: string): string [];
+    constructor(config: EurekaClient.EurekaConfig | EurekaClient.EurekaYmlConfig)
+    start(cb?: (err: Error, ...rest: any[]) => void): void;
+    stop(cb?: (err: Error, ...rest: any[]) => void): void;
+    getInstancesByAppId(appId: string): EurekaClient.EurekaInstanceConfig[];
+    getInstancesByVipAddress(vidAddress: string): EurekaClient.EurekaInstanceConfig[];
 }
 
 export namespace EurekaClient {
@@ -28,11 +28,11 @@ export namespace EurekaClient {
         ipAddr: string;
         vipAddress: string;
         dataCenterInfo: DataCenterInfo;
-        port?: number | LegacyPortWrapper;
+        port?: number | PortWrapper | LegacyPortWrapper;
         instanceId?: string;
         appGroupName?: string;
         sid?: string;
-        securePort?: PortWrapper;
+        securePort?: number | PortWrapper | LegacyPortWrapper;
         homePageUrl?: string;
         statusPageUrl?: string;
         healthCheckUrl?: string;
@@ -43,6 +43,12 @@ export namespace EurekaClient {
         overriddenstatus?: InstanceStatus;
         leaseInfo?: LeaseInfo;
         isCoordinatingDiscoveryServer?: boolean;
+        lastUpdatedTimestamp?: number;
+        lastDirtyTimestamp?: number;
+        actionType?: ActionType;
+        metadata?: {
+            [index: string]: string;
+        };
     }
     interface EurekaClientConfig {
         host: string;
@@ -62,6 +68,17 @@ export namespace EurekaClient {
         registerWithEureka?: boolean;
         useLocalMetadata?: boolean;
         preferIpAddress?: boolean;
+        shouldUseDelta?: boolean;
+        logger?: {
+            warn: (...args: any[]) => void;
+            info: (...args: any[]) => void;
+            debug: (...args: any[]) => void;
+            error: (...args: any[]) => void;
+        };
+    }
+    interface EurekaYmlConfig {
+        cwd: string;
+        filename?: string;
     }
     interface LegacyPortWrapper {
         '$': number;
@@ -72,8 +89,12 @@ export namespace EurekaClient {
         port: number;
     }
     interface LeaseInfo {
-        renewalIntervalInSecs: number;
-        durationInSecs: number;
+        renewalIntervalInSecs?: number;
+        durationInSecs?: number;
+        registrationTimestamp?: number;
+        lastRenewalTimestamp?: number;
+        evictionTimestamp?: number;
+        serviceUpTimestamp?: number;
     }
     interface DataCenterInfo {
         name: DataCenterName;

--- a/types/eureka-js-client/index.d.ts
+++ b/types/eureka-js-client/index.d.ts
@@ -1,12 +1,14 @@
 // Type definitions for eureka-js-client 4.4
 // Project: https://github.com/jquatier/eureka-js-client
-// Definitions by: Ilko Hoffmann <https://github.com/Schnillz>, Karl O. <https://github.com/karl-run>
+// Definitions by: Ilko Hoffmann <https://github.com/Schnillz>
+//                 Karl O. <https://github.com/karl-run>
+//                 Tom Barton <https://github.com/tombarton>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 export class Eureka {
     constructor(config: EurekaClient.EurekaConfig)
-    start(): void;
-    stop(): void;
+    start(cb?: (err?: Error) => void): void;
+    stop(cb?: (err?: Error) => void): void;
     getInstancesByAppId(appId: string): string[];
     getInstancesByVipAddress(vidAddress: string): string [];
 }


### PR DESCRIPTION
Update the Eurkea JS Client typings to include optional callbacks in the `start` and `stop` methods.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/jquatier/eureka-js-client/blob/master/src/EurekaClient.js
- [X] Increase the version number in the header if appropriate.
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
