### PR TITLE
[Slate, Slate-React]: Additional 0.42.0 changes

### DIFF
--- a/types/slate-react/index.d.ts
+++ b/types/slate-react/index.d.ts
@@ -6,7 +6,7 @@
 //                 Patrick Sachs <https://github.com/PatrickSachs>
 //                 Brandon Shelton <https://github.com/YangusKhan>
 //                 Irwan Fario Subastian <https://github.com/isubasti>
-//                 Sebastian Greaves <https://github.com/sgreav>
+//                 Hanna Greaves <https://github.com/sgreav>
 //                 Francesco Agnoletto <https://github.com/Kornil>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
@@ -18,8 +18,7 @@ import {
     Block,
     Inline,
     Operations,
-    Schema,
-    Stack,
+    SchemaProperties,
     Value,
     Operation,
     MarkProperties,
@@ -112,7 +111,7 @@ export interface BasicEditorProps {
     plugins?: Plugin[];
     readOnly?: boolean;
     role?: string;
-    schema?: Schema;
+    schema?: SchemaProperties;
     spellCheck?: boolean;
     style?: React.CSSProperties;
     tabIndex?: number;
@@ -121,15 +120,11 @@ export interface BasicEditorProps {
 export type EditorProps = BasicEditorProps & Plugin;
 
 export interface EditorState {
-    schema: Schema;
     value: Value;
-    stack: Stack;
 }
 
 export class Editor extends React.Component<EditorProps, EditorState> implements Controller {
     controller: CoreEditor;
-    schema: Schema;
-    stack: Stack;
 
     readonly plugins: Plugin[];
     readonly operations: Immutable.List<Operation>;
@@ -137,7 +132,7 @@ export class Editor extends React.Component<EditorProps, EditorState> implements
     readonly value: Value;
 
     // Instance methods
-    resolveController(plugins: Plugin[], schema: Schema, commands: any[], queries: any[]): void;
+    resolveController(plugins: Plugin[], schema: SchemaProperties, commands: any[], queries: any[]): void;
 
     // Controller
     addMark: CoreEditor['addMark'];

--- a/types/slate/index.d.ts
+++ b/types/slate/index.d.ts
@@ -56,7 +56,6 @@ export interface SchemaProperties {
 export interface ValueProperties {
     document?: Document;
     selection?: Selection;
-    history?: History;
     data?: Data;
     decorations?: Immutable.List<Decoration> | null;
 }
@@ -64,7 +63,6 @@ export interface ValueProperties {
 export interface ValueJSON {
     document?: DocumentJSON;
     selection?: Selection;
-    history?: History;
     data?: Data;
     decorations?: Immutable.List<Decoration> | null;
     object?: "value";
@@ -75,7 +73,6 @@ export type Path = Immutable.List<number> | string;
 export class Value extends Immutable.Record({}) {
     document: Document;
     selection: Selection;
-    history: History;
     data: Data;
     object: "value";
     decorations: Immutable.List<Decoration>;

--- a/types/slate/index.d.ts
+++ b/types/slate/index.d.ts
@@ -410,7 +410,6 @@ declare class BaseNode<
     getClosestBlock(path: Path): Block | null;
     getClosestInline(path: Path): Inline | null;
     getClosestVoid(key: string | Path): Node | null;
-    getClosestVoid(key: string): Node | null;
     getClosest(path: Path, iterator: (node: Node) => boolean): Node | null;
     getCommonAncestor(a: Path, b: Path): Node;
     getDecorations(editor: Editor): Immutable.List<Decoration>;

--- a/types/slate/index.d.ts
+++ b/types/slate/index.d.ts
@@ -53,39 +53,10 @@ export interface SchemaProperties {
     inlines?: RulesByNodeType;
 }
 
-export class Schema extends Immutable.Record({}) {
-    stack: Stack;
-    rules: Rules[];
-
-    static create(properties: SchemaProperties | Schema): Schema;
-    static fromJSON(object: SchemaProperties): Schema;
-    static fromJS(object: SchemaProperties): Schema;
-    static isSchema(maybeSchema: any): maybeSchema is Schema;
-
-    validateNode(node: Node): Error | void;
-    testNode(node: Node): boolean;
-    assertNode(node: Node): boolean;
-    getNodeRules(node: Node): any[];
-    isVoid(node: Node): boolean;
-    isAtomic(mark: Mark): boolean;
-    normalizeNode(node: Node): () => void;
-    testRules(object: any, rules: object | any[]): boolean;
-    validateRules(
-        object: any,
-        rule: object | any[],
-        rules: any[] | null,
-        options?: object
-    ): Error | void;
-
-    toJSON(): SchemaProperties;
-    toJS(): SchemaProperties;
-}
-
 export interface ValueProperties {
     document?: Document;
     selection?: Selection;
     history?: History;
-    schema?: Schema;
     data?: Data;
     decorations?: Immutable.List<Decoration> | null;
 }
@@ -94,7 +65,6 @@ export interface ValueJSON {
     document?: DocumentJSON;
     selection?: Selection;
     history?: History;
-    schema?: Schema;
     data?: Data;
     decorations?: Immutable.List<Decoration> | null;
     object?: "value";
@@ -106,7 +76,6 @@ export class Value extends Immutable.Record({}) {
     document: Document;
     selection: Selection;
     history: History;
-    schema: Schema;
     data: Data;
     object: "value";
     decorations: Immutable.List<Decoration>;
@@ -350,9 +319,6 @@ export class Text extends Immutable.Record({}) {
     ): Text;
     splitText(offset: number): Text[];
     mergeText(text: Text): Text;
-    normalize(schema: Schema): () => void | null;
-    validate(schema: Schema): Error | null;
-    getFirstInvalidNode(schema: Schema): Text | null;
     setLeaves(leaves: Immutable.List<Leaf>): Text;
 }
 
@@ -446,13 +412,13 @@ declare class BaseNode<
     getChild(path: Path): Node | null;
     getClosestBlock(path: Path): Block | null;
     getClosestInline(path: Path): Inline | null;
-    getClosestVoid(path: Path, schema: Schema): Node | null;
+    getClosestVoid(path: Path): Node | null;
+    getClosestVoid(key: string): Node | null;
     getClosest(path: Path, iterator: (node: Node) => boolean): Node | null;
     getCommonAncestor(a: Path, b: Path): Node;
-    getDecorations(stack: Stack): Immutable.List<Range>;
+    getDecorations(editor: Editor): Immutable.List<Decoration>;
     getDepth(path: Path, startAt?: number): number;
     getDescendant(path: Path): Node | null;
-    getFirstInvalidNode(schema: Schema): Node | null;
     getFirstText(): Text | null;
     getFragmentAtRange(range: Range): Document;
     getFurthest(path: Path, iterator: (node: Node) => boolean): Node | null;
@@ -514,7 +480,7 @@ declare class BaseNode<
     hasInlineChildren(): boolean;
     hasDescendant(path: Path): boolean;
     hasNode(path: Path): boolean;
-    hasVoidParent(path: Path, schema: Schema): boolean;
+    hasVoidParent(path: Path, editor: Editor): boolean;
     insertNode(path: Path, node: Node): Node;
     insertText(
         path: Path,
@@ -528,7 +494,7 @@ declare class BaseNode<
     mapDescendants(iterator: () => void): Node;
     mergeNode(path: Path): Node;
     moveNode(path: Path, newPath: Path, newIndex?: number): Node;
-    normalize(schema: Schema): () => void | void;
+    normalize(editor: Editor): () => void | void;
     refinedNOde(path: Path, key: string): Node | null;
     refindPath(path: Path, key: string): Immutable.List<string> | null;
     regenerateKey(): Node;
@@ -548,7 +514,7 @@ declare class BaseNode<
         properties: MarkProperties
     ): Node;
     splitNode(path: Path, position: number, properties: NodeProperties): Node;
-    validate(schema: Schema): Error | void;
+    validate(editor: Editor): Error | void;
 }
 
 export interface MarkProperties {
@@ -912,61 +878,6 @@ export interface SetValueOperation {
 export interface Operations {
     apply: (value: Value, operation: Operation) => Value;
     invert: (operation: Operation) => Operation;
-}
-
-export interface StackProperties {
-    plugins?: any[];
-}
-
-export interface StackJSON {
-    object: "stack";
-    plugins: any[];
-}
-
-export class Stack extends Immutable.Record({}) {
-    object: "stack";
-    plugins: any[];
-
-    static create(attrs: StackProperties): Stack;
-    static isStack(maybeStack: any): maybeStack is Stack;
-
-    static fromJSON(properties: StackJSON): Stack;
-    static fromJS(properties: StackJSON): Stack;
-    toJSON(options: any): object;
-}
-
-export interface HistoryProperties {
-    undos?: Operation[];
-    redos?: Operation[];
-}
-
-export interface HistoryJSON {
-    object: "history";
-    undos: any[];
-    redos: any[];
-}
-
-export interface HistoryOptions {
-    merge?: boolean;
-    skip?: boolean;
-}
-
-export class History extends Immutable.Record({}) {
-    redos: Stack;
-    undos: Stack;
-    object: "history";
-
-    static create(attrs: History | HistoryProperties): History;
-    static createOperationsList(
-        oeprations?: Immutable.List<Operation> | Operation[]
-    ): Immutable.List<Operation>;
-    static fromJSON(object: HistoryJSON): History;
-    static fromJS(object: HistoryJSON): History;
-    static isHistory(maybeHistory: any): maybeHistory is History;
-
-    save(operation: Operation, options?: HistoryOptions): History;
-    toJSON(): HistoryJSON;
-    toJS(): HistoryJSON;
 }
 
 export type ErrorCode =

--- a/types/slate/index.d.ts
+++ b/types/slate/index.d.ts
@@ -409,7 +409,7 @@ declare class BaseNode<
     getChild(path: Path): Node | null;
     getClosestBlock(path: Path): Block | null;
     getClosestInline(path: Path): Inline | null;
-    getClosestVoid(path: Path): Node | null;
+    getClosestVoid(key: string | Path): Node | null;
     getClosestVoid(key: string): Node | null;
     getClosest(path: Path, iterator: (node: Node) => boolean): Node | null;
     getCommonAncestor(a: Path, b: Path): Node;


### PR DESCRIPTION
Several changes were missed from the major 0.42.0 update, namely that Schema, Stack and History have all been deleted and folded in to Editor. This change removes these types.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/ianstormtaylor/slate/blob/master/packages/slate/Changelog.md#breaking-2
