### PR TITLE
ByteBuffer: fix writeString to have lowercase W

### DIFF
--- a/types/bytebuffer/index.d.ts
+++ b/types/bytebuffer/index.d.ts
@@ -582,7 +582,7 @@ declare class ByteBuffer
     /**
      * Writes an UTF8 encoded string.This is an alias of ByteBuffer#writeUTF8String.
      */
-    WriteString( str: string, offset?: number ): ByteBuffer | number;
+    writeString( str: string, offset?: number ): ByteBuffer | number;
 
     /**
      * Writes an UTF8 encoded string.

--- a/types/bytebuffer/index.d.ts
+++ b/types/bytebuffer/index.d.ts
@@ -580,7 +580,7 @@ declare class ByteBuffer
     writeShort( value: number, offset?: number ): ByteBuffer;
 
     /**
-     * Writes an UTF8 encoded string.This is an alias of ByteBuffer#writeUTF8String.
+     * Writes an UTF8 encoded string. This is an alias of ByteBuffer#writeUTF8String.
      */
     writeString( str: string, offset?: number ): ByteBuffer | number;
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
    - https://github.com/dcodeIO/bytebuffer.js/wiki/API#bytebufferwritestringstr-offset
    - https://github.com/dcodeIO/bytebuffer.js/blob/master/dist/bytebuffer.js#L2153
    - https://github.com/dcodeIO/bytebuffer.js/blob/master/dist/bytebuffer-node.js#L2014

- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
