### PR TITLE
[datatables.net] Added null to ColumnSettings.data union type

### DIFF
--- a/types/datatables.net/index.d.ts
+++ b/types/datatables.net/index.d.ts
@@ -1602,7 +1602,7 @@ declare namespace DataTables {
         /**
          * Class to assign to each cell in the column. Since: 1.10
          */
-        data?: number | string | ObjectColumnData | FunctionColumnData;
+        data?: number | string | ObjectColumnData | FunctionColumnData | null;
 
         /**
          * Set default, static, content for a column. Since: 1.10


### PR DESCRIPTION
Allows user to set value to null to allow for the special case documented here: https://datatables.net/reference/option/columns.data

This explicitly puts "null" in the domain of the ColumnSettings.data type. This will work even with strictNullChecking on in tsc options which makes sense to me since "null" is a special value in this case.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://datatables.net/reference/option/columns.data
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
