### PR TITLE
aws-lambda: Add CloudWatch events for CodePipeline

### DIFF
--- a/types/aws-lambda/aws-lambda-tests.ts
+++ b/types/aws-lambda/aws-lambda-tests.ts
@@ -599,6 +599,27 @@ const CodePipelineEvent: AWSLambda.CodePipelineEvent = {
 
 CodePipelineEvent["CodePipeline.job"].data.encryptionKey = { type: 'KMS', id: 'key' };
 
+/* CodePipeline CloudWatch Events
+ * see https://docs.aws.amazon.com/codepipeline/latest/userguide/detect-state-changes-cloudwatch-events.html
+ * Their documentation says that detail.version is a string, but it is actually an integer
+ */
+const CodePipelineCloudWatchEvent: AWSLambda.CodePipelineCloudWatchEvent = {
+    version: '0',
+    id: 'event_Id',
+    'detail-type': 'CodePipeline Pipeline Execution State Change',
+    source: 'aws.codepipeline',
+    account: 'Pipeline_Account',
+    time: 'TimeStamp',
+    region: 'us-east-1',
+    resources: ['arn:aws:codepipeline:us-east-1:account_ID:myPipeline'],
+    detail: {
+        pipeline: 'myPipeline',
+        version: 1,
+        state: 'STARTED',
+        'execution-id': 'execution_Id',
+    },
+};
+
 /* CloudFront events, see http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/lambda-event-structure.html */
 const CloudFrontRequestWithCustomOriginEvent: AWSLambda.CloudFrontRequestEvent = {
   Records: [

--- a/types/aws-lambda/index.d.ts
+++ b/types/aws-lambda/index.d.ts
@@ -24,6 +24,7 @@
 //                 Oliver Hookins <https://github.com/ohookins>
 //                 Trevor Leach <https://github.com/trevor-leach>
 //                 James Gregory <https://github.com/jagregory>
+//                 Erik Dalén <https://github.com/dalen>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -575,6 +576,109 @@ export interface CodePipelineEvent {
         };
     };
 }
