### PR TITLE
feat(@types/mongodb): export `Condition`

### DIFF
--- a/types/mongodb/index.d.ts
+++ b/types/mongodb/index.d.ts
@@ -999,7 +999,7 @@ export interface Collection<TSchema = Default> {
     watch(pipeline?: Object[], options?: ChangeStreamOptions & { startAtClusterTime?: Timestamp, session?: ClientSession }): ChangeStream;
 }
 
-type Condition<T, P extends keyof T> = {
+export type Condition<T, P extends keyof T> = {
     $eq?: T[P];
     $gt?: T[P];
     $gte?: T[P];


### PR DESCRIPTION

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

**Changed the existing definition:**
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://docs.mongodb.com/manual/reference/operator/query/or/>

Conditions can be used at the top level:

```typescript
db.inventory.find( { $or: [ { quantity: { $lt: 20 } }, { price: 10 } ] } )
```

Seems like the types in `@types/mongoose` marked the conditions as `any`, but exposing this `Condition` would provide for better typing in there as well.

```typescript
    findOne(conditions?: any,
      callback?: (err: any, res: T | null) => void): DocumentQuery<T | null, T> & QueryHelpers;
    findOne(conditions: any, projection: any,
      callback?: (err: any, res: T | null) => void): DocumentQuery<T | null, T> & QueryHelpers;
    findOne(conditions: any, projection: any, options: any,
      callback?: (err: any, res: T | null) => void): DocumentQuery<T | null, T> & QueryHelpers;
```


- [ ] Increase the version number in the header if appropriate.

Not sure what this is referring to (first time here), but based on the current time in writing.. This should be a patch bump from 3.1.17 to 3.1.18.
