### PR TITLE
chrome-apps: requestFullscreen returns Promise<void>.

### DIFF
--- a/types/chrome-apps/index.d.ts
+++ b/types/chrome-apps/index.d.ts
@@ -13274,7 +13274,7 @@ interface HTMLElement {
     /**
      * ❗ Unprefixed version are not available as of Chrome 68, in Chrome apps ❗
      */
-    requestFullscreen(): void;
+    requestFullscreen(): Promise<void>;
     /**
      * ❗ Unprefixed version are not available as of Chrome 68, in Chrome apps ❗
      */

--- a/types/chrome-apps/test/index.ts
+++ b/types/chrome-apps/test/index.ts
@@ -917,7 +917,7 @@ chrome.app.runtime.onLaunched.addListener(() => {
 
 // #region chrome.gcm
 
-const gcmMessage = <chrome.gcm.OutgoingMessage>{};
+const gcmMessage = {} as chrome.gcm.OutgoingMessage;
 gcmMessage.data = {
     /*goog: 'any', should not be allowed, and it is not :) */
     test: true
@@ -1078,8 +1078,7 @@ chrome.networking.config.finishAuthentication(filter.HexSSID || '', 'rejected');
 // #region chrome.networking.onc
 
 const TLSFormatExample = {
-    NetworkConfigurations: <chrome.networking.onc.NetworkConfigProperties>
-        {
+    NetworkConfigurations: {
             GUID: '{00f79111-51e0-e6e0-76b3b55450d80a1b}',
             Name: 'MyTTLSNetwork',
             Type: 'WiFi',
@@ -1103,7 +1102,7 @@ const TLSFormatExample = {
                 'SSID': 'MyTTLSNetwork',
                 'Security': 'WPA-EAP'
             }
-        }
+        } as chrome.networking.onc.NetworkConfigProperties
 }
 
 chrome.networking.onc.getNetworks({ 'networkType': 'All' }, (networkList) => {

--- a/types/chrome-apps/test/index.ts
+++ b/types/chrome-apps/test/index.ts
@@ -2012,5 +2012,8 @@ appview.connect('id of app');
 document.appendChild(appview);
 //#endregion
 
+// #region HTMLElement correctly subtypes Element in TS3.1.
+const htmlElement = document.querySelector('zzzzzz') as HTMLElement;
+//#endregion
 
 


### PR DESCRIPTION
This matches the current state of the API specification and TypeScript
3.1+'s DOM definitions.

This fixes a problem where this file re-opens HTMLElement in an
incompatible way, which in turn causes various subtyping failures in
lib.dom.d.ts.

See also https://fullscreen.spec.whatwg.org/#api

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://fullscreen.spec.whatwg.org/#api