### PR TITLE
Add types for get-urls

### DIFF
--- a/types/get-urls/get-urls-tests.ts
+++ b/types/get-urls/get-urls-tests.ts
@@ -1,0 +1,16 @@
+import getUrls = require('get-urls');
+
+const text =
+    'Lorem ipsum dolor sit amet, //sindresorhus.com consectetuer adipiscing http://yeoman.io elit.';
+
+// $ExpectType Set<string>
+getUrls(text);
+
+// $ExpectType Set<string>
+getUrls(text, { extractFromQueryString: true });
+
+// $ExpectType Set<string>
+getUrls(text, { exclude: ['foo'] });
+
+// $ExpectType Set<string>
+getUrls(text, { defaultProtocol: 'ftp' });

--- a/types/get-urls/index.d.ts
+++ b/types/get-urls/index.d.ts
@@ -1,0 +1,17 @@
+// Type definitions for get-urls 8.0
+// Project: https://github.com/sindresorhus/get-urls#readme
+// Definitions by: BendingBender <https://github.com/BendingBender>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import { Options as NormalizeUrlOptions } from 'normalize-url';
+
+export = getUrls;
+
+declare function getUrls(text: string, options?: getUrls.Options): Set<string>;
+
+declare namespace getUrls {
+    interface Options extends NormalizeUrlOptions {
+        extractFromQueryString?: boolean;
+        exclude?: string[];
+    }
+}

--- a/types/get-urls/tsconfig.json
+++ b/types/get-urls/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "get-urls-tests.ts"
+    ]
+}

--- a/types/get-urls/tslint.json
+++ b/types/get-urls/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.