### PR TITLE
Fix intersect hoc props with component props for recompose

### DIFF
--- a/types/recompose/index.d.ts
+++ b/types/recompose/index.d.ts
@@ -70,13 +70,13 @@ declare module 'recompose' {
     // withProps: https://github.com/acdlite/recompose/blob/master/docs/API.md#withprops
     export function withProps<TInner, TOutter>(
         createProps: TInner | mapper<TOutter, TInner>
-    ): InferableComponentEnhancerWithProps<TInner & TOutter, TOutter>;
+    ): InferableComponentEnhancerWithProps<TInner, TOutter>;
 
     // withPropsOnChange: https://github.com/acdlite/recompose/blob/master/docs/API.md#withpropsonchange
     export function withPropsOnChange<TInner, TOutter>(
         shouldMapOrKeys: string[] | predicateDiff<TOutter>,
         createProps: mapper<TOutter, TInner>
-    ): InferableComponentEnhancerWithProps<TInner & TOutter, TOutter>;
+    ): InferableComponentEnhancerWithProps<TInner, TOutter>;
 
     // withHandlers: https://github.com/acdlite/recompose/blob/master/docs/API.md#withhandlers
     type EventHandler = Function;
@@ -98,7 +98,7 @@ declare module 'recompose' {
         handlerCreators:
             | HandleCreators<TOutter, THandlers>
             | HandleCreatorsFactory<TOutter, THandlers>
-    ): InferableComponentEnhancerWithProps<THandlers & TOutter, TOutter>;
+    ): InferableComponentEnhancerWithProps<THandlers, TOutter>;
 
     // defaultProps: https://github.com/acdlite/recompose/blob/master/docs/API.md#defaultprops
     export function defaultProps<T = {}>(
@@ -268,7 +268,7 @@ declare module 'recompose' {
 
     // toRenderProps: https://github.com/acdlite/recompose/blob/master/docs/API.md#torenderprops
     export function toRenderProps<TInner, TOutter>(
-        hoc: InferableComponentEnhancerWithProps<TInner & TOutter, TOutter>
+        hoc: InferableComponentEnhancerWithProps<TInner, TOutter>
     ): StatelessComponent<TOutter & { children: (props: TInner) => React.ReactElement<any> }>;
 
     // fromRenderProps: https://github.com/acdlite/recompose/blob/master/docs/API.md#fromrenderprops

--- a/types/recompose/recompose-tests.tsx
+++ b/types/recompose/recompose-tests.tsx
@@ -133,12 +133,12 @@ function testWithHandlers() {
     }
     interface HandlerProps {
         onSubmit: React.MouseEventHandler<HTMLDivElement>;
-        onChange: Function;
+        onChange: (e: any) => void;
     }
-    const InnerComponent: React.StatelessComponent<InnerProps & HandlerProps & OutterProps> = ({onChange, onSubmit, foo}) =>
+    const InnerComponent: React.StatelessComponent<InnerProps & HandlerProps> = ({onChange, onSubmit, foo}) =>
       <div onClick={onSubmit}>{foo}</div>;
 
-    const enhancer = withHandlers<OutterProps & InnerProps, HandlerProps>({
+    const enhancer = withHandlers<OutterProps, HandlerProps>({
       onChange: (props) => (e: any) => {},
       onSubmit: (props) => (e: React.MouseEvent<any>) => {},
     });
@@ -150,7 +150,7 @@ function testWithHandlers() {
         />
     )
 
-    const enhancer2 = withHandlers<OutterProps & InnerProps, HandlerProps>((props) => ({
+    const enhancer2 = withHandlers<OutterProps, HandlerProps>((props) => ({
       onChange: (props) => (e: any) => {},
       onSubmit: (props) => (e: React.MouseEvent<any>) => {},
     }));
@@ -167,12 +167,12 @@ function testWithHandlers() {
       notAKeyOnHandlerProps: () => () => {},
     });
 
-    // The inner props should be fully inferrable
+    // Internal props should be separately
     const enhancer3 = withHandlers({
       onChange: (props: OutterProps) => (e: any) => {},
       onSubmit: (props: OutterProps) => (e: React.MouseEvent<any>) => {},
     });
-    const Enhanced3 = enhancer3(({onChange, onSubmit, out}) =>
+    const Enhanced3 = enhancer3(({onChange, onSubmit, out}) => // $ExpectError
         <div onClick={onSubmit}>{out}</div>);
     const rendered3 = (
         <Enhanced3
@@ -184,10 +184,23 @@ function testWithHandlers() {
       onChange: (props) => (e: any) => {},
       onSubmit: (props) => (e: React.MouseEvent<any>) => {},
     }));
-    const Enhanced4 = enhancer4(({onChange, onSubmit, out}) =>
+    const Enhanced4 = enhancer4(({onChange, onSubmit, out}) => // $ExpectError
         <div onClick={onSubmit}>{out}</div>);
     const rendered4 = (
         <Enhanced4
+            out={42}
+        />
+    )
+
+    const InnerComponent1: React.StatelessComponent<OutterProps & HandlerProps> = ({onChange, onSubmit, out}) =>
+        <div onClick={onSubmit}>{out}</div>;
+    const enhancer5 = withHandlers((props: OutterProps) => ({
+        onChange: (props) => (e: any) => { },
+        onSubmit: (props) => (e: React.MouseEvent<any>) => {},
+    }));
+    const Enhanced5 = enhancer5(InnerComponent1);
+    const rendered5 = (
+        <Enhanced5
             out={42}
         />
     )


### PR DESCRIPTION
Due to the intersection of InnerProps and OutterProps, types becomes more complicated. 

### Example

```typescript

// Some.tsx

import React, { FC } from 'react'

interface ISomeProps {
  item: any
  onClickRemove: () => void
}

const Some: React.FC<ISomeProps> = ({ item, onClickRemove }) =>
  <div onClick={onClickRemove}>{item.name}</div>

export default Some

// withOnClickRemove.tsx
import { withHandlers } from 'recompose'

export interface OutterProps {
  item: any
  onRemoveItem: (item: any) => void
}

export interface Handlers {
  onClickRemove: () => void
}

const withOnClickRemove = withHandlers<OutterProps, Handlers>({
  onClickRemove: ({ onRemoveItem, item }) => () => onRemoveItem(item)
})

export default withOnClickRemove

// SomeWithOnClickRemove.tsx
import withOnClickRemove from './withOnClickRemove'
import Some from './Some'

const Enhanced = withOnClickRemove(Some)
```

The above example will not work with the current types. This issue fixed in pull request.