### PR TITLE
Sortablejs: add missing callback 'onClone'

### DIFF
--- a/types/sortablejs/index.d.ts
+++ b/types/sortablejs/index.d.ts
@@ -225,6 +225,10 @@ declare namespace Sortable {
          */
         onAdd?: (event: SortableEvent) => void;
         /**
+         * Created a clone of an element
+         */
+        onClone?: (event: SortableEvent) => void;
+        /**
          * Changed sorting within list
          */
         onUpdate?: (event: SortableEvent) => void;

--- a/types/sortablejs/index.d.ts
+++ b/types/sortablejs/index.d.ts
@@ -229,6 +229,14 @@ declare namespace Sortable {
          */
         onClone?: (event: SortableEvent) => void;
         /**
+         * Element is chosen
+         */
+        onChoose?: (event: SortableEvent) => void;
+        /**
+         * Element is unchosen
+         */
+        onUnchoose?: (event: SortableEvent) => void;
+        /**
          * Changed sorting within list
          */
         onUpdate?: (event: SortableEvent) => void;


### PR DESCRIPTION
The callback onClone was missing from the typings even though it is part of Sortablejs 1.7 (and has always been apparently)
See https://github.com/SortableJS/Sortable .

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.


@alexeagle 