### PR TITLE
xrm v7 index- added Attribute.getValue and setValue

### DIFF
--- a/types/xrm/v7/index.d.ts
+++ b/types/xrm/v7/index.d.ts
@@ -1054,6 +1054,19 @@ declare namespace Xrm
              * A collection of all the controls on the form that interface with this attribute.
              */
             controls: Collection.ItemCollection<Control>;
+
+            /**
+             * Gets the value.
+             * 
+             * @return  The value.
+             */
+            getValue(): any;
+
+            /**
+             * 
+             * @param       value   The value.
+             */
+            setValue(value: any): void;
         }
 
         /**

--- a/types/xrm/v7/index.d.ts
+++ b/types/xrm/v7/index.d.ts
@@ -1163,6 +1163,24 @@ declare namespace Xrm
              * @remarks Valid for optionset and boolean attribute types
              */
             getInitialValue(): number | boolean;
+
+            /**
+             * Gets the value.
+             *
+             * @return  The value.
+             */
+            getValue(): string;
+
+            /**
+             * Sets the value.
+             *
+             * @param   {string}    value   The value.
+             *
+             * @remarks     A String field with the {@link Attribute.getFormat|email} format enforces email
+             *              address formatting. Attributes on Quick Create Forms will not save values set
+             *              with this method.
+             */
+            setValue( value: string ): void;
         }
 
         /**

--- a/types/xrm/v7/index.d.ts
+++ b/types/xrm/v7/index.d.ts
@@ -1163,24 +1163,6 @@ declare namespace Xrm
              * @remarks Valid for optionset and boolean attribute types
              */
             getInitialValue(): number | boolean;
-
-            /**
-             * Gets the value.
-             *
-             * @return  The value.
-             */
-            getValue(): string;
-
-            /**
-             * Sets the value.
-             *
-             * @param   {string}    value   The value.
-             *
-             * @remarks     A String field with the {@link Attribute.getFormat|email} format enforces email
-             *              address formatting. Attributes on Quick Create Forms will not save values set
-             *              with this method.
-             */
-            setValue( value: string ): void;
         }
 
         /**

--- a/types/xrm/v7/xrm-tests.ts
+++ b/types/xrm/v7/xrm-tests.ts
@@ -43,8 +43,8 @@ grids.forEach(( gridControl: Xrm.Page.GridControl ) =>
 
 /// Demonstrate generic overload vs typecast
 
-const lookupAttribute = <Xrm.Page.LookupControl>Xrm.Page.getControl( "customerid" );
-const lookupAttribute2 = Xrm.Page.getControl<Xrm.Page.LookupControl>( "customerid" );
+const lookupAttribute = Xrm.Page.getControl( "customerid" ) as Xrm.Page.LookupControl;
+const lookupAttribute2 = Xrm.Page.getControl( "customerid" ) as Xrm.Page.LookupControl;
 
 /// Demonstrate ES6 String literal syntax
 
@@ -105,7 +105,7 @@ alert( `The current entity type is: ${Xrm.Page.data.entity.getEntityName() }` );
 
 /// Demonstrate Optionset Value as int in Turbo Forms
 
-const optionSetAttribute = Xrm.Page.getAttribute<Xrm.Page.OptionSetAttribute>( "statuscode" );
+const optionSetAttribute = Xrm.Page.getAttribute( "statuscode" ) as Xrm.Page.OptionSetAttribute;
 const optionValue: number = optionSetAttribute.getOptions()[0].value;
 
 /// Demonstrate Control.setFocus();
@@ -125,7 +125,7 @@ let requirementLevelString = "none";
 let submitMode: Xrm.Page.SubmitMode = "always";
 let submitModeString = "always";
 
-let attribute = Xrm.Page.getAttribute<Xrm.Page.LookupAttribute>("customerid");
+let attribute = Xrm.Page.getAttribute("customerid") as Xrm.Page.LookupAttribute;
 attribute.setSubmitMode(submitMode);
 attribute.setSubmitMode(submitMode);
 attribute.setRequiredLevel(requirementLevel);


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
NOTE: the documentation link below is to the v9 documentation. There is no published documentation for v7; however, the code itself proves this change to be correct. In the v7 definitions, each interface that extends Attribute has a getValue() function.

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://docs.microsoft.com/en-us/dynamics365/customer-engagement/developer/clientapi/reference/attributes/getvalue>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
