### PR TITLE
rename Options to searchOptions in props [react-places-autocomplete]

### DIFF
--- a/types/react-places-autocomplete/index.d.ts
+++ b/types/react-places-autocomplete/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/kenny-hibino/react-places-autocomplete/
 // Definitions by: Guilherme Hübner <https://github.com/guilhermehubner>
 //                 Andrew Makarov <https://github.com/r3nya>
+//                 Nokky Goren
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 //
@@ -38,7 +39,7 @@ export interface PropTypes {
         autocompleteItem?: React.CSSProperties;
         autocompleteItemActive?: React.CSSProperties;
     };
-    options?: {
+    searchOptions?: {
         bounds?: google.maps.LatLngBounds | google.maps.LatLngBoundsLiteral;
         componentRestrictions?: google.maps.GeocoderComponentRestrictions;
         location?: google.maps.LatLng | google.maps.LatLngLiteral;

--- a/types/react-places-autocomplete/index.d.ts
+++ b/types/react-places-autocomplete/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/kenny-hibino/react-places-autocomplete/
 // Definitions by: Guilherme Hübner <https://github.com/guilhermehubner>
 //                 Andrew Makarov <https://github.com/r3nya>
-//                 Nokky Goren
+//                 Nokky Goren <https://github.com/ApeNox>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 //


### PR DESCRIPTION
This should have been added before, but has been left out.

If changing an existing definition:
https://github.com/hibiken/react-places-autocomplete -  README states searchOptions clearly.