### PR TITLE
Add inputElement field to the MaskedInput instance

### DIFF
--- a/types/react-text-mask/index.d.ts
+++ b/types/react-text-mask/index.d.ts
@@ -10,7 +10,7 @@ import * as React from "react";
 
 export type maskArray = Array<string | RegExp>;
 
-export interface MaskedInputProps
+export interface   MaskedInputProps
     extends React.InputHTMLAttributes<HTMLInputElement> {
     mask?: maskArray | ((value: string) => maskArray);
 
@@ -40,7 +40,9 @@ export interface conformToMaskResult {
 export default class MaskedInput extends React.Component<
     MaskedInputProps,
     any
-> {}
+> {
+  inputElement: HTMLElement;
+}
 
 export function conformToMask(
     text: string,

--- a/types/react-text-mask/index.d.ts
+++ b/types/react-text-mask/index.d.ts
@@ -10,7 +10,7 @@ import * as React from "react";
 
 export type maskArray = Array<string | RegExp>;
 
-export interface   MaskedInputProps
+export interface MaskedInputProps
     extends React.InputHTMLAttributes<HTMLInputElement> {
     mask?: maskArray | ((value: string) => maskArray);
 


### PR DESCRIPTION
MaskedInput provides inputElement field, that is used internally for rendering and which is accessible from outside via ref. For accessing this field for ref its required to type in the MaskedInput instance

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
