### PR TITLE
Allow plugins options augmentation for chart.js

### DIFF
--- a/types/chart.js/chart.js-tests.ts
+++ b/types/chart.js/chart.js-tests.ts
@@ -71,7 +71,11 @@ const chart: Chart = new Chart(ctx, {
                 padding: 40
             }
         },
-        devicePixelRatio: 2
+        devicePixelRatio: 2,
+        plugins: {
+            bar: false,
+            foo: {}
+        }
     }
 });
 chart.update();

--- a/types/chart.js/index.d.ts
+++ b/types/chart.js/index.d.ts
@@ -284,8 +284,7 @@ declare namespace Chart {
         circumference?: number;
         rotation?: number;
         devicePixelRatio?: number;
-        // Plugins can require any options
-        plugins?: { [pluginId: string]: any };
+        plugins?: ChartPluginsOptions;
     }
 
     interface ChartFontOptions {
@@ -365,6 +364,12 @@ declare namespace Chart {
         displayColors?: boolean;
         borderColor?: ChartColor;
         borderWidth?: number;
+    }
+
+    // NOTE: declare plugin options as interface instead of inline '{ [plugin: string]: any }'
+    // to allow module augmentation in case some plugins want to strictly type their options.
+    interface ChartPluginsOptions {
+        [pluginId: string]: any;
     }
 
     interface ChartTooltipsStaticConfiguration {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
https://www.chartjs.org/docs/latest/developers/plugins.html#plugin-options

----

Chart.js plugins expose their options under `options.plugins`. #24127 "disables" typing for plugin options by using `any` but it seems that this notation doesn't allow module augmentation in case a plugin wants to type more strictly their options, for example:

```typescript
import { ChartDataSets, ChartOptions } from "chart.js"

interface IChartDataLabelsOptions{
    color?: string | string[],
    // other options...
}

declare module 'chart.js' {
    interface ChartDataSets {
        datalabels?: IChartDataLabelsOptions
    }
    // with the current definition (master), I didn't find alternative to do this:
    interface ChartPluginsOptions {
        datalabels?: IChartDataLabelsOptions
    }
}
```

```typescript
new Chart('chart', {
    data: {
        datasets: [{
            datalabels: {
                color: 'green'  //< compilation OK
            }
        }]
    },
    options: {
        plugins: {
            datalabels: {
                foo: 'bar'   // invalid property: compiles with the current
                             // definition (master) but fails with this PR,
                             // the latter one being the expected behavior
            }
        }
   }
});
```

This need comes from /chartjs/chartjs-plugin-datalabels/issues/105 for which I may plan to provide a definition for dataset and plugin options.

