### PR TITLE
Update typings for handlebars: Add options param to parse

### DIFF
--- a/types/handlebars/handlebars-tests.ts
+++ b/types/handlebars/handlebars-tests.ts
@@ -1,6 +1,6 @@
 
 //import Handlebars = require('handlebars');
-import * as Handlerbars from 'handlebars';
+import * as Handlebars from 'handlebars';
 
 const context = {
     author: { firstName: 'Alan', lastName: 'Johnson' },
@@ -78,3 +78,10 @@ template6([{url:"", title:""}])
 const escapedExpression = Handlebars.Utils.escapeExpression('<script>alert(\'xss\');</script>');
 
 Handlebars.helpers !== undefined;
+
+const parsedTmpl = Handlebars.parse('<p>Hello, my name is {{name}}.</p>', {
+  srcName: "/foo/bar/baz.hbs",
+  ignoreStandalone: true
+});
+
+const parsedTmplWithoutOptions = Handlebars.parse('<p>Hello, my name is {{name}}.</p>');

--- a/types/handlebars/index.d.ts
+++ b/types/handlebars/index.d.ts
@@ -35,6 +35,11 @@ declare namespace Handlebars {
         [key: string]: HelperDelegate;
     }
 
+    export interface ParseOptions {
+        srcName?: string,
+        ignoreStandalone?: boolean
+    }
+
     export function registerHelper(name: string, fn: HelperDelegate): void;
     export function registerHelper(name: HelperDeclareSpec): void;
     export function unregisterHelper(name: string): void;
@@ -52,7 +57,7 @@ declare namespace Handlebars {
     export function blockParams(obj: any[], ids: any[]): any[];
     export function Exception(message: string): void;
     export function log(level: number, obj: any): void;
-    export function parse(input: string): hbs.AST.Program;
+    export function parse(input: string, options?: ParseOptions): hbs.AST.Program;
     export function compile<T = any>(input: any, options?: CompileOptions): HandlebarsTemplateDelegate<T>;
     export function precompile(input: any, options?: PrecompileOptions): TemplateSpecification;
     export function template<T = any>(precompilation: TemplateSpecification): HandlebarsTemplateDelegate<T>;

--- a/types/handlebars/tsconfig.json
+++ b/types/handlebars/tsconfig.json
@@ -19,9 +19,5 @@
         "types": [],
         "noEmit": true,
         "forceConsistentCasingInFileNames": true
-    },
-    "files": [
-        "index.d.ts",
-        "handlebars-tests.ts"
-    ]
+    }
 }


### PR DESCRIPTION
- Add optional `options` param to `parse`. This reflects the `options` param
in the Handlebars source code. Also defines interface `ParseOptions`,
which includes the options that have an effect on Handlebars parsing.
- Fix duplicate properties in `tsconfig.json`.
- Fix typo in import in `handlebars-tests.ts`.

Reference Source:
https://github.com/wycats/handlebars.js/blob/master/lib/handlebars/compiler/base.js#L11

Non-breaking change (new param is optional).

--------------------

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
  - Tested by patching modified types into glimmer-vm.
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/wycats/handlebars.js/blob/master/lib/handlebars/compiler/base.js#L11
- [X] Increase the version number in the header if appropriate.
  - N/A
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
  - N/A (Already present)