### PR TITLE
Added type definitions for flushable

### DIFF
--- a/types/flushable/flushable-tests.ts
+++ b/types/flushable/flushable-tests.ts
@@ -1,0 +1,20 @@
+/**
+ * The usage example is taken directly
+ * from the package's README
+ */
+
+import flushable from 'flushable';
+
+// prints a message to the console after 1 second
+const operation = flushable(flushed => {
+    const result = `I completed ${flushed ? 'early' : 'on time'}`;
+}, 1000);
+
+// true if the callback has not been executed
+operation.pending();
+
+// stops the callback from being executed
+operation.cancel();
+
+// immediately executes the callback
+operation.flush();

--- a/types/flushable/index.d.ts
+++ b/types/flushable/index.d.ts
@@ -1,8 +1,7 @@
-// Type definitions for flushable 1.0.0
-// Project: https://github.com/petegleeson/flushable
+// Type definitions for flushable 1.0
+// Project: https://github.com/petegleeson/flushable#readme
 // Definitions by: Parth Mehta <https://github.com/pash90>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.0
 
 export type FlushableOnCompleteHandler = (flushed: boolean) => any;
 

--- a/types/flushable/index.d.ts
+++ b/types/flushable/index.d.ts
@@ -14,9 +14,7 @@ export interface FlushableOperation {
     flush: () => void;
 }
 
-declare module 'flushable' {
-    export default function flushable(
-        onComplete: FlushableOnCompleteHandler,
-        delay: number
-    ): FlushableOperation;
-}
+export default function flushable(
+    onComplete: FlushableOnCompleteHandler,
+    delay: number
+): FlushableOperation;

--- a/types/flushable/index.d.ts
+++ b/types/flushable/index.d.ts
@@ -1,0 +1,23 @@
+// Type definitions for flushable 1.0.0
+// Project: https://github.com/petegleeson/flushable
+// Definitions by: Parth Mehta <https://github.com/pash90>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.0
+
+export type FlushableOnCompleteHandler = (flushed: boolean) => any;
+
+export interface FlushableOperation {
+    /** Returns whether or not the callback has been executed */
+    pending: () => boolean;
+    /** Stops the callback from being executed */
+    cancel: () => void;
+    /** Immediately executes the callback */
+    flush: () => void;
+}
+
+declare module 'flushable' {
+    export default function flushable(
+        onComplete: FlushableOnCompleteHandler,
+        delay: number
+    ): FlushableOperation;
+}

--- a/types/flushable/tsconfig.json
+++ b/types/flushable/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6", "dom"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": false,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": ["index.d.ts"]
+}

--- a/types/flushable/tsconfig.json
+++ b/types/flushable/tsconfig.json
@@ -5,6 +5,7 @@
         "noImplicitAny": true,
         "noImplicitThis": true,
         "strictNullChecks": true,
+        "strictFunctionTypes": true,
         "baseUrl": "../",
         "typeRoots": ["../"],
         "types": [],

--- a/types/flushable/tsconfig.json
+++ b/types/flushable/tsconfig.json
@@ -1,16 +1,15 @@
 {
     "compilerOptions": {
         "module": "commonjs",
-        "lib": ["es6", "dom"],
+        "lib": ["es6"],
         "noImplicitAny": true,
         "noImplicitThis": true,
-        "strictNullChecks": false,
-        "strictFunctionTypes": true,
+        "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": ["../"],
         "types": [],
         "noEmit": true,
         "forceConsistentCasingInFileNames": true
     },
-    "files": ["index.d.ts"]
+    "files": ["index.d.ts", "flushable-tests.ts"]
 }

--- a/types/flushable/tslint.json
+++ b/types/flushable/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.