### PR TITLE
[AngularJS] Update Directive typings to allow type checking links with TS compiler's strict mode

### DIFF
--- a/types/angular/angular-tests.ts
+++ b/types/angular/angular-tests.ts
@@ -1513,55 +1513,17 @@ interface MyController extends ng.INgModelController {
     foo: string;
 }
 
-const directiveCompileFnWithGeneric: ng.IDirectiveCompileFn<MyScope, MyElement, MyAttributes, MyController> = (
-        templateElement: MyElement,
-        templateAttributes: MyAttributes,
-        transclude: ng.ITranscludeFunction,
-    ): ng.IDirectiveLinkFn<MyScope, MyElement, MyAttributes, MyController> => {
-    return (
-        scope: MyScope,
-        instanceElement: MyElement,
-        instanceAttributes: MyAttributes,
-        controller: MyController,
-    ) => {
-        return null;
-    };
-};
-
-const directiveFactoryWithGeneric: ng.IDirectiveFactory<MyScope, MyElement, MyAttributes, MyController> = (
-    templateElement: MyElement,
-    templateAttributes: MyAttributes,
-    transclude: ng.ITranscludeFunction,
-): ng.IDirective<MyScope, MyElement, MyAttributes, MyController> => {
-    return {
-        link: ($scope: MyScope, templateElement: MyElement, templateAttributes: MyAttributes, controller: MyController) => {return; }
-    };
-};
-
-const directiveFactoryWithGeneric2: ng.IDirectiveFactory<MyScope, MyElement, MyAttributes, MyController> = (
-    templateElement: MyElement,
-    templateAttributes: MyAttributes,
-    transclude: ng.ITranscludeFunction,
-): ng.IDirectiveLinkFn<MyScope, MyElement, MyAttributes, MyController> => {
-    return ($scope: MyScope, templateElement: MyElement, templateAttributes: MyAttributes, controller: MyController) => {return; };
-};
-
-angular.module('WithGenerics', []).directive('usingDirectiveFactoryWithGeneric', directiveFactoryWithGeneric).directive('usingDirectiveFactoryWithGeneric2', directiveFactoryWithGeneric2);
-
-class DirectiveWithGenerics implements ng.IDirective<MyScope, MyElement, MyAttributes, MyController> {
-    restrict = 'EAC';
-
-    compile(templateElement: MyElement) {
+angular.module('WithGenerics', [])
+    .directive('directiveUsingGenerics', () => {
         return {
-            pre: this.link
+            restrict: 'E',
+            link(scope: MyScope, element: MyElement, templateAttributes: MyAttributes, controller: MyController) {
+                scope['name'] = 'Jeff';
+            }
         };
-    }
-
-    static instance(): ng.IDirective<MyScope, MyElement, MyAttributes, MyController> {
-        return new DirectiveWithGenerics();
-    }
-
-    link($scope: MyScope, templateElement: MyElement, templateAttributes: MyAttributes, controller: MyController) {}
-}
-
-angular.module('WithGenerics', []).directive('directiveWithGenerics', DirectiveWithGenerics.instance);
+    })
+    .directive('linkFunctionUsingGenerics', () => {
+        return (scope: MyScope, element: MyElement, templateAttributes: MyAttributes, controller: MyController) => {
+            scope['name'] = 'Jeff';
+        };
+    });

--- a/types/angular/angular-tests.ts
+++ b/types/angular/angular-tests.ts
@@ -1545,3 +1545,23 @@ const directiveFactoryWithGeneric2: ng.IDirectiveFactory<MyScope, MyElement, MyA
 ): ng.IDirectiveLinkFn<MyScope, MyElement, MyAttributes, MyController> => {
     return ($scope: MyScope, templateElement: MyElement, templateAttributes: MyAttributes, controller: MyController) => {return; };
 };
