### PR TITLE
Update express-rate-limiter, options message type

### DIFF
--- a/types/express-rate-limit/express-rate-limit-tests.ts
+++ b/types/express-rate-limit/express-rate-limit-tests.ts
@@ -6,6 +6,15 @@ const apiLimiter = new RateLimit({
   delayMs: 0 // disabled
 });
 
+const apiLimiterWithMessageObject = new RateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100,
+  message: {
+     status: 429,
+     message: 'To many requests, try again later'
+  }
+});
+
 const createAccountLimiter = new RateLimit({
   windowMs: 60 * 60 * 1000, // 1 hour window
   delayAfter: 1, // begin slowing down responses after the first request

--- a/types/express-rate-limit/index.d.ts
+++ b/types/express-rate-limit/index.d.ts
@@ -22,7 +22,7 @@ declare namespace RateLimit {
         headers?: boolean;
         keyGenerator?(req: express.Request, res: express.Response): string;
         max?: number;
-        message?: string | Buffer | Object;
+        message?: string | Buffer | object;
         skip?(req: express.Request, res: express.Response): boolean;
         skipFailedRequests?: boolean;
         statusCode?: number;

--- a/types/express-rate-limit/index.d.ts
+++ b/types/express-rate-limit/index.d.ts
@@ -14,6 +14,12 @@ declare namespace RateLimit {
         decrement(key: string): void;
         resetKey(key: string): void;
     }
+    
+    interface Message {
+        status: number
+        message: string
+        [key: string]: any
+    }
 
     interface Options {
         delayAfter?: number;
@@ -22,7 +28,7 @@ declare namespace RateLimit {
         headers?: boolean;
         keyGenerator?(req: express.Request, res: express.Response): string;
         max?: number;
-        message?: string | Buffer | object;
+        message?: string | Buffer | Message;
         skip?(req: express.Request, res: express.Response): boolean;
         skipFailedRequests?: boolean;
         statusCode?: number;

--- a/types/express-rate-limit/index.d.ts
+++ b/types/express-rate-limit/index.d.ts
@@ -14,11 +14,11 @@ declare namespace RateLimit {
         decrement(key: string): void;
         resetKey(key: string): void;
     }
-    
+
     interface Message {
-        status: number
-        message: string
-        [key: string]: any
+        status: number;
+        message: string;
+        [key: string]: any;
     }
 
     interface Options {

--- a/types/express-rate-limit/index.d.ts
+++ b/types/express-rate-limit/index.d.ts
@@ -22,7 +22,7 @@ declare namespace RateLimit {
         headers?: boolean;
         keyGenerator?(req: express.Request, res: express.Response): string;
         max?: number;
-        message?: string;
+        message?: string | Buffer | Object;
         skip?(req: express.Request, res: express.Response): boolean;
         skipFailedRequests?: boolean;
         statusCode?: number;


### PR DESCRIPTION
Updated Options -> message type to mirror express typings, ran into this issue when trying to use an object as the message value.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://www.npmjs.com/package/express-rate-limit#message> <https://github.com/types/express/blob/master/lib/response.d.ts#L68>
