### PR TITLE
[expo] Add NotificationChannel functions from sdk 31

### DIFF
--- a/types/expo/index.d.ts
+++ b/types/expo/index.d.ts
@@ -1835,7 +1835,6 @@ export namespace Notifications {
         origin: 'selected' | 'received';
         data: any;
         remote: boolean;
-        isMultiple: boolean;
     }
 
     interface LocalNotification {

--- a/types/expo/index.d.ts
+++ b/types/expo/index.d.ts
@@ -1835,6 +1835,7 @@ export namespace Notifications {
         origin: 'selected' | 'received';
         data: any;
         remote: boolean;
+        isMultiple: boolean;
     }
 
     interface LocalNotification {

--- a/types/expo/index.d.ts
+++ b/types/expo/index.d.ts
@@ -13,6 +13,7 @@
 //                 Martin Olsson <https://github.com/mo>
 //                 Levan Basharuli <https://github.com/levansuper>
 //                 Pavel Ihm <https://github.com/ihmpavel>
+//                 Bartosz Dotryw <https://github.com/burtek>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -1855,6 +1856,15 @@ export namespace Notifications {
         };
     }
 
+    interface ChannelAndroid {
+        name: string;
+        description?: string;
+        sound?: boolean;
+        priority?: 'min' | 'low' | 'default' | 'high' | 'max';
+        vibrate?: boolean | number[];
+        badge?: boolean;
+    }
+
     type LocalNotificationId = string | number;
 
     function addListener(listener: (notification: Notification) => any): EventSubscription;
@@ -1862,12 +1872,15 @@ export namespace Notifications {
     function presentLocalNotificationAsync(localNotification: LocalNotification): Promise<LocalNotificationId>;
     function scheduleLocalNotificationAsync(
         localNotification: LocalNotification,
-        schedulingOptions: { time: Date | number, repeat?: 'minute' | 'hour' | 'day' | 'week' | 'month' | 'year' }
+        schedulingOptions: { time: Date | number, repeat?: 'minute' | 'hour' | 'day' | 'week' | 'month' | 'year' },
+        intervalMs?: number
     ): Promise<LocalNotificationId>;
     function dismissNotificationAsync(localNotificationId: LocalNotificationId): Promise<void>;
     function dismissAllNotificationsAsync(): Promise<void>;
     function cancelScheduledNotificationAsync(localNotificationId: LocalNotificationId): Promise<void>;
     function cancelAllScheduledNotificationsAsync(): Promise<void>;
+    function createChannelAndroidAsync(id: string, channel: ChannelAndroid): Promise<void>;
+    function deleteChannelAndroidAsync(id: string): Promise<void>;
     function getBadgeNumberAsync(): Promise<number>;
     function setBadgeNumberAsync(number: number): Promise<void>;
 }

--- a/types/expo/index.d.ts
+++ b/types/expo/index.d.ts
@@ -1856,6 +1856,12 @@ export namespace Notifications {
         };
     }
 
+    interface SchedulingOptions {
+        time: Date | number;
+        repeat?: 'minute' | 'hour' | 'day' | 'week' | 'month' | 'year';
+        intervalMs?: number;
+    }
+
     interface ChannelAndroid {
         name: string;
         description?: string;
@@ -1872,8 +1878,7 @@ export namespace Notifications {
     function presentLocalNotificationAsync(localNotification: LocalNotification): Promise<LocalNotificationId>;
     function scheduleLocalNotificationAsync(
         localNotification: LocalNotification,
-        schedulingOptions: { time: Date | number, repeat?: 'minute' | 'hour' | 'day' | 'week' | 'month' | 'year' },
-        intervalMs?: number
+        schedulingOptions: SchedulingOptions
     ): Promise<LocalNotificationId>;
     function dismissNotificationAsync(localNotificationId: LocalNotificationId): Promise<void>;
     function dismissAllNotificationsAsync(): Promise<void>;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.expo.io/versions/v31.0.0/sdk/notifications#exponotificationscreatechannelandroidasyncid-channel
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
