### PR TITLE
flickity slider asNavFor property fix

### DIFF
--- a/types/flickity/index.d.ts
+++ b/types/flickity/index.d.ts
@@ -457,7 +457,7 @@ interface FlickityOptions {
      *
      * default: disabled
      */
-    asNavFor?: string;
+    asNavFor?: string | HTMLElement;
 
     /**
      * The number of pixels a mouse or touch has to move before dragging begins. Increase dragThreshold to allow for more wiggle room for vertical page scrolling on touch devices.


### PR DESCRIPTION
flickity slider's definition for `asNavFor` property may be string *or* HTMLElement proper to its documentation.
Please take a look at https://flickity.metafizzy.co/options.html#asnavfor for further information