### PR TITLE
d3-fetch and d3-request: remove use of deprecated DsvRowAny

### DIFF
--- a/types/d3-fetch/d3-fetch-tests.ts
+++ b/types/d3-fetch/d3-fetch-tests.ts
@@ -1,5 +1,5 @@
 import * as d3Fetch from 'd3-fetch';
-import { DSVParsedArray, DSVRowString, DSVRowAny } from 'd3-dsv';
+import { DSVParsedArray, DSVRowString } from 'd3-dsv';
 
 interface MyType {
     foo: string;

--- a/types/d3-fetch/index.d.ts
+++ b/types/d3-fetch/index.d.ts
@@ -6,7 +6,7 @@
 
 // Last module patch version validated against: 1.1.0
 
-import { DSVParsedArray, DSVRowString, DSVRowAny } from 'd3-dsv';
+import { DSVParsedArray, DSVRowString } from 'd3-dsv';
 
 /**
  * Fetches the binary file at the specified input URL and returns it as a Promise of a Blob.
@@ -55,7 +55,7 @@ export function csv(
  * the row is skipped and will be omitted from the array returned by dsv.csvParse; otherwise, the returned value defines the corresponding row object.
  * In effect, row is similar to applying a map and filter operator to the returned rows.
  */
-export function csv<ParsedRow extends DSVRowAny>(
+export function csv<ParsedRow extends object>(
     url: string,
     row: (rawRow: DSVRowString, index: number, columns: string[]) => ParsedRow | undefined | null
 ): Promise<DSVParsedArray<ParsedRow>>;
@@ -77,7 +77,7 @@ export function csv<ParsedRow extends DSVRowAny>(
  * the row is skipped and will be omitted from the array returned by dsv.csvParse; otherwise, the returned value defines the corresponding row object.
  * In effect, row is similar to applying a map and filter operator to the returned rows.
  */
-export function csv<ParsedRow extends DSVRowAny>(
+export function csv<ParsedRow extends object>(
     url: string,
     init: RequestInit,
     row: (rawRow: DSVRowString, index: number, columns: string[]) => ParsedRow | undefined | null
@@ -115,7 +115,7 @@ export function dsv(
  * the row is skipped and will be omitted from the array returned by dsv.parse; otherwise, the returned value defines the corresponding row object.
  * In effect, row is similar to applying a map and filter operator to the returned rows.
  */
-export function dsv<ParsedRow extends DSVRowAny>(
+export function dsv<ParsedRow extends object>(
     delimiter: string,
     url: string,
     row: (rawRow: DSVRowString, index: number, columns: string[]) => ParsedRow | undefined | null
@@ -139,7 +139,7 @@ export function dsv<ParsedRow extends DSVRowAny>(
  * the row is skipped and will be omitted from the array returned by dsv.parse; otherwise, the returned value defines the corresponding row object.
  * In effect, row is similar to applying a map and filter operator to the returned rows.
  */
-export function dsv<ParsedRow extends DSVRowAny>(
+export function dsv<ParsedRow extends object>(
     delimiter: string,
     url: string,
     init: RequestInit,
@@ -227,7 +227,7 @@ export function tsv(
  * the row is skipped and will be omitted from the array returned by dsv.tsvParse; otherwise, the returned value defines the corresponding row object.
  * In effect, row is similar to applying a map and filter operator to the returned rows.
  */
-export function tsv<ParsedRow extends DSVRowAny>(
+export function tsv<ParsedRow extends object>(
     url: string,
     row: (rawRow: DSVRowString, index: number, columns: string[]) => ParsedRow | undefined | null
 ): Promise<DSVParsedArray<ParsedRow>>;
@@ -249,7 +249,7 @@ export function tsv<ParsedRow extends DSVRowAny>(
  * the row is skipped and will be omitted from the array returned by dsv.tsvParse; otherwise, the returned value defines the corresponding row object.
  * In effect, row is similar to applying a map and filter operator to the returned rows.
  */
-export function tsv<ParsedRow extends DSVRowAny>(
+export function tsv<ParsedRow extends object>(
     url: string,
     init: RequestInit,
     row: (rawRow: DSVRowString, index: number, columns: string[]) => ParsedRow | undefined | null

--- a/types/d3-request/index.d.ts
+++ b/types/d3-request/index.d.ts
@@ -10,7 +10,7 @@
 
 // Last module patch version validated against: 1.0.6
 
-import { DSVParsedArray, DSVRowString, DSVRowAny } from 'd3-dsv';
+import { DSVParsedArray, DSVRowString } from 'd3-dsv';
 
 export interface Request {
     /**
@@ -230,7 +230,7 @@ export interface Request {
 }
 
 export interface DsvRequest extends Request {
-    row<ParsedRow extends DSVRowAny>(value: (rawRow: DSVRowString, index: number, columns: string[]) => ParsedRow): DsvRequest;
+    row<ParsedRow extends object>(value: (rawRow: DSVRowString, index: number, columns: string[]) => ParsedRow): DsvRequest;
 }
 
 /**
@@ -247,7 +247,7 @@ export function csv(url: string, callback: (this: DsvRequest, error: any, d: DSV
  * And send a GET request.
  * Use a row conversion function to map and filter row objects to a more-specific representation; see `dsv.parse` for details.
  */
-export function csv<ParsedRow extends DSVRowAny>(
+export function csv<ParsedRow extends object>(
     url: string,
     row: (rawRow: DSVRowString, index: number, columns: string[]) => ParsedRow,
     callback: (this: DsvRequest, error: any, d: DSVParsedArray<ParsedRow>) => void
@@ -314,7 +314,7 @@ export function tsv(url: string, callback: (this: DsvRequest, error: any, d: DSV
  * And send a GET request.
  * Use a row conversion function to map and filter row objects to a more-specific representation; see `dsv.parse` for details.
  */
-export function tsv<ParsedRow extends DSVRowAny>(
+export function tsv<ParsedRow extends object>(
     url: string,
     row: (rawRow: DSVRowString, index: number, columns: string[]) => ParsedRow,
     callback: (this: DsvRequest, error: any, d: DSVParsedArray<ParsedRow>) => void


### PR DESCRIPTION
In #30466, `DSVRowAny` was deprecated to prefer him `object`.
However, it is still in use in d3-fetch and d3-request.
This PR remove any use of `DSVRowAny` in this repository.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
