### PR TITLE
This fixes return type of `send` property of a `TransactionObject` in @types/web3

### DIFF
--- a/types/web3/eth/types.d.ts
+++ b/types/web3/eth/types.d.ts
@@ -1,4 +1,4 @@
-import { Callback } from "../types";
+import { Callback, TransactionReceipt } from "../types";
 import PromiEvent from "../promiEvent";
 import { ABIDefinition } from "./abi";
 export interface Tx {
@@ -82,7 +82,7 @@ export interface Transaction {
 export interface TransactionObject<T> {
 	arguments: any[];
 	call(tx?: Tx): Promise<T>;
-	send(tx?: Tx): PromiEvent<T>;
+	send(tx?: Tx): PromiEvent<TransactionReceipt>;
 	estimateGas(tx?: Tx): Promise<number>;
 	encodeABI(): string;
 }

--- a/types/web3/web3-tests.ts
+++ b/types/web3/web3-tests.ts
@@ -90,6 +90,30 @@ myContract.options.from = "0x1234567890123456789012345678901234567891";
 myContract.options.gasPrice = "20000000000000";
 myContract.options.gas = 5000000;
 
+const newContract = new web3.eth.Contract(
+    [],
+    contractAddress,
+    {
+        from: "0x1234567890123456789012345678901234567891",
+        gasPrice: "20000000000"
+    }
+);
+const new_contract: Promise<TransactionReceipt> = newContract.deploy({
+    data: '0x12345...',
+    arguments: [123, 'My String']
+})
+.send({
+    from: '0x1234567890123456789012345678901234567891',
+    gas: 1500000,
+    gasPrice: '20000000000'
+// tslint:disable-next-line:only-arrow-functions
+})
+// tslint:disable-next-line:only-arrow-functions
+.then(function(value)  {
+    console.log(value);
+    return value;
+});
+
 //
 // web3.eth.accounts
 // --------------------------------------------------------------------------


### PR DESCRIPTION
TransactionObject.send() on calling should return the type TransactionReceipt!!