### PR TITLE
[stellar-sdk] Misc improvements

### DIFF
--- a/types/stellar-sdk/index.d.ts
+++ b/types/stellar-sdk/index.d.ts
@@ -5,13 +5,14 @@
 //                 Paul Selden <https://github.com/pselden>
 //                 Max Bause <https://github.com/maxbause>
 //                 Timur Ramazanov <https://github.com/charlie-wasp>
+//                 Kalvis Kalniņš <https://github.com/Akuukis>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.4
 
 /// <reference types="node" />
 
 export class Account {
-    constructor(accountId: string, sequence: string)
+    constructor(accountId: string, sequence: string | number)
     accountId(): string;
     sequenceNumber(): string;
     incrementSequenceNumber(): void;
@@ -21,7 +22,7 @@ export class CallBuilder<T extends Record> {
     constructor(serverUrl: string)
     call(): Promise<CollectionPage<T>>;
     cursor(cursor: string): this;
-    limit(limit: number): this;
+    limit(limit: number | string): this;
     order(direction: 'asc' | 'desc'): this;
     stream(options?: { onmessage?: (record: T) => void, onerror?: (error: Error) => void }): () => void;
 }
@@ -65,6 +66,25 @@ export type CallFunction<T extends Record> = () => Promise<T>;
 export type CallCollectionFunction<T extends Record> =
     (options?: CallFunctionTemplateOptions) => Promise<CollectionRecord<T>>;
 
+export enum ASSET_TYPE {
+    native = 'native',
+    credit4 = 'credit_alphanum4',
+    credit12 = 'credit_alphanum12',
+}
+
+export interface BalanceLineNative {
+    balance: string;
+    asset_type: ASSET_TYPE.native;
+}
+export interface BalanceLineAsset {
+    balance: string;
+    limit: string;
+    asset_type: ASSET_TYPE.credit4 | ASSET_TYPE.credit12;
+    asset_code: string;
+    asset_issuer: string;
+}
+export type BalanceLine = BalanceLineNative | BalanceLineAsset;
+
 export interface AccountRecord extends Record {
     id: string;
     paging_token: string;
@@ -80,19 +100,7 @@ export interface AccountRecord extends Record {
         auth_required: boolean
         auth_revocable: boolean
     };
-    balances: Array<
-    {
-        balance: string
-        asset_type: 'native'
-    } |
-    {
-        balance: string
-        limit: string
-        asset_type: 'credit_alphanum4' | 'credit_alphanum12'
-        asset_code: string
-        asset_issuer: string
-    }
-    >;
+    balances: BalanceLine[];
     signers: Array<
     {
         public_key: string
@@ -111,7 +119,7 @@ export interface AccountRecord extends Record {
 }
 
 export interface AssetRecord extends Record {
-    asset_type: 'credit_alphanum4' | 'credit_alphanum12';
+    asset_type: ASSET_TYPE.credit4 | ASSET_TYPE.credit12;
     asset_code: string;
     asset_issuer: string;
     paging_token: string;
@@ -129,6 +137,7 @@ export interface EffectRecord extends Record {
     starting_balance: string;
     type_i: string;
     type: string;
+    amount?: any;
 
     operation?: CallFunction<OperationRecord>;
     precedes?: CallFunction<EffectRecord>;
@@ -178,6 +187,7 @@ export interface BaseOperationRecord extends Record {
     paging_token: string;
     type: string;
     type_i: number;
+    source_account: string;
 
     self: CallFunction<OperationRecord>;
     succeeds: CallFunction<OperationRecord>;
@@ -390,6 +400,8 @@ export interface TransactionRecord extends Record {
     result_xdr: string;
     result_meta_xdr: string;
     memo: string;
+    envelope: any;
+    memo_type: any;
 
     account: CallFunction<AccountRecord>;
     effects: CallCollectionFunction<EffectRecord>;
@@ -419,19 +431,7 @@ export class AccountResponse implements AccountRecord {
         auth_required: boolean
         auth_revocable: boolean
     };
-    balances: Array<
-        {
-            balance: string
-            asset_type: 'native'
-        } |
-        {
-            balance: string
-            limit: string
-            asset_type: 'credit_alphanum4' | 'credit_alphanum12'
-            asset_code: string
-            asset_issuer: string
-        }
-        >;
+    balances: BalanceLine[];
     signers: Array<
         {
             public_key: string
@@ -442,6 +442,7 @@ export class AccountResponse implements AccountRecord {
     data_attr: {
         [key: string]: string
     };
+    inflation_destination?: any;
 
     effects: CallCollectionFunction<EffectRecord>;
     offers: CallCollectionFunction<OfferRecord>;
@@ -462,7 +463,7 @@ export class Asset {
 
     getCode(): string;
     getIssuer(): string;
-    getAssetType(): 'native' | 'credit_alphanum4' | 'credit_alphanum12';
+    getAssetType(): ASSET_TYPE;
     isNative(): boolean;
     equals(other: Asset): boolean;
     toXDRObject(): xdr.Asset;
@@ -510,6 +511,13 @@ export class FederationServer {
 
 export class LedgerCallBuilder extends CallBuilder<LedgerRecord> { }
 
+export const MemoNone = 'none';
+export const MemoID = 'id';
+export const MemoText = 'text';
+export const MemoHash = 'hash';
+export const MemoReturn = 'return';
+export type MemoType = typeof MemoNone | typeof MemoID | typeof MemoText | typeof MemoHash | typeof MemoReturn;
+
 export class Memo {
     static fromXDRObject(memo: xdr.Memo): Memo;
     static hash(hash: string): Memo;
@@ -518,21 +526,15 @@ export class Memo {
     static return(hash: string): Memo;
     static text(text: string): Memo;
 
-    constructor(type: 'none');
-    constructor(type: 'id' | 'text' | 'hash' | 'return', value: string)
-    constructor(type: 'hash' | 'return', value: Buffer)
+    constructor(type: typeof MemoNone);
+    constructor(type: typeof MemoID | typeof MemoText | typeof MemoHash | typeof MemoReturn, value: string)
+    constructor(type: typeof MemoHash | typeof MemoReturn, value: Buffer)
 
     type: string;
     value: null | string | Buffer;
 
     toXDRObject(): xdr.Memo;
 }
-
-export const MemoNone = 'none';
-export const MemoID = 'id';
-export const MemoText = 'text';
-export const MemoHash = 'hash';
-export const MemoReturn = 'return';
 
 export enum Networks {
     PUBLIC = 'Public Global Stellar Network ; September 2015',
@@ -660,7 +662,7 @@ export namespace Operation {
     interface ManageData extends Operation {
         type: OperationType.manageData;
         name: string;
-        value: string;
+        value: Buffer;
     }
     interface ManageDataOptions {
         name: string;
@@ -678,7 +680,7 @@ export namespace Operation {
         offerId: string;
     }
     interface ManageOfferOptions extends CreatePassiveOfferOptions {
-        offerId: number | string;
+        offerId?: number | string;
     }
     function manageOffer(options: ManageOfferOptions): xdr.Operation<ManageOffer>;
 
@@ -784,8 +786,12 @@ export class PaymentCallBuilder extends CallBuilder<PaymentOperationRecord> {
     forTransaction(transactionId: string): this;
 }
 
+export interface ServerOptions {
+    allowHttp: boolean;
+}
+
 export class Server {
-    constructor(serverURL: string, options?: { allowHttp: boolean })
+    constructor(serverURL: string, options?: ServerOptions)
     accounts(): AccountCallBuilder;
     assets(): AssetsCallBuilder;
     effects(): EffectCallBuilder;
@@ -801,7 +807,7 @@ export class Server {
         destinationAmount: string,
     ): PathCallBuilder;
     payments(): PaymentCallBuilder;
-    submitTransaction(transaction: Transaction): Promise<any>;
+    submitTransaction(transaction: Transaction): Promise<TransactionRecord>;
     tradeAggregation(
         base: Asset,
         counter: Asset,
@@ -811,6 +817,8 @@ export class Server {
     ): TradeAggregationCallBuilder;
     trades(): TradesCallBuilder;
     transactions(): TransactionCallBuilder;
+
+    serverURL: any;  // TODO: require("urijs")
 }
 
 export namespace StrKey {
@@ -877,6 +885,7 @@ export class TransactionCallBuilder extends CallBuilder<TransactionRecord> {
 
 export class Keypair {
     static fromRawEd25519Seed(secretSeed: Buffer): Keypair;
+    static fromBase58Seed(secretSeed: string): Keypair;
     static fromSecret(secretKey: string): Keypair;
     static master(): Keypair;
     static fromPublicKey(publicKey: string): Keypair;
@@ -890,6 +899,7 @@ export class Keypair {
     rawSecretKey(): Buffer;
     canSign(): boolean;
     sign(data: Buffer): Buffer;
+    signDecorated(data: Buffer): xdr.DecoratedSignature;
     signatureHint(): xdr.SignatureHint;
     verify(data: Buffer, signature: Buffer): boolean;
 }
@@ -898,21 +908,35 @@ export namespace xdr {
     class XDRStruct {
         static fromXDR(xdr: Buffer): XDRStruct;
 
-        toXDR(): Buffer;
+        toXDR(base?: string): Buffer;
         toXDR(encoding: string): string;
     }
-    class Operation<T extends Operation.Operation> extends XDRStruct { }
-    class Asset extends XDRStruct { }
-    class Memo extends XDRStruct { }
-    class TransactionEnvelope extends XDRStruct { }
+    class Operation<T extends Operation.Operation> extends XDRStruct {
+        static fromXDR(xdr: Buffer): Operation<Operation.Operation>;
+    }
+    class Asset extends XDRStruct {
+        static fromXDR(xdr: Buffer): Asset;
+    }
+    class Memo extends XDRStruct {
+        static fromXDR(xdr: Buffer): Memo;
+    }
+    class TransactionEnvelope extends XDRStruct {
+        static fromXDR(xdr: Buffer): TransactionEnvelope;
+    }
     class DecoratedSignature extends XDRStruct {
-      constructor(keys: { hint: SignatureHint, signature: Signature })
+        static fromXDR(xdr: Buffer): DecoratedSignature;
 
-      hint(): SignatureHint;
-      signature(): Buffer;
+        constructor(keys: { hint: SignatureHint, signature: Signature })
+
+        hint(): SignatureHint;
+        signature(): Buffer;
     }
     type SignatureHint = Buffer;
     type Signature = Buffer;
+
+    class TransactionResult extends XDRStruct {
+        static fromXDR(xdr: Buffer): TransactionResult;
+    }
 }
 
 export namespace StellarTomlResolver {

--- a/types/stellar-sdk/stellar-sdk-tests.ts
+++ b/types/stellar-sdk/stellar-sdk-tests.ts
@@ -12,6 +12,6 @@ transaction; // $ExpectType Transaction
 StellarSdk.StellarTomlResolver.resolve("example.com", {allowHttp: true, timeout: 100})
     .then(toml => toml.FEDERATION_SERVER);
 
-const sig = StellarSdk.xdr.DecoratedSignature.fromXDR(Buffer.of(1, 2)) as StellarSdk.xdr.DecoratedSignature;
+const sig = StellarSdk.xdr.DecoratedSignature.fromXDR(Buffer.of(1, 2)); // $ExpectType DecoratedSignature
 sig.hint(); // $ExpectType Buffer
 sig.signature(); // $ExpectType Buffer


### PR DESCRIPTION
## Changing an existing definition ([Docs](https://stellar.github.io/js-stellar-sdk/), Source: [SDK](https://github.com/stellar/js-stellar-sdk) & [BASE](https://github.com/stellar/js-stellar-sdk))

Changes:

- feat: generic xdr namespace `.fromXDR`
    ```
    // Example
    const memo: xdr.Memo = Memo.fromXDR(buffer)  // Before it was xdr.XDRStruct
    ```
- feat: type MemoType and reuse Memo* constants
    ```
    // Example
    const memo = new Memo(MemoText, 'my comment')  // No magic string anymore :)
    function doWithMemo(type: MemoType, value?: string) {
        // Now TS nicely narrows down type after each if-else.
    }
    ```
- feat: enum ASSET_TYPE and interface BalanceLine*
    ```
    // Example
    for(balance of accountRecord.balances) {
        if(balance.asset_type === ASSET_TYPE.native) {
            console.log(`Credit line ${balance.asset_code}@${balance.asset_issuer}.`)
        } else {
            console.log(`Native asset.`)  // No asset_code nor asset_issuer in scope anymore.
        }
    }
    ```
- fix: missing methods
    ```
    keypair.signDecorated()
    Keypair.fromBase58Seed()
    ```
- fix: extract `interface ServerOptions`
- fix: parameter types here and there
- fix: add props to horizon responses
- fix: `serverURL` prop for Server


### Work to be done

The above mentioned changes are not comprehensive, and only solves pain-points that my repos touches. For anyone who would like to contribute but doesn't know where to get started, here's outstanding problems what I noticed:

- refactor: separate sdk, base and horizonResponse in different modules
- feat: copy over comments from source for intellisense
- fix: split Operation.* interfaces into param* and option*
    SDK allows different values to be passed (e.g. `string | number`) to operation constructor. But properties in parsed operations always have only one of both types although uses the same interface, which is wrong.
- feat: introduce AccountId, PublicKey and Secret as types
    That's because at some places is confusing whenever you need an address of existing account, random publicKey or just a string. Comments and intellisense may help a lot:
    ```
    /**
    * 56-character long string, starts with G and passes StrKey.isValidEd25519PublicKey().
    * Do not confuse with AccountId.
    */
    export type PublicKey = string;

    /**
    * Like PublicKey, but also points to existing account on the given Network.
    */
    export type AccountId = string;
    ```

