### PR TITLE
Allow both JSX elements and strings to be passed as ReactTable.TextProps

### DIFF
--- a/types/react-table/index.d.ts
+++ b/types/react-table/index.d.ts
@@ -362,22 +362,22 @@ export interface ComponentProps {
 
 export interface TextProps {
     /** Default: 'Previous' */
-    previousText: string;
+    previousText: React.ReactNode;
 
     /** Default: 'Next' */
-    nextText: string;
+    nextText: React.ReactNode;
 
     /** Default: 'Loading...' */
-    loadingText: string;
+    loadingText: React.ReactNode;
 
     /** Default: 'No rows found' */
-    noDataText: string;
+    noDataText: React.ReactNode | React.ComponentType;
 
     /** Default: 'Page' */
-    pageText: string;
+    pageText: React.ReactNode;
 
     /** Default: 'of' */
-    ofText: string;
+    ofText: React.ReactNode;
 
     /** Default: 'rows' */
     rowsText: string;


### PR DESCRIPTION
Looking at [the library](https://github.com/react-tools/react-table/blob/master/src/index.js#L857) it's perfectly fine to pass a JSX element as a TextProp. Therefore both `JSX.Element` and `string` types are valid.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [https://github.com/react-tools/react-table/blob/master/src/index.js#L857](https://github.com/react-tools/react-table/blob/master/src/index.js#L857)
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.