### PR TITLE
Fix pem readPkcs12 parameter type

### DIFF
--- a/types/pem/index.d.ts
+++ b/types/pem/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/andris9/pem
 // Definitions by: Anthony Trinh <https://github.com/tony19>, Ruslan Arkhipau <https://github.com/DethAriel>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+/// <reference types="node" />
 
 export interface ModuleConfiguration {
     /**
@@ -135,6 +136,12 @@ export interface CertificateSubjectReadResult {
     emailAddress: string;
 }
 
+export interface Pkcs12ReadResult {
+    key: string;
+    cert: string;
+    ca: string[];
+}
+
 export type Callback<T> = (error: any, result: T) => any;
 
 /**
@@ -244,8 +251,8 @@ export function createPkcs12(key: string, certificate: string, password: string,
  * @param callback Callback function with an error object and {pkcs12}
  * @returns the result of the callback
  */
-export function readPkcs12(bufferOrPath: string, options: Pkcs12ReadOptions, callback: Callback<{ pkcs12: any }>): any;
-export function readPkcs12(bufferOrPath: string, callback: Callback<{ pkcs12: any }>): any;
+export function readPkcs12(bufferOrPath: Buffer | string, options: Pkcs12ReadOptions, callback: Callback<Pkcs12ReadResult>): any;
+export function readPkcs12(bufferOrPath: Buffer | string, callback: Callback<Pkcs12ReadResult>): any;
 
 /**
  * Verifies the signing chain of the passed certificate

--- a/types/pem/pem-tests.ts
+++ b/types/pem/pem-tests.ts
@@ -1,4 +1,5 @@
 import * as pem from 'pem';
+import * as fs from 'fs';
 
 const tests = {
   'Create default sized dhparam key': (test: any) => {
@@ -557,8 +558,21 @@ const tests = {
           test.ok(pkcs12.pkcs12);
 
           // test.ok(fs.readdirSync('./tmp').length === 0);
+          const pkcs12Buffer = new Buffer(pkcs12.pkcs12);
 
-          pem.readPkcs12(pkcs12.pkcs12, (error: any, keystore: any) => {
+          pem.readPkcs12(pkcs12Buffer, (error: any, keystore: pem.Pkcs12ReadResult) => {
+            test.ifError(error);
+            test.ok(keystore);
+
+            test.equal(ca.certificate, keystore.ca[0]);
+            test.equal(cert.certificate, keystore.cert);
+            test.equal(cert.clientKey, keystore.key);
+          });
+
+          const pkcs12File: string = __dirname + '/test.pkcs12';
+          fs.writeFileSync(pkcs12File, pkcs12Buffer);
+
+          pem.readPkcs12(pkcs12File, (error: any, keystore: pem.Pkcs12ReadResult) => {
             test.ifError(error);
             test.ok(keystore);
 


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.deineagentur.com/projects/pem/module-pem.html#.readPkcs12
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
