### PR TITLE
Fixing TransactionObject.send return type in @types/web3

### DIFF
--- a/types/web3/eth/types.d.ts
+++ b/types/web3/eth/types.d.ts
@@ -1,4 +1,4 @@
-import { Callback } from "../types";
+import { Callback, TransactionReceipt } from "../types";
 import PromiEvent from "../promiEvent";
 import { ABIDefinition } from "./abi";
 export interface Tx {
@@ -82,7 +82,7 @@ export interface Transaction {
 export interface TransactionObject<T> {
 	arguments: any[];
 	call(tx?: Tx): Promise<T>;
-	send(tx?: Tx): PromiEvent<T>;
+	send(tx?: Tx): PromiEvent<TransactionReceipt>;
 	estimateGas(tx?: Tx): Promise<number>;
 	encodeABI(): string;
 }


### PR DESCRIPTION
TransactionObject.send() on calling should return the type TransactionReceipt!!

