### PR TITLE
Success and error shouldn't be optional as per the alt documentation

### DIFF
--- a/types/alt/index.d.ts
+++ b/types/alt/index.d.ts
@@ -58,8 +58,8 @@ declare namespace AltJS {
     remote(state:any, ...args: any[]):Promise<S>;
     shouldFetch?(fetchFn:(...args:Array<any>) => boolean):void;
     loading?:(args:any) => void;
-    success?:(state:S) => void;
-    error?:(args:any) => void;
+    success:(state:S) => void;
+    error:(args:any) => void;
     interceptResponse?(response:any, action:Action<any>, ...args:Array<any>):any;
   }
 


### PR DESCRIPTION
As per the [alt documentation](http://alt.js.org/docs/async/), success and error shouldn't be optional