+
+angular.module('WithGenerics', []).directive('usingDirectiveFactoryWithGeneric', directiveFactoryWithGeneric).directive('usingDirectiveFactoryWithGeneric2', directiveFactoryWithGeneric2);
+
+class DirectiveWithGenerics implements ng.IDirective<MyScope, MyElement, MyAttributes, MyController> {
+    restrict = 'EAC';
+
+    compile(templateElement: MyElement) {
+        return {
+            pre: this.link
+        };
+    }
+
+    static instance(): ng.IDirective<MyScope, MyElement, MyAttributes, MyController> {
+        return new DirectiveWithGenerics();
+    }
+
+    link($scope: MyScope, templateElement: MyElement, templateAttributes: MyAttributes, controller: MyController) {}
+}
+
+angular.module('WithGenerics', []).directive('directiveWithGenerics', DirectiveWithGenerics.instance);

--- a/types/angular/angular-tests.ts
+++ b/types/angular/angular-tests.ts
@@ -1502,16 +1502,46 @@ interface MyScope extends ng.IScope {
     foo: string;
 }
 
-const directiveCompileFnWithGeneric: ng.IDirectiveCompileFn<MyScope> = (
-        templateElement: JQLite,
-        templateAttributes: ng.IAttributes,
-        transclude: ng.ITranscludeFunction
-    ): ng.IDirectiveLinkFn<MyScope> => {
+interface MyElement extends JQLite {
+    foo: string;
+}
+
+interface MyAttributes extends ng.IAttributes {
+    foo: string;
+}
+interface MyController extends ng.INgModelController {
+    foo: string;
+}
+
+const directiveCompileFnWithGeneric: ng.IDirectiveCompileFn<MyScope, MyElement, MyAttributes, MyController> = (
+        templateElement: MyElement,
+        templateAttributes: MyAttributes,
+        transclude: ng.ITranscludeFunction,
+    ): ng.IDirectiveLinkFn<MyScope, MyElement, MyAttributes, MyController> => {
     return (
         scope: MyScope,
-        instanceElement: JQLite,
-        instanceAttributes: ng.IAttributes
+        instanceElement: MyElement,
+        instanceAttributes: MyAttributes,
+        controller: MyController,
     ) => {
         return null;
     };
+};
+
+const directiveFactoryWithGeneric: ng.IDirectiveFactory<MyScope, MyElement, MyAttributes, MyController> = (
+    templateElement: MyElement,
+    templateAttributes: MyAttributes,
+    transclude: ng.ITranscludeFunction,
+): ng.IDirective<MyScope, MyElement, MyAttributes, MyController> => {
+    return {
+        link: ($scope: MyScope, templateElement: MyElement, templateAttributes: MyAttributes, controller: MyController) => {return; }
+    };
+};
+
+const directiveFactoryWithGeneric2: ng.IDirectiveFactory<MyScope, MyElement, MyAttributes, MyController> = (
+    templateElement: MyElement,
+    templateAttributes: MyAttributes,
+    transclude: ng.ITranscludeFunction,
+): ng.IDirectiveLinkFn<MyScope, MyElement, MyAttributes, MyController> => {
+    return ($scope: MyScope, templateElement: MyElement, templateAttributes: MyAttributes, controller: MyController) => {return; };
 };

--- a/types/angular/index.d.ts
+++ b/types/angular/index.d.ts
@@ -240,8 +240,9 @@ declare namespace angular {
          * @param name Name of the directive in camel-case (i.e. ngBind which will match as ng-bind)
          * @param directiveFactory An injectable directive factory function.
          */
-        directive<TScope extends IScope = IScope>(name: string, directiveFactory: Injectable<IDirectiveFactory<TScope>>): IModule;
-        directive<TScope extends IScope = IScope>(object: {[directiveName: string]: Injectable<IDirectiveFactory<TScope>>}): IModule;
+        directive<TScope extends IScope = IScope, TElement extends JQLite = JQLite, TAttributes extends IAttributes = IAttributes, TController extends IDirectiveController = IController>(name: string, directiveFactory: Injectable<IDirectiveFactory<TScope, TElement, TAttributes, TController>>): IModule;
+        directive<TScope extends IScope = IScope, TElement extends JQLite = JQLite, TAttributes extends IAttributes = IAttributes, TController extends IDirectiveController = IController>(object: {[directiveName: string]: Injectable<IDirectiveFactory<TScope, TElement, TAttributes, TController>>}): IModule;
+
         /**
          * Register a service factory, which will be called to return the service instance. This is short for registering a service where its provider consists of only a $get property, which is the given service factory function. You should use $provide.factory(getFn) if you do not need to configure your service in a provider.
          *
@@ -1346,8 +1347,8 @@ declare namespace angular {
     }
 
     interface ICompileProvider extends IServiceProvider {
-        directive<TScope extends IScope = IScope>(name: string, directiveFactory: Injectable<IDirectiveFactory<TScope>>): ICompileProvider;
-        directive<TScope extends IScope = IScope>(object: {[directiveName: string]: Injectable<IDirectiveFactory<TScope>>}): ICompileProvider;
+        directive<TScope extends IScope = IScope, TElement extends JQLite = JQLite, TAttributes extends IAttributes = IAttributes, TController extends IDirectiveController = IController>(name: string, directiveFactory: Injectable<IDirectiveFactory<TScope, TElement, TAttributes, TController>>): ICompileProvider;
+        directive<TScope extends IScope = IScope, TElement extends JQLite = JQLite, TAttributes extends IAttributes = IAttributes, TController extends IDirectiveController = IController>(object: {[directiveName: string]: Injectable<IDirectiveFactory<TScope, TElement, TAttributes, TController>>}): ICompileProvider;
 
         component(name: string, options: IComponentOptions): ICompileProvider;
         component(object: {[componentName: string]: IComponentOptions}): ICompileProvider;

--- a/types/angular/index.d.ts
+++ b/types/angular/index.d.ts
@@ -2066,29 +2066,31 @@ declare namespace angular {
     // and http://docs.angularjs.org/guide/directive
     ///////////////////////////////////////////////////////////////////////////
 
-    interface IDirectiveFactory<TScope extends IScope = IScope> {
-        (...args: any[]): IDirective<TScope> | IDirectiveLinkFn<TScope>;
+    type IDirectiveController = IController | IController[] | {[key: string]: IController};
+
+    interface IDirectiveFactory<TScope extends IScope = IScope, TElement extends JQLite = JQLite, TAttributes extends IAttributes = IAttributes, TController extends IDirectiveController = IController> {
+        (...args: any[]): IDirective<TScope, TElement, TAttributes, TController> | IDirectiveLinkFn<TScope, TElement, TAttributes, TController>;
     }
 
-    interface IDirectiveLinkFn<TScope extends IScope = IScope> {
+    interface IDirectiveLinkFn<TScope extends IScope = IScope, TElement extends JQLite = JQLite, TAttributes extends IAttributes = IAttributes, TController extends IDirectiveController = IController> {
         (
             scope: TScope,
-            instanceElement: JQLite,
-            instanceAttributes: IAttributes,
-            controller?: IController | IController[] | {[key: string]: IController},
+            instanceElement: TElement,
+            instanceAttributes: TAttributes,
+            controller?: TController,
             transclude?: ITranscludeFunction
         ): void;
     }
 
-    interface IDirectivePrePost<TScope extends IScope = IScope> {
-        pre?: IDirectiveLinkFn<TScope>;
-        post?: IDirectiveLinkFn<TScope>;
+    interface IDirectivePrePost<TScope extends IScope = IScope, TElement extends JQLite = JQLite, TAttributes extends IAttributes = IAttributes, TController extends IDirectiveController = IController> {
+        pre?: IDirectiveLinkFn<TScope, TElement, TAttributes, TController>;
+        post?: IDirectiveLinkFn<TScope, TElement, TAttributes, TController>;
     }
 
-    interface IDirectiveCompileFn<TScope extends IScope = IScope> {
+    interface IDirectiveCompileFn<TScope extends IScope = IScope, TElement extends JQLite = JQLite, TAttributes extends IAttributes = IAttributes, TController extends IDirectiveController = IController> {
         (
-            templateElement: JQLite,
-            templateAttributes: IAttributes,
+            templateElement: TElement,
+            templateAttributes: TAttributes,
             /**
              * @deprecated
              * Note: The transclude function that is passed to the compile function is deprecated,
@@ -2096,11 +2098,11 @@ declare namespace angular {
              * that is passed to the link function instead.
              */
             transclude: ITranscludeFunction
-        ): void | IDirectiveLinkFn<TScope> | IDirectivePrePost<TScope>;
+        ): void | IDirectiveLinkFn<TScope, TElement, TAttributes, TController> | IDirectivePrePost<TScope, TElement, TAttributes, TController>;
     }
 
