### PR TITLE
Fix type of Redux Form event handlers.

### DIFF
--- a/types/redux-form/lib/Field.d.ts
+++ b/types/redux-form/lib/Field.d.ts
@@ -17,7 +17,7 @@ export type Parser = (value: any, name: string) => any;
 export type Validator = (value: any, allValues?: any, props?: any, name?: any) => any;
 
 export type EventHandler<Event> = (event: Event) => void;
-export type EventWithDataHandler<Event> = (event?: Event, newValue?: any, previousValue?: any, fieldName?: any) => void;
+export type EventWithDataHandler<Event> = (event?: Event, newValue?: any, previousValue?: any, name?: string) => void;
 
 export interface EventOrValueHandler<Event> extends EventHandler<Event> {
     (value: any): void;

--- a/types/redux-form/lib/Field.d.ts
+++ b/types/redux-form/lib/Field.d.ts
@@ -17,7 +17,7 @@ export type Parser = (value: any, name: string) => any;
 export type Validator = (value: any, allValues?: any, props?: any, name?: any) => any;
 
 export type EventHandler<Event> = (event: Event) => void;
-export type EventWithDataHandler<Event> = (event?: Event, newValue?: any, previousValue?: any) => void;
+export type EventWithDataHandler<Event> = (event?: Event, newValue?: any, previousValue?: any, fieldName?: any) => void;
 
 export interface EventOrValueHandler<Event> extends EventHandler<Event> {
     (value: any): void;

--- a/types/redux-form/lib/Field.d.ts
+++ b/types/redux-form/lib/Field.d.ts
@@ -16,7 +16,7 @@ export type Formatter = (value: any, name: string) => any;
 export type Parser = (value: any, name: string) => any;
 export type Validator = (value: any, allValues?: any, props?: any, name?: any) => any;
 
-export type EventHandler<Event> = (event: Event) => void;
+ export type EventHandler<Event> = (event: Event, name?: string) => void;
 export type EventWithDataHandler<Event> = (event?: Event, newValue?: any, previousValue?: any, name?: string) => void;
 
 export interface EventOrValueHandler<Event> extends EventHandler<Event> {

--- a/types/redux-form/lib/Field.d.ts
+++ b/types/redux-form/lib/Field.d.ts
@@ -16,7 +16,7 @@ export type Formatter = (value: any, name: string) => any;
 export type Parser = (value: any, name: string) => any;
 export type Validator = (value: any, allValues?: any, props?: any, name?: any) => any;
 
- export type EventHandler<Event> = (event: Event, name?: string) => void;
+export type EventHandler<Event> = (event: Event, name?: string) => void;
 export type EventWithDataHandler<Event> = (event?: Event, newValue?: any, previousValue?: any, name?: string) => void;
 
 export interface EventOrValueHandler<Event> extends EventHandler<Event> {

--- a/types/redux-form/redux-form-tests.tsx
+++ b/types/redux-form/redux-form-tests.tsx
@@ -279,8 +279,8 @@ const Test = reduxForm<TestFormData>({
                             <Field
                                 name="field4"
                                 component="input"
-                                onChange={(event, newValue, previousValue) => {}}
-                                onBlur={(event, newValue, previousValue) => {}}
+                                onChange={(event, newValue, previousValue, fieldName) => {}}
+                                onBlur={(event, newValue, previousValue, fieldName) => {}}
                             />
 
                             <ImmutableField


### PR DESCRIPTION
This PR updates the event handlers for the `onBlur`, `onDragStart`, `onChange`, `onDrop` and `onFocus` to support the optional `name` (field name) parameter.

I ran `npm run test` and `npm run lint redux-form`. Both returned no errors.

https://redux-form.com/7.4.2/docs/api/field.md/#-code-onblur-event-newvalue-previousvalue-name-gt-void-code-optional-

Here above is the API definition for the functions that I changed, which were missing the last argument.