### PR TITLE
[polymer] Expose polymer.PolymerElement type in Polymer 1.x typings.

### DIFF
--- a/types/polymer/index.d.ts
+++ b/types/polymer/index.d.ts
@@ -3,6 +3,8 @@
 // Definitions by: Louis Grignon <https://github.com/lgrignon>, Suguru Inatomi <https://github.com/laco0416>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
+// tslint:disable:no-any Describing some permissive APIs.
+
 import { CustomElementConstructor } from "webcomponents.js";
 
 declare global {
@@ -20,19 +22,17 @@ declare global {
       observer?: string;
     }
 
-    interface Base {
-      /** Need to allow all properties for callback methods. */
-      [prop: string]: any;
-
+    interface CommonBase {
       /* polymer-micro */
 
       // Attributes
 
-      hostAttributes?: {[name:string]:any};
+      hostAttributes?: {[name: string]: any};
 
       reflectPropertiesToAttribute?(name: string): void;
 
-      serializeValueToAttribute?(value: any, attribute: string, node?: Element): void;
+      serializeValueToAttribute?
+          (value: any, attribute: string, node?: Element): void;
 
       deserialize?(value: string, type: NumberConstructor): number;
       deserialize?(value: string, type: BooleanConstructor): boolean;
@@ -120,7 +120,8 @@ declare global {
 
       notifyPath?(path: string, value: any, fromAbove: any): void;
 
-      set?<Value>(path: string|(string|number)[], value: Value, root?: Object): void;
+      set?<Value>(path: string|(string|number)[], value: Value, root?: Object):
+          void;
 
       get?(path: string|(string|number)[], root?: Object): any;
 
@@ -139,7 +140,8 @@ declare global {
 
       unshift?(path: string, ...item: any[]): number;
 
-      notifySplices?(path: string, splices: ReadonlyArray<polymer.PolymerSplice>): void;
+      notifySplices?
+          (path: string, splices: ReadonlyArray<polymer.PolymerSplice>): void;
 
       // ResolveUrl
 
@@ -154,8 +156,6 @@ declare global {
       $$?(selector: string): Element;
 
       toggleClass?(name: string, bool?: boolean, node?: HTMLElement): void;
-
-      toggleAttribute?(name: string, bool?: boolean, node?: HTMLElement): void;
 
       classFollows?(name: string, toElement: HTMLElement, fromElement: HTMLElement): void;
 
@@ -220,7 +220,19 @@ declare global {
       detached?(): void;
 
       attributeChanged?(name: string, oldValue: any, newValue: any): void;
+    }
 
+    // This is the type of a Polymer element after it has gone through the
+    // Polymer() function.
+    interface PolymerElement extends CommonBase, HTMLElement {}
+
+    interface Base extends CommonBase {
+      /** Need to allow all properties for callback methods. */
+      [prop: string]: any;
+
+      // Has to live on Base because it is incompatible with
+      // HTMLElement#toggleAttribute
+      toggleAttribute?(name: string, bool?: boolean, node?: HTMLElement): void;
     }
 
     interface DomApiStatic {

--- a/types/polymer/index.d.ts
+++ b/types/polymer/index.d.ts
@@ -3,8 +3,6 @@
 // Definitions by: Louis Grignon <https://github.com/lgrignon>, Suguru Inatomi <https://github.com/laco0416>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-// tslint:disable:no-any Describing some permissive APIs.
-
 import { CustomElementConstructor } from "webcomponents.js";
 
 declare global {

--- a/types/polymer/polymer-tests.ts
+++ b/types/polymer/polymer-tests.ts
@@ -51,14 +51,14 @@ Polymer({
   }
 });
 
-var MyElement = Polymer.Class(<polymer.Base>{
+var MyElement = Polymer.Class({
   is: 'my-element',
 
   created: function () {
     this.textContent = 'My element!';
   }
 
-});
+} as polymer.Base);
 
 document.registerElement('my-element', MyElement);
 


### PR DESCRIPTION
This is a type that represents a Polymer element after its class has been constructed by the Polymer() function.

Previously people would construct such a type by doing:

```typescript
interface MyElement extends HTMLElement, polymer.Base {}
```

But after TypeScript 3.0, the type of `HTMLElement#toggleAttribute` is different than the type of `polymer.Base#toggleAttribute`, which makes it an error to declare the MyElement type as above.

Unfortunately, we can't change the type of toggleElement on polymer.Base, so instead we introduce a new type polymer.PolymerElement that already extends `HTMLElement`.

So after this change, a Polymer 1.0 user can write their type as:

```typescript
interface MyElement extends polymer.PolymerElement {}
```

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/Polymer/polymer/pull/5372 is where we made this change for the types we ship with Polymer 3.x. I'm also on the Polymer team at Google, if that makes a difference.
- [x] Increase the version number in the header if appropriate.
