### PR TITLE
[ember-qunit] Fixing typo in option types

### DIFF
--- a/types/ember-qunit/index.d.ts
+++ b/types/ember-qunit/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/emberjs/ember-qunit#readme
 // Definitions by: Derek Wickern <https://github.com/dwickern>
 //                 Mike North <https://github.com/mike-north>
+//                 Steve Calvert <https://github.com/scalvert>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
@@ -136,7 +137,7 @@ declare module 'ember-qunit' {
         /**
          * If `false` test isolation validation will be disabled.
          */
-        setupTestIsolationValidatoin?: boolean;
+        setupTestIsolationValidation?: boolean;
     }
 
     export function start(options?: QUnitStartOptions): void;


### PR DESCRIPTION
The following ember-qunit option has a spelling mistake:

https://github.com/DefinitelyTyped/DefinitelyTyped/blob/5dd028ddc714da299c72e3a0345afa2a539b5cd6/types/ember-qunit/index.d.ts#L136-L139

It should be:

https://github.com/emberjs/ember-qunit/blob/faddd902d313721c33f20dd80a225946fbbd7979/addon-test-support/ember-qunit/index.js#L179-L180

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
