### PR TITLE
graphql-errors: Add type definitions

### DIFF
--- a/types/graphql-errors/graphql-errors-tests.ts
+++ b/types/graphql-errors/graphql-errors-tests.ts
@@ -1,0 +1,47 @@
+import { GraphQLSchema, buildSchema } from 'graphql';
+import {
+    UserError,
+    maskErrors,
+    handlerFunction,
+    setDefaultHandler
+} from 'graphql-errors';
+
+// $ExpectType GraphQLSchema
+const schema: GraphQLSchema = buildSchema(`
+  # graphql schema definition
+`);
+
+const customHandler: handlerFunction = err => {
+    return { ...err, message: 'Internal error' };
+};
+
+/**
+ * Mask GraphQL error messages
+ */
+
+// $ExpectType void
+maskErrors(schema);
+
+// $ExpectType void
+maskErrors(schema, customHandler);
+
+// $ExpectError
+maskErrors('schema');
+
+/**
+ * Set callback function that modifies the errors
+ */
+
+// $ExpectType void
+setDefaultHandler(customHandler);
+
+// $ExpectError
+setDefaultHandler();
+
+// $ExpectError
+setDefaultHandler(err => {});
+
+/**
+ * Thrown an user error
+ */
+new UserError("Uh, Houston, we've had a problem");

--- a/types/graphql-errors/index.d.ts
+++ b/types/graphql-errors/index.d.ts
@@ -1,0 +1,17 @@
+// Type definitions for graphql-errors 2.1
+// Project: https://github.com/kadirahq/graphql-errors
+// Definitions by: Matías Olivera <https://github.com/MatiasOlivera>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.6
+
+import { GraphQLSchema } from 'graphql';
+
+export type handlerFunction = (err: Error) => Error;
+
+export function setDefaultHandler(fn: handlerFunction): void;
+
+export function maskErrors(schema: GraphQLSchema, fn?: handlerFunction): void;
+
+export class UserError extends Error {
+    constructor(message: string);
+}

--- a/types/graphql-errors/tsconfig.json
+++ b/types/graphql-errors/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6", "esnext.asynciterable"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "strictFunctionTypes": true
+    },
+    "files": ["index.d.ts", "graphql-errors-tests.ts"]
+}

--- a/types/graphql-errors/tslint.json
+++ b/types/graphql-errors/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
