### PR TITLE
Meteor: Let the transform option in collection methods be set to null, fix linting errors.

### DIFF
--- a/types/meteor/globals/mongo.d.ts
+++ b/types/meteor/globals/mongo.d.ts
@@ -126,7 +126,7 @@ declare module Mongo {
         new <T>(name: string, options?: {
             connection?: Object | null;
             idGeneration?: string;
-            transform?: Function;
+            transform?: Function | null;
         }): Collection<T>;
     }
     interface Collection<T> {
@@ -135,14 +135,14 @@ declare module Mongo {
             update?: (userId: string, doc: T, fieldNames: string[], modifier: any) => boolean;
             remove?: (userId: string, doc: T) => boolean;
             fetch?: string[];
-            transform?: Function;
+            transform?: Function | null;
         }): boolean;
         deny(options: {
             insert?: (userId: string, doc: T) => boolean;
             update?: (userId: string, doc: T, fieldNames: string[], modifier: any) => boolean;
             remove?: (userId: string, doc: T) => boolean;
             fetch?: string[];
-            transform?: Function;
+            transform?: Function | null;
         }): boolean;
         find(selector?: Selector<T> | ObjectID | string, options?: {
             sort?: SortSpecifier;
@@ -150,14 +150,14 @@ declare module Mongo {
             limit?: number;
             fields?: FieldSpecifier;
             reactive?: boolean;
-            transform?: Function;
+            transform?: Function | null;
         }): Cursor<T>;
         findOne(selector?: Selector<T> | ObjectID | string, options?: {
             sort?: SortSpecifier;
             skip?: number;
             fields?: FieldSpecifier;
             reactive?: boolean;
-            transform?: Function;
+            transform?: Function | null;
         }): T;
         insert(doc: T, callback?: Function): string;
         rawCollection(): any;
@@ -229,6 +229,6 @@ declare module Mongo {
         update?: (userId: string, doc: any, fieldNames: string[], modifier: any) => boolean;
         remove?: (userId: string, doc: any) => boolean;
         fetch?: string[];
-        transform?: Function;
+        transform?: Function | null;
     }
 }

--- a/types/meteor/index.d.ts
+++ b/types/meteor/index.d.ts
@@ -9,6 +9,7 @@
 //                 Stefan Holzapfel <https://github.com/stefanholzapfel>
 //                 Andrey Markeev <https://github.com/andrei-markeev>
 //                 Leon Machens <https://github.com/lmachens>
+//                 Arthur Gunn <https://github.com/gunn>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 

--- a/types/meteor/mongo.d.ts
+++ b/types/meteor/mongo.d.ts
@@ -127,7 +127,7 @@ declare module "meteor/mongo" {
             new <T>(name: string, options?: {
                 connection?: Object | null;
                 idGeneration?: string;
-                transform?: Function;
+                transform?: Function | null;
             }): Collection<T>;
         }
         interface Collection<T> {
@@ -136,14 +136,14 @@ declare module "meteor/mongo" {
                 update?: (userId: string, doc: T, fieldNames: string[], modifier: any) => boolean;
                 remove?: (userId: string, doc: T) => boolean;
                 fetch?: string[];
-                transform?: Function;
+                transform?: Function | null;
             }): boolean;
             deny(options: {
                 insert?: (userId: string, doc: T) => boolean;
                 update?: (userId: string, doc: T, fieldNames: string[], modifier: any) => boolean;
                 remove?: (userId: string, doc: T) => boolean;
                 fetch?: string[];
-                transform?: Function;
+                transform?: Function | null;
             }): boolean;
             find(selector?: Selector<T> | ObjectID | string, options?: {
                 sort?: SortSpecifier;
@@ -151,14 +151,14 @@ declare module "meteor/mongo" {
                 limit?: number;
                 fields?: FieldSpecifier;
                 reactive?: boolean;
-                transform?: Function;
+                transform?: Function | null;
             }): Cursor<T>;
             findOne(selector?: Selector<T> | ObjectID | string, options?: {
                 sort?: SortSpecifier;
                 skip?: number;
                 fields?: FieldSpecifier;
                 reactive?: boolean;
-                transform?: Function;
+                transform?: Function | null;
             }): T;
             insert(doc: T, callback?: Function): string;
             rawCollection(): any;
@@ -230,7 +230,7 @@ declare module "meteor/mongo" {
             update?: (userId: string, doc: any, fieldNames: string[], modifier: any) => boolean;
             remove?: (userId: string, doc: any) => boolean;
             fetch?: string[];
-            transform?: Function;
+            transform?: Function | null;
         }
     }
 }

--- a/types/meteor/test/globals/meteor-tests.ts
+++ b/types/meteor/test/globals/meteor-tests.ts
@@ -201,7 +201,7 @@ Posts.insert({ title: "Hello world", body: "First post" });
  **/
 
 class Animal {
-    constructor(doc: any) {}
+    constructor(public doc: any) {}
 }
 
 interface AnimalDAO {

--- a/types/meteor/test/meteor-tests.ts
+++ b/types/meteor/test/meteor-tests.ts
@@ -213,7 +213,7 @@ Posts.insert({ title: "Hello world", body: "First post" });
  **/
 
 class Animal {
-    constructor(doc: any) {}
+    constructor(public doc: any) {}
 }
 
 interface AnimalDAO {


### PR DESCRIPTION
This is a very simple change to allow the transform option in collection methods to be set to null which is the way to disable the default transformation. See:  https://docs.meteor.com/api/collections.html#Mongo-Collection-find

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

The linting error that's fixed was: `unnecessary-constructor  Remove unnecessary empty constructor.`