### PR TITLE
[jasmine] Remove Spy properties, which are no longer available

### DIFF
--- a/types/jasmine/index.d.ts
+++ b/types/jasmine/index.d.ts
@@ -8,6 +8,7 @@
 //                 Boris Breuer <https://github.com/Engineer2B>
 //                 Chris Yungmann <https://github.com/cyungmann>
 //                 Giles Roadnight <https://github.com/Roaders>
+//                 Yaroslav Admin <https://github.com/devoto13>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 // For ddescribe / iit use : https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/karma-jasmine/karma-jasmine.d.ts
@@ -634,11 +635,8 @@ declare namespace jasmine {
     interface Spy {
         (...params: any[]): any;
 
-        identity: string;
         and: SpyAnd;
         calls: Calls;
-        mostRecentCall: { args: any[]; };
-        argsForCall: any[];
         withArgs(...args: any[]): Spy;
     }
 
@@ -647,6 +645,8 @@ declare namespace jasmine {
     }
 
     interface SpyAnd {
+        identity: string;
+
         /** By chaining the spy with and.callThrough, the spy will still track all calls to it but in addition it will delegate to the actual implementation. */
         callThrough(): Spy;
         /** By chaining the spy with and.returnValue, all calls to the function will return a specific value. */

--- a/types/jasmine/jasmine-tests.ts
+++ b/types/jasmine/jasmine-tests.ts
@@ -335,6 +335,12 @@ describe("A spy", () => {
     it("stops all execution on a function", () => {
         expect(bar).toBeNull();
     });
+
+    it("tracks if it was called at all", function () {
+        foo.setBar();
+
+        expect(foo.setBar.calls.any()).toEqual(true);
+    });
 });
 
 describe("A spy, when configured to call through", () => {

--- a/types/jasmine/v2/index.d.ts
+++ b/types/jasmine/v2/index.d.ts
@@ -7,6 +7,7 @@
 //                 Lukas Zech <https://github.com/lukas-zech-software>
 //                 Boris Breuer <https://github.com/Engineer2B>
 //                 Chris Yungmann <https://github.com/cyungmann>
+//                 Yaroslav Admin <https://github.com/devoto13>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 // For ddescribe / iit use : https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/karma-jasmine/karma-jasmine.d.ts
@@ -623,11 +624,8 @@ declare namespace jasmine {
     interface Spy {
         (...params: any[]): any;
 
-        identity: string;
         and: SpyAnd;
         calls: Calls;
-        mostRecentCall: { args: any[]; };
-        argsForCall: any[];
     }
 
     type SpyObj<T> = T & {
@@ -635,6 +633,8 @@ declare namespace jasmine {
     }
 
     interface SpyAnd {
+        identity: string;
+
         /** By chaining the spy with and.callThrough, the spy will still track all calls to it but in addition it will delegate to the actual implementation. */
         callThrough(): Spy;
         /** By chaining the spy with and.returnValue, all calls to the function will return a specific value. */

--- a/types/jasmine/v2/jasmine-tests.ts
+++ b/types/jasmine/v2/jasmine-tests.ts
@@ -311,6 +311,12 @@ describe("A spy", () => {
     it("stops all execution on a function", () => {
         expect(bar).toBeNull();
     });
+
+    it("tracks if it was called at all", function () {
+        foo.setBar();
+
+        expect(foo.setBar.calls.any()).toEqual(true);
+    });
 });
 
 describe("A spy, when configured to call through", () => {


### PR DESCRIPTION
These properties were removed in 2.0 (long time ago), but they still appear in completion and confuse users.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [here](https://github.com/jasmine/jasmine/commit/3847557bbcf0308de99c6fc91e5553e2db016050#diff-f627290893ae16272e030bb1632e9c0dL225), [here](https://github.com/jasmine/jasmine/commit/3847557bbcf0308de99c6fc91e5553e2db016050#diff-f627290893ae16272e030bb1632e9c0dL23) and [here](https://github.com/jasmine/jasmine/commit/3847557bbcf0308de99c6fc91e5553e2db016050#diff-d024c451af49dc9e271cbabe45f88122L292)
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.