### PR TITLE
recompose: Fix fromRenderProps() with statefull render prop component

### DIFF
--- a/types/recompose/index.d.ts
+++ b/types/recompose/index.d.ts
@@ -273,10 +273,10 @@ declare module 'recompose' {
 
     // fromRenderProps: https://github.com/acdlite/recompose/blob/master/docs/API.md#fromrenderprops
     export function fromRenderProps<TInner, TOutter, TRenderProps = {}>(
-        RenderPropsComponent: StatelessComponent<any>,
-        propsMapper: (props: TRenderProps) => Partial<TInner>,
+        RenderPropsComponent: Component<any>,
+        propsMapper: (props: TRenderProps) => TInner,
         renderPropName?: string
-    ): ComponentEnhancer<TInner, TOutter>;
+    ): ComponentEnhancer<TInner & TOutter, TOutter>;
 
     // Static property helpers: https://github.com/acdlite/recompose/blob/master/docs/API.md#static-property-helpers
 

--- a/types/recompose/recompose-tests.tsx
+++ b/types/recompose/recompose-tests.tsx
@@ -521,18 +521,30 @@ function testFromRenderProps() {
 
     interface InnerProps {
         renderValue: string;
-        outterValue: number;
     }
 
     interface OutterProps {
         outterValue: number;
     }
 
-    const RenderPropComponent: React.StatelessComponent<{
-        render: (renderProps: RenderProps) => React.ReactElement<any>;
-    }> = ({ render }) => render({ value: 'test' });
+    interface ComponentProps {
+        renderValue: string;
+        outterValue: number;
+    }
 
-    const component: React.StatelessComponent<InnerProps> = ({ renderValue }) => <div>{renderValue}</div>;
+    interface RenderComponentProps {
+        render: (renderProps: RenderProps) => React.ReactElement<any>;
+    }
+
+    class RenderPropComponent extends React.Component<RenderComponentProps> {
+        render () {
+            return this.props.render({ value: 'test' });
+        }
+    }
+
+    const component: React.StatelessComponent<ComponentProps> = ({ outterValue, renderValue }) => (
+        <div>{outterValue}{renderValue}</div>
+    );
 
     const Enhanced = fromRenderProps<InnerProps, OutterProps, RenderProps>(
         RenderPropComponent,


### PR DESCRIPTION
- `fromRenderProps()`  should accept any type of component (stateless or statefull)
- Enhanced component's props are sent to the inner component, so the typings should reflect this behaviour: `ComponentEnhancer<TInner & TOutter, TOutter>`

Tasks:

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/acdlite/recompose/blob/master/src/packages/recompose/fromRenderProps.js#L16
- [x] Increase the version number in the header if appropriate.
- [ ] ~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.~
