### PR TITLE
Changed Wrong ContentRenderer Type

### DIFF
--- a/types/recharts/index.d.ts
+++ b/types/recharts/index.d.ts
@@ -867,7 +867,7 @@ export interface LabelListProps {
     children?: React.ReactNode[] | React.ReactNode;
     className?: string;
     clockWise?: boolean;
-    content?: React.ReactElement<any> | ContentRenderer<Label>;
+    content?: React.ReactElement<any> | ContentRenderer<LabelProps>;
     data?: number;
     dataKey: string | number | RechartsFunction;
     formatter?: LabelFormatter;


### PR DESCRIPTION
Labellist's ContentRenderer must have props.

Examples : 

For tooltip
https://github.com/DefinitelyTyped/DefinitelyTyped/blob/ab4ae1f6fc47f909de597d540eabc8e34440ba53/types/recharts/index.d.ts#L808-L809

For LegendProps
https://github.com/DefinitelyTyped/DefinitelyTyped/blob/9f198a0137fc89748741b13c0ed3a1064dd63e5e/types/recharts/index.d.ts#L372-L374

For LabellistProps
https://github.com/DefinitelyTyped/DefinitelyTyped/blob/9f198a0137fc89748741b13c0ed3a1064dd63e5e/types/recharts/index.d.ts#L864-L871


// console.log(props) from functional content
<img width="667" alt="ekran resmi 2018-12-15 01 37 56" src="https://user-images.githubusercontent.com/16364199/50033564-15631a00-000a-11e9-9032-66db93bcc4d1.png">
