### PR TITLE
[node-polyglot] Fix `t` and `locale` overloads to allow optional arguments

### DIFF
--- a/types/node-polyglot/index.d.ts
+++ b/types/node-polyglot/index.d.ts
@@ -25,19 +25,13 @@ declare class Polyglot {
 
     extend(phrases: any): void;
 
-    t(phrase: string): string;
-
-    t(phrase: string, smartCount: number): string;
-
-    t(phrase: string, interpolationOptions: Polyglot.InterpolationOptions): string;
+    t(phrase: string, options?: number | Polyglot.InterpolationOptions): string;
 
     clear(): void;
 
     replace(phrases: any): void;
 
-    locale(): string;
-
-    locale(locale: string): void;
+    locale(locale?: string): void;
 
     has(phrase: string): boolean;
 }

--- a/types/node-polyglot/index.d.ts
+++ b/types/node-polyglot/index.d.ts
@@ -1,8 +1,8 @@
-// Type definitions for node-polyglot v0.4.2
+// Type definitions for node-polyglot v0.4.3
 // Project: https://github.com/airbnb/polyglot.js
 // Definitions by: Tim Jackson-Kiely <https://github.com/timjk>
+//                 Liam Ross <https://github.com/liamross>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 
 declare namespace Polyglot {
     interface InterpolationOptions {


### PR DESCRIPTION
## Details:

Node polyglot typing breaks if you attempt to do the following:

```ts
import * as Polyglot from 'node-polyglot';

const polyglot = new Polyglot();

export const polyglotProxy = {
  t: (phrase: string, options?: number | Polyglot.InterpolationOptions) =>
    polyglot.t(phrase, options),
};
```

In this example, `options` in the final line of the proxy has the following error:

```sh
Argument of type 'number | InterpolationOptions | undefined' is not assignable to parameter of type 'InterpolationOptions'.
  Type 'undefined' is not assignable to type 'InterpolationOptions'.ts(2345)
(parameter) options: number | Polyglot.InterpolationOptions | undefined
```

This can be solved by transforming the following overloads:

https://github.com/DefinitelyTyped/DefinitelyTyped/blob/640f20d6358d674a1d38df3754196084e0446e48/types/node-polyglot/index.d.ts#L28-L32

Into a single line as follows:

```ts
t(phrase: string, options?: number | Polyglot.InterpolationOptions): string;
```

This also exactly matches the terminology used within the `node-polyglot` itself:

```ts
Polyglot.prototype.t = function (key, options) { ... }
```

As such, there seems to be no reason for the complex overloads used in the typescript definitions file.

Additionally, the same can be done for the `locale` method.

## PR Information:

Please fill in this template:

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
    - **hack needed to fix this error**
        https://github.com/hetznerZA/localize-toolkit/blob/e0d8c22a338bb3dfc3962ddfe93a2c729c69afd4/src/Globals.ts#L75-L77
    - **once custom `.d.ts` file is added instead of these type definitions** 
        https://github.com/hetznerZA/localize-toolkit/blob/f2b40f043e80ac05442fce7686af893895fd1d62/src/Globals.ts#L75-L77
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
