### PR TITLE
-split KnockoutComputedDefine interface and small fix @knockout

### DIFF
--- a/types/knockout/index.d.ts
+++ b/types/knockout/index.d.ts
@@ -196,7 +196,7 @@ interface KnockoutComputedStatic {
      * @param context Defines the value of 'this' when evaluating the computed observable
      * @param options An object with further properties for the computed observable
      */
-    <T>(evaluatorFunction: () => T, context?: any, options?: any): KnockoutComputed<T>;
+    <T>(evaluatorFunction: () => T, context?: any, options?: KnockoutComputedOptions<T>): KnockoutComputed<T>;
     /**
      * Creates computed observable
      * @param options An object that defines the computed observable options and behavior
@@ -300,11 +300,7 @@ interface KnockoutObservable<T> extends KnockoutReadonlyObservable<T> {
     extend(requestedExtenders: { [key: string]: any; }): KnockoutObservable<T>;
 }
 
-interface KnockoutComputedDefine<T> {
-    /**
-     * A function that is used to evaluate the computed observable’s current value.
-     */
-    read(): T;
+interface KnockoutComputedOptions<T> {
     /**
      * Makes the computed observable writable. This is a function that receives values that other code is trying to write to your computed observable.
      * It’s up to you to supply custom logic to handle the incoming values, typically by writing the values to some underlying observable(s).
@@ -334,6 +330,13 @@ interface KnockoutComputedDefine<T> {
      * If true, the computed observable will be set up as a purecomputed observable. This option is an alternative to the ko.pureComputed constructor.
      */
     pure?: boolean;
+}
+
+interface KnockoutComputedDefine<T> extends KnockoutComputedOptions<T> {
+    /**
+     * A function that is used to evaluate the computed observable’s current value.
+     */
+    read(): T;
 }
 
 interface KnockoutBindingContext {
@@ -583,7 +586,7 @@ interface KnockoutTemplateSources {
 // nativeTemplateEngine.js
 //////////////////////////////////
 
-interface KnockoutNativeTemplateEngine {
+interface KnockoutNativeTemplateEngine extends KnockoutTemplateEngine {
 
     renderTemplateSource(templateSource: Object, bindingContext?: KnockoutBindingContext, options?: Object): any[];
 }
@@ -592,7 +595,7 @@ interface KnockoutNativeTemplateEngine {
 // templateEngine.js
 //////////////////////////////////
 
-interface KnockoutTemplateEngine extends KnockoutNativeTemplateEngine {
+interface KnockoutTemplateEngine {
 
     createJavaScriptEvaluatorBlock(script: string): string;
 


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://knockoutjs.com/documentation/computed-reference.html>>
- [] Increase the version number in the header if appropriate.
- [] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
____________________________________________________
- The nativeTemplateEngine should inherit from templateEngine, and not the other way around.
- Split the KnockoutComputedDefine options because in some situations, the read property is unnecessary and in others it is required.