-    interface IDirective<TScope extends IScope = IScope> {
-        compile?: IDirectiveCompileFn<TScope>;
+    interface IDirective<TScope extends IScope = IScope, TElement extends JQLite = JQLite, TAttributes extends IAttributes = IAttributes, TController extends IDirectiveController = IController> {
+        compile?: IDirectiveCompileFn<TScope, TElement, TAttributes, TController>;
         controller?: string | Injectable<IControllerConstructor>;
         controllerAs?: string;
         /**
@@ -2109,7 +2111,7 @@ declare namespace angular {
          * relies upon bindings inside a $onInit method on the controller, instead.
          */
         bindToController?: boolean | {[boundProperty: string]: string};
-        link?: IDirectiveLinkFn<TScope> | IDirectivePrePost<TScope>;
+        link?: IDirectiveLinkFn<TScope, TElement, TAttributes, TController> | IDirectivePrePost<TScope, TElement, TAttributes, TController>;
         multiElement?: boolean;
         priority?: number;
         /**
@@ -2119,9 +2121,9 @@ declare namespace angular {
         require?: string | string[] | {[controller: string]: string};
         restrict?: string;
         scope?: boolean | {[boundProperty: string]: string};
-        template?: string | ((tElement: JQLite, tAttrs: IAttributes) => string);
+        template?: string | ((tElement: TElement, tAttrs: TAttributes) => string);
         templateNamespace?: string;
-        templateUrl?: string | ((tElement: JQLite, tAttrs: IAttributes) => string);
+        templateUrl?: string | ((tElement: TElement, tAttrs: TAttributes) => string);
         terminal?: boolean;
         transclude?: boolean | 'element' | {[slot: string]: string};
     }


### PR DESCRIPTION

As described in https://github.com/DefinitelyTyped/DefinitelyTyped/issues/21160, if we want to use TypeScript's strict mode, we currently have to declare directive's link parameters as `any`, and type them later is we want to use our own type definitions. To cite @thorn0: 

> This time the problem is $attrs: ISetFocusOnAttrs. In TS 2.6+, function parameters are contravariant > when strictFunctionTypes is set to true. However, ISetFocusOnAttrs is a subtype of 
> angular.IAttributes, not a supertype. The workaround would look like this:
> ```js
> const linkFn = (_$scope: angular.IScope, $element: JQLite, $attrs0: angular.IAttributes) => {
> 	const $attrs = $attrs0 as ISetFocusOnAttrs
> 	// ...
> };
> ```
> Seems like one more type argument should be added to IDirective. A PR is welcome. 🛠

So here is a PR with a proposal to fix it ! 

I chose to use generics for the link function parameters, in order to use custom types for the element, attributes and controller. 

With these changes, providing generics to `IDirective` (for example) will allow us to type the `link` function variables to subtypes of `JQuery`, `IAttributes` and  `IDirectiveController`. (as we do it currently for custom scopes)

### Questions / concerns

- Existing tests did not break, but should I add a test section with generics for each parameter ?
- I did not encounter breaking changes in my project when using these changes, but could it break existing typings in other's projects ?
- The typings are made for TS 2.3, and strict mode appeared in TS 2.6 => Is this change wanted and should I bump the version in the comments ?
- Should I cascade generics in `line 243` and `line 1349`

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.angularjs.org/api/ng/service/$compile#-link- https://github.com/DefinitelyTyped/DefinitelyTyped/issues/21160
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