+
+/**
+ * CodePipeline CloudWatch Events
+ * https://docs.aws.amazon.com/codepipeline/latest/userguide/detect-state-changes-cloudwatch-events.html
+ *
+ * The above CodePipelineEvent is when a lambda is invoked by a CodePipeline.
+ * These events are when you subsribe to CodePipeline events in CloudWatch.
+ *
+ * Their documentation says that detail.version is a string, but it is actually an integer
+ */
+export type CodePipelineState =
+    | 'STARTED'
+    | 'SUCCEEDED'
+    | 'RESUMED'
+    | 'FAILED'
+    | 'CANCELED'
+    | 'SUPERSEDED';
+
+export type CodePipelineStageState =
+    | 'STARTED'
+    | 'SUCCEEDED'
+    | 'RESUMED'
+    | 'FAILED'
+    | 'CANCELED';
+
+export type CodePipelineActionState =
+    | 'STARTED'
+    | 'SUCCEEDED'
+    | 'FAILED'
+    | 'CANCELED';
+
+export interface CodePipelinePiplelineEvent {
+    version: string;
+    id: string;
+    'detail-type': 'CodePipeline Pipeline Execution State Change';
+    source: 'aws.codepipeline';
+    account: string;
+    time: string;
+    region: string;
+    resources: string[];
+    detail: {
+        pipeline: string;
+        version: number;
+        state: CodePipelineState;
+        'execution-id': string;
+    };
+}
+
+export interface CodePipelineStageEvent {
+    version: string;
+    id: string;
+    'detail-type': 'CodePipeline Stage Execution State Change';
+    source: 'aws.codepipeline';
+    account: string;
+    time: string;
+    region: string;
+    resources: string[];
+    detail: {
+        pipeline: string;
+        version: number;
+        'execution-id': string;
+        stage: string;
+        state: CodePipelineStageState;
+    };
+}
+
+export type CodePipelineActionCategory =
+    | 'Approval'
+    | 'Build'
+    | 'Deploy'
+    | 'Invoke'
+    | 'Source'
+    | 'Test';
+
+export interface CodePipelineActionEvent {
+    version: string;
+    id: string;
+    'detail-type': 'CodePipeline Action Execution State Change';
+    source: 'aws.codepipeline';
+    account: string;
+    time: string;
+    region: string;
+    resources: string[];
+    detail: {
+        pipeline: string;
+        version: number;
+        'execution-id': string;
+        stage: string;
+        action: string;
+        state: CodePipelineActionState;
+        type: {
+            owner: 'AWS' | 'Custom' | 'ThirdParty';
+            category: CodePipelineActionCategory;
+            provider: 'CodeDeploy';
+            version: number;
+        };
+    };
+}
+
+export type CodePipelineCloudWatchEvent =
+    | CodePipelinePiplelineEvent
+    | CodePipelineStageEvent
+    | CodePipelineActionEvent;
 
 /**
  * CloudFront events

--- a/types/aws-lambda/index.d.ts
+++ b/types/aws-lambda/index.d.ts
@@ -607,7 +607,7 @@ export type CodePipelineActionState =
     | 'FAILED'
     | 'CANCELED';
 
-export interface CodePipelinePipelineEvent {
+export interface CodePipelineCloudWatchPipelineEvent {
     version: string;
     id: string;
     'detail-type': 'CodePipeline Pipeline Execution State Change';
@@ -624,7 +624,7 @@ export interface CodePipelinePipelineEvent {
     };
 }
 
-export interface CodePipelineStageEvent {
+export interface CodePipelineCloudWatchStageEvent {
     version: string;
     id: string;
     'detail-type': 'CodePipeline Stage Execution State Change';
@@ -650,7 +650,7 @@ export type CodePipelineActionCategory =
     | 'Source'
     | 'Test';
 
-export interface CodePipelineActionEvent {
+export interface CodePipelineCloudWatchActionEvent {
     version: string;
     id: string;
     'detail-type': 'CodePipeline Action Execution State Change';
@@ -676,9 +676,9 @@ export interface CodePipelineActionEvent {
 }
 
 export type CodePipelineCloudWatchEvent =
-    | CodePipelinePipelineEvent
-    | CodePipelineStageEvent
-    | CodePipelineActionEvent;
+    | CodePipelineCloudWatchPipelineEvent
+    | CodePipelineCloudWatchStageEvent
+    | CodePipelineCloudWatchActionEvent;
 
 /**
  * CloudFront events

--- a/types/aws-lambda/index.d.ts
+++ b/types/aws-lambda/index.d.ts
@@ -941,6 +941,11 @@ export type ProxyCallback = APIGatewayProxyCallback; // Old name
 
 export type CodePipelineHandler = Handler<CodePipelineEvent, void>;
 
+export type CodePipelineCloudWatchHandler = Handler<CodePipelineCloudWatchEvent, void>;
+export type CodePipelineCloudWatchPipelineHandler = Handler<CodePipelineCloudWatchPipelineEvent, void>;
+export type CodePipelineCloudWatchStageHandler = Handler<CodePipelineCloudWatchStageEvent, void>;
+export type CodePipelineCloudWatchActionHandler = Handler<CodePipelineCloudWatchActionEvent, void>;
+
 export type CloudFrontRequestHandler = Handler<CloudFrontRequestEvent, CloudFrontRequestResult>;
 export type CloudFrontRequestCallback = Callback<CloudFrontRequestResult>;
 

--- a/types/aws-lambda/index.d.ts
+++ b/types/aws-lambda/index.d.ts
@@ -607,7 +607,7 @@ export type CodePipelineActionState =
     | 'FAILED'
     | 'CANCELED';
 
-export interface CodePipelinePiplelineEvent {
+export interface CodePipelinePipelineEvent {
     version: string;
     id: string;
     'detail-type': 'CodePipeline Pipeline Execution State Change';
@@ -676,7 +676,7 @@ export interface CodePipelineActionEvent {
 }
 
 export type CodePipelineCloudWatchEvent =
-    | CodePipelinePiplelineEvent
+    | CodePipelinePipelineEvent
     | CodePipelineStageEvent
     | CodePipelineActionEvent;
 

--- a/types/aws-lambda/index.d.ts
+++ b/types/aws-lambda/index.d.ts
@@ -669,7 +669,7 @@ export interface CodePipelineActionEvent {
         type: {
             owner: 'AWS' | 'Custom' | 'ThirdParty';
             category: CodePipelineActionCategory;
-            provider: 'CodeDeploy';
+            provider: string;
             version: number;
         };
     };


### PR DESCRIPTION
 Add AWS lambda event type definitions for CodePipeline. See events here: https://docs.aws.amazon.com/codepipeline/latest/userguide/detect-state-changes-cloudwatch-events.html

As `CodePipelineEvent` was taken it uses `CodePipelineCloudWatchEvent` for the new event.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.aws.amazon.com/codepipeline/latest/userguide/detect-state-changes-cloudwatch-events.html
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

