### PR TITLE
Add types for dir-glob

### DIFF
--- a/types/dir-glob/dir-glob-tests.ts
+++ b/types/dir-glob/dir-glob-tests.ts
@@ -1,0 +1,23 @@
+import dirGlob = require('dir-glob');
+
+dirGlob('index.js').then(files => {
+    // ExpectType string[]
+    files;
+});
+dirGlob(['index.js', 'test.js', 'fixtures']).then(files => {
+    // ExpectType string[]
+    files;
+});
+
+dirGlob(['index.js', 'inner_folder'], { cwd: 'fixtures' });
+dirGlob(['lib/**', 'fixtures'], { files: ['test', 'unicorn'] });
+dirGlob(['lib/**', 'fixtures'], { extensions: ['js'] });
+
+// ExpectType string[]
+dirGlob.sync('index.js');
+// ExpectType string[]
+dirGlob.sync(['index.js', 'test.js', 'fixtures']);
+
+dirGlob.sync(['index.js', 'inner_folder'], { cwd: 'fixtures' });
+dirGlob.sync(['lib/**', 'fixtures'], { files: ['test', 'unicorn'] });
+dirGlob.sync(['lib/**', 'fixtures'], { extensions: ['js'] });

--- a/types/dir-glob/index.d.ts
+++ b/types/dir-glob/index.d.ts
@@ -1,0 +1,18 @@
+// Type definitions for dir-glob 2.0
+// Project: https://github.com/kevva/dir-glob#readme
+// Definitions by: BendingBender <https://github.com/BendingBender>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export = dirGlob;
+
+declare function dirGlob(input: string | string[], options?: dirGlob.Options): Promise<string[]>;
+
+declare namespace dirGlob {
+    function sync(input: string | string[], options?: Options): string[];
+
+    interface Options {
+        extensions?: string[];
+        files?: string[];
+        cwd?: string;
+    }
+}

--- a/types/dir-glob/tsconfig.json
+++ b/types/dir-glob/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "dir-glob-tests.ts"
+    ]
+}

--- a/types/dir-glob/tslint.json
+++ b/types/dir-glob/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.