### PR TITLE
react-json-tree: Adjusted the definition of the valueRenderer method.

### DIFF
--- a/types/react-json-tree/index.d.ts
+++ b/types/react-json-tree/index.d.ts
@@ -19,7 +19,7 @@ export interface JSONTreeProps extends Props<JSONTreeComponent> {
     shouldExpandNode?: (keyPath: (string | number)[], data: [any] | {}, level: number) => boolean;
     getItemString?: (type: string, data: [any] | {}, itemType: string, itemString: string) => JSX.Element;
     labelRenderer?: (raw: [string, string]) => JSX.Element;
-    valueRenderer?: (raw: string) => JSX.Element;
+    valueRenderer?: (displayValue: string, rawValue: string, key: string, parentKey: string) => JSX.Element;
     postprocessValue?: (raw: string) => JSX.Element;
     isCustomNode?: () => boolean;
     collectionLimit?: number;

--- a/types/react-json-tree/index.d.ts
+++ b/types/react-json-tree/index.d.ts
@@ -19,7 +19,7 @@ export interface JSONTreeProps extends Props<JSONTreeComponent> {
     shouldExpandNode?: (keyPath: (string | number)[], data: [any] | {}, level: number) => boolean;
     getItemString?: (type: string, data: [any] | {}, itemType: string, itemString: string) => JSX.Element;
     labelRenderer?: (raw: [string, string]) => JSX.Element;
-    valueRenderer?: (displayValue: string, rawValue: string, key: string, parentKey: string) => JSX.Element;
+    valueRenderer?: (displayValue: string|number, rawValue?: any, ...path?) => JSX.Element;
     postprocessValue?: (raw: string) => JSX.Element;
     isCustomNode?: () => boolean;
     collectionLimit?: number;

--- a/types/react-json-tree/index.d.ts
+++ b/types/react-json-tree/index.d.ts
@@ -19,7 +19,7 @@ export interface JSONTreeProps extends Props<JSONTreeComponent> {
     shouldExpandNode?: (keyPath: (string | number)[], data: [any] | {}, level: number) => boolean;
     getItemString?: (type: string, data: [any] | {}, itemType: string, itemString: string) => JSX.Element;
     labelRenderer?: (raw: [string, string]) => JSX.Element;
-    valueRenderer?: (displayValue: string|number, rawValue?: string|number|boolean, ...keyPath) => JSX.Element;
+    valueRenderer?: (displayValue: string|number, rawValue?: string|number|boolean|null, ...keyPath: (string|number)[]) => JSX.Element;
     postprocessValue?: (raw: string) => JSX.Element;
     isCustomNode?: () => boolean;
     collectionLimit?: number;

--- a/types/react-json-tree/index.d.ts
+++ b/types/react-json-tree/index.d.ts
@@ -19,7 +19,7 @@ export interface JSONTreeProps extends Props<JSONTreeComponent> {
     shouldExpandNode?: (keyPath: (string | number)[], data: [any] | {}, level: number) => boolean;
     getItemString?: (type: string, data: [any] | {}, itemType: string, itemString: string) => JSX.Element;
     labelRenderer?: (raw: [string, string]) => JSX.Element;
-    valueRenderer?: (displayValue: string|number, rawValue?: any, ...path?) => JSX.Element;
+    valueRenderer?: (displayValue: string|number, rawValue?: string|number|boolean, ...keyPath) => JSX.Element;
     postprocessValue?: (raw: string) => JSX.Element;
     isCustomNode?: () => boolean;
     collectionLimit?: number;


### PR DESCRIPTION
The valueRenderer is actually invoked with more attributes then just a raw value. Also the first attribute is not the rawValue but the already pre-parsed displayValue (e.g. with quotes around a string).


- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/alexkuz/react-json-tree/blob/master/src/JSONValueNode.js#L22