### PR TITLE
@types/googlemaps - extend PlaceSearchRequest declaration

### DIFF
--- a/types/googlemaps/index.d.ts
+++ b/types/googlemaps/index.d.ts
@@ -2775,7 +2775,7 @@ declare namespace google.maps {
       radius?: number;
       rankBy?: RankBy;
       types?: string[]; /* Deprecated. Will be removed February 16, 2017 */
-      type?: string;
+      type?: string|string[];
     }
 
     export class PlacesService {


### PR DESCRIPTION
Extend the declaration because "types" is deprecated and the "type" attribute also supports arrays:
https://developers.google.com/maps/documentation/javascript/places#place_search_requests