### PR TITLE
mark.js: Add correct typings for .markRegExp()

### DIFF
--- a/types/mark.js/index.d.ts
+++ b/types/mark.js/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://markjs.io/
 // Definitions by: Soner Köksal <https://github.com/renjfk>
 //                 Roman Hotsiy <https://github.com/RomanGotsiy>
+//                 Lucian Buzzo <https://github.com/LucianBuzzo>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -38,6 +39,27 @@ declare namespace Mark {
 
         done?(marksTotal: number): void;
 
+        debug?: boolean;
+        log?: object;
+    }
+
+    interface MarkRegExpOptions {
+        element?: string;
+        className?: string;
+        exclude?: string[];
+        iframes?: boolean;
+        iframesTimeout?: number;
+        acrossElements?: boolean;
+        ignoreGroups?: number;
+        each?(element: Element): void;
+        filter?(
+            textNode: Element,
+            term: string,
+            marksSoFar: number,
+            marksTotal: number
+        ): boolean;
+        noMatch?(term: string): void;
+        done?(marksTotal: number): void;
         debug?: boolean;
         log?: object;
     }
@@ -84,7 +106,7 @@ declare class Mark {
      * Note that groups will be ignored and mark.js will always find all matches, regardless of the g flag.
      * @param options Optional options
      */
-    markRegExp(regexp: RegExp, options?: Mark.MarkOptions): void;
+    markRegExp(regexp: RegExp, options?: Mark.MarkRegExpOptions): void;
 
     /**
      * A method to mark ranges with a start position and length. They will be applied


### PR DESCRIPTION
The .markRegExp() function has different options than the .mark()
method.
See https://markjs.io/#markregexp

Change-type: patch
Signed-off-by: Lucian <lucian.buzzo@gmail.com>

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
