### PR TITLE
[microservice-utilities] Fix typing issue on the PlatformClient constructor

### DIFF
--- a/types/microservice-utilities/index.d.ts
+++ b/types/microservice-utilities/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for microservice-utilities 0.1
+// Type definitions for microservice-utilities 0.2
 // Project: https://github.com/Cimpress-MCP/microservice-utilities.js
 // Definitions by: Daan Boerlage <https://github.com/runebaas>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -41,7 +41,7 @@ export interface PlatformClientResponse {
 }
 
 export class PlatformClient {
-    constructor(logFunction: (msg: any) => void, tokenResolverFunction?: Promise<() => string>, configuration?: PlatformClientConfiguration)
+    constructor(logFunction: (msg: any) => void, tokenResolverFunction?: () => Promise<string>, configuration?: PlatformClientConfiguration)
     get(url: string, headers?: { [s: string]: string; }, type?: string): Promise<PlatformClientResponse>;
     post(url: string, data: object, headers?: { [s: string]: string; }): Promise<PlatformClientResponse>;
     put(url: string, data: object, headers?: { [s: string]: string; }): Promise<PlatformClientResponse>;

--- a/types/microservice-utilities/microservice-utilities-tests.ts
+++ b/types/microservice-utilities/microservice-utilities-tests.ts
@@ -4,7 +4,7 @@ import { Authorizer, PlatformClient, RequestLogger, ServiceTokenProvider } from 
     const authorizer = new Authorizer((msg: any) => msg, { jwkKeyListUrl: 'aaa' });
     const authorizerPolicy = authorizer.getPolicy({ test: true });
 
-    const platformClient = new PlatformClient((msg: any) => msg);
+    const platformClient = new PlatformClient((msg: any) => msg, (): Promise<string> => Promise.resolve('secretToken'));
     const result = await platformClient.get('https://www.typescriptlang.org/');
     const data = result.data as string;
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>> (`Promise<() => string>` is silly if you can do `() => Promise<string>`
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
