### PR TITLE
[@types/koa]: add State interface to enable `ctx.state` props annotation

### DIFF
--- a/types/koa/index.d.ts
+++ b/types/koa/index.d.ts
@@ -693,11 +693,15 @@ declare namespace Application {
         originalUrl: string;
         cookies: Cookies;
         accept: accepts.Accepts;
-        state: any;
+        state: State;
         /**
          * To bypass Koa's built-in response handling, you may explicitly set `ctx.respond = false;`
          */
         respond?: boolean;
+    }
+
+    interface State {
+        [key: string]: any
     }
 }
 


### PR DESCRIPTION
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/koajs/koa/blob/a007198fa23c19902b1f3ffb81498629e0e9c875/docs/api/context.md#ctxstate

Let's say I have a middleware that adds props to `ctx.state`, e.g.:
```typescript
import { Context } from 'koa';

export default (ctx: Context, next: () => Promise<void>): Promise<void> => {
    ctx.state.foo = 'FOO';

    await next();
};
```
Currently it is not possible to define type for my `foo` prop, because `Context.state` has `any` type.

This PR allows me to define type like this:
```typescript
import { Context } from 'koa';

declare module 'koa' {
    interface State {
        foo: string;
    }
}

export default (ctx: Context, next: () => Promise<void>): Promise<void> => {
    ctx.state.foo = 'FOO';

    await next();
};
```

and this way consumers of the middleware will have type for `ctx.state.foo` when they use the middleware.