### PR TITLE
[next] Stop referring to functional React components as "stateless"

### DIFF
--- a/types/next/index.d.ts
+++ b/types/next/index.d.ts
@@ -87,14 +87,31 @@ declare namespace next {
         | NextStatelessComponent<P, IP, C>;
 
     /**
-     * Next.js counterpart of React.SFC/React.StatelessComponent.
+     * @deprecated as of recent React versions, function components can no
+     * longer be considered 'stateless'. Please use `NextFunctionComponent` instead.
+     *
+     * @see [React Hooks](https://reactjs.org/docs/hooks-intro.html)
+     */
+    type NextSFC<P = {}, IP = P, C = NextContext> = NextFunctionComponent<P, IP, C>;
+
+    /**
+     * @deprecated as of recent React versions, function components can no
+     * longer be considered 'stateless'. Please use `NextFunctionComponent` instead.
+     *
+     * @see [React Hooks](https://reactjs.org/docs/hooks-intro.html)
+     */
+    type NextStatelessComponent<P = {}, IP = P, C = NextContext> = NextFunctionComponent<P, IP, C>;
+
+    type NextFC<P = {}, IP = P, C = NextContext> = NextFunctionComponent<P, IP, C>;
+
+    /**
+     * Next.js counterpart of React.FC/React.FunctionComponent.
      *
      * @template P Component props.
      * @template IP Initial props returned from getInitialProps.
      * @template C Context passed to getInitialProps.
      */
-    type NextSFC<P = {}, IP = P, C = NextContext> = NextStatelessComponent<P, IP, C>;
-    type NextStatelessComponent<P = {}, IP = P, C = NextContext> = React.StatelessComponent<P> &
+    type NextFunctionComponent<P = {}, IP = P, C = NextContext> = React.FunctionComponent<P> &
         NextStaticLifecycle<IP, C>;
 
     /**

--- a/types/next/test/next-component-tests.tsx
+++ b/types/next/test/next-component-tests.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { NextStatelessComponent, NextContext, NextComponentType } from "next";
+import { NextStatelessComponent, NextContext, NextComponentType, NextFunctionComponent } from "next";
 import { DefaultQuery } from "next/router";
 
 interface NextComponentProps {
@@ -29,11 +29,20 @@ class ClassNextWithTypedQuery extends React.Component {
     }
 }
 
-const StatelessNext: NextStatelessComponent<NextComponentProps> = ({ example }) => (
+const LegacyStatelessNext: NextStatelessComponent<NextComponentProps> = ({ example }) => (
     <div>I'm a stateless component! {example}</div>
 );
 
-StatelessNext.getInitialProps = async ({ query }: NextContext) => {
+LegacyStatelessNext.getInitialProps = async ({ query }: NextContext) => {
+    const { example } = query;
+    return { example: example as string };
+};
+
+const FunctionNext: NextFunctionComponent<NextComponentProps> = ({ example }) => (
+    <div>I'm a functional component! {example}</div>
+);
+
+FunctionNext.getInitialProps = async ({ query }: NextContext) => {
     const { example } = query;
     return { example: example as string };
 };

--- a/types/next/test/next-dynamic-tests.tsx
+++ b/types/next/test/next-dynamic-tests.tsx
@@ -5,7 +5,7 @@ import dynamic, { LoadingComponentProps } from "next/dynamic";
 interface MyComponentProps {
     foo: string;
 }
-const MyComponent: React.StatelessComponent<MyComponentProps> = () => <div>I'm async!</div>;
+const MyComponent: React.FunctionComponent<MyComponentProps> = () => <div>I'm async!</div>;
 const asyncComponent = Promise.resolve(MyComponent);
 
 // Examples from

--- a/types/next/test/next-router-tests.tsx
+++ b/types/next/test/next-router-tests.tsx
@@ -99,12 +99,12 @@ class TestComponent extends React.Component<TestComponentProps & WithRouterProps
 
 withRouter(TestComponent);
 
-interface TestSFCQuery {
+interface TestFCQuery {
     test?: string;
 }
 
-interface TestSFCProps extends WithRouterProps<TestSFCQuery> { }
+interface TestFCProps extends WithRouterProps<TestFCQuery> { }
 
-const TestSFC: React.SFC<TestSFCProps> = ({ router }) => {
+const TestFC: React.FunctionComponent<TestFCProps> = ({ router }) => {
     return <div>{router && router.query && router.query.test}</div>;
 };


### PR DESCRIPTION
This PR:
- renames `NextStatelessComponent` to `NextFuntionalComponent`
- renames  `NextSFC` to `NextFC`
- introduces type aliases to ensure `NextStatelessComponent` and `NextSFC` continue working

This change is motivated by the recent "upstream" changes to `react` typings from #30364. Do read that PR for context, but the gist of it is that as of recent React versions there are ways to keep state inside functional components (using [React hooks](https://reactjs.org/docs/hooks-intro.html)), and it is [recommended](https://twitter.com/dan_abramov/status/1057625147216220162) that one stops referring to functional components as "stateless".

Due to the introduction of the aliases (like upstream) this should be a backwards-compatible change.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/30364
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.