### PR TITLE
[microservice-utilities] Use generics in the PlatformClient

### DIFF
--- a/types/microservice-utilities/index.d.ts
+++ b/types/microservice-utilities/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for microservice-utilities 0.2
+// Type definitions for microservice-utilities 0.3
 // Project: https://github.com/Cimpress-MCP/microservice-utilities.js
 // Definitions by: Daan Boerlage <https://github.com/runebaas>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -31,8 +31,9 @@ export interface PlatformClientConfiguration {
     client: object;
 }
 
-export interface PlatformClientResponse {
-    data?: any;
+/* tslint:disable:no-unnecessary-generics */
+export interface PlatformClientResponse<T> {
+    data?: T;
     status: number;
     statusText: string;
     headers: any;
@@ -42,14 +43,15 @@ export interface PlatformClientResponse {
 
 export class PlatformClient {
     constructor(logFunction: (msg: any) => void, tokenResolverFunction?: () => Promise<string>, configuration?: PlatformClientConfiguration)
-    get(url: string, headers?: { [s: string]: string; }, type?: string): Promise<PlatformClientResponse>;
-    post(url: string, data: object, headers?: { [s: string]: string; }): Promise<PlatformClientResponse>;
-    put(url: string, data: object, headers?: { [s: string]: string; }): Promise<PlatformClientResponse>;
-    patch(url: string, data: object, headers?: { [s: string]: string; }): Promise<PlatformClientResponse>;
-    delete(url: string, headers?: { [s: string]: string; }): Promise<PlatformClientResponse>;
-    head(url: string, headers?: { [s: string]: string; }): Promise<PlatformClientResponse>;
-    options(url: string, headers?: { [s: string]: string; }): Promise<PlatformClientResponse>;
+    get<T>(url: string, headers?: { [s: string]: string; }, type?: string): Promise<PlatformClientResponse<T>>;
+    post<T>(url: string, data: object, headers?: { [s: string]: string; }): Promise<PlatformClientResponse<T>>;
+    put<T>(url: string, data: object, headers?: { [s: string]: string; }): Promise<PlatformClientResponse<T>>;
+    patch<T>(url: string, data: object, headers?: { [s: string]: string; }): Promise<PlatformClientResponse<T>>;
+    delete <T>(url: string, headers?: { [s: string]: string; }): Promise<PlatformClientResponse<T>>;
+    head<T>(url: string, headers?: { [s: string]: string; }): Promise<PlatformClientResponse<T>>;
+    options<T>(url: string, headers?: { [s: string]: string; }): Promise<PlatformClientResponse<T>>;
 }
+/* tslint:enable:no-unnecessary-generics */
 
 /**
  * RequestLogger

--- a/types/microservice-utilities/microservice-utilities-tests.ts
+++ b/types/microservice-utilities/microservice-utilities-tests.ts
@@ -5,10 +5,10 @@ import { Authorizer, PlatformClient, RequestLogger, ServiceTokenProvider } from 
     const authorizerPolicy = authorizer.getPolicy({ test: true });
 
     const platformClient = new PlatformClient((msg: any) => msg, (): Promise<string> => Promise.resolve('secretToken'));
-    const result = await platformClient.get('https://www.typescriptlang.org/');
-    const data = result.data as string;
+    const result = await platformClient.get<string>('https://www.typescriptlang.org/');
+    const data = result.data;
 
-    platformClient.post('https://www.typescriptlang.org/', { testData: 'abc' });
+    platformClient.post<string>('https://www.typescriptlang.org/', { testData: 'abc' });
 
     const serviceTokenProvider = new ServiceTokenProvider(platformClient, {});
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <see below[1]>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

<br>
<br>

[1] I am disabling the rule `no-unnecessary-generics` around a block of code which fails on this error but is the perfect use case for generics.