### PR TITLE
[node] fix parameter name of tls.connect()

### DIFF
--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -6612,7 +6612,7 @@ declare module "tls" {
      */
     function checkServerIdentity(host: string, cert: PeerCertificate): Error | undefined;
     function createServer(options: TlsOptions, secureConnectionListener?: (socket: TLSSocket) => void): Server;
-    function connect(options: ConnectionOptions, secureConnectionListener?: () => void): TLSSocket;
+    function connect(options: ConnectionOptions, secureConnectListener?: () => void): TLSSocket;
     function connect(port: number, host?: string, options?: ConnectionOptions, secureConnectListener?: () => void): TLSSocket;
     function connect(port: number, options?: ConnectionOptions, secureConnectListener?: () => void): TLSSocket;
     function createSecurePair(credentials?: crypto.Credentials, isServer?: boolean, requestCert?: boolean, rejectUnauthorized?: boolean): SecurePair;


### PR DESCRIPTION
The callback parameter of `tls.connect(options[, callback])` is for the `secureConnect` event, not for the `secureConnection` event, and should therefore be named `secureConnectListener` instead of `secureConnectionListener`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/dist/latest-v11.x/docs/api/tls.html#tls_tls_connect_options_callback
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.