### PR TITLE
[redis] Fix types for hmset and flushdb commands. Fix tslint callable-types error

### DIFF
--- a/types/redis/index.d.ts
+++ b/types/redis/index.d.ts
@@ -1170,9 +1170,7 @@ export interface Commands<R> {
     ZSCAN: OverloadedKeyCommand<string, [string, string[]], R>;
 }
 
-export const RedisClient: {
-    new (options: ClientOpts): RedisClient;
-};
+export const RedisClient: new (options: ClientOpts) => RedisClient;
 
 export interface RedisClient extends Commands<boolean>, EventEmitter {
     connected: boolean;
@@ -1222,9 +1220,7 @@ export interface RedisClient extends Commands<boolean>, EventEmitter {
     BATCH(args?: Array<Array<string | number | Callback<any>>>): Multi;
 }
 
-export const Multi: {
-    new (): Multi;
-};
+export const Multi: new () => Multi;
 
 export interface Multi extends Commands<Multi> {
     exec(cb?: Callback<any[]>): boolean;

--- a/types/redis/index.d.ts
+++ b/types/redis/index.d.ts
@@ -8,6 +8,7 @@
 //                 James Garbutt <https://github.com/43081j>
 //                 Bartek Szczepański <https://github.com/barnski>
 //                 Pirasis Leelatanon <https://github.com/1pete>
+//                 Stanislav Dzhus <https://github.com/blablapolicja>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 // Imported from: https://github.com/types/npm-redis
@@ -159,8 +160,8 @@ export interface Commands<R> {
     /**
      * Set multiple hash fields to multiple values.
      */
-    hmset: OverloadedSetCommand<string | number, boolean, R>;
-    HMSET: OverloadedSetCommand<string | number, boolean, R>;
+    hmset: OverloadedSetCommand<string | number, 'OK', R>;
+    HMSET: OverloadedSetCommand<string | number, 'OK', R>;
 
     /**
      * Listen for messages published to the given channels.
@@ -393,8 +394,8 @@ export interface Commands<R> {
     /**
      * Remove all keys from the current database.
      */
-    flushdb(cb?: Callback<string>): R;
-    FLUSHDB(cb?: Callback<string>): R;
+    flushdb(cb?: Callback<'OK'>): R;
+    FLUSHDB(cb?: Callback<'OK'>): R;
 
     /**
      * Add one or more geospatial items in the geospatial index represented using a sorted set.

--- a/types/redis/redis-tests.ts
+++ b/types/redis/redis-tests.ts
@@ -9,6 +9,7 @@ const args: any[] = [];
 const resCallback: (err: Error | null, res: any) => void = () => {};
 const numCallback: (err: Error | null, res: number) => void = () => {};
 const strCallback: (err: Error | null, res: string) => void = () => {};
+const okCallback: (err: Error | null, res: 'OK') => void = () => {};
 const messageHandler: (channel: string, message: any) => void = () => {};
 
 // ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ----
@@ -66,7 +67,7 @@ client.unref();
 client.append(str, str, numCallback);
 client.bitcount(str, numCallback);
 client.bitcount(str, num, num, numCallback);
-client.set(str, str, strCallback);
+client.set(str, str, okCallback);
 client.get(str, strCallback);
 client.exists(str, numCallback);
 
@@ -80,15 +81,15 @@ client.once(str, messageHandler);
 client.get('test');
 client.get('test', resCallback);
 client.set('test', 'test');
-client.set('test', 'test', resCallback);
+client.set('test', 'test', okCallback);
 client.mset(args, resCallback);
 
 client.incr(str, resCallback);
 
 // Friendlier hash commands
 client.hgetall(str, resCallback);
-client.hmset(str, value, resCallback);
-client.hmset(str, str, str, str, str, resCallback);
+client.hmset(str, value, okCallback);
+client.hmset(str, str, str, str, str, okCallback);
 
 // Publish / Subscribe
 client.publish(str, value);
@@ -133,3 +134,5 @@ client.hincrbyfloat('a', 'b', 1.5, (error, value) => value.startsWith('1'));
 client.HINCRBYFLOAT('a', 'b', 1.5, (error, value) => value.startsWith('1'));
 client.zincrby('a', 1, 'b', strCallback);
 client.ZINCRBY('a', 1, 'b', strCallback);
+
+client.flushdb(okCallback);


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: for `hmset` <https://redis.io/commands/hmset>, for `flushdb` https://redis.io/commands/flushdb, for `callable-types` error <https://palantir.github.io/tslint/rules/callable-types/>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.