### PR TITLE
[@types/aframe] Add AFRAME.utils.device

### DIFF
--- a/types/aframe/index.d.ts
+++ b/types/aframe/index.d.ts
@@ -319,6 +319,22 @@ export interface Utils {
 			delimiter?: string
 		): void;
 	};
+	device: {
+		isWebXRAvailable: boolean;
+		getVRDisplay(): VRDisplay[];
+		checkHeadsetConnected(): boolean;
+		checkHasPositionalTracking(): boolean;
+		isMobile(): boolean;
+		isTablet(): boolean;
+		isIOS(): boolean;
+		isGearVR(): boolean;
+		isOculusGo(): boolean;
+		isR7(): boolean;
+		isLandscape(): boolean;
+		isBrowserEnvironment(): boolean;
+		isNodeEnvironment(): boolean;
+		PolyfillControls(object3D: THREE.Object3D): void;
+	};
 	styleParser: {
 		parse(value: string): object;
 		stringify(data: object): string;


### PR DESCRIPTION
A-Frame has a utils.device package that has a bunch of device checks.
This was not typed, so this PR adds these typings.

The source can be found here https://github.com/aframevr/aframe/blob/master/src/utils/device.js

Linting has been run and is fine.

@devpaul is the original type committer.