### PR TITLE
Add types for stringify-attributes

### DIFF
--- a/types/stringify-attributes/index.d.ts
+++ b/types/stringify-attributes/index.d.ts
@@ -1,0 +1,14 @@
+// Type definitions for stringify-attributes 1.0
+// Project: https://github.com/sindresorhus/stringify-attributes#readme
+// Definitions by: BendingBender <https://github.com/BendingBender>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export = stringifyAttributes;
+
+declare function stringifyAttributes(attributes: stringifyAttributes.Attributes): string;
+
+declare namespace stringifyAttributes {
+    interface Attributes {
+        [attrName: string]: string | number | boolean | Array<string | number>;
+    }
+}

--- a/types/stringify-attributes/stringify-attributes-tests.ts
+++ b/types/stringify-attributes/stringify-attributes-tests.ts
@@ -1,0 +1,18 @@
+import stringifyAttributes = require('stringify-attributes');
+
+// $ExpectType string
+stringifyAttributes({
+    unicorn: '🦄',
+});
+// $ExpectType string
+stringifyAttributes({
+    rainbow: true,
+});
+// $ExpectType string
+stringifyAttributes({
+    number: 1,
+});
+// $ExpectType string
+stringifyAttributes({
+    multiple: ['a', 1],
+});

--- a/types/stringify-attributes/tsconfig.json
+++ b/types/stringify-attributes/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "stringify-attributes-tests.ts"
+    ]
+}

--- a/types/stringify-attributes/tslint.json
+++ b/types/stringify-attributes/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.