### PR TITLE
google-map-react : Add 'libraries' key to BootstrapURLKeys

### DIFF
--- a/types/google-map-react/index.d.ts
+++ b/types/google-map-react/index.d.ts
@@ -6,7 +6,7 @@
 
 import * as React from 'react';
 
-export type BootstrapURLKeys = ({ key: string; } | { client: string; v: string; }) & { language?: string };
+export type BootstrapURLKeys = ({libraries?: string[] | string;} | { key: string; } | { client: string; v: string; }) & { language?: string };
 
 export interface MapTypeStyle {
   elementType?: string;


### PR DESCRIPTION
BootstrapURLKeys allows for adding a list of libraries with the key `libraries`. 
`libraries` can take either an array of strings or a comma separated single string.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).

- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>