### PR TITLE
elliptic: Update SignatureOptions to use BNInput for r and s

### DIFF
--- a/types/elliptic/index.d.ts
+++ b/types/elliptic/index.d.ts
@@ -144,8 +144,8 @@ export namespace ec {
 	}
 
 	interface SignatureOptions {
-		r: number;
-		s: number;
+		r: BNInput;
+		s: BNInput;
 		recoveryParam?: number;
 	}
 


### PR DESCRIPTION
As you can see here: https://github.com/indutny/elliptic/blob/master/lib/elliptic/ec/signature.js#L17-L18

options.r and options.s is fed as input to BN and thus should be typed as BNInput. 

Without this, I believe it is impossible to import a signature with these typings, because the number type can't hold numbers large enough for r and s.
