### PR TITLE
Argument type for onSwatchHover is incorrect🐛  NG: Color , OK: ColorResult

### DIFF
--- a/types/react-color/index.d.ts
+++ b/types/react-color/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-color 2.13
+// Type definitions for react-color 2.14
 // Project: https://github.com/casesandberg/react-color/
 // Definitions by: Karol Janyst <https://github.com/LKay>, Marks Polakovs <https://github.com/markspolakovs>, Matthieu Montaudouin <https://github.com/mntdn>, Nokogiri <https://github.com/nkgrnkgr>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/react-color/index.d.ts
+++ b/types/react-color/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for react-color 2.13
 // Project: https://github.com/casesandberg/react-color/
-// Definitions by: Karol Janyst <https://github.com/LKay>, Marks Polakovs <https://github.com/markspolakovs>, Matthieu Montaudouin <https://github.com/mntdn>
+// Definitions by: Karol Janyst <https://github.com/LKay>, Marks Polakovs <https://github.com/markspolakovs>, Matthieu Montaudouin <https://github.com/mntdn>, Nokogiri <https://github.com/nkgrnkgr>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 

--- a/types/react-color/lib/components/circle/Circle.d.ts
+++ b/types/react-color/lib/components/circle/Circle.d.ts
@@ -1,12 +1,12 @@
 import { Component } from "react";
-import { ColorPickerProps, Color } from "../../..";
+import { ColorPickerProps, ColorResult } from "../../..";
 
 export interface CirclePickerProps extends ColorPickerProps<CirclePicker> {
     colors?: string[];
     width?: string;
     circleSize?: number;
     circleSpacing?: number;
-    onSwatchHover?(color: Color, event: MouseEvent): void;
+    onSwatchHover?(colorResult: ColorResult, event: MouseEvent): void;
 }
 
 export default class CirclePicker extends Component<CirclePickerProps> {}


### PR DESCRIPTION
I found incorrect arguments for onSwatchHover of CirclePicker In debugging.
Please accept my PR 😄

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/nkgrnkgr/DefinitelyTyped/blob/master/types/react-color/lib/components/circle/Circle.d.ts
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
