### PR TITLE
[slate.js] Add 'object' fields to slate's LeafJSON and MarkJSON

### DIFF
--- a/types/slate/index.d.ts
+++ b/types/slate/index.d.ts
@@ -327,6 +327,7 @@ export interface LeafProperties {
 export interface LeafJSON {
     marks?: MarkJSON[];
     text?: string;
+    object: "leaf";
 }
 
 export class Leaf extends Immutable.Record({}) {
@@ -521,6 +522,7 @@ export interface MarkProperties {
 export interface MarkJSON {
     type: string;
     data?: { [key: string]: any };
+    object: "mark";
 }
 
 export class Mark extends Immutable.Record({}) {

--- a/types/slate/slate-tests.ts
+++ b/types/slate/slate-tests.ts
@@ -12,10 +12,12 @@ const node: BlockJSON = {
 			key: "a",
 			leaves: [
 				{
+                    object: "leaf",
 					text: "example",
 					marks: [{
                         data: { testData: "data"},
-                        type: "mark"
+                        type: "mark",
+                        object: "mark"
                     }]
 				}
 			]


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:  <<https://docs.slatejs.org/slate-core/mark#object>>
- ~[ ] Increase the version number in the header if appropriate.~
- ~[ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.~

