### PR TITLE
fix(@ember/object/core): add variadic `...args` to `init`

### DIFF
--- a/types/ember/test/core-object.ts
+++ b/types/ember/test/core-object.ts
@@ -62,7 +62,7 @@ const co6 = Ember.CoreObject.extend({
     },
     func1() {
         // this includes stuff from CoreObject
-        this.init; // $ExpectType () => void
+        this.init; // $ExpectType (...args: any[]) => void
         // this includes stuff from this extend-arg
         this.foo; // $ExpectType string
         // this does not include stuff from later extend args
@@ -73,7 +73,7 @@ const co6 = Ember.CoreObject.extend({
     bee: 'honey',
     func2() {
         // this includes stuff from CoreObject
-        this.init; // $ExpectType () => void
+        this.init; // $ExpectType (...args: any[]) => void
         // this includes stuff from this extend-arg
         // TODO: switch to "$ExpectType number" in TS 3.0  see: https://github.com/typed-ember/ember-cli-typescript/issues/291
         this.foo; // $ExpectType string & number
@@ -96,7 +96,7 @@ const co7 = Ember.CoreObject.extend({
     },
     func1() {
         // this includes stuff from CoreObject
-        this.init; // $ExpectType () => void
+        this.init; // $ExpectType (...args: any[]) => void
         // this includes stuff from this extend-arg
         this.foo; // $ExpectType string
         // this does not include stuff from later extend args
@@ -107,7 +107,7 @@ const co7 = Ember.CoreObject.extend({
     bee: 'honey',
     func2() {
         // this includes stuff from CoreObject
-        this.init; // $ExpectType () => void
+        this.init; // $ExpectType (...args: any[]) => void
         // this includes stuff from this extend-arg
         // TODO: switch to "$ExpectType number" in TS 3.0  see: https://github.com/typed-ember/ember-cli-typescript/issues/291
         this.foo; // $ExpectType string & number
@@ -119,7 +119,7 @@ const co7 = Ember.CoreObject.extend({
     money: 'in the banana stand',
     func3() {
         // this includes stuff from CoreObject
-        this.init; // $ExpectType () => void
+        this.init; // $ExpectType (...args: any[]) => void
         // this includes stuff from this extend-arg
         this.money; // $ExpectType string
         // this includes stuff from earlier extend-args
@@ -142,7 +142,7 @@ const co8 = Ember.CoreObject.extend({
     },
     func1() {
         // this includes stuff from CoreObject
-        this.init; // $ExpectType () => void
+        this.init; // $ExpectType (...args: any[]) => void
         // this includes stuff from this extend-arg
         this.foo; // $ExpectType string
         // this does not include stuff from later extend args
@@ -153,7 +153,7 @@ const co8 = Ember.CoreObject.extend({
     bee: 'honey',
     func2() {
         // this includes stuff from CoreObject
-        this.init; // $ExpectType () => void
+        this.init; // $ExpectType (...args: any[]) => void
         // this includes stuff from this extend-arg
         // TODO: switch to "$ExpectType number" in TS 3.0  see: https://github.com/typed-ember/ember-cli-typescript/issues/291
         this.foo; // $ExpectType string & number
@@ -167,7 +167,7 @@ const co8 = Ember.CoreObject.extend({
     money: 'in the banana stand',
     func3() {
         // this includes stuff from CoreObject
-        this.init; // $ExpectType () => void
+        this.init; // $ExpectType (...args: any[]) => void
         // this includes stuff from this extend-arg
         this.money; // $ExpectType string
         // this includes stuff from earlier extend-args
@@ -181,7 +181,7 @@ const co8 = Ember.CoreObject.extend({
     neighborhood: 'sudden valley',
     func4() {
         // this includes stuff from CoreObject
-        this.init; // $ExpectType () => void
+        this.init; // $ExpectType (...args: any[]) => void
         // this includes stuff from this extend-arg
         this.neighborhood; // $ExpectType string
         // this includes stuff from earlier extend-args

--- a/types/ember__object/core.d.ts
+++ b/types/ember__object/core.d.ts
@@ -21,7 +21,7 @@ export default class CoreObject {
      * An overridable method called when objects are instantiated. By default,
      * does nothing unless it is overridden during class definition.
      */
-    init(): void;
+    init(...args: any[]): void;
 
     /**
      * Defines the properties that will be concatenated from the superclass (instead of overridden).

--- a/types/ember__object/test/core.ts
+++ b/types/ember__object/test/core.ts
@@ -63,7 +63,7 @@ const co6 = CoreObject.extend(
         },
         func1() {
             // this includes stuff from CoreObject
-            this.init; // $ExpectType () => void
+            this.init; // $ExpectType (...args: any[]) => void
             // this includes stuff from this extend-arg
             this.foo; // $ExpectType string
             // this does not include stuff from later extend args
@@ -75,7 +75,7 @@ const co6 = CoreObject.extend(
         bee: 'honey',
         func2() {
             // this includes stuff from CoreObject
-            this.init; // $ExpectType () => void
+            this.init; // $ExpectType (...args: any[]) => void
             // this includes stuff from this extend-arg
             // TODO: switch to "$ExpectType number" in TS 3.0  see: https://github.com/typed-ember/ember-cli-typescript/issues/291
             this.foo; // $ExpectType string & number
@@ -100,7 +100,7 @@ const co7 = CoreObject.extend(
         },
         func1() {
             // this includes stuff from CoreObject
-            this.init; // $ExpectType () => void
+            this.init; // $ExpectType (...args: any[]) => void
             // this includes stuff from this extend-arg
             this.foo; // $ExpectType string
             // this does not include stuff from later extend args
@@ -112,7 +112,7 @@ const co7 = CoreObject.extend(
         bee: 'honey',
         func2() {
             // this includes stuff from CoreObject
-            this.init; // $ExpectType () => void
+            this.init; // $ExpectType (...args: any[]) => void
             // this includes stuff from this extend-arg
             // TODO: switch to "$ExpectType number" in TS 3.0  see: https://github.com/typed-ember/ember-cli-typescript/issues/291
             this.foo; // $ExpectType string & number
@@ -125,7 +125,7 @@ const co7 = CoreObject.extend(
         money: 'in the banana stand',
         func3() {
             // this includes stuff from CoreObject
-            this.init; // $ExpectType () => void
+            this.init; // $ExpectType (...args: any[]) => void
             // this includes stuff from this extend-arg
             this.money; // $ExpectType string
             // this includes stuff from earlier extend-args
@@ -150,7 +150,7 @@ const co8 = CoreObject.extend(
         },
         func1() {
             // this includes stuff from CoreObject
-            this.init; // $ExpectType () => void
+            this.init; // $ExpectType (...args: any[]) => void
             // this includes stuff from this extend-arg
             this.foo; // $ExpectType string
             // this does not include stuff from later extend args
@@ -162,7 +162,7 @@ const co8 = CoreObject.extend(
         bee: 'honey',
         func2() {
             // this includes stuff from CoreObject
-            this.init; // $ExpectType () => void
+            this.init; // $ExpectType (...args: any[]) => void
             // this includes stuff from this extend-arg
             // TODO: switch to "$ExpectType number" in TS 3.0  see: https://github.com/typed-ember/ember-cli-typescript/issues/291
             this.foo; // $ExpectType string & number
@@ -177,7 +177,7 @@ const co8 = CoreObject.extend(
         money: 'in the banana stand',
         func3() {
             // this includes stuff from CoreObject
-            this.init; // $ExpectType () => void
+            this.init; // $ExpectType (...args: any[]) => void
             // this includes stuff from this extend-arg
             this.money; // $ExpectType string
             // this includes stuff from earlier extend-args
@@ -192,7 +192,7 @@ const co8 = CoreObject.extend(
         neighborhood: 'sudden valley',
         func4() {
             // this includes stuff from CoreObject
-            this.init; // $ExpectType () => void
+            this.init; // $ExpectType (...args: any[]) => void
             // this includes stuff from this extend-arg
             this.neighborhood; // $ExpectType string
             // this includes stuff from earlier extend-args


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - https://guides.emberjs.com/release/applications/services/#toc_defining-services
  - https://discordapp.com/channels/480462759797063690/484421406659182603/524230021435359232
- ~~Increase the version number in the header if appropriate.~~
- ~~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.~~

---

In the guides linked above it is recommended to _always_, even for services, pass along all arguments:

```js
export default Service.extend({
  init() {
    this._super(...arguments);
    // ...
  }
});
```

Which translates to:

```ts
export default class MyService extends Service {
  init(...args: any[]) {
    super.init(...args);
    // ...
  }
});
```

But this currently causes the following type mismatch:

![image](https://user-images.githubusercontent.com/834636/50094340-4a8e8880-0213-11e9-9573-10d19cc1b3c5.png)

This PR fixes the root cause by making `CoreObject#init` variadic.