### PR TITLE
Bootstrap v4: improve relatedTarget typing

### DIFF
--- a/types/bootstrap/bootstrap-tests.ts
+++ b/types/bootstrap/bootstrap-tests.ts
@@ -34,12 +34,16 @@ $("#carousel").carousel("pause");
 
 $("#carousel").carousel(100);
 
-$("#carousel").on("slide.bs.carousel", function(ev) {
+$("#carousel").on("slide.bs.carousel", function(e) {
     const that: HTMLElement = this;
-    const from: number = ev.from;
-    const to: number = ev.to;
-    const direction: string = ev.direction;
-    const data: undefined = ev.data;
+
+    const data: undefined = e.data;
+    const carousel: HTMLElement = e.target;
+
+    const direction: string = e.direction;
+    const relatedTarget: HTMLElement = e.relatedTarget;
+    const from: number = e.from;
+    const to: number = e.to;
 });
 
 $("#carousel").carousel({
@@ -101,7 +105,11 @@ $("#dropdown").dropdown();
 // $ExpectType JQuery<HTMLElement>
 $("#dropdown").dropdown("update");
 
-$("#dropdown").on("hide.bs.dropdown", () => {});
+$("#dropdown").on("hide.bs.dropdown", (e) => {
+    const data: undefined = e.data;
+    const container: HTMLElement = e.target;
+    const togglingAnchorElement: HTMLElement = e.relatedTarget;
+});
 
 $("#dropdown").dropdown({
     offset: 10,
@@ -141,7 +149,13 @@ $("#modal").modal();
 // $ExpectType JQuery<HTMLElement>
 $("#modal").modal("show");
 
-$("#modal").on("hide.bs.modal", () => {});
+$("#modal").on("show.bs.modal", (e) => {
+    const data: undefined = e.data;
+    const modal: HTMLElement = e.target;
+    if (e.relatedTarget) {
+        const clickedElement: HTMLElement = e.relatedTarget;
+    }
+});
 
 $("#modal").modal({
     backdrop: false,
@@ -226,8 +240,9 @@ $("#scrollspy").scrollspy({
 $("#someListItem").tab("show");
 
 $("a[data-toggle=\"list\"]").on("shown.bs.tab", (e) => {
-    e.target; // newly activated tab
-    e.relatedTarget; // previous active tab
+    const data: undefined = e.data;
+    const newlyActivatedTab: HTMLElement = e.target;
+    const previousActiveTab: HTMLElement = e.relatedTarget;
 });
 
 // --------------------------------------------------------------------------------------

--- a/types/bootstrap/index.d.ts
+++ b/types/bootstrap/index.d.ts
@@ -185,7 +185,10 @@ export interface PopoverOption extends TooltipOption {
 
 export interface ScrollspyOption {
     /**
-     * TODO: https://github.com/twbs/bootstrap/issues/25799
+     * Finds which section the spied element is in:
+     * * `auto` will choose the best method get scroll coordinates.
+     * * `offset` will use jQuery offset method to get scroll coordinates.
+     * * `position` will use jQuery position method to get scroll coordinates.
      *
      * @default "auto"
      */

--- a/types/bootstrap/index.d.ts
+++ b/types/bootstrap/index.d.ts
@@ -325,11 +325,21 @@ export interface TooltipOption {
 // Events
 // --------------------------------------------------------------------------------------
 
-export interface CarouselEventHandler<TElement> extends JQuery.TriggeredEvent<TElement, undefined> {
+export interface CarouselEventHandler<TElement> extends JQuery.TriggeredEvent<TElement, undefined, HTMLElement, HTMLElement> {
+    /**
+     * The carousel dom element.
+     */
+    target: HTMLElement; // overridden only for better JsDoc
+
     /**
      * The direction in which the carousel is sliding.
      */
     direction: "left" | "right";
+
+    /**
+     * The DOM element that is being slid into place as the active item.
+     */
+    relatedTarget: HTMLElement;
 
     /**
      * The index of the current item.
@@ -342,7 +352,44 @@ export interface CarouselEventHandler<TElement> extends JQuery.TriggeredEvent<TE
     to: number;
 }
 
-export interface TapEventHandler<TElement> extends JQuery.TriggeredEvent<TElement, undefined> {
+export interface DropdownsEventHandler<TElement> extends JQuery.TriggeredEvent<TElement, undefined, HTMLElement, HTMLElement> {
+    /**
+     * The the dropdown's toggle and the dropdown menu container (the `.dropdown` element).
+     */
+    target: HTMLElement; // overridden only for better JsDoc
+
+    /**
+     * The toggling anchor element.
+     */
+    relatedTarget: HTMLElement;
+}
+
+export interface ModalEventHandler<TElement> extends JQuery.TriggeredEvent<TElement, undefined, HTMLElement, HTMLElement> {
+    /**
+     * The modal dom element.
+     */
+    target: HTMLElement; // overridden only for better JsDoc
+
+    /**
+     * For `show.bs.modal` and `shown.bs.modal` is the clicked element, when caused by a _click_.
+     * Otherwise is undefined.
+     */
+    relatedTarget: HTMLElement | undefined;
+}
+
+export interface TapEventHandler<TElement> extends JQuery.TriggeredEvent<TElement, undefined, HTMLElement, HTMLElement> {
+    /**
+     * * For `show.bs.tab` and `shown.bs.tab`, is the newly activated tab.
+     * * For `hide.bs.tab`, is the current active tab.
+     * * For `hidden.bs.tab`, is the previous active tab.
+     */
+    target: HTMLElement; // overridden only for better JsDoc
+
+    /**
+     * * For `show.bs.tab` and `shown.bs.tab`, is the previous active tab.
+     * * For `hide.bs.tab`, is the new soon-to-be-active tab.
+     * * For `hidden.bs.tab`, is the new active tab.
+     */
     relatedTarget: HTMLElement;
 }
 
@@ -390,10 +437,12 @@ declare global {
         tooltip(options?: TooltipOption): this;
 
         on(events: CarouselEvent, handler: JQuery.EventHandlerBase<TElement, CarouselEventHandler<TElement>>): this;
+        on(events: DropdownEvent, handler: JQuery.EventHandlerBase<TElement, DropdownsEventHandler<TElement>>): this;
+        on(events: ModalEvent, handler: JQuery.EventHandlerBase<TElement, ModalEventHandler<TElement>>): this;
         on(events: TapEvent, handler: JQuery.EventHandlerBase<TElement, TapEventHandler<TElement>>): this;
-        on(events:
-            AlertEvent | CollapseEvent | DropdownEvent | ModalEvent |
-            PopoverEvent | ScrollspyEvent | TooltipEvent,
-            handler: JQuery.EventHandler<TElement>): this;
+        on(
+            events: AlertEvent | CollapseEvent | PopoverEvent | ScrollspyEvent | TooltipEvent,
+            handler: JQuery.EventHandler<TElement>
+        ): this;
     }
 }

--- a/types/bootstrap/index.d.ts
+++ b/types/bootstrap/index.d.ts
@@ -409,31 +409,154 @@ export type TooltipEvent = "show.bs.tooltip" | "shown.bs.tooltip" | "hide.bs.too
 
 declare global {
     interface JQuery<TElement = HTMLElement> {
+        /**
+         * If no _method_ is specified, makes an alert listen for click events on descendant elements which have the `data-dismiss="alert"` attribute.
+         * (Not necessary when using the data-api's auto-initialization.)
+         * Otherwise, call the method on the alert element:
+         * * `close` — Closes an alert by removing it from the DOM. If the `.fade` and `.show` classes are present on the element, the alert will fade out before it is removed.
+         * * `dispose` — Destroys an element's alert.
+         */
         alert(action?: "close" | "dispose"): this;
 
+        /**
+         * Call a method on the button element:
+         * * `toggle` — Toggles push state. Gives the button the appearance that it has been activated.
+         * * `dispose` — Destroys an element's button.
+         */
         button(action: "toggle" | "dispose"): this;
 
+        /**
+         * Call a method on the carousel element:
+         * * `cycle` — Cycles through the carousel items from left to right.
+         * * `pause` — Stops the carousel from cycling through items.
+         * * _number_ — Cycles the carousel to a particular frame (0 based, similar to an array).
+         * * `prev` — Cycles to the previous item.
+         * * `next` — Cycles to the next item.
+         * * `dispose` — Destroys an element's carousel.
+         *
+         * Returns to the caller before the target item has been shown (i.e. before the `slid.bs.carousel` event occurs).
+         */
         carousel(action: "cycle" | "pause" | number | "prev" | "next" | "dispose"): this;
+        /**
+         * Initializes the carousel and starts cycling through items.
+         */
         carousel(options?: CarouselOption): this;
 
+        /**
+         * Call a method on the collapsible element:
+         * * `toggle` – Toggles a collapsible element to shown or hidden.
+         * * `show` – Shows a collapsible element.
+         * * `hide` – Hides a collapsible element.
+         * * `dispose` – Destroys an element's collapse.
+         *
+         * Returns to the caller before the collapsible element has actually been shown or hidden (i.e. before the `shown.bs.collapse` or `hidden.bs.collapse` event occurs).
+         */
         collapse(action: "toggle" | "show" | "hide" | "dispose"): this;
+        /**
+         * Activates a content as a collapsible element.
+         */
         collapse(options?: CollapseOption): this;
 
+        /**
+         * Call a method on the dropdown element:
+         * * `toggle` – Toggles the dropdown menu of a given navbar or tabbed navigation.
+         * * `update` – Updates the position of an element's dropdown.
+         * * `dispose` — Destroys an element's dropdown.
+         */
         dropdown(action: "toggle" | "update" | "dispose"): this;
+        /**
+         * Toggle contextual overlays for displaying lists of links.
+         *
+         * The data-api, `data-toggle="dropdown"` is always required to be present on the dropdown's trigger element.
+         */
         dropdown(options?: DropdownOption): this;
 
+        /**
+         * Call a method on the modal element:
+         * * `toggle` – Manually toggles a modal.
+         * * `show` – Manually opens a modal.
+         * * `hide` – Manually hides a modal.
+         * * `handleUpdate` – Manually readjust the modal's position if the height of a modal changes while it is open (i.e. in case a scrollbar appears).
+         * * `dispose` – Destroys an element's modal.
+         *
+         * Returns to the caller before the modal has actually been shown or hidden (i.e. before the `shown.bs.modal` or `hidden.bs.modal` event occurs).
+         */
         modal(action: "toggle" | "show" | "hide" | "handleUpdate" | "dispose"): this;
+        /**
+         * Activates a content as a modal.
+         */
         modal(options?: ModalOption): this;
 
+        /**
+         * Call a method on the popover element:
+         * * `show` – Reveals an element's popover.
+         * * `hide` – Hides an element's popover.
+         * * `toggle` – Toggles an element's popover.
+         * * `dispose` – Hides and destroys an element's popover.
+         * Popovers that use delegation (which are created using the `selector` option) cannot be individually destroyed on descendant trigger elements.
+         * * `enable` – Gives an element's popover the ability to be shown. Popovers are enabled by default.
+         * * `disable` – Removes the ability for an element's popover to be shown. The popover will only be able to be shown if it is re-enabled.
+         * * `toggleEnabled` – Toggles the ability for an element's popover to be shown or hidden.
+         * * `update` – Updates the position of an element's popover.
+         *
+         * Returns to the caller before the popover has actually been shown or hidden (i.e. before the `shown.bs.popover` or `hidden.bs.popover` event occurs).
+         * This is considered a "manual" triggering of the popover. Popovers whose both title and content are zero-length are never displayed.
+         */
         popover(action: "show" | "hide" | "toggle" | "dispose" | "enable" | "disable" | "toggleEnabled" | "update"): this;
+        /**
+         * Initializes popovers for an element collection.
+         */
         popover(options?: PopoverOption): this;
 
+// tslint:disable:jsdoc-format
+        /**
+         * Call a method on the scrollspy element:
+         * * `refresh` – When using scrollspy in conjunction with adding or removing of elements from the DOM, you'll need to call the refresh, see example.
+         * * `dispose` – Destroys an element's scrollspy.
+         *
+         * @example
+```javascript
+$('[data-spy="scroll"]').each(function () {
+   var $spy = $(this).scrollspy('refresh')
+})
+```
+         */
+// tslint:enable:jsdoc-format
         scrollspy(action: "refresh" | "dispose"): this;
+        /**
+         * Add scrollspy behavior to a topbar navigation.
+         */
         scrollspy(options?: ScrollspyOption): this;
 
+        /**
+         * Call a method on the list item or tab element:
+         * * `show` – Selects the given list item or tab and shows its associated pane.
+         * Any other list item or tab that was previously selected becomes unselected and its associated pane is hidden.
+         * * `dispose` – Destroys an element's tab.
+         *
+         * Returns to the caller before the tab pane has actually been shown (i.e. before the `shown.bs.tab` event occurs).
+         */
         tab(action: "show" | "dispose"): this;
 
+        /**
+         * Call a method on the tooltip element:
+         * * `show` – Reveals an element's tooltip.
+         * * `hide` – Hides an element's tooltip.
+         * * `toggle` – Toggles an element's tooltip.
+         * * `dispose` – Hides and destroys an element's tooltip.
+         * Tooltips that use delegation (which are created using `selector` option) cannot be individually destroyed on descendant trigger elements.
+         * * `enable` – Gives an element's tooltip the ability to be shown. Tooltips are enabled by default.
+         * * `disable` – Removes the ability for an element's tooltip to be shown. The tooltip will only be able to be shown if it is re-enabled.
+         * * `toggleEnabled` – Toggles the ability for an element's tooltip to be shown or hidden.
+         * * `update` – Updates the position of an element's tooltip.
+         *
+         * Returns to the caller before the tooltip has actually been shown or hidden (i.e. before the `shown.bs.tooltip` or `hidden.bs.tooltip` event occurs).
+         * This is considered a "manual" triggering of the tooltip.
+         */
         tooltip(action: "show" | "hide" | "toggle" | "dispose" | "enable" | "disable" | "toggleEnabled" | "update"): this;
+        /**
+         * Attaches a tooltip handler to an element collection.
+         */
         tooltip(options?: TooltipOption): this;
 
         on(events: CarouselEvent, handler: JQuery.EventHandlerBase<TElement, CarouselEventHandler<TElement>>): this;


### PR DESCRIPTION
Add JsDoc for scrollspy#method: twbs/bootstrap#25799.
Improve relatedTarget typing: #30144.
Add JsDoc for methods: [getbootstrap.com/docs/4.1/components](https://getbootstrap.com/docs/4.1/components).

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
