### PR TITLE
Fix post 3.3 errors

### DIFF
--- a/types/blissfuljs/index.d.ts
+++ b/types/blissfuljs/index.d.ts
@@ -2,6 +2,7 @@
 // Project: http://blissfuljs.com/
 // Definitions by: François Skorzec <https://github.com/fskorzec>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 3.0
 
 interface Element {
     _: BlissNS.BlissBindedElement<Element>;
@@ -285,7 +286,6 @@ declare namespace BlissNS {
         addEventListener(type: "MSGotPointerCapture", listener: (ev: MSPointerEvent) => any, useCapture?: boolean): T;
         addEventListener(type: "MSInertiaStart", listener: (ev: MSGestureEvent) => any, useCapture?: boolean): T;
         addEventListener(type: "MSLostPointerCapture", listener: (ev: MSPointerEvent) => any, useCapture?: boolean): T;
-        addEventListener(type: "MSManipulationStateChanged", listener: (ev: MSManipulationEvent) => any, useCapture?: boolean): T;
         addEventListener(type: "MSPointerCancel", listener: (ev: MSPointerEvent) => any, useCapture?: boolean): T;
         addEventListener(type: "MSPointerDown", listener: (ev: MSPointerEvent) => any, useCapture?: boolean): T;
         addEventListener(type: "MSPointerEnter", listener: (ev: MSPointerEvent) => any, useCapture?: boolean): T;
@@ -555,18 +555,15 @@ declare namespace BlissNS {
         getElementsByTagName(name: "video"): NodeListOf<HTMLVideoElement>;
         getElementsByTagName(name: "view"): NodeListOf<SVGViewElement>;
         getElementsByTagName(name: "wbr"): NodeListOf<HTMLElement>;
-        getElementsByTagName(name: "x-ms-webview"): NodeListOf<MSHTMLWebViewElement>;
         getElementsByTagName(name: "xmp"): NodeListOf<HTMLElement>;
         getElementsByTagName(name: string): NodeListOf<Element>;
         getElementsByTagNameNS(namespaceURI: string, localName: string): NodeListOf<Element>;
         hasAttribute(name: string): boolean;
         hasAttributeNS(namespaceURI: string, localName: string): boolean;
-        msGetRegionContent(): MSRangeCollection;
         msGetUntransformedBounds(): ClientRect;
         msMatchesSelector(selectors: string): boolean;
         msReleasePointerCapture(pointerId: number): T;
         msSetPointerCapture(pointerId: number): T;
-        msZoomTo(args: MsZoomToOptions): T;
         releasePointerCapture(pointerId: number): T;
         removeAttribute(name?: string): T;
         removeAttributeNS(namespaceURI: string, localName: string): T;

--- a/types/blissfuljs/index.d.ts
+++ b/types/blissfuljs/index.d.ts
@@ -2,7 +2,6 @@
 // Project: http://blissfuljs.com/
 // Definitions by: François Skorzec <https://github.com/fskorzec>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.0
 
 interface Element {
     _: BlissNS.BlissBindedElement<Element>;

--- a/types/debounce-promise/package.json
+++ b/types/debounce-promise/package.json
@@ -1,0 +1,7 @@
+{
+    "private": true,
+    "types": "index",
+    "typesVersions": {
+        ">=3.1.0-0": { "*": ["ts3.1/*"] }
+    }
+}

--- a/types/debounce-promise/ts3.1/debounce-promise-tests.ts
+++ b/types/debounce-promise/ts3.1/debounce-promise-tests.ts
@@ -1,0 +1,25 @@
+import debounce = require("debounce-promise");
+import { DebounceOptions } from "debounce-promise";
+
+const options: DebounceOptions = {};
+const optionsA: DebounceOptions = { leading: true };
+const f = async () => 2;
+const f2 = (a: string) => 2;
+debounce(f, 100);
+debounce(f, 0, options);
+debounce(f, 100, optionsA);
+debounce(f, 10, { accumulate: true });
+const foo = debounce(async () => f2, 10, {
+    leading: true,
+    accumulate: true
+});
+foo().then(f => f("2"));
+const bar = debounce(async () => [1, 2, 3], 100);
+bar().then(ar => ar.concat());
+
+// Converts the return value from the producer function to a promise
+const two = debounce((a: string, b: number, c: { d: boolean }) => [4], 10, {
+    leading: true,
+    accumulate: true
+});
+two("1", 2, { d: false }).then(ar => ar.pop(), () => 2);

--- a/types/debounce-promise/ts3.1/index.d.ts
+++ b/types/debounce-promise/ts3.1/index.d.ts
@@ -1,9 +1,3 @@
-// Type definitions for debounce-promise 3.1
-// Project: https://github.com/bjoerge/debounce-promise
-// Definitions by: Wu Haotian <https://github.com/whtsky>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.0
-
 declare namespace debounce {
     interface DebounceOptions {
         leading?: boolean;
@@ -11,14 +5,12 @@ declare namespace debounce {
     }
 }
 
-type ArgumentsType<T> = T extends (...args: infer A) => any ? A : never;
-
 declare function debounce<T extends (...args: any[]) => any>(
     func: T,
     wait?: number,
     options?: debounce.DebounceOptions
 ): (
-    ...args: ArgumentsType<T>
+    ...args: Parameters<T>
 ) => ReturnType<T> extends Promise<any>
     ? ReturnType<T>
     : Promise<ReturnType<T>>;

--- a/types/debounce-promise/ts3.1/package.json
+++ b/types/debounce-promise/ts3.1/package.json
@@ -1,0 +1,7 @@
+{
+    "private": true,
+    "types": "index",
+    "typesVersions": {
+        ">=3.2.0-0": { "*": ["ts3.2/*"] }
+    }
+}

--- a/types/debounce-promise/ts3.1/package.json
+++ b/types/debounce-promise/ts3.1/package.json
@@ -1,7 +1,0 @@
-{
-    "private": true,
-    "types": "index",
-    "typesVersions": {
-        ">=3.2.0-0": { "*": ["ts3.2/*"] }
-    }
-}

--- a/types/debounce-promise/ts3.1/tsconfig.json
+++ b/types/debounce-promise/ts3.1/tsconfig.json
@@ -1,25 +1,16 @@
 {
     "compilerOptions": {
         "module": "commonjs",
-        "lib": [
-            "es6",
-            "dom"
-        ],
+        "lib": ["es6"],
         "noImplicitAny": true,
         "noImplicitThis": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
-        "baseUrl": "../",
-        "typeRoots": [
-            "../"
-        ],
+        "baseUrl": "../../",
+        "typeRoots": ["../../"],
         "types": [],
         "noEmit": true,
-        "esModuleInterop": true,
         "forceConsistentCasingInFileNames": true
     },
-    "files": [
-        "index.d.ts",
-        "quill-tests.ts"
-    ]
+    "files": ["index.d.ts", "debounce-promise-tests.ts"]
 }

--- a/types/debounce-promise/ts3.1/tslint.json
+++ b/types/debounce-promise/ts3.1/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/pixi.js/index.d.ts
+++ b/types/pixi.js/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/pixijs/pixi.js/tree/dev
 // Definitions by: clark-stevenson <https://github.com/clark-stevenson>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.1
+// TypeScript Version: 2.3
 
 declare namespace PIXI {
     // from CONST

--- a/types/styled-components/test/index.tsx
+++ b/types/styled-components/test/index.tsx
@@ -655,8 +655,8 @@ async function typedThemes() {
         createGlobalStyle,
         ThemeProvider,
         ThemeConsumer
-    } = (await import("styled-components")) as ThemedStyledComponentsModule<
-        typeof theme
+    } = (await import("styled-components")) as any as ThemedStyledComponentsModule<
+    typeof theme
     >;
 
     const ThemedDiv = styled.div`
@@ -753,10 +753,10 @@ async function themeAugmentation() {
         accent: string;
     }
 
-    const base = (await import("styled-components")) as ThemedStyledComponentsModule<
+    const base = (await import("styled-components")) as any as ThemedStyledComponentsModule<
         BaseTheme
     >;
-    const extra = (await import("styled-components")) as ThemedStyledComponentsModule<
+    const extra = (await import("styled-components")) as any as ThemedStyledComponentsModule<
         ExtraTheme,
         BaseTheme
     >;

--- a/types/tingle.js/tingle.js-tests.ts
+++ b/types/tingle.js/tingle.js-tests.ts
@@ -15,9 +15,6 @@ instance = new modal({
     },
 });
 
-instance.addFooterBtn('text', undefined, function(e) {
-    e.x;
-    this.innerText;
-});
+instance.addFooterBtn('text', undefined, e => e.x);
 
 instance.setStickyFooter(false);

--- a/types/workbox-sw/tsconfig.json
+++ b/types/workbox-sw/tsconfig.json
@@ -8,7 +8,6 @@
         "target": "es2017",
         "lib": [
             "es2015",
-            "dom",
             "webworker"
         ],
         "noImplicitAny": true,


### PR DESCRIPTION
This still doesn't fix vast-client, because `document.fullscreenElement` is still missing after switching to generating standards-based DOM types instead of Edge-based DOM types.

1. blissfuljs: In TS 3.0 or higher, some MS-specific event listeners aren't available anymore. blissfuljs removes those event listeners.
2. debounce-promise now has a types-versions directory for TS 3.1+, which includes a Parameters type. The top-level directory is now for 3.0 support and below. The 3.0 code makes its own Parameters-equivalent type.
3. pixi.js now requires TS2.3 or higher.
4. quill and anybody who depends on quill needs to have esModuleInterop: true. The quill team have decided not to change this since esModuleInterop: true is the default for new code.
5. styled-components has a test that only works in TS 3.2 and higher because it relies on improved assignability rules for conditional types. I didn't want to add typesVersions for a single test, so I just added an intermediate cast to any. The intermediate cast is only needed in versions less than 3.2.
6. tingle.js: The type of `this` changed in tests, so I removed the reference since it didn't seem relevant to the test anyway.
7. workbox-sw had duplicate lib references to dom and webworker. Only webworker was necessary.