### PR TITLE
[@types/event-emitter] incorrect typing for Emitter factory function

### DIFF
--- a/types/event-emitter/index.d.ts
+++ b/types/event-emitter/index.d.ts
@@ -15,6 +15,6 @@ declare namespace ee {
     }
 }
 
-declare function ee(obj: any): ee.Emitter;
+declare function ee(obj?: any): ee.Emitter;
 
 export = ee;


### PR DESCRIPTION
Emitter factory function does not require a base object
[link to factory method](https://github.com/medikoo/event-emitter/blob/0f358e71fcd780cf306e3c7c272cb6075fc449da/index.js#L129)
For ease of review:
```
module.exports = exports = function (o) {
    return (o == null) ? create(base) : defineProperties(Object(o), descriptors);
};
```