### PR TITLE
[expo] Update Permission typings to match SDK31 docs

### DIFF
--- a/types/expo/expo-tests.tsx
+++ b/types/expo/expo-tests.tsx
@@ -695,13 +695,12 @@ Permissions.CAMERA === 'camera';
 Permissions.CAMERA_ROLL === 'cameraRoll';
 Permissions.AUDIO_RECORDING === 'audioRecording';
 Permissions.CONTACTS === 'contacts';
-Permissions.NOTIFICATIONS === 'remoteNotifications';
-Permissions.REMOTE_NOTIFICATIONS === 'remoteNotifications';
+Permissions.NOTIFICATIONS === 'notifications';
 Permissions.SYSTEM_BRIGHTNESS === 'systemBrightness';
 Permissions.USER_FACING_NOTIFICATIONS === 'userFacingNotifications';
 Permissions.REMINDERS === 'reminders';
 async () => {
-    const result = await Permissions.askAsync(Permissions.CAMERA);
+    const result = await Permissions.askAsync(Permissions.CAMERA, Permissions.CONTACTS);
 
     result.status === 'granted';
     result.status === 'denied';

--- a/types/expo/index.d.ts
+++ b/types/expo/index.d.ts
@@ -1905,7 +1905,7 @@ export namespace Pedometer {
 export namespace Permissions {
     type PermissionType = 'audioRecording' | 'calendar' |
     'cameraRoll' | 'camera' | 'contacts' | 'location' | 'reminders' |
-    'notifications' | 'systemBrightness' | 'userFacingNotifications';
+    'notifications' | 'systemBrightness' | 'userFacingNotifications' | 'SMS';
     type PermissionStatus = 'undetermined' | 'granted' | 'denied';
     type PermissionExpires = 'never';
 
@@ -1944,7 +1944,11 @@ export namespace Permissions {
     const NOTIFICATIONS: 'notifications';
     const REMINDERS: 'reminders';
     const SYSTEM_BRIGHTNESS: 'systemBrightness';
-    const USER_FACING_NOTIFICATIONS = 'userFacingNotifications';
+    const USER_FACING_NOTIFICATIONS: 'userFacingNotifications';
+    /**
+     * Will be removed in SDK 32
+     */
+    const SMS: 'SMS';
 }
 
 /**

--- a/types/expo/index.d.ts
+++ b/types/expo/index.d.ts
@@ -1905,7 +1905,7 @@ export namespace Pedometer {
 export namespace Permissions {
     type PermissionType = 'audioRecording' | 'calendar' |
     'cameraRoll' | 'camera' | 'contacts' | 'location' | 'reminders' |
-    'remoteNotifications' | 'systemBrightness' | 'userFacingNotifications';
+    'notifications' | 'systemBrightness' | 'userFacingNotifications';
     type PermissionStatus = 'undetermined' | 'granted' | 'denied';
     type PermissionExpires = 'never';
 
@@ -1917,17 +1917,23 @@ export namespace Permissions {
         scope: 'fine' | 'coarse' | 'none';
     }
 
-    interface PermissionResponse {
+    interface SinglePermissionResponse {
         status: PermissionStatus;
         expires: PermissionExpires;
         ios?: PermissionDetailsLocationIOS;
         android?: PermissionDetailsLocationAndroid;
     }
 
-    function getAsync(type: PermissionType): Promise<PermissionResponse>;
-    function askAsync(type: PermissionType): Promise<PermissionResponse>;
+    interface PermissionResponse {
+        status: PermissionStatus;
+        expires: PermissionExpires;
+        permissions: {
+            [key in PermissionType]: SinglePermissionResponse
+        };
+    }
 
-    type RemoteNotificationPermission = 'remoteNotifications';
+    function getAsync(...permissionTypes: PermissionType[]): Promise<PermissionResponse>;
+    function askAsync(...permissionTypes: PermissionType[]): Promise<PermissionResponse>;
 
     const AUDIO_RECORDING: 'audioRecording';
     const CALENDAR: 'calendar';
@@ -1935,9 +1941,8 @@ export namespace Permissions {
     const CAMERA: 'camera';
     const CONTACTS: 'contacts';
     const LOCATION: 'location';
-    const NOTIFICATIONS: RemoteNotificationPermission;
-    const REMINDERS = 'reminders';
-    const REMOTE_NOTIFICATIONS: RemoteNotificationPermission;
+    const NOTIFICATIONS: 'notifications';
+    const REMINDERS: 'reminders';
     const SYSTEM_BRIGHTNESS: 'systemBrightness';
     const USER_FACING_NOTIFICATIONS = 'userFacingNotifications';
 }


### PR DESCRIPTION
@janaagaard75 @moshfeu another one from me :)
Comparing to the docs, you might notice there is no `Permissions.SMS` in the typings. There are two reasons for this:

1. expo is removing that in SDK32 which is due this month ([motiations and backstory](https://github.com/expo/expo/pull/2982))
2. since it wasn't there by now, I assumed noone needs it anyway

Having those two in mind, I decided not to add SMS permissions.

--------

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.expo.io/versions/v31.0.0/sdk/permissions
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.