### PR TITLE
Add type definitions for find-java-home 0.2

### DIFF
--- a/types/find-java-home/find-java-home-tests.ts
+++ b/types/find-java-home/find-java-home-tests.ts
@@ -1,0 +1,6 @@
+import findJavaHome = require("find-java-home");
+import { promisify } from "util";
+
+findJavaHome(() => { }); // $ExpectType void
+findJavaHome({ allowJre: true }, () => { }); // $ExpectType void
+promisify(findJavaHome); // $ExpectType (options?: { allowJre?: boolean | undefined; } | undefined) => Promise<string>

--- a/types/find-java-home/index.d.ts
+++ b/types/find-java-home/index.d.ts
@@ -1,0 +1,15 @@
+// Type definitions for find-java-home 0.2
+// Project: https://github.com/jsdevel/node-find-java-home
+// Definitions by: sjx233 <https://github.com/sjx233>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types="node" />
+
+declare function findJavaHome(callback: (err: Error | undefined, home: string) => void): void;
+declare function findJavaHome(options: { allowJre?: boolean }, callback: (err: Error | undefined, home: string) => void): void;
+
+declare namespace findJavaHome {
+    function __promisify__(options?: { allowJre?: boolean }): Promise<string>;
+}
+
+export = findJavaHome;

--- a/types/find-java-home/tsconfig.json
+++ b/types/find-java-home/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "find-java-home-tests.ts"
+    ]
+}

--- a/types/find-java-home/tslint.json
+++ b/types/find-java-home/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
