### PR TITLE
passport-azure-ad: fix constructor use of 'withRequest' in OIDCStrategy

### DIFF
--- a/types/passport-azure-ad/oidc-strategy.d.ts
+++ b/types/passport-azure-ad/oidc-strategy.d.ts
@@ -55,9 +55,9 @@ export type VerifyOIDCFunctionWithReq =
 export class OIDCStrategy implements passport.Strategy {
     constructor(
         options: IOIDCStrategyOptionWithRequest,
-        verify: VerifyOIDCFunction
+        verify: VerifyOIDCFunctionWithReq
     );
-    constructor(options: IOIDCStrategyOption, verify: VerifyOIDCFunctionWithReq);
+    constructor(options: IOIDCStrategyOption, verify: VerifyOIDCFunction);
 
     name: string;
 


### PR DESCRIPTION
per [README section 5.1.1.3](https://github.com/AzureAD/passport-azure-ad#5113-verify-callback):

> If you set `passReqToCallback` option to `false` you can [use the `VerifyOIDCFunction` callback signature]

> If you set `passReqToCallback` option to true you can [use the `VerifyOIDCFunctionWithReq` callback signature]

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/AzureAD/passport-azure-ad#5113-verify-callback
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

