### PR TITLE
React-Table: When filterAll is set, filterMethod must take and return rows (any[])

### DIFF
--- a/types/react-table/index.d.ts
+++ b/types/react-table/index.d.ts
@@ -23,7 +23,7 @@ export type ComponentPropsGetterC = (finalState: any, rowInfo?: undefined, colum
 export type ComponentPropsGetterRC = (finalState: any, rowInfo?: RowInfo, column?: Column, instance?: any) => object | undefined;
 
 export type DefaultFilterFunction = (filter: Filter, row: any, column: any) => boolean;
-export type FilterFunction = (filter: Filter, rows: any[], column: any) => boolean;
+export type FilterFunction = (filter: Filter, rows: any[], column: any) => any[];
 export type SubComponentFunction = (rowInfo: RowInfo) => React.ReactNode;
 export type PageChangeFunction = (page: number) => void;
 export type PageSizeChangeFunction = (newPageSize: number, newPage: number) => void;


### PR DESCRIPTION
- [x] Have tested the change in my own code.
- [ ] Did not add or change any tests
- [x] Trying to follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Trying to avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Has run `npm run lint react-table`

- [x] URL to documentation or source code which provides context for the suggested changes: 
https://react-table.js.org/#filtering

> 
> By default, filterMethod is passed a single row of data at a time, and you are responsible for returning true or false, indicating whether it should be shown.
> 
> Alternatively, you can set filterAll to true, and filterMethod will be passed the entire array of rows to be filtered, and you will then be responsible for returning the new filtered array.

- [x] Increasing the version number: Minimal change, strictly making more correct programs typecheck, so I don't think it would be necessary (feel free to comment).
- [x] Not making substantial changes, so no need for a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

Stricter typechecking may be possible. Ideally, the "take one row, return a boolean" type (DefaultFilterFunction) should be required when filterAll is false, and the "take rows, return rows" type (FilterFunction, as it is in this code) should be required when filterAll is true. It may be possible to enforce this with the type system; I don't know how.