### PR TITLE
[moment-timezone] Fix `setDefault()` type signature

### DIFF
--- a/types/moment-timezone/index.d.ts
+++ b/types/moment-timezone/index.d.ts
@@ -1,6 +1,8 @@
 // Type definitions for moment-timezone.js 0.5
 // Project: http://momentjs.com/timezone/
-// Definitions by: Michel Salib <https://github.com/michelsalib>, Alan Brazil Lins <https://github.com/alanblins>
+// Definitions by: Michel Salib <https://github.com/michelsalib>
+//                 Alan Brazil Lins <https://github.com/alanblins>
+//                 Agustin Carrasco <https://github.com/asermax>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 import moment = require('moment');
@@ -53,7 +55,7 @@ declare module "moment" {
         names(): string[];
         guess(ignoreCache?: boolean): string;
 
-        setDefault(timezone: string): MomentTimezone;
+        setDefault(timezone?: string): MomentTimezone;
     }
 
     interface Moment {

--- a/types/moment-timezone/moment-timezone-tests.ts
+++ b/types/moment-timezone/moment-timezone-tests.ts
@@ -77,6 +77,8 @@ moment.tz.names();
 
 moment.tz.setDefault('America/Los_Angeles');
 
+moment.tz.setDefault();
+
 moment.tz.guess();
 
 moment.tz.guess(true);


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://momentjs.com/timezone/docs/#/using-timezones/default-timezone/
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

