### PR TITLE
Update typings for lru-cache v5.1

### DIFF
--- a/types/lru-cache/index.d.ts
+++ b/types/lru-cache/index.d.ts
@@ -194,5 +194,5 @@ declare namespace LRU {
     /**
      * @deprecated just use the `LRU` type instead
      */
-    type Cache<K = any, V = any> = LRU<K, V>
+    type Cache<K = any, V = any> = LRU<K, V>;
 }

--- a/types/lru-cache/index.d.ts
+++ b/types/lru-cache/index.d.ts
@@ -1,19 +1,125 @@
-// Type definitions for lru-cache 4.1
+// Type definitions for lru-cache 5.1
 // Project: https://github.com/isaacs/node-lru-cache
 // Definitions by: Bart van der Schoor <https://github.com/Bartvds>
 //                 BendingBender <https://github.com/BendingBender>
+//                 Emily Marigold Klassen <https://github.com/forivall>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
 export = LRU;
 
-declare const LRU: LRU;
+declare class LRU<K = any, V = any> {
+    constructor(opts?: LRU.Options<K, V>)
+    constructor(max: number)
+    /**
+     * Return total length of objects in cache taking into account `length` options function.
+     */
+    readonly length: number;
 
-interface LRU {
-    <K, V>(opts?: LRU.Options<K, V>): LRU.Cache<K, V>;
-    <K, V>(max: number): LRU.Cache<K, V>;
-    new <K, V>(opts?: LRU.Options<K, V>): LRU.Cache<K, V>;
-    new <K, V>(max: number): LRU.Cache<K, V>;
+    /**
+     * Return total quantity of objects currently in cache. Note,
+     * that `stale` (see options) items are returned as part of this item count.
+     */
+    readonly itemCount: number;
+
+    /**
+     * Same as Options.allowStale.
+     */
+    allowStale: boolean;
+
+    /**
+     * Same as Options.length.
+     */
+    lengthCalculator(value: V): number;
+
+    /**
+     * Same as Options.max. Resizes the cache when the `max` changes.
+     */
+    max: number;
+
+    /**
+     * Same as Options.maxAge. Resizes the cache when the `maxAge` changes.
+     */
+    maxAge: number;
+
+    /**
+     * Will update the "recently used"-ness of the key. They do what you think.
+     * `maxAge` is optional and overrides the cache `maxAge` option if provided.
+     */
+    set(key: K, value: V, maxAge?: number): boolean;
+
+    /**
+     * Will update the "recently used"-ness of the key. They do what you think.
+     * `maxAge` is optional and overrides the cache `maxAge` option if provided.
+     *
+     * If the key is not found, will return `undefined`.
+     */
+    get(key: K): V | undefined;
+
+    /**
+     * Returns the key value (or `undefined` if not found) without updating
+     * the "recently used"-ness of the key.
+     *
+     * (If you find yourself using this a lot, you might be using the wrong
+     * sort of data structure, but there are some use cases where it's handy.)
+     */
+    peek(key: K): V | undefined;
+
+    /**
+     * Check if a key is in the cache, without updating the recent-ness
+     * or deleting it for being stale.
+     */
+    has(key: K): boolean;
+
+    /**
+     * Deletes a key out of the cache.
+     */
+    del(key: K): void;
+
+    /**
+     * Clear the cache entirely, throwing away all values.
+     */
+    reset(): void;
+
+    /**
+     * Manually iterates over the entire cache proactively pruning old entries.
+     */
+    prune(): void;
+
+    /**
+     * Just like `Array.prototype.forEach`. Iterates over all the keys in the cache,
+     * in order of recent-ness. (Ie, more recently used items are iterated over first.)
+     */
+    forEach<T = this>(callbackFn: (this: T, value: V, key: K, cache: this) => void, thisArg?: T): void;
+
+    /**
+     * The same as `cache.forEach(...)` but items are iterated over in reverse order.
+     * (ie, less recently used items are iterated over first.)
+     */
+    rforEach<T = this>(callbackFn: (this: T, value: V, key: K, cache: this) => void, thisArg?: T): void;
+
+    /**
+     * Return an array of the keys in the cache.
+     */
+    keys(): K[];
+
+    /**
+     * Return an array of the values in the cache.
+     */
+    values(): V[];
+
+    /**
+     * Return an array of the cache entries ready for serialization and usage with `destinationCache.load(arr)`.
+     */
+    dump(): Array<LRU.LRUEntry<K, V>>;
+
+    /**
+     * Loads another cache entries array, obtained with `sourceCache.dump()`,
+     * into the cache. The destination cache is reset before loading new entries
+     *
+     * @param cacheEntries Obtained from `sourceCache.dump()`
+     */
+    load(cacheEntries: ReadonlyArray<LRU.LRUEntry<K, V>>): void;
 }
 
 declare namespace LRU {
@@ -69,118 +175,14 @@ declare namespace LRU {
          * not when it is overwritten.
          */
         noDisposeOnSet?: boolean;
-    }
-
-    interface Cache<K, V> {
-        /**
-         * Return total length of objects in cache taking into account `length` options function.
-         */
-        readonly length: number;
 
         /**
-         * Return total quantity of objects currently in cache. Note,
-         * that `stale` (see options) items are returned as part of this item count.
+         * When using time-expiring entries with `maxAge`, setting this to
+         * `true` will make each item's effective time update to the current
+         * time whenever it is retrieved from cache, causing it to not expire.
+         * (It can still fall out of cache based on recency of use, of course.)
          */
-        readonly itemCount: number;
-
-        /**
-         * Same as Options.allowStale.
-         */
-        allowStale: boolean;
-
-        /**
-         * Same as Options.length.
-         */
-        lengthCalculator(value: V): number;
-
-        /**
-         * Same as Options.max. Resizes the cache when the `max` changes.
-         */
-        max: number;
-
-        /**
-         * Same as Options.maxAge. Resizes the cache when the `maxAge` changes.
-         */
-        maxAge: number;
-
-        /**
-         * Will update the "recently used"-ness of the key. They do what you think.
-         * `maxAge` is optional and overrides the cache `maxAge` option if provided.
-         */
-        set(key: K, value: V, maxAge?: number): boolean;
-
-        /**
-         * Will update the "recently used"-ness of the key. They do what you think.
-         * `maxAge` is optional and overrides the cache `maxAge` option if provided.
-         *
-         * If the key is not found, will return `undefined`.
-         */
-        get(key: K): V | undefined;
-
-        /**
-         * Returns the key value (or `undefined` if not found) without updating
-         * the "recently used"-ness of the key.
-         *
-         * (If you find yourself using this a lot, you might be using the wrong
-         * sort of data structure, but there are some use cases where it's handy.)
-         */
-        peek(key: K): V | undefined;
-
-        /**
-         * Check if a key is in the cache, without updating the recent-ness
-         * or deleting it for being stale.
-         */
-        has(key: K): boolean;
-
-        /**
-         * Deletes a key out of the cache.
-         */
-        del(key: K): void;
-
-        /**
-         * Clear the cache entirely, throwing away all values.
-         */
-        reset(): void;
-
-        /**
-         * Manually iterates over the entire cache proactively pruning old entries.
-         */
-        prune(): void;
-
-        /**
-         * Just like `Array.prototype.forEach`. Iterates over all the keys in the cache,
-         * in order of recent-ness. (Ie, more recently used items are iterated over first.)
-         */
-        forEach<T = this>(callbackFn: (this: T, value: V, key: K, cache: this) => void, thisArg?: T): void;
-
-        /**
-         * The same as `cache.forEach(...)` but items are iterated over in reverse order.
-         * (ie, less recently used items are iterated over first.)
-         */
-        rforEach<T = this>(callbackFn: (this: T, value: V, key: K, cache: this) => void, thisArg?: T): void;
-
-        /**
-         * Return an array of the keys in the cache.
-         */
-        keys(): K[];
-
-        /**
-         * Return an array of the values in the cache.
-         */
-        values(): V[];
-
-        /**
-         * Return an array of the cache entries ready for serialization and usage with `destinationCache.load(arr)`.
-         */
-        dump(): Array<LRUEntry<K, V>>;
-
-        /**
-         * Loads another cache entries array, obtained with `sourceCache.dump()`,
-         * into the cache. The destination cache is reset before loading new entries
-         *
-         * @param cacheEntries Obtained from `sourceCache.dump()`
-         */
-        load(cacheEntries: ReadonlyArray<LRUEntry<K, V>>): void;
+        updateAgeOnGet?: boolean;
     }
 
     interface LRUEntry<K, V> {
@@ -188,4 +190,9 @@ declare namespace LRU {
         v: V;
         e: number;
     }
+
+    /**
+     * @deprecated just use the `LRU` type instead
+     */
+    type Cache<K = any, V = any> = LRU<K, V>
 }

--- a/types/lru-cache/lru-cache-tests.ts
+++ b/types/lru-cache/lru-cache-tests.ts
@@ -11,8 +11,8 @@ const foo = {
 };
 
 const cache = new LRU<string, Foo>();
-cache; // $ExpectType Cache<string, Foo>
-new LRU<string, Foo>({ // $ExpectType Cache<string, Foo>
+cache; // $ExpectType LRU<string, Foo>
+new LRU<string, Foo>({ // $ExpectType LRU<string, Foo>
     max: num,
     maxAge: num,
     length(value) {
@@ -27,9 +27,9 @@ new LRU<string, Foo>({ // $ExpectType Cache<string, Foo>
     noDisposeOnSet: false,
     updateAgeOnGet: false,
 });
-new LRU<string, Foo>(num); // $ExpectType Cache<string, Foo>
-new LRU<string, Foo>(); // $ExpectType Cache<string, Foo>
-new LRU<string, Foo>({ // $ExpectType Cache<string, Foo>
+new LRU<string, Foo>(num); // $ExpectType LRU<string, Foo>
+new LRU<string, Foo>(); // $ExpectType LRU<string, Foo>
+new LRU<string, Foo>({ // $ExpectType LRU<string, Foo>
     max: num,
     maxAge: num,
     length: (value) => {
@@ -40,7 +40,7 @@ new LRU<string, Foo>({ // $ExpectType Cache<string, Foo>
     noDisposeOnSet: false,
     updateAgeOnGet: false,
 });
-new LRU<string, Foo>(num); // $ExpectType Cache<string, Foo>
+new LRU<string, Foo>(num); // $ExpectType LRU<string, Foo>
 
 cache.length; // $ExpectType number
 cache.length = 1; // $ExpectError
@@ -82,26 +82,26 @@ cache.prune();
 cache.forEach(function(value, key, cache) {
     value; // $ExpectType Foo
     key; // $ExpectType string
-    cache; // $ExpectType Cache<string, Foo>
-    this; // $ExpectType Cache<string, Foo>
+    cache; // $ExpectType LRU<string, Foo>
+    this; // $ExpectType LRU<string, Foo>
 });
 cache.forEach(function(value, key, cache) {
     value; // $ExpectType Foo
     key; // $ExpectType string
-    cache; // $ExpectType Cache<string, Foo>
+    cache; // $ExpectType LRU<string, Foo>
     this; // $ExpectType { foo(): void; }
 }, foo);
 
 cache.rforEach(function(value, key, cache) {
     value; // $ExpectType Foo
     key; // $ExpectType string
-    cache; // $ExpectType Cache<string, Foo>
-    this; // $ExpectType Cache<string, Foo>
+    cache; // $ExpectType LRU<string, Foo>
+    this; // $ExpectType LRU<string, Foo>
 });
 cache.rforEach(function(value, key, cache) {
     value; // $ExpectType Foo
     key; // $ExpectType string
-    cache; // $ExpectType Cache<string, Foo>
+    cache; // $ExpectType LRU<string, Foo>
     this; // $ExpectType { foo(): void; }
 }, foo);
 

--- a/types/lru-cache/lru-cache-tests.ts
+++ b/types/lru-cache/lru-cache-tests.ts
@@ -3,30 +3,31 @@ import LRU = require('lru-cache');
 const num = 1;
 
 interface Foo {
-	foo(): void;
+    foo(): void;
 }
 
 const foo = {
     foo() {}
 };
 
-const cache = LRU<string, Foo>();
+const cache = new LRU<string, Foo>();
 cache; // $ExpectType Cache<string, Foo>
-LRU<string, Foo>({ // $ExpectType Cache<string, Foo>
-	max: num,
-	maxAge: num,
-	length(value) {
+new LRU<string, Foo>({ // $ExpectType Cache<string, Foo>
+    max: num,
+    maxAge: num,
+    length(value) {
         value; // $ExpectType Foo
         return num;
-	},
-	dispose(key, value) {
+    },
+    dispose(key, value) {
         key; // $ExpectType string
         value; // $ExpectType Foo
-	},
-	stale: false,
+    },
+    stale: false,
     noDisposeOnSet: false,
+    updateAgeOnGet: false,
 });
-LRU<string, Foo>(num); // $ExpectType Cache<string, Foo>
+new LRU<string, Foo>(num); // $ExpectType Cache<string, Foo>
 new LRU<string, Foo>(); // $ExpectType Cache<string, Foo>
 new LRU<string, Foo>({ // $ExpectType Cache<string, Foo>
     max: num,
@@ -37,6 +38,7 @@ new LRU<string, Foo>({ // $ExpectType Cache<string, Foo>
     dispose: (key, value) => {},
     stale: false,
     noDisposeOnSet: false,
+    updateAgeOnGet: false,
 });
 new LRU<string, Foo>(num); // $ExpectType Cache<string, Foo>
 


### PR DESCRIPTION
BREAKING CHANGE: major version bump for lru-cache, which uses native js
class type, and so the typings use a class as well

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - [uses `class`](https://github.com/isaacs/node-lru-cache/commit/9ce69193c4cefbeee27e759b1cf94e02a3eadf8b)
  - [ageOnGet Option](https://github.com/isaacs/node-lru-cache/commit/fc66d5af76cf9b3b77da87a2448612b18f13482b)
- [x] Increase the version number in the header if appropriate.
