### PR TITLE
[react-native] Add nativeID on ViewProps

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -912,6 +912,11 @@ export interface TextProps extends TextPropsIOS, TextPropsAndroid, Accessibility
      * Used to locate this view in end-to-end tests.
      */
     testID?: string;
+
+    /**
+     * Used to reference react managed views from native code.
+     */
+    nativeID?: string;
 }
 
 /**
@@ -2031,6 +2036,11 @@ export interface ViewProps
      * Used to locate this view in end-to-end tests.
      */
     testID?: string;
+
+    /**
+     * Used to reference react managed views from native code.
+     */
+    nativeID?: string;
 }
 
 /**

--- a/types/react-native/test/index.tsx
+++ b/types/react-native/test/index.tsx
@@ -832,3 +832,12 @@ const SwitchColorTest = () => (
 const SwitchThumbColorTest = () => (
     <Switch thumbColor={'red'} />
 )
+
+const NativeIDTest = () => (
+    <ScrollView nativeID={'nativeID'}>
+        <View nativeID={'nativeID'} />
+        <Text nativeID={'nativeID'} >
+            Text
+        </Text>
+    </ScrollView>
+)


### PR DESCRIPTION
The 'nativeID' property is used to reference react managed views from native code

http://facebook.github.io/react-native/docs/view.html#nativeid