### PR TITLE
js-yaml: fix types of LoadOptions and DumpOptions

### DIFF
--- a/types/js-yaml/index.d.ts
+++ b/types/js-yaml/index.d.ts
@@ -39,34 +39,34 @@ export function safeDump(obj: any, opts?: DumpOptions): string;
 export function dump(obj: any, opts?: DumpOptions): string;
 
 export interface LoadOptions {
-	//  string to be used as a file path in error/warning messages.
+	// string to be used as a file path in error/warning messages.
 	filename?: string;
-	//  function to call on warning messages.
+	// function to call on warning messages.
 	onWarning?(this: null, e: YAMLException): void;
-	//  specifies a schema to use.
+	// specifies a schema to use.
 	schema?: SchemaDefinition;
-	//  compatibility with JSON.parse behaviour.
+	// compatibility with JSON.parse behaviour.
 	json?: boolean;
 }
 
 export interface DumpOptions {
-	//  indentation width to use (in spaces).
+	// indentation width to use (in spaces).
 	indent?: number;
-	//  do not throw on invalid types (like function in the safe schema) and skip pairs and single values with such types.
+	// do not throw on invalid types (like function in the safe schema) and skip pairs and single values with such types.
 	skipInvalid?: boolean;
-	//  specifies level of nesting, when to switch from block to flow style for collections. -1 means block style everwhere
+	// specifies level of nesting, when to switch from block to flow style for collections. -1 means block style everwhere
 	flowLevel?: number;
-	//  Each tag may have own set of styles.	- "tag" => "style" map.
+	// Each tag may have own set of styles.	- "tag" => "style" map.
 	styles?: { [x: string]: any; };
-	//  specifies a schema to use.
+	// specifies a schema to use.
 	schema?: SchemaDefinition;
-	//  if true, sort keys when dumping YAML. If a function, use the function to sort the keys. (default: false)
+	// if true, sort keys when dumping YAML. If a function, use the function to sort the keys. (default: false)
 	sortKeys?: boolean | ((a: any, b: any) => number);
-	//  set max line width. (default: 80)
+	// set max line width. (default: 80)
 	lineWidth?: number;
-	//  if true, don't convert duplicate objects into references (default: false)
+	// if true, don't convert duplicate objects into references (default: false)
 	noRefs?: boolean;
-	//  if true don't try to be compatible with older yaml versions. Currently: don't quote "yes", "no" and so on, as required for YAML 1.1 (default: false)
+	// if true don't try to be compatible with older yaml versions. Currently: don't quote "yes", "no" and so on, as required for YAML 1.1 (default: false)
 	noCompatMode?: boolean;
 	// if true flow sequences will be condensed, omitting the space between `key: value` or `a, b`. Eg. `'[a,b]'` or `{a:{b:c}}`.
 	// Can be useful when using yaml for pretty URL query params as spaces are %-encoded. (default: false).
@@ -90,15 +90,15 @@ export interface SchemaDefinition {
 	include?: Schema[];
 }
 
-//  only strings, arrays and plain objects: http://www.yaml.org/spec/1.2/spec.html#id2802346
+// only strings, arrays and plain objects: http://www.yaml.org/spec/1.2/spec.html#id2802346
 export let FAILSAFE_SCHEMA: Schema;
-//  only strings, arrays and plain objects: http://www.yaml.org/spec/1.2/spec.html#id2802346
+// only strings, arrays and plain objects: http://www.yaml.org/spec/1.2/spec.html#id2802346
 export let JSON_SCHEMA: Schema;
-//  same as JSON_SCHEMA: http://www.yaml.org/spec/1.2/spec.html#id2804923
+// same as JSON_SCHEMA: http://www.yaml.org/spec/1.2/spec.html#id2804923
 export let CORE_SCHEMA: Schema;
-//  all supported YAML types, without unsafe ones (!!js/undefined, !!js/regexp and !!js/function): http://yaml.org/type/
+// all supported YAML types, without unsafe ones (!!js/undefined, !!js/regexp and !!js/function): http://yaml.org/type/
 export let DEFAULT_SAFE_SCHEMA: Schema;
-//  all supported YAML types.
+// all supported YAML types.
 export let DEFAULT_FULL_SCHEMA: Schema;
 export let MINIMAL_SCHEMA: Schema;
 export let SAFE_SCHEMA: Schema;

--- a/types/js-yaml/index.d.ts
+++ b/types/js-yaml/index.d.ts
@@ -39,39 +39,37 @@ export function safeDump(obj: any, opts?: DumpOptions): string;
 export function dump(obj: any, opts?: DumpOptions): string;
 
 export interface LoadOptions {
-	/** string to be used as a file path in error/warning messages. */
+	//  string to be used as a file path in error/warning messages.
 	filename?: string;
-	/** function to call on warning messages. */
+	//  function to call on warning messages.
 	onWarning?(this: null, e: YAMLException): void;
-	/** specifies a schema to use. */
+	//  specifies a schema to use.
 	schema?: SchemaDefinition;
-	/** compatibility with JSON.parse behaviour. */
+	//  compatibility with JSON.parse behaviour.
 	json?: boolean;
 }
 
 export interface DumpOptions {
-	/** indentation width to use (in spaces). */
+	//  indentation width to use (in spaces).
 	indent?: number;
-	/** do not throw on invalid types (like function in the safe schema) and skip pairs and single values with such types. */
+	//  do not throw on invalid types (like function in the safe schema) and skip pairs and single values with such types.
 	skipInvalid?: boolean;
-	/** specifies level of nesting, when to switch from block to flow style for collections. -1 means block style everwhere */
+	//  specifies level of nesting, when to switch from block to flow style for collections. -1 means block style everwhere
 	flowLevel?: number;
-	/** Each tag may have own set of styles.	- "tag" => "style" map. */
+	//  Each tag may have own set of styles.	- "tag" => "style" map.
 	styles?: { [x: string]: any; };
-	/** specifies a schema to use. */
+	//  specifies a schema to use.
 	schema?: SchemaDefinition;
-	/** if true, sort keys when dumping YAML. If a function, use the function to sort the keys. (default: false) */
+	//  if true, sort keys when dumping YAML. If a function, use the function to sort the keys. (default: false)
 	sortKeys?: boolean | ((a: any, b: any) => number);
-	/** set max line width. (default: 80) */
+	//  set max line width. (default: 80)
 	lineWidth?: number;
-	/** if true, don't convert duplicate objects into references (default: false) */
+	//  if true, don't convert duplicate objects into references (default: false)
 	noRefs?: boolean;
-	/** if true don't try to be compatible with older yaml versions. Currently: don't quote "yes", "no" and so on, as required for YAML 1.1 (default: false) */
+	//  if true don't try to be compatible with older yaml versions. Currently: don't quote "yes", "no" and so on, as required for YAML 1.1 (default: false)
 	noCompatMode?: boolean;
-	/**
-	 * if true flow sequences will be condensed, omitting the space between `key: value` or `a, b`. Eg. `'[a,b]'` or `{a:{b:c}}`.
-	 *  Can be useful when using yaml for pretty URL query params as spaces are %-encoded. (default: false).
-	 */
+	// if true flow sequences will be condensed, omitting the space between `key: value` or `a, b`. Eg. `'[a,b]'` or `{a:{b:c}}`.
+	// Can be useful when using yaml for pretty URL query params as spaces are %-encoded. (default: false).
 	condenseFlow?: boolean;
 }
 
@@ -92,15 +90,15 @@ export interface SchemaDefinition {
 	include?: Schema[];
 }
 
-/** only strings, arrays and plain objects: http://www.yaml.org/spec/1.2/spec.html#id2802346 */
+//  only strings, arrays and plain objects: http://www.yaml.org/spec/1.2/spec.html#id2802346
 export let FAILSAFE_SCHEMA: Schema;
-/** only strings, arrays and plain objects: http://www.yaml.org/spec/1.2/spec.html#id2802346 */
+//  only strings, arrays and plain objects: http://www.yaml.org/spec/1.2/spec.html#id2802346
 export let JSON_SCHEMA: Schema;
-/** same as JSON_SCHEMA: http://www.yaml.org/spec/1.2/spec.html#id2804923 */
+//  same as JSON_SCHEMA: http://www.yaml.org/spec/1.2/spec.html#id2804923
 export let CORE_SCHEMA: Schema;
-/** all supported YAML types, without unsafe ones (!!js/undefined, !!js/regexp and !!js/function): http://yaml.org/type/ */
+//  all supported YAML types, without unsafe ones (!!js/undefined, !!js/regexp and !!js/function): http://yaml.org/type/
 export let DEFAULT_SAFE_SCHEMA: Schema;
-/** all supported YAML types. */
+//  all supported YAML types.
 export let DEFAULT_FULL_SCHEMA: Schema;
 export let MINIMAL_SCHEMA: Schema;
 export let SAFE_SCHEMA: Schema;

--- a/types/js-yaml/index.d.ts
+++ b/types/js-yaml/index.d.ts
@@ -40,9 +40,9 @@ export function dump(obj: any, opts?: DumpOptions): string;
 
 export interface LoadOptions {
 	/** string to be used as a file path in error/warning messages. */
-    filename?: string;
-    /** function to call on warning messages. */
-    onWarning?(this: null, e: YAMLException): void;
+	filename?: string;
+	/** function to call on warning messages. */
+	onWarning?(this: null, e: YAMLException): void;
 	/** specifies a schema to use. */
 	schema?: SchemaDefinition;
 	/** compatibility with JSON.parse behaviour. */
@@ -68,10 +68,10 @@ export interface DumpOptions {
 	noRefs?: boolean;
 	/** if true don't try to be compatible with older yaml versions. Currently: don't quote "yes", "no" and so on, as required for YAML 1.1 (default: false) */
 	noCompatMode?: boolean;
-    /**
-     * if true flow sequences will be condensed, omitting the space between `key: value` or `a, b`. Eg. `'[a,b]'` or `{a:{b:c}}`.
-     *  Can be useful when using yaml for pretty URL query params as spaces are %-encoded. (default: false).
-     */
+	/**
+	 * if true flow sequences will be condensed, omitting the space between `key: value` or `a, b`. Eg. `'[a,b]'` or `{a:{b:c}}`.
+	 *  Can be useful when using yaml for pretty URL query params as spaces are %-encoded. (default: false).
+	 */
 	condenseFlow?: boolean;
 }
 

--- a/types/js-yaml/index.d.ts
+++ b/types/js-yaml/index.d.ts
@@ -39,37 +39,39 @@ export function safeDump(obj: any, opts?: DumpOptions): string;
 export function dump(obj: any, opts?: DumpOptions): string;
 
 export interface LoadOptions {
-	// string to be used as a file path in error/warning messages.
-	filename?: string;
-	// makes the loader to throw errors instead of warnings.
-	strict?: boolean;
-	// specifies a schema to use.
-	schema?: any;
-	// compatibility with JSON.parse behaviour.
+	/** string to be used as a file path in error/warning messages. */
+    filename?: string;
+    /** function to call on warning messages. */
+    onWarning?(this: null, e: YAMLException): void;
+	/** specifies a schema to use. */
+	schema?: SchemaDefinition;
+	/** compatibility with JSON.parse behaviour. */
 	json?: boolean;
 }
 
 export interface DumpOptions {
-	// indentation width to use (in spaces).
+	/** indentation width to use (in spaces). */
 	indent?: number;
-	// do not throw on invalid types (like function in the safe schema) and skip pairs and single values with such types.
+	/** do not throw on invalid types (like function in the safe schema) and skip pairs and single values with such types. */
 	skipInvalid?: boolean;
-	// specifies level of nesting, when to switch from block to flow style for collections. -1 means block style everwhere
+	/** specifies level of nesting, when to switch from block to flow style for collections. -1 means block style everwhere */
 	flowLevel?: number;
-	// Each tag may have own set of styles.	- "tag" => "style" map.
+	/** Each tag may have own set of styles.	- "tag" => "style" map. */
 	styles?: { [x: string]: any; };
-	// specifies a schema to use.
-	schema?: any;
-	// if true, sort keys when dumping YAML. If a function, use the function to sort the keys. (default: false)
+	/** specifies a schema to use. */
+	schema?: SchemaDefinition;
+	/** if true, sort keys when dumping YAML. If a function, use the function to sort the keys. (default: false) */
 	sortKeys?: boolean | ((a: any, b: any) => number);
-	// set max line width. (default: 80)
+	/** set max line width. (default: 80) */
 	lineWidth?: number;
-	// if true, don't convert duplicate objects into references (default: false)
+	/** if true, don't convert duplicate objects into references (default: false) */
 	noRefs?: boolean;
-	// if true don't try to be compatible with older yaml versions. Currently: don't quote "yes", "no" and so on, as required for YAML 1.1 (default: false)
+	/** if true don't try to be compatible with older yaml versions. Currently: don't quote "yes", "no" and so on, as required for YAML 1.1 (default: false) */
 	noCompatMode?: boolean;
-	// if true flow sequences will be condensed, omitting the space between `key: value` or `a, b`. Eg. `'[a,b]'` or `{a:{b:c}}`.
-	// Can be useful when using yaml for pretty URL query params as spaces are %-encoded. (default: false)
+    /**
+     * if true flow sequences will be condensed, omitting the space between `key: value` or `a, b`. Eg. `'[a,b]'` or `{a:{b:c}}`.
+     *  Can be useful when using yaml for pretty URL query params as spaces are %-encoded. (default: false).
+     */
 	condenseFlow?: boolean;
 }
 
@@ -90,15 +92,15 @@ export interface SchemaDefinition {
 	include?: Schema[];
 }
 
-// only strings, arrays and plain objects: http://www.yaml.org/spec/1.2/spec.html#id2802346
+/** only strings, arrays and plain objects: http://www.yaml.org/spec/1.2/spec.html#id2802346 */
 export let FAILSAFE_SCHEMA: Schema;
-// only strings, arrays and plain objects: http://www.yaml.org/spec/1.2/spec.html#id2802346
+/** only strings, arrays and plain objects: http://www.yaml.org/spec/1.2/spec.html#id2802346 */
 export let JSON_SCHEMA: Schema;
-// same as JSON_SCHEMA: http://www.yaml.org/spec/1.2/spec.html#id2804923
+/** same as JSON_SCHEMA: http://www.yaml.org/spec/1.2/spec.html#id2804923 */
 export let CORE_SCHEMA: Schema;
-// all supported YAML types, without unsafe ones (!!js/undefined, !!js/regexp and !!js/function): http://yaml.org/type/
+/** all supported YAML types, without unsafe ones (!!js/undefined, !!js/regexp and !!js/function): http://yaml.org/type/ */
 export let DEFAULT_SAFE_SCHEMA: Schema;
-// all supported YAML types.
+/** all supported YAML types. */
 export let DEFAULT_FULL_SCHEMA: Schema;
 export let MINIMAL_SCHEMA: Schema;
 export let SAFE_SCHEMA: Schema;

--- a/types/js-yaml/js-yaml-tests.ts
+++ b/types/js-yaml/js-yaml-tests.ts
@@ -58,13 +58,13 @@ loadOpts = {
 	filename: str
 };
 loadOpts = {
-	strict: bool
-};
-loadOpts = {
-	schema: bool
+	onWarning(e) { e.stack; }
 };
 loadOpts = {
 	json: bool
+};
+loadOpts = {
+    schema: yaml.DEFAULT_SAFE_SCHEMA
 };
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
@@ -83,6 +83,9 @@ dumpOpts = {
 };
 dumpOpts = {
 	schema: value
+};
+dumpOpts = {
+    schema: yaml.DEFAULT_FULL_SCHEMA
 };
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --

--- a/types/js-yaml/js-yaml-tests.ts
+++ b/types/js-yaml/js-yaml-tests.ts
@@ -64,7 +64,7 @@ loadOpts = {
 	json: bool
 };
 loadOpts = {
-    schema: yaml.DEFAULT_SAFE_SCHEMA
+	schema: yaml.DEFAULT_SAFE_SCHEMA
 };
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
@@ -85,7 +85,7 @@ dumpOpts = {
 	schema: value
 };
 dumpOpts = {
-    schema: yaml.DEFAULT_FULL_SCHEMA
+	schema: yaml.DEFAULT_FULL_SCHEMA
 };
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --


### PR DESCRIPTION
There's no `strict` property on `LoadOptions` according to the docs.
Added `onWarning` to `LoadOptions`.
`schema` in `LoadOptions` and `DumpOptions` is now typed as `SchemaDefinition` instead of `any`.