### PR TITLE
Fix [backbone.marionette] behavior constructor definition

### DIFF
--- a/types/backbone.marionette/index.d.ts
+++ b/types/backbone.marionette/index.d.ts
@@ -1693,7 +1693,7 @@ export class Application extends Object {
  * allowing you to share common user-facing operations between your views.
  */
 export class Behavior extends Object {
-    constructor(options?: any);
+    constructor(options: any, view?: any);
 
     options: any;
 

--- a/types/backbone.marionette/index.d.ts
+++ b/types/backbone.marionette/index.d.ts
@@ -1693,7 +1693,7 @@ export class Application extends Object {
  * allowing you to share common user-facing operations between your views.
  */
 export class Behavior extends Object {
-    constructor(options: any, view?: any);
+    constructor(options?: any, view?: any);
 
     options: any;
 


### PR DESCRIPTION
when initializing a view with behaviors, the parseBehaviors function on BehaviorsMixins instanciate the behaviors with `new BehaviorClass(options, view)`.
Without this view parameter, the view is undefined.

If adding the `view` parameter in the behavior declaration `super(options, view)` typescript throw an error :(

That is why i have added the parameter view in the backbone.marionette definition. It works in my case.

I am not a typescript expert, advices are welcome.

**view file :**
```javascript
import _ from "underscore";
import { View } from "backbone.marionette";
import MyBehavior from "./behavior";
const myViewProperties = {
  el: "#view",
  behaviors: [MyBehavior]
};
export class MyView extends View<Backbone.Model> {
 constructor(options: any = {}) {
   _.extend(options, pageViewProperties);
    super(options);
 }
initialize() {}
...
}
```
**behavior file:**
```javascript
import _ from "underscore";
import { Behavior } from "backbone.marionette";
const behaviorProperties = {
  ui: {
    "button": ".button"
  },
  events: {
    "click @ui.button": "onClickButton"
  }
}
export class MyBehavior extends Behavior {
  constructor(options: any = {}, view: any) {
    _.extend(options, behaviorProperties);
    super(options, view);
  }
  onClickButton(event: MouseEvent) {
    ...
  }
}
